### PR TITLE
[Feature] Add accurate fp32 SFPU path for ttnn.min and ttnn.sum via fast_and_approximate_mode

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -144,7 +144,7 @@ def test_max_dim(device, input_shape_and_dim, keepdim):
     assert_equal(torch_output_tensor, output_tensor)
 
 
-@pytest.mark.parametrize("input_shape", [(16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("input_shape", [(32, 32), (16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
 @pytest.mark.parametrize("dim", [None, -1, -2])
 @pytest.mark.parametrize("scalar", [1.0, 2.5, -2.5])
 @pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
@@ -164,9 +164,7 @@ def test_max_fp32_fast_and_approximate_mode(device, input_shape, dim, scalar, fa
     output_tensor = ttnn.max(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim, scalar=scalar)
     output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
 
-    # A negative scalar dispatches to min, and fp32 min is not routed to the SFPU yet,
-    # so it stays on the FPU path.
-    if fast_and_approximate_mode or scalar < 0 or device.arch() == ttnn.device.Arch.QUASAR:
+    if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
         assert_allclose(torch_output_tensor, output_tensor, rtol=1e-3, atol=1e-2)
     else:
         assert_equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -9,18 +9,10 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_allclose, assert_numeric_metrics, assert_with_ulp
 from models.common.utility_functions import torch_random
 
 TEST_PADDING_VALUE = -42
-
-
-def _skip_fp32_nc_reduce(dtype, dim):
-    # The accurate SFPU fp32 path covers H/W reductions only; batch/channel (dim 0/1) reductions use
-    # the NC path with a bf16-rounded 1/N scaler (~1e-3 error), so fp32 there is not ULP-exact.
-    axes = [dim] if isinstance(dim, int) else list(dim)
-    if dtype == ttnn.float32 and any(a in (0, 1) for a in axes):
-        pytest.skip("fp32 batch/channel-dim mean uses the bf16-scaler NC path; accurate SFPU covers H/W only")
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])
@@ -76,7 +68,6 @@ def test_mean(device, batch_size, h, w, dim, keepdim, dtype):
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
 def test_mean_scaling(device, shape, dim, keepdim, dtype):
     """Ones input → uniform mean; check the exact result via ULP (both dtypes)."""
-    _skip_fp32_nc_reduce(dtype, dim)
     torch.manual_seed(0)
     torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
     torch_input_tensor = torch.ones(shape, dtype=torch_dtype)
@@ -96,7 +87,6 @@ def test_mean_scaling(device, shape, dim, keepdim, dtype):
 @pytest.mark.parametrize("scalar", [2.0])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
 def test_mean_scaling_factor(device, shape, dim, scalar, dtype):
-    _skip_fp32_nc_reduce(dtype, dim)
     torch.manual_seed(0)
     torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
     torch_input_tensor = torch.ones(shape, dtype=torch_dtype)
@@ -176,3 +166,28 @@ def test_mean_shard(device, mem_config, keepdim, dtype):
     else:
         assert output_mem_config.buffer_type == ttnn.BufferType.L1
         assert output_mem_config.is_sharded()
+
+
+@pytest.mark.parametrize("input_shape", [(16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
+def test_mean_fp32_fast_and_approximate_mode_no_dim(device, input_shape, fast_and_approximate_mode):
+    """FLOAT32 global mean (dim=None) with both values of fast_and_approximate_mode.
+
+    dim=None covers every axis, so the reduce is decomposed into per-axis Sum sub-steps rather than
+    taking a single W/H/HW dispatch; this pins that decomposition to the accurate path.
+    """
+    torch.manual_seed(1)
+
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.mean(torch_input_tensor.to(torch.float64)).to(torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+
+    output_tensor = ttnn.mean(input_tensor, dim=None, fast_and_approximate_mode=fast_and_approximate_mode)
+    output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
+
+    if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
+        assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=8)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -168,13 +168,12 @@ def test_mean_shard(device, mem_config, keepdim, dtype):
         assert output_mem_config.is_sharded()
 
 
-@pytest.mark.parametrize("input_shape", [(16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("input_shape", [(32, 32), (16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
 @pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
 def test_mean_fp32_fast_and_approximate_mode_no_dim(device, input_shape, fast_and_approximate_mode):
-    """FLOAT32 global mean (dim=None) with both values of fast_and_approximate_mode.
-
-    dim=None covers every axis, so the reduce is decomposed into per-axis Sum sub-steps rather than
-    taking a single W/H/HW dispatch; this pins that decomposition to the accurate path.
+    """FLOAT32 mean (dim=None) with both values of fast_and_approximate_mode.
+    - False (default): accurate SFPU path.
+    - True: faster FPU/TF32 path.
     """
     torch.manual_seed(1)
 
@@ -190,4 +189,4 @@ def test_mean_fp32_fast_and_approximate_mode_no_dim(device, input_shape, fast_an
     if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
         assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)
     else:
-        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=8)
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=2)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_allclose, assert_equal, assert_numeric_metrics
 from models.common.utility_functions import torch_random
 
 TEST_PADDING_VALUE = -142
@@ -132,3 +132,33 @@ def test_min_multi_dim(device, input_shape):
         frobenius_threshold=1e-09,
         check_ulp=True,
     )
+
+
+@pytest.mark.parametrize("input_shape", [(16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("dim", [None, -1, -2])
+@pytest.mark.parametrize("scalar", [1.0, 2.5, -2.5])
+@pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
+def test_min_fp32_fast_and_approximate_mode(device, input_shape, dim, scalar, fast_and_approximate_mode):
+    """FLOAT32 min with both values of fast_and_approximate_mode.
+    - False (default): accurate SFPU path (LLK MIN reduce) - result matches torch exactly.
+    - True: faster FPU/TF32 path via -MAX(-x) - result is approximate.
+
+    The scalar is applied after the reduction, so it costs the accurate path no precision. A negative
+    scalar flips the op, since min(scalar * x) == scalar * max(x).
+    """
+    torch.manual_seed(1)
+
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.amin(scalar * torch_input_tensor, dim=dim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+
+    output_tensor = ttnn.min(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim, scalar=scalar)
+    output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
+
+    # A negative scalar dispatches to max, which is accurate for fp32, so only fast mode is loose.
+    if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
+        assert_allclose(torch_output_tensor, output_tensor, rtol=1e-3, atol=1e-2)
+    else:
+        assert_equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -134,7 +134,7 @@ def test_min_multi_dim(device, input_shape):
     )
 
 
-@pytest.mark.parametrize("input_shape", [(16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("input_shape", [(32, 32), (16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
 @pytest.mark.parametrize("dim", [None, -1, -2])
 @pytest.mark.parametrize("scalar", [1.0, 2.5, -2.5])
 @pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
@@ -142,9 +142,6 @@ def test_min_fp32_fast_and_approximate_mode(device, input_shape, dim, scalar, fa
     """FLOAT32 min with both values of fast_and_approximate_mode.
     - False (default): accurate SFPU path (LLK MIN reduce) - result matches torch exactly.
     - True: faster FPU/TF32 path via -MAX(-x) - result is approximate.
-
-    The scalar is applied after the reduction, so it costs the accurate path no precision. A negative
-    scalar flips the op, since min(scalar * x) == scalar * max(x).
     """
     torch.manual_seed(1)
 
@@ -157,7 +154,6 @@ def test_min_fp32_fast_and_approximate_mode(device, input_shape, dim, scalar, fa
     output_tensor = ttnn.min(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim, scalar=scalar)
     output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
 
-    # A negative scalar dispatches to max, which is accurate for fp32, so only fast mode is loose.
     if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
         assert_allclose(torch_output_tensor, output_tensor, rtol=1e-3, atol=1e-2)
     else:

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -736,7 +736,7 @@ def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, ou
 
     # Accurate SFPU (full fp32) vs FPU (tf32 truncation). The FPU path roughly doubles the relative
     # error at these depths; Quasar has no SFPU reduce LLKs, so it always takes the FPU bound.
-    rtol = 0.004 if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR else 0.001
+    rtol = 0.004 if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR else 0.0011
     assert_numeric_metrics(
         torch_ref,
         output,

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -736,7 +736,7 @@ def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, ou
 
     # Accurate SFPU (full fp32) vs FPU (tf32 truncation). The FPU path roughly doubles the relative
     # error at these depths; Quasar has no SFPU reduce LLKs, so it always takes the FPU bound.
-    rtol = 0.004 if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR else 0.002
+    rtol = 0.004 if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR else 0.001
     assert_numeric_metrics(
         torch_ref,
         output,

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -715,8 +715,6 @@ def test_rm_reduce_interleaved_program_cache(device, reduce_op, shape, dim):
 )
 def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, output_layout, shape):
     """H reduce on tall ROW_MAJOR input — exercises the multi-shard H-axis-split + combine path."""
-    if fast_and_approximate_mode and reduce_op != "mean":
-        pytest.skip("fast_and_approximate_mode only affects mean")
     torch.manual_seed(0)
     torch_input = torch.rand(shape, dtype=torch.float32)
     torch_ref = _golden(torch_input, reduce_op, dim=-2, keepdim=False)
@@ -725,17 +723,20 @@ def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, ou
     assert tt_input.layout == ttnn.ROW_MAJOR_LAYOUT
 
     ttnn_op = _OPS[reduce_op][1]
-    op_kwargs = {"dim": -2, "keepdim": False, "output_layout": output_layout}
-    if reduce_op == "mean":
-        op_kwargs["fast_and_approximate_mode"] = fast_and_approximate_mode
+    op_kwargs = {
+        "dim": -2,
+        "keepdim": False,
+        "output_layout": output_layout,
+        "fast_and_approximate_mode": fast_and_approximate_mode,
+    }
     tt_output = ttnn_op(tt_input, **op_kwargs)
     # None keeps the dense RM path's natural ROW_MAJOR output.
     assert tt_output.layout == (output_layout or ttnn.ROW_MAJOR_LAYOUT)
     output = ttnn.to_torch(tt_output)
 
-    # Only mean has an accurate fp32 SFPU reduce; the FPU path truncates to TF32, roughly doubling
-    # the relative error at these depths.
-    rtol = 0.002 if (reduce_op == "mean" and not fast_and_approximate_mode) else 0.004
+    # Accurate SFPU (full fp32) vs FPU (tf32 truncation). The FPU path roughly doubles the relative
+    # error at these depths; Quasar has no SFPU reduce LLKs, so it always takes the FPU bound.
+    rtol = 0.004 if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR else 0.002
     assert_numeric_metrics(
         torch_ref,
         output,

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.use_module_device
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_allclose, assert_numeric_metrics, assert_with_ulp
 from models.common.utility_functions import torch_random
 
 TEST_PADDING_VALUE = -42
@@ -209,3 +209,44 @@ def test_sum_subcores(device, sub_core_grids, dtype, shape):
         atol=atol,
         frobenius_threshold=frobenius_threshold,
     )
+
+
+# Accurate-path ULP cap, matching _SFPU_ULP_MAX in
+# tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py: sum is the accumulation mean
+# lowers to, so it is held to the same bar.
+SUM_SFPU_ULP_MAX = 8
+
+
+@pytest.mark.parametrize("input_shape", [(16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("dim", [None, -1, -2])
+@pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
+def test_sum_fp32_fast_and_approximate_mode(device, input_shape, dim, fast_and_approximate_mode):
+    """FLOAT32 sum with both values of fast_and_approximate_mode.
+    - False (default): accurate SFPU path - within a few ULP of an fp64 golden.
+    - True: faster FPU/TF32 path - result is approximate.
+
+    Unlike max/min, sum accumulates, so it is not bit-exact against torch (the reduction order
+    differs) and accuracy is measured in ULP instead. The input is uniform [1, 2): strictly positive,
+    so the reduction is well conditioned. A zero-mean input would cancel toward zero, where one ULP
+    is tiny and the metric becomes unstable.
+    """
+    torch.manual_seed(1)
+
+    torch_input_tensor = torch.empty(input_shape, dtype=torch.float32).uniform_(1.0, 2.0)
+    # fp64 golden, so the bound measures the device against exact arithmetic rather than against
+    # torch's own fp32 accumulation order.
+    golden_fp64 = torch_input_tensor.to(torch.float64)
+    torch_output_tensor = (torch.sum(golden_fp64) if dim is None else torch.sum(golden_fp64, dim=dim)).to(torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+
+    output_tensor = ttnn.sum(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode, dim=dim)
+    output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
+
+    if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
+        # tf32 truncation puts this path thousands of ULP out, past the range where ULP stays
+        # comparable, so bound it with a loose relative check instead.
+        assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)
+    else:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=SUM_SFPU_ULP_MAX)

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -211,32 +211,18 @@ def test_sum_subcores(device, sub_core_grids, dtype, shape):
     )
 
 
-# Accurate-path ULP cap, matching _SFPU_ULP_MAX in
-# tests/ttnn/nightly/unit_tests/operations/reduction/test_mean_ulp.py: sum is the accumulation mean
-# lowers to, so it is held to the same bar.
-SUM_SFPU_ULP_MAX = 8
-
-
-@pytest.mark.parametrize("input_shape", [(16, 2, 32, 24), (1, 1, 64, 64)])
+@pytest.mark.parametrize("input_shape", [(32, 32), (16, 2, 32, 3), (16, 2, 32, 24), (1, 1, 64, 64)])
 @pytest.mark.parametrize("dim", [None, -1, -2])
 @pytest.mark.parametrize("fast_and_approximate_mode", [False, True], ids=["accurate", "fast"])
 def test_sum_fp32_fast_and_approximate_mode(device, input_shape, dim, fast_and_approximate_mode):
     """FLOAT32 sum with both values of fast_and_approximate_mode.
-    - False (default): accurate SFPU path - within a few ULP of an fp64 golden.
+    - False (default): accurate SFPU path.
     - True: faster FPU/TF32 path - result is approximate.
-
-    Unlike max/min, sum accumulates, so it is not bit-exact against torch (the reduction order
-    differs) and accuracy is measured in ULP instead. The input is uniform [1, 2): strictly positive,
-    so the reduction is well conditioned. A zero-mean input would cancel toward zero, where one ULP
-    is tiny and the metric becomes unstable.
     """
     torch.manual_seed(1)
 
-    torch_input_tensor = torch.empty(input_shape, dtype=torch.float32).uniform_(1.0, 2.0)
-    # fp64 golden, so the bound measures the device against exact arithmetic rather than against
-    # torch's own fp32 accumulation order.
-    golden_fp64 = torch_input_tensor.to(torch.float64)
-    torch_output_tensor = (torch.sum(golden_fp64) if dim is None else torch.sum(golden_fp64, dim=dim)).to(torch.float32)
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.float32)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
@@ -245,8 +231,6 @@ def test_sum_fp32_fast_and_approximate_mode(device, input_shape, dim, fast_and_a
     output_tensor = ttnn.to_torch(ttnn.from_device(output_tensor)).reshape(torch_output_tensor.shape)
 
     if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR:
-        # tf32 truncation puts this path thousands of ULP out, past the range where ULP stays
-        # comparable, so bound it with a loose relative check instead.
         assert_allclose(torch_output_tensor, output_tensor, rtol=1e-2, atol=1e-2)
     else:
-        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=SUM_SFPU_ULP_MAX)
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=2)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -12,8 +12,8 @@
  * @brief Float32 reduce precision mode.
  *
  * Fast keeps fp32 on the FPU/GMPOOL path (inputs truncated to tf32 — faster, lossy); Accurate
- * routes fp32 through the SFPU at full fp32 (accurate ttnn.mean / ttnn.max). Only affects
- * Float32 SUM and MAX; Int32 always uses the SFPU regardless of this mode.
+ * routes fp32 through the SFPU at full fp32. Only affects Float32; Int32 always uses the SFPU
+ * regardless of this mode.
  */
 enum class ReduceFp32Mode : uint8_t { Fast, Accurate };
 
@@ -25,8 +25,9 @@ enum class ReduceFp32Mode : uint8_t { Fast, Accurate };
  * Int32 HW reduce into a W-then-H two-step (see reduce_op.cpp use_two_step_hw_sfpu_reduce).
  * Int32 MIN drives the LLK MIN reduce directly, instead of the -MAX(-x) reduce_{h,w}_neg path that FPU MIN uses.
  *
- * Float32 SUM and MAX additionally opt into the SFPU path when the caller passes
- * ReduceFp32Mode::Accurate; the host threads that mode in from the kernel's compile-time args.
+ * Float32 additionally opts into the SFPU path when the caller passes ReduceFp32Mode::Accurate;
+ * the host threads that mode in from the kernel's compile-time args. Accurate Float32 MIN drives
+ * the LLK MIN reduce directly, like Int32 MIN, so the host skips the -MAX(-x) lowering.
  */
 template <
     ckernel::PoolType pool_type,
@@ -55,9 +56,8 @@ constexpr bool is_sfpu_reduce_path() {
         return false;
     }
     if constexpr (data_format != DataFormat::Int32) {
-        // Float32 opts into the SFPU path only in Accurate mode, and only for SUM (accurate ttnn.mean,
-        // which the host lowers to SUM + a 1/N post-mul) or MAX (accurate ttnn.max). Everything else
-        // non-Int32 stays on the FPU.
+        // pool_type is already narrowed to MAX/SUM/MIN above and all three have an SFPU fold, so
+        // Float32 only has to opt in via Accurate mode. Everything else non-Int32 stays on the FPU.
         if constexpr (fp32_mode != ReduceFp32Mode::Accurate || data_format != DataFormat::Float32) {
             return false;
         }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -74,7 +74,7 @@ constexpr bool is_sfpu_reduce_path() {
  *
  * REDUCE_ROW SUM/AVG uses matmul with scaler in SrcA and data in SrcB (the opposite of the
  * default data→SrcA, scaler→SrcB ordering). This does not apply to MAX (which uses GMPOOL)
- * or to the SFPU path (Int32), which bypasses matmul entirely.
+ * or to the SFPU path (Int32 and Accurate fp32), which bypasses matmul entirely.
  */
 template <ckernel::PoolType pool_type, ckernel::ReduceDim reduce_dim, bool is_sfpu>
 constexpr bool reduce_swaps_operands() {

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp
@@ -58,9 +58,7 @@ constexpr bool is_sfpu_reduce_path() {
         // Float32 opts into the SFPU path only in Accurate mode, and only for SUM (accurate ttnn.mean,
         // which the host lowers to SUM + a 1/N post-mul) or MAX (accurate ttnn.max). Everything else
         // non-Int32 stays on the FPU.
-        if constexpr (
-            fp32_mode != ReduceFp32Mode::Accurate || data_format != DataFormat::Float32 ||
-            (pool_type != ckernel::PoolType::SUM && pool_type != ckernel::PoolType::MAX)) {
+        if constexpr (fp32_mode != ReduceFp32Mode::Accurate || data_format != DataFormat::Float32) {
             return false;
         }
     }

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -293,14 +293,14 @@ struct NoOp {
  * @tparam scaler_dfb_id DataflowBuffer ID containing scaler tile (compile-time CB id)
  * @tparam output_dfb_id Output DataflowBuffer ID for reduced tiles (compile-time CB id)
  *                       The input/output formats are deduced from these CB ids
- *                       (unpack_src_format / pack_dst_format), so Int32 MAX and SUM are routed to
- *                       the SFPU path automatically (Int32 has no FPU support).
- *                       Other formats use FPU/GMPOOL. Only REDUCE_ROW/REDUCE_COL Int32 MAX/SUM on
- *                       SFPU; MIN dispatched via reduce_{h,w}_neg.cpp (SFPU vs FPU branch).
+ *                       (unpack_src_format / pack_dst_format), so Int32 is routed to the SFPU path
+ *                       automatically (Int32 has no FPU support). Other formats use FPU/GMPOOL
+ *                       unless Accurate fp32 is requested. SFPU covers REDUCE_ROW/REDUCE_COL only;
+ *                       fast-mode float/bf16 MIN is dispatched via reduce_{h,w}_neg.cpp.
  * @tparam input_policy Input handling policy (default: WaitAndPopPerTile - streaming mode)
  * @tparam reconfig_mode Data format reconfiguration mode (default: INPUT_AND_OUTPUT)
- * @tparam fp32_mode Float32 precision mode (default: Fast). Accurate routes Float32 SUM and MAX
- *                   through the SFPU at full fp32; see ReduceFp32Mode.
+ * @tparam fp32_mode Float32 precision mode (default: Fast). Accurate routes Float32 through the
+ *                   SFPU at full fp32; see ReduceFp32Mode.
  *
  * @param input_block_shape Tile grid dimensions (rows x cols x batches)
  *              Use ReduceInputBlockShape::of(r, c, b), ::row(c), ::col(r), or ::single()

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -74,7 +74,7 @@ ALWI void sfpu_reduce_sum_fold_init() {
 #ifndef ARCH_QUASAR
         add_binary_tile_init();
 #else
-        static_assert(format == DataFormat::Int32, "Accurate fp32 SFPU mean is not supported on Quasar");
+        static_assert(format == DataFormat::Int32, "Accurate fp32 SFPU reduce is not supported on Quasar");
 #endif
     }
 }
@@ -87,13 +87,13 @@ ALWI void sfpu_reduce_sum_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
 #ifndef ARCH_QUASAR
         add_binary_tile(a, b, out);
 #else
-        static_assert(format == DataFormat::Int32, "Accurate fp32 SFPU mean is not supported on Quasar");
+        static_assert(format == DataFormat::Int32, "Accurate fp32 SFPU reduce is not supported on Quasar");
 #endif
     }
 }
 
 // Pool-type dispatched cross-tile fold init (MAX -> binary_max, MIN -> binary_min, SUM -> add).
-// Used by compute_kernel_lib::reduce() for the Int32 SFPU path and for accurate fp32 SUM/MAX.
+// Used by compute_kernel_lib::reduce() for the Int32 SFPU path and for accurate fp32 reduces.
 template <PoolType pool_type, DataFormat format>
 ALWI void sfpu_reduce_fold_init() {
     if constexpr (pool_type == PoolType::SUM) {
@@ -303,7 +303,7 @@ ALWI void reduce(
     ReduceInputMemoryLayout input_memory_layout,
     AccumulateT accumulate,
     PostReduceOp post_reduce_op) {
-    // Int32 MAX and Accurate fp32 SUM/MAX route to the SFPU via is_sfpu_reduce_path<>(); others use FPU/GMPOOL.
+    // Int32 and Accurate fp32 route to the SFPU via is_sfpu_reduce_path<>(); others use FPU/GMPOOL.
     constexpr DataFormat reduce_format = static_cast<DataFormat>(unpack_src_format[input_dfb_id]);
     // =============================================================================
     // Static Assertions (compile-time validation)
@@ -318,8 +318,7 @@ ALWI void reduce(
 #ifndef ARCH_QUASAR  // Quasar's ckernel::PoolType has no MIN, so this check is vacuous there
     static_assert(
         reduce_type != PoolType::MIN || is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format, fp32_mode>(),
-        "MIN is only valid on the Int32 SFPU reduce path; the FPU path implements MIN as -MAX(-x)");
-#endif
+        "MIN is only valid on an SFPU path (Int32 or Accurate fp32); FPU MIN arrives as PoolType::MAX via -MAX(-x)");
     static_assert(
         is_accumulation_type_v<AccumulateT>,
         "AccumulateT must be a valid accumulation type (NoAccumulation or Accumulate)");

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -47,14 +47,20 @@ ALWI void sfpu_reduce_max_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
 // SFPU MIN fold
 template <DataFormat format>
 ALWI void sfpu_reduce_min_fold_init() {
-    static_assert(format == DataFormat::Int32, "SFPU reduce MIN fold: Int32 only");
-    binary_min_int32_tile_init();
+    if constexpr (format == DataFormat::Int32) {
+        binary_min_int32_tile_init();
+    } else {
+        binary_min_tile_init();
+    }
 }
 
 template <DataFormat format>
 ALWI void sfpu_reduce_min_fold_tile(uint32_t a, uint32_t b, uint32_t out) {
-    static_assert(format == DataFormat::Int32, "SFPU reduce MIN fold: Int32 only");
-    binary_min_int32_tile(a, b, out);
+    if constexpr (format == DataFormat::Int32) {
+        binary_min_int32_tile(a, b, out);
+    } else {
+        binary_min_tile(a, b, out);
+    }
 }
 
 // SFPU cross-tile add. Int32 uses add_int_tile; Float32 uses add_binary_tile for

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -319,6 +319,7 @@ ALWI void reduce(
     static_assert(
         reduce_type != PoolType::MIN || is_sfpu_reduce_path<reduce_type, reduce_dim, reduce_format, fp32_mode>(),
         "MIN is only valid on an SFPU path (Int32 or Accurate fp32); FPU MIN arrives as PoolType::MAX via -MAX(-x)");
+#endif
     static_assert(
         is_accumulation_type_v<AccumulateT>,
         "AccumulateT must be a valid accumulation type (NoAccumulation or Accumulate)");

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -158,7 +158,7 @@ std::vector<uint32_t> build_rm_compute_ct_args(
         post_mul_scaler_bits,
         plan.wt_tiles_per_chunk,
         plan.ht_tiles_per_chunk,
-        fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
+        fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 through the SFPU
     };
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -52,11 +52,10 @@ inline uint32_t dense_rm_padding_identity_bits(tt::DataFormat df, tt::tt_metal::
 }
 
 // True when the reduce uses the SFPU path instead of the FPU GMPOOL/matmul path.
-// Int32 MAX, MIN and SUM always use SFPU (FPU has no Int32 support); Int32 MIN drives the LLK MIN
-// directly, while float/bf16 MIN lowers to -MAX(-x). Float32 SUM and MAX opt into SFPU only when the
-// host requests the accurate path (`use_sfpu_reduce`): the FPU path truncates fp32 to tf32,
-// so the SFPU preserves full fp32. mean is lowered to SUM + a 1/N post-mul before this is consulted,
-// so only SUM (never AVG) is checked for fp32.
+// Int32 always uses SFPU (FPU has no Int32 support). Float32 opts in only when the host requests
+// the accurate path (`use_sfpu_reduce`): the FPU truncates fp32 to tf32, so the SFPU preserves full
+// fp32. mean arrives as SUM (the host lowers it to SUM + a 1/N post-mul), and fast-mode float/bf16
+// MIN arrives as MAX with negate=true via -MAX(-x), so only accurate MIN reaches here as MIN.
 inline bool use_sfpu_reduce_path(
     tt::tt_metal::DataType dtype, tt::tt_metal::ReduceOpMath math_op, bool use_sfpu_reduce = false) {
     using tt::tt_metal::ReduceOpMath;
@@ -68,7 +67,7 @@ inline bool use_sfpu_reduce_path(
 }
 
 // True when a non-unity scalar must be a post-reduce multiply instead of via the scaler CB: MAX/MIN,
-// the Int32 SFPU path, and the accurate fp32 SFPU mean all ignore the scaler CB (fp32 matches AVG/SUM).
+// the Int32 SFPU path, and the accurate fp32 SFPU path all ignore the scaler CB.
 inline bool requires_post_mul(
     tt::tt_metal::ReduceOpMath math_op, tt::tt_metal::DataType dtype, float scaler, bool use_sfpu_reduce = false) {
     using tt::tt_metal::ReduceOpMath;
@@ -151,8 +150,8 @@ std::vector<uint32_t> build_rm_writer_ct_args(
 
 // Build the compute compile-time args vector for the RM path (slots match reduce_rm.cpp).
 // `Ht_arg` is the per-core ht count (W path) or the global Ht_rm (H path); the helper
-// keeps NC pinned at 1. `fp32_sfpu_reduce` (slot 6) routes Float32 SUM through the SFPU for
-// full-fp32 accumulation (accurate ttnn.mean) instead of the tf32 FPU path.
+// keeps NC pinned at 1. `fp32_sfpu_reduce` (slot 6) routes Float32 through the SFPU for
+// full-fp32 accumulation instead of the tf32 FPU path.
 std::vector<uint32_t> build_rm_compute_ct_args(
     const RmPlan& plan, uint32_t Ht_arg, uint32_t post_mul_scaler_bits, bool fp32_sfpu_reduce);
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -64,7 +64,7 @@ inline bool use_sfpu_reduce_path(
         return math_op == ReduceOpMath::MAX || math_op == ReduceOpMath::SUM || math_op == ReduceOpMath::MIN;
     }
     return use_sfpu_reduce && dtype == tt::tt_metal::DataType::FLOAT32 &&
-           (math_op == ReduceOpMath::SUM || math_op == ReduceOpMath::MAX);
+           (math_op == ReduceOpMath::SUM || math_op == ReduceOpMath::MAX || math_op == ReduceOpMath::MIN);
 }
 
 // True when a non-unity scalar must be a post-reduce multiply instead of via the scaler CB: MAX/MIN,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce.cpp
@@ -4,7 +4,8 @@
 
 // Thin wrapper around compute_kernel_lib::reduce<>. The input data format is deduced from the input
 // CB id inside the helper, so Int32 MAX, MIN and SUM are routed to the SFPU path automatically;
-// otherwise FPU/GMPOOL. float/bf16 MIN is lowered to -MAX(-x) via reduce_{h,w}_neg on the host.
+// otherwise FPU/GMPOOL. Accurate fp32 also uses the SFPU; fast-mode float/bf16 MIN is lowered to
+// -MAX(-x) via reduce_{h,w}_neg on the host.
 
 #include <cstdint>
 #include "api/compute/cb_api.h"
@@ -15,7 +16,7 @@ void kernel_main() {
     uint32_t Ht = get_compile_time_arg_val(0);
     uint32_t Wt = get_compile_time_arg_val(1);
     uint32_t NC = get_compile_time_arg_val(2);
-    // Accurate fp32 mean: host sets CT arg 4 to route Float32 SUM through the SFPU (full fp32) vs the FPU (tf32).
+    // Accurate fp32: host sets CT arg 4 to route Float32 through the SFPU (full fp32) vs the FPU (tf32).
     constexpr auto fp32_mode = get_compile_time_arg_val(4) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp
@@ -47,7 +47,7 @@ constexpr auto rm_reconfig_mode =
     compute_kernel_lib::ReduceDataFormatReconfigMode::INPUT;
 #endif
 
-// Accurate fp32 mean: CT arg 6 routes Float32 SUM through the SFPU (full fp32) instead of the FPU (tf32).
+// Accurate fp32: CT arg 6 routes Float32 through the SFPU (full fp32) instead of the FPU (tf32).
 constexpr auto fp32_mode = get_compile_time_arg_val(6) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
 
 // One reduce() call over the (ht_in_chunk × wt_in_chunk × NC) block currently staged in cb_tile_in.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     // unified reduce compute kernel (row_chunk = DEST_AUTO_LIMIT). For shard_Wt=1 this
     // degenerates to one column per chunk; for shard_Wt>1 it interleaves columns.
     // Int32 SFPU max reserves one DST for the binary-fold work tile (DEST_AUTO_LIMIT - 1).
-    // Accurate fp32 mean: host sets CT arg 4 to 1 so SFPU chunk sizing here matches the compute kernel.
+    // Accurate fp32: host sets CT arg 4 to 1 so SFPU chunk sizing here matches the compute kernel.
     constexpr auto fp32_mode = get_compile_time_arg_val(4) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
     constexpr DataFormat reduce_format = get_dataformat(dfb_id_in0);
     constexpr bool use_sfpu_reduce_path = is_sfpu_reduce_path<REDUCE_OP, REDUCE_DIM, reduce_format, fp32_mode>();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -156,12 +156,12 @@ Tensor reduce(
     const bool use_rm_dense = use_rm_dense_w || use_rm_dense_h;
 
     // Accurate fp32 SFPU path (the FPU truncates fp32 to tf32 on the way into SrcA/SrcB). Falls back
-    // to the FPU without fp32_dest_acc_en, on Quasar (no SFPU reduce LLKs), or on the dense RM path
-    // (its own kernels, no SFPU variant). negate=true marks the FPU's -MAX(-x) min lowering, which
-    // has no SFPU fold, so MAX/MIN exclude it.
+    // to the FPU without fp32_dest_acc_en or on Quasar (no SFPU reduce LLKs). The dense RM kernels
+    // share the same SFPU fold via CT arg 6. negate=true marks the FPU's -MAX(-x) min lowering,
+    // which has no SFPU fold, so MAX/MIN exclude it.
     const bool fp32_sfpu_eligible = !fast_and_approximate_mode &&
                                     input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
-                                    arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en && !use_rm_dense;
+                                    arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en;
 
     const bool use_sfpu_fp32_sum = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::SUM;
     const bool use_sfpu_fp32_mean = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::AVG;
@@ -354,7 +354,7 @@ Tensor reduce(
                 /*post_mul_scaler=*/1.0f,
                 /*row_major_w_dense_path=*/false,
                 /*row_major_h_dense_path=*/true,
-                /*use_sfpu_reduce=*/use_sfpu_fp32_mean,
+                /*use_sfpu_reduce=*/use_sfpu_fp32_reduce,
                 /*num_h_slices=*/num_h_slices,
                 /*output_layout=*/tt::tt_metal::Layout::ROW_MAJOR);
 
@@ -371,7 +371,7 @@ Tensor reduce(
                 /*post_mul_scaler=*/post_mul,
                 /*row_major_w_dense_path=*/false,
                 /*row_major_h_dense_path=*/true,
-                /*use_sfpu_reduce=*/use_sfpu_fp32_mean,
+                /*use_sfpu_reduce=*/use_sfpu_fp32_reduce,
                 /*num_h_slices=*/1,
                 /*output_layout=*/rm_dense_out_layout);
         }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -128,25 +128,6 @@ Tensor reduce(
         /*default_fp32_acc=*/true));
     ttnn::verify_numerical_configuration(arch, compute_kernel_config);
 
-    // Accurate fp32 SFPU path (FPU truncates to TF32). Falls back to FPU without fp32_dest_acc_en or on Quasar.
-    const bool fp32_sfpu_eligible = !fast_and_approximate_mode &&
-                                    input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
-                                    arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en;
-
-    const bool use_sfpu_fp32_mean = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::AVG;
-    const bool use_sfpu_fp32_max = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::MAX && !negate;
-    const bool use_sfpu_fp32_min = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::MIN && !negate;
-
-    const bool use_sfpu_fp32_reduce = use_sfpu_fp32_mean || use_sfpu_fp32_max || use_sfpu_fp32_min;
-
-    // The FPU has no float/bf16 MIN primitive, so fast-mode MIN lowers to -MAX(-x) via the fused
-    // negate kernels. Accurate fp32 MIN drives the LLK MIN reduce directly (like Int32 MIN) and must
-    // skip that lowering.
-    if (reduce_math == tt::tt_metal::ReduceOpMath::MIN && input_tensor.dtype() != tt::tt_metal::DataType::INT32 &&
-        !use_sfpu_fp32_min) {
-        return reduce_min(input_tensor, reduce_dim, scaler, output_mem_config, compute_kernel_config, sub_core_grids);
-    }
-
     // Dense row-major reduce: a fast path that consumes ROW_MAJOR input directly (no host tilize)
     // and is currently restricted to mean (AVG) / sum (SUM) on 4D BF16/FLOAT32 tensors with
     // interleaved I/O on both sides. Anything else — MAX/MIN, HW reduce, other dtypes, sharded
@@ -173,6 +154,26 @@ Tensor reduce(
         rm_base_eligible && reduce_dim == tt::tt_metal::ReduceOpDim::W && !explicit_tile_request;
     const bool use_rm_dense_h = rm_base_eligible && reduce_dim == tt::tt_metal::ReduceOpDim::H;
     const bool use_rm_dense = use_rm_dense_w || use_rm_dense_h;
+
+    // Accurate fp32 SFPU path (FPU truncates to TF32). Falls back to FPU without fp32_dest_acc_en or on Quasar.
+    const bool fp32_sfpu_eligible = !fast_and_approximate_mode &&
+                                    input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
+                                    arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en && !use_rm_dense;
+
+    const bool use_sfpu_fp32_sum = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::SUM;
+    const bool use_sfpu_fp32_mean = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::AVG;
+    const bool use_sfpu_fp32_max = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::MAX && !negate;
+    const bool use_sfpu_fp32_min = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::MIN && !negate;
+
+    const bool use_sfpu_fp32_reduce = use_sfpu_fp32_sum || use_sfpu_fp32_mean || use_sfpu_fp32_max || use_sfpu_fp32_min;
+
+    // The FPU has no float/bf16 MIN primitive, so fast-mode MIN lowers to -MAX(-x) via the fused
+    // negate kernels. Accurate fp32 MIN drives the LLK MIN reduce directly (like Int32 MIN) and must
+    // skip that lowering.
+    if (reduce_math == tt::tt_metal::ReduceOpMath::MIN && input_tensor.dtype() != tt::tt_metal::DataType::INT32 &&
+        !use_sfpu_fp32_min) {
+        return reduce_min(input_tensor, reduce_dim, scaler, output_mem_config, compute_kernel_config, sub_core_grids);
+    }
     // Layout the dense RM path will be asked to produce; ROW_MAJOR unless TILE was requested.
     const auto rm_dense_out_layout =
         explicit_tile_request ? tt::tt_metal::Layout::TILE : tt::tt_metal::Layout::ROW_MAJOR;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -106,10 +106,6 @@ Tensor reduce(
         "output_layout is only supported for sum (SUM) and mean (AVG) reductions, got {}",
         reduce_math);
 
-    if (reduce_math == tt::tt_metal::ReduceOpMath::MIN && input_tensor.dtype() != tt::tt_metal::DataType::INT32) {
-        return reduce_min(input_tensor, reduce_dim, scaler, output_mem_config, compute_kernel_config, sub_core_grids);
-    }
-
     auto parallelization_strategy = ttnn::prim::get_parallelization_strategy(input_tensor, reduce_dim);
     auto is_multicore_hw = parallelization_strategy == tt::tt_metal::ReduceOpParallelizationStrategy::MULTI_CORE_HW;
     const ttnn::PadValue pad_value = reduce_op_utils::get_tilize_pad_value(reduce_math, input_tensor.dtype());
@@ -139,8 +135,17 @@ Tensor reduce(
 
     const bool use_sfpu_fp32_mean = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::AVG;
     const bool use_sfpu_fp32_max = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::MAX && !negate;
+    const bool use_sfpu_fp32_min = fp32_sfpu_eligible && reduce_math == tt::tt_metal::ReduceOpMath::MIN && !negate;
 
-    const bool use_sfpu_fp32_reduce = use_sfpu_fp32_mean || use_sfpu_fp32_max;
+    const bool use_sfpu_fp32_reduce = use_sfpu_fp32_mean || use_sfpu_fp32_max || use_sfpu_fp32_min;
+
+    // The FPU has no float/bf16 MIN primitive, so fast-mode MIN lowers to -MAX(-x) via the fused
+    // negate kernels. Accurate fp32 MIN drives the LLK MIN reduce directly (like Int32 MIN) and must
+    // skip that lowering.
+    if (reduce_math == tt::tt_metal::ReduceOpMath::MIN && input_tensor.dtype() != tt::tt_metal::DataType::INT32 &&
+        !use_sfpu_fp32_min) {
+        return reduce_min(input_tensor, reduce_dim, scaler, output_mem_config, compute_kernel_config, sub_core_grids);
+    }
 
     // Dense row-major reduce: a fast path that consumes ROW_MAJOR input directly (no host tilize)
     // and is currently restricted to mean (AVG) / sum (SUM) on 4D BF16/FLOAT32 tensors with

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -155,7 +155,10 @@ Tensor reduce(
     const bool use_rm_dense_h = rm_base_eligible && reduce_dim == tt::tt_metal::ReduceOpDim::H;
     const bool use_rm_dense = use_rm_dense_w || use_rm_dense_h;
 
-    // Accurate fp32 SFPU path (FPU truncates to TF32). Falls back to FPU without fp32_dest_acc_en or on Quasar.
+    // Accurate fp32 SFPU path (the FPU truncates fp32 to tf32 on the way into SrcA/SrcB). Falls back
+    // to the FPU without fp32_dest_acc_en, on Quasar (no SFPU reduce LLKs), or on the dense RM path
+    // (its own kernels, no SFPU variant). negate=true marks the FPU's -MAX(-x) min lowering, which
+    // has no SFPU fold, so MAX/MIN exclude it.
     const bool fp32_sfpu_eligible = !fast_and_approximate_mode &&
                                     input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 &&
                                     arch != tt::ARCH::QUASAR && config.fp32_dest_acc_en && !use_rm_dense;
@@ -174,6 +177,7 @@ Tensor reduce(
         !use_sfpu_fp32_min) {
         return reduce_min(input_tensor, reduce_dim, scaler, output_mem_config, compute_kernel_config, sub_core_grids);
     }
+
     // Layout the dense RM path will be asked to produce; ROW_MAJOR unless TILE was requested.
     const auto rm_dense_out_layout =
         explicit_tile_request ? tt::tt_metal::Layout::TILE : tt::tt_metal::Layout::ROW_MAJOR;
@@ -181,8 +185,8 @@ Tensor reduce(
     // High-level mean uses AVG with scaler (1/N). On the tiled path, GMPOOL AVG matches that intent. On the dense
     // row-major W/H path we tilize one logical row at a time from a narrow RM page; AVG applies an extra normalization
     // for full tile faces that does not match torch.mean together with partial-row tilize. Use SUM + the same scaler.
-    // SUM and MAX pass through unchanged.
-    // The accurate fp32 SFPU mean path also lowers AVG to SUM: the SFPU folds tiles with a plain
+    // SUM, MAX and MIN pass through unchanged.
+    // The accurate fp32 SFPU mean also lowers AVG to SUM: the SFPU folds tiles with a plain
     // add (add_binary_tile) and normalizes via the 1/N post-mul below, so it needs SUM semantics.
     tt::tt_metal::ReduceOpMath prim_reduce_math = reduce_math;
     if ((use_rm_dense || use_sfpu_fp32_mean) && reduce_math == tt::tt_metal::ReduceOpMath::AVG) {
@@ -200,7 +204,8 @@ Tensor reduce(
     // A non-unity scalar is applied after the reduction (see requires_post_mul() in common.hpp):
     // GMPOOL keeps only the scaler's exponent for MAX/MIN, and the Int32 SFPU path ignores the
     // scaler CB. Int32 post-mul rounds through fp32, so it is lossy for |result| > 2^24.
-    // The accurate fp32 SFPU reduces also post-mul: mean applies its 1/N here, max its user scalar.
+    // The accurate fp32 SFPU path also post-muls (the SFPU ignores the scaler CB): mean applies its
+    // 1/N here, the rest their user scalar.
     const bool use_post_mul =
         ttnn::prim::requires_post_mul(reduce_math, prepared_input.dtype(), scaler, use_sfpu_fp32_reduce);
     const float reduce_scaler = use_post_mul ? 1.0f : scaler;
@@ -240,8 +245,8 @@ Tensor reduce(
     // INT32 SFPU reduce has no REDUCE_SCALAR primitive (ROW/COL only), so Int32 HW always uses
     // W-then-H. Fast-mode Float32 max HW can use single-core REDUCE_SCALAR (FPU) when num_tiles == 1;
     // multi-tile HW still uses W-then-H via is_multicore_hw. Applies to Int32 MAX/SUM/MIN.
-    // The accurate fp32 SFPU reduces likewise have no SFPU REDUCE_SCALAR, so they must decompose HW
-    // into W-then-H regardless of tile count; both do so exactly (sum of sums, max of maxes).
+    // The accurate fp32 SFPU path likewise has no SFPU REDUCE_SCALAR, so it decomposes HW into
+    // W-then-H regardless of tile count; every op does so exactly (sum of sums, max of maxes, ...).
     const bool use_two_step_hw_sfpu_reduce =
         (reduce_dim == tt::tt_metal::ReduceOpDim::HW) &&
         ((prepared_input.dtype() == tt::tt_metal::DataType::INT32 &&

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.hpp
@@ -24,8 +24,8 @@ Tensor reduce(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
     bool negate = false,
-    // When false (default), fp32 mean and max run on the accurate SFPU path (full fp32); true selects the FPU.
-    // Ignored for non-fp32 and for math ops other than AVG/MAX.
+    // When false (default), fp32 reduces run on the accurate SFPU path (full fp32); true selects the FPU.
+    // Ignored for non-fp32 inputs.
     bool fast_and_approximate_mode = false,
     // Requested layout of the result; std::nullopt means "whatever the selected path emits":
     // ROW_MAJOR on the dense RM paths, TILE on the tilized ones.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
@@ -34,8 +34,8 @@ struct ReduceParams {
     // may be set at a time (validated in validate_on_program_cache_miss).
     bool row_major_w_dense_path{false};
     bool row_major_h_dense_path{false};
-    // Accurate fp32 mean: route Float32 SUM through the SFPU (full fp32); set from
-    // ttnn.mean(fast_and_approximate_mode=False).
+    // Accurate fp32: route Float32 through the SFPU (full fp32); set from
+    // fast_and_approximate_mode=False on sum/mean/max/min.
     bool use_sfpu_reduce{false};
     // Number of contiguous H segments to reduce independently (RM-H dense path; 1 = no split).
     // Spreads a tall-H reduce over more cores, yielding a (N, C, num_h_slices, W) partial.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -378,9 +378,12 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     }
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    // UnpackToDestFp32 unpacks c_0 straight into the fp32 DEST, bypassing the SrcA tf32 truncation.
+    // UnpackToDestFp32 unpacks c_0 (and RM cb_acc) into the fp32 DEST, bypassing SrcA tf32.
     if (fp32_sfpu_reduce) {
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        if (rm_path) {
+            unpack_to_dest_mode[CBIndex::c_5] = UnpackToDestMode::UnpackToDestFp32;
+        }
     }
 
     KernelDescriptor reader_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -366,7 +366,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
     if (use_post_mul) {
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
-    // Accurate fp32 mean: route Float32 SUM through the SFPU (needs 32-bit DEST)
+    // Accurate fp32: route Float32 through the SFPU (needs 32-bit DEST)
     const bool fp32_sfpu_reduce = is_sfpu_reduce && a.dtype() == DataType::FLOAT32 && fp32_dest_acc_en;
     // A bf16 input packed into an FP32 partial needs the packer reconfigured, not just the unpacker.
     if (rm_path && dst_cb_data_format != src0_cb_data_format) {
@@ -476,12 +476,12 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
             compute_Wt,                  // Wt
             compute_NC,                  // NC
             post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
-            fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
+            fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 through the SFPU
         };
     }
 
-    // Int32 MIN uses the base reduce.cpp SFPU path (negate=false); float/bf16 MIN uses -MAX(-x) in
-    // reduce_h_neg.
+    // MIN on an SFPU path uses the base reduce.cpp kernel (negate=false); fast-mode float/bf16 MIN
+    // uses -MAX(-x) in reduce_h_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +
@@ -515,7 +515,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreHProgramFa
                 compute_Wt_group_2,          // Wt
                 compute_NC_group_2,          // NC
                 post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
-                fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
+                fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 through the SFPU
             };
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -233,9 +233,12 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     const bool fp32_sfpu_reduce = is_sfpu_reduce && a.dtype() == DataType::FLOAT32 && fp32_dest_acc_en;
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    // UnpackToDestFp32 unpacks c_0 straight into the fp32 DEST, bypassing the SrcA tf32 truncation.
+    // UnpackToDestFp32 unpacks c_0 (and RM cb_acc) into the fp32 DEST, bypassing SrcA tf32.
     if (fp32_sfpu_reduce) {
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+        if (rm_path) {
+            unpack_to_dest_mode[CBIndex::c_5] = UnpackToDestMode::UnpackToDestFp32;
+        }
     }
 
     KernelDescriptor reader_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -229,7 +229,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     if (use_post_mul) {
         reduce_defines["REDUCE_POST_MUL"] = "1";
     }
-    // Accurate fp32 mean: route Float32 SUM through the SFPU (needs 32-bit DEST)
+    // Accurate fp32: route Float32 through the SFPU (needs 32-bit DEST)
     const bool fp32_sfpu_reduce = is_sfpu_reduce && a.dtype() == DataType::FLOAT32 && fp32_dest_acc_en;
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
@@ -280,12 +280,12 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
             Wt,                          // Wt
             1,                           // NC
             post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
-            fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
+            fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 through the SFPU
         };
     }
 
-    // Int32 MIN uses the base reduce.cpp SFPU path (negate=false); float/bf16 MIN uses -MAX(-x) in
-    // reduce_w_neg.
+    // MIN on an SFPU path uses the base reduce.cpp kernel (negate=false); fast-mode float/bf16 MIN
+    // uses -MAX(-x) in reduce_w_neg.
     const std::string compute_kernel =
         rm_path ? std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_rm.cpp")
                 : std::string("ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce") +
@@ -315,7 +315,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
                 Wt,                          // Wt
                 1,                           // NC
                 post_mul_scaler_bits,        // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
-                fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 SUM through the SFPU
+                fp32_sfpu_reduce ? 1u : 0u,  // enable_fp32_sfpu: route Float32 through the SFPU
             };
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -182,7 +182,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceSingleCoreHwProgram
         Wt,                    // Wt
         NC,                    // NC
         post_mul_scaler_bits,  // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
-        0u,                    // enable_fp32_sfpu: always 0 (fp32 mean HW is forced to the two-step W-then-H path)
+        0u,                    // enable_fp32_sfpu: always 0 (accurate fp32 HW is forced to the two-step W-then-H path)
     };
 
     const std::string compute_kernel =

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -181,6 +181,9 @@ static Tensor reduce_impl(
     bool single_reduce_op = (dim.empty()) || (dim.size() == 1 && (dim[0] == rank - 1 || dim[0] == rank - 2)) ||
                             (dim.size() == 2 && dim[1] == rank - 1 && dim[0] == rank - 2);
     if (!single_reduce_op) {
+        // Multi-axis reduces run one axis at a time. Every decomposition here is exact (a sum of
+        // partial sums, a max of maxes, a min of mins) and the intermediates stay fp32, so each
+        // sub-step carries the caller's fast_and_approximate_mode rather than being pinned.
         auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
             Tensor output_tensor = input_tensor_arg;
             bool first = true;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -184,7 +184,8 @@ static Tensor reduce_impl(
         // Multi-axis reduces run one axis at a time. Max of maxes is exact, so Max keeps the
         // caller's fast_and_approximate_mode; Mean scales each axis by 1/N, so it stays on FPU.
         const bool sub_step_fast_mode =
-            (reduce_type == reduction_common::ReduceType::Max || reduce_type == reduction_common::ReduceType::Min)
+            (reduce_type == reduction_common::ReduceType::Sum || reduce_type == reduction_common::ReduceType::Max ||
+             reduce_type == reduction_common::ReduceType::Min)
                 ? fast_and_approximate_mode
                 : true;
         auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
@@ -300,7 +301,7 @@ static Tensor reduce_impl(
                 compute_kernel_config,
                 sub_core_grids,
                 /*negate=*/false,
-                /*fast_and_approximate_mode=*/false,
+                /*fast_and_approximate_mode=*/fast_and_approximate_mode,
                 output_layout);
         } else if constexpr (reduce_type == reduction_common::ReduceType::Mean) {
             output_tensor = ttnn::operations::reduction::generic::detail::reduce(
@@ -682,6 +683,7 @@ Tensor sum(
     float scalar,
     bool correction,
     const std::optional<CoreRangeSet>& sub_core_grids,
+    bool fast_and_approximate_mode,
     const std::optional<Layout>& output_layout) {
     return operations::reduction::convert_output_layout(
         operations::reduction::reduce<reduction_common::ReduceType::Sum>(
@@ -693,7 +695,7 @@ Tensor sum(
             scalar,
             correction,
             sub_core_grids,
-            /*fast_and_approximate_mode=*/false,
+            fast_and_approximate_mode,
             output_layout),
         output_layout);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -184,7 +184,9 @@ static Tensor reduce_impl(
         // Multi-axis reduces run one axis at a time. Max of maxes is exact, so Max keeps the
         // caller's fast_and_approximate_mode; Mean scales each axis by 1/N, so it stays on FPU.
         const bool sub_step_fast_mode =
-            reduce_type == reduction_common::ReduceType::Max ? fast_and_approximate_mode : true;
+            (reduce_type == reduction_common::ReduceType::Max || reduce_type == reduction_common::ReduceType::Min)
+                ? fast_and_approximate_mode
+                : true;
         auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
             Tensor output_tensor = input_tensor_arg;
             bool first = true;
@@ -334,7 +336,9 @@ static Tensor reduce_impl(
                 memory_config,
                 std::nullopt,
                 compute_kernel_config,
-                sub_core_grids);
+                sub_core_grids,
+                /*negate=*/false,
+                /*fast_and_approximate_mode=*/fast_and_approximate_mode);
         } else {
             TT_THROW("Unsupported reduction operation");
         }
@@ -741,7 +745,8 @@ Tensor max(
             compute_kernel_config,
             scalar,
             correction,
-            sub_core_grids);
+            sub_core_grids,
+            fast_and_approximate_mode);
     }
     return operations::reduction::reduce<reduction_common::ReduceType::Max>(
         input_tensor_arg,
@@ -763,7 +768,8 @@ Tensor min(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    bool fast_and_approximate_mode) {
     /* Scaling is applied after reduction, so flip the op for negative scalars:
      * min(s * x) = s * max(x) when s < 0.*/
     if (scalar < 0.0f) {
@@ -775,7 +781,8 @@ Tensor min(
             compute_kernel_config,
             scalar,
             correction,
-            sub_core_grids);
+            sub_core_grids,
+            fast_and_approximate_mode);
     }
     return operations::reduction::reduce<reduction_common::ReduceType::Min>(
         input_tensor_arg,
@@ -785,7 +792,8 @@ Tensor min(
         compute_kernel_config,
         scalar,
         correction,
-        sub_core_grids);
+        sub_core_grids,
+        fast_and_approximate_mode);
 }
 
 Tensor std(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -181,13 +181,6 @@ static Tensor reduce_impl(
     bool single_reduce_op = (dim.empty()) || (dim.size() == 1 && (dim[0] == rank - 1 || dim[0] == rank - 2)) ||
                             (dim.size() == 2 && dim[1] == rank - 1 && dim[0] == rank - 2);
     if (!single_reduce_op) {
-        // Multi-axis reduces run one axis at a time. Max of maxes is exact, so Max keeps the
-        // caller's fast_and_approximate_mode; Mean scales each axis by 1/N, so it stays on FPU.
-        const bool sub_step_fast_mode =
-            (reduce_type == reduction_common::ReduceType::Sum || reduce_type == reduction_common::ReduceType::Max ||
-             reduce_type == reduction_common::ReduceType::Min)
-                ? fast_and_approximate_mode
-                : true;
         auto reduce_nd_loop = [&](const bool use_reduce_type, float scalar) -> Tensor {
             Tensor output_tensor = input_tensor_arg;
             bool first = true;
@@ -227,7 +220,7 @@ static Tensor reduce_impl(
                             sub_core_grids,
                             chain_active,
                             sub_is_last,
-                            /*fast_and_approximate_mode=*/sub_step_fast_mode);
+                            /*fast_and_approximate_mode=*/fast_and_approximate_mode);
                     } else {
                         output_tensor = reduce_impl<reduction_common::ReduceType::Sum>(
                             output_tensor,
@@ -239,7 +232,8 @@ static Tensor reduce_impl(
                             non_height_width_dims,
                             sub_core_grids,
                             chain_active,
-                            sub_is_last);
+                            sub_is_last,
+                            /*fast_and_approximate_mode=*/fast_and_approximate_mode);
                     }
                     if (transpose) {
                         output_tensor = ttnn::transpose(output_tensor, i_dim, -2, memory_config, pad_value);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -38,6 +38,8 @@ Tensor sum(
     float scalar = 1.0f,
     bool correction = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    // When false (default), fp32 sum runs on the accurate SFPU path; true selects the faster tf32 FPU path.
+    bool fast_and_approximate_mode = false,
     // Layout of the result. std::nullopt (default) is TILE, except a ROW_MAJOR input reduced over
     // -1/-2 on the dense RM path, which stays ROW_MAJOR. An explicit layout is always honored.
     const std::optional<Layout>& output_layout = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -77,7 +77,9 @@ Tensor min(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    // When false (default), fp32 min selects the accurate SFPU path; true selects the faster FPU path.
+    bool fast_and_approximate_mode = false);
 
 Tensor std(
     const Tensor& input_tensor_arg,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -53,8 +53,7 @@ Tensor mean(
     float scalar = 1.0f,
     bool correction = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    // When false (default), fp32 mean reduces on the accurate SFPU path (full fp32); true selects the faster tf32 FPU
-    // path.
+    // When false (default), fp32 mean runs on the accurate SFPU path; true selects the faster tf32 FPU path.
     bool fast_and_approximate_mode = false,
     // See ttnn::sum above.
     const std::optional<Layout>& output_layout = std::nullopt);
@@ -68,7 +67,7 @@ Tensor max(
     float scalar = 1.0f,
     bool correction = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    // When false (default), fp32 max selects the accurate SFPU path; true selects the faster FPU path.
+    // When false (default), fp32 max runs on the accurate SFPU path; true selects the faster tf32 FPU path.
     bool fast_and_approximate_mode = false);
 
 Tensor min(
@@ -80,7 +79,7 @@ Tensor min(
     float scalar = 1.0f,
     bool correction = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    // When false (default), fp32 min selects the accurate SFPU path; true selects the faster FPU path.
+    // When false (default), fp32 min runs on the accurate SFPU path; true selects the faster tf32 FPU path.
     bool fast_and_approximate_mode = false);
 
 Tensor std(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -90,43 +90,6 @@ inline std::string get_generic_reduction_doc(
         output_layout_kwarg);
 }
 
-// Wrapper that detects explicit use of the deprecated 'correction' parameter and
-// emits a Python DeprecationWarning before forwarding to the real implementation.
-// The binding-layer type is std::optional<bool> (default nb::none()) so we can
-// distinguish "user passed correction=True" from "used the default".
-// This whole function can be removed when the deprecated 'correction' parameter is removed.
-template <auto Func>
-Tensor generic_reduction_with_deprecated_correction(
-    const Tensor& input_tensor,
-    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    std::optional<bool> correction,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    if (correction.has_value()) {
-        // Re-acquire the GIL: this function is registered via bind_function<>(),
-        // which applies nb::call_guard<nb::gil_scoped_release>(), so the GIL is
-        // released by default. PyErr_WarnEx / PyExc_DeprecationWarning are Python
-        // C API and require the GIL.
-        nb::gil_scoped_acquire acquire;
-        PyErr_WarnEx(
-            PyExc_DeprecationWarning,
-            "The 'correction' parameter is deprecated and will be removed in a future release.",
-            1);
-    }
-    return Func(
-        input_tensor,
-        dim,
-        keepdim,
-        memory_config,
-        compute_kernel_config,
-        scalar,
-        correction.value_or(true),
-        sub_core_grids);
-}
-
 // sum takes a trailing 'output_layout' that min/max do not, so it needs its own wrapper instead of
 // the shared generic_reduction_with_deprecated_correction<>. Same deprecated-correction handling.
 inline Tensor sum_with_deprecated_correction(
@@ -192,8 +155,10 @@ inline Tensor mean_with_deprecated_correction(
         output_layout);
 }
 
-// max exposes 'fast_and_approximate_mode' but not 'output_layout', so it cannot share mean's wrapper.
-inline Tensor max_with_deprecated_correction(
+// max and min expose 'fast_and_approximate_mode' but not 'output_layout', so they cannot share
+// mean's wrapper.
+template <auto Func>
+inline Tensor reduction_with_fast_mode(
     const Tensor& input_tensor,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
     bool keepdim,
@@ -210,7 +175,7 @@ inline Tensor max_with_deprecated_correction(
             "The 'correction' parameter is deprecated and will be removed in a future release.",
             1);
     }
-    return ttnn::max(
+    return Func(
         input_tensor,
         dim,
         keepdim,
@@ -269,7 +234,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
     ttnn::bind_function<"max">(
         mod,
         max_doc.c_str(),
-        &max_with_deprecated_correction,
+        &reduction_with_fast_mode<&ttnn::max>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -281,11 +246,12 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("sub_core_grids") = nb::none(),
         nb::arg("fast_and_approximate_mode") = false);
 
-    const auto min_doc = get_generic_reduction_doc("min", "ttnn.min", /*int32_supported=*/true);
+    const auto min_doc = get_generic_reduction_doc(
+        "min", "ttnn.min", /*int32_supported=*/true, /*has_output_layout=*/false, /*has_fast_approximate_mode=*/true);
     ttnn::bind_function<"min">(
         mod,
         min_doc.c_str(),
-        &generic_reduction_with_deprecated_correction<&ttnn::min>,
+        &reduction_with_fast_mode<&ttnn::min>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -294,7 +260,8 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("scalar") = 1.0f,
         nb::arg("correction") = nb::none(),
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("fast_and_approximate_mode") = false);
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -31,7 +31,8 @@ inline std::string get_generic_reduction_doc(
                 * - INT32
                   - TILE)doc"
                                             : "";
-    // ttnn.mean and ttnn.max expose fast_and_approximate_mode.
+    // All four generic reductions (sum/mean/max/min) expose fast_and_approximate_mode. std/var do
+    // not: Welford already reduces on the SFPU at full fp32, so there is no FPU path to select.
     // ttnn.sum and ttnn.mean both expose output_layout.
     const char* output_layout_kwarg = has_output_layout ? R"doc(
             output_layout (ttnn.Layout, optional): layout of the output tensor. Defaults to `None`, which keeps the layout the chosen path produces naturally (see the Note below). `ttnn.TILE_LAYOUT` or `ttnn.ROW_MAJOR_LAYOUT` is always honored: it is produced directly by the kernel for a -2 reduce of a ROW_MAJOR input, and converted after reducing otherwise. `ttnn.ROW_MAJOR_LAYOUT` is rejected for block-float results (BFLOAT8_B, BFLOAT4_B), which only exist in TILE layout; typecast explicitly if a row-major result is needed.)doc"

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -91,11 +91,14 @@ inline std::string get_generic_reduction_doc(
         output_layout_kwarg);
 }
 
-// sum and mean expose both 'fast_and_approximate_mode' and 'output_layout', so they cannot share
-// max/min's wrapper. Same deprecated-correction handling, plus the trailing accurate flag and
-// output_layout forwarded to Func.
+// Wrapper that detects explicit use of the deprecated 'correction' parameter and
+// emits a Python DeprecationWarning before forwarding to the real implementation.
+// The binding-layer type is std::optional<bool> (default nb::none()) so we can
+// distinguish "user passed correction=True" from "used the default".
+// This whole function can be removed when the deprecated 'correction' parameter is removed.
+// Used by sum and mean, which take a trailing output_layout.
 template <auto Func>
-inline Tensor reduction_with_fast_mode_and_layout(
+inline Tensor reduction_with_deprecated_correction_and_layout(
     const Tensor& input_tensor,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
     bool keepdim,
@@ -126,10 +129,9 @@ inline Tensor reduction_with_fast_mode_and_layout(
         output_layout);
 }
 
-// max and min expose 'fast_and_approximate_mode' but not 'output_layout', so they cannot share
-// mean's wrapper.
+// As above, used by max and min, which do not take output_layout.
 template <auto Func>
-inline Tensor reduction_with_fast_mode(
+inline Tensor reduction_with_deprecated_correction(
     const Tensor& input_tensor,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
     bool keepdim,
@@ -164,7 +166,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
     ttnn::bind_function<"sum">(
         mod,
         sum_doc.c_str(),
-        &reduction_with_fast_mode_and_layout<&ttnn::sum>,
+        &reduction_with_deprecated_correction_and_layout<&ttnn::sum>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -186,7 +188,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
     ttnn::bind_function<"mean">(
         mod,
         mean_doc.c_str(),
-        &reduction_with_fast_mode_and_layout<&ttnn::mean>,
+        &reduction_with_deprecated_correction_and_layout<&ttnn::mean>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -201,12 +203,12 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("fast_and_approximate_mode") = false,
         nb::arg("output_layout") = nb::none());
 
-    const auto max_doc =
-        get_generic_reduction_doc("max", "ttnn.max", /*int32_supported=*/true, /*has_fast_approximate_mode=*/true);
+    const auto max_doc = get_generic_reduction_doc(
+        "max", "ttnn.max", /*int32_supported=*/true, /*has_output_layout=*/false, /*has_fast_approximate_mode=*/true);
     ttnn::bind_function<"max">(
         mod,
         max_doc.c_str(),
-        &reduction_with_fast_mode<&ttnn::max>,
+        &reduction_with_deprecated_correction<&ttnn::max>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -223,7 +225,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
     ttnn::bind_function<"min">(
         mod,
         min_doc.c_str(),
-        &reduction_with_fast_mode<&ttnn::min>,
+        &reduction_with_deprecated_correction<&ttnn::min>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -90,41 +90,11 @@ inline std::string get_generic_reduction_doc(
         output_layout_kwarg);
 }
 
-// sum takes a trailing 'output_layout' that min/max do not, so it needs its own wrapper instead of
-// the shared generic_reduction_with_deprecated_correction<>. Same deprecated-correction handling.
-inline Tensor sum_with_deprecated_correction(
-    const Tensor& input_tensor,
-    const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
-    bool keepdim,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar,
-    std::optional<bool> correction,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const std::optional<Layout>& output_layout) {
-    if (correction.has_value()) {
-        nb::gil_scoped_acquire acquire;
-        PyErr_WarnEx(
-            PyExc_DeprecationWarning,
-            "The 'correction' parameter is deprecated and will be removed in a future release.",
-            1);
-    }
-    return ttnn::sum(
-        input_tensor,
-        dim,
-        keepdim,
-        memory_config,
-        compute_kernel_config,
-        scalar,
-        correction.value_or(true),
-        sub_core_grids,
-        output_layout);
-}
-
-// mean exposes both 'fast_and_approximate_mode' and 'output_layout', so it needs its own wrapper
-// instead of the shared generic_reduction_with_deprecated_correction<>. Same deprecated-correction
-// handling, plus the trailing accurate flag and output_layout forwarded to ttnn::mean.
-inline Tensor mean_with_deprecated_correction(
+// sum and mean expose both 'fast_and_approximate_mode' and 'output_layout', so they cannot share
+// max/min's wrapper. Same deprecated-correction handling, plus the trailing accurate flag and
+// output_layout forwarded to Func.
+template <auto Func>
+inline Tensor reduction_with_fast_mode_and_layout(
     const Tensor& input_tensor,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim,
     bool keepdim,
@@ -142,7 +112,7 @@ inline Tensor mean_with_deprecated_correction(
             "The 'correction' parameter is deprecated and will be removed in a future release.",
             1);
     }
-    return ttnn::mean(
+    return Func(
         input_tensor,
         dim,
         keepdim,
@@ -188,12 +158,12 @@ inline Tensor reduction_with_fast_mode(
 }
 
 inline void bind_generic_reductions(nb::module_& mod) {
-    const auto sum_doc =
-        get_generic_reduction_doc("sum", "ttnn.sum", /*int32_supported=*/true, /*has_output_layout=*/true);
+    const auto sum_doc = get_generic_reduction_doc(
+        "sum", "ttnn.sum", /*int32_supported=*/true, /*has_output_layout=*/true, /*has_fast_approximate_mode=*/true);
     ttnn::bind_function<"sum">(
         mod,
         sum_doc.c_str(),
-        &sum_with_deprecated_correction,
+        &reduction_with_fast_mode_and_layout<&ttnn::sum>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,
@@ -203,6 +173,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
         nb::arg("scalar") = 1.0f,
         nb::arg("correction") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("fast_and_approximate_mode") = false,
         nb::arg("output_layout") = nb::none());
 
     const auto mean_doc = get_generic_reduction_doc(
@@ -214,7 +185,7 @@ inline void bind_generic_reductions(nb::module_& mod) {
     ttnn::bind_function<"mean">(
         mod,
         mean_doc.c_str(),
-        &mean_with_deprecated_correction,
+        &reduction_with_fast_mode_and_layout<&ttnn::mean>,
         nb::arg("input_tensor"),
         nb::arg("dim") = nb::none(),
         nb::arg("keepdim") = false,


### PR DESCRIPTION
### PR Category
- Feature

### Summary
- Fixes #32274.

FLOAT32 generic reductions on the FPU truncate operands to TF32. For `min`/`max` that can return a value not in the input; for `sum`/`mean` the accumulator is lossy.

`fast_and_approximate_mode` selects the path:

| Mode | Default | Path | Precision |
| --- | --- | --- | --- |
| `False` | yes | SFPU | full fp32 |
| `True` | | FPU | TF32 (faster) |

Falls back to FPU when `fp32_dest_acc_en=False` or on Quasar. No effect for non-FLOAT32.

Accurate SFPU coverage (`fast_and_approximate_mode=False`):

| | `ttnn.max` | `ttnn.mean` | `ttnn.min` | `ttnn.sum` |
| --- | --- | --- | --- | --- |
| Single-axis (W / H / HW) | #52718 | #48896 | this PR | this PR |
| Multi-axis / `dim=None` | #52718 | this PR | this PR | this PR |

- #48896 put FLOAT32 mean on SFPU as SUM + 1/N, but only for a single W/H/HW dispatch. Multi-axis / `dim=None` (rank > 2) still ran per-axis sub-steps on the FPU. This PR does forward the caller’s mode through those mean sub-steps.

Default FLOAT32 `min`/`sum` (and multi-axis `mean`) are slower than before. Pass `fast_and_approximate_mode=True` to keep the old FPU path.

### Notes for reviewers

- **MIN** - Accurate fp32 min drives the LLK MIN reduce directly, like Int32 min. Fast-mode float/bf16 min still lowers to `-MAX(-x)`. Both negative-scalar flips (`max→min`, `min→max`) forward the flag.

- **SUM / mean** - Mean already lowered to SUM + post-mul `1/N` (#48896). Dense RM mean/sum keep the same SFPU fold.

- **Multi-axis** - Every decomposition here is exact (sum of sums, max of maxes, min of mins), so sub-steps carry the caller's mode.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-generic-reductions-fastandapproxmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-generic-reductions-fastandapproxmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-generic-reductions-fastandapproxmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-generic-reductions-fastandapproxmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-generic-reductions-fastandapproxmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-generic-reductions-fastandapproxmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-generic-reductions-fastandapproxmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-generic-reductions-fastandapproxmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-generic-reductions-fastandapproxmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-generic-reductions-fastandapproxmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-generic-reductions-fastandapproxmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-generic-reductions-fastandapproxmode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-generic-reductions-fastandapproxmode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-generic-reductions-fastandapproxmode)