### PR TITLE
[Performance] Update topk large indices perf baselines

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -181,7 +181,7 @@ TOPK_LARGE_INDICES_PERF_MARGIN = 0.01
 # regressions and unexpected speedups that should trigger baseline review.
 TOPK_LARGE_INDICES_PRODUCTION_PERF_CONFIGS = [
     # (case_id, num_rows, allocated_length, valid_length, k, expected_duration_ns)
-    ("prefill", 640, 51200, None, 1536, 1_683_850),
+    ("prefill", 640, 51200, None, 1536, 1_652_800),
     ("bounded_cache", 2, 102400, 56320, 1536, 316_890),
 ]
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -182,7 +182,7 @@ TOPK_LARGE_INDICES_PERF_MARGIN = 0.01
 TOPK_LARGE_INDICES_PRODUCTION_PERF_CONFIGS = [
     # (case_id, num_rows, allocated_length, valid_length, k, expected_duration_ns)
     ("prefill", 640, 51200, None, 1536, 1_652_800),
-    ("bounded_cache", 2, 102400, 56320, 1536, 316_890),
+    ("bounded_cache", 2, 102400, 56320, 1536, 310_724),
 ]
 
 


### PR DESCRIPTION
### PR Category
Performance

### Summary
Update the `topk_large_indices` production real-time profiler baselines after #53455:

- `prefill`: 1,683,850 ns → 1,652,800 ns
- `bounded_cache`: 316,890 ns → 310,724 ns

Both previous baselines now fail because current measurements are consistently faster. Ten consecutive prefill measurements averaged 1,652,787.547 ns (range 1,652,600.358–1,653,024.811 ns). Ten consecutive bounded-cache measurements averaged 310,723.559 ns (range 310,683.114–310,752.745 ns). The updated targets are the rounded 10-run means.

### Notes for reviewers
The existing ±1% symmetric regression/acceleration margin is unchanged.

Validation:
- `scripts/run_safe_pytest.sh --run-all tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py -q -s --tb=short --count=10 -k test_topk_large_indices_production_perf_check`
- Result: 20 passed (10/10 prefill and 10/10 bounded cache).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/bump-topk-large-indices-prefill-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/bump-topk-large-indices-prefill-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/bump-topk-large-indices-prefill-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/bump-topk-large-indices-prefill-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/bump-topk-large-indices-prefill-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/bump-topk-large-indices-prefill-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/bump-topk-large-indices-prefill-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/bump-topk-large-indices-prefill-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/bump-topk-large-indices-prefill-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/bump-topk-large-indices-prefill-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/bump-topk-large-indices-prefill-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/bump-topk-large-indices-prefill-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/bump-topk-large-indices-prefill-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/bump-topk-large-indices-prefill-perf-baseline)