### PR TITLE
feat: extract list of tensix functional workers from exalens

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -456,7 +456,7 @@ def pytest_configure(config):
 
         is_ttsim = _SIMULATOR_PATH and _SIMULATOR_PATH.endswith(".so")
         if (
-            (is_ttsim or not TestConfig.TEST_TARGET.run_simulator)
+            is_ttsim or not TestConfig.TEST_TARGET.run_simulator
             and TestConfig.ARCH != ChipArchitecture.QUASAR
         ):
             override_gprs_used_by_tensix_dump()

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -456,7 +456,8 @@ def pytest_configure(config):
 
         is_ttsim = _SIMULATOR_PATH and _SIMULATOR_PATH.endswith(".so")
         if (
-            is_ttsim or not TestConfig.TEST_TARGET.run_simulator
+            is_ttsim
+            or not TestConfig.TEST_TARGET.run_simulator
             and TestConfig.ARCH != ChipArchitecture.QUASAR
         ):
             override_gprs_used_by_tensix_dump()

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -404,14 +404,6 @@ def pytest_configure(config):
         _RECORD_TEST_ORDER = True
         utils_module._RECORD_TEST_ORDER = True
 
-    is_ttsim = _SIMULATOR_PATH and _SIMULATOR_PATH.endswith(".so")
-    if (
-        (is_ttsim or not TestConfig.TEST_TARGET.run_simulator)
-        and TestConfig.ARCH != ChipArchitecture.QUASAR
-        and TestConfig.BUILD_MODE != BuildMode.PRODUCE
-    ):
-        override_gprs_used_by_tensix_dump()
-
     log_file = "pytest_errors.log"
     if not hasattr(config, "workerinput"):  # executed only by master pytest runner
         # Refresh order folder with setup_files function
@@ -448,9 +440,11 @@ def pytest_configure(config):
                         "Re-run without it.",
                         returncode=1,
                     )
+                TestConfig.resolve_worker_tensix_location()
             elif not hasattr(config, "workerinput"):
                 # RTL simulator: only the controller process manages the server; xdist workers
-                # just connect to the already-running instance.
+                # just connect to the already-running instance. TENSIX_LOCATION is bound
+                # after init_ttexalens_remote in pytest_runtest_setup, once the server is up.
                 global _exalens_server
                 _exalens_server = ExalensServer(
                     simulator_path=_SIMULATOR_PATH,
@@ -458,6 +452,14 @@ def pytest_configure(config):
                 )
         else:
             tt_exalens_init.init_ttexalens()
+            TestConfig.resolve_worker_tensix_location()
+
+        is_ttsim = _SIMULATOR_PATH and _SIMULATOR_PATH.endswith(".so")
+        if (
+            (is_ttsim or not TestConfig.TEST_TARGET.run_simulator)
+            and TestConfig.ARCH != ChipArchitecture.QUASAR
+        ):
+            override_gprs_used_by_tensix_dump()
 
 
 def pytest_ignore_collect(collection_path, config):
@@ -831,6 +833,7 @@ def pytest_runtest_setup(item):
         tt_exalens_init.init_ttexalens_remote(
             port=TestConfig.TEST_TARGET.simulator_port
         )
+        TestConfig.resolve_worker_tensix_location()
     elif not _exalens_server.running:
         logger.error("tt-exalens server is no longer running unexpectedly.")
         pytest.exit(returncode=1)
@@ -841,6 +844,7 @@ def pytest_runtest_setup(item):
         tt_exalens_init.init_ttexalens_remote(
             port=TestConfig.TEST_TARGET.simulator_port
         )
+        TestConfig.resolve_worker_tensix_location()
 
 
 def pytest_sessionstart(session):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/chip_architecture.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/chip_architecture.py
@@ -22,9 +22,6 @@ class ChipArchitecture(Enum):
                 "blackhole": cls.BLACKHOLE,
                 "quasar": cls.QUASAR,
                 "wormhole": cls.WORMHOLE,
-                # Metal / UMD name for the same part. ttexalens reports
-                # devices[0]._arch as this, and ARCH_NAME/CHIP_ARCH are often
-                # exported this way from a tt-metal tree.
                 "wormhole_b0": cls.WORMHOLE,
             }
         return cls._cached_string_map

--- a/tt_metal/tt-llk/tests/python_tests/helpers/chip_architecture.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/chip_architecture.py
@@ -22,6 +22,10 @@ class ChipArchitecture(Enum):
                 "blackhole": cls.BLACKHOLE,
                 "quasar": cls.QUASAR,
                 "wormhole": cls.WORMHOLE,
+                # Metal / UMD name for the same part. ttexalens reports
+                # devices[0]._arch as this, and ARCH_NAME/CHIP_ARCH are often
+                # exported this way from a tt-metal tree.
+                "wormhole_b0": cls.WORMHOLE,
             }
         return cls._cached_string_map
 
@@ -48,9 +52,10 @@ def get_chip_architecture():
     if not chip_architecture:
         context = check_context()
         chip_architecture = str(context.devices[0]._arch)
-        if chip_architecture == "wormhole_b0":
-            chip_architecture = "wormhole"
-        os.environ["CHIP_ARCH"] = chip_architecture
 
     _cached_chip_architecture = ChipArchitecture.from_string(chip_architecture)
+    # Always write the LLK name back. Several CLIs take --arch $CHIP_ARCH and
+    # only accept wormhole|blackhole|quasar; leaving wormhole_b0 in the
+    # environment is what produces "invalid choice: 'wormhole_b0'".
+    os.environ["CHIP_ARCH"] = _cached_chip_architecture.value
     return _cached_chip_architecture

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -5,6 +5,7 @@ import datetime
 import os
 import time
 from enum import Enum, IntEnum
+from functools import lru_cache
 from pathlib import Path
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
@@ -111,6 +112,59 @@ def get_all_cores(trisc_only: bool = False):
 # Constant - list of all valid cores on the chip
 ALL_CORES = get_all_cores()
 TRISC_CORES = get_all_cores(trisc_only=True)
+
+
+@lru_cache(maxsize=None)
+def get_functional_tensix_locations(device_id: int = 0) -> tuple:
+    """Logical coordinates of every Tensix this card actually has, in a stable order.
+
+    "functional_workers" is the post-harvesting list, so this is what is really on
+    the part rather than what the architecture nominally provides. Logical
+    coordinates are already dense over that set and print as "x,y", which is the
+    form TENSIX_LOCATION carries and OnChipCoordinate.create parses back.
+
+    Empty if the card cannot be reached, so a caller that does not need one (the
+    compile phase, a host with no card) is not stopped by asking.
+    """
+    try:
+        device = check_context().devices[device_id]
+        locations = [
+            coordinate.to_str("logical")
+            for coordinate in device.get_block_locations("functional_workers")
+        ]
+    except Exception as err:
+        logger.warning(f"Could not enumerate Tensix cores: {type(err).__name__}: {err}")
+        return ()
+    # Every worker derives its own core from this list independently, so the order
+    # has to come out identical in each process; get_block_locations promises none.
+    return tuple(
+        sorted(locations, key=lambda loc: tuple(int(v) for v in loc.split(",")))
+    )
+
+
+def tensix_location_for_worker(worker_index: int, device_id: int = 0) -> str:
+    """The Tensix an xdist worker owns.
+
+    Two workers sharing a core would silently corrupt each other's results, so
+    running wider than the card is fatal rather than wrapped.
+    """
+    locations = get_functional_tensix_locations(device_id)
+    if not locations:
+        # Falling back keeps a card-less host working; it is only wrong on a part
+        # whose harvesting makes the nominal 8-wide grid untrue, which is exactly
+        # what we could not check here.
+        row, col = divmod(worker_index, 8)
+        return f"{row},{col}"
+    if worker_index >= len(locations):
+        # Also reachable without over-subscribing: xdist numbers a replacement for
+        # a crashed worker above every existing one, so a run that keeps losing
+        # cores climbs into this eventually.
+        raise RuntimeError(
+            f"worker {worker_index} has no Tensix to run on: the card has "
+            f"{len(locations)} functional core(s). Lower --device-jobs, or stop "
+            f"replacing wedged workers, so the total stays under that."
+        )
+    return locations[worker_index]
 
 
 def get_register_store(location="0,0", device_id=0, neo_id=0):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -5,7 +5,6 @@ import datetime
 import os
 import time
 from enum import Enum, IntEnum
-from functools import lru_cache
 from pathlib import Path
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
@@ -114,7 +113,12 @@ ALL_CORES = get_all_cores()
 TRISC_CORES = get_all_cores(trisc_only=True)
 
 
-@lru_cache(maxsize=None)
+# Successful enumerations only. A miss must not stick: pytest_configure used to
+# call this before silicon/RTL Exalens init, and caching an empty tuple pinned
+# the session to a fake 8-wide grid.
+_functional_tensix_locations: dict[int, tuple] = {}
+
+
 def get_functional_tensix_locations(device_id: int = 0) -> tuple:
     """Logical coordinates of every Tensix this card actually has, in a stable order.
 
@@ -123,9 +127,12 @@ def get_functional_tensix_locations(device_id: int = 0) -> tuple:
     coordinates are already dense over that set and print as "x,y", which is the
     form TENSIX_LOCATION carries and OnChipCoordinate.create parses back.
 
-    Empty if the card cannot be reached, so a caller that does not need one (the
-    compile phase, a host with no card) is not stopped by asking.
+    Raises if Exalens cannot answer. Compile-producer never calls this; a miss
+    here is a device-backed run that failed to find its cores.
     """
+    cached = _functional_tensix_locations.get(device_id)
+    if cached is not None:
+        return cached
     try:
         device = check_context().devices[device_id]
         locations = [
@@ -133,28 +140,31 @@ def get_functional_tensix_locations(device_id: int = 0) -> tuple:
             for coordinate in device.get_block_locations("functional_workers")
         ]
     except Exception as err:
-        logger.warning(f"Could not enumerate Tensix cores: {type(err).__name__}: {err}")
-        return ()
+        raise RuntimeError(
+            f"Could not enumerate Tensix cores from Exalens: "
+            f"{type(err).__name__}: {err}"
+        ) from err
     # Every worker derives its own core from this list independently, so the order
     # has to come out identical in each process; get_block_locations promises none.
-    return tuple(
+    result = tuple(
         sorted(locations, key=lambda loc: tuple(int(v) for v in loc.split(",")))
     )
+    if not result:
+        raise RuntimeError(
+            "Exalens reported no functional Tensix workers on this device."
+        )
+    _functional_tensix_locations[device_id] = result
+    return result
 
 
 def tensix_location_for_worker(worker_index: int, device_id: int = 0) -> str:
     """The Tensix an xdist worker owns.
 
     Two workers sharing a core would silently corrupt each other's results, so
-    running wider than the card is fatal rather than wrapped.
+    running wider than the card is fatal rather than wrapped. Call after Exalens
+    has a context; an enumeration failure is not a reason to invent cores.
     """
     locations = get_functional_tensix_locations(device_id)
-    if not locations:
-        # Falling back keeps a card-less host working; it is only wrong on a part
-        # whose harvesting makes the nominal 8-wide grid untrue, which is exactly
-        # what we could not check here.
-        row, col = divmod(worker_index, 8)
-        return f"{row},{col}"
     if worker_index >= len(locations):
         # Also reachable without over-subscribing: xdist numbers a replacement for
         # a crashed worker above every existing one, so a run that keeps losing

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -568,11 +568,20 @@ class TestConfig:
     ):
         TestConfig.WORKER_ID = worker_id
 
-        if worker_id != "master":
+        if worker_id == "master":
+            TestConfig.TENSIX_LOCATION = "0,0"
+        elif compile_producer:
+            # Builds ELFs on the CPU and never reads the device, so it is not worth
+            # opening a context per worker to answer a question it does not ask.
             row, col = divmod(int(worker_id[2:]), 8)
             TestConfig.TENSIX_LOCATION = f"{row},{col}"
         else:
-            TestConfig.TENSIX_LOCATION = "0,0"
+            # Ask the card rather than assuming an 8-wide grid: the nominal shape is
+            # not what a harvested part has, and the arithmetic silently produced
+            # coordinates for cores that need not exist.
+            TestConfig.TENSIX_LOCATION = device_module.tensix_location_for_worker(
+                int(worker_id[2:])
+            )
 
         if compile_consumer and compile_producer:
             raise RuntimeError(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -184,6 +184,9 @@ class TestConfig:
 
     WORKER_ID: ClassVar[str] = "master"
     TENSIX_LOCATION: ClassVar[str] = "0,0"
+    # xdist worker index waiting for Exalens. setup_mode cannot ask the card yet:
+    # silicon init_ttexalens and the RTL remote connect both happen after it.
+    _PENDING_WORKER_INDEX: ClassVar[int | None] = None
     STIMULI_ADDRESS_MAP: ClassVar[dict[str, int]] = {}
     SIMULATOR_TIMEOUT: ClassVar[int] = 600
 
@@ -568,6 +571,7 @@ class TestConfig:
     ):
         TestConfig.WORKER_ID = worker_id
 
+        TestConfig._PENDING_WORKER_INDEX = None
         if worker_id == "master":
             TestConfig.TENSIX_LOCATION = "0,0"
         elif compile_producer:
@@ -576,12 +580,10 @@ class TestConfig:
             row, col = divmod(int(worker_id[2:]), 8)
             TestConfig.TENSIX_LOCATION = f"{row},{col}"
         else:
-            # Ask the card rather than assuming an 8-wide grid: the nominal shape is
-            # not what a harvested part has, and the arithmetic silently produced
-            # coordinates for cores that need not exist.
-            TestConfig.TENSIX_LOCATION = device_module.tensix_location_for_worker(
-                int(worker_id[2:])
-            )
+            # Silicon and RTL do not have an Exalens context until later in
+            # pytest_configure / pytest_runtest_setup. Asking now would miss,
+            # and a cached miss used to pin the session to the 8-wide fallback.
+            TestConfig._PENDING_WORKER_INDEX = int(worker_id[2:])
 
         if compile_consumer and compile_producer:
             raise RuntimeError(
@@ -632,6 +634,15 @@ class TestConfig:
             and worker_id == "master"
         ):
             shutil.rmtree(TestConfig.ARTEFACTS_DIR.absolute(), ignore_errors=True)
+
+    @staticmethod
+    def resolve_worker_tensix_location():
+        """Bind TENSIX_LOCATION from the card once Exalens has a context."""
+        index = TestConfig._PENDING_WORKER_INDEX
+        if index is None:
+            return
+        TestConfig.TENSIX_LOCATION = device_module.tensix_location_for_worker(index)
+        TestConfig._PENDING_WORKER_INDEX = None
 
     # === Instance fields and methods ===
     def __init__(

--- a/tt_metal/tt-llk/tests/python_tests/pytest.ini
+++ b/tt_metal/tt-llk/tests/python_tests/pytest.ini
@@ -3,7 +3,7 @@ filterwarnings =
     ignore::UserWarning
     ignore::DeprecationWarning
     ignore::FutureWarning
-addopts = -s --maxschedchunk=10
+addopts = -s --maxschedchunk=2000
 python_files =
     test_*.py
     perf_*.py

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -59,10 +59,7 @@ Options:
   -t, --timeout SEC     Per-test timeout in seconds (default: 300; env: TIMEOUT).
   -a, --architecture A  ttsim architecture: 'blackhole', 'wormhole', or
                         'quasar' (default: blackhole; env: TTSIM_ARCHITECTURE).
-                        Controls test selection and collection. Also controls
-                        auto-provisioning for blackhole/wormhole when
-                        TT_METAL_SIMULATOR is unset. Quasar currently requires
-                        TT_METAL_SIMULATOR to be set by the caller.
+                        Controls test selection and collection.
   -h, --help            Show this help message.
 
 Environment:

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -151,8 +151,10 @@ provision_ttsim() {
             hash_var=ttsim_wh_so_hash
             ;;
         quasar)
-            echo "ERROR: Quasar auto-provisioning is not available yet; set TT_METAL_SIMULATOR" >&2
-            exit 1
+            architecture=quasar
+            so_name=libttsim_qsr.so
+            soc_src="${REPO_ROOT}/tt_metal/soc_descriptors/quasar_32_arch.yaml"
+            hash_var=ttsim_qsr_so_hash
             ;;
         *)
             echo "ERROR: unknown --architecture '$architecture' (expected 'blackhole', 'wormhole', or 'quasar')" >&2
@@ -285,7 +287,7 @@ PYTEST_BASE_ARGS=(
 if [[ "$WORKERS" -gt 0 ]]; then
     PYTEST_BASE_ARGS+=(
         -n "$WORKERS"
-        --dist=loadfile
+        --dist=worksteal
         --max-worker-restart=10000
     )
 fi

--- a/tt_metal/tt-llk/tests/ttsim-version
+++ b/tt_metal/tt-llk/tests/ttsim-version
@@ -6,3 +6,4 @@ ttsim_tag="v${ttsim_version}"
 ttsim_hashtype='sha256'
 ttsim_wh_so_hash='4f09253cc707c7a83627b10ba484ef3603fded482f110fd69fcc9fec2ea4da23'
 ttsim_bh_so_hash='b276a5fba26064eb72fe964126e34bad4bbf515175890570ba2eaef670fed572'
+ttsim_qsr_so_hash='b82063169370cb49ceab219fb853310f4dd19cb6a799fab460876a7f65c10b60'


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Instead of hardcoding Tensix functional workers, consume the list provided by exalens which guarantees correctness, independent of the grid topology.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/harden-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/harden-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/harden-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/harden-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/harden-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/harden-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/harden-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/harden-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/harden-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/harden-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/harden-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/harden-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/harden-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/harden-llk-test-harness)