### PR TITLE
[Bug fix] typecast: uint16 destination truncates like the other integer destinations

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
@@ -42,7 +42,8 @@ def _host_typecast_golden(torch_tensor, output_dtype):
     if output_dtype == ttnn.uint8:
         return torch.clamp(torch_tensor, 0, 255).to(torch.uint8)
     if output_dtype == ttnn.uint16:
-        # Host fp32→uint16 truncates; device float_to_uint16 rounds in float32 first.
+        # The host truncates on every architecture. The device now matches it on Blackhole and
+        # still rounds elsewhere, so this cannot fall through to the device golden.
         return torch.clamp(torch_tensor.to(torch.int32), min=0, max=65535)
     return eltwise_typecast(torch_tensor, tt_input_dtype=ttnn.float32, tt_output_dtype=output_dtype)
 

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
@@ -7,6 +7,7 @@ import math
 import ttnn
 import torch
 from tests.tt_eager.python_api_testing.sweep_tests.model_tests import TorchConvConv, TorchConvReluConv, BertFeedForward
+from tests.ttnn.python_api_testing.typecast_test_helpers import device_truncates_float_to_uint16
 import transformers
 from loguru import logger
 
@@ -224,8 +225,13 @@ def _simulate_bfp_quantization(x, man_bits):
 
 
 def _float_to_uint16_clamp(x):
-    # Device float_to_uint16 converts to float32 before std::round; match in float32.
-    return torch.clamp(torch.floor(x.float() + 0.5).to(torch.int32), min=0, max=65535)
+    # Truncation, matching every other float -> integer typecast destination and the host path,
+    # on the architectures whose uint16 kernel truncates. The rest still round to nearest with
+    # ties away from zero; see device_truncates_float_to_uint16.
+    values = x.float()
+    if not device_truncates_float_to_uint16():
+        values = torch.floor(values + 0.5)
+    return torch.clamp(values.to(torch.int32), min=0, max=65535)
 
 
 def eltwise_typecast(x, *args, tt_input_dtype, tt_output_dtype, **kwargs):

--- a/tests/ttnn/python_api_testing/typecast_test_helpers.py
+++ b/tests/ttnn/python_api_testing/typecast_test_helpers.py
@@ -40,6 +40,18 @@ _CLAMP_HIGH = _DTYPE_MAX[ttnn.uint16] + 14465
 _CLAMP_LOW_MAGNITUDE = 1000
 
 
+def device_truncates_float_to_uint16():
+    """Whether the device float -> uint16 typecast truncates toward zero, as every other
+    integer destination and the host path do.
+
+    uint16 is the only destination that hands the conversion to SFP_STOCH_RND rather than
+    building the integer by mantissa shift, and round to zero is a Blackhole mode, so uint16
+    still rounds to nearest with ties away from zero everywhere else. Deleting this predicate
+    and the two branches that use it is the last step of #51655.
+    """
+    return "blackhole" in ttnn.get_arch_name()
+
+
 def _output_allows_negative(tt_output_dtype):
     return tt_output_dtype == ttnn.int32
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -9,6 +9,7 @@ import ttnn
 from tests.ttnn.python_api_testing.sweep_tests.ttnn_pytorch_ops import eltwise_typecast
 from tests.ttnn.python_api_testing.typecast_test_helpers import (
     assert_integer_typecast_equal,
+    device_truncates_float_to_uint16,
     make_typecast_test_input,
     typecast_test_input_bounds,
     uses_exact_integer_typecast_check,
@@ -742,3 +743,69 @@ def test_typecast_uint8_to_bfloat16_exhaustive(shape, layout, memory_config, dev
         f"Mismatch: {(expected != result).sum().item()} / {expected.numel()} elements differ. "
         f"First bad value at index {(expected != result).nonzero()[0].tolist()}"
     )
+
+
+def _fractional_typecast_stimulus(signed, pt_input_dtype):
+    """Values whose fractional part tells truncation apart from any rounding mode.
+
+    Half-integers are the discriminator: truncation, round-to-nearest with ties away
+    from zero, and round-to-nearest-even all disagree on them. bfloat16 has 8 mantissa
+    bits, so quarter steps below 64 are exact and survive the trip to the device.
+    """
+    offsets = torch.tensor([0.25, 0.5, 0.75], dtype=torch.float32)
+    base = torch.arange(0, 63, dtype=torch.float32)
+    values = (base[:, None] + offsets[None, :]).flatten()
+    if signed:
+        values = torch.cat([values, -values])
+    repeats = (TILE_HEIGHT * TILE_WIDTH + values.numel() - 1) // values.numel()
+    values = values.repeat(repeats)[: TILE_HEIGHT * TILE_WIDTH]
+    return values.reshape(1, 1, TILE_HEIGHT, TILE_WIDTH).to(pt_input_dtype)
+
+
+@pytest.mark.parametrize(
+    "tt_output_dtype, signed",
+    [
+        (ttnn.uint8, False),
+        (ttnn.uint16, False),
+        (ttnn.uint32, False),
+        (ttnn.int32, True),
+    ],
+)
+@pytest.mark.parametrize(
+    "pt_input_dtype, tt_input_dtype",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+@pytest.mark.parametrize("memory_config", mem_configs)
+def test_typecast_rounding_fractional(tt_output_dtype, signed, pt_input_dtype, tt_input_dtype, memory_config, device):
+    """float -> integer typecast truncates toward zero, for every integer destination.
+
+    Truncation is what the host path (`static_cast`), torch, and the int32/uint32/uint8
+    kernels all do. What pins it here is the stimulus: deterministic quarter steps that
+    include exact half-integers, the values where truncation and both round-to-nearest
+    modes disagree. The uniform random stimuli used elsewhere in this file land on a
+    half-integer only by accident, and the LLK suite feeds whole numbers, where every
+    rounding mode agrees.
+
+    Both input dtypes matter: a float32 source sets `preserve_fp32_precision`, so it takes
+    the 32-bit Dest path of the uint16 kernel while a bfloat16 source takes the 16-bit one.
+    """
+    torch_input = _fractional_typecast_stimulus(signed, pt_input_dtype)
+    expected = torch.trunc(torch_input.float())
+    if tt_output_dtype == ttnn.uint16 and not device_truncates_float_to_uint16():
+        # Round to zero is a Blackhole mode, so uint16 still rounds elsewhere. The stimulus is
+        # non-negative for uint16, so round half up is the same as ties away from zero here.
+        expected = torch.floor(torch_input.float() + 0.5)
+
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        dtype=tt_input_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=memory_config,
+    )
+    result = ttnn.to_torch(ttnn.typecast(input_tensor, tt_output_dtype))
+
+    assert_integer_typecast_equal(expected, result)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -30,6 +30,14 @@ constexpr std::uint32_t SFPSTORE_MODE_SWAP_HI_LO16 = 9;
 // SFPGT mod1 selector that sets the destination to all-ones (-1) when the comparison is true.
 constexpr std::uint32_t SFPGT_MOD1_SET_ALL_ONES = 8;
 
+// SFP_STOCH_RND rounding mode. RND_ZERO truncates toward zero, which is what the mantissa-shift
+// destinations (int32, uint32, uint8), the host static_cast and torch all do; the default operand 0
+// is round to nearest with ties away from zero. Three FP32 inputs are a documented hardware
+// exception that RND_ZERO cannot fix: 0x3F7FFFFE, 0x3F7FFFFF and 0x3FFFFFFF still round away from
+// zero (tt-isa-documentation, BlackholeA0 SFPSTOCHRND_FloatInt.md). No bfloat16 or block-float input
+// can encode them, and round to nearest got them wrong as well.
+constexpr std::uint32_t SFPSTOCHRND_TRUNCATE = sfpi::SFPSTOCHRND_RND_ZERO;
+
 template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
 inline void calculate_typecast_fp32_to_uint16() {
 #ifdef DISABLE_SFPLOADMACRO
@@ -37,7 +45,8 @@ inline void calculate_typecast_fp32_to_uint16() {
     for (int d = 0; d < ITERATIONS; d++) {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFP_STOCH_RND(
+            SFPSTOCHRND_TRUNCATE, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         if (is_fp32_dest_acc_en) {
             TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
         } else {
@@ -80,7 +89,8 @@ inline void calculate_typecast_fp32_to_uint16() {
         for (int d = 0; d < ITERATIONS; d++) {
             TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
             TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
-            TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+            TTI_SFP_STOCH_RND(
+                SFPSTOCHRND_TRUNCATE, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
             TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
         }
     }
@@ -538,7 +548,8 @@ inline void calculate_typecast_int32_to_uint16() {
         TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPSWAP(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 9);
-        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+        TTI_SFP_STOCH_RND(
+            SFPSTOCHRND_TRUNCATE, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
         TTI_SFPSTORE(p_sfpu::LREG0, SFPSTORE_MODE_SWAP_HI_LO16, ADDR_MOD_6, 0);
     }
 #else
@@ -874,7 +885,7 @@ inline void init_typecast_fp32_to_uint16() {
     TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
 
     // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+    TTI_SFP_STOCH_RND(SFPSTOCHRND_TRUNCATE, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
 
     // Macro 0
     {
@@ -912,7 +923,7 @@ inline void init_typecast_int32_to_uint16() {
     TTI_SFPSWAP(0, p_sfpu::LCONST_0, 12, 0xf);  // L[VD] = max(0, L[VD])
 
     // InstructionTemplate[1]
-    TTI_SFP_STOCH_RND(0, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
+    TTI_SFP_STOCH_RND(SFPSTOCHRND_TRUNCATE, 0, 0, 0, 13, sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT16);
 
     // Macro 0
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1854,9 +1854,8 @@ class TypecastGolden:
     block-float (Bfp8_b / Bfp4_b) source/destination dtypes:
       * block-float input round-trips through ``quantize_input_to_unpack_format``, matching
         what the SFPU sees;
-      * float/int -> integer: truncate toward zero for int32/uint32, round-to-nearest for
-        uint16/uint8 (whole-number stimuli make both exact); UInt8 keeps the low byte, others
-        clamp to the dest range;
+      * float/int -> integer: truncate toward zero for every integer destination; UInt8 keeps
+        the low byte, others clamp to the dest range;
       * -> plain float: value-preserving cast;
       * -> block-float: tilized into 16-element BFP blocks, through the packer's
         shared-exponent quantization, untilized back to row-major (as DataCopyGolden).
@@ -1887,8 +1886,9 @@ class TypecastGolden:
             if input_format.is_integer():
                 values = operand.to(torch.int64)
             else:
-                # int32/uint32 truncate; uint16/uint8 round. Whole-number
-                # stimuli make trunc == round, so trunc models both exactly.
+                # Every integer destination truncates toward zero. Stimuli are
+                # whole numbers, so this arm is not what pins the contract down;
+                # test_typecast_rounding_fractional covers the fractional cases.
                 values = torch.trunc(operand.float()).to(torch.int64)
             result = self._to_integer(values, output_format)
         elif output_format in self._BLOCK_FLOAT_FORMATS:


### PR DESCRIPTION
### PR Category

Bug fix. Closes #51655.

### Summary

`ttnn.typecast` to `uint16` rounds to nearest with ties away from zero, while `int32`, `uint32`, `uint8` and the host path all truncate toward zero, as torch does. The analysis and the exhaustive measurement are in #51655.

`uint16` is the only destination that hands the conversion to the hardware float-to-int instruction; the others extract the mantissa and shift, which truncates by construction. `SFP_STOCH_RND`'s rounding-mode operand was left at `0`, which the ISA calls `RND_NEAREST`. This passes round to zero at the five uint16 sites instead, through a named constant, because sfpi calls mode 0 `SFPSTOCHRND_RND_EVEN` (#45086, closed but still shipping under that name in the pinned 7.67.0) and a reader of these call sites would otherwise have to know that the neighbouring constant lies.

Measured on Blackhole P300 across all 65536 bfloat16 patterns: uint16 goes from 576 disagreements with truncation to 0, and int32, uint32 and uint8 stay at 0. It costs nothing, and the cheapest way to see that is the generated code rather than a cycle count: the math ELF's `.text` is 924 bytes before and after, and the two differ in exactly one byte, the rounding-mode immediate of an instruction that was already there. Same instruction, same count, same order, so there is nothing for a cycle to hide in. `perf_eltwise_typecast.py` also reports the same cycles in `MATH_ISOLATE` and `L1_TO_L1`.

**Blackhole only, and the test suite has to say so.** Round to zero is new in Blackhole; Wormhole's `SFPSTOCHRND` has two modes and neither truncates. Passing mode 2 there is not a compile error, it is simply ignored: I tried it on an n300 and the uint16 output did not change by a single bit. That matters to this PR because the goldens are shared, so correcting them unconditionally turns 28 tests red on Wormhole, the 24 `eltwise_typecast` cases plus the 4 uint16 cases of the new test. `device_truncates_float_to_uint16()` in `typecast_test_helpers.py` gates the two places that care, and its docstring says that deleting the predicate is the last step of #51655.

I did look for a Wormhole fix rather than assuming there wasn't one. `max(0, x) - 0.5` fed to round-to-nearest-ties-away is exactly truncation over the whole uint16 domain, it needs one extra instruction, and on Wormhole it produces the right answer for every value I threw at it. It does not fit the existing kernel: the 16-bit Dest path runs through `SFPLOADMACRO`, and a macro takes at most one MAD instruction while the `SFPSWAP` doing `max(0, x)` on the Simple sub-unit requires that slot to hold `SFPNOP` at the same time. Scheduling anything at all there breaks it, including a `+0.0` no-op, which is how I established that it is the slot and not the arithmetic. Forcing the plain loop instead costs 13% of the math thread by measurement, so Wormhole needs either that trade or a redesign of the clamp, and both belong in their own change.

### Tests

`test_typecast_rounding_fractional` is new. It feeds deterministic quarter steps, including exact half-integers, to all four integer destinations from both a bfloat16 and a float32 source. Half-integers are the discriminator: truncation, ties-away and ties-to-even all disagree on them, and nothing else in the suite feeds one deterministically. Both sources matter because a float32 source sets `preserve_fp32_precision` and so exercises the 32-bit Dest path of the uint16 kernel while a bfloat16 source exercises the 16-bit one. Without the fix, the uint16 cases fail on Blackhole and the others pass.

Three goldens encoded the old behaviour and are corrected: `_float_to_uint16_clamp` in `ttnn_pytorch_ops.py` now truncates where the kernel truncates, so all three `-> uint16` arms of that dispatch agree; `_host_typecast_golden` in `test_copy_ops.py` says why the host golden still cannot fall through to the device one; `golden_generators.py` had a comment stating the divergence, and the code there already truncated.

`test_eltwise_typecast.py` and `test_copy_ops.py` together, same counts on both machines:

| | result |
|---|---|
| Blackhole P300 | 981 passed, 0 failed, 502 skipped |
| Wormhole n300 | 981 passed, 0 failed, 502 skipped |

Without the golden corrections, 24 fail on Blackhole. Without the arch predicate, 28 fail on Wormhole. One earlier Blackhole run failed `bfloat4_b -> uint16` at `[1, 3, 320, 320]`; that test draws unseeded random input against a block-float quantisation golden, and 30 consecutive reruns of the block-float subset give 0 failing runs, so I am reporting it as a pre-existing flake rather than leaving it to surprise someone.

### Not covered

Three FP32 values are still rounded away from zero on Blackhole: `0x3F7FFFFE`, `0x3F7FFFFF` and `0x3FFFFFFF`. The ISA documents this as a bug in the round-to-zero mode, they were equally wrong before this change, and no bfloat16 or block-float input can encode them, so only a float32 source can reach them. The `max(0, x) - 0.5` construction described above does get them right, and it is the reason I know that: it costs an instruction and, on the 16-bit Dest path, the `SFPLOADMACRO` fast path. Say the word if you would rather trade that for the last three encodings.

Quasar has no uint16 typecast at all, so Blackhole and Wormhole are the only architectures involved.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218118069917559