### PR TITLE
[Fix] Cap matmul per-core block to output dimensions

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3690,6 +3690,65 @@ def test_matmul_default_width_sharded(
 
 
 @pytest.mark.parametrize(
+    "batch_size, m_size, n_size, expected_shard_shape",
+    [
+        (1, 400, 400, (416, 416)),
+        (1, 400, 128, (416, 128)),
+        (1, 512, 512, (512, 512)),
+        pytest.param(
+            5,
+            400,
+            400,
+            (416, 416),
+            marks=pytest.mark.skip(
+                reason="Blocked on a separate bug, not on the per-core cap. compute_output_specs "
+                "derives the output shard grid with fuse_batch=true (M=65 tiles -> 5 cores) while "
+                "the 2D mcast factory derives its work grid from program_config.fuse_batch=false "
+                "(Mt=13 tiles -> 1 core), so batched A on this path allocates an output the factory "
+                "never fully writes. The cap corrects the shard shape but not that mismatch."
+            ),
+        ),
+    ],
+    ids=["reported_13x13", "asymmetric_13x4", "cap_is_noop_16x16", "reported_batched"],
+)
+def test_matmul_default_block_sharded_single_core(device, batch_size, m_size, n_size, expected_shard_shape):
+    """BLOCK_SHARDED output with no program_config: the shard shape must follow the output size.
+
+    Issue #32435: the per-core block was sized to fit L1 (starting at 16x16 tiles) and never
+    capped to the output, so a 13x13 tile output got a 16x16 block and a requested 416x416
+    shard came back as 512x512.
+
+    Keep the shard grid 1x1, else matmul takes the 1D mcast path, which never runs this code.
+    """
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = torch.randn((batch_size, m_size, 32), dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn((batch_size, 32, n_size), dtype=torch.bfloat16)
+    torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
+
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    output_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            expected_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+
+    output_tensor = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+
+    actual_memory_config = output_tensor.memory_config()
+    # Guards against passing via the 1D path, which would rewrite the layout to HEIGHT_SHARDED.
+    assert actual_memory_config.memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+    assert tuple(actual_memory_config.shard_spec.shape) == expected_shard_shape
+    assert_with_pcc(torch_output_tensor, ttnn.to_torch(output_tensor), pcc=0.99)
+
+
+@pytest.mark.parametrize(
     "memory_layout, m_size, k_size, n_size",
     [
         (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, 384, 32, 32),

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3690,16 +3690,27 @@ def test_matmul_default_width_sharded(
 
 
 @pytest.mark.parametrize(
-    "a_shape, b_shape, expected_shard_shape",
+    "a_shape, b_shape, expected_shard_shape, fp32_dest_acc_en",
     [
-        ((1, 400, 32), (1, 32, 400), (416, 416)),
-        ((1, 400, 32), (1, 32, 128), (416, 128)),
-        ((1, 512, 32), (1, 32, 512), (512, 512)),
-        ((5, 400, 32), (32, 400), (416, 416)),
+        ((1, 400, 32), (1, 32, 400), (416, 416), False),
+        ((1, 400, 32), (1, 32, 128), (416, 128), False),
+        ((1, 512, 32), (1, 32, 512), (512, 512), False),
+        ((5, 400, 32), (32, 400), (416, 416), False),
+        ((1, 320, 32), (1, 32, 64), (320, 64), False),
+        ((1, 128, 32), (1, 32, 128), (128, 128), False),
+        ((1, 128, 32), (1, 32, 128), (128, 128), True),
     ],
-    ids=["400x400", "400x128", "512x512", "batch5_broadcast_b"],
+    ids=[
+        "400x400",
+        "400x128",
+        "512x512",
+        "batch5_broadcast_b",
+        "320x64_10x2tiles",
+        "128x128_4x4tiles",
+        "128x128_4x4tiles_fp32",
+    ],
 )
-def test_matmul_default_block_sharded_single_core(device, a_shape, b_shape, expected_shard_shape):
+def test_matmul_default_block_sharded_single_core(device, a_shape, b_shape, expected_shard_shape, fp32_dest_acc_en):
     """BLOCK_SHARDED output with no program_config: the shard shape must follow the output size.
 
     Issue #32435: the per-core block was sized to fit L1 (starting at 16x16 tiles) and never
@@ -3709,6 +3720,9 @@ def test_matmul_default_block_sharded_single_core(device, a_shape, b_shape, expe
     Keep the shard grid 1x1 so this stays on the 2D path. A multi-core 1-row/1-col grid is
     routed to 1D (or fatals when B is batched, issue #32306). When A batch > 1 and B batch
     == 1, auto-config sets fuse_batch so the sharded out CB is not written in a batch loop.
+
+    The 10x2/4x4-tile cases also cover shapes where the sharded-output out_subblock must be
+    picked from a legal (h, w) pair other than out_subblock_h == 1.
     """
     torch.manual_seed(0)
 
@@ -3729,7 +3743,19 @@ def test_matmul_default_block_sharded_single_core(device, a_shape, b_shape, expe
         ),
     )
 
-    output_tensor = ttnn.matmul(input_tensor_a, input_tensor_b, memory_config=output_memory_config)
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        packer_l1_acc=True,
+    )
+
+    output_tensor = ttnn.matmul(
+        input_tensor_a,
+        input_tensor_b,
+        memory_config=output_memory_config,
+        compute_kernel_config=compute_kernel_config,
+    )
 
     actual_memory_config = output_tensor.memory_config()
     # Guards against passing via the 1D path, which would rewrite the layout to HEIGHT_SHARDED.

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -3690,40 +3690,30 @@ def test_matmul_default_width_sharded(
 
 
 @pytest.mark.parametrize(
-    "batch_size, m_size, n_size, expected_shard_shape",
+    "a_shape, b_shape, expected_shard_shape",
     [
-        (1, 400, 400, (416, 416)),
-        (1, 400, 128, (416, 128)),
-        (1, 512, 512, (512, 512)),
-        pytest.param(
-            5,
-            400,
-            400,
-            (416, 416),
-            marks=pytest.mark.skip(
-                reason="Blocked on a separate bug, not on the per-core cap. compute_output_specs "
-                "derives the output shard grid with fuse_batch=true (M=65 tiles -> 5 cores) while "
-                "the 2D mcast factory derives its work grid from program_config.fuse_batch=false "
-                "(Mt=13 tiles -> 1 core), so batched A on this path allocates an output the factory "
-                "never fully writes. The cap corrects the shard shape but not that mismatch."
-            ),
-        ),
+        ((1, 400, 32), (1, 32, 400), (416, 416)),
+        ((1, 400, 32), (1, 32, 128), (416, 128)),
+        ((1, 512, 32), (1, 32, 512), (512, 512)),
+        ((5, 400, 32), (32, 400), (416, 416)),
     ],
-    ids=["reported_13x13", "asymmetric_13x4", "cap_is_noop_16x16", "reported_batched"],
+    ids=["400x400", "400x128", "512x512", "batch5_broadcast_b"],
 )
-def test_matmul_default_block_sharded_single_core(device, batch_size, m_size, n_size, expected_shard_shape):
+def test_matmul_default_block_sharded_single_core(device, a_shape, b_shape, expected_shard_shape):
     """BLOCK_SHARDED output with no program_config: the shard shape must follow the output size.
 
     Issue #32435: the per-core block was sized to fit L1 (starting at 16x16 tiles) and never
     capped to the output, so a 13x13 tile output got a 16x16 block and a requested 416x416
     shard came back as 512x512.
 
-    Keep the shard grid 1x1, else matmul takes the 1D mcast path, which never runs this code.
+    Keep the shard grid 1x1 so this stays on the 2D path. A multi-core 1-row/1-col grid is
+    routed to 1D (or fatals when B is batched, issue #32306). When A batch > 1 and B batch
+    == 1, auto-config sets fuse_batch so the sharded out CB is not written in a batch loop.
     """
     torch.manual_seed(0)
 
-    torch_input_tensor_a = torch.randn((batch_size, m_size, 32), dtype=torch.bfloat16)
-    torch_input_tensor_b = torch.randn((batch_size, 32, n_size), dtype=torch.bfloat16)
+    torch_input_tensor_a = torch.randn(a_shape, dtype=torch.bfloat16)
+    torch_input_tensor_b = torch.randn(b_shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -1300,8 +1300,18 @@ MatmulProgramConfig create_simple_matmul_program_config(
             out_subblock_h = std::get<0>(subblock_hw);
             out_subblock_w = std::get<1>(subblock_hw);
             // Sharded output additionally requires out_subblock_w == per_core_N or out_subblock_h == 1.
-            if (out_subblock_w != per_core_N) {
-                out_subblock_h = 1;
+            if (out_subblock_h != 1 and out_subblock_w != per_core_N) {
+                for (const auto& subblock_hw : SUBBLOCK_HW_CHOICES) {
+                    out_subblock_h = std::get<0>(subblock_hw);
+                    out_subblock_w = std::get<1>(subblock_hw);
+                    if (fp32_dest_acc_en and (out_subblock_h * out_subblock_w) > 4) {
+                        continue;
+                    }
+                    if ((out_subblock_h == 1 or out_subblock_w == per_core_N) and per_core_M % out_subblock_h == 0 and
+                        per_core_N % out_subblock_w == 0) {
+                        break;
+                    }
+                }
             }
             if (all_dram_interleaved) {
                 in0_block_w = !transpose_mcast ? (Kt % num_cores_x == 0 ? Kt / num_cores_x : 1)

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -1340,7 +1340,10 @@ MatmulProgramConfig create_simple_matmul_program_config(
                 .per_core_N = per_core_N,
                 .transpose_mcast = transpose_mcast,
                 .fused_activation = std::nullopt,
-                .fuse_batch = false,
+                // Sharded out CB cannot hold a batch loop. Fold A's batch into M when B is
+                // unbatched (fuse_batch requires B batch == 1).
+                .fuse_batch = mem_config.is_sharded() and get_batch_size(a_shape_padded) > 1 and
+                              get_batch_size(b_shape_padded) == 1,
             };
         }
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -1153,6 +1153,8 @@ MatmulProgramConfig create_simple_matmul_program_config(
         compute_kernel_config,
         output_dtype);
     per_core_N = per_core_M;
+    per_core_M = std::min(per_core_M, Mt);
+    per_core_N = std::min(per_core_N, Nt);
 
     // Calculate number of blocks along x and y; tensor dims are padded up to 512
     num_blocks_y = (Mt - 1) / per_core_M + 1;
@@ -1292,8 +1294,12 @@ MatmulProgramConfig create_simple_matmul_program_config(
                 input_tensor_a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
             uint32_t out_block_h = per_core_M;
             uint32_t out_block_w = per_core_N;
-            out_subblock_h = 4;
-            out_subblock_w = 2;
+            const bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
+            auto subblock_hw =
+                bmm_op_utils::get_matmul_subblock_params(per_core_M, per_core_N, false, false, fp32_dest_acc_en);
+            out_subblock_h = std::get<0>(subblock_hw);
+            out_subblock_w = std::get<1>(subblock_hw);
+            // Sharded output additionally requires out_subblock_w == per_core_N or out_subblock_h == 1.
             if (out_subblock_w != per_core_N) {
                 out_subblock_h = 1;
             }
@@ -1318,8 +1324,7 @@ MatmulProgramConfig create_simple_matmul_program_config(
                 out_block_w = mutlti_dim_per_core_factor[1];
                 in0_block_w = mutlti_dim_per_core_factor[2];
 
-                bool fp32_dest_acc_en = get_fp32_dest_acc_en(compute_kernel_config);
-                auto subblock_hw =
+                subblock_hw =
                     bmm_op_utils::get_matmul_subblock_params(out_block_h, out_block_w, false, false, fp32_dest_acc_en);
                 out_subblock_h = std::get<0>(subblock_hw);
                 out_subblock_w = std::get<1>(subblock_hw);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -2567,7 +2567,7 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
                                          ProgramConfigType,
                                          operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
                     const auto M =
-                        operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/true);
+                        operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
                     const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
                     uint32_t per_core_M = program_config.per_core_M;
                     uint32_t per_core_N = program_config.per_core_N;


### PR DESCRIPTION
## Summary
- Fixes: #32435
- Caps the per-core output block used for `BLOCK_SHARDED` matmul output to the tensor's actual output size, instead of sizing it from L1 capacity alone, picks a legal and efficient `out_subblock` for that block, and turns on `fuse_batch` when a sharded output would otherwise loop `A`'s batch into a one-block CB.

## Problem Description
- `get_per_core_factor()` sizes the per-core output block using only L1 capacity - it starts at a `16x16` tile block and halves until one fits, never checking it against the actual output tile dimensions.
- The output shard shape is derived from this block (`per_core_M * tile_h`, `per_core_N * tile_w`), so a `13x13`-tile output was assigned a `16x16` block. A requested `416x416` `BLOCK_SHARDED` shard came back as `512x512` instead.
- Separately, `2D` auto-config always set `fuse_batch=false`. With sharded output that loops `A`'s batch into a CB sized for one block, so `A` batch `> 1` hangs or fatals. `fuse_batch=true` is only legal when `B` batch is `1`.

## What's Changed

**Cap the per-core block**
- `per_core_M` / `per_core_N` are now clamped with `std::min` against `Mt` / `Nt` (the padded output tile dimensions) in `create_simple_matmul_program_config()`.

**Pick a legal `out_subblock`**
- After the cap, `per_core` can be a value the old hardcoded subblock does not divide. Example: `400×400` → `per_core_N = 13`. The previous `out_subblock_w = 2` fails `13 % 2 != 0` (`TT_FATAL`: `out_block_w` must be divisible by `out_subblock_w`).
- So the hardcoded `out_subblock_h = 4, out_subblock_w = 2` is replaced with `bmm_op_utils::get_matmul_subblock_params()`, which picks a pair that divides the (possibly capped) `per_core_M` / `per_core_N`. For `13` that is `(1, 1)`. For `16×16` it still yields a pair that divides, so existing shapes stay valid.
- For sharded output, the picked pair must also satisfy `out_subblock_w == per_core_N` or `out_subblock_h == 1`. The first version of this handled that by forcing `out_subblock_h = 1` whenever the check failed, without re-checking whether a wider `out_subblock_w` was still legal - e.g. for a `16x16` block it picked `(4, 2)` then truncated to `(1, 2)`, when `(1, 8)` is legal and needs `4x` fewer subblocks (`32` vs `128`). This is now a search over `SUBBLOCK_HW_CHOICES` for the first pair satisfying `out_subblock_h == 1 OR out_subblock_w == per_core_N` (plus the existing divisibility and `fp32_dest_acc_en` `<= 4`-tile checks), so it can also pick an `out_subblock_h > 1` option when that's the more efficient legal choice - e.g. for a `4x4` block, `(2, 4)` over `(1, 4)`.

**Fuse batch for sharded output when `B` is unbatched**
- `2D` auto-config now sets `fuse_batch` when the output is sharded, `A` batch `> 1`, and `B` batch `== 1`, so the kernel folds `A`'s batch into `M` instead of writing a batch loop into one shard CB.
- `compute_output_specs()` for `2D` mcast uses `program_config.fuse_batch` instead of hardcoding `true`, so the host shard grid matches the factory work grid.

## Tests
- Added `test_matmul_default_block_sharded_single_core` in `tests/ttnn/unit_tests/operations/matmul/test_matmul.py`, covering the shard-shape cap and `out_subblock` selection, including a run with `fp32_dest_acc_en` on.

## Coverage
- `13x13` tile repro, asymmetric `13x4`, `16x16` unchanged at the L1-ladder start, and sharded `A` batch `5` with broadcast `B`, all on a single-core request grid.
- `10x2` and `4x4` tile blocks where a legal `out_subblock_h > 1` beats the `out_subblock_h == 1` fallback, plus the same `4x4` block with `fp32_dest_acc_en` on to confirm the `<= 4`-tile cap still picks a legal subblock (`(1, 4)`).

## Further Scope / Improvements
- For prime-ish `per_core_N` (`13`, `11`, `3`, ...), the picked subblock is `(1, 1)` - legal, but the least efficient choice with `169 iterations`, since sharded output requires `out_subblock_w == per_core_N` or `out_subblock_h == 1`. This PR prioritizes the correct shard shape. A follow-up can pad the compute block width instead of the shard - e.g. `13 -> 14` tiles, moving the subblock from `(1, 1)` to `(1, 7)` to reduce the iterations from `169 to ~26` - without changing the shard size.



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/matmul-per-core-cap-functional-32435)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/matmul-per-core-cap-functional-32435)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/matmul-per-core-cap-functional-32435)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/matmul-per-core-cap-functional-32435)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/matmul-per-core-cap-functional-32435)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/matmul-per-core-cap-functional-32435)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/matmul-per-core-cap-functional-32435)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/matmul-per-core-cap-functional-32435)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/matmul-per-core-cap-functional-32435)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/matmul-per-core-cap-functional-32435)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/matmul-per-core-cap-functional-32435)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/matmul-per-core-cap-functional-32435)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/matmul-per-core-cap-functional-32435)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/matmul-per-core-cap-functional-32435)