### PR TITLE
glm52 indexer cache pipeline aware

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -186,7 +186,7 @@ shield:
     wh_n150: 100
     bh_p150: 60
   demo:
-    bh_sc4: 15
+    bh_sc4: 35
 
 scaleout:
   merge_gate:

--- a/models/demos/common/prefill/docs/ADDING_A_PREFILL_MODEL.md
+++ b/models/demos/common/prefill/docs/ADDING_A_PREFILL_MODEL.md
@@ -153,7 +153,13 @@ class PrefillRuntime:  # structural contract — not a base class you must inher
         """This rank's KV base DRAM address — the anchor the engine all-gathers to merge every pipeline
         stage into one table. Return `int(<your base tensor>.buffer_address())`; you pick which of your
         cache tensors is the migratable base, since the engine treats `kv_cache` as opaque and cannot.
-        Required whenever migration is enabled."""
+        Enough for a model with ONE migratable cache; otherwise implement `kv_migration_stages`."""
+
+    def kv_migration_stages(self, kv_cache, first_layer_idx=None, num_my_layers=None):
+        """One `KvCacheStage` (common/prefill/runners/migration.py) per config of your merged table, in
+        config order — the engine gathers a layout for each, on every rank, and hands them to
+        `build_kv_chunk_table`. Implement it instead of `kv_migration_base_address` when your model
+        migrates SEVERAL caches, or one whose layer numbering is not the model's global numbering."""
 
     def set_layer_ack_channel(self, channel) -> None:
         """Register the per-layer LayerAck channel (the engine creates and owns it); the

--- a/models/demos/common/prefill/docs/PREFILL_MIGRATION_TESTING.md
+++ b/models/demos/common/prefill/docs/PREFILL_MIGRATION_TESTING.md
@@ -66,7 +66,7 @@ stays 32-token-block aligned).
 rank would publish a table covering just its own layer slice and a merged mock table is not implemented. So
 **Gate 1** needs a 1-rank binding. `PREFILL_ENABLE_MIGRATION=1` (Gate 2) has no such restriction: the real
 path merges the per-rank stage layouts through the worker
-(`deliver_device_map_and_gather_stage_layout`), so a pipelined runner publishes one table spanning every
+(`deliver_device_map_and_gather_stage_layouts`), so a pipelined runner publishes one table spanning every
 rank's layers. Gate 2 runs on 1, 2 or 4 ranks — see *Covering every rank* below for what that costs on the
 read-back side.
 
@@ -443,7 +443,7 @@ Expect `[producer] KV cache PCC PASSED` (threshold `PREFILL_STANDALONE_CHUNKED_P
 This gate is not a prerequisite for the producer's golden PCC on the real-migration path, because the runner
 serialises the device map there too: one `serialize_device_map` call sits above the mock/real split inside the
 `_migration_enabled` block, so **every rank on either path** publishes its own host-local sidecar. It has to
-be: `deliver_device_map_and_gather_stage_layout` hands the map to the co-located *worker* over the migration
+be: `deliver_device_map_and_gather_stage_layouts` hands the map to the co-located *worker* over the migration
 client and leaves nothing on disk, while every device-less read-back resolves chips from the JSON.
 
 That call **had** regressed to living under `if _mock_migration:` only, and the symptom is exactly as quiet as
@@ -539,7 +539,8 @@ gates you intend to run require.
 | Gate | Hook | Signature requirement |
 |------|------|-----------------------|
 | 1 | `build_kv_chunk_table` | serialises the block-cyclic layout; issues no comms |
-| 2 | `kv_migration_base_address` | this rank's KV base DRAM address, for the cross-stage table merge |
+| 2 | `kv_migration_stages` | one `KvCacheStage` per migratable cache, for the cross-stage table merge |
+| 2 | `kv_migration_base_address` | alternative to the above, for a model with a SINGLE cache: just that cache's base DRAM address |
 | 2 `dst-bytes` | **none** | nothing is decoded — the byte compare is model-agnostic |
 | 2 `dst-golden` | none beyond Gate 1 | reuses the producer's own read-back, not a runtime hook |
 

--- a/models/demos/common/prefill/runners/ci/run_multirank_kv_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_kv_pcc.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# Multi-galaxy disaggregated prefill KV-accuracy leg: a background N-rank runner opens the mesh, loads the
+# model, warmup-compiles and publishes the merged KV chunk table to shared NFS; a device-less producer then
+# feeds it, reads the device caches back over UMD and PCCs them against the golden trace. The producer's
+# exit code is the verdict, so this script's exit code is the producer's.
+#
+# Usage: run_multirank_kv_pcc.sh <model-key>       # model-key selects a block in the case below
+#
+# Everything outside that case block is model-independent launcher plumbing (host-order derivation, table
+# poll, runner reaping, durable-verdict dump), so a new model is a case entry, not another copy.
+set -euo pipefail
+
+MODEL="${1:?usage: run_multirank_kv_pcc.sh <model-key>}"
+
+: "${TT_METAL_HOME:?TT_METAL_HOME must be set}"
+: "${PREFILL_SUMMARIES:?PREFILL_SUMMARIES must be set by the blaze impl (shared /ci scratch for the KV table)}"
+export PYTHONPATH="${TT_METAL_HOME}"
+MANIFEST_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests"
+MGD_DIR="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration"
+
+# Shared defaults; a case block below overrides what its model needs.
+MAX_SEQ_LEN=56320
+PCC_THRESHOLD=0.85
+RUNNER_ENV=""
+PRODUCER_ENV=""
+
+case "${MODEL}" in
+  kimi27)
+    SLUG=prefill_runner_kv
+    MGD="${MGD_DIR}/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto"
+    MANIFEST="${MANIFEST_DIR}/kimi27.json"
+    # Dense MLA: one device cache, and the manifest carries the producer's schedule and golden trace.
+    RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized;"
+    PRODUCER_ENV="export PREFILL_MANIFEST='${MANIFEST}'; \
+        export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized;"
+    ;;
+  glm52)
+    SLUG=glm52_prefill_runner_kv
+    # LINE/LINE variant: GLM-5.2's MoE all_to_all deadlocks in warmup under the torus fabric modes on
+    # multi-galaxy pipeline prefill, so the descriptor declares no wrap and the fabric mode stays 2d.
+    MGD="${MGD_DIR}/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto"
+    MANIFEST="${MANIFEST_DIR}/glm52.json"
+    # Sparse DSA: TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over the
+    # 21 `full` layers), both PCC'd. The trace must be the indexer-K dump -- the adapter's default golden
+    # carries no dsa/indexer_k_layer_*, which would silently downgrade this leg to a KVPE-only check -- so
+    # the producer takes its model/depth/schedule explicitly rather than through the manifest.
+    PRODUCER_ENV="export PREFILL_MODEL=glm_5_2; \
+        export PREFILL_NUM_LAYERS=78; \
+        export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k; \
+        export PREFILL_PRODUCER_CHUNKS=4,4;"
+    ;;
+  *)
+    echo "unknown model key '${MODEL}'" >&2
+    exit 2
+    ;;
+esac
+
+export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/${SLUG}}"
+mkdir -p "${PIPELINE_DIR}"
+TTRUN_DIR="${TTRUN_DIR:-/etc/ttop}"
+TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
+
+# The runner goes through tt-run automapper, which discovers rank->mesh placement from the MGD and takes
+# the plain comma-separated host list. The producer (raw mpirun) needs a slotted host list in the SAME rank
+# order tt-run's discovery chose (parsed from the generated rankfile below) so its master co-locates with
+# runner rank 0 -- the H2D stream service is host-local /dev/shm IPC.
+RESOLVED_HOSTS=$(awk 'NF {printf "%s,", $1}' "${TTRUN_DIR}/hostfile" | sed 's/,$//')
+# tt-run Phase 1 (generate_rank_bindings) writes generated/ttrun/ under the launch cwd; keep it on shared
+# NFS so the runner pod can read rank-0 outputs.
+TTRUN_CWD="${PIPELINE_DIR}/ttrun-cwd"
+mkdir -p "${TTRUN_CWD}"
+
+MR_DIR=$(mktemp -d "${PIPELINE_DIR}/${MODEL}_prefill_ci_mr.XXXXXX")
+export TABLE_PATH="${MR_DIR}/kv_chunk_table.pb"
+# Each producer rank drops its PCC verdict here before the shutdown sentinel; mpirun drops buffered stdout
+# when the runner tears down, so this file is the only durable record of the measured per-cache PCC.
+PCC_DIR="${MR_DIR}/kv_pcc_verdict"
+# Per-rank stdout/stderr files (mpirun --output-filename). These survive the teardown race that truncates
+# forwarded stdout, so their tails are the authoritative debug log.
+RANKLOGS="${MR_DIR}/ranklogs"
+
+# The runner idles owning the multi-galaxy allocation until the producer's shutdown sentinel; on any early
+# exit (table-publish timeout, producer failure) it must be reaped or it strands the hardware until the
+# step timeout. Killing ttrun.py tears down the remote ranks with it.
+cleanup() {
+  if [ -n "${RUNNER_PID:-}" ] && kill -0 "${RUNNER_PID}" 2>/dev/null; then
+    kill "${RUNNER_PID}" 2>/dev/null || true
+    wait "${RUNNER_PID}" 2>/dev/null || true
+  fi
+  # Dump diagnostics before rm: on every exit path (success, producer failure, table timeout, step-timeout
+  # kill) the live mpirun stdout may be truncated at teardown, so the durable verdict JSON and per-rank
+  # ranklog tails are the authoritative record.
+  echo "==================== KV PCC verdicts (PROD_RC=${PROD_RC:-<unset>}) ===================="
+  for f in "${PCC_DIR}"/rank*.json; do
+    [ -e "$f" ] || { echo "no PCC verdict files under ${PCC_DIR}"; break; }
+    echo "$(basename "$f"): $(cat "$f")"
+  done
+  if [ -d "${RANKLOGS}" ]; then
+    echo "==================== ranklog tails ===================="
+    find "${RANKLOGS}" -type f | sort | while read -r f; do
+      echo "---- ${f#"${RANKLOGS}"/} ----"
+      tail -n 40 "$f" 2>/dev/null || true
+    done
+  fi
+  rm -rf "${MR_DIR}"
+}
+trap cleanup EXIT
+
+# tt-run automapper: --mesh-graph-descriptor + --hosts generate the rank binding by discovery, so no static
+# binding is committed. tt-run forwards only the device vars it owns (TT_MESH_*) plus its
+# ENV_PASSTHROUGH_PREFIXES; PREFILL_* fall outside that set, so -- exactly as the producer launch below does
+# -- export them inside a per-rank bash -lc rather than relying on tt-run to carry them. Launch from
+# TTRUN_CWD so Phase 1 caches on shared NFS; RUNNER_PID stays ttrun.py's pid so cleanup()'s kill still tears
+# the remote ranks down.
+cd "${TTRUN_CWD}"
+python3 "${TTRUN_PY}" \
+  --skip-executable-check \
+  --force-rediscovery \
+  --tcp-interface ens5f0np0 \
+  --mesh-graph-descriptor "${MGD}" \
+  --hosts "${RESOLVED_HOSTS}" \
+  --mpi-args "--bind-to none --tag-output --allow-run-as-root --wdir ${TT_METAL_HOME} --output-filename ${RANKLOGS}/runner -x PATH -x LD_LIBRARY_PATH" \
+  bash -lc "cd '${TT_METAL_HOME}'; \
+    export PYTHONPATH='${TT_METAL_HOME}'; \
+    export PYTHONUNBUFFERED=1; \
+    export PREFILL_MANIFEST='${MANIFEST}'; \
+    export MESH_DEVICE=TG; \
+    export PREFILL_FABRIC_MODE=2d; \
+    export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
+    export PREFILL_ENABLE_MIGRATION=1; \
+    export PREFILL_MOCK_MIGRATION=1; \
+    export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
+    ${RUNNER_ENV} \
+    export LOGURU_LEVEL=INFO; \
+    exec python3 -m models.demos.common.prefill.runners.prefill_runner" &
+RUNNER_PID=$!
+cd "${TT_METAL_HOME}"
+
+for _ in $(seq 1 360); do
+  [ -f "${TABLE_PATH}" ] && break
+  kill -0 "${RUNNER_PID}" 2>/dev/null || { echo "runner exited before publishing the KV table"; wait "${RUNNER_PID}"; exit 1; }
+  sleep 5
+done
+[ -f "${TABLE_PATH}" ] || { echo "KV table not published within timeout"; exit 1; }
+
+# Producer rank i must land on the host running runner rank i (host-local /dev/shm H2D descriptor), and
+# tt-run discovery -- not hostfile order -- decides that mapping, so derive the host order from the rankfile
+# --force-rediscovery just wrote. Using raw hostfile order races discovery and intermittently strands the
+# master on the wrong host -- H2DStreamService.connect then times out and TT_THROWs.
+RANKFILE=$(ls -t "${TTRUN_CWD}"/generated/ttrun/*/rankfile 2>/dev/null | head -1)
+[ -f "${RANKFILE}" ] || { echo "tt-run rankfile not found under ${TTRUN_CWD}/generated/ttrun/*/rankfile"; exit 1; }
+# rankfile lines are "rank N=hostname slots=X"; emit "N hostname", sort by rank, join as host:1.
+HOSTS=$(awk '/^rank[[:space:]]+[0-9]+=/ {n=$2; sub(/=.*/,"",n); h=$2; sub(/^[0-9]+=/,"",h); print n" "h}' "${RANKFILE}" | sort -n | awk '{printf "%s%s:1", (NR>1?",":""), $2}')
+[ -n "${HOSTS}" ] || { echo "failed to parse producer host order from ${RANKFILE}"; exit 1; }
+echo "producer host order from tt-run discovery: ${HOSTS}"
+
+MPIRUN=$(command -v mpirun-ulfm || command -v mpirun)
+set +e
+"${MPIRUN}" \
+  --host "${HOSTS}" --map-by slot --bind-to none --tag-output --allow-run-as-root \
+  --output-filename "${RANKLOGS}/producer" \
+  --mca btl self,tcp --mca btl_tcp_if_include ens5f0np0 \
+  bash -lc "cd '${TT_METAL_HOME}'; \
+    export PYTHONPATH='${TT_METAL_HOME}'; \
+    export PYTHONUNBUFFERED=1; \
+    export MESH_DEVICE=TG; \
+    export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
+    export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
+    export PREFILL_PCC_SUMMARY_DIR='${PCC_DIR}'; \
+    export PREFILL_PRODUCER_CHECK_PCC=1; \
+    export PREFILL_SEND_SHUTDOWN=1; \
+    export PREFILL_STANDALONE_CHUNKED_PCC=${PCC_THRESHOLD}; \
+    export PREFILL_H2D_CONNECT_TIMEOUT=120; \
+    ${PRODUCER_ENV} \
+    export LOGURU_LEVEL=INFO; \
+    exec python3 -m models.demos.common.prefill.runners.prefill_producer"
+PROD_RC=$?
+set -e
+
+# The cleanup() EXIT trap dumps the durable PCC verdicts and ranklog tails on every exit path, so no inline
+# diagnostics are needed here. On success the producer already sent the shutdown sentinel; wait for the
+# runner to finish teardown so a hung shutdown surfaces here instead of being orphaned.
+if [ "${PROD_RC}" -eq 0 ]; then
+  wait "${RUNNER_PID}" || echo "runner exited non-zero after producer success (rc=$?)"
+fi
+
+exit ${PROD_RC}

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -22,7 +22,9 @@ export PYTHONPATH="${TT_METAL_HOME}"
 MANIFEST_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests"
 MGD_DIR="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration"
 
-# Shared defaults; a case block below overrides what its model needs.
+# Shared defaults; a case block below overrides what its model needs. Each branch also names its own
+# scratch dir by swapping the summaries component out of PREFILL_SUMMARIES: that keeps the run-scoped leaf
+# and the shared-NFS root the blaze impl chose, while leaving the summaries dir itself alone.
 MAX_SEQ_LEN=56320
 PCC_THRESHOLD=0.85
 RUNNER_ENV=""
@@ -30,28 +32,25 @@ PRODUCER_ENV=""
 
 case "${MODEL}" in
   kimi27)
-    SLUG=prefill_runner_kv
+    export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/prefill_runner_kv}"
     MGD="${MGD_DIR}/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto"
     MANIFEST="${MANIFEST_DIR}/kimi27.json"
-    # Dense MLA: one device cache, and the manifest carries the producer's schedule and golden trace.
+    # Dense MLA: one device cache, so the manifest's model + depth are all the producer needs. The runner
+    # needs the weight path on top: the K2.7 adapter inherits K2.6's reference default.
     RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized;"
-    PRODUCER_ENV="export PREFILL_MANIFEST='${MANIFEST}'; \
-        export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized;"
+    PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}';"
     ;;
   glm52)
-    SLUG=glm52_prefill_runner_kv
+    export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/glm52_prefill_runner_kv}"
     # LINE/LINE variant: GLM-5.2's MoE all_to_all deadlocks in warmup under the torus fabric modes on
     # multi-galaxy pipeline prefill, so the descriptor declares no wrap and the fabric mode stays 2d.
     MGD="${MGD_DIR}/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto"
     MANIFEST="${MANIFEST_DIR}/glm52.json"
     # Sparse DSA: TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over the
     # 21 `full` layers), both PCC'd. The trace must be the indexer-K dump -- the adapter's default golden
-    # carries no dsa/indexer_k_layer_*, which would silently downgrade this leg to a KVPE-only check -- so
-    # the producer takes its model/depth/schedule explicitly rather than through the manifest.
-    PRODUCER_ENV="export PREFILL_MODEL=glm_5_2; \
-        export PREFILL_NUM_LAYERS=78; \
-        export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k; \
-        export PREFILL_PRODUCER_CHUNKS=4,4;"
+    # carries no dsa/indexer_k_layer_*, which would silently downgrade this leg to a KVPE-only check.
+    PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}'; \
+        export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k;"
     ;;
   *)
     echo "unknown model key '${MODEL}'" >&2
@@ -59,7 +58,6 @@ case "${MODEL}" in
     ;;
 esac
 
-export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/${SLUG}}"
 mkdir -p "${PIPELINE_DIR}"
 TTRUN_DIR="${TTRUN_DIR:-/etc/ttop}"
 TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
@@ -128,7 +126,6 @@ python3 "${TTRUN_PY}" \
     export PYTHONPATH='${TT_METAL_HOME}'; \
     export PYTHONUNBUFFERED=1; \
     export PREFILL_MANIFEST='${MANIFEST}'; \
-    export MESH_DEVICE=TG; \
     export PREFILL_FABRIC_MODE=2d; \
     export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
     export PREFILL_ENABLE_MIGRATION=1; \
@@ -167,7 +164,6 @@ set +e
   bash -lc "cd '${TT_METAL_HOME}'; \
     export PYTHONPATH='${TT_METAL_HOME}'; \
     export PYTHONUNBUFFERED=1; \
-    export MESH_DEVICE=TG; \
     export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
     export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
     export PREFILL_PCC_SUMMARY_DIR='${PCC_DIR}'; \

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 #
-# Multi-galaxy disaggregated prefill KV-accuracy leg: a background N-rank runner opens the mesh, loads the
-# model, warmup-compiles and publishes the merged KV chunk table to shared NFS; a device-less producer then
-# feeds it, reads the device caches back over UMD and PCCs them against the golden trace. The producer's
+# Multi-galaxy disaggregated prefill cache-accuracy leg: a background N-rank runner opens the mesh, loads
+# the model, warmup-compiles and publishes the merged KV chunk table to shared NFS; a device-less producer
+# then feeds it, reads EVERY device cache the model published back over UMD (a sparse model's indexer key
+# cache as well as its KVPE cache) and PCCs each against the golden trace. The producer's
 # exit code is the verdict, so this script's exit code is the producer's.
 #
-# Usage: run_multirank_kv_pcc.sh <model-key>       # model-key selects a block in the case below
+# Usage: run_multirank_pcc.sh <model-key>       # model-key selects a block in the case below
 #
 # Everything outside that case block is model-independent launcher plumbing (host-order derivation, table
 # poll, runner reaping, durable-verdict dump), so a new model is a case entry, not another copy.
 set -euo pipefail
 
-MODEL="${1:?usage: run_multirank_kv_pcc.sh <model-key>}"
+MODEL="${1:?usage: run_multirank_pcc.sh <model-key>}"
 
 : "${TT_METAL_HOME:?TT_METAL_HOME must be set}"
 : "${PREFILL_SUMMARIES:?PREFILL_SUMMARIES must be set by the blaze impl (shared /ci scratch for the KV table)}"
@@ -77,7 +78,7 @@ MR_DIR=$(mktemp -d "${PIPELINE_DIR}/${MODEL}_prefill_ci_mr.XXXXXX")
 export TABLE_PATH="${MR_DIR}/kv_chunk_table.pb"
 # Each producer rank drops its PCC verdict here before the shutdown sentinel; mpirun drops buffered stdout
 # when the runner tears down, so this file is the only durable record of the measured per-cache PCC.
-PCC_DIR="${MR_DIR}/kv_pcc_verdict"
+PCC_DIR="${MR_DIR}/pcc_verdict"
 # Per-rank stdout/stderr files (mpirun --output-filename). These survive the teardown race that truncates
 # forwarded stdout, so their tails are the authoritative debug log.
 RANKLOGS="${MR_DIR}/ranklogs"
@@ -93,7 +94,7 @@ cleanup() {
   # Dump diagnostics before rm: on every exit path (success, producer failure, table timeout, step-timeout
   # kill) the live mpirun stdout may be truncated at teardown, so the durable verdict JSON and per-rank
   # ranklog tails are the authoritative record.
-  echo "==================== KV PCC verdicts (PROD_RC=${PROD_RC:-<unset>}) ===================="
+  echo "==================== per-cache PCC verdicts (PROD_RC=${PROD_RC:-<unset>}) ===================="
   for f in "${PCC_DIR}"/rank*.json; do
     [ -e "$f" ] || { echo "no PCC verdict files under ${PCC_DIR}"; break; }
     echo "$(basename "$f"): $(cat "$f")"

--- a/models/demos/common/prefill/runners/migration.py
+++ b/models/demos/common/prefill/runners/migration.py
@@ -6,7 +6,7 @@
 The RUNNER owns the control flow; this module provides the generic (model-free) pieces and the model
 runtime owns the table build. The split for a migration bring-up:
 
-    1. deliver_device_map_and_gather_stage_layout(...)   # ALL RANKS: deliver local FNID->UMD map to
+    1. deliver_device_map_and_gather_stage_layouts(...)  # ALL RANKS: deliver local FNID->UMD map to
                                                           #   the co-located worker + all-gather barrier
     2. runtime.build_kv_chunk_table(kv_cache, path, ...) # RANK 0: model builds + serializes the table
                                                           #   (via serialize_kv_chunk_table here)
@@ -29,12 +29,29 @@ import sys
 import time
 import zlib
 from ctypes import c_int32
+from typing import NamedTuple
 
 from loguru import logger
 
 import ttnn
 
 _DEFAULT_DEVICE_MAP_FILE = "/tmp/prefill_device_map.txt"
+
+
+class KvCacheStage(NamedTuple):
+    """One migratable device cache on THIS rank -- one per config of the model's table, in config
+    order, since caches need not share a layer-index space.
+
+    ``first_layer``/``count`` are the layers this stage OWNS, in THIS cache's index space. Every cache
+    must be allocated to its own stage, so its physical slot 0 is ``first_layer`` and it holds exactly
+    ``count`` slots per user -- the address walk assumes that.
+
+    Field names match the keys :func:`allgather_kv_stage_layout` gathers them into.
+    """
+
+    base_addr: int
+    first_layer: int
+    count: int
 
 
 def migration_file_export_enabled() -> bool:
@@ -55,8 +72,12 @@ def _disaggregation():
 
 
 def _serialize_table_to_path(table, path: str) -> None:
-    """Serialize a KvChunkAddressTable to a protobuf file for the worker's SET_TABLE."""
-    _disaggregation().export_to_protobuf_file(table, path)
+    """Serialize a KvChunkAddressTable to a protobuf file for the worker's SET_TABLE. Atomic, like the
+    two device-map writers: a reader polls for this path's existence and deserializes the instant it
+    appears, so writing in place hands it a truncated protobuf whenever the poll lands mid-write."""
+    tmp = f"{path}.tmp"
+    _disaggregation().export_to_protobuf_file(table, tmp)
+    os.replace(tmp, path)
 
 
 def _resolve_queue_names() -> tuple[str, str, str]:
@@ -300,26 +321,22 @@ def export_device_map_to_file(mesh_device, mesh_shape, path: str) -> str:
     return path
 
 
-def export_device_map_file_and_gather_stage_layout(
-    mesh_device, kv_base_addr, mesh_shape, first_layer_idx, num_my_layers, device_map_path: str
-):
-    """ALL RANKS: file-export counterpart of :func:`deliver_device_map_and_gather_stage_layout` —
+def export_device_map_file_and_gather_stage_layouts(mesh_device, stages, mesh_shape, device_map_path: str):
+    """ALL RANKS: file-export counterpart of :func:`deliver_device_map_and_gather_stage_layouts` —
     drop the local FNID->UMD map to a host-local text file instead of pushing it to a co-located
-    worker, then join the same collective all-gather. Returns the gathered ``stage_layout``."""
+    worker, then join the same collective all-gather. Returns one gathered layout per stage."""
     export_device_map_to_file(mesh_device, mesh_shape, device_map_path)
-    return allgather_kv_stage_layout(mesh_device, kv_base_addr, mesh_shape, first_layer_idx, num_my_layers)
+    return allgather_kv_stage_layouts(mesh_device, stages, mesh_shape)
 
 
-def deliver_device_map_and_gather_stage_layout(
-    mesh_device, kv_base_addr, mesh_shape, first_layer_idx, num_my_layers, rank
-):
+def deliver_device_map_and_gather_stage_layouts(mesh_device, stages, mesh_shape, rank):
     """ALL RANKS run this (the runner drives it for every rank). Deliver THIS rank's local FNID->UMD
     device map to its co-located worker, then join the collective all-gather that merges every stage
-    into one table. Returns the gathered ``stage_layout`` (the runner passes it to rank 0's
-    ``runtime.build_kv_chunk_table``; non-rank-0 callers just needed to join the collective).
+    into one table. Returns the gathered layouts, one per stage (the runner passes them to rank
+    0's ``runtime.build_kv_chunk_table``; non-rank-0 callers just needed to join the collective).
 
-    ``kv_base_addr`` is this stage's KV base address, supplied by the model via
-    ``runtime.kv_migration_base_address`` -- the engine never introspects the cache struct itself.
+    ``stages`` are this rank's per-cache :class:`KvCacheStage` descriptions, supplied by the model via
+    ``runtime.kv_migration_stages`` -- the engine never introspects the cache struct itself.
 
     The delivery happens BEFORE the gather so every rank's map is in place before rank 0 SET_TABLEs;
     the all-gather doubles as the barrier that guarantees it. The gather is an MPI collective -- EVERY
@@ -327,7 +344,7 @@ def deliver_device_map_and_gather_stage_layout(
     """
     device_map = _build_device_map(mesh_device, mesh_shape)
     _deliver_local_device_map(device_map, rank)
-    return allgather_kv_stage_layout(mesh_device, kv_base_addr, mesh_shape, first_layer_idx, num_my_layers)
+    return allgather_kv_stage_layouts(mesh_device, stages, mesh_shape)
 
 
 def publish_serialized_table_and_wait_ready(*, table_path: str, wait_ready_timeout_ms: int = 120_000):
@@ -336,7 +353,7 @@ def publish_serialized_table_and_wait_ready(*, table_path: str, wait_ready_timeo
 
     The table is built + serialized by the model runtime (``runtime.build_kv_chunk_table`` — the model
     owns the cache layout / block-cyclic address math), and the runner runs the all-ranks device-map
-    delivery + all-gather barrier (``deliver_device_map_and_gather_stage_layout``) FIRST, so by the
+    delivery + all-gather barrier (``deliver_device_map_and_gather_stage_layouts``) FIRST, so by the
     time this attaches the endpoint ``MigrationLayerClient`` on the master cmd/table/resp queues and
     SET_TABLEs, every rank's local device map has landed and the worker can reach WORKER_READY.
     """
@@ -363,6 +380,16 @@ def _host_tag_int():
     hosts, so one tag per owning rank correctly groups every FNID to its worker.
     """
     return zlib.crc32(socket.gethostname().encode()) & 0x7FFFFFFF
+
+
+def allgather_kv_stage_layouts(mesh_device, stages, mesh_shape):
+    """COLLECTIVE (all ranks): :func:`allgather_kv_stage_layout` once per stage, in config order. EVERY
+    rank must pass the same stages in the same order -- each costs a fixed sequence of allgathers, so an
+    asymmetric list desynchronizes the communicator."""
+    return [
+        allgather_kv_stage_layout(mesh_device, stage.base_addr, mesh_shape, stage.first_layer, stage.count)
+        for stage in stages
+    ]
 
 
 def allgather_kv_stage_layout(mesh_device, kv_base_addr, mesh_shape, first_layer_idx, num_my_layers):

--- a/models/demos/common/prefill/runners/migration_driver.py
+++ b/models/demos/common/prefill/runners/migration_driver.py
@@ -712,7 +712,7 @@ def _verify_dst_vs_golden(table, device_map: dict, triples: list, slot_traces: d
     when you want the transport and the model correctness reported separately.
 
     FULL DEPTH, ALWAYS. ``_read_slot_kv_and_check_pcc`` takes a slot and a trace, not a layer list: it
-    walks every layer of the model and reports the min. There is no layer subset to pass, which is why
+    walks every layer of the model and reports each of its caches' min. There is no layer subset to pass, which is why
     the caller (``_verify_migrated_slots``) decides whether this check may run at all rather than passing
     one down — see the gate there. Unlike ``_verify_dst_vs_src_bytes``, this cannot honour
     PREFILL_VERIFY_MIGRATION_LAYERS, and it must not run against a partially migrated destination.
@@ -727,14 +727,18 @@ def _verify_dst_vs_golden(table, device_map: dict, triples: list, slot_traces: d
             continue
         logger.info(f"[migration_driver] verify golden: dst slot {dst} (migrated from {src}) over [0,{real_len})")
         try:
-            pcc = producer._read_slot_kv_and_check_pcc(table, device_map, dst, real_len, trace_dir)
+            slot_mins = producer._read_slot_kv_and_check_pcc(table, device_map, dst, real_len, trace_dir)
         except Exception as e:
             logger.error(f"[migration_driver] verify golden: dst slot {dst} read/PCC raised {type(e).__name__}: {e}")
             failures.append((src, dst, float("nan")))
             continue
         checked += 1
+        # The reader reports one min per MODEL cache (a sparse model migrates its index cache too); gate on
+        # the weakest and print the breakdown so a regression names the cache that moved wrong.
+        pcc = min(slot_mins.values())
         min_pcc = min(min_pcc, pcc)
-        print(f"[migration_driver] AFTER dst_slot={dst} (src={src}) min_pcc={pcc:.6f}")
+        per_cache = "".join(f" {cache}_pcc={value:.6f}" for cache, value in slot_mins.items())
+        print(f"[migration_driver] AFTER dst_slot={dst} (src={src}) min_pcc={pcc:.6f}{per_cache}")
         if pcc < threshold:
             failures.append((src, dst, pcc))
 

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -693,7 +693,10 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
 def _read_slot_kv_and_check_pcc(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
     """Read slot `slot_id`'s KV over [0, real_len) via the published table and PCC-check it against the
     golden trace. Dispatches on the model: MLA (single merged kvpe config), M3 (multi-config triple
-    cache), or GPT-OSS (multi-config K/V heads, no index_k). Returns the min PCC across layers.
+    cache), or GPT-OSS (multi-config K/V heads, no index_k). Returns ``{cache name: min PCC across that
+    cache's layers}`` — one entry per MODEL cache actually validated, so the caller can gate on the min
+    while still reporting each cache separately. A cache with no golden to compare against is ABSENT from
+    the mapping rather than present at 1.0.
 
     The reader is NOT adapter-pluggable — a new model whose cache is neither of those layouts needs
     a branch here (and its own decode), not just an adapter.
@@ -735,7 +738,8 @@ def _read_kv_slice(table, device_map, config_id, layer, slot_id, read_len, head_
 
 def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
     """GPT-OSS multi-config read-back: reconstruct per-head K/V from the 2N-config table and PCC vs the
-    GQA golden (no index_k). Config layout: k_h0..N-1 = 0..N-1, v_h0..N-1 = N..2N-1."""
+    GQA golden (no index_k). Config layout: k_h0..N-1 = 0..N-1, v_h0..N-1 = N..2N-1. Returns the per-cache
+    minima keyed by cache name."""
     from pathlib import Path
 
     from safetensors import safe_open
@@ -787,13 +791,13 @@ def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, r
         f"[producer] slot {slot_id} GPT-OSS KV PCC over [0,{real_len}) across {NUM_LAYERS} layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} (min {min_pcc:.6f})"
     )
-    return min_pcc
+    return mins
 
 
 def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
     """M3 multi-config read-back: reconstruct per-head K/V + index_k from the 9-config table and PCC vs the
     separate_k_v golden. Config layout matches the builder: k_h0..N-1 = 0..N-1, v_h0..N-1 = N..2N-1,
-    index_k = 2N."""
+    index_k = 2N. Returns the per-cache minima keyed by cache name."""
     from pathlib import Path
 
     from safetensors import safe_open
@@ -815,6 +819,7 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
     )
     kv_dir = Path(trace_dir) / "kv_cache"
     mins = {"k": 1.0, "v": 1.0, "index_k": 1.0}
+    ik_checked = 0
     for layer in range(NUM_LAYERS):
         dev_k = torch.stack(
             [
@@ -850,6 +855,7 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
             dev_ik = _read_kv_slice(table, device_map, ik_cfg, layer, slot_id, read_len, head_dim, ik_decode)[:real_len]
             pcc_ik = float(comp_pcc(g_ik, dev_ik, 0.0)[1])
             mins["index_k"] = min(mins["index_k"], pcc_ik)
+            ik_checked += 1
             line += f" index_k={pcc_ik:.5f}"
         logger.info(line)
 
@@ -858,7 +864,11 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
         f"[producer] slot {slot_id} M3 KV PCC over [0,{real_len}) across {NUM_LAYERS} layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} index_k={mins['index_k']:.5f} (min {min_pcc:.6f})"
     )
-    return min_pcc
+    # Only some traces carry an index_k golden. Its min is still the 1.0 init when none did, so drop the
+    # key rather than reporting an unmeasured cache as perfect.
+    if not ik_checked:
+        del mins["index_k"]
+    return mins
 
 
 def _full_indexer_layer_indices(num_layers: int):
@@ -884,9 +894,10 @@ def _full_indexer_layer_indices(num_layers: int):
 def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_len: int, trace_dir):
     """Read slot `slot_id`'s KV over [0, real_len) via the table and validate it. Config 0 (the KVPE
     cache) is PCC'd vs the golden trace. For a sparse/DSA model the merged table also carries config 1
-    (the index-key cache), which is PCC'd vs the golden indexer key. Returns the min PCC across both
-    caches / all layers, or across config 0 alone when the trace carries no indexer-key golden (warned,
-    not fatal — see below). Raises on an index-cache READ failure."""
+    (the index-key cache), which is PCC'd vs the golden indexer key. Returns ``{"kvpe": min}`` plus
+    ``"index": min`` when the index cache was validated — omitted, not defaulted to 1.0, when the model is
+    dense or the trace carries no indexer-key golden (warned, not fatal — see below). Raises on an
+    index-cache READ failure."""
     from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import (
         _load_golden_index_k,
         _load_golden_kv_post,
@@ -954,13 +965,14 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
     # config-0 PCC rather than failing the slot: the KVPE result is still a valid check.
     # `_num_model_configs`, not `num_configs()`: under DFlash the same table also carries the drafter's
     # `dflash_*` configs, and config 1 is only the index cache when the MODEL published two caches.
+    mins = {"kvpe": min_pcc}
     if _num_model_configs(table) > 1:
         if not index_golden_present(trace_dir):
             logger.warning(
                 f"[producer] slot {slot_id}: table has an index config but {trace_dir} carries no "
                 f"indexer-key golden; validating the KVPE cache only (device index cache NOT checked)."
             )
-            return min_pcc
+            return mins
 
         index_head_dim = ADAPTER.model_config.INDEX_HEAD_DIM
         n_index_layers = table.config(1).num_layers
@@ -1012,21 +1024,34 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
             f"[producer] slot {slot_id} index PCC over [0,{real_len}) across "
             f"{checked_index}/{n_index_layers} local layers -> {min_index:.6f}"
         )
-        min_pcc = min(min_pcc, min_index)
+        mins["index"] = min_index
 
-    return min_pcc
+    return mins
 
 
-def _write_pcc_verdict(rank: int, ok: bool, min_pcc: float, checked: int, threshold: float) -> None:
+def _write_pcc_verdict(
+    rank: int, ok: bool, min_pcc: float, checked: int, threshold: float, per_cache: dict | None = None
+) -> None:
     """Persist this rank's PCC verdict to PREFILL_PCC_SUMMARY_DIR (opt-in). The verdict is logged to
     stdout just before the shutdown sentinel, and mpirun drops its buffered output forwarding when the
     runner tears down in response — so under a launcher the numbers never reach the captured log. A file
-    on shared storage is read back by the harness independently of that teardown."""
+    on shared storage is read back by the harness independently of that teardown.
+
+    `min_pcc` is the gated number: the min over every validated cache. `per_cache` breaks it down by cache
+    (a sparse model's KVPE vs index cache), so a durable verdict distinguishes which cache set the bar and
+    shows that the others were checked at all — a cache missing from it was NOT validated."""
     summary_dir = os.environ.get("PREFILL_PCC_SUMMARY_DIR")
     if not summary_dir:
         return
     os.makedirs(summary_dir, exist_ok=True)
-    verdict = {"rank": rank, "ok": bool(ok), "min_pcc": min_pcc, "slots_checked": checked, "threshold": threshold}
+    verdict = {
+        "rank": rank,
+        "ok": bool(ok),
+        "min_pcc": min_pcc,
+        "per_cache": per_cache or {},
+        "slots_checked": checked,
+        "threshold": threshold,
+    }
     with open(os.path.join(summary_dir, f"rank{rank}.json"), "w") as f:
         json.dump(verdict, f)
 
@@ -1042,7 +1067,7 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
     device_map = _read_device_map(int(os.environ.get("PREFILL_H2D_CONNECT_TIMEOUT", "60")))
     if not device_map:
         logger.error("[producer] no device map available; skipping KV read/PCC.")
-        _write_pcc_verdict(rank, ok=False, min_pcc=0.0, checked=0, threshold=threshold)
+        _write_pcc_verdict(rank, ok=False, min_pcc=0.0, checked=0, threshold=threshold, per_cache={})
         return False
 
     dflash_threshold = float(os.environ.get("PREFILL_DFLASH_PCC", "0.88"))
@@ -1059,6 +1084,7 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
             )
 
     min_pcc_overall = 1.0
+    per_cache = {}  # cache name -> min over slots; a cache never validated stays absent
     min_dflash_overall = None  # stays None unless a drafter slice is actually measured
     checked = 0
     failures = []
@@ -1067,7 +1093,10 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
         real_len = res.real_len
         if real_len <= 0:
             continue
-        pcc = _read_slot_kv_and_check_pcc(kv_table, device_map, slot_id, real_len, slot_traces[slot_id])
+        slot_mins = _read_slot_kv_and_check_pcc(kv_table, device_map, slot_id, real_len, slot_traces[slot_id])
+        for cache, value in slot_mins.items():
+            per_cache[cache] = value if cache not in per_cache else min(per_cache[cache], value)
+        pcc = min(slot_mins.values())  # the gate is the weakest cache
         min_pcc_overall = min(min_pcc_overall, pcc)
         checked += 1
         if pcc < threshold:
@@ -1086,9 +1115,13 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
     # what it was before this gate existed. Keep `min_pcc=` last-but-one so a `min_pcc=([\d.]+)` reader is
     # unaffected either way.
     dflash_field = "" if min_dflash_overall is None else f" min_dflash_pcc={min_dflash_overall:.6f}"
-    print(f"[producer] kv_cache_pcc_complete slots_checked={checked} min_pcc={min_pcc_overall:.6f}{dflash_field}")
+    per_cache_field = "".join(f" {cache}_pcc={value:.6f}" for cache, value in per_cache.items())
+    print(
+        f"[producer] kv_cache_pcc_complete slots_checked={checked} min_pcc={min_pcc_overall:.6f}"
+        f"{dflash_field}{per_cache_field}"
+    )
     ok = bool(checked) and not failures and not dflash_failures
-    _write_pcc_verdict(rank, ok=ok, min_pcc=min_pcc_overall, checked=checked, threshold=threshold)
+    _write_pcc_verdict(rank, ok=ok, min_pcc=min_pcc_overall, checked=checked, threshold=threshold, per_cache=per_cache)
     if failures:
         logger.error(f"[producer] KV cache PCC below {threshold} for (slot, real_len, pcc): {failures}")
     if dflash_failures:
@@ -1098,7 +1131,11 @@ def _verify_resident_slots(kv_table, stats: RunStats, threshold: float, slot_tra
     if not checked:
         logger.error("[producer] verify requested but no resident slots had data to check.")
         return False
-    logger.success(f"[producer] KV cache PCC PASSED (min {min_pcc_overall:.6f} >= {threshold} across {checked} slots)")
+    per_cache_note = ", ".join(f"{cache}={value:.6f}" for cache, value in per_cache.items())
+    logger.success(
+        f"[producer] KV cache PCC PASSED (min {min_pcc_overall:.6f} >= {threshold} across {checked} slots"
+        f"{f'; per cache: {per_cache_note}' if per_cache_note else ''})"
+    )
     if min_dflash_overall is not None:
         logger.success(
             f"[producer] drafter KV PCC PASSED (min {min_dflash_overall:.6f} >= {dflash_threshold} "

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -274,8 +274,11 @@ def _read_kv_chunk_table(timeout_s: int):
 
 
 def _read_device_map(timeout_s: int) -> dict:
-    """Poll for and read the runner's fabric_node -> ASIC-unique_id sidecar (JSON), so read_dram_umd can
-    pick chips by unique_id without touching the ControlPlane. Returns {(mesh_id, chip_id): unique_id}."""
+    """Poll for and read the runner's fabric_node -> ASIC-unique_id sidecar, so read_dram_umd can pick
+    chips by unique_id without touching the ControlPlane. Returns {(mesh_id, chip_id): unique_id}.
+
+    The runner's two publishers do not share an encoding -- the shmem path writes JSON keyed
+    "<mesh>:<chip>", the file-export path writes "<mesh> <chip> <umd>" lines -- so accept either."""
     import json
 
     path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
@@ -287,8 +290,18 @@ def _read_device_map(timeout_s: int) -> dict:
         time.sleep(0.1)
 
     with open(path) as f:
-        raw_map = json.load(f)
-    device_map = {tuple(int(x) for x in key.split(":")): int(unique_id) for key, unique_id in raw_map.items()}
+        raw = f.read()
+    try:
+        device_map = {
+            tuple(int(x) for x in key.split(":")): int(unique_id) for key, unique_id in json.loads(raw).items()
+        }
+    except json.JSONDecodeError:
+        device_map = {}
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            mesh_id, chip_id, unique_id = line.split()
+            device_map[(int(mesh_id), int(chip_id))] = int(unique_id)
     logger.info(f"[producer] read device map {path}: {len(device_map)} chips")
     return device_map
 

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -790,7 +790,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     # Mock integration (prefill_producer.py's PREFILL_PRODUCER_CHECK_PCC): publish the KV chunk table +
     # device map for an external device-less reader, with NO migration worker. Deliberately OUTSIDE the
     # _migration_enabled block below: that block's first step is
-    # deliver_device_map_and_gather_stage_layout(), which imports the _migration_client .so and joins a
+    # deliver_device_map_and_gather_stage_layouts(), which imports the _migration_client .so and joins a
     # cross-rank all-gather. Mock has neither a client nor peers, so routing it through there raises
     # ImportError(_migration_client) — which is exactly what happens if you only make the old in-block
     # `elif PREFILL_MOCK_MIGRATION` reachable. Both writes here are local (build table + serialize map).
@@ -817,17 +817,22 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         # With PREFILL_MIGRATION_EXPORT_TO_FILE=1 the device map goes to a host-local text file
         # and the table stays on disk instead; no worker handshake.
         from models.demos.common.prefill.runners.migration import (
-            allgather_kv_stage_layout,
-            deliver_device_map_and_gather_stage_layout,
-            export_device_map_file_and_gather_stage_layout,
+            KvCacheStage,
+            allgather_kv_stage_layouts,
+            deliver_device_map_and_gather_stage_layouts,
+            export_device_map_file_and_gather_stage_layouts,
             migration_device_map_file_path,
             publish_serialized_table_and_wait_ready,
         )
 
         # This rank's pipeline stage owns layers [first_layer_idx, first_layer_idx + num_my_layers).
         # The layer-aware merge gathers each rank's range so the table spans all stages; pass this
-        # rank's range (same split the runtime/cache was built with).
-        first_layer_idx, num_my_layers = compute_layer_split(NUM_LAYERS, num_ranks)[rank]
+        # rank's range -- via the adapter's boundaries, so it is the split the MODEL was built with in
+        # main(). Without them a cross-layer-reuse model (GLM-5.2 snaps 39/39 to 38/40) describes a
+        # partition its KV cache does not hold, mismapping every layer of the second stage.
+        first_layer_idx, num_my_layers = compute_layer_split(
+            NUM_LAYERS, num_ranks, ADAPTER.layer_split_boundaries(NUM_LAYERS)
+        )[rank]
         table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
         wait_ready_ms = int(os.environ.get("PREFILL_MIGRATION_WAIT_READY_MS", "120000"))
 
@@ -855,32 +860,36 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         # its co-located worker first; mock has no worker (the producer reads a serialized JSON map),
         # so it joins the gather directly and never imports the worker client extension.
         #
-        # Ask the runtime for this stage's KV base -- the engine must not introspect the opaque
-        # KvCaches struct, whose shape is per-model.
-        if not hasattr(runtime, "kv_migration_base_address"):
+        # Ask the runtime to describe its migratable caches -- the engine must not introspect the opaque
+        # KvCaches struct, whose shape is per-model. One stage per config of the model's table, since a
+        # layout carries one cache's DRAM base and one layer-index space. A runtime predating
+        # `kv_migration_stages` exposes only the single-cache base address.
+        _multi_cache_runtime = hasattr(runtime, "kv_migration_stages")
+        if _multi_cache_runtime:
+            kv_stages = runtime.kv_migration_stages(kv_caches, first_layer_idx, num_my_layers)
+        elif hasattr(runtime, "kv_migration_base_address"):
+            kv_stages = [KvCacheStage(runtime.kv_migration_base_address(kv_caches), first_layer_idx, num_my_layers)]
+        else:
             raise RuntimeError(
-                f"migration enabled but runtime {type(runtime).__name__} implements no "
-                "kv_migration_base_address (see docs/ADDING_A_PREFILL_MODEL.md §2)."
+                f"migration enabled but runtime {type(runtime).__name__} implements neither "
+                "kv_migration_stages nor kv_migration_base_address "
+                "(see docs/ADDING_A_PREFILL_MODEL.md §2)."
             )
-        kv_base_addr = runtime.kv_migration_base_address(kv_caches)
         _mock_migration = os.environ.get("PREFILL_MOCK_MIGRATION", "0") == "1"
         if _mock_migration:
-            stage_layout = allgather_kv_stage_layout(
-                mesh_device, kv_base_addr, GLOBAL_MESH_SHAPE, first_layer_idx, num_my_layers
-            )
+            stage_layouts = allgather_kv_stage_layouts(mesh_device, kv_stages, GLOBAL_MESH_SHAPE)
         elif _file_export:
-            stage_layout = export_device_map_file_and_gather_stage_layout(
-                mesh_device,
-                kv_base_addr,
-                GLOBAL_MESH_SHAPE,
-                first_layer_idx,
-                num_my_layers,
-                migration_device_map_file_path(),
+            stage_layouts = export_device_map_file_and_gather_stage_layouts(
+                mesh_device, kv_stages, GLOBAL_MESH_SHAPE, migration_device_map_file_path()
             )
         else:
-            stage_layout = deliver_device_map_and_gather_stage_layout(
-                mesh_device, kv_base_addr, GLOBAL_MESH_SHAPE, first_layer_idx, num_my_layers, rank
-            )
+            stage_layouts = deliver_device_map_and_gather_stage_layouts(mesh_device, kv_stages, GLOBAL_MESH_SHAPE, rank)
+
+        # A runtime predating `kv_migration_stages` describes ONE cache and takes the singular
+        # `stage_layout=` -- its single gathered layout. Keep calling it that way: its single-rank guard
+        # counts stages in that layout, and handing it the outer per-cache list would count caches (always
+        # 1) and silently stop rejecting multi-rank migration.
+        _layout_kwarg = {"stage_layouts": stage_layouts} if _multi_cache_runtime else {"stage_layout": stage_layouts[0]}
 
         if _mock_migration:
             # Mock integration (prefill_producer.py): the SAME merged table the real publish builds, but
@@ -905,7 +914,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                     table_path,
                     first_layer_idx=first_layer_idx,
                     num_my_layers=num_my_layers,
-                    stage_layout=stage_layout,
+                    **_layout_kwarg,
                 )
                 logger.info(f"[mock-migration] merged KV chunk table -> {table_path} (no migration worker)")
             logger.info(f"[mock-migration] rank {rank}: local device map -> {device_map_path}")
@@ -917,7 +926,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                     table_path,
                     first_layer_idx=first_layer_idx,
                     num_my_layers=num_my_layers,
-                    stage_layout=stage_layout,
+                    **_layout_kwarg,
                 )
                 logger.info(f"[migration] merged KV chunk table -> {table_path} (file export; no worker handshake)")
             logger.info(f"[migration] rank {rank}: exported local device map -> {migration_device_map_file_path()}")
@@ -941,7 +950,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                     table_path,
                     first_layer_idx=first_layer_idx,
                     num_my_layers=num_my_layers,
-                    stage_layout=stage_layout,
+                    **_layout_kwarg,
                 )
                 migration_endpoint = publish_serialized_table_and_wait_ready(
                     table_path=table_path,
@@ -967,7 +976,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         # out of the pre-#48826 `if single_rank:` wrapper, so with num_ranks>1 every rank would build
         # a table covering only ITS layer slice and publish over the same paths -- and co-located
         # ranks would race serialize_device_map's `<path>.tmp` -> os.replace as well. Only the real
-        # migration path merges stages (deliver_device_map_and_gather_stage_layout), and that needs
+        # migration path merges stages (deliver_device_map_and_gather_stage_layouts), and that needs
         # the worker. Same guard #48826 removed for PREFILL_ENABLE_MIGRATION, kept for the mock path.
         if not single_rank:
             raise ValueError(

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto
@@ -1,0 +1,46 @@
+# CONNECTED 4-galaxy mesh graph descriptor for the D2D-socket pipeline prefill, FABRIC_2D variant.
+#
+# Four 8x4 BH-galaxy meshes chained mesh 0 <-> 1 <-> 2 <-> 3 by inter-galaxy fabric links, one per
+# pipeline boundary (rank r sends to rank r+1).
+#
+# Host order matters: discovery maps mesh 0 -> first --host, mesh 1 -> second, etc., and the chained
+# connections require consecutive hosts to be physically cabled. List the --host slots in the order
+# the galaxies are cabled in the superpod chain.
+#
+# dim_types [LINE, LINE]: no row/column wrap, so this pairs with PREFILL_FABRIC_MODE=2d. GLM-5.2's MoE
+# all_to_all deadlocks in warmup under the torus modes on multi-galaxy pipeline prefill, which is why
+# the wrap is dropped here rather than declared and left unused.
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -994,3 +994,95 @@ def test_glm52_kv_cache_table(
         chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
         assert_equal(chunk_torch, tt_kvpe_cache_torch[:, :, position:pos_end, :])
     logger.info(f"[glm52] kvpe-cache (config {KVPE_CONFIG_ID}, bf16 RM) readback verified over {seq_len} tokens")
+
+
+class _RecordingKvChunkAddressTable:
+    """Host-only stand-in for KvChunkAddressTable: records what populate_kv_chunk_address_table_kimi
+    would write, resolving each entry's device group back to its fabric nodes so two tables built from
+    different stage layouts stay comparable (group INDICES are assignment order, not identity)."""
+
+    def __init__(self):
+        self._groups = {}
+        self._group_fnids = {}
+        self.entries = {}
+
+    def add_device_group(self, fnids):
+        key = tuple((int(f.mesh_id), int(f.chip_id)) for f in fnids)
+        idx = self._groups.setdefault(key, len(self._groups))
+        self._group_fnids[idx] = key
+        return ttnn.experimental.disaggregation.DeviceGroupIndex(idx)
+
+    def set_fabric_node_host(self, fid, host_name):
+        pass
+
+    def set(self, layer, position, slot, location, config_id):
+        key = (config_id, layer, position, slot)
+        assert key not in self.entries, f"duplicate table entry {key}"
+        self.entries[key] = (
+            int(location.noc_addr),
+            int(location.size_bytes),
+            self._group_fnids[int(location.device_group_index)],
+        )
+
+
+def test_glm52_index_cache_pipeline_stage_addresses():
+    """Every rank allocates the GLM-5.2 index cache for its OWN full-indexer layers, so its physical slot 0
+    is that stage's first compacted layer. The merged table must place a stage at its compacted offset
+    while addressing the slots exactly as that stage's cache-local walk does.
+
+    Golden = each rank's cache walked ALONE from slot 0 (how the tensor is laid out), shifted to the
+    offset the merged table assigns it. Host-only: the address math needs no device.
+    """
+    rows, cols, sp_axis = 4, 8, 0
+    num_users, seq_len, num_banks = 2, 2 * PREFILL_CHUNK_OUTPUT_TOKENS, BH_NUM_DRAM_BANKS
+    index_chunk_size_bytes = 4 * 1088  # [1,1,32,128] bfp8
+    config_id = 1  # the index cache is config 1 of the merged table
+    num_full = 21  # GLM-5.2: 21 of 78 layers own an indexer
+    # Compacted full-indexer ranges for the boundary-snapped 38/40 two-rank split.
+    stage_ranges = [(0, 11), (11, 10)]
+    base_addrs = [0x1000_0000, 0x2000_0000]
+
+    def stage(rank, first_layer, count):
+        return {
+            "rank": rank,
+            "first_layer": first_layer,
+            "count": count,
+            "base_addr": base_addrs[rank],
+            "num_banks": num_banks,
+            "host_tag": 0xABC0000 + rank,
+            "fnids": [[ttnn.FabricNodeId(ttnn.MeshId(rank), r * cols + c) for c in range(cols)] for r in range(rows)],
+        }
+
+    def populate(stage_layout):
+        config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+        config.num_layers = num_full
+        table = _RecordingKvChunkAddressTable()
+        populate_kv_chunk_address_table_kimi(
+            lookup_table=table,
+            config=config,
+            mesh_device=None,  # unused on the stage_layout path (base addr / bank count come per stage)
+            mesh_shape=(rows, cols),
+            seq_len=seq_len,
+            sp_axis=sp_axis,
+            tt_kvpe_cache=None,
+            chunk_size_bytes=index_chunk_size_bytes,
+            num_users=num_users,
+            config_id=config_id,
+            stage_layout=stage_layout,
+        )
+        return table.entries
+
+    golden = {}
+    for rank, (first_layer, count) in enumerate(stage_ranges):
+        solo = populate([stage(rank, 0, count)])
+        golden.update({(cid, layer + first_layer, pos, slot): v for (cid, layer, pos, slot), v in solo.items()})
+
+    merged = populate([stage(rank, first, count) for rank, (first, count) in enumerate(stage_ranges)])
+
+    assert merged.keys() == golden.keys(), (
+        f"merged table covers {len(merged)} entries vs {len(golden)} golden — the stages do not tile the "
+        f"cache (layers {sorted({k[1] for k in merged})} vs {sorted({k[1] for k in golden})})"
+    )
+    mismatched = {k: (merged[k], golden[k]) for k in golden if merged[k] != golden[k]}
+    assert not mismatched, f"{len(mismatched)} entries mismapped, e.g. {list(mismatched.items())[:2]}"
+    logger.info(f"[glm52] merged 2-stage index-cache table matches the per-rank walk over {len(merged)} entries")

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -36,7 +36,7 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
-from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import full_indexer_rank, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
@@ -427,12 +427,13 @@ def run_model(
 
     # Sparse single-shot is folded onto the block-cyclic path, so (like chunked) it needs the caller-owned,
     # user-major layer-stacked indexer key cache [num_users*index_cache_layers, 1, T, D_idx]. Unlike the
-    # per-layer KVPE cache, the indexer stride is the COMPACTED full-indexer count (num_full_indexer_layers)
-    # for GLM-5.2 cross-layer reuse — "shared" layers reuse a "full" layer's cache and get no slot of their
-    # own — falling back to num_layers when there is no indexer_types map. Dense variants use no index cache.
+    # per-layer KVPE cache, the indexer stride is the COMPACTED full-indexer count over the layers this
+    # instance builds — GLM-5.2 "shared" layers reuse a "full" layer's cache and get no slot of their own.
+    # full_indexer_rank returns num_layers unchanged when there is no indexer_types map. Dense variants use
+    # no index cache.
     tt_index_kv_cache = None
     if has_indexer:
-        index_cache_layers = num_full_indexer_layers(config) or num_layers
+        index_cache_layers = full_indexer_rank(config, num_layers)
         tt_index_kv_cache = init_kvpe_cache(
             kvpe_cache_head_dim=config.index_head_dim,
             mesh_device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -44,7 +44,6 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_p
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
     full_indexer_rank,
     get_fused_ring_host_timing,
-    num_full_indexer_layers,
     reset_fused_ring_host_timing,
     resolve_has_indexer,
 )
@@ -314,7 +313,7 @@ def _record_indexer_k_cache_pcc(
     indexer_k is captured for a subset of layers (glm_5_1: all; glm_5_2: 0-2 + every 4th) — layers without
     a golden are skipped. GLM DSA variants only."""
     logger.info("Device indexer-K cache vs golden dsa/indexer_k:")
-    cache_full = gather_cache_tp0(tt_index_kv_cache, mesh_device)  # [num_full_indexer_layers or num_layers, T, D]
+    cache_full = gather_cache_tp0(tt_index_kv_cache, mesh_device)  # [full layers built, T, D]
     layers = [i for i in range(num_layers) if (trace_dir / "dsa" / f"indexer_k_layer_{i}").exists()]
     if not layers:
         logger.info("  (no indexer_k golden layers present -- skipping)")
@@ -411,7 +410,8 @@ def _preload_indexer_k_prefix_from_trace(
     trace, so a measured chunk at KV depth preload_isl has a REAL indexer prefix (representative top-k
     selection at depth) rather than a zero prior. Only "full" indexer layers own a cache slot / have a
     golden (glm_5_1: all; glm_5_2: 0-2 + every 4th); layer i is written to its compacted slot
-    full_indexer_rank(config, i), and the cache is strided by num_full_indexer_layers. The golden
+    full_indexer_rank(config, i), and the cache is strided by the full-layer count over the built
+    layers. The golden
     index_head_dim key is [rope | nope] already in the device's interleaved basis (GLM), so it is written
     verbatim -- no re-interleave (unlike KVPE's k_pe half-split -> interleaved). Rows past the trace are
     random (timing-representative). Mirrors _preload_kvpe_prefix_from_trace otherwise."""
@@ -419,7 +419,7 @@ def _preload_indexer_k_prefix_from_trace(
     if not full_layers:
         logger.info(f"no indexer_k golden in trace {trace_dir}; leaving the indexer prefix zero")
         return
-    num_slots = num_full_indexer_layers(config) or num_layers
+    num_slots = full_indexer_rank(config, num_layers)
     real_len = min(preload_isl, trace_len)
     rand_len = preload_isl - real_len
     logger.info(
@@ -746,15 +746,15 @@ def run_chunked_transformer(
     # forward, exactly like the KVPE cache. It is user-major layer-stacked
     # [num_users*index_cache_layers, 1, T, D_idx], so the indexer addresses slot
     # user*index_cache_layers + cache_layer_idx. Unlike the per-layer KVPE cache, the indexer stride is the
-    # COMPACTED full-indexer count (num_full_indexer_layers) for GLM-5.2 cross-layer reuse — "shared" layers
-    # reuse a "full" layer's cache and get no slot of their own — falling back to num_layers when there is no
-    # indexer_types map. bf8 (half the memory, top-k within bf16 noise). Dense variants get None.
+    # COMPACTED full-indexer count over the layers this instance builds — GLM-5.2 "shared" layers reuse a
+    # "full" layer's cache and get no slot of their own, and full_indexer_rank returns num_layers unchanged
+    # without an indexer_types map. bf8 (half the memory, top-k within bf16 noise). Dense variants get None.
     tt_index_kv_cache = None
     if has_indexer:
         # A sparse config must carry index_head_dim; assert rather than silently defaulting so a
         # misconfigured (missing-field) sparse setup fails loudly with a clear message.
         assert getattr(config, "index_head_dim", None) is not None, "sparse config must provide index_head_dim"
-        index_cache_layers = num_full_indexer_layers(config) or num_layers
+        index_cache_layers = full_indexer_rank(config, num_layers)
         tt_index_kv_cache = init_kvpe_cache(
             kvpe_cache_head_dim=config.index_head_dim,
             mesh_device=mesh_device,
@@ -1337,9 +1337,9 @@ def run_chunked_transformer_updated(
     )
 
     # Sparse (DSA) layers read a block-cyclic indexer key cache that is caller-owned and passed into
-    # forward, exactly like the KVPE cache. Strided by the compacted full-indexer count
-    # (num_full_indexer_layers, >1 for glm_5_2 cross-layer reuse; num_layers without an indexer_types map)
-    # so it matches the indexer's cache_batch stride. bf8 TILE. Dense variants get None.
+    # forward, exactly like the KVPE cache. Strided by the compacted full-indexer count over the built
+    # layers (>1 for glm_5_2 cross-layer reuse; num_layers without an indexer_types map) so it matches the
+    # indexer's cache_batch stride. bf8 TILE. Dense variants get None.
     tt_index_kv_cache = None
     if resolve_has_indexer(config):
         assert getattr(config, "index_head_dim", None) is not None, "sparse config must provide index_head_dim"
@@ -1349,7 +1349,7 @@ def run_chunked_transformer_updated(
             seq_len=SEQ_CACHE_NOPCC,
             mesh_shape=mesh_shape,
             sp_axis=sp_axis,
-            num_kvpe_cache_layers=num_full_indexer_layers(config) or num_layers,
+            num_kvpe_cache_layers=full_indexer_rank(config, num_layers),
             num_users=1,
             dtype=ttnn.bfloat8_b,
         )

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -259,6 +259,7 @@ class TtIndexer:
         active_seq_len: int | None = None,
         slot_num: int = 1,
         layer_num: int = 1,
+        first_layer_idx: int | None = None,
     ):
         """Architecture constants are read from the HF config with no defaults (index_n_heads,
         index_head_dim, index_topk, index_rope_interleave — a sparse config that omits any of them
@@ -340,12 +341,25 @@ class TtIndexer:
         # validated — rotated + chunked suites match BF16 within bf16 noise, ~5e-4 PCC — so it can be
         # allocated BF8 to halve mem).
         # GLM-5.2 cross-layer indexer reuse: the index key cache is allocated for full layers only, so this
-        # layer writes/reads its compacted rank among full layers, and the folded (user-major) slot stride
-        # is num_full, not all layers. _index_cache_layers is that stride.
-        self._num_index_layers = num_full_indexer_layers(config)
-        self._is_index_compact = self._num_index_layers is not None
-        self._index_layer_idx = full_indexer_rank(config, layer_idx) if self._is_index_compact else layer_idx
-        self._index_cache_layers = self._num_index_layers if self._is_index_compact else self.layer_num
+        # layer writes/reads its compacted rank among them and the folded (user-major) slot stride is the
+        # cache's full-layer count, not its layer count. _index_cache_layers is that stride.
+        # `first_layer_idx` declares this instance a pipeline stage owning global layers
+        # [first_layer_idx, first_layer_idx + layer_num): the cache then holds THAT stage's full layers
+        # only, numbered from 0. None means the cache spans the whole model -- what a layer built outside
+        # the transformer (unit tests) allocates.
+        num_full = num_full_indexer_layers(config)
+        self._is_index_compact = num_full is not None
+        base = full_indexer_rank(config, first_layer_idx) if first_layer_idx is not None else 0
+        if not self._is_index_compact:
+            self._index_layer_idx = layer_idx
+            self._index_cache_layers = self.layer_num
+        else:
+            self._index_layer_idx = full_indexer_rank(config, layer_idx) - base
+            self._index_cache_layers = (
+                num_full
+                if first_layer_idx is None
+                else full_indexer_rank(config, first_layer_idx + self.layer_num) - base
+            )
         # Stable, worst-case TP gather outputs.  Indexer layers execute serially, so TT_CCL shares each
         # buffer across them.  This keeps the high-bandwidth gathers allocation-free and their output
         # address fixed on the hot forward path.
@@ -525,6 +539,12 @@ class TtIndexer:
         ttnn.deallocate(nope)
         return out
 
+    def _cache_slot(self, cache_layer_idx: int) -> int:
+        """Slot this layer owns in the index key cache. A compacted cache (GLM-5.2 cross-layer reuse)
+        holds one slot per FULL layer, so the caller's per-layer KVPE slot does not address it; every
+        entry point has to translate, not just forward()."""
+        return self._index_layer_idx if self._is_index_compact else cache_layer_idx
+
     def write_k(
         self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0, cache_layer_idx=0, index_kbuf=None
     ):
@@ -556,6 +576,7 @@ class TtIndexer:
         # offset (pad-aware) — the same math the query/key rope above uses. Single-shot is folded onto this
         # path as one full-seq chunk at start_pos=0, so the indexer is always block-cyclic. num_layers is the
         # compacted stride (_index_cache_layers) so it matches the cache_batch_idx computed in forward().
+        cache_layer_idx = self._cache_slot(cache_layer_idx)
         k = self._bc_rope_pe(k, rope_tensors, start_pos)  # [1, 1, S/sp, D_idx] bf16
         if k.dtype != index_kbuf.dtype:  # write dtype must match the cache (update_padded_kv_cache asserts)
             k = ttnn.typecast(k, index_kbuf.dtype)
@@ -600,8 +621,7 @@ class TtIndexer:
         drive the per-user block-cyclic key cache + block-cyclic scoring. Scoring and transport are bounded
         by the written prefix, rounded to complete block-cyclic slabs for the fixed-size ring protocol."""
         a = self.index_args
-        if self._is_index_compact:
-            cache_layer_idx = self._index_layer_idx
+        cache_layer_idx = self._cache_slot(cache_layer_idx)
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
         # Block-cyclic key cache is caller-owned (like the KVPE cache) — required, never self-allocated.

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -292,6 +292,7 @@ class ttMLA:
         has_indexer: bool | None = None,
         sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
         active_seq_len: Optional[int] = None,
+        first_layer_idx: Optional[int] = None,
     ):
         # DSA indexer weights (v3.2 / GLM): extract NON-mutating, so the caller's state_dict survives
         # repeated construction / cache build+load (the old pop() emptied it on the first pass). Dense
@@ -583,6 +584,7 @@ class ttMLA:
                     active_seq_len=self.active_seq_len,
                     slot_num=slot_num,
                     layer_num=self.layer_num,
+                    first_layer_idx=first_layer_idx,
                 )
         else:
             self._indexer = NullIndexer()  # dense v3.1: forward calls .forward() -> None (dense path)

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -61,14 +61,15 @@ class GLM52Adapter(MLAPrefillAdapter):
           * index 1 — the lightning-indexer's per-user block-cyclic KEY cache (bfp8 TILE, ``index_head_dim``
             wide). GLM-5.2 cross-layer reuse: only ``full`` layers own an indexer and write this cache
             (``shared`` layers reuse a prior full layer's top-k and never write), so it is sized to the
-            FULL-layer count (``num_full_indexer_layers``), not all layers — each full layer writes its
-            compacted rank slot (see ``TtIndexer``), and the merged migration table's index config sizes
-            itself from this tensor's shape. Falls back to ``num_layers`` when there is no ``indexer_types``
-            map (GLM-5.1: every layer is full).
+            FULL-layer count, not all layers — each full layer writes its compacted rank slot (see
+            ``TtIndexer``). Like the KVPE cache it holds THIS pipeline stage only, so its slots are
+            numbered from this stage's first full layer and the migration table needs no extra stride.
+            ``full_indexer_rank`` degenerates to the layer count without an ``indexer_types`` map
+            (GLM-5.1: every layer is full).
 
         The engine owns both, exactly like the dense KVPE cache."""
         import ttnn
-        from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
+        from models.demos.deepseek_v3_d_p.tt.mla.indexer import full_indexer_rank
         from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
             MlaKvCacheFormat,
             init_kvpe_cache,
@@ -85,7 +86,8 @@ class GLM52Adapter(MLAPrefillAdapter):
             num_kvpe_cache_layers=params.num_layers,
             num_users=params.num_users,
         )
-        num_index_layers = num_full_indexer_layers(hf_config) or params.num_layers
+        first_full = full_indexer_rank(hf_config, params.first_layer_idx)
+        num_index_layers = full_indexer_rank(hf_config, params.first_layer_idx + params.num_layers) - first_full
         index_cache = init_kvpe_cache(
             kvpe_cache_head_dim=hf_config.index_head_dim,
             mesh_device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -27,6 +27,7 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     PREFILL_CHUNK_OUTPUT_TOKENS,
     create_kv_chunk_address_table_kimi,
+    merged_num_layers,
     populate_kv_chunk_address_table_dflash,
     populate_kv_chunk_address_table_kimi,
 )
@@ -94,7 +95,7 @@ def build_and_serialize_kv_chunk_table(
     tp_axis=1,
     first_layer_idx=0,
     num_my_layers=None,
-    stage_layout=None,
+    stage_layouts=None,
 ) -> str:
     """Build the MLA block-cyclic KV chunk address table and serialize it to ``path`` for the
     inference server's SET_TABLE. Returns the path on success.
@@ -119,10 +120,10 @@ def build_and_serialize_kv_chunk_table(
     ``num_kv_heads`` from ``shape[1] * tp`` (dim 1 is this chip's TP head slice), head_dim from
     ``shape[-1]``. Passing these turns even a DENSE model's table into a merged one.
 
-    ``first_layer_idx`` / ``num_my_layers`` / ``stage_layout`` (pipeline-parallel only): this rank owns
-    layers [first_layer_idx, first_layer_idx + num_my_layers); ``stage_layout`` is the all-gathered
-    per-stage layout so rank 0 builds one table spanning every stage. Single-rank defaults (stage_layout
-    None) build over this host's KVPE cache alone. Only the single-config (KVPE) path is PP-aware."""
+    ``first_layer_idx`` / ``num_my_layers`` / ``stage_layouts`` (pipeline-parallel only): this rank owns
+    layers [first_layer_idx, first_layer_idx + num_my_layers); ``stage_layouts`` holds ONE all-gathered
+    per-stage layout per block-cyclic cache (config order), so rank 0 builds one table spanning every
+    stage while the collectives ran on all ranks. Leave it None to gather inline (single-rank / tests)."""
     assert chunk_size_global == PREFILL_CHUNK_OUTPUT_TOKENS, (
         f"create_kv_chunk_address_table_kimi assumes a block-cyclic period of "
         f"PREFILL_CHUNK_OUTPUT_TOKENS={PREFILL_CHUNK_OUTPUT_TOKENS}, but chunk_size_global={chunk_size_global}. "
@@ -139,13 +140,6 @@ def build_and_serialize_kv_chunk_table(
     if dflash_caches is not None:
         all_caches.append(("dflash", dflash_caches))
     if index_kv_cache is not None or dflash_caches is not None:
-        # The cross-stage (pipeline-parallel) merge is not wired through the multi-cache merged table
-        # yet; callers gate this out (build_kv_chunk_table asserts index is None / drops the drafter on
-        # the PP path).
-        assert stage_layout is None, (
-            "build_and_serialize_kv_chunk_table: pipeline-parallel stage_layout is not supported for the "
-            "merged (KVPE + index / drafter) table yet."
-        )
         return _build_and_serialize_merged_kv_chunk_table(
             mesh_device=mesh_device,
             caches=all_caches,
@@ -157,7 +151,11 @@ def build_and_serialize_kv_chunk_table(
             num_users=num_users,
             chunk_size_global=chunk_size_global,
             path=path,
+            stage_layouts=stage_layouts,
         )
+
+    # Single config: the KVPE cache is the only one described, so its layout is the only one gathered.
+    stage_layout = stage_layouts[0] if stage_layouts else None
 
     def _builder(*, config, chunk_size_bytes, num_users):
         return create_kv_chunk_address_table_kimi(
@@ -197,25 +195,20 @@ def _build_and_serialize_merged_kv_chunk_table(
     path,
     tp_axis=1,
     chunk_size_global=None,
+    stage_layouts=None,
 ) -> str:
     """Build ONE KvChunkAddressTable over every cache this rank owns and serialize it to ``path``.
     ``caches`` is a tagged list of ``(kind, payload)``: ``("kvpe", tensor)`` / ``("index", tensor)`` for
     the block-cyclic MLA caches, named "0" (KVPE), "1" (GLM-5.2 index); ``("dflash", (k_cache, v_cache))``
     for the DFlash drafter (Kimi-only), which adds one config per (K|V, kv-head) via
     :func:`dflash_config_name`. Names must stay in sorted order (asserted) so the protobuf round-trip
-    keeps KVPE at config id 0 and the index at 1 — see the naming note at the top of this module."""
-    disagg = ttnn.experimental.disaggregation
+    keeps KVPE at config id 0 and the index at 1 — see the naming note at the top of this module.
 
-    def _table_config(cache):
-        cfg = disagg.KvChunkAddressTableConfig()
-        # num_layers comes off the cache itself: all layers for KVPE, full-layers-only for the GLM-5.2
-        # index cache, the 6 draft layers for a drafter cache (each is user-major shape[0] // num_users).
-        cfg.num_layers = _num_layers_from_cache(cache, num_users)
-        cfg.max_sequence_length = seq_len
-        cfg.num_slots = num_users
-        cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
-        cfg.chunk_size_bytes = _dram_chunk_size_bytes(cache)
-        return cfg
+    ``stage_layouts`` is one all-gathered layout per block-cyclic cache, in the same order — each config
+    needs its own, since a layout carries one cache's DRAM base and one layer-index space. Only rank 0
+    reaches this function, so the gather cannot happen here; None gathers inline, correct only
+    single-rank."""
+    disagg = ttnn.experimental.disaggregation
 
     # (name, cache, head_idx); head_idx is None for the block-cyclic MLA caches ("kvpe" / "index"), the
     # global kv-head otherwise ("dflash" drafter). Block-cyclic entries come first so config names sort
@@ -245,24 +238,64 @@ def _build_and_serialize_merged_kv_chunk_table(
         else:
             raise ValueError(f"unknown KV table cache kind: {kind!r} (expected 'kvpe', 'index', or 'dflash')")
 
+    block_cyclic = [(name, cache) for name, cache, head_idx in entries if head_idx is None]
+    if stage_layouts is None:
+        stage_layouts = [
+            allgather_kv_stage_layout(
+                mesh_device,
+                int(cache.buffer_address()),
+                mesh_shape,
+                first_layer_idx=0,
+                num_my_layers=_num_layers_from_cache(cache, num_users),
+            )
+            for _, cache in block_cyclic
+        ]
+    if len(stage_layouts) != len(block_cyclic):
+        raise RuntimeError(
+            f"merged table has {len(block_cyclic)} block-cyclic caches but got {len(stage_layouts)} gathered "
+            "stage layouts; the runtime must describe every config it merges (one KvCacheStage per cache, "
+            "in config order)."
+        )
+    layout_of = {name: layout for (name, _), layout in zip(block_cyclic, stage_layouts)}
+
+    # int(): the binding hands back a strong Rank type, which never compares equal to the plain int
+    # the gathered stages are keyed by.
+    my_rank = int(ttnn.distributed_context_get_rank())
+
+    def _table_config(cache, stage_layout):
+        cfg = disagg.KvChunkAddressTableConfig()
+        if stage_layout is None:
+            # Drafter cache: single-stage, so its layer count comes off the cache itself (the 6 draft
+            # layers, user-major shape[0] // num_users).
+            cfg.num_layers = _num_layers_from_cache(cache, num_users)
+        else:
+            # Match a layout to its cache by DRAM base, so a runtime returning its stages out of config
+            # order is caught here instead of silently addressing one cache with the other's layout.
+            base_addr = int(cache.buffer_address())
+            if not any(s["rank"] == my_rank and s["base_addr"] == base_addr for s in stage_layout):
+                raise RuntimeError(
+                    f"gathered stage layout does not describe this cache: rank {my_rank} has no stage at "
+                    f"{hex(base_addr)} in {[(s['rank'], hex(s['base_addr'])) for s in stage_layout]} — "
+                    "stages are out of config order."
+                )
+            # Size the config to the GLOBAL layer total, summed over the gathered stages: the KVPE cache's
+            # every layer, and the index cache's full-indexer layers only (GLM-5.2 cross-layer reuse — the
+            # shared layers own no indexer slot; GLM-5.1 / dense have one per layer, so it equals num_layers).
+            cfg.num_layers = merged_num_layers(stage_layout)
+        cfg.max_sequence_length = seq_len
+        cfg.num_slots = num_users
+        cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+        cfg.chunk_size_bytes = _dram_chunk_size_bytes(cache)
+        return cfg
+
     names = [name for name, _, _ in entries]
     assert names == sorted(names), f"config names must already be sorted (protobuf renumbers by name): {names}"
-    configs = {name: _table_config(cache) for name, cache, _ in entries}
+    configs = {name: _table_config(cache, layout_of.get(name)) for name, cache, _ in entries}
     table = disagg.KvChunkAddressTable(configs)
 
     for name, cache, head_idx in entries:
         cfg, config_id = configs[name], table.config_id_of(name)
         if head_idx is None:  # MLA/kimi block-cyclic model cache
-            # The merged table has one config per physical cache, so each config needs a layout with that
-            # cache's DRAM base address. The multi-cache path is single-stage today, but this remains a
-            # collective to match the single-config builder and to produce the mesh/fabric-node metadata.
-            stage_layout = allgather_kv_stage_layout(
-                mesh_device,
-                int(cache.buffer_address()),
-                mesh_shape,
-                first_layer_idx=0,
-                num_my_layers=cfg.num_layers,
-            )
             populate_kv_chunk_address_table_kimi(
                 lookup_table=table,
                 config=cfg,
@@ -274,7 +307,7 @@ def _build_and_serialize_merged_kv_chunk_table(
                 chunk_size_bytes=cfg.chunk_size_bytes,
                 num_users=num_users,
                 config_id=config_id,
-                stage_layout=stage_layout,
+                stage_layout=layout_of[name],
             )
         else:  # one global kv-head of the drafter's K or V cache
             populate_kv_chunk_address_table_dflash(

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -254,6 +254,7 @@ class TtPrefillBlock(LightweightModule):
         routing_use_l1_small_for_semaphores: bool = False,
         sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
         overlap_shared_expert_with_dispatch: bool = True,
+        first_layer_idx: Optional[int] = None,
     ):
         super().__init__()
         self.routing_use_l1_small_for_semaphores = routing_use_l1_small_for_semaphores
@@ -324,6 +325,7 @@ class TtPrefillBlock(LightweightModule):
             layer_num=layer_num,
             kv_only=kv_only,
             sparse_kv_cache_format=sparse_kv_cache_format,
+            first_layer_idx=first_layer_idx,
         )
 
         if kv_only:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -731,11 +731,42 @@ class TtPrefillRuntime:
             self._controller.set_layer_ack_callback(on_layer_complete)
 
     def kv_migration_base_address(self, kv_caches: MlaKvCaches) -> int:
-        """This stage's KV base DRAM address — the engine's per-rank anchor for the migration
-        all-gather (it holds the cache but must not introspect its layout). The pipeline-parallel
-        path migrates the primary KVPE cache, so that is the base; `.kvpe` is an MlaKvCache wrapper
-        rather than a bare tensor, hence `.storage`."""
+        """This stage's primary KV base DRAM address — the engine's single-cache hook for the
+        migration all-gather (it holds the cache but must not introspect its layout). `.kvpe` is an
+        MlaKvCache wrapper rather than a bare tensor, hence `.storage`. A sparse/DSA model migrates a
+        second cache too: see `kv_migration_stages`, which the engine prefers."""
         return int(kv_caches.kvpe.storage.buffer_address())
+
+    def kv_migration_stages(self, kv_caches: MlaKvCaches, first_layer_idx=None, num_my_layers=None):
+        """One `KvCacheStage` per merged-table config: KVPE first, then the sparse/DSA index-key cache
+        when present. The engine all-gathers one layout per entry (on ALL ranks) and hands them to
+        `build_kv_chunk_table`.
+
+        The two caches do NOT share a layer-index space, which is why a stage is per-cache: KVPE holds
+        this stage's layers under the model's global numbering, while the index cache is numbered in
+        COMPACTED full-indexer space (`full_indexer_rank`) because only `full` layers own an indexer and
+        write a slot. Both hold THIS stage only, so each stage's layers sit at its own slot 0.
+        """
+        from models.demos.common.prefill.runners.migration import KvCacheStage
+        from models.demos.deepseek_v3_d_p.tt.mla.indexer import full_indexer_rank
+
+        first_layer_idx = self.config.first_layer_idx if first_layer_idx is None else int(first_layer_idx)
+        num_my_layers = self.config.num_layers if num_my_layers is None else int(num_my_layers)
+        stages = [KvCacheStage(self.kv_migration_base_address(kv_caches), first_layer_idx, num_my_layers)]
+
+        index_cache = kv_caches.index
+        if index_cache is not None:
+            first_full = full_indexer_rank(self.hf_config, first_layer_idx)
+            count_full = full_indexer_rank(self.hf_config, first_layer_idx + num_my_layers) - first_full
+            slots_per_user = index_cache.shape[0] // self.config.num_users
+            if slots_per_user != count_full:
+                raise RuntimeError(
+                    f"index cache holds {slots_per_user} layers per slot but this stage owns "
+                    f"{count_full} full-indexer layers; the table cannot place its layers unless the "
+                    "cache is sized to the stage (see the GLM-5.2 adapter's allocate_kv_cache)."
+                )
+            stages.append(KvCacheStage(int(index_cache.buffer_address()), first_full, count_full))
+        return stages
 
     def build_kv_chunk_table(
         self,
@@ -744,7 +775,7 @@ class TtPrefillRuntime:
         *,
         first_layer_idx: int = 0,
         num_my_layers: Optional[int] = None,
-        stage_layout=None,
+        stage_layouts=None,
     ) -> str:
         """Build + serialize the KV-chunk address table for the engine-owned `MlaKvCaches` to
         `path` and return it.
@@ -755,35 +786,17 @@ class TtPrefillRuntime:
         cache layout; it issues no migration comms.
 
         Multi-rank (pipeline-parallel): this rank owns layers [first_layer_idx, first_layer_idx +
-        num_my_layers). The runner runs the all-ranks all-gather and passes the merged `stage_layout`
-        so ONLY rank 0 builds the table spanning every stage; the single-rank default (stage_layout
-        None) covers config.num_layers == the full model.
+        num_my_layers). The runner runs the all-ranks all-gathers and passes `stage_layouts` — one
+        layout per cache, in config order, from `kv_migration_stages` — so ONLY rank 0 builds
+        the table spanning every stage. The single-rank default (None) gathers inline.
 
         For a sparse/DSA model (``.index`` present) the result is a single MERGED table describing BOTH
         caches — config 0 = the KVPE cache, config 1 = the index-key cache. A dense model (``.index`` None)
-        → the usual single-config table over the KVPE cache alone. The index-cache merge is single-rank
-        only; the pipeline-parallel path (stage_layout given) migrates the KVPE cache alone.
+        → the usual single-config table over the KVPE cache alone.
 
         Under DFlash, this rank's drafter context caches join the same merged table as
         ``2 * num_kv_heads`` further named configs (see the gate below)."""
         from models.demos.deepseek_v3_d_p.tt.runners.kv_chunk_table import build_and_serialize_kv_chunk_table
-
-        # The CROSS-STAGE merge migrates the primary (KVPE) cache only; the sparse/DSA index cache
-        # isn't wired through it yet (port it into _build_and_serialize_merged_kv_chunk_table to add
-        # it) — fail loudly rather than silently drop it.
-        #
-        # A SINGLE-stage layout is not that case: the runner all-gathers one unconditionally whenever
-        # migration is enabled (prefill_runner._serve_request), so a single-galaxy sparse run arrived
-        # here with a 1-element stage_layout and tripped the assert before it could ever reach the
-        # endpoint. The merged builder does not consume stage_layout — it gathers its OWN layout per
-        # cache, since each config needs that cache's DRAM base — so dropping it here is lossless and
-        # keeps the dual-cache table reachable single-rank.
-        if stage_layout is not None and kv_caches.index is not None:
-            assert len(stage_layout) == 1, (
-                "build_kv_chunk_table: index-cache (sparse/DSA) migration is not supported on the "
-                f"pipeline-parallel path yet (got {len(stage_layout)} stages)."
-            )
-            stage_layout = None
 
         # DFlash: register the drafter's context K/V as further configs of the same merged table, so a
         # device-less consumer (prefill_producer) can read them back per (layer, head) and PCC them
@@ -798,7 +811,9 @@ class TtPrefillRuntime:
         #     into live migration needs that ordering fixed first.
         dflash_caches = None
         if self._dflash_k_cache is not None:
-            if stage_layout is None:
+            # The runner all-gathers whenever migration is enabled, so a layout carrying one stage still
+            # means single-rank; only a genuine cross-stage merge has to drop the drafter.
+            if stage_layouts is None or all(len(layout) == 1 for layout in stage_layouts):
                 dflash_caches = (self._dflash_k_cache, self._dflash_v_cache)
             else:
                 logger.warning(
@@ -822,7 +837,7 @@ class TtPrefillRuntime:
             dflash_caches=dflash_caches,
             first_layer_idx=first_layer_idx,
             num_my_layers=num_my_layers,
-            stage_layout=stage_layout,
+            stage_layouts=stage_layouts,
         )
 
     def read_slot_kv(self, kv_caches: MlaKvCaches, slot: int):
@@ -863,7 +878,7 @@ class TtPrefillRuntime:
             # having checked only the KVPE half.
             #
             # Two ways it differs from `.kvpe`: its per-slot stride is its OWN layer count, NOT
-            # config.num_layers (GLM-5.2 sizes it to the `full` indexer layers only, so 21 vs 78);
+            # config.num_layers (GLM-5.2 sizes it to this stage's `full` indexer layers only);
             # and it is a plain ttnn.Tensor, so there is no `.storage` / `unpack_host` (bfp8_b TILE
             # dequantizes on to_torch).
             index = kv_caches.index

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -198,8 +198,10 @@ class TtPrefillTransformer(LightweightModule):
         # layer_idx is the GLOBAL index (drives weight cache keys + dense/MoE selection);
         # cache_layer_idx in forward is the LOCAL slot. layer_num is this instance's slice
         # length so the block's flat KV slot (cache_user_id * layer_num + cache_layer_idx)
-        # matches the per-rank cache sized to num_layers. With kv_only_last_layer, the last block is
-        # built kv_only=True (only attn_norm + the KV branch of MLA).
+        # matches the per-rank cache sized to num_layers. first_layer_idx additionally tells the
+        # sparse indexer which stage it is, so its (separately numbered) key cache is rank-local too.
+        # With kv_only_last_layer, the last block is built kv_only=True (only attn_norm + the KV
+        # branch of MLA).
         self.layers = []
         for local_idx in range(num_layers):
             layer_idx = first_layer_idx + local_idx
@@ -235,6 +237,7 @@ class TtPrefillTransformer(LightweightModule):
                 routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
                 sparse_kv_cache_format=sparse_kv_cache_format,
                 overlap_shared_expert_with_dispatch=overlap_shared_expert_with_dispatch,
+                first_layer_idx=first_layer_idx,
             )
             self.layers.append(layer)
 

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -370,6 +370,22 @@ def create_kv_chunk_address_table_ds(
     return lookup_table
 
 
+def merged_num_layers(stage_layout):
+    """Layers a merged (all-stage) table config spans: the sum of every stage's owned count. Also
+    enforces tt-blaze's missing-layer guard -- the stages must tile ``[0, total)`` with no gaps or
+    overlaps, which compute_layer_split's contiguous partition satisfies."""
+    total = sum(s["count"] for s in stage_layout)
+    expected = 0
+    for s in sorted(stage_layout, key=lambda s: s["first_layer"]):
+        if s["first_layer"] != expected:
+            raise RuntimeError(
+                f"gathered layer ranges are not contiguous: expected next stage at layer {expected} but got "
+                f"first_layer={s['first_layer']} (stages={[(x['first_layer'], x['count']) for x in stage_layout]})"
+            )
+        expected += s["count"]
+    return total
+
+
 def create_kv_chunk_address_table_kimi(
     config,
     mesh_device,
@@ -424,20 +440,8 @@ def create_kv_chunk_address_table_kimi(
         kvpe_cache.shape[0] == num_users * num_my_layers
     ), f"cache batch dim {kvpe_cache.shape[0]} != num_users({num_users}) * num_my_layers({num_my_layers})"
 
-    # Stages must tile [0, effective_num_layers) contiguously, no gaps/overlaps (tt-blaze's
-    # missing-layer guard). compute_layer_split produces a contiguous partition, so this should hold.
-    effective_num_layers = sum(s["count"] for s in stage_layout)
-    expected = 0
-    for s in sorted(stage_layout, key=lambda s: s["first_layer"]):
-        if s["first_layer"] != expected:
-            raise RuntimeError(
-                f"gathered layer ranges are not contiguous: expected next stage at layer {expected} but got "
-                f"first_layer={s['first_layer']} (stages={[(x['first_layer'], x['count']) for x in stage_layout]})"
-            )
-        expected += s["count"]
-
     # The merged table spans ALL layers (not just this rank's), so size the table to the global total.
-    config.num_layers = effective_num_layers
+    config.num_layers = merged_num_layers(stage_layout)
     lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
     return populate_kv_chunk_address_table_kimi(
         lookup_table=lookup_table,

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -722,9 +722,6 @@
   cmd: |
     set -euo pipefail
     export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
-    # TT_METAL_HOME on the GH runner pod holds build artifacts only -- source reaches the galaxy workers
-    # via mpirun but never this pod, while ttrun.py, the MGD and the launcher below resolve against source
-    # here, so overlay the pod-local /ci checkout without clobbering the build.
     if [ ! -f "${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py" ]; then
       cp -rn /ci/tt-metal/. "${TT_METAL_HOME}/"
     fi
@@ -746,13 +743,10 @@
 # its 21 `full` layers), and the pipeline split is layer-aware (18/20/20/20, snapped to `full` starts).
 # Both caches are PCC'd: the producer gates on min(config 0, config 1), so this is the only leg that
 # covers the merged multi-cache KV chunk table and the per-stage index-cache numbering.
-- name: "GLM-5.2-744B disaggregated prefill runner/producer KV accuracy 20k@5k (SC4)"
+- name: "GLM-5.2-744B disaggregated prefill runner/producer KV accuracy 55k@5k (SC4)"
   cmd: |
     set -euo pipefail
     export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
-    # TT_METAL_HOME on the GH runner pod holds build artifacts only -- source reaches the galaxy workers
-    # via mpirun but never this pod, while ttrun.py, the MGD and the launcher below resolve against source
-    # here, so overlay the pod-local /ci checkout without clobbering the build.
     if [ ! -f "${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py" ]; then
       cp -rn /ci/tt-metal/. "${TT_METAL_HOME}/"
     fi
@@ -762,9 +756,9 @@
   test_group: module
   skus:
     bh_sc4:
-      # Measured 4-galaxy run ~8 min end to end (5.5 min weight load from the warm 8x4 cache, 45 s for
-      # the 4-chunk request plus both-cache PCC readback); headroom for the 120 s producer connect and
-      # NFS variance. Counts against the shield/demo budget together with the Kimi entry.
+      # 5.5 min weight load from the warm 8x4 cache, then a full-depth 11-chunk request over 78 layers
+      # plus both-cache UMD readback; headroom for the 120 s producer connect and NFS variance. Counts
+      # against the shield/demo budget together with the Kimi entry.
       timeout: 20
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -729,7 +729,7 @@
       cp -rn /ci/tt-metal/. "${TT_METAL_HOME}/"
     fi
     cd "${TT_METAL_HOME}"
-    exec bash models/demos/common/prefill/runners/ci/run_multirank_kv_pcc.sh kimi27
+    exec bash models/demos/common/prefill/runners/ci/run_multirank_pcc.sh kimi27
   test_type: prefill_runner_kv_pcc
   test_group: module
   skus:
@@ -757,7 +757,7 @@
       cp -rn /ci/tt-metal/. "${TT_METAL_HOME}/"
     fi
     cd "${TT_METAL_HOME}"
-    exec bash models/demos/common/prefill/runners/ci/run_multirank_kv_pcc.sh glm52
+    exec bash models/demos/common/prefill/runners/ci/run_multirank_pcc.sh glm52
   test_type: prefill_runner_kv_pcc
   test_group: module
   skus:

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -722,155 +722,14 @@
   cmd: |
     set -euo pipefail
     export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
-    # This launcher runs on the GH runner pod, whose TT_METAL_HOME holds build
-    # artifacts only -- full source reaches the galaxy workers via `mpirun --pernode`
-    # but never this pod. ttrun.py and the MGD resolve against source here, so
-    # overlay it from the pod-local /ci checkout without clobbering the build.
+    # TT_METAL_HOME on the GH runner pod holds build artifacts only -- source reaches the galaxy workers
+    # via mpirun but never this pod, while ttrun.py, the MGD and the launcher below resolve against source
+    # here, so overlay the pod-local /ci checkout without clobbering the build.
     if [ ! -f "${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py" ]; then
       cp -rn /ci/tt-metal/. "${TT_METAL_HOME}/"
     fi
     cd "${TT_METAL_HOME}"
-    export PYTHONPATH="${TT_METAL_HOME}"
-    : "${PREFILL_SUMMARIES:?PREFILL_SUMMARIES must be set by the blaze impl (shared /ci scratch for the KV table)}"
-    export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/prefill_runner_kv}"
-    mkdir -p "${PIPELINE_DIR}"
-    TTRUN_DIR=/etc/ttop
-    TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
-    MGD="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto"
-    # The runner goes through tt-run automapper, which discovers rank->mesh placement
-    # from the MGD and takes the plain comma-separated host list. The producer (raw
-    # mpirun) needs a slotted host list in the SAME rank order tt-run's discovery chose
-    # (parsed from the generated rankfile below) so its master co-locates with runner
-    # rank 0 -- the H2D stream service is host-local /dev/shm IPC.
-    RESOLVED_HOSTS=$(awk 'NF {printf "%s,", $1}' "${TTRUN_DIR}/hostfile" | sed 's/,$//')
-    # tt-run Phase 1 (generate_rank_bindings) writes generated/ttrun/ under the
-    # launch cwd; keep it on shared NFS so the runner pod can read rank-0 outputs.
-    TTRUN_CWD="${PIPELINE_DIR}/ttrun-cwd"
-    mkdir -p "${TTRUN_CWD}"
-
-    MR_DIR=$(mktemp -d "${PIPELINE_DIR}/prefill_ci_mr.XXXXXX")
-    export TABLE_PATH="${MR_DIR}/kv_chunk_table.pb"
-    # Each producer rank drops its PCC verdict here before the shutdown sentinel; mpirun drops buffered
-    # stdout when the runner tears down, so this file is the only durable record of the measured PCC.
-    PCC_DIR="${MR_DIR}/kv_pcc_verdict"
-    # Per-rank stdout/stderr files (mpirun --output-filename). These survive the teardown
-    # race that truncates forwarded stdout, so their tails are the authoritative debug log.
-    RANKLOGS="${MR_DIR}/ranklogs"
-
-    # The runner idles owning the 4-galaxy allocation until the producer's shutdown
-    # sentinel; on any early exit (table-publish timeout, producer failure) it must be
-    # reaped or it strands the hardware until the step timeout. Killing ttrun.py tears
-    # down the remote ranks with it.
-    cleanup() {
-      if [ -n "${RUNNER_PID:-}" ] && kill -0 "${RUNNER_PID}" 2>/dev/null; then
-        kill "${RUNNER_PID}" 2>/dev/null || true
-        wait "${RUNNER_PID}" 2>/dev/null || true
-      fi
-      # Dump diagnostics before rm: on every exit path (success, producer failure, table
-      # timeout, step-timeout kill) the live mpirun stdout may be truncated at teardown, so
-      # the durable verdict JSON and per-rank ranklog tails are the authoritative record.
-      echo "==================== KV PCC verdicts (PROD_RC=${PROD_RC:-<unset>}) ===================="
-      for f in "${PCC_DIR}"/rank*.json; do
-        [ -e "$f" ] || { echo "no PCC verdict files under ${PCC_DIR}"; break; }
-        echo "$(basename "$f"): $(cat "$f")"
-      done
-      if [ -d "${RANKLOGS}" ]; then
-        echo "==================== ranklog tails ===================="
-        find "${RANKLOGS}" -type f | sort | while read -r f; do
-          echo "---- ${f#"${RANKLOGS}"/} ----"
-          tail -n 40 "$f" 2>/dev/null || true
-        done
-      fi
-      rm -rf "${MR_DIR}"
-    }
-    trap cleanup EXIT
-
-    # tt-run automapper: --mesh-graph-descriptor + --hosts generate the rank
-    # binding by discovery, so no static binding is committed. tt-run forwards only
-    # the device vars it owns (TT_MESH_*) plus its ENV_PASSTHROUGH_PREFIXES; PREFILL_*
-    # fall outside that set, so -- exactly as the producer launch below does --
-    # export them inside a per-rank bash -lc rather than relying on tt-run to carry
-    # them. Launch from TTRUN_CWD so Phase 1 caches on shared NFS; RUNNER_PID stays
-    # ttrun.py's pid so cleanup()'s kill still tears the remote ranks down.
-    cd "${TTRUN_CWD}"
-    python3 "${TTRUN_PY}" \
-      --skip-executable-check \
-      --force-rediscovery \
-      --tcp-interface ens5f0np0 \
-      --mesh-graph-descriptor "${MGD}" \
-      --hosts "${RESOLVED_HOSTS}" \
-      --mpi-args "--bind-to none --tag-output --allow-run-as-root --wdir ${TT_METAL_HOME} --output-filename ${RANKLOGS}/runner -x PATH -x LD_LIBRARY_PATH" \
-      bash -lc "cd '${TT_METAL_HOME}'; \
-        export PYTHONPATH='${TT_METAL_HOME}'; \
-        export PYTHONUNBUFFERED=1; \
-        export PREFILL_MANIFEST='${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests/kimi27.json'; \
-        export MESH_DEVICE=TG; \
-        export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized; \
-        export PREFILL_FABRIC_MODE=2d; \
-        export PREFILL_MAX_SEQ_LEN=56320; \
-        export PREFILL_ENABLE_MIGRATION=1; \
-        export PREFILL_MOCK_MIGRATION=1; \
-        export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
-        export LOGURU_LEVEL=INFO; \
-        exec python3 -m models.demos.common.prefill.runners.prefill_runner" &
-    RUNNER_PID=$!
-    cd "${TT_METAL_HOME}"
-
-    for i in $(seq 1 360); do
-      [ -f "${TABLE_PATH}" ] && break
-      kill -0 "${RUNNER_PID}" 2>/dev/null || { echo "runner exited before publishing the KV table"; wait "${RUNNER_PID}"; exit 1; }
-      sleep 5
-    done
-    [ -f "${TABLE_PATH}" ] || { echo "KV table not published within timeout"; exit 1; }
-
-    # tt-run discovery -- not hostfile order -- decides which host runs runner rank i.
-    # The H2D stream service is host-local IPC (a /dev/shm descriptor written by runner
-    # rank 0), so the producer's master (rank 0) must land on that same host. Derive the
-    # producer host order from the generated rankfile (--force-rediscovery guarantees it
-    # was written fresh this run) so producer rank i co-locates with runner rank i. Using
-    # raw hostfile order races discovery and intermittently strands the master on the
-    # wrong host -- H2DStreamService.connect then times out and TT_THROWs.
-    RANKFILE=$(ls -t "${TTRUN_CWD}"/generated/ttrun/*/rankfile 2>/dev/null | head -1)
-    [ -f "${RANKFILE}" ] || { echo "tt-run rankfile not found under ${TTRUN_CWD}/generated/ttrun/*/rankfile"; exit 1; }
-    # rankfile lines are "rank N=hostname slots=X"; emit "N hostname", sort by rank, join as host:1.
-    HOSTS=$(awk '/^rank[[:space:]]+[0-9]+=/ {n=$2; sub(/=.*/,"",n); h=$2; sub(/^[0-9]+=/,"",h); print n" "h}' "${RANKFILE}" | sort -n | awk '{printf "%s%s:1", (NR>1?",":""), $2}')
-    [ -n "${HOSTS}" ] || { echo "failed to parse producer host order from ${RANKFILE}"; exit 1; }
-    echo "producer host order from tt-run discovery: ${HOSTS}"
-
-    MPIRUN=$(command -v mpirun-ulfm || command -v mpirun)
-    set +e
-    "${MPIRUN}" \
-      --host "${HOSTS}" --map-by slot --bind-to none --tag-output --allow-run-as-root \
-      --output-filename "${RANKLOGS}/producer" \
-      --mca btl self,tcp --mca btl_tcp_if_include ens5f0np0 \
-      bash -lc "cd '${TT_METAL_HOME}'; \
-        export PYTHONPATH='${TT_METAL_HOME}'; \
-        export PYTHONUNBUFFERED=1; \
-        export PREFILL_MANIFEST='${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests/kimi27.json'; \
-        export MESH_DEVICE=TG; \
-        export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized; \
-        export PREFILL_MAX_SEQ_LEN=56320; \
-        export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
-        export PREFILL_PCC_SUMMARY_DIR='${PCC_DIR}'; \
-        export PREFILL_PRODUCER_CHECK_PCC=1; \
-        export PREFILL_SEND_SHUTDOWN=1; \
-        export PREFILL_STANDALONE_CHUNKED_PCC=0.85; \
-        export PREFILL_H2D_CONNECT_TIMEOUT=120; \
-        export LOGURU_LEVEL=INFO; \
-        exec python3 -m models.demos.common.prefill.runners.prefill_producer"
-    PROD_RC=$?
-    set -e
-
-    # The cleanup() EXIT trap dumps the durable PCC verdicts and ranklog tails on every
-    # exit path, so no inline diagnostics are needed here.
-
-    # On success the producer already sent the shutdown sentinel; wait for the runner
-    # to finish teardown so a hung shutdown surfaces here instead of being orphaned.
-    if [ "${PROD_RC}" -eq 0 ]; then
-      wait "${RUNNER_PID}" || echo "runner exited non-zero after producer success (rc=$?)"
-    fi
-
-    exit ${PROD_RC}
+    exec bash models/demos/common/prefill/runners/ci/run_multirank_kv_pcc.sh kimi27
   test_type: prefill_runner_kv_pcc
   test_group: module
   skus:
@@ -882,8 +741,8 @@
   team: shield
   sp_config: sc4
 
-# 4-galaxy (SC4) disaggregated prefill for GLM-5.2: same launcher shape as the Kimi-K2.7 entry above,
-# but GLM-5.2 owns TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over
+# 4-galaxy (SC4) disaggregated prefill for GLM-5.2: the same launcher script as the Kimi-K2.7 entry above
+# under a different model key, but GLM-5.2 owns TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over
 # its 21 `full` layers), and the pipeline split is layer-aware (18/20/20/20, snapped to `full` starts).
 # Both caches are PCC'd: the producer gates on min(config 0, config 1), so this is the only leg that
 # covers the merged multi-cache KV chunk table and the per-stage index-cache numbering.
@@ -891,136 +750,14 @@
   cmd: |
     set -euo pipefail
     export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
-    # The GH runner pod's TT_METAL_HOME holds build artifacts only -- full source reaches the galaxy
-    # workers via mpirun but never this pod, and ttrun.py plus the MGD resolve against source here.
+    # TT_METAL_HOME on the GH runner pod holds build artifacts only -- source reaches the galaxy workers
+    # via mpirun but never this pod, while ttrun.py, the MGD and the launcher below resolve against source
+    # here, so overlay the pod-local /ci checkout without clobbering the build.
     if [ ! -f "${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py" ]; then
       cp -rn /ci/tt-metal/. "${TT_METAL_HOME}/"
     fi
     cd "${TT_METAL_HOME}"
-    export PYTHONPATH="${TT_METAL_HOME}"
-    : "${PREFILL_SUMMARIES:?PREFILL_SUMMARIES must be set by the blaze impl (shared /ci scratch for the KV table)}"
-    export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/glm52_prefill_runner_kv}"
-    mkdir -p "${PIPELINE_DIR}"
-    TTRUN_DIR=/etc/ttop
-    TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
-    # LINE/LINE variant: GLM-5.2's MoE all_to_all deadlocks in warmup under the torus fabric modes on
-    # multi-galaxy pipeline prefill, so the descriptor declares no wrap and the fabric mode stays 2d.
-    MGD="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto"
-    # tt-run automapper discovers rank->mesh placement from the MGD and takes a plain host list; the
-    # producer (raw mpirun) needs a slotted list in the SAME rank order discovery chose, parsed from the
-    # generated rankfile below, so its master co-locates with runner rank 0 (H2D is host-local /dev/shm).
-    RESOLVED_HOSTS=$(awk 'NF {printf "%s,", $1}' "${TTRUN_DIR}/hostfile" | sed 's/,$//')
-    # tt-run Phase 1 writes generated/ttrun/ under the launch cwd; keep it on shared NFS so the runner
-    # pod can read rank-0 outputs.
-    TTRUN_CWD="${PIPELINE_DIR}/ttrun-cwd"
-    mkdir -p "${TTRUN_CWD}"
-
-    MR_DIR=$(mktemp -d "${PIPELINE_DIR}/glm52_prefill_ci_mr.XXXXXX")
-    export TABLE_PATH="${MR_DIR}/kv_chunk_table.pb"
-    # mpirun drops buffered stdout when the runner tears down, so the per-rank verdict files and the
-    # --output-filename ranklogs are the only durable record of the measured PCC.
-    PCC_DIR="${MR_DIR}/kv_pcc_verdict"
-    RANKLOGS="${MR_DIR}/ranklogs"
-
-    # The runner idles owning the 4-galaxy allocation until the producer's shutdown sentinel; on any
-    # early exit it must be reaped or it strands the hardware until the step timeout. Killing ttrun.py
-    # tears down the remote ranks with it.
-    cleanup() {
-      if [ -n "${RUNNER_PID:-}" ] && kill -0 "${RUNNER_PID}" 2>/dev/null; then
-        kill "${RUNNER_PID}" 2>/dev/null || true
-        wait "${RUNNER_PID}" 2>/dev/null || true
-      fi
-      echo "==================== KV PCC verdicts (PROD_RC=${PROD_RC:-<unset>}) ===================="
-      for f in "${PCC_DIR}"/rank*.json; do
-        [ -e "$f" ] || { echo "no PCC verdict files under ${PCC_DIR}"; break; }
-        echo "$(basename "$f"): $(cat "$f")"
-      done
-      if [ -d "${RANKLOGS}" ]; then
-        echo "==================== ranklog tails ===================="
-        find "${RANKLOGS}" -type f | sort | while read -r f; do
-          echo "---- ${f#"${RANKLOGS}"/} ----"
-          tail -n 40 "$f" 2>/dev/null || true
-        done
-      fi
-      rm -rf "${MR_DIR}"
-    }
-    trap cleanup EXIT
-
-    # tt-run forwards only the device vars it owns plus its ENV_PASSTHROUGH_PREFIXES; PREFILL_* fall
-    # outside that set, so export them inside a per-rank bash -lc as the producer launch does.
-    # RUNNER_PID stays ttrun.py's pid so cleanup()'s kill still tears the remote ranks down.
-    cd "${TTRUN_CWD}"
-    python3 "${TTRUN_PY}" \
-      --skip-executable-check \
-      --force-rediscovery \
-      --tcp-interface ens5f0np0 \
-      --mesh-graph-descriptor "${MGD}" \
-      --hosts "${RESOLVED_HOSTS}" \
-      --mpi-args "--bind-to none --tag-output --allow-run-as-root --wdir ${TT_METAL_HOME} --output-filename ${RANKLOGS}/runner -x PATH -x LD_LIBRARY_PATH" \
-      bash -lc "cd '${TT_METAL_HOME}'; \
-        export PYTHONPATH='${TT_METAL_HOME}'; \
-        export PYTHONUNBUFFERED=1; \
-        export PREFILL_MANIFEST='${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm52.json'; \
-        export MESH_DEVICE=TG; \
-        export PREFILL_FABRIC_MODE=2d; \
-        export PREFILL_MAX_SEQ_LEN=56320; \
-        export PREFILL_ENABLE_MIGRATION=1; \
-        export PREFILL_MOCK_MIGRATION=1; \
-        export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
-        export LOGURU_LEVEL=INFO; \
-        exec python3 -m models.demos.common.prefill.runners.prefill_runner" &
-    RUNNER_PID=$!
-    cd "${TT_METAL_HOME}"
-
-    for i in $(seq 1 360); do
-      [ -f "${TABLE_PATH}" ] && break
-      kill -0 "${RUNNER_PID}" 2>/dev/null || { echo "runner exited before publishing the KV table"; wait "${RUNNER_PID}"; exit 1; }
-      sleep 5
-    done
-    [ -f "${TABLE_PATH}" ] || { echo "KV table not published within timeout"; exit 1; }
-
-    # Producer rank i must land on the host running runner rank i (host-local /dev/shm H2D descriptor),
-    # and tt-run discovery -- not hostfile order -- decides that mapping, so derive the host order from
-    # the rankfile --force-rediscovery just wrote.
-    RANKFILE=$(ls -t "${TTRUN_CWD}"/generated/ttrun/*/rankfile 2>/dev/null | head -1)
-    [ -f "${RANKFILE}" ] || { echo "tt-run rankfile not found under ${TTRUN_CWD}/generated/ttrun/*/rankfile"; exit 1; }
-    HOSTS=$(awk '/^rank[[:space:]]+[0-9]+=/ {n=$2; sub(/=.*/,"",n); h=$2; sub(/^[0-9]+=/,"",h); print n" "h}' "${RANKFILE}" | sort -n | awk '{printf "%s%s:1", (NR>1?",":""), $2}')
-    [ -n "${HOSTS}" ] || { echo "failed to parse producer host order from ${RANKFILE}"; exit 1; }
-    echo "producer host order from tt-run discovery: ${HOSTS}"
-
-    MPIRUN=$(command -v mpirun-ulfm || command -v mpirun)
-    set +e
-    "${MPIRUN}" \
-      --host "${HOSTS}" --map-by slot --bind-to none --tag-output --allow-run-as-root \
-      --output-filename "${RANKLOGS}/producer" \
-      --mca btl self,tcp --mca btl_tcp_if_include ens5f0np0 \
-      bash -lc "cd '${TT_METAL_HOME}'; \
-        export PYTHONPATH='${TT_METAL_HOME}'; \
-        export PYTHONUNBUFFERED=1; \
-        export MESH_DEVICE=TG; \
-        export PREFILL_MODEL=glm_5_2; \
-        export PREFILL_NUM_LAYERS=78; \
-        export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k; \
-        export PREFILL_MAX_SEQ_LEN=56320; \
-        export PREFILL_PRODUCER_CHUNKS=4,4; \
-        export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
-        export PREFILL_PCC_SUMMARY_DIR='${PCC_DIR}'; \
-        export PREFILL_PRODUCER_CHECK_PCC=1; \
-        export PREFILL_SEND_SHUTDOWN=1; \
-        export PREFILL_STANDALONE_CHUNKED_PCC=0.85; \
-        export PREFILL_H2D_CONNECT_TIMEOUT=120; \
-        export LOGURU_LEVEL=INFO; \
-        exec python3 -m models.demos.common.prefill.runners.prefill_producer"
-    PROD_RC=$?
-    set -e
-
-    # On success the producer already sent the shutdown sentinel; wait for the runner so a hung
-    # shutdown surfaces here instead of being orphaned.
-    if [ "${PROD_RC}" -eq 0 ]; then
-      wait "${RUNNER_PID}" || echo "runner exited non-zero after producer success (rc=$?)"
-    fi
-
-    exit ${PROD_RC}
+    exec bash models/demos/common/prefill/runners/ci/run_multirank_kv_pcc.sh glm52
   test_type: prefill_runner_kv_pcc
   test_group: module
   skus:

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -882,6 +882,157 @@
   team: shield
   sp_config: sc4
 
+# 4-galaxy (SC4) disaggregated prefill for GLM-5.2: same launcher shape as the Kimi-K2.7 entry above,
+# but GLM-5.2 owns TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over
+# its 21 `full` layers), and the pipeline split is layer-aware (18/20/20/20, snapped to `full` starts).
+# Both caches are PCC'd: the producer gates on min(config 0, config 1), so this is the only leg that
+# covers the merged multi-cache KV chunk table and the per-stage index-cache numbering.
+- name: "GLM-5.2-744B disaggregated prefill runner/producer KV accuracy 20k@5k (SC4)"
+  cmd: |
+    set -euo pipefail
+    export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
+    # The GH runner pod's TT_METAL_HOME holds build artifacts only -- full source reaches the galaxy
+    # workers via mpirun but never this pod, and ttrun.py plus the MGD resolve against source here.
+    if [ ! -f "${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py" ]; then
+      cp -rn /ci/tt-metal/. "${TT_METAL_HOME}/"
+    fi
+    cd "${TT_METAL_HOME}"
+    export PYTHONPATH="${TT_METAL_HOME}"
+    : "${PREFILL_SUMMARIES:?PREFILL_SUMMARIES must be set by the blaze impl (shared /ci scratch for the KV table)}"
+    export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/glm52_prefill_runner_kv}"
+    mkdir -p "${PIPELINE_DIR}"
+    TTRUN_DIR=/etc/ttop
+    TTRUN_PY="${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py"
+    # LINE/LINE variant: GLM-5.2's MoE all_to_all deadlocks in warmup under the torus fabric modes on
+    # multi-galaxy pipeline prefill, so the descriptor declares no wrap and the fabric mode stays 2d.
+    MGD="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto"
+    # tt-run automapper discovers rank->mesh placement from the MGD and takes a plain host list; the
+    # producer (raw mpirun) needs a slotted list in the SAME rank order discovery chose, parsed from the
+    # generated rankfile below, so its master co-locates with runner rank 0 (H2D is host-local /dev/shm).
+    RESOLVED_HOSTS=$(awk 'NF {printf "%s,", $1}' "${TTRUN_DIR}/hostfile" | sed 's/,$//')
+    # tt-run Phase 1 writes generated/ttrun/ under the launch cwd; keep it on shared NFS so the runner
+    # pod can read rank-0 outputs.
+    TTRUN_CWD="${PIPELINE_DIR}/ttrun-cwd"
+    mkdir -p "${TTRUN_CWD}"
+
+    MR_DIR=$(mktemp -d "${PIPELINE_DIR}/glm52_prefill_ci_mr.XXXXXX")
+    export TABLE_PATH="${MR_DIR}/kv_chunk_table.pb"
+    # mpirun drops buffered stdout when the runner tears down, so the per-rank verdict files and the
+    # --output-filename ranklogs are the only durable record of the measured PCC.
+    PCC_DIR="${MR_DIR}/kv_pcc_verdict"
+    RANKLOGS="${MR_DIR}/ranklogs"
+
+    # The runner idles owning the 4-galaxy allocation until the producer's shutdown sentinel; on any
+    # early exit it must be reaped or it strands the hardware until the step timeout. Killing ttrun.py
+    # tears down the remote ranks with it.
+    cleanup() {
+      if [ -n "${RUNNER_PID:-}" ] && kill -0 "${RUNNER_PID}" 2>/dev/null; then
+        kill "${RUNNER_PID}" 2>/dev/null || true
+        wait "${RUNNER_PID}" 2>/dev/null || true
+      fi
+      echo "==================== KV PCC verdicts (PROD_RC=${PROD_RC:-<unset>}) ===================="
+      for f in "${PCC_DIR}"/rank*.json; do
+        [ -e "$f" ] || { echo "no PCC verdict files under ${PCC_DIR}"; break; }
+        echo "$(basename "$f"): $(cat "$f")"
+      done
+      if [ -d "${RANKLOGS}" ]; then
+        echo "==================== ranklog tails ===================="
+        find "${RANKLOGS}" -type f | sort | while read -r f; do
+          echo "---- ${f#"${RANKLOGS}"/} ----"
+          tail -n 40 "$f" 2>/dev/null || true
+        done
+      fi
+      rm -rf "${MR_DIR}"
+    }
+    trap cleanup EXIT
+
+    # tt-run forwards only the device vars it owns plus its ENV_PASSTHROUGH_PREFIXES; PREFILL_* fall
+    # outside that set, so export them inside a per-rank bash -lc as the producer launch does.
+    # RUNNER_PID stays ttrun.py's pid so cleanup()'s kill still tears the remote ranks down.
+    cd "${TTRUN_CWD}"
+    python3 "${TTRUN_PY}" \
+      --skip-executable-check \
+      --force-rediscovery \
+      --tcp-interface ens5f0np0 \
+      --mesh-graph-descriptor "${MGD}" \
+      --hosts "${RESOLVED_HOSTS}" \
+      --mpi-args "--bind-to none --tag-output --allow-run-as-root --wdir ${TT_METAL_HOME} --output-filename ${RANKLOGS}/runner -x PATH -x LD_LIBRARY_PATH" \
+      bash -lc "cd '${TT_METAL_HOME}'; \
+        export PYTHONPATH='${TT_METAL_HOME}'; \
+        export PYTHONUNBUFFERED=1; \
+        export PREFILL_MANIFEST='${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm52.json'; \
+        export MESH_DEVICE=TG; \
+        export PREFILL_FABRIC_MODE=2d; \
+        export PREFILL_MAX_SEQ_LEN=56320; \
+        export PREFILL_ENABLE_MIGRATION=1; \
+        export PREFILL_MOCK_MIGRATION=1; \
+        export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
+        export LOGURU_LEVEL=INFO; \
+        exec python3 -m models.demos.common.prefill.runners.prefill_runner" &
+    RUNNER_PID=$!
+    cd "${TT_METAL_HOME}"
+
+    for i in $(seq 1 360); do
+      [ -f "${TABLE_PATH}" ] && break
+      kill -0 "${RUNNER_PID}" 2>/dev/null || { echo "runner exited before publishing the KV table"; wait "${RUNNER_PID}"; exit 1; }
+      sleep 5
+    done
+    [ -f "${TABLE_PATH}" ] || { echo "KV table not published within timeout"; exit 1; }
+
+    # Producer rank i must land on the host running runner rank i (host-local /dev/shm H2D descriptor),
+    # and tt-run discovery -- not hostfile order -- decides that mapping, so derive the host order from
+    # the rankfile --force-rediscovery just wrote.
+    RANKFILE=$(ls -t "${TTRUN_CWD}"/generated/ttrun/*/rankfile 2>/dev/null | head -1)
+    [ -f "${RANKFILE}" ] || { echo "tt-run rankfile not found under ${TTRUN_CWD}/generated/ttrun/*/rankfile"; exit 1; }
+    HOSTS=$(awk '/^rank[[:space:]]+[0-9]+=/ {n=$2; sub(/=.*/,"",n); h=$2; sub(/^[0-9]+=/,"",h); print n" "h}' "${RANKFILE}" | sort -n | awk '{printf "%s%s:1", (NR>1?",":""), $2}')
+    [ -n "${HOSTS}" ] || { echo "failed to parse producer host order from ${RANKFILE}"; exit 1; }
+    echo "producer host order from tt-run discovery: ${HOSTS}"
+
+    MPIRUN=$(command -v mpirun-ulfm || command -v mpirun)
+    set +e
+    "${MPIRUN}" \
+      --host "${HOSTS}" --map-by slot --bind-to none --tag-output --allow-run-as-root \
+      --output-filename "${RANKLOGS}/producer" \
+      --mca btl self,tcp --mca btl_tcp_if_include ens5f0np0 \
+      bash -lc "cd '${TT_METAL_HOME}'; \
+        export PYTHONPATH='${TT_METAL_HOME}'; \
+        export PYTHONUNBUFFERED=1; \
+        export MESH_DEVICE=TG; \
+        export PREFILL_MODEL=glm_5_2; \
+        export PREFILL_NUM_LAYERS=78; \
+        export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k; \
+        export PREFILL_MAX_SEQ_LEN=56320; \
+        export PREFILL_PRODUCER_CHUNKS=4,4; \
+        export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
+        export PREFILL_PCC_SUMMARY_DIR='${PCC_DIR}'; \
+        export PREFILL_PRODUCER_CHECK_PCC=1; \
+        export PREFILL_SEND_SHUTDOWN=1; \
+        export PREFILL_STANDALONE_CHUNKED_PCC=0.85; \
+        export PREFILL_H2D_CONNECT_TIMEOUT=120; \
+        export LOGURU_LEVEL=INFO; \
+        exec python3 -m models.demos.common.prefill.runners.prefill_producer"
+    PROD_RC=$?
+    set -e
+
+    # On success the producer already sent the shutdown sentinel; wait for the runner so a hung
+    # shutdown surfaces here instead of being orphaned.
+    if [ "${PROD_RC}" -eq 0 ]; then
+      wait "${RUNNER_PID}" || echo "runner exited non-zero after producer success (rc=$?)"
+    fi
+
+    exit ${PROD_RC}
+  test_type: prefill_runner_kv_pcc
+  test_group: module
+  skus:
+    bh_sc4:
+      # Measured 4-galaxy run ~8 min end to end (5.5 min weight load from the warm 8x4 cache, 45 s for
+      # the 4-chunk request plus both-cache PCC readback); headroom for the 120 s producer connect and
+      # NFS variance. Counts against the shield/demo budget together with the Kimi entry.
+      timeout: 20
+  owner_id: U0AC4LTJH1P # Jaksa Jovicic
+  team: shield
+  sp_config: sc4
+
 # MiniMax-M3 full-model real-weights prefill + per-layer KV PCC (standalone harness, not pytest).
 # Requires staged mounts (same layout as models/demos/minimax_m3/scripts/README_golden_kv.md):
 #   HF_MODEL          -> /mnt/models/MiniMaxAI/MiniMax-M3-ref/


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
GLM-5.2 prefill owns **two** device KV caches: config 0 is the MLA KVPE cache (78 layers) and config 1
is the lightning-indexer key cache, which holds one slot per `full` indexer layer (21 of the 78).

Migration assumed one cache per rank whose tensor holds exactly the layers that rank owns. That was
true of config 0 and false of config 1: `TtIndexer` numbered itself in the model-global compacted
full-indexer space and every rank allocated all 21 slots, so under pipeline parallelism the merged KV
chunk address table addressed the indexer cache with the KVPE cache's layer geometry and the migrated
indexer keys were wrong on every rank but the first.

The fix makes the index cache rank-local, like the KVPE cache already is. `TtIndexer` takes
`first_layer_idx` — the stage's first global layer — and subtracts that stage's compacted base from
both its slot index and its folded slot stride, so a stage allocates and addresses only its OWN full
indexer layers, numbered from 0. `KvCacheStage` is then plain `(base_addr, first_layer, count)` for
both caches and the address walk needs no stride/offset special case. The runtime reports a *list* of
stages (`kv_migration_stages`), one per config, and each config's stage layout is all-gathered
separately — a layout carries one cache's DRAM base and one layer-index space, so one cannot describe
both.

Side effect: the index cache shrinks from 21 slots on every rank to `count` slots, ~4x less indexer
cache DRAM per rank at 4-way pipeline parallelism.

### Notes for reviewers
- `stage_layout` → `stage_layouts` is a type change, not a rename: the value is now one gathered
  layout **per cache**, in config order. `_table_config` matches a layout to its cache by DRAM base so
  a runtime returning its stages out of config order fails loudly instead of silently addressing one
  cache with the other's geometry.
- `ttMLA` gains a `first_layer_idx` it never reads; it exists only to reach `TtIndexer`. Threading it
  also fixes a latent bug: `_forward_kv_only` called `write_k()` with the caller's per-layer KVPE slot,
  which is not the index cache's slot on a compacted cache. Both entry points now go through
  `_cache_slot()`. Unreachable on the 78-layer config (layer 77 is `shared`) but live for any stack
  ending on a `full` layer.
- `layer_split_boundaries` already forces a rank to start on a `full` layer (it seeds that stage's
  indexer-reuse chain), which is what makes per-stage compaction well defined: 78 layers over 4 ranks
  snaps to 18/20/20/20, and the index stages tile 21 slots as 0/6, 6/5, 11/5, 16/5.
- No other model's files are touched. minimax_m3 and gpt_oss_d_p describe a single cache and keep
  main's singular `stage_layout=` call: the runner picks the kwarg from the same `kv_migration_stages`
  dispatch it already used. That is deliberate rather than cosmetic — M3's single-rank guard counts
  stages in that one layout, so handing it the outer per-cache list would count caches (always 1) and
  stop rejecting multi-rank migration. Follow-up moves both onto `kv_migration_stages` and deletes the
  `elif`.
- `test_glm52_index_cache_pipeline_stage_addresses` is host-only (~0.8s) and compares a merged 4-stage
  table against per-rank solo walks; its duplicate-key assert is the only detector for two stages
  claiming the same table entry.
- The new SC4 CI leg costs 20 min against `shield/demo/bh_sc4`, which is why `.github/time_budget.yaml`
  goes 15 → 35 (the Kimi-K2.7 SC4 leg already consumed all 15).
- That leg and the existing Kimi-K2.7 one were the same 130-line inline launcher twice, so both now call
  `models/demos/common/prefill/runners/ci/run_multirank_pcc.sh <model-key>`; the per-model deltas (MGD,
  manifest, producer env) are a `case` block and each yaml entry is 10 lines. The expansion was diffed
  against both previous inline launches before the collapse — same MGD, same env set, same order — and both
  legs re-run below to prove it on hardware rather than on inspection.
- The launcher's per-model env is trimmed to what is actually read: `PREFILL_MODEL`/`PREFILL_NUM_LAYERS`
  come from the manifest, `MESH_DEVICE` is read by nothing on this path (only `perf_utils._is_galaxy_env`,
  for pytest device-perf skips), and the producer's `PREFILL_HF_MODEL` is only reachable on the >1-config
  path. The Kimi producer was also exporting `PREFILL_MANIFEST`, which the producer never reads — it takes
  `PREFILL_PRODUCER_MANIFEST`/`--manifest` — so that leg was running on `DEFAULT_MODEL` and the 61-layer
  default, correct only by coincidence. Both legs now run the full 11-chunk (55k) depth: 11 is the producer
  default, so the GLM leg no longer pins itself to 4 chunks.
- The producer verdict now reports **per-cache** PCC (`per_cache` in the durable rank JSON, `kvpe_pcc=` /
  `index_pcc=` on the marker line) instead of only the folded `min(config 0, config 1)`. The folded number
  cannot show which cache set the bar, and it reads identically whether the index cache was checked or
  silently skipped for want of a golden. A cache that was NOT validated is absent from the breakdown rather
  than reported at 1.0 — which also removes MiniMax-M3's unmeasured `index_k` 1.0.

### Hardware validation

**Both SC4 CI legs pass on 4 Blackhole galaxies at the full 55k depth** — run
https://github.com/tenstorrent/tt-metal/actions/runs/32356450506 (`f929efc4f20`, `test-type=prefill_runner_kv_pcc`),
seq 56320 on both legs, gate 0.85, all eight per-rank verdicts `ok: true` and `PROD_RC=0`. Numbers below are
read from the durable per-rank verdict JSON, not inferred from the job status:

| leg | rank | kvpe | index | KVPE layers | index slots |
|---|---|---|---|---|---|
| GLM-5.2 | 0 | 0.976696 | 0.999521 | 18/78 | 6/21 |
| GLM-5.2 | 1 | 0.933677 | 0.997771 | 20/78 | 5/21 |
| GLM-5.2 | 2 | 0.878766 | 0.992160 | 20/78 | 5/21 |
| GLM-5.2 | 3 | 0.860911 | 0.984355 | 20/78 | 5/21 |
| Kimi-K2.7 | 0 | 0.985171 | — | 16/61 | — |
| Kimi-K2.7 | 1 | 0.939456 | — | 15/61 | — |
| Kimi-K2.7 | 2 | 0.912775 | — | 15/61 | — |
| Kimi-K2.7 | 3 | 0.880732 | — | 15/61 | — |

Coverage is complete on both axes for GLM-5.2: 78/78 KVPE layers and 21/21 indexer layers, the index slots
tiling 6/5/5/5 exactly as the 18/20/20/20 split predicts.

Kimi-K2.7 reproduces its pre-refactor SC4 numbers **exactly** (0.985171 / 0.939456 / 0.912775 / 0.880732),
which is the evidence that the shared launcher is behaviourally identical to the inline one it replaced —
hardware, not inspection. Its `per_cache` carries only `kvpe`: the dense path omits the index cache rather
than reporting an unmeasured 1.0.

Test-step durations 8m33s (GLM, 20 min cap) and 6m28s (Kimi, 15 min cap). `shield/bh_sc4` is saturated at
exactly 35/35 min, so a future timeout bump needs a budget bump.

#### Local 4-rank run behind the migration fix
Same 4 galaxies (`bh-glx-120-c04u02/c04u08/c05u08/c05u02`), FABRIC_2D, seq 20480, measured on `062bf64184c`:
kvpe 0.977546 / 0.933549 / 0.880732 / 0.863028, index 0.999545 / 0.997798 / 0.992209 / 0.983966. A 1-rank
control on the same commit reproduces every per-layer number — 78/78 KVPE lines and 21/21 index lines
identical, same index-slot → global-layer mapping. Config 0's droop below 0.93 on ranks 2-3 is therefore the
pre-existing `nope` depth droop, not migration: the 1-rank control trips the same gate.

### Manually dispatched CI (this branch)
Filtered to the jobs that actually import the changed files:

- Blaze Models Prefill tests (`test-type=prefill_runner_kv_pcc`, BOTH SC4 legs on the shared launcher,
  per-cache verdict, full 55k depth) — https://github.com/tenstorrent/tt-metal/actions/runs/32356450506
  — **the authoritative run, table above.** Supersedes 32354573736 (cancelled during build).
- Blaze Models Prefill tests (`test-type=kv_cache_table,prefill_runner,prefill_runner_kv_pcc,minimax_prefill_kv_pcc`) — https://github.com/tenstorrent/tt-metal/actions/runs/32349390699
- (Blackhole) e2e tests (`model=deepseek_prefill`) — https://github.com/tenstorrent/tt-metal/actions/runs/32349420531

Two annotations on the green run, neither a gate:

- `LayerCompletionRouter master: teardown timed out after 5000 ms` — 3 occurrences on the GLM leg and
  **zero** on the Kimi leg from the same commit and the same launcher, so it is GLM-specific rather than a
  generic router race. It lands after the verdict is written and gated; every step exits 0. An AI job
  summariser keys a red `TIMEOUT` badge off this line. Nothing in this diff touches the router or the D2H
  ack path — subordinate sentinels miss the 5000 ms window after the producer is already done. I am not
  bumping `teardown_timeout_ms` to hide it; the race deserves its own issue.
- `The artifact name is not valid: test-log-<leg name>` — the leg names contain `/` and `[]`, so test logs
  are never uploaded. Pre-existing and unrelated to this PR: the same annotations appear on run
  32349390699, and on both legs equally.

Earlier runs on the pre-squash tip are superseded. The one genuine failure they surfaced
(`allgather_kv_stage_layout()` called with the dict keys instead of the parameter names) is fixed;
`bh_qb_DeepSeek_PREFILL` → `test_ttnn_hca.py::test_hca_forward[flash-seq5120]` is known issue #53510
and unrelated to this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/glm52-pp-run)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/glm52-pp-run)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/glm52-pp-run)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/glm52-pp-run)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/glm52-pp-run)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/glm52-pp-run)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/glm52-pp-run)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/glm52-pp-run)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/glm52-pp-run)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/glm52-pp-run)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/glm52-pp-run)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/glm52-pp-run)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/glm52-pp-run)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/glm52-pp-run)






