### PR TITLE
#53646: Preserve 32-bit TopK indices in multi-core sorting

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -81,7 +81,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     const tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     const tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(value_tensor.dtype());
     tt::DataFormat index_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(index_tensor.dtype());
-    const bool is32_bit_data =
+    const bool has_32bit_index =
         index_cb_data_format == tt::DataFormat::UInt32 || index_cb_data_format == tt::DataFormat::Int32;
     // The sort datapath handles 32-bit indices as UInt32. INT32 shares the same 4-byte little-endian layout for
     // the non-negative positions TopK produces, so run the compute in UInt32 and let the writer copy the raw tile
@@ -96,7 +96,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // fp32 is kept full-width (no downcast): with fp32_dest_acc_en + UnpackToDestFp32 the value CBs
     // stay fp32 and the sort's default SFPLOAD mode resolves to FP32, so the inter-core transfer
     // and compute buffers stay fp32.
-    const bool is_fp32_input = input_cb_data_format == tt::DataFormat::Float32;
+    const bool has_fp32_values = input_cb_data_format == tt::DataFormat::Float32;
     const tt::DataFormat compute_cb_data_format =
         (input_cb_data_format == tt::DataFormat::Bfp8_b || input_cb_data_format == tt::DataFormat::Bfp4_b)
             ? tt::DataFormat::Float16_b
@@ -467,7 +467,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // default SFPLOAD mode resolves to FP32 and reads full-precision values.
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_local(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (is_fp32_input) {
+    if (has_fp32_values) {
         unpack_local[input_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_local[input_transposed_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
@@ -480,7 +480,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // 32-bit indices require the full-width DST registers (fp32 dest accumulation) so the index values
     // survive the transpose/sort datapath without truncation.
     compute_local_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = is_fp32_input || is32_bit_data,
+        .fp32_dest_acc_en = has_fp32_values || has_32bit_index,
         .dst_full_sync_en = false,
         .unpack_to_dest_mode = unpack_local,
     };
@@ -509,7 +509,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // Final-core value CBs (gathered input + final workspace) also unpack to fp32 dest.
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_final(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (is_fp32_input) {
+    if (has_fp32_values) {
         unpack_final[gathered_values_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
         unpack_final[final_values_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
@@ -522,7 +522,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // 32-bit indices require the full-width DST registers (fp32 dest accumulation) so the index values
     // survive the merge datapath without truncation.
     compute_final_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = is_fp32_input || is32_bit_data,
+        .fp32_dest_acc_en = has_fp32_values || has_32bit_index,
         .dst_full_sync_en = false,
         .unpack_to_dest_mode = unpack_final,
     };
@@ -536,10 +536,10 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         reader_local_desc.emplace_runtime_args(
             core,
             {
-                input_tensor,                          // DRAM address of input values tensor
-                0u,                                    // Height offset (no height parallelism currently)
-                core_id * Wt_local,                    // Width offset for this core's chunk
-                static_cast<uint32_t>(is32_bit_data),  // Flag indicating if data is 32-bit
+                input_tensor,                            // DRAM address of input values tensor
+                0u,                                      // Height offset (no height parallelism currently)
+                core_id * Wt_local,                      // Width offset for this core's chunk
+                static_cast<uint32_t>(has_32bit_index),  // Flag indicating if data is 32-bit
                 input_indices_tensor.has_value()
                     ? std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>{std::cref(*input_indices_tensor)}
                     : std::variant<uint32_t, std::reference_wrapper<const MeshTensor>>{0u},  // DRAM address of input

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -480,7 +480,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // 32-bit indices require the full-width DST registers (fp32 dest accumulation) so the index values
     // survive the transpose/sort datapath without truncation.
     compute_local_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = is_fp32_input,
+        .fp32_dest_acc_en = is_fp32_input || is32_bit_data,
         .dst_full_sync_en = false,
         .unpack_to_dest_mode = unpack_local,
     };
@@ -522,7 +522,7 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // 32-bit indices require the full-width DST registers (fp32 dest accumulation) so the index values
     // survive the merge datapath without truncation.
     compute_final_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = is_fp32_input,
+        .fp32_dest_acc_en = is_fp32_input || is32_bit_data,
         .dst_full_sync_en = false,
         .unpack_to_dest_mode = unpack_final,
     };


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #53646 

- updates fp32_dest_acc_en conditional to be true if either input or data is 32 bits instead of just inputs
- tested locally that tests/ttnn/unit_tests/operations/reduce/test_topk.py has no failures:
```
208 passed, 8 skipped, 80 xfailed
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-53646_int32_topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-53646_int32_topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-53646_int32_topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-53646_int32_topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-53646_int32_topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-53646_int32_topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-53646_int32_topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-53646_int32_topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-53646_int32_topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-53646_int32_topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-53646_int32_topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-53646_int32_topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-53646_int32_topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-53646_int32_topk)