### PR TITLE
#53648: move slowest sim dram group_norm test shapes to nightly

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -59,8 +59,11 @@ GROUP_NORM_ROW_MAJOR_SHAPES = [
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",
     [
-        # Only SDXL/sd35 tests with 512x512 or larger sizes moved to nightly
+        # SDXL/sd35 tests with 512x512 or larger sizes and cases taking more than 4 minutes in sim moved to nightly.
         #  SDXL VAE
+        (1, 256, 256, 256, 32, 4, 8, 8),
+        (1, 512, 256, 256, 32, 4, 8, 8),
+        (1, 128, 1, 262144, 32, 64, 8, 4),  # SD 1.4 VAE Issue #21131
         (1, 128, 1024, 1024, 32, 32, 8, 8),
         (1, 128, 512, 512, 32, 8, 8, 8),
         (1, 256, 1024, 1024, 32, 48, 8, 8),

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -59,7 +59,7 @@ GROUP_NORM_ROW_MAJOR_SHAPES = [
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",
     [
-        # SDXL/sd35 tests with 512x512 or larger sizes and cases taking more than 4 minutes in sim moved to nightly.
+        # SDXL/sd35 tests with 512x512 or larger sizes and cases taking more than 4 minutes in sim.
         #  SDXL VAE
         (1, 256, 256, 256, 32, 4, 8, 8),
         (1, 512, 256, 256, 32, 4, 8, 8),

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -40,7 +40,7 @@ GROUP_NORM_DRAM_SHAPES = [
         4,
         4,
     ),  # test all groups on core fit in less than one tile, so need to reduce col core count
-    # All SDXL/sd35 tests with 512x512 or larger sizes and cases taking more than 4 minutes in sim moved to nightly.
+    # SDXL/sd35 test cases. Additional slower test cases in nightly test.
     # SDXL Base
     (1, 1920, 16, 16, 32, 1, 4, 4),
     # SDXL Refiner

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -40,12 +40,9 @@ GROUP_NORM_DRAM_SHAPES = [
         4,
         4,
     ),  # test all groups on core fit in less than one tile, so need to reduce col core count
-    # All SDXL/sd35 tests with 512x512 or larger sizes moved to nightly
+    # All SDXL/sd35 tests with 512x512 or larger sizes and cases taking more than 4 minutes in sim moved to nightly.
     # SDXL Base
     (1, 1920, 16, 16, 32, 1, 4, 4),
-    # SDXL VAE
-    (1, 256, 256, 256, 32, 4, 8, 8),
-    (1, 512, 256, 256, 32, 4, 8, 8),
     # SDXL Refiner
     (1, 1536, 8, 8, 32, 1, 2, 8),
     (1, 1152, 128, 128, 32, 2, 8, 4),
@@ -56,7 +53,6 @@ GROUP_NORM_DRAM_SHAPES = [
     (1, 256 // 4, 256, 256, 32 // 4, 1, 8, 8),
     (1, 512 // 4, 128, 128, 32 // 4, 1, 8, 8),
     (1, 512 // 4, 256, 256, 32 // 4, 2, 8, 8),
-    (1, 128, 1, 262144, 32, 64, 8, 4),  # SD 1.4 VAE Issue #21131
     # mochi
     # (21, 128, 480, 848, 32, 140, 8, 8), Failing on single device CI.
 ]


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #53648 

Sometimes sanity runs timed out on fused group 1 for sim. Looking at the slowest jobs, 4/5 slowest were dram test shapes (3 shapes, one appearing twice with different parameters) that already have a mechanism to move slow test shapes to nightly. Moved these over to l2 nightly.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-53648_gn_dram_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-53648_gn_dram_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-53648_gn_dram_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-53648_gn_dram_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-53648_gn_dram_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-53648_gn_dram_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-53648_gn_dram_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-53648_gn_dram_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-53648_gn_dram_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-53648_gn_dram_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-53648_gn_dram_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-53648_gn_dram_l2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-53648_gn_dram_l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-53648_gn_dram_l2)