### PR TITLE
[Bug fix] Fix Wormhole dest-reuse wait and TF32 golden for COL-sub then DEST_TO_SRCB

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -37,6 +37,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
+#include <impl/context/metal_context.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/distributed.hpp>
 
@@ -166,7 +167,15 @@ static std::vector<T> apply_row_broadcast_to_tiled_input(const std::vector<T>& i
     return broadcast_input;
 }
 
-static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& test_config, bool is_quasar) {
+// Wormhole unpacks L1 FP32 into SrcA/SrcB as TF32 by dropping the low 13 mantissa bits.
+// Blackhole can keep FP32 through dest / unpack-to-dest, so this is WH-only.
+constexpr uint32_t kTf32MantissaTruncMask = 0xffffe000u;
+static float quantize_fp32_src_to_tf32(float value) {
+    return std::bit_cast<float>(std::bit_cast<uint32_t>(value) & kTf32MantissaTruncMask);
+}
+
+static BinaryStimulus generate_binary_stimulus(
+    const SingleCoreBinaryConfig& test_config, bool is_quasar, bool fp32_src_is_tf32) {
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
     BinaryStimulus s;
     // Use fixed seeds so test results are deterministic and reproducible.
@@ -199,7 +208,19 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
             const auto broadcast_input1 = apply_col_broadcast_to_tiled_input(input1, test_config.num_tiles);
             for (size_t i = 0; i < golden.size(); ++i) {
                 constexpr size_t tile_size = 32 * 32;
-                golden[i] = input2[i % tile_size] * (input0[i] - broadcast_input1[i]);
+                float in0 = input0[i];
+                float in1_bcast = broadcast_input1[i];
+                float in2 = input2[i % tile_size];
+                if (fp32_src_is_tf32) {
+                    // COL-broadcast sub unpacks both operands to TF32 Src; dest is FP32.
+                    // DEST_TO_SRCB then moves dest into SrcB (TF32) and unpacks in2 to SrcA (TF32).
+                    in0 = quantize_fp32_src_to_tf32(in0);
+                    in1_bcast = quantize_fp32_src_to_tf32(in1_bcast);
+                    in2 = quantize_fp32_src_to_tf32(in2);
+                    golden[i] = in2 * quantize_fp32_src_to_tf32(in0 - in1_bcast);
+                } else {
+                    golden[i] = in2 * (in0 - in1_bcast);
+                }
             }
         } else {
             TT_FATAL(
@@ -413,7 +434,9 @@ bool single_core_binary(
         num_runs > 0 && test_config.block_size > 0 && test_config.num_tiles % test_config.block_size == 0,
         "num_runs and block_size must be positive, and num_tiles must be divisible by block_size");
     TT_FATAL(!(test_config.col_broadcast && test_config.row_broadcast), "Only one broadcast type may be selected");
-    const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
+    const auto arch = MetalContext::instance().get_cluster().arch();
+    const bool is_quasar = arch == ARCH::QUASAR;
+    const bool fp32_src_is_tf32 = arch == ARCH::WORMHOLE_B0;
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -421,7 +444,7 @@ bool single_core_binary(
         static_cast<uint32_t>(test_config.core.x), static_cast<uint32_t>(test_config.core.y)};
 
     // Math-fidelity masks model WH/BH LLK behavior; Quasar HW does not apply them.
-    auto stimulus = generate_binary_stimulus(test_config, is_quasar);
+    auto stimulus = generate_binary_stimulus(test_config, is_quasar, fp32_src_is_tf32);
     auto buffers = create_and_populate_binary_buffers(mesh_device, cq, zero_coord, byte_size, stimulus);
     auto& input0_dram_buffer = buffers.input0;
     auto& input1_dram_buffer = buffers.input1;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -120,7 +120,10 @@ inline void incr_counters(const std::uint32_t incr_a, const std::uint32_t incr_b
 
 inline void move_d2a_fixed_face(const std::uint8_t addrmod)
 {
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD); // MOVD2A for a whole face assumes unpacker will set a dummy data_valid, so we want to wait on that
+    // Drain preceding math instructions so their source-bank release is visible before testing
+    // the DVALID of the bank that MOVD2A will write. SRCA_VLD alone can observe stale state after
+    // a COL-broadcast / SETRWC predecessor and collide with dest-reuse dummy unpack (see BH #52256).
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, addrmod, p_movd2a::MOV_4_ROWS, 0);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 4, addrmod, p_movd2a::MOV_4_ROWS, 4);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 8, addrmod, p_movd2a::MOV_4_ROWS, 8);
@@ -129,7 +132,10 @@ inline void move_d2a_fixed_face(const std::uint8_t addrmod)
 
 inline void move_d2b_fixed_face(const std::uint8_t addrmod)
 {
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy data_valid, so we want to wait on that
+    // Drain preceding math instructions so their source-bank release is visible before testing
+    // the DVALID of the bank that MOVD2B will write. Required for COL-broadcast then DEST_TO_SRCB
+    // sequences (Welford-style). See #53522 / BH #52256.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, addrmod, p_movd2b::MOV_4_ROWS, 0);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, addrmod, p_movd2b::MOV_4_ROWS, 4);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, addrmod, p_movd2b::MOV_4_ROWS, 8);


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #53522

Two Wormhole issues in the Welford-style LLK test `TensixBinaryComputeColBroadcastThenDestReuseSrcB` (COL-broadcast `sub` into DEST, then immediate `DEST_TO_SRCB` `mul`):

1. **Handshake:** Wormhole dest-reuse `MOVD2A`/`MOVD2B` waited only on source `DVALID`. After a COL-broadcast predecessor that wait can observe a stale bank. Ports the Blackhole math-pipeline drain from #52256 so Wormhole waits on `MATH | SRCA_VLD` / `MATH | SRCB_VLD`.
2. **Golden:** Nightly WH SD still failed after the wait. The assertion is `is_close` vs a **full-FP32** host golden (`rtol=0.0155`). Wormhole unpacks L1 FP32 into SrcA/SrcB as TF32; cancellation in `in2 * (in0 - bcast_col(in1))` lands just over that rtol (N300 `reldiff=0.01589`, N150 `0.01692`). The golden now models TF32 src on Wormhole only. Blackhole keeps the full-FP32 golden.

### Ticket

- https://github.com/tenstorrent/tt-metal/issues/53522
- Related Blackhole dest-reuse sync: https://github.com/tenstorrent/tt-metal/issues/52252 / https://github.com/tenstorrent/tt-metal/pull/52256

### Problem description

Nightly `LLK SD wormhole (full suite, nightly)` failed on both `wh_n150_civ2` and `wh_n300_civ2`:

```
[  FAILED  ] LLKMeshDeviceFixtureSlowDispatchOnly.TensixBinaryComputeColBroadcastThenDestReuseSrcB
Value of: unit_tests::compute::binary::single_core_binary(device, test_config, 10)
  Actual: false
Expected: true
```

The 10-run identity check did **not** fail (that path logs no `Discrepacy`). First-run `is_close` failed:

| SKU | Actual | Golden | absdiff | atol | reldiff | rtol |
|---|---|---|---|---|---|---|
| N300 | 0.11848068 | 0.12039389 | 0.001913 | 0.001 | 0.01589 | 0.0155 |
| N150 | 0.085803986 | 0.08728065 | 0.001477 | 0.001 | 0.01692 | 0.0155 |

Same class of error on both cards, just over `rtol=0.0155`. Consistent with Wormhole TF32 Src vs a full-FP32 golden, not stale dest-reuse data.

The test was added in #52256 as a 128-tile FP32 stand-in for Welford. Merge-gate FD skips this SlowDispatchOnly fixture; nightly WH SD is the first place it is required on Wormhole.

### Repro

On Wormhole, slow dispatch (same binary/filter as nightly):

```bash
source python_env/bin/activate
./build_metal.sh --build-tests   # or: cmake --build build --target unit_tests_llk -j8

export ARCH_NAME=wormhole_b0
export TT_METAL_HOME=$(pwd)
export LD_LIBRARY_PATH=$(pwd)/build/lib
export TT_METAL_SLOW_DISPATCH_MODE=1

./build/test/tt_metal/unit_tests_llk \
  --gtest_filter='LLKMeshDeviceFixtureSlowDispatchOnly.TensixBinaryComputeColBroadcastThenDestReuseSrcB'
```

Also run with `TT_METAL_LLK_ASSERTS=1` (merge-gate default). Nightly L2 uses asserts off.

### What's changed

**Wait** in `tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h`:

- `move_d2a_fixed_face`: `STALLWAIT(STALL_MATH, SRCA_VLD)` → `STALLWAIT(STALL_MATH, MATH | SRCA_VLD)`
- `move_d2b_fixed_face`: `STALLWAIT(STALL_MATH, SRCB_VLD)` → `STALLWAIT(STALL_MATH, MATH | SRCB_VLD)`

Dummy unpack on Wormhole is unchanged (`UNPACR_NOP` has no `Stall_Clr_Cntrl`).

**Golden** in `tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp`:

- On Wormhole, quantize FP32 operands (and dest-to-SrcB) to TF32 (`bits & 0xffffe000`) before computing `in2 * (in0 - bcast_col(in1))`.
- Same truncation used by `test_sfpu_binary_bcast.cpp` for Wormhole's FP32-to-SrcA path.
- Blackhole and the BF16 dest-reuse goldens are unchanged.

### Local validation (Wormhole N300, SD)

| Test | Result |
|---|---|
| `TensixBinaryComputeColBroadcastThenDestReuseSrcB` (no LLK asserts) | pass |
| `*DestReuse*` SD suite | 5 passed, 2 BH-only skipped |

### Notes for reviewers

- Keep the MATH wait even though CI's remaining failure was golden tightness: it is the Wormhole counterpart of #52256.
- Do not skip this test on Wormhole. Production kernels use the same COL-sub → `mul_reuse_dest_tiles<DEST_TO_SRCB>` switch (e.g. Welford layernorm).
- PR gate does **not** run LLK unit tests. Merge-gate runs them only on merge queue.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (workflow retired; merge-gate covers the equivalent bar on merge queue)
- [ ] Sanity CI passes
- [x] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable) — no new LLK asserts; existing dest-reuse path re-run with `TT_METAL_LLK_ASSERTS=1`

### CI

PR-gate does not run LLK unit tests. Re-dispatching the nightly job that failed in #53522 after the TF32 golden fix.