### PR TITLE
Fix p100 core range set failure in ttnn-p100-tests / core ttnn unit test group

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -12,25 +12,15 @@ import ttnn
 import math
 
 from models.common.utility_functions import is_blackhole
-from tests.ttnn.utils_for_testing import assert_equal, assert_allclose, assert_with_pcc
+from tests.ttnn.utils_for_testing import (
+    assert_equal,
+    assert_allclose,
+    assert_with_pcc,
+    make_disjoint_dram_core_range_set,
+    make_full_dram_core_range_set,
+)
 
 pytestmark = pytest.mark.use_module_device
-
-
-def _make_disjoint_dram_core_range_set(device):
-    num_dram_banks = device.dram_grid_size().x
-    first_range_end = 2 if num_dram_banks == 7 else 1
-    return ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(first_range_end, 0)),
-            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(num_dram_banks - 1, 0)),
-        }
-    )
-
-
-def _make_full_dram_core_range_set(device):
-    num_dram_banks = device.dram_grid_size().x
-    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
 
 
 # Test for int types
@@ -430,10 +420,10 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-1 and 4-7)
-        ([4, 3, 16, 32], [2, 1, 16, 32], _make_disjoint_dram_core_range_set),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
+        # 4-D tensor → 6 shards on disjoint DRAM banks
+        ([4, 3, 16, 32], [2, 1, 16, 32], make_disjoint_dram_core_range_set),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
+        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -1173,12 +1163,12 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
         (
             [4, 3, 32, 64],
             [2, 1, 32, 64],
-            _make_disjoint_dram_core_range_set,
+            make_disjoint_dram_core_range_set,
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
+        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
         # 3-D tensor sharded across all dims → 8 shards on the full DRAM bank grid
-        ([4, 64, 64], [2, 32, 32], _make_full_dram_core_range_set),
+        ([4, 64, 64], [2, 32, 32], make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -1228,10 +1218,10 @@ def test_copy_tilized_interleaved_to_nd_sharded_dram(device, tensor_shape, shard
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
+        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
         # 3-D tensor sharded across all dims → disjoint DRAM banks
-        ([3, 160, 160], [2, 64, 64], _make_disjoint_dram_core_range_set),
+        ([3, 160, 160], [2, 64, 64], make_disjoint_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -2650,7 +2640,7 @@ def test_copy_tile_interleaved_to_width_sharded_bf8(device):
 
     input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    shard_grid = _make_full_dram_core_range_set(device)
+    shard_grid = make_full_dram_core_range_set(device)
     shard_shape = (8192, 256)
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -414,14 +414,14 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-1 and 4-7)
+        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-2 and 4-6)
         (
             [4, 3, 16, 32],
             [2, 1, 16, 32],
             ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 0)),
                 }
             ),
         ),

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -425,8 +425,8 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
                 }
             ),
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (7 banks)
+        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 0))})),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -17,6 +17,22 @@ from tests.ttnn.utils_for_testing import assert_equal, assert_allclose, assert_w
 pytestmark = pytest.mark.use_module_device
 
 
+def _make_disjoint_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    first_range_end = 2 if num_dram_banks == 7 else 1
+    return ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(first_range_end, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(num_dram_banks - 1, 0)),
+        }
+    )
+
+
+def _make_full_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
+
+
 # Test for int types
 @pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
@@ -415,18 +431,9 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
         # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-1 and 4-7)
-        (
-            [4, 3, 16, 32],
-            [2, 1, 16, 32],
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
-                }
-            ),
-        ),
+        ([4, 3, 16, 32], [2, 1, 16, 32], _make_disjoint_dram_core_range_set),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -435,6 +442,9 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
 )
 def test_copy_rm_interleaved_to_nd_sharded_dram(device, tensor_shape, shard_shape, grid, shard_orientation):
     torch.manual_seed(0)
+
+    if callable(grid):
+        grid = grid(device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1144,22 +1154,6 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
 # ---------------------------------------------------------------------------
 # Tilized interleaved → ND sharded DRAM (tile layout)
 # ---------------------------------------------------------------------------
-def _make_disjoint_dram_core_range_set(device):
-    num_dram_banks = device.dram_grid_size().x
-    first_range_end = 2 if num_dram_banks == 7 else 1
-    return ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(first_range_end, 0)),
-            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(num_dram_banks - 1, 0)),
-        }
-    )
-
-
-def _make_full_dram_core_range_set(device):
-    num_dram_banks = device.dram_grid_size().x
-    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
-
-
 @pytest.mark.parametrize(
     "tensor_shape, shard_shape, grid",
     [
@@ -1234,19 +1228,10 @@ def test_copy_tilized_interleaved_to_nd_sharded_dram(device, tensor_shape, shard
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (7 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
+        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
         # 3-D tensor sharded across all dims → disjoint DRAM banks
-        (
-            [3, 160, 160],
-            [2, 64, 64],
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 0)),
-                }
-            ),
-        ),
+        ([3, 160, 160], [2, 64, 64], _make_disjoint_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -1266,6 +1251,9 @@ def test_copy_tilized_interleaved_to_nd_sharded_dram_dtype_conversion(
     device, tensor_shape, shard_shape, grid, input_dtype, output_dtype, pcc, shard_orientation
 ):
     torch.manual_seed(0)
+
+    if callable(grid):
+        grid = grid(device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -414,19 +414,19 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-2 and 4-6)
+        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-1 and 4-7)
         (
             [4, 3, 16, 32],
             [2, 1, 16, 32],
             ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
                 }
             ),
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (7 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
+        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
     ],
 )
 @pytest.mark.parametrize(
@@ -1144,6 +1144,22 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
 # ---------------------------------------------------------------------------
 # Tilized interleaved → ND sharded DRAM (tile layout)
 # ---------------------------------------------------------------------------
+def _make_disjoint_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    first_range_end = 2 if num_dram_banks == 7 else 1
+    return ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(first_range_end, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(num_dram_banks - 1, 0)),
+        }
+    )
+
+
+def _make_full_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
+
+
 @pytest.mark.parametrize(
     "tensor_shape, shard_shape, grid",
     [
@@ -1159,21 +1175,16 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-1 and 4-7)
+        # 4-D tensor → 6 shards on disjoint DRAM banks
         (
             [4, 3, 32, 64],
             [2, 1, 32, 64],
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 0)),
-                }
-            ),
+            _make_disjoint_dram_core_range_set,
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
         ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
-        # 3-D tensor sharded across all dims → 8 shards on 8 DRAM banks
-        ([4, 64, 64], [2, 32, 32], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        # 3-D tensor sharded across all dims → 8 shards on the full DRAM bank grid
+        ([4, 64, 64], [2, 32, 32], _make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -1182,6 +1193,9 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
 )
 def test_copy_tilized_interleaved_to_nd_sharded_dram(device, tensor_shape, shard_shape, grid, shard_orientation):
     torch.manual_seed(0)
+
+    if callable(grid):
+        grid = grid(device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1220,16 +1234,16 @@ def test_copy_tilized_interleaved_to_nd_sharded_dram(device, tensor_shape, shard
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (7 banks)
+        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 0))})),
         # 3-D tensor sharded across all dims → disjoint DRAM banks
         (
             [3, 160, 160],
             [2, 64, 64],
             ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 0)),
                 }
             ),
         ),

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -2644,12 +2644,13 @@ def test_copy_tilized_override_runtime_arguments(
 
 def test_copy_tile_interleaved_to_width_sharded_bf8(device):
     torch.manual_seed(0)
-    shape = [1, 1, 8192, 2048]
+    num_dram_banks = device.dram_grid_size().x
+    shape = [1, 1, 8192, 256 * num_dram_banks]
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})
+    shard_grid = _make_full_dram_core_range_set(device)
     shard_shape = (8192, 256)
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -1165,8 +1165,8 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
             [2, 1, 32, 64],
             ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 0)),
                 }
             ),
         ),

--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -13,6 +13,22 @@ from tests.ttnn.utils_for_testing import assert_equal, assert_allclose
 pytestmark = pytest.mark.use_module_device
 
 
+def _make_disjoint_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    first_range_end = 2 if num_dram_banks == 7 else 1
+    return ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(first_range_end, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(num_dram_banks - 1, 0)),
+        }
+    )
+
+
+def _make_full_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
+
+
 # Test for int types
 @pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
@@ -372,19 +388,14 @@ def test_to_memory_config_rm_interleaved_to_nd_sharded(
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-1 and 4-7)
+        # 4-D tensor → 6 shards on disjoint DRAM banks
         (
             [4, 3, 16, 32],
             [2, 1, 16, 32],
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
-                }
-            ),
+            _make_disjoint_dram_core_range_set,
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
+        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -393,6 +404,9 @@ def test_to_memory_config_rm_interleaved_to_nd_sharded(
 )
 def test_to_memory_config_rm_interleaved_to_nd_sharded_dram(device, tensor_shape, shard_shape, grid, shard_orientation):
     torch.manual_seed(0)
+
+    if callable(grid):
+        grid = grid(device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1120,21 +1134,16 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dtype_conversion(
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 4-D tensor → 6 shards on disjoint DRAM banks (banks 0-1 and 4-7)
+        # 4-D tensor → 6 shards on disjoint DRAM banks
         (
             [4, 3, 32, 64],
             [2, 1, 32, 64],
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
-                }
-            ),
+            _make_disjoint_dram_core_range_set,
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
-        # 3-D tensor sharded across all dims → 8 shards on 8 DRAM banks
-        ([4, 64, 64], [2, 32, 32], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
+        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
+        # 3-D tensor sharded across all dims → 8 shards on the full DRAM bank grid
+        ([4, 64, 64], [2, 32, 32], _make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -1145,6 +1154,9 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dram(
     device, tensor_shape, shard_shape, grid, shard_orientation
 ):
     torch.manual_seed(0)
+
+    if callable(grid):
+        grid = grid(device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1183,18 +1195,13 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dram(
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
-        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards (8 banks)
-        ([5, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})),
+        # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
+        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
         # 3-D tensor sharded across all dims → disjoint DRAM banks
         (
             [3, 160, 160],
             [2, 64, 64],
-            ttnn.CoreRangeSet(
-                {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
-                    ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(7, 0)),
-                }
-            ),
+            _make_disjoint_dram_core_range_set,
         ),
     ],
 )
@@ -1215,6 +1222,9 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dram_dtype_conversio
     device, tensor_shape, shard_shape, grid, input_dtype, output_dtype, pcc, shard_orientation
 ):
     torch.manual_seed(0)
+
+    if callable(grid):
+        grid = grid(device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -2605,12 +2615,13 @@ def test_to_memory_config_tilized_override_runtime_arguments(
 
 def test_to_memory_config_tile_interleaved_to_width_sharded_bf8(device):
     torch.manual_seed(0)
-    shape = [1, 1, 8192, 2048]
+    num_dram_banks = device.dram_grid_size().x
+    shape = [1, 1, 8192, 256 * num_dram_banks]
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})
+    shard_grid = _make_full_dram_core_range_set(device)
     shard_shape = (8192, 256)
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)

--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -8,25 +8,14 @@ import torch
 import ttnn
 import math
 
-from tests.ttnn.utils_for_testing import assert_equal, assert_allclose
+from tests.ttnn.utils_for_testing import (
+    assert_equal,
+    assert_allclose,
+    make_disjoint_dram_core_range_set,
+    make_full_dram_core_range_set,
+)
 
 pytestmark = pytest.mark.use_module_device
-
-
-def _make_disjoint_dram_core_range_set(device):
-    num_dram_banks = device.dram_grid_size().x
-    first_range_end = 2 if num_dram_banks == 7 else 1
-    return ttnn.CoreRangeSet(
-        {
-            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(first_range_end, 0)),
-            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(num_dram_banks - 1, 0)),
-        }
-    )
-
-
-def _make_full_dram_core_range_set(device):
-    num_dram_banks = device.dram_grid_size().x
-    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
 
 
 # Test for int types
@@ -392,10 +381,10 @@ def test_to_memory_config_rm_interleaved_to_nd_sharded(
         (
             [4, 3, 16, 32],
             [2, 1, 16, 32],
-            _make_disjoint_dram_core_range_set,
+            make_disjoint_dram_core_range_set,
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
+        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -1138,12 +1127,12 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dtype_conversion(
         (
             [4, 3, 32, 64],
             [2, 1, 32, 64],
-            _make_disjoint_dram_core_range_set,
+            make_disjoint_dram_core_range_set,
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
+        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
         # 3-D tensor sharded across all dims → 8 shards on the full DRAM bank grid
-        ([4, 64, 64], [2, 32, 32], _make_full_dram_core_range_set),
+        ([4, 64, 64], [2, 32, 32], make_full_dram_core_range_set),
     ],
 )
 @pytest.mark.parametrize(
@@ -1196,12 +1185,12 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dram(
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], _make_full_dram_core_range_set),
+        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
         # 3-D tensor sharded across all dims → disjoint DRAM banks
         (
             [3, 160, 160],
             [2, 64, 64],
-            _make_disjoint_dram_core_range_set,
+            make_disjoint_dram_core_range_set,
         ),
     ],
 )
@@ -2621,7 +2610,7 @@ def test_to_memory_config_tile_interleaved_to_width_sharded_bf8(device):
 
     input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    shard_grid = _make_full_dram_core_range_set(device)
+    shard_grid = make_full_dram_core_range_set(device)
     shard_shape = (8192, 256)
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -58,6 +58,22 @@ TORCH_INTEGER_DTYPES = [
 NP_INTEGER_DTYPES = [np.byte, np.int16, np.int32, np.int64, np.uint16, np.uint32, np.uint64]
 
 
+def make_disjoint_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    first_range_end = 2 if num_dram_banks == 7 else 1
+    return ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(first_range_end, 0)),
+            ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(num_dram_banks - 1, 0)),
+        }
+    )
+
+
+def make_full_dram_core_range_set(device):
+    num_dram_banks = device.dram_grid_size().x
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
+
+
 def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorch_result):
     messages = []
     messages.append(message)


### PR DESCRIPTION
### PR Category

Fixes https://github.com/tenstorrent/tt-metal/issues/53093

### Summary

Update the core range set on the test_copy.py tests to match the core range set allowed on the P100

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=martemov/p100-test-copy-grid-disjoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:martemov/p100-test-copy-grid-disjoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=martemov/p100-test-copy-grid-disjoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:martemov/p100-test-copy-grid-disjoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=martemov/p100-test-copy-grid-disjoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:martemov/p100-test-copy-grid-disjoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=martemov/p100-test-copy-grid-disjoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:martemov/p100-test-copy-grid-disjoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=martemov/p100-test-copy-grid-disjoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:martemov/p100-test-copy-grid-disjoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=martemov/p100-test-copy-grid-disjoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:martemov/p100-test-copy-grid-disjoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=martemov/p100-test-copy-grid-disjoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:martemov/p100-test-copy-grid-disjoint)