### PR TITLE
[LLK] Retire the Blackhole INT32_MIN reduce xfail; the kernel is fixed

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
@@ -3,7 +3,6 @@
 
 import pytest
 import torch
-from helpers.chip_architecture import ChipArchitecture
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
     ELEMENTS_PER_TILE,
@@ -560,16 +559,16 @@ def _run_int32_reduce(mathop, reduce_pool, injected_value, base_range=(-1000, 10
     return golden_tensor[:, 0], res_tensor[:, 0]
 
 
-# The #44750 fix is Wormhole-only: the Blackhole calculate_reduce_max_min_int32 path still converts to
-# sign-magnitude around a plain SFPSWAP (INT32_MIN still loads as sign-magnitude "-0"), so this repro
-# still fails there (tracked by https://github.com/tenstorrent/tt-metal/issues/44750).
+# Green on both arches. The Blackhole INT32_MIN divergence this was written against is fixed: #49589
+# routes Int32 MAX/MIN through calculate_reduce_max_min_int32_col and perform_reduce_row_max_min_int32,
+# dedicated two's-complement compare-and-swap paths correct over the full Int32 range, rather than the
+# sign-magnitude cast around a plain SFPSWAP that ranked INT32_MIN as 0.
 #
-# xfail rather than skip: the Blackhole fix is an external dependency, and a skip cannot tell us when it
-# lands — it stays green by omission forever. As a non-strict xfail the case still executes on Blackhole
-# and reports XPASS the moment the kernel is fixed. The marker is applied in the body (see below) rather
-# than as a decorator, because it depends on three of the parameters and pytest.mark.xfail's `condition`
-# takes a bool or a string, not a per-param callable — a decorator would have to blanket the whole
-# parametrization, masking the combinations that are still expected to be correct on Blackhole.
+# The Blackhole non-strict xfail this carried is retired. All 24 variants pass on a p100a, on this branch
+# and on main alike, which is the signal it was built to emit — it reported XPASS once the kernel was
+# fixed — and keeping it would leave 6 permanent XPASSes asserting nothing. Its "measured on p100a:
+# exactly these 6 fail" note no longer reproduces on that SKU; #49589 landed 2026-08-07 and the note was
+# written on the 12th, so what the two runs disagree about is not recorded here.
 @pytest.mark.parametrize(
     "mathop", [MathOperation.ReduceColumn, MathOperation.ReduceRow]
 )
@@ -582,7 +581,7 @@ def _run_int32_reduce(mathop, reduce_pool, injected_value, base_range=(-1000, 10
     [(-1000, 1000), (-1000, -1), (1, 1000)],
     ids=["mixed", "all_negative", "all_positive"],
 )
-def test_int32_reduce_extreme(request, mathop, reduce_pool, injected_value, base_range):
+def test_int32_reduce_extreme(mathop, reduce_pool, injected_value, base_range):
     """Repro/guard for tenstorrent/tt-metal#44750: INT32 SFPU reduce (min/max) must stay correct when
     the input contains INT32_MIN or INT32_MAX.
 
@@ -592,33 +591,6 @@ def test_int32_reduce_extreme(request, mathop, reduce_pool, injected_value, base
     """
     if reduce_pool == ReducePool.Min and TestConfig.WITH_COVERAGE:
         pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1040")
-
-    # On Blackhole the injected INT32_MIN reaches the comparator as sign-magnitude "negative zero", so it
-    # is ranked as 0 — but a datum that wins keeps its bit pattern. A lane is therefore wrong only where
-    # ranking INT32_MIN as 0 changes which datum wins, which depends on the sign of the base data:
-    #   MIN — a negative base datum ranks below 0 and is picked instead of INT32_MIN. With all-positive
-    #         base data INT32_MIN still ranks lowest, and the lane comes out correct.
-    #   MAX — 0 outranks every base datum only when they are all negative; otherwise the true maximum
-    #         still wins.
-    # Measured on p100a: exactly these 6 of the 24 variants fail. Marking the other 6 INT32_MIN variants
-    # would mask an unrelated Blackhole regression rather than isolate the tracked issue.
-    if reduce_pool == ReducePool.Min:
-        int32_min_changes_winner = base_range[0] < 0
-    else:
-        int32_min_changes_winner = base_range[1] <= 0
-    if (
-        TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
-        and injected_value == INT32_MIN
-        and int32_min_changes_winner
-    ):
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Blackhole calculate_reduce_max_min_int32 converts to sign-magnitude around "
-                "a plain SFPSWAP, so INT32_MIN loads as 'negative zero'. "
-                "https://github.com/tenstorrent/tt-metal/issues/44750.",
-                strict=False,
-            )
-        )
 
     golden_slice, res_slice = _run_int32_reduce(
         mathop, reduce_pool, injected_value, base_range=base_range

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce.py
@@ -564,11 +564,6 @@ def _run_int32_reduce(mathop, reduce_pool, injected_value, base_range=(-1000, 10
 # dedicated two's-complement compare-and-swap paths correct over the full Int32 range, rather than the
 # sign-magnitude cast around a plain SFPSWAP that ranked INT32_MIN as 0.
 #
-# The Blackhole non-strict xfail this carried is retired. All 24 variants pass on a p100a, on this branch
-# and on main alike, which is the signal it was built to emit — it reported XPASS once the kernel was
-# fixed — and keeping it would leave 6 permanent XPASSes asserting nothing. Its "measured on p100a:
-# exactly these 6 fail" note no longer reproduces on that SKU; #49589 landed 2026-08-07 and the note was
-# written on the 12th, so what the two runs disagree about is not recorded here.
 @pytest.mark.parametrize(
     "mathop", [MathOperation.ReduceColumn, MathOperation.ReduceRow]
 )


### PR DESCRIPTION
## What this PR does

Removes a Blackhole-only `xfail` from `test_int32_reduce_extreme` that has been dead since the
kernel it was written against was fixed. All 24 variants pass; the marker was producing 6 permanent
XPASSes that asserted nothing.

## Why

The marker read that the #44750 fix was Wormhole-only, and that the Blackhole path "still converts to
sign-magnitude around a plain SFPSWAP", so `INT32_MIN` loads as sign-magnitude `-0` and is ranked as 0.

That is no longer what the kernel does. #49589 routes Int32 MAX/MIN through
`calculate_reduce_max_min_int32_col` and `perform_reduce_row_max_min_int32` — dedicated
two's-complement compare-and-swap paths, which `ckernel_sfpu_reduce.h` documents as correct over the
full Int32 range including `INT32_MIN`.

So the marker was emitting exactly the signal its own comment said it existed to emit — "reports
XPASS the moment the kernel is fixed". Retired rather than re-scoped.

## Measured

Blackhole p100a:

| | Before | After |
| --- | --- | --- |
| `test_sfpu_reduce.py -k int32_reduce_extreme` | 18 passed · 6 xpassed | **24 passed** |
| `test_sfpu_reduce.py` | 972 passed · 548 skipped · 6 xpassed | **978 passed · 548 skipped · 0 xpassed** |

Zero failures either way — this changes how the suite reports, not what it computes.

## How it was found

Re-running the SFPU sweeps for #52938 on Blackhole. The 6 XPASS showed up there, and were confirmed
pre-existing rather than induced by that branch by running `main`'s own copy of the suite on the same
board, where the same 6 XPASS. On that branch the same removal takes the suite from
`1068 passed · 548 skipped · 6 xpassed` to `1074 · 548 · 0`, identical to its Wormhole figure.

Split out to here because #52938 is a test-coverage change and this is a marker retirement. It is
not a rider on it.

## One loose end, recorded rather than resolved

The removed note read "Measured on p100a: exactly these 6 of the 24 variants fail". #49589 landed
2026-08-07; that note was written on the 12th, five days later. It does not reproduce on a p100a now.
What the two runs disagree about is not recoverable from here, so the replacement comment states the
dates rather than guessing.

## Incidental

`request` is dropped from the test signature with the marker, being its only use, and `autoflake`
removes the now-unused `ChipArchitecture` import.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/retire_bh_int32_reduce_xfail)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/retire_bh_int32_reduce_xfail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/retire_bh_int32_reduce_xfail)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/retire_bh_int32_reduce_xfail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/retire_bh_int32_reduce_xfail)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/retire_bh_int32_reduce_xfail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/retire_bh_int32_reduce_xfail)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/retire_bh_int32_reduce_xfail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/retire_bh_int32_reduce_xfail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/retire_bh_int32_reduce_xfail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/retire_bh_int32_reduce_xfail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/retire_bh_int32_reduce_xfail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/retire_bh_int32_reduce_xfail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/retire_bh_int32_reduce_xfail)