### PR TITLE
[LLK] Guard two out-of-bounds metadata reads in compressed_custom_mm

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_matmul_custom_compressed.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_matmul_custom_compressed.py
@@ -117,7 +117,19 @@ EXT_MULTI_FORMATS = [
     ("bfp8", "bfp4", "bfp2", "bfp0"),
 ]
 
-SHAPES = BASE_SHAPES + DEEPSEEK_SHAPES + EXT_SHAPES
+# kt_dim * ct_dim an exact multiple of the kernel's 10-tiles-per-metadata-word packing, so the
+# metadata buffer ends exactly on a word boundary. That is the case both walkers' end-of-buffer
+# guards exist for, and no shape above has it: every product there is 2, 4, 6 or 8 mod 10. Kept as
+# its own list because BASE/DEEPSEEK/EXT_SHAPES are shared verbatim with test_matmul_face_compressed,
+# whose packing density is a different one (5 metas per word).
+META_WORD_BOUNDARY_SHAPES = [
+    (1, 320, 32),  # 10x1 -- the smallest such shape
+    # 10x4: the same boundary at ct_dim > 1, where two of the intermediate word boundaries
+    # (tiles 10 and 30) fall mid-row rather than on a row tail.
+    (1, 320, 128),
+]
+
+SHAPES = BASE_SHAPES + DEEPSEEK_SHAPES + EXT_SHAPES + META_WORD_BOUNDARY_SHAPES
 MULTI_FORMATS = BASE_MULTI_FORMATS  # EXT_MULTI_FORMATS is not supported in face version
 
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_compressed_custom_mm.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_compressed_custom_mm.h
@@ -164,9 +164,13 @@ inline void _llk_math_compressed_custom_mm_(
 
     const std::uint32_t iterations = finalize ? kt_dim - 1 : kt_dim;
     const std::uint32_t* meta_ptr  = reinterpret_cast<const std::uint32_t*>(base_address_meta);
-    std::uint32_t index            = 0;
-    std::uint32_t meta_index       = 0;
-    std::uint32_t meta             = meta_ptr[meta_index] >> 3;
+    // The metadata buffer holds one word per 10 tiles, i.e. ceil(kt_dim * ct_dim / 10) words.
+    // Each reload below advances meta_index *after* consuming an item, so on the last item of
+    // an exact-multiple-of-10 block it would step one word past the end. Bound it.
+    const std::uint32_t num_meta_words = (kt_dim * ct_dim + 9) / 10;
+    std::uint32_t index                = 0;
+    std::uint32_t meta_index           = 0;
+    std::uint32_t meta                 = meta_ptr[meta_index] >> 3;
 
     for (std::uint32_t i = 0; i < iterations; i++)
     {
@@ -189,7 +193,10 @@ inline void _llk_math_compressed_custom_mm_(
             {
                 index = 0;
                 meta_index++;
-                meta = meta_ptr[meta_index] >> 3;
+                if (meta_index < num_meta_words)
+                {
+                    meta = meta_ptr[meta_index] >> 3;
+                }
             }
             else
             {
@@ -212,7 +219,10 @@ inline void _llk_math_compressed_custom_mm_(
         {
             index = 0;
             meta_index++;
-            meta = meta_ptr[meta_index] >> 3;
+            if (meta_index < num_meta_words)
+            {
+                meta = meta_ptr[meta_index] >> 3;
+            }
         }
         else
         {
@@ -239,7 +249,10 @@ inline void _llk_math_compressed_custom_mm_(
             {
                 index = 0;
                 meta_index++;
-                meta = meta_ptr[meta_index] >> 3;
+                if (meta_index < num_meta_words)
+                {
+                    meta = meta_ptr[meta_index] >> 3;
+                }
             }
             else
             {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_compressed_custom_mm.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_compressed_custom_mm.h
@@ -162,15 +162,24 @@ inline void _llk_math_compressed_custom_mm_(
     const std::uint32_t replay_buf_len = operandB_face_r_dim == 8 ? 11 : 9;
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
+    // One 3-bit format meta per tile, ten per 32-bit word: the metadata buffer holds
+    // ceil(kt_dim * ct_dim / tiles_per_meta_word) words, and num_meta_words is deliberately spelled with
+    // the caller's own sizing expression so the bound and the allocation cannot drift apart.
+    constexpr std::uint32_t tiles_per_meta_word = 10;
+    const std::uint32_t num_meta_words          = (kt_dim * ct_dim + tiles_per_meta_word - 1) / tiles_per_meta_word;
+    // Each reload below advances meta_index *after* consuming an item. Only the row-tail site can
+    // actually step past the end, and only at finalize == false, where the last of the kt_dim * ct_dim
+    // items is a row tail: on an exact multiple of tiles_per_meta_word its index++ drives meta_index to
+    // num_meta_words. The other two sites are always followed by another consume in the same pass, so
+    // meta_index stays <= (kt_dim * ct_dim - 1) / tiles_per_meta_word, and at finalize == true the walk
+    // ends on an item that does no index++ at all. Bounding all three keeps every meta_ptr load
+    // in-bounds by inspection, rather than by that whole-function argument continuing to hold.
+
     const std::uint32_t iterations = finalize ? kt_dim - 1 : kt_dim;
     const std::uint32_t* meta_ptr  = reinterpret_cast<const std::uint32_t*>(base_address_meta);
-    // The metadata buffer holds one word per 10 tiles, i.e. ceil(kt_dim * ct_dim / 10) words.
-    // Each reload below advances meta_index *after* consuming an item, so on the last item of
-    // an exact-multiple-of-10 block it would step one word past the end. Bound it.
-    const std::uint32_t num_meta_words = (kt_dim * ct_dim + 9) / 10;
-    std::uint32_t index                = 0;
-    std::uint32_t meta_index           = 0;
-    std::uint32_t meta                 = meta_ptr[meta_index] >> 3;
+    std::uint32_t index            = 0;
+    std::uint32_t meta_index       = 0;
+    std::uint32_t meta             = meta_ptr[meta_index] >> 3;
 
     for (std::uint32_t i = 0; i < iterations; i++)
     {
@@ -189,7 +198,7 @@ inline void _llk_math_compressed_custom_mm_(
                 // TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_AB);
             }
             index++;
-            if (index == 10)
+            if (index == tiles_per_meta_word)
             {
                 index = 0;
                 meta_index++;
@@ -215,7 +224,7 @@ inline void _llk_math_compressed_custom_mm_(
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
         }
         index++;
-        if (index == 10)
+        if (index == tiles_per_meta_word)
         {
             index = 0;
             meta_index++;
@@ -245,7 +254,7 @@ inline void _llk_math_compressed_custom_mm_(
                 lltt::replay(ckernel::math::replay_buf_offset + 4, replay_buf_len - 4);
             }
             index++;
-            if (index == 10)
+            if (index == tiles_per_meta_word)
             {
                 index = 0;
                 meta_index++;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_compressed_custom_mm.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_compressed_custom_mm.h
@@ -240,13 +240,18 @@ inline void _llk_unpack_AB_compressed_custom_mm_(
         ckernel::instrn_buffer[0] = data8;
         ckernel::instrn_buffer[0] = data9;
     }
-    std::uint32_t meta = meta_ptr[full_iters];
-    for (std::uint32_t i = 0; i < rem_iters; ++i)
+    // Guarded: when (kt_dim * ct_dim) is a multiple of 10 the metadata buffer holds exactly
+    // full_iters words, so meta_ptr[full_iters] would read one word past it.
+    if (rem_iters != 0)
     {
-        std::uint32_t idx0        = (meta >> 0) & 0b11111;
-        std::uint32_t data0       = FMTABLE[idx0];
-        ckernel::instrn_buffer[0] = data0;
-        meta >>= 3;
+        std::uint32_t meta = meta_ptr[full_iters];
+        for (std::uint32_t i = 0; i < rem_iters; ++i)
+        {
+            std::uint32_t idx0        = (meta >> 0) & 0b11111;
+            std::uint32_t data0       = FMTABLE[idx0];
+            ckernel::instrn_buffer[0] = data0;
+            meta >>= 3;
+        }
     }
 
     t6_semaphore_get(semaphore::UNPACK_SYNC);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_compressed_custom_mm.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_compressed_custom_mm.h
@@ -176,10 +176,15 @@ inline void _llk_unpack_AB_compressed_custom_mm_(
 
     volatile std::uint32_t* cfg = get_cfg_pointer();
 
+    // One 3-bit format meta per tile, ten per 32-bit word: the packing the caller sizes the metadata
+    // buffer with (ceil(kt_dim * ct_dim / tiles_per_meta_word) words), and the width the whole-word
+    // loop body below is unrolled to.
+    constexpr std::uint32_t tiles_per_meta_word = 10;
+
     const std::uint32_t address_a  = base_address_a;
     const std::uint32_t address_b  = base_address_b;
-    const std::uint32_t full_iters = (kt_dim * ct_dim) / 10;
-    const std::uint32_t rem_iters  = (kt_dim * ct_dim) % 10;
+    const std::uint32_t full_iters = (kt_dim * ct_dim) / tiles_per_meta_word;
+    const std::uint32_t rem_iters  = (kt_dim * ct_dim) % tiles_per_meta_word;
     const std::uint32_t* meta_ptr  = reinterpret_cast<const std::uint32_t*>(base_address_meta);
 
     wait_for_next_context(1);
@@ -240,8 +245,8 @@ inline void _llk_unpack_AB_compressed_custom_mm_(
         ckernel::instrn_buffer[0] = data8;
         ckernel::instrn_buffer[0] = data9;
     }
-    // Guarded: when (kt_dim * ct_dim) is a multiple of 10 the metadata buffer holds exactly
-    // full_iters words, so meta_ptr[full_iters] would read one word past it.
+    // Guarded: when (kt_dim * ct_dim) is an exact multiple of tiles_per_meta_word the metadata buffer
+    // holds exactly full_iters words, so meta_ptr[full_iters] would read one word past it.
     if (rem_iters != 0)
     {
         std::uint32_t meta = meta_ptr[full_iters];


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Two out-of-bounds reads in the `compressed_custom_mm` format-metadata walkers, one on each thread. The metadata buffer holds `ceil(kt_dim * ct_dim / 10)` words — one per 10 tiles, as `encode_meta` sizes it — and both sides step past the end when the tile count is an exact multiple of 10. Reachable inside the documented ranges (`kt_dim` even 2..256, `ct_dim` 1..16); `kt_dim=10, ct_dim=1` is the smallest case.

**`llk_unpack_AB_compressed_custom_mm.h`** — the remainder load is unconditional:

```cpp
std::uint32_t meta = meta_ptr[full_iters];
for (i = 0; i < rem_iters; ++i) ...
```

At `rem_iters == 0` the buffer ends at `full_iters`, so the load is off the end. Now guarded on `rem_iters != 0`.

**`llk_math_compressed_custom_mm.h`** — three reload sites do `meta_index++` and then read `meta_ptr[meta_index]` *after* consuming an item, so on the final item of an exact-multiple block they step one word past. Bounded with `num_meta_words = (kt_dim * ct_dim + 9) / 10` — deliberately the same expression the caller sizes the buffer with, so the guard and the allocation cannot drift apart.

### Notes for reviewers

**On severity, so it is not over- or under-read.** In both cases the word read past the buffer is never *used*: the unpack-side remainder loop does not execute at `rem_iters == 0`, and the math-side reload happens after the last item. So this is a memory-safety defect — an L1 read of whatever follows the metadata buffer — not a wrong-answer one. No golden comparison can observe it, which is exactly why the existing suite passes with the reads live; I confirmed that empirically by running the exact-multiple shapes against the unguarded kernel, where they also pass.

That also makes the change **provably behaviour-neutral**: it only elides reads whose results were discarded.

**Why the guard bound and not a "more items remain" counter.** Using the caller's own sizing expression means a future change to how the buffer is allocated shows up as a mismatch in one place rather than silently desynchronising. I checked the bound holds for both template paths: at `finalize=false` the main loop consumes `kt*ct` items; at `finalize=true` it consumes `(kt-1)*ct` in the loop plus `ct` in the finalize block — same total.

**Verification.** BH p100a, `test_matmul_custom_compressed.py`: **582 passed**, unchanged from before the guards.

**Coverage.** No test here, because no golden-comparison test can detect these reads. The shape coverage for the exact-multiple case is on #53130 (`test_matmul_custom_compressed_metadata_word_boundary`, three shapes with `kt*ct` divisible by 10 — worth knowing that **none** of the 16 shapes in `SHAPES` reaches that boundary, which is why this went unnoticed). Catching the read itself would need a memory-safety check on L1, which the harness does not have.

### Provenance
Found by Copilot while reviewing #53130, which promoted the tests for this family. Split out here so the fix can land on its own rather than waiting on a test PR — #52727 promoted these headers without it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/fix-compressed-custom-mm-oob-reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/fix-compressed-custom-mm-oob-reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/fix-compressed-custom-mm-oob-reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/fix-compressed-custom-mm-oob-reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/fix-compressed-custom-mm-oob-reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/fix-compressed-custom-mm-oob-reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/fix-compressed-custom-mm-oob-reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/fix-compressed-custom-mm-oob-reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/fix-compressed-custom-mm-oob-reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/fix-compressed-custom-mm-oob-reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/fix-compressed-custom-mm-oob-reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/fix-compressed-custom-mm-oob-reads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/fix-compressed-custom-mm-oob-reads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/fix-compressed-custom-mm-oob-reads)