### PR TITLE
[LLK] Add tests for blaze topk_xl additions

### DIFF
--- a/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
+++ b/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
@@ -67,7 +67,9 @@ ALWI void topk_xl_local_sort(std::uint32_t idst, bool ascending) {
  * The default (full-sort) instantiation runs the same network as
  * topk_xl_local_sort and does issue it.
  *
- * early_exit_K64 requires K >= 1024; K = 512 is rejected by static_assert.
+ * early_exit_K64 requires K >= 1024, and the full sort K = 512 or K = 1024: the
+ * generic network does not converge at K = 2048, so that size has to go through
+ * topk_xl_local_sort and its fast path. Both are enforced by static_assert.
  */
 template <std::uint32_t K, bool early_exit_K64 = false>
 ALWI void topk_xl_local_sort_generic(std::uint32_t idst, bool ascending) {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -806,6 +806,21 @@ class TopKXLChunkBaseMode(Enum):
     Runtime = 2
 
 
+class TopKXLSortMode(Enum):
+    """Which local-sort entry point the topk_xl kernel calls.
+
+    ``Dispatch`` goes through ``_topk_xl_local_sort_``, which routes K=2048 to its
+    fast path and K=512/1024 to the generic body. ``Generic`` calls
+    ``_topk_xl_local_sort_generic_`` directly, reaching the generic body for K=2048
+    as well. ``EarlyExitK64`` stops the generic body after the per-column len-64
+    builds, leaving each 64-element column sorted in isolation (K >= 1024).
+    """
+
+    Dispatch = 0
+    Generic = 1
+    EarlyExitK64 = 2
+
+
 class VectorMode(Enum):
     """Mirrors ckernel::VectorMode in tt_llk_quasar/llk_lib/llk_defs.h.
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -807,14 +807,7 @@ class TopKXLChunkBaseMode(Enum):
 
 
 class TopKXLSortMode(Enum):
-    """Which local-sort entry point the topk_xl kernel calls.
-
-    ``Dispatch`` goes through ``_topk_xl_local_sort_``, which routes K=2048 to its
-    fast path and K=512/1024 to the generic body. ``Generic`` calls
-    ``_topk_xl_local_sort_generic_`` directly, reaching the generic body for K=2048
-    as well. ``EarlyExitK64`` stops the generic body after the per-column len-64
-    builds, leaving each 64-element column sorted in isolation (K >= 1024).
-    """
+    """Which local-sort entry point the topk_xl kernel calls."""
 
     Dispatch = 0
     Generic = 1

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -37,6 +37,7 @@ from .llk_params import (
     TopKSortDirection,
     TopKXLChunkBaseMode,
     TopKXLIndexOp,
+    TopKXLSortMode,
     Transpose,
     UnpackerEngine,
     VectorMode,
@@ -745,6 +746,9 @@ class TOPK_XL(TemplateParameter):
     chunk_base: int = 0
     fused_e2e: bool = False
     seg_base: int = 0
+    sort_mode: TopKXLSortMode = TopKXLSortMode.Dispatch
+    lsb_row_major: bool = False
+    reinit_after_copy: bool = False
 
     def convert_to_cpp(self) -> str:
         lines: list[str] = [
@@ -762,6 +766,9 @@ class TOPK_XL(TemplateParameter):
             f"constexpr std::uint32_t TOPK_XL_CHUNK_BASE = {self.chunk_base};",
             f"constexpr bool TOPK_XL_FUSED_E2E = {str(self.fused_e2e).lower()};",
             f"constexpr std::uint32_t TOPK_XL_SEG_BASE = {self.seg_base};",
+            f"constexpr std::uint32_t TOPK_XL_SORT_MODE = {self.sort_mode.value};",
+            f"constexpr bool TOPK_XL_LSB_ROW_MAJOR = {str(self.lsb_row_major).lower()};",
+            f"constexpr bool TOPK_XL_REINIT_AFTER_COPY = {str(self.reinit_after_copy).lower()};",
         ]
         return "\n".join(lines)
 

--- a/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
@@ -585,26 +585,36 @@ def test_topk_xl_separate_indices(K, core_id, group_shift):
     )
 
 
-@parametrize(K=[512, 1024, 2048])
-def test_topk_xl_remove_msb(K):
+def _check_remove_msb(result, K, rows, core_id=0, row_major=False):
     """
-    remove_msb_values: fused region -> [0 | raw], packed in place as one region.
-    Check the value half is zeroed and the decoded positions form the full 0..K-1 set.
+    remove_msb_values packs the fused region in place as one region of
+    [0 | core_id<<11 | coordinate]. Check the value half is zeroed, the core_id field
+    survives, and the coordinates form the full 0..K-1 set. `row_major` selects the
+    add_lsb numbering the coordinate is in.
     """
-    (K,) = K
-
-    result, rows = _run(
-        K, index_op=TopKXLIndexOp.RemoveMsb, group_id=GROUP_ID, group_shift=GROUP_SHIFT
-    )
     for r, (fused, _) in enumerate(_extract_hw_topk(result, K, rows.shape[0], 1)):
         assert fused.numel() == K, f"row {r}: expected {K} lanes, got {fused.numel()}"
         untouched = int(torch.count_nonzero(fused >> 16))
         assert untouched == 0, f"row {r}: value half not zeroed in {untouched} lanes"
 
-        pos = [_decode_row_major(int(x), K) for x in (fused & 0xFFFF).tolist()]
+        hw_core = (fused >> CORE_ID_SHIFT) & CORE_ID_MASK
+        assert torch.all(hw_core == core_id), (
+            f"row {r}: core_id field is "
+            f"{sorted(set(int(c) for c in hw_core.tolist()))[:4]}, want {core_id}"
+        )
+
+        pos = [_index_to_chunk_offset(int(x), K, row_major) for x in fused.tolist()]
         assert set(pos) == set(
             range(K)
-        ), f"row {r}: decoded positions are not the full 0..K-1 set"
+        ), f"row {r}: coordinates are not the full 0..K-1 set"
+
+
+@parametrize(K=[512, 1024, 2048])
+def test_topk_xl_remove_msb(K):
+    (K,) = K
+
+    result, rows = _run(K, index_op=TopKXLIndexOp.RemoveMsb)
+    _check_remove_msb(result, K, rows)
 
 
 # chunk_base is saved by one of three inits, based on a template argument:
@@ -859,26 +869,10 @@ def test_topk_xl_dest_sync_half(K):
     _run_test_topk(K, num_chunks=2, num_rows=2, dest_sync=DestSync.Half)
 
 
-# The generic body is what local_sort dispatches to for K = 512 and K = 1024, so both
-# modes have to leave a total order there. K = 2048 has no generic full sort, so it runs
-# Dispatch only, through its own fast path.
-@parametrize(
-    K=[512, 1024, 2048],
-    sort_direction=list(TopKSortDirection),
-    sort_mode=lambda K: (
-        [TopKXLSortMode.Dispatch]
-        if K == 2048
-        else [TopKXLSortMode.Dispatch, TopKXLSortMode.Generic]
-    ),
-)
-def test_topk_xl_local_sort_order(K, sort_direction, sort_mode):
+@parametrize(K=[512, 1024, 2048], sort_direction=list(TopKSortDirection))
+def test_topk_xl_local_sort_order(K, sort_direction):
     """local_sort leaves the whole K-element sequence sorted in Dest."""
-    values = [
-        hi16
-        for hi16, _ in _sorted_sequence(
-            K, sort_direction=sort_direction, sort_mode=sort_mode
-        )
-    ]
+    values = [hi16 for hi16, _ in _sorted_sequence(K, sort_direction=sort_direction)]
 
     ascending = sort_direction == TopKSortDirection.Ascending
     inversions = [p for p in range(K - 1) if (values[p] < values[p + 1]) != ascending]
@@ -889,11 +883,15 @@ def test_topk_xl_local_sort_order(K, sort_direction, sort_mode):
     )
 
 
-@parametrize(K=[512, 1024], num_chunks=[1, 2])
-def test_topk_xl_local_sort_generic(K, num_chunks):
-    _run_test_topk(
-        K, num_chunks=num_chunks, num_rows=2, sort_mode=TopKXLSortMode.Generic
-    )
+# Smoke test on the entry point only. `_topk_xl_local_sort_` is a pure forward to
+# `_topk_xl_local_sort_generic_` for K != 2048, so calling the generic body directly
+# builds the same SFPU code the default path already covers; both legal K are kept
+# because the network itself differs between them, but nothing past that would.
+@parametrize(K=[512, 1024])
+def test_topk_xl_local_sort_generic(K):
+    (K,) = K
+
+    _run_test_topk(K, num_rows=2, sort_mode=TopKXLSortMode.Generic)
 
 
 # early_exit_K64 stops the generic body after the per-column len-64 builds, so each
@@ -963,21 +961,7 @@ def test_topk_xl_remove_msb_row_major(K, core_id):
     result, rows = _run(
         K, index_op=TopKXLIndexOp.RemoveMsb, core_id=core_id, lsb_row_major=True
     )
-    for r, (fused, _) in enumerate(_extract_hw_topk(result, K, rows.shape[0], 1)):
-        assert fused.numel() == K, f"row {r}: expected {K} lanes, got {fused.numel()}"
-        untouched = int(torch.count_nonzero(fused >> 16))
-        assert untouched == 0, f"row {r}: value half not zeroed in {untouched} lanes"
-
-        hw_core = (fused >> CORE_ID_SHIFT) & CORE_ID_MASK
-        assert torch.all(hw_core == core_id), (
-            f"row {r}: core_id field is "
-            f"{sorted(set(int(c) for c in hw_core.tolist()))[:4]}, want {core_id}"
-        )
-
-        pos = [_index_to_chunk_offset(int(x), K, True) for x in fused.tolist()]
-        assert set(pos) == set(
-            range(K)
-        ), f"row {r}: offsets are not the full 0..K-1 set"
+    _check_remove_msb(result, K, rows, core_id=core_id, row_major=True)
 
 
 # Check reinits that run after copy init.

--- a/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
@@ -859,16 +859,33 @@ def test_topk_xl_dest_sync_half(K):
     _run_test_topk(K, num_chunks=2, num_rows=2, dest_sync=DestSync.Half)
 
 
-@parametrize(K=[512, 1024, 2048])
-def test_topk_xl_local_sort_order(K):
-    """local_sort leaves the whole K-element sequence sorted descending in Dest."""
-    (K,) = K
+# The generic body is what local_sort dispatches to for K = 512 and K = 1024, so both
+# modes have to leave a total order there. K = 2048 has no generic full sort, so it runs
+# Dispatch only, through its own fast path.
+@parametrize(
+    K=[512, 1024, 2048],
+    sort_direction=list(TopKSortDirection),
+    sort_mode=lambda K: (
+        [TopKXLSortMode.Dispatch]
+        if K == 2048
+        else [TopKXLSortMode.Dispatch, TopKXLSortMode.Generic]
+    ),
+)
+def test_topk_xl_local_sort_order(K, sort_direction, sort_mode):
+    """local_sort leaves the whole K-element sequence sorted in Dest."""
+    values = [
+        hi16
+        for hi16, _ in _sorted_sequence(
+            K, sort_direction=sort_direction, sort_mode=sort_mode
+        )
+    ]
 
-    values = [hi16 for hi16, _ in _sorted_sequence(K)]
-    inversions = [p for p in range(K - 1) if values[p] < values[p + 1]]
+    ascending = sort_direction == TopKSortDirection.Ascending
+    inversions = [p for p in range(K - 1) if (values[p] < values[p + 1]) != ascending]
     assert not inversions, (
-        f"Dest is not descending in sort-position order: {len(inversions)} inversions, "
-        f"first between positions {inversions[0]} and {inversions[0] + 1}"
+        f"Dest is not {'ascending' if ascending else 'descending'} in sort-position "
+        f"order: {len(inversions)} inversions, first between positions "
+        f"{inversions[0]} and {inversions[0] + 1}"
     )
 
 
@@ -936,6 +953,31 @@ def test_topk_xl_add_lsb_indices_row_major(K, core_id):
         core_id=core_id,
         row_major=True,
     )
+
+
+# The other index op that reports a raw coordinate. remove_msb_values packs in place,
+# so the row_major numbering has to survive as [0 | core_id<<11 | chunk offset] with
+# nothing left to decode.
+@parametrize(K=[512, 1024, 2048], core_id=[0, 31])
+def test_topk_xl_remove_msb_row_major(K, core_id):
+    result, rows = _run(
+        K, index_op=TopKXLIndexOp.RemoveMsb, core_id=core_id, lsb_row_major=True
+    )
+    for r, (fused, _) in enumerate(_extract_hw_topk(result, K, rows.shape[0], 1)):
+        assert fused.numel() == K, f"row {r}: expected {K} lanes, got {fused.numel()}"
+        untouched = int(torch.count_nonzero(fused >> 16))
+        assert untouched == 0, f"row {r}: value half not zeroed in {untouched} lanes"
+
+        hw_core = (fused >> CORE_ID_SHIFT) & CORE_ID_MASK
+        assert torch.all(hw_core == core_id), (
+            f"row {r}: core_id field is "
+            f"{sorted(set(int(c) for c in hw_core.tolist()))[:4]}, want {core_id}"
+        )
+
+        pos = [_index_to_chunk_offset(int(x), K, True) for x in fused.tolist()]
+        assert set(pos) == set(
+            range(K)
+        ), f"row {r}: offsets are not the full 0..K-1 set"
 
 
 # Check reinits that run after copy init.

--- a/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
@@ -861,13 +861,7 @@ def test_topk_xl_dest_sync_half(K):
 
 @parametrize(K=[512, 1024, 2048])
 def test_topk_xl_local_sort_order(K):
-    """
-    local_sort leaves the whole K-element sequence sorted descending in Dest.
-
-    Nothing else here reads Dest lane order, but the early-exit sort below is defined in
-    terms of it, so pin `_sort_position` against a full sort: a wrong permutation would
-    make that test's notion of a column meaningless.
-    """
+    """local_sort leaves the whole K-element sequence sorted descending in Dest."""
     (K,) = K
 
     values = [hi16 for hi16, _ in _sorted_sequence(K)]
@@ -878,9 +872,6 @@ def test_topk_xl_local_sort_order(K):
     )
 
 
-# _topk_xl_local_sort_generic_ is the body _topk_xl_local_sort_ dispatches to below
-# K = 2048; the compute API now exposes it directly as well. K = 2048 has no generic
-# full sort and is rejected by static_assert, hence its absence here.
 @parametrize(K=[512, 1024], num_chunks=[1, 2])
 def test_topk_xl_local_sort_generic(K, num_chunks):
     _run_test_topk(
@@ -947,11 +938,7 @@ def test_topk_xl_add_lsb_indices_row_major(K, core_id):
     )
 
 
-# The tt-blaze merge tree copies each incoming operand into Dest, so the copy init is
-# the last thing to touch the math thread's config before the merge: it rewrites
-# ADDR_MOD_0/3 and reprograms the MOP Expander for datacopy. The two reinit entry
-# points restore that much, in place of the full topk_xl_init this test issues per
-# merge stage otherwise.
+# Check reinits that run after copy init.
 @parametrize(K=[512, 1024, 2048], num_chunks=[2, 4], fused=[False, True])
 def test_topk_xl_reinit_after_copy(K, num_chunks, fused):
     if not fused:

--- a/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
@@ -22,6 +22,7 @@ from helpers.llk_params import (
     TopKSortDirection,
     TopKXLChunkBaseMode,
     TopKXLIndexOp,
+    TopKXLSortMode,
     format_dict,
 )
 from helpers.param_config import parametrize
@@ -73,6 +74,38 @@ def _decode_row_major(raw: int, K: int) -> int:
     face = (row // FACE_DIM) * 2 + (column // FACE_DIM)
     offset_in_face = (row % FACE_DIM) * FACE_DIM + (column % FACE_DIM)
     return tile * ELEMENTS_PER_TILE + face * ELEMENTS_PER_FACE + offset_in_face
+
+
+def _index_to_chunk_offset(raw: int, K: int, row_major: bool = False) -> int:
+    """
+    Turn an add_lsb index field into the element's offset in its chunk. The default
+    numbering is the tile coordinate `_decode_row_major` translates; the row_major
+    numbering is already the offset, in bits [10:0].
+    """
+    return (raw & 0x7FF) if row_major else _decode_row_major(raw, K)
+
+
+def _sort_position(dest_offset: int, K: int) -> int:
+    """
+    Position of a Dest word in the sequence the bitonic network sorts, 0 .. K-1.
+
+    `dest_offset` indexes a slot's Dest region in packed order, which is also the L1
+    order the copy reads, so an element's starting offset is its chunk offset. The
+    sort's order is a bit permutation of that (tile, row, column): from the most
+    significant field down, column bits [3:0], tile, row bit [4], column bit [4], row
+    bits [3:0]. K=512 uses one tile and rows 0 .. 15, dropping the two middle fields.
+    """
+    tile, within_tile = divmod(dest_offset, ELEMENTS_PER_TILE)
+    face, within_face = divmod(within_tile, ELEMENTS_PER_FACE)
+    row = (face // 2) * FACE_DIM + within_face // FACE_DIM
+    column = (face % 2) * FACE_DIM + within_face % FACE_DIM
+    return (
+        (K // FACE_DIM) * (column % FACE_DIM)
+        + 64 * tile
+        + 32 * (row // FACE_DIM)
+        + FACE_DIM * (column // FACE_DIM)
+        + row % FACE_DIM
+    )
 
 
 def _bitcast_float32(words: torch.Tensor) -> torch.Tensor:
@@ -189,6 +222,9 @@ def _variant(
     chunk_base=0,
     fused_e2e=False,
     seg_base=0,
+    sort_mode=TopKXLSortMode.Dispatch,
+    lsb_row_major=False,
+    reinit_after_copy=False,
     dest_sync=DestSync.Full,
     formats=FORMATS,
 ):
@@ -231,6 +267,9 @@ def _variant(
                 chunk_base=chunk_base,
                 fused_e2e=fused_e2e,
                 seg_base=seg_base,
+                sort_mode=sort_mode,
+                lsb_row_major=lsb_row_major,
+                reinit_after_copy=reinit_after_copy,
             ),
         ],
         variant_stimuli=StimuliConfig(
@@ -269,6 +308,56 @@ def _run_test_topk(K, compare_index_set=True, index_offset=0, **kwargs):
         index_offset=index_offset,
         value_format=kwargs.get("formats", FORMATS).input_format,
     )
+
+
+def _regions(result, K):
+    """
+    Row 0's value and index regions as raw uint32 words, still in packed Dest order.
+    `_extract_hw_topk` drops that order; the sort-order tests need it.
+    """
+    res = torch.tensor(result, dtype=format_dict[FORMATS.output_format])
+    region = _tiles_per_sequence(K) * ELEMENTS_PER_TILE
+    return res[:region], res[region : 2 * region]
+
+
+def _sorted_sequence(K, **kwargs):
+    """
+    Run a single-chunk Separate variant and return the K-element sequence local_sort
+    left in Dest, indexed by sort position: sequence[p] = (bf16 high 16, chunk offset).
+    The pairing is asserted here, so callers only have to look at the order.
+
+    The default `positive` stimulus is distinct and all positive, so the high 16 bits
+    compare as integers in value order.
+    """
+    result, rows = _run(
+        K,
+        index_op=TopKXLIndexOp.Separate,
+        group_id=GROUP_ID,
+        group_shift=GROUP_SHIFT,
+        **kwargs,
+    )
+    value_words, index_words = _regions(result, K)
+    sequence = {}
+    for offset in range(value_words.numel()):
+        value = int(value_words[offset])
+        if (value >> 16) == BF16_NEG_INF_HI16:  # only K=512 pads its Dest tile
+            continue
+        raw = int(index_words[offset]) & ((1 << GROUP_SHIFT) - 1)
+        sequence[_sort_position(offset, K)] = (
+            value >> 16,
+            _index_to_chunk_offset(raw, K),
+        )
+    assert sorted(sequence) == list(
+        range(K)
+    ), f"Dest holds {len(sequence)} finite lanes, not the sequence 0..K-1"
+
+    row = rows[0]
+    for position, (hi16, offset) in sequence.items():
+        assert (int(row[offset].view(torch.int32)) >> 16) & 0xFFFF == hi16, (
+            f"sort position {position} reports offset {offset}, which does not hold "
+            f"the value alongside it"
+        )
+    return [sequence[p] for p in range(K)]
 
 
 def _extract_hw_topk(result, K, num_rows, num_regions=2):
@@ -368,10 +457,11 @@ def _check_coordinates(
     group_id=0,
     group_shift=GROUP_SHIFT,
     core_id=None,
+    row_major=False,
 ):
     """
-    Validate the index ops that report a tile coordinate instead of a flat index:
-    index word is [group_id<<shift | core_id<<11 | tile coordinate].
+    Validate the index ops that report a per-chunk coordinate instead of a flat index:
+    index word is [group_id<<shift | core_id<<11 | coordinate].
 
     Checks the group_id and core_id fields, that every coordinate identifies its
     element's position, and that the values are the top-K. With num_chunks == 1
@@ -380,6 +470,7 @@ def _check_coordinates(
 
     `core_id=None` skips the core_id check: a group_shift of 11 or less puts the
     group id over bits [15:11], leaving no separable core bits to read back.
+    `row_major` selects the add_lsb numbering the coordinate is in.
     """
     num_rows = rows.shape[0]
     for r, (hw_iw, hw_val) in enumerate(_extract_hw_topk(result, K, num_rows)):
@@ -399,7 +490,7 @@ def _check_coordinates(
                 f"{sorted(set(int(c) for c in hw_core.tolist()))[:4]}, want {core_id}"
             )
 
-        pos = [_decode_row_major(int(x), K) for x in raw.tolist()]
+        pos = [_index_to_chunk_offset(int(x), K, row_major) for x in raw.tolist()]
         if num_chunks == 1:
             assert set(pos) == set(range(K)), f"row {r}: decoded positions != 0..K-1"
         else:
@@ -766,3 +857,115 @@ def test_topk_xl_dest_sync_half(K):
     (K,) = K
 
     _run_test_topk(K, num_chunks=2, num_rows=2, dest_sync=DestSync.Half)
+
+
+@parametrize(K=[512, 1024, 2048])
+def test_topk_xl_local_sort_order(K):
+    """
+    local_sort leaves the whole K-element sequence sorted descending in Dest.
+
+    Nothing else here reads Dest lane order, but the early-exit sort below is defined in
+    terms of it, so pin `_sort_position` against a full sort: a wrong permutation would
+    make that test's notion of a column meaningless.
+    """
+    (K,) = K
+
+    values = [hi16 for hi16, _ in _sorted_sequence(K)]
+    inversions = [p for p in range(K - 1) if values[p] < values[p + 1]]
+    assert not inversions, (
+        f"Dest is not descending in sort-position order: {len(inversions)} inversions, "
+        f"first between positions {inversions[0]} and {inversions[0] + 1}"
+    )
+
+
+# _topk_xl_local_sort_generic_ is the body _topk_xl_local_sort_ dispatches to below
+# K = 2048; the compute API now exposes it directly as well. K = 2048 has no generic
+# full sort and is rejected by static_assert, hence its absence here.
+@parametrize(K=[512, 1024], num_chunks=[1, 2])
+def test_topk_xl_local_sort_generic(K, num_chunks):
+    _run_test_topk(
+        K, num_chunks=num_chunks, num_rows=2, sort_mode=TopKXLSortMode.Generic
+    )
+
+
+# early_exit_K64 stops the generic body after the per-column len-64 builds, so each
+# 64-element column is sorted on its own and nothing crosses a column boundary. The
+# tt-blaze sparse-K reader wants that: it can stop scanning a column at the first
+# all-zero packed mask word.
+#
+# The len-64 build flips direction between pairs of columns and early exit keeps that
+# flip whenever there is more than one pair, so K=2048 alternates column directions
+# while K=1024, a single pair, does not.
+@parametrize(K=[1024, 2048], sort_direction=list(TopKSortDirection))
+def test_topk_xl_local_sort_early_exit(K, sort_direction):
+    sequence = _sorted_sequence(
+        K, sort_mode=TopKXLSortMode.EarlyExitK64, sort_direction=sort_direction
+    )
+
+    # An element's starting Dest offset is its chunk offset, so this is the set each
+    # column has to still hold afterwards.
+    members = {}
+    for offset in range(K):
+        members.setdefault(_sort_position(offset, K) // 64, set()).add(offset)
+
+    ascending = sort_direction == TopKSortDirection.Ascending
+    for column, expected in sorted(members.items()):
+        entries = sequence[64 * column : 64 * (column + 1)]
+        values = [hi16 for hi16, _ in entries]
+        column_ascending = ascending != (K == 2048 and column % 2 == 1)
+        assert values == sorted(values, reverse=not column_ascending), (
+            f"column {column} is not sorted "
+            f"{'ascending' if column_ascending else 'descending'}"
+        )
+        assert {offset for _, offset in entries} == expected, (
+            f"column {column} does not hold the elements it started with: "
+            f"missing {sorted(expected - {o for _, o in entries})[:8]}, "
+            f"unexpected {sorted({o for _, o in entries} - expected)[:8]}"
+        )
+
+
+# row_major=true stamps each element's chunk offset instead of the tile coordinate the
+# default numbering needs decoding from. The offset fits in bits [10:0] for every K, so
+# core_id keeps bits [15:11] either way.
+@parametrize(K=[512, 1024, 2048], core_id=[0, 31])
+def test_topk_xl_add_lsb_indices_row_major(K, core_id):
+    result, rows = _run(
+        K,
+        index_op=TopKXLIndexOp.Separate,
+        group_id=GROUP_ID,
+        group_shift=GROUP_SHIFT,
+        core_id=core_id,
+        lsb_row_major=True,
+    )
+    _check_coordinates(
+        result,
+        K,
+        rows,
+        group_id=GROUP_ID,
+        core_id=core_id,
+        row_major=True,
+    )
+
+
+# The tt-blaze merge tree copies each incoming operand into Dest, so the copy init is
+# the last thing to touch the math thread's config before the merge: it rewrites
+# ADDR_MOD_0/3 and reprograms the MOP Expander for datacopy. The two reinit entry
+# points restore that much, in place of the full topk_xl_init this test issues per
+# merge stage otherwise.
+@parametrize(K=[512, 1024, 2048], num_chunks=[2, 4], fused=[False, True])
+def test_topk_xl_reinit_after_copy(K, num_chunks, fused):
+    if not fused:
+        _run_test_topk(K, num_chunks=num_chunks, num_rows=2, reinit_after_copy=True)
+        return
+
+    result, rows = _run(
+        K,
+        num_chunks=num_chunks,
+        fused_reduce=True,
+        reinit_after_copy=True,
+        group_id=GROUP_ID,
+        group_shift=GROUP_SHIFT,
+    )
+    _check_coordinates(
+        result, K, rows, num_chunks=num_chunks, group_id=GROUP_ID, core_id=None
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_topk_xl_unfused_macro.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_topk_xl_unfused_macro.py
@@ -84,7 +84,9 @@ class TOPK_XL_MACRO_KNOBS(TemplateParameter):
         return "\n".join(lines)
 
 
-def _variant(K, num_chunks, opt_out=False, mutate=False, num_rows=2):
+def _variant(
+    K, num_chunks, opt_out=False, mutate=False, num_rows=2, reinit_after_copy=False
+):
     """The op path: row-major index split, UNFUSED merge/rebuild, descending.
     Mirrors test_topk_xl._variant with the macro knobs added."""
     tail_elements = K
@@ -111,6 +113,7 @@ def _variant(K, num_chunks, opt_out=False, mutate=False, num_rows=2):
                 fused_reduce=False,
                 chunk_base_mode=TopKXLChunkBaseMode.Static,
                 chunk_base=0,
+                reinit_after_copy=reinit_after_copy,
             ),
             TOPK_XL_MACRO_KNOBS(opt_out=opt_out, mutate=mutate),
         ],
@@ -189,3 +192,16 @@ def test_topk_xl_unfused_macro_mutation(K):
         f"is void; the macro path is either not being compiled in or not "
         f"being exercised."
     )
+
+
+@parametrize(K=[512, 1024, 2048], opt_out=[False, True])
+def test_topk_xl_unfused_macro_reinit_after_copy(K, opt_out):
+    """The post-copy unfused reinit reaches the MOP Expander through
+    ``topk_mop_config<false>``, whose recording window is the macro body (16
+    instructions) on the default build and the shipping body (18) under
+    ``DISABLE_TOPK_XL_SFPLOADMACRO``. A reinit that programs the other build's
+    length replays a truncated or overlong merge body, so run both arms at
+    num_chunks = 4 for the same reason the chained gate does."""
+    config, rows = _variant(K, num_chunks=4, opt_out=opt_out, reinit_after_copy=True)
+    result = config.run().result
+    _check(result, K, rows, compare_index_set=True)

--- a/tt_metal/tt-llk/tests/sources/topk_xl_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_xl_test.cpp
@@ -94,8 +94,21 @@ constexpr bool FUSED_E2E = TOPK_XL_FUSED_E2E;
 // dummy SrcB valid: it returns before anything consumes the operand.
 constexpr bool LOCAL_SORT_NEEDS_SRCB = !SORT_MODE_EARLY_EXIT;
 
-static_assert(!SORT_MODE_EARLY_EXIT || (TOPK_XL_NUM_CHUNKS == 1 && !FUSED_REDUCE), "the early-exit sort leaves a partial order, so there is nothing to merge");
-static_assert(!TOPK_XL_LSB_ROW_MAJOR || !INDEX_OP_ROW_MAJOR, "separate_indices_row_major decodes the coordinate add_lsb numbering");
+// copy_sort_rt hard-codes the dispatch sort, so TOPK_XL_SORT_MODE reaches copy_sort
+// only. Under fused-e2e a non-default mode would compile and then be ignored: Generic
+// silently runs the dispatch sort, and early exit also drops the SrcB dummy valid on
+// UNPACK (below) that the dispatch sort it actually runs still waits for, so MATH hangs.
+static_assert(TOPK_XL_SORT_MODE == 0 || !FUSED_E2E, "TOPK_XL_SORT_MODE has no effect on the fused-e2e path: copy_sort_rt always calls the dispatch sort");
+// The early-exit sort leaves each column sorted on its own, so nothing may merge or
+// rebuild over it: no second chunk, neither fused reduction, and not the row-major op
+// path, whose lone-chunk rebuild would permute the partial order into a bogus one.
+static_assert(
+    !SORT_MODE_EARLY_EXIT || (TOPK_XL_NUM_CHUNKS == 1 && !FUSED_REDUCE && !INDEX_OP_ROW_MAJOR),
+    "the early-exit sort leaves a partial order, so nothing may merge or rebuild over it");
+// Op 0 is the only index op that decodes the tile-coordinate numbering. It is also the
+// ignored default under the fused branches, which reach their own terminal split, so
+// exclude those before rejecting the combination.
+static_assert(!TOPK_XL_LSB_ROW_MAJOR || !INDEX_OP_ROW_MAJOR || FUSED_REDUCE, "separate_indices_row_major decodes the coordinate add_lsb numbering");
 
 // Second merge operand. `_topk_xl_merge_` reads it at a fixed distance from the
 // first: 64 dest units (one tile) per sequence-tile when fused, 128 (value +
@@ -336,11 +349,11 @@ __attribute__((noinline)) void copy_sort(std::uint32_t slot, std::uint32_t activ
     topk_xl_init<K, true>();
     if constexpr (SORT_MODE_EARLY_EXIT)
     {
-        topk_xl_local_sort_generic<K, true>(slot, ascending);
+        topk_xl_local_sort_generic<K, true /* early_exit_K64 */>(slot, ascending);
     }
     else if constexpr (SORT_MODE_GENERIC)
     {
-        topk_xl_local_sort_generic<K, false>(slot, ascending);
+        topk_xl_local_sort_generic<K, false /* early_exit_K64 */>(slot, ascending);
     }
     else
     {
@@ -406,7 +419,7 @@ inline void topk_xl_reinit_after_copy(std::uint32_t dst_format)
 {
     if constexpr (!fused)
     {
-        topk_xl_init<K, false>();
+        topk_xl_init<K, false /* fused */>();
     }
     ckernel::_llk_math_topk_xl_copy_init_(dst_format);
     if constexpr (fused)
@@ -424,6 +437,9 @@ inline void topk_xl_reinit_after_copy(std::uint32_t dst_format)
 // length and iteration count all differ (see topk_mop_config / _topk_xl_merge_).
 // `_topk_xl_merge_` always keeps the max half, so TOPK_XL_ASCENDING changes only
 // the order the surviving top-K is rebuilt into, not which elements survive.
+// Under TOPK_XL_REINIT_AFTER_COPY the stage is reached through topk_xl_reinit_after_copy
+// instead of a full init, which is why `dst_format` is needed: the copy init it replays
+// takes it.
 template <std::uint32_t K, bool fused>
 __attribute__((noinline)) void merge_and_rebuild(bool do_merge, std::uint32_t dst_format)
 {

--- a/tt_metal/tt-llk/tests/sources/topk_xl_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_xl_test.cpp
@@ -10,11 +10,13 @@
 // llk_math_eltwise_unary_sfpu_topk_xl.h), which wrap the llk_lib entry points:
 //   * ckernel::_llk_unpack_topk_xl_copy_init_ / _llk_unpack_topk_xl_copy_
 //   * ckernel::_llk_math_topk_xl_copy_init_ / _llk_math_topk_xl_copy_
-//   * ckernel::sfpu::_topk_xl_init_ / _topk_xl_local_sort_ / _topk_xl_merge_ /
-//     _topk_xl_rebuild_ / _topk_xl_add_lsb_indices_(_init_) /
+//   * ckernel::sfpu::_topk_xl_init_ / _topk_xl_local_sort_ /
+//     _topk_xl_local_sort_generic_ / _topk_xl_merge_ / _topk_xl_rebuild_ /
+//     _topk_xl_add_lsb_indices_(_init_) /
 //     _topk_xl_separate_indices_row_major_(_init_static_ / _reinit_ /
 //     _advance_chunk_base_) / _topk_xl_separate_indices_(_init_) /
-//     _topk_xl_remove_msb_values_(_init_)
+//     _topk_xl_remove_msb_values_(_init_) / topk_mop_config /
+//     topk_reinit_unfused_rebuild_after_copy
 //
 // The shared core is copy_sort (copy -> add_lsb_indices -> init(fused) ->
 // local_sort); TOPK_XL_INDEX_OP picks the terminal index step. Op 0 mirrors the
@@ -51,11 +53,25 @@ std::uint32_t math_sync_tile_dst_index = 0;
 //                   chunk.
 //   TOPK_XL_GROUP_ID / TOPK_XL_GROUP_SHIFT : generic separate_indices params
 //   TOPK_XL_CORE_ID:         add_lsb_indices core_id, index bits [15:11] (0 .. 31)
-//   TOPK_XL_ASCENDING:       rebuild direction (false descending, true ascending)
+//   TOPK_XL_ASCENDING:       rebuild direction (false descending, true ascending),
+//                            or, for the single-chunk terminal index ops that never
+//                            rebuild, the local-sort direction
 //   TOPK_XL_FUSED_REDUCE:    false unfused merge/rebuild (op path), true fused
 //   TOPK_XL_CHUNK_BASE_MODE: three ways to init chunk_base:
 //                            0 init_static<hi,lo> | 1 init_upper<hi>(lo) | 2 init(runtime)
 //   TOPK_XL_CHUNK_BASE:      starting chunk_base (must be a multiple of K)
+//   TOPK_XL_SORT_MODE:       which local-sort entry point copy_sort calls:
+//     0 dispatch    _topk_xl_local_sort_, K=2048 through its fast path
+//     1 generic     _topk_xl_local_sort_generic_ direct, K=512 | 1024
+//     2 early_exit  the same, stopping after the per-column len-64 builds so each
+//                   64-element column ends up sorted on its own. K=1024 | 2048,
+//                   single chunk, no merge.
+//   TOPK_XL_LSB_ROW_MAJOR:   add_lsb_indices numbering: false stamps a tile coordinate
+//                            to decode, true the element's chunk offset directly. Only
+//                            the raw-coordinate index ops (1, 2) read it back;
+//                            separate_indices_row_major decodes the coordinate one.
+//   TOPK_XL_REINIT_AFTER_COPY: reach each merge stage through the post-copy reinit
+//                            entry points instead of a full topk_xl_init
 
 constexpr std::uint32_t ELEMENTS_PER_TILE = ckernel::TILE_R_DIM * ckernel::TILE_C_DIM;
 constexpr std::uint32_t TILES_PER_SEQ     = (TOPK_XL_K + ELEMENTS_PER_TILE - 1) / ELEMENTS_PER_TILE;
@@ -65,11 +81,21 @@ constexpr bool INDEX_OP_ROW_MAJOR  = (TOPK_XL_INDEX_OP == 0);
 constexpr bool INDEX_OP_SEPARATE   = (TOPK_XL_INDEX_OP == 1);
 constexpr bool INDEX_OP_REMOVE_MSB = (TOPK_XL_INDEX_OP == 2);
 
+constexpr bool SORT_MODE_GENERIC    = (TOPK_XL_SORT_MODE == 1);
+constexpr bool SORT_MODE_EARLY_EXIT = (TOPK_XL_SORT_MODE == 2);
+
 constexpr bool FUSED_REDUCE = TOPK_XL_FUSED_REDUCE;
 // Fused END-TO-END (the topk_large_indices wide-row family): runtime chunk-id
 // stamp in index bits [15:11], fused merge/rebuild, one row-major GLOBAL split
 // at the end (plain, or with a segment base for segmented fusion).
 constexpr bool FUSED_E2E = TOPK_XL_FUSED_E2E;
+
+// The early-exit column sort is the one sort the compute API does not pair with a
+// dummy SrcB valid: it returns before anything consumes the operand.
+constexpr bool LOCAL_SORT_NEEDS_SRCB = !SORT_MODE_EARLY_EXIT;
+
+static_assert(!SORT_MODE_EARLY_EXIT || (TOPK_XL_NUM_CHUNKS == 1 && !FUSED_REDUCE), "the early-exit sort leaves a partial order, so there is nothing to merge");
+static_assert(!TOPK_XL_LSB_ROW_MAJOR || !INDEX_OP_ROW_MAJOR, "separate_indices_row_major decodes the coordinate add_lsb numbering");
 
 // Second merge operand. `_topk_xl_merge_` reads it at a fixed distance from the
 // first: 64 dest units (one tile) per sequence-tile when fused, 128 (value +
@@ -148,7 +174,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         for (std::uint32_t c = 0; c < TOPK_XL_NUM_CHUNKS; c++)
         {
             unpack_copy_tile(params, r, c, src_format, dst_format); // chunk 0 -> slot0, the rest -> slot1
-            _llk_unpack_set_srcb_dummy_valid_();                    // local_sort
+            if constexpr (LOCAL_SORT_NEEDS_SRCB)
+            {
+                _llk_unpack_set_srcb_dummy_valid_(); // local_sort
+            }
             if (c > 0)
             {
                 _llk_unpack_set_srcb_dummy_valid_(); // rebuild(slot0)
@@ -189,6 +218,26 @@ inline void topk_xl_local_sort(std::uint32_t dst_index, bool ascending)
     _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_local_sort_<K>, dst_index, VectorMode::RC_custom, dst_index, ascending);
 }
 
+template <std::uint32_t K, bool early_exit_K64>
+inline void topk_xl_local_sort_generic(std::uint32_t dst_index, bool ascending)
+{
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_xl_local_sort_generic_<K, early_exit_K64>, dst_index, VectorMode::RC_custom, dst_index, ascending);
+}
+
+// The two post-copy reinit entry points, verbatim from the Metal wrappers
+// llk_math_eltwise_unary_sfpu_topk_xl_reinit_{mop,unfused_rebuild}_after_copy.
+template <bool fused>
+inline void topk_xl_reinit_mop_after_copy()
+{
+    ckernel::sfpu::topk_mop_config<fused>();
+}
+
+inline void topk_xl_reinit_unfused_rebuild_after_copy()
+{
+    ckernel::sfpu::topk_reinit_unfused_rebuild_after_copy();
+}
+
 template <std::uint32_t K, bool fused>
 inline void topk_xl_merge(std::uint32_t dst_index)
 {
@@ -207,11 +256,11 @@ inline void topk_xl_add_lsb_indices_init()
     ckernel::sfpu::_topk_xl_add_lsb_indices_init_();
 }
 
-template <std::uint32_t K, std::uint32_t core_id>
+template <std::uint32_t K, std::uint32_t core_id, bool row_major>
 inline void topk_xl_add_lsb_indices(std::uint32_t dst_index)
 {
     static_assert(core_id < 32, "core_id occupies index bits [15:11]");
-    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_add_lsb_indices_<K, core_id>, dst_index, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_add_lsb_indices_<K, core_id, row_major>, dst_index, VectorMode::RC_custom);
 }
 
 // --- Row-major index split (topk_large_indices op path) ---
@@ -282,10 +331,21 @@ __attribute__((noinline)) void copy_sort(std::uint32_t slot, std::uint32_t activ
     }
 
     topk_xl_add_lsb_indices_init();
-    topk_xl_add_lsb_indices<K, TOPK_XL_CORE_ID>(slot);
+    topk_xl_add_lsb_indices<K, TOPK_XL_CORE_ID, TOPK_XL_LSB_ROW_MAJOR>(slot);
 
     topk_xl_init<K, true>();
-    topk_xl_local_sort<K>(slot, ascending);
+    if constexpr (SORT_MODE_EARLY_EXIT)
+    {
+        topk_xl_local_sort_generic<K, true>(slot, ascending);
+    }
+    else if constexpr (SORT_MODE_GENERIC)
+    {
+        topk_xl_local_sort_generic<K, false>(slot, ascending);
+    }
+    else
+    {
+        topk_xl_local_sort<K>(slot, ascending);
+    }
 }
 
 // Fused-e2e variant of copy_sort: the chunk id is stamped at RUNTIME into
@@ -334,15 +394,47 @@ __attribute__((noinline)) void process_chunk_math(std::uint32_t slot, std::uint3
     topk_xl_separate_indices_row_major_advance_chunk_base<K>();
 }
 
+// Put the math thread in the state a merge stage sees on the tt-blaze recv path, where
+// the operand arrives by copy so the copy init is the last thing to touch the config.
+// The init is what rewrites ADDR_MOD_0/3 and reprograms the MOP Expander for datacopy,
+// so issuing it alone reproduces that state without an operand to copy.
+//
+// The unfused reinit restores ADDR_MOD_2/3 and the MOP only, and add_lsb_indices_init
+// left ADDR_MOD_4/6 on its own values, hence the full unfused init first.
+template <std::uint32_t K, bool fused>
+inline void topk_xl_reinit_after_copy(std::uint32_t dst_format)
+{
+    if constexpr (!fused)
+    {
+        topk_xl_init<K, false>();
+    }
+    ckernel::_llk_math_topk_xl_copy_init_(dst_format);
+    if constexpr (fused)
+    {
+        topk_xl_reinit_mop_after_copy<fused>();
+    }
+    else
+    {
+        topk_xl_reinit_unfused_rebuild_after_copy();
+    }
+}
+
 // Init + (optional) merge of slot1 into slot0 + rebuild, in either fused mode.
 // `fused` selects the whole merge/rebuild code family: operand distance, MOP body
 // length and iteration count all differ (see topk_mop_config / _topk_xl_merge_).
 // `_topk_xl_merge_` always keeps the max half, so TOPK_XL_ASCENDING changes only
 // the order the surviving top-K is rebuilt into, not which elements survive.
 template <std::uint32_t K, bool fused>
-__attribute__((noinline)) void merge_and_rebuild(bool do_merge)
+__attribute__((noinline)) void merge_and_rebuild(bool do_merge, std::uint32_t dst_format)
 {
-    topk_xl_init<K, fused>();
+    if constexpr (TOPK_XL_REINIT_AFTER_COPY)
+    {
+        topk_xl_reinit_after_copy<K, fused>(dst_format);
+    }
+    else
+    {
+        topk_xl_init<K, fused>();
+    }
     if (do_merge)
     {
         topk_xl_merge<K, fused>(SLOT0);
@@ -390,7 +482,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             for (std::uint32_t c = 1; c < TOPK_XL_NUM_CHUNKS; c++)
             {
                 copy_sort_rt<TOPK_XL_K>(SLOT1, chunk_active_elements(c), true /* ascending */, c, math_format);
-                merge_and_rebuild<TOPK_XL_K, true /* fused */>(true /* do_merge */);
+                merge_and_rebuild<TOPK_XL_K, true /* fused */>(true /* do_merge */, math_format);
             }
             topk_xl_separate_indices_row_major_global_init();
             if constexpr (TOPK_XL_SEG_BASE != 0)
@@ -411,7 +503,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             for (std::uint32_t c = 1; c < TOPK_XL_NUM_CHUNKS; c++)
             {
                 copy_sort<TOPK_XL_K>(SLOT1, chunk_active_elements(c), true /* ascending */, math_format);
-                merge_and_rebuild<TOPK_XL_K, true /* fused */>(true /* do_merge */);
+                merge_and_rebuild<TOPK_XL_K, true /* fused */>(true /* do_merge */, math_format);
             }
 
             topk_xl_separate_indices_init(TOPK_XL_GROUP_SHIFT);
@@ -428,11 +520,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 // chunk c -> slot1, local-sort ascending, then merge into slot0.
                 process_chunk_math<TOPK_XL_K>(SLOT1, chunk_active_elements(c), true /* ascending */, math_format);
-                merge_and_rebuild<TOPK_XL_K, false /* fused */>(true /* do_merge */);
+                merge_and_rebuild<TOPK_XL_K, false /* fused */>(true /* do_merge */, math_format);
             }
             if constexpr (REBUILD_LONE_CHUNK)
             {
-                merge_and_rebuild<TOPK_XL_K, false /* fused */>(false /* do_merge */);
+                merge_and_rebuild<TOPK_XL_K, false /* fused */>(false /* do_merge */, math_format);
             }
         }
         else
@@ -440,8 +532,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // Single-chunk terminal ops: copy_sort, then the index step. For separate
             // the split is here (MATH). For remove_msb the value-half zero runs on
             // PACK (as the op does), so MATH just leaves the fused [value|index] in slot0.
+            // Nothing rebuilds here, so TOPK_XL_ASCENDING drives the local sort instead.
             static_assert(INDEX_OP_ROW_MAJOR || TOPK_XL_NUM_CHUNKS == 1, "terminal index ops (INDEX_OP 1/2) are single-chunk only");
-            copy_sort<TOPK_XL_K>(SLOT0, chunk_active_elements(0), false /* fused */, math_format);
+            copy_sort<TOPK_XL_K>(SLOT0, chunk_active_elements(0), TOPK_XL_ASCENDING, math_format);
 
             if constexpr (INDEX_OP_SEPARATE)
             {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -1765,6 +1765,10 @@ inline void _topk_xl_local_sort_generic_(const std::uint32_t dst_index, const bo
     // to the bottom of each column). The length-64 build lives in the K >= 1024
     // block, so a K=512 instantiation would return before it runs.
     static_assert(!early_exit_K64 || K >= 1024, "early_exit_K64 requires K >= 1024: the length-64 build phase lives in the K >= 1024 block");
+    // The cross-column phases do not converge at row_scale_factor = 4: they leave the
+    // length-64 runs unmerged, so a K=2048 full sort here comes back with each column
+    // sorted but the columns out of order with respect to each other.
+    static_assert(early_exit_K64 || K != 2048, "K = 2048 has no generic full sort: call _topk_xl_local_sort_, which routes it to the K=2048 fast path");
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
     bool dir                            = ascending;
     const std::uint32_t tile_offset     = dst_index << DstTileSizeLog2[DstTileShape::Tile32x32];


### PR DESCRIPTION
### PR Category
Test only

### Summary
This PR adds tests for the new functions that came in with #53350.

### Notes for reviewers
Only change worthy of note is that I added a static assert into the API to forbid a K=2048 setup that always yields incorrect results.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iklikovac/topk-xl-blaze-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iklikovac/topk-xl-blaze-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iklikovac/topk-xl-blaze-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iklikovac/topk-xl-blaze-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iklikovac/topk-xl-blaze-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iklikovac/topk-xl-blaze-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iklikovac/topk-xl-blaze-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iklikovac/topk-xl-blaze-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iklikovac/topk-xl-blaze-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iklikovac/topk-xl-blaze-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iklikovac/topk-xl-blaze-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iklikovac/topk-xl-blaze-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iklikovac/topk-xl-blaze-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iklikovac/topk-xl-blaze-tests)