### PR TITLE
[Bug fix] tt-fabric: honor RELIABILITY_MODE in control-plane setup

### DIFF
--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -284,7 +284,12 @@ bool MetalEnvImpl::set_fabric_config(
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED ||
         fabric_config == tt_fabric::FabricConfig::DISABLED) {
         this->fabric_config_ = fabric_config;
-        this->fabric_reliability_mode_ = reliability_mode;
+        // Honor a user-specified RELIABILITY_MODE (RunTimeOptions) over the caller-passed default.
+        // Callers (fabric-topology setup, dispatch enablement) hardcode STRICT; that ignored the
+        // documented RELAXED mode ("initialize with fewer routing planes than the MGD, per live
+        // links"), so a partially-cabled mesh FATAL'd in configure_routing_tables even in RELAXED.
+        // Default (unset) preserves the caller's value (STRICT).
+        this->fabric_reliability_mode_ = rtoptions_->get_reliability_mode().value_or(reliability_mode);
     } else {
         TT_FATAL(
             this->fabric_config_ == fabric_config,

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -274,12 +274,15 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
     bool is_mock = env_impl_.get_cluster().is_mock_or_emulated();
     if (any_remote_devices && !is_mock) {
         auto fabric_config = ctx_.get_fabric_config();
+        // Honor a user-specified RELIABILITY_MODE for the dispatch-fabric path too (mirrors the
+        // set_fabric_config chokepoint); default (unset) stays STRICT.
+        const auto dispatch_reliability_mode = env_impl_.get_rtoptions().get_reliability_mode().value_or(
+            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
         if (fabric_config == tt::tt_fabric::FabricConfig::DISABLED) {
             fabric_config = tt::tt_fabric::FabricConfig::FABRIC_1D;
             // TODO: This is using an internal API.
             // Externally, we should decide how/where to have SetFabricConfig on the correct MetalEnv
-            ctx_.set_fabric_config(
-                fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+            ctx_.set_fabric_config(fabric_config, dispatch_reliability_mode, 1);
             // Update the fabric config in the descriptor
             MetalEnvAccessor(descriptor_->env()).impl().fabric_config_ = fabric_config;
             // Call initialize again because previously it was a no-op
@@ -291,11 +294,9 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
                 fabric_config);
         } else {
             // Use the same mode
-            ctx_.set_fabric_config(
-                fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+            ctx_.set_fabric_config(fabric_config, dispatch_reliability_mode, 1);
         }
-        MetalEnvAccessor(descriptor_->env()).impl().fabric_reliability_mode_ =
-            tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+        MetalEnvAccessor(descriptor_->env()).impl().fabric_reliability_mode_ = dispatch_reliability_mode;
         log_info(tt::LogMetal, "Dispatch on {} with {} Command Queues\n", fabric_config, num_hw_cqs_);
     }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`RELIABILITY_MODE=relaxed` is parsed into `RunTimeOptions` but never propagated to the fabric
control plane: every `set_fabric_config` caller passes a hardcoded `STRICT_SYSTEM_HEALTH_SETUP_MODE`.
The topology solver honors `RELAXED`, but `ControlPlane::configure_routing_tables_for_fabric_ethernet_channels`
still runs in `STRICT` and `TT_FATAL`s (`"Expected N eth links from physical chip X to physical chip Y"`)
on any mesh with fewer live inter-chip links than its mesh-graph descriptor declares. This makes
`RELAXED` a no-op for its documented purpose ("fabric can be initialized with fewer routing planes
than are in the mesh graph descriptor, according to the number of live links") and blocks
partially-cabled meshes — e.g. a `P150_X2` whose descriptor declares 4 links but is physically
cabled on 2.

Fix: resolve the user-specified reliability mode at the `set_fabric_config` chokepoint
(`rtoptions.get_reliability_mode().value_or(<caller default>)`) so it reaches
`fabric_reliability_mode_`, and mirror it in the dispatch-fabric enablement path
(`device_manager`). When `RELIABILITY_MODE` is unset, behavior is unchanged (`STRICT`).

### Notes for reviewers
- `tt_metal/impl/context/metal_env.cpp` (the chokepoint) is **runtime-validated**: on 2× p150
  cabled on 2 of 4 links, the stock `p150_x2` mesh graph descriptor + `RELIABILITY_MODE=relaxed`
  now initializes with no FATAL, collectives route over the ethernet fabric, and a single-chip
  run is **bit-identical** to before (STRICT default path unchanged).
- `tt_metal/impl/device/device_manager.cpp` (dispatch-fabric path) is **compile-validated only** —
  that path requires remote/ethernet-only devices, which the 2× local-MMIO p150 test box does not
  have. Please confirm on a T3K / remote-device setup.
- No behavior change when `RELIABILITY_MODE` is unset.
- No new API surface. A focused regression test (assert `RELIABILITY_MODE=relaxed` propagates to
  `fabric_reliability_mode_`, or a partial-link mesh initializes in relaxed mode) is a reasonable
  follow-up; happy to add one under `tests/tt_metal/tt_fabric/` with codeowner guidance on the
  preferred mock/harness.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ezietlowtt/fabric-honor-reliability-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ezietlowtt/fabric-honor-reliability-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ezietlowtt/fabric-honor-reliability-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ezietlowtt/fabric-honor-reliability-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ezietlowtt/fabric-honor-reliability-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ezietlowtt/fabric-honor-reliability-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ezietlowtt/fabric-honor-reliability-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ezietlowtt/fabric-honor-reliability-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ezietlowtt/fabric-honor-reliability-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ezietlowtt/fabric-honor-reliability-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ezietlowtt/fabric-honor-reliability-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ezietlowtt/fabric-honor-reliability-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ezietlowtt/fabric-honor-reliability-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ezietlowtt/fabric-honor-reliability-mode)