### PR TITLE
[moe_compute] Support scalar-page routing scores

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_score_organization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_score_organization.py
@@ -1,0 +1,662 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused coverage for moe_compute routing-score physical organizations."""
+
+import json
+import os
+import random
+import statistics
+import time
+
+import pytest
+import torch
+import ttnn
+
+from ttnn.experimental.moe_compute_utils import (
+    auto_output_width_shard_dim,
+    effective_matmul_ring_size,
+    get_weight_core_shard_maps,
+    get_weight_mem_configs,
+)
+from ttnn.operations.ccl import MoEActivationFunction
+
+from tests.nightly.tg.ccl.moe.test_moe_compute_6U import (
+    create_sharded_memory_config,
+    create_torch_w0,
+    create_torch_w1,
+    create_torch_w2,
+    gen_expert_mapping,
+    gen_sparse_buffer_and_indices,
+    prepare_output_tensor_from_combine_writer,
+)
+from tests.ttnn.nightly.unit_tests.operations.experimental.test_moe_compute_single_card import (
+    _build_quantized_weight_tensors_cpu_prepare,
+)
+
+
+_TOKEN_VALUES = (1, 2, 31, 32, 33)
+_K_VALUES = (2, 4, 6, 8)
+_SCORE_CASES = tuple(pytest.param(tokens, k, id=f"t{tokens}-k{k}") for tokens in _TOKEN_VALUES for k in _K_VALUES)
+
+
+def _make_scores(tokens, selected_experts_k, score_case):
+    lane = torch.arange(1, selected_experts_k + 1, dtype=torch.float32)
+    token = torch.arange(tokens, dtype=torch.float32).unsqueeze(1)
+
+    if score_case == "distinct":
+        scores = lane.unsqueeze(0) / 32.0 + token / 256.0
+    elif score_case == "signed":
+        # Token zero keeps every lane distinct and nonzero. Token one also covers
+        # a zero and negative, finite, non-softmax score without losing the first guard.
+        scores = lane.unsqueeze(0) / 8.0 + token / 64.0
+        scores[0, 0] = -0.5
+        scores[1, 0] = -0.75
+        scores[1, 1] = 0.0
+    elif score_case == "non_normalized":
+        scores = lane.unsqueeze(0) * 0.5 + token / 128.0
+    elif score_case == "normalized":
+        scores = lane.unsqueeze(0).repeat(tokens, 1)
+        scores = scores / scores.sum(dim=-1, keepdim=True)
+    elif score_case == "one_hot":
+        scores = torch.zeros(tokens, selected_experts_k, dtype=torch.float32)
+        scores[torch.arange(tokens), torch.arange(tokens) % selected_experts_k] = 1.0
+        assert set(torch.argmax(scores, dim=-1).tolist()) == set(range(selected_experts_k))
+    else:
+        raise AssertionError(f"unknown score case: {score_case}")
+
+    assert torch.isfinite(scores).all()
+    return scores.to(torch.bfloat16).unsqueeze(0)
+
+
+def _single_core_range(core):
+    coord = ttnn.CoreCoord(core.x, core.y)
+    return ttnn.CoreRangeSet({ttnn.CoreRange(coord, coord)})
+
+
+def _upload_tensor(
+    mesh_device,
+    host_tensor,
+    dtype,
+    memory_config=ttnn.L1_MEMORY_CONFIG,
+    layout=ttnn.ROW_MAJOR_LAYOUT,
+):
+    return ttnn.from_torch(
+        host_tensor,
+        device=mesh_device,
+        layout=layout,
+        dtype=dtype,
+        memory_config=memory_config,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+    )
+
+
+def _upload_mapping(mesh_device, experts_per_device):
+    expert_mapping = gen_expert_mapping(1, 1, None, experts_per_device, experts_per_device, experts_per_device)
+    return ttnn.from_torch(
+        expert_mapping,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def _moe_kwargs(output_height_shard_dim, intermediate_size, compute_only):
+    return {
+        "layer_id": 0,
+        "output_height_shard_dim": output_height_shard_dim,
+        "intermediate_size": intermediate_size,
+        "has_bias": False,
+        "activation_type": MoEActivationFunction.SILU,
+        "compute_only": compute_only,
+    }
+
+
+def _upload_sparse_inputs(mesh_device, sparse_buffer, expert_indices, logical_scores, drain_core):
+    tokens = expert_indices.shape[-2]
+    selected_experts_k = expert_indices.shape[-1]
+    indices_mem_config = create_sharded_memory_config(drain_core, [tokens, selected_experts_k], ttnn.uint16)
+    contiguous_scores_mem_config = create_sharded_memory_config(drain_core, [tokens, selected_experts_k], ttnn.bfloat16)
+    scalar_page_scores_mem_config = create_sharded_memory_config(
+        drain_core, [tokens * selected_experts_k, 1], ttnn.bfloat16
+    )
+
+    tt_sparse = _upload_tensor(mesh_device, sparse_buffer, ttnn.bfloat16)
+    tt_indices = _upload_tensor(mesh_device, expert_indices, ttnn.uint16, indices_mem_config)
+    tt_scores_contiguous = _upload_tensor(mesh_device, logical_scores, ttnn.bfloat16, contiguous_scores_mem_config)
+    # Construct the scalar-page tensor directly at upload. No TTNN reshape,
+    # permute, slice, or concat operation is part of the test or feature path.
+    tt_scores_scalar_page = _upload_tensor(
+        mesh_device,
+        logical_scores.unsqueeze(-1),
+        ttnn.bfloat16,
+        scalar_page_scores_mem_config,
+    )
+    return tt_sparse, tt_indices, tt_scores_contiguous, tt_scores_scalar_page
+
+
+def _make_optional_output(mesh_device, selected_experts_k, tokens, hidden_size):
+    return ttnn.from_torch(
+        torch.zeros([selected_experts_k, tokens, hidden_size], dtype=torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=1),
+    )
+
+
+def _capture_outputs(mesh_device, outputs, compute_only):
+    metadata_dram = ttnn.to_memory_config(outputs[1], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    result_index = 4 if compute_only else 5
+    result_dram = ttnn.to_memory_config(outputs[result_index], memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+    metadata_host = ttnn.to_torch(metadata_dram, mesh_composer=composer)
+    result_host = ttnn.to_torch(result_dram, mesh_composer=composer)
+
+    if metadata_dram.buffer_address() != outputs[1].buffer_address():
+        ttnn.deallocate(metadata_dram)
+    if result_dram.buffer_address() != outputs[result_index].buffer_address():
+        ttnn.deallocate(result_dram)
+    return metadata_host, result_host
+
+
+def _deallocate_outputs(outputs, keep_optional_output=False):
+    # Slots 3 and 4 alias the same L1 buffer; deallocating slot 4 releases it.
+    for index in (0, 1, 2, 4):
+        ttnn.deallocate(outputs[index])
+    if len(outputs) == 6 and not keep_optional_output:
+        ttnn.deallocate(outputs[5])
+
+
+def _assert_every_score_bit(metadata, expert_indices, logical_scores, experts_per_device):
+    selected_experts_k = expert_indices.shape[-1]
+    tokens = expert_indices.shape[-2]
+    aligned_row_elements = ((2 * experts_per_device + 1) * 4 + 15) // 16 * 4
+    flat = metadata[0].flatten().to(torch.int64)
+    expected_score_bits = logical_scores.contiguous().view(torch.int16).to(torch.int32) & 0xFFFF
+
+    for token in range(tokens):
+        row = token * aligned_row_elements
+        assert flat[row].item() == token
+        observed_lanes = set()
+        for lane in range(selected_experts_k):
+            expert = expert_indices[0, token, lane].item()
+            actual_lane = flat[row + 1 + expert].item()
+            actual_score_bits = flat[row + 1 + experts_per_device + expert].item() & 0xFFFF
+            assert actual_lane == lane, f"token={token} expert={expert}: expected K lane {lane}, got {actual_lane}"
+            assert actual_score_bits == expected_score_bits[0, token, lane].item(), (
+                f"token={token} lane={lane} expert={expert}: expected score bits "
+                f"0x{expected_score_bits[0, token, lane].item():04x}, got 0x{actual_score_bits:04x}"
+            )
+            observed_lanes.add(actual_lane)
+        assert observed_lanes == set(range(selected_experts_k))
+
+
+def _assert_organizations_match(
+    contiguous_metadata,
+    scalar_page_metadata,
+    contiguous_result,
+    scalar_page_result,
+    mesh_device,
+    expert_indices,
+    compute_only,
+    tokens,
+    experts_per_device,
+    output_height_shard_dim,
+    output_width_shard_dim,
+    hidden_size,
+):
+    aligned_row_elements = ((2 * experts_per_device + 1) * 4 + 15) // 16 * 4
+    relevant_metadata_elements = tokens * aligned_row_elements
+    torch.testing.assert_close(
+        contiguous_metadata[0].flatten()[:relevant_metadata_elements],
+        scalar_page_metadata[0].flatten()[:relevant_metadata_elements],
+        rtol=0,
+        atol=0,
+    )
+
+    if not compute_only:
+        torch.testing.assert_close(contiguous_result, scalar_page_result, rtol=0, atol=0, equal_nan=True)
+        return
+
+    # ComputeOnly slot 4 is a two-expert double buffer; compare only initialized rows.
+    worker_grid = mesh_device.compute_with_storage_grid_size()
+    all_core_range_set = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(worker_grid.x - 1, worker_grid.y - 1),
+            )
+        }
+    )
+    output_shard_cores = ttnn.experimental.get_moe_combine_cores(
+        mesh_device, output_height_shard_dim, output_width_shard_dim, hidden_size
+    )
+    expert_counts = torch.bincount(expert_indices.flatten().to(torch.int64), minlength=experts_per_device)
+    active_buffer_counts = expert_counts[-2:]
+
+    def meaningful_compute_output(raw_result):
+        return prepare_output_tensor_from_combine_writer(
+            raw_result,
+            active_buffer_counts,
+            0,
+            all_core_range_set,
+            output_shard_cores,
+            output_height_shard_dim,
+            output_width_shard_dim,
+            2,
+            hidden_size,
+        )
+
+    torch.testing.assert_close(
+        meaningful_compute_output(contiguous_result),
+        meaningful_compute_output(scalar_page_result),
+        rtol=0,
+        atol=0,
+        equal_nan=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 500000}],
+    indirect=True,
+)
+@pytest.mark.parametrize("tokens,selected_experts_k", _SCORE_CASES)
+@pytest.mark.parametrize("mesh_shape,mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
+@torch.no_grad()
+def test_moe_compute_score_organizations(
+    mesh_device,
+    mesh_shape,
+    tokens,
+    selected_experts_k,
+):
+    """The two physical organizations must preserve every score bit and output."""
+    arch = mesh_device.arch()
+    if arch not in (ttnn.device.Arch.WORMHOLE_B0, ttnn.device.Arch.BLACKHOLE):
+        pytest.skip(f"moe_compute score organization is supported only on Wormhole and Blackhole, got {arch}")
+
+    torch.manual_seed(20260817)
+    random.seed(20260817)
+    assert mesh_shape == (1, 1)
+    key = (tokens, selected_experts_k)
+    score_case = {(2, 4): "signed", (32, 8): "one_hot"}.get(
+        key, {31: "non_normalized", 33: "normalized"}.get(tokens, "distinct")
+    )
+    compute_only = key not in ((2, 4), (32, 8))
+    exercise_cache_hit = key == (2, 4)
+
+    experts_per_device = 8
+    hidden_size = 320
+    ring_n = effective_matmul_ring_size(mesh_device)
+    intermediate_size = max(256, 32 * ring_n)
+    output_height_shard_dim = 4
+    output_width_shard_dim = auto_output_width_shard_dim(hidden_size, matmul_ring_size=ring_n)
+
+    drain_core_coord = ttnn.experimental.get_moe_tilize_drain_core(
+        mesh_device,
+        output_height_shard_dim,
+        output_width_shard_dim,
+        hidden_size,
+    )
+    drain_core = _single_core_range(drain_core_coord)
+
+    sparse_buffer, generated_indices, _, _ = gen_sparse_buffer_and_indices(
+        tokens,
+        hidden_size,
+        experts_per_device,
+        selected_experts_k,
+        mesh_shape,
+        None,
+        dtype=torch.bfloat16,
+    )
+    expert_indices = generated_indices.reshape(1, tokens, selected_experts_k)
+    logical_scores = _make_scores(tokens, selected_experts_k, score_case)
+
+    tt_mapping = _upload_mapping(mesh_device, experts_per_device)
+
+    w0_w1_shard_map, w2_shard_map, dram_core_range_set = get_weight_core_shard_maps(
+        mesh_device, hidden_size, intermediate_size
+    )
+    torch_w0 = create_torch_w0(1, experts_per_device, hidden_size, intermediate_size)
+    torch_w1 = create_torch_w1(1, experts_per_device, hidden_size, intermediate_size)
+    torch_w2 = create_torch_w2(1, experts_per_device, intermediate_size, hidden_size)
+    w0_w1_mem_config, w2_mem_config, _, _ = get_weight_mem_configs(
+        1,
+        experts_per_device,
+        hidden_size,
+        intermediate_size,
+        w0_w1_shard_map,
+        w2_shard_map,
+        dram_core_range_set,
+        has_bias=False,
+    )
+    tt_w0_w1, tt_w2 = _build_quantized_weight_tensors_cpu_prepare(
+        mesh_device,
+        torch_w0,
+        torch_w1,
+        torch_w2,
+        None,
+        None,
+        None,
+        1,
+        experts_per_device,
+        hidden_size,
+        intermediate_size,
+        False,
+        w0_w1_shard_map,
+        w2_shard_map,
+        w0_w1_mem_config,
+        w2_mem_config,
+    )
+
+    tt_sparse, tt_indices, tt_scores_contiguous, tt_scores_scalar_page = _upload_sparse_inputs(
+        mesh_device, sparse_buffer, expert_indices, logical_scores, drain_core
+    )
+
+    def run(sparse_tensor, score_tensor, indices_tensor, optional_output_tensor):
+        return ttnn.experimental.moe_compute(
+            sparse_tensor,
+            indices_tensor,
+            score_tensor,
+            tt_mapping,
+            tt_w0_w1,
+            tt_w2,
+            optional_output_tensor=optional_output_tensor,
+            **_moe_kwargs(output_height_shard_dim, intermediate_size, compute_only),
+        )
+
+    def execute_pair(
+        sparse_tensor,
+        indices_tensor,
+        contiguous_scores,
+        scalar_scores,
+        optional_outputs,
+        *,
+        expect_cache_hit,
+        capture_scalar_graph=False,
+        keep_optional_outputs=False,
+    ):
+        captured = []
+        output_handles = []
+        for organization, scores, optional_output in zip(
+            ("ContiguousK", "ScalarPageK"),
+            (contiguous_scores, scalar_scores),
+            optional_outputs,
+        ):
+            cache_entries_before = mesh_device.num_program_cache_entries()
+            if capture_scalar_graph and organization == "ScalarPageK":
+                ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+                try:
+                    outputs = run(sparse_tensor, scores, indices_tensor, optional_output)
+                finally:
+                    graph = ttnn.graph.end_graph_capture()
+                calltrace = ttnn.graph.extract_calltrace(graph)
+                calltrace_text = "\n".join(calltrace).lower()
+                assert "moe" in calltrace_text
+                for forbidden_op in ("reshape", "slice", "concat", "permute"):
+                    assert (
+                        forbidden_op not in calltrace_text
+                    ), f"ScalarPageK graph unexpectedly dispatched {forbidden_op}: {calltrace}"
+                print(f"MOE_SCORE_SCALAR_PAGE_GRAPH_CALLTRACE={calltrace}")
+            else:
+                outputs = run(sparse_tensor, scores, indices_tensor, optional_output)
+
+            cache_entries_after = mesh_device.num_program_cache_entries()
+            if expect_cache_hit:
+                assert cache_entries_after == cache_entries_before
+            else:
+                assert cache_entries_after > cache_entries_before
+            metadata, result = _capture_outputs(mesh_device, outputs, compute_only)
+            _assert_every_score_bit(metadata, expert_indices, logical_scores, experts_per_device)
+            captured.append((metadata, result))
+            output_handles.append(outputs)
+            _deallocate_outputs(outputs, keep_optional_output=keep_optional_outputs)
+
+        _assert_organizations_match(
+            captured[0][0],
+            captured[1][0],
+            captured[0][1],
+            captured[1][1],
+            mesh_device,
+            expert_indices,
+            compute_only,
+            tokens,
+            experts_per_device,
+            output_height_shard_dim,
+            output_width_shard_dim,
+            hidden_size,
+        )
+        return tuple(output_handles)
+
+    cold_optional_outputs = tuple(
+        None if compute_only else _make_optional_output(mesh_device, selected_experts_k, tokens, hidden_size)
+        for _ in range(2)
+    )
+    contiguous_outputs, scalar_outputs = execute_pair(
+        tt_sparse,
+        tt_indices,
+        tt_scores_contiguous,
+        tt_scores_scalar_page,
+        cold_optional_outputs,
+        expect_cache_hit=False,
+        capture_scalar_graph=tokens == 32 and selected_experts_k == 8 and score_case == "one_hot",
+        keep_optional_outputs=exercise_cache_hit,
+    )
+
+    perf_repeats = int(os.environ.get("MOE_SCORE_PERF_REPEATS", "0"))
+    assert 0 <= perf_repeats <= 100
+    if perf_repeats:
+        assert compute_only
+        host_samples_ns = {}
+        for organization, scores in (("ContiguousK", tt_scores_contiguous), ("ScalarPageK", tt_scores_scalar_page)):
+            samples = []
+            for _ in range(perf_repeats):
+                start_ns = time.perf_counter_ns()
+                outputs = run(tt_sparse, scores, tt_indices, None)
+                ttnn.synchronize_device(mesh_device)
+                samples.append(time.perf_counter_ns() - start_ns)
+                _deallocate_outputs(outputs)
+            host_samples_ns[organization] = samples
+        perf_result = {
+            "tokens": tokens,
+            "K": selected_experts_k,
+            "repeats": perf_repeats,
+            "execution_order": list(host_samples_ns),
+            "host_sync_ns": host_samples_ns,
+            "host_sync_median_ns": {name: statistics.median(samples) for name, samples in host_samples_ns.items()},
+        }
+        print("MOE_SCORE_MICROBENCH=" + json.dumps(perf_result, sort_keys=True))
+
+    if exercise_cache_hit:
+        # Allocate replacements while the originals are live so address changes are guaranteed.
+        new_sparse, new_indices, new_scores_contiguous, new_scores_scalar_page = _upload_sparse_inputs(
+            mesh_device, sparse_buffer, expert_indices, logical_scores, drain_core
+        )
+        new_optional_outputs = tuple(
+            _make_optional_output(mesh_device, selected_experts_k, tokens, hidden_size) for _ in range(2)
+        )
+        for replacement, original in zip(
+            (new_sparse, new_indices, new_scores_contiguous, new_scores_scalar_page, *new_optional_outputs),
+            (
+                tt_sparse,
+                tt_indices,
+                tt_scores_contiguous,
+                tt_scores_scalar_page,
+                contiguous_outputs[5],
+                scalar_outputs[5],
+            ),
+        ):
+            assert replacement.buffer_address() != original.buffer_address()
+
+        for tensor in (
+            tt_indices,
+            tt_scores_contiguous,
+            tt_scores_scalar_page,
+            contiguous_outputs[5],
+            scalar_outputs[5],
+        ):
+            ttnn.deallocate(tensor)
+        ttnn.synchronize_device(mesh_device)
+
+        execute_pair(
+            new_sparse,
+            new_indices,
+            new_scores_contiguous,
+            new_scores_scalar_page,
+            new_optional_outputs,
+            expect_cache_hit=True,
+        )
+        for tensor in (new_sparse, new_indices, new_scores_contiguous, new_scores_scalar_page):
+            ttnn.deallocate(tensor)
+    else:
+        for tensor in (tt_indices, tt_scores_contiguous, tt_scores_scalar_page):
+            ttnn.deallocate(tensor)
+
+    for tensor in (tt_sparse, tt_mapping, tt_w0_w1, tt_w2):
+        ttnn.deallocate(tensor)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 500000}],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_shape,mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
+@torch.no_grad()
+def test_moe_compute_score_validation(mesh_device, mesh_shape, expect_error):
+    """Malformed score contracts fail on the host without populating the program cache."""
+    arch = mesh_device.arch()
+    if arch not in (ttnn.device.Arch.WORMHOLE_B0, ttnn.device.Arch.BLACKHOLE):
+        pytest.skip(f"moe_compute score validation is supported only on Wormhole and Blackhole, got {arch}")
+
+    assert mesh_shape == (1, 1)
+    tokens = 2
+    k = 4
+    experts_per_device = 8
+    hidden_size = 320
+    ring_n = effective_matmul_ring_size(mesh_device)
+    intermediate_size = max(256, 32 * ring_n)
+    output_height_shard_dim = 4
+    output_width_shard_dim = auto_output_width_shard_dim(hidden_size, matmul_ring_size=ring_n)
+
+    drain_core_coord = ttnn.experimental.get_moe_tilize_drain_core(
+        mesh_device,
+        output_height_shard_dim,
+        output_width_shard_dim,
+        hidden_size,
+    )
+    drain_core = _single_core_range(drain_core_coord)
+    worker_grid = mesh_device.compute_with_storage_grid_size()
+    if worker_grid.x > 1:
+        other_core_coord = ttnn.CoreCoord((drain_core_coord.x + 1) % worker_grid.x, drain_core_coord.y)
+    else:
+        assert worker_grid.y > 1
+        other_core_coord = ttnn.CoreCoord(drain_core_coord.x, (drain_core_coord.y + 1) % worker_grid.y)
+    other_core = _single_core_range(other_core_coord)
+
+    sparse_buffer = torch.zeros([1, tokens, hidden_size], dtype=torch.bfloat16)
+    expert_indices = torch.arange(k, dtype=torch.int32).reshape(1, 1, -1).repeat(1, tokens, 1)
+    logical_scores = _make_scores(tokens, k, "distinct")
+    tt_sparse, tt_indices, tt_scores, tt_scalar_scores = _upload_sparse_inputs(
+        mesh_device, sparse_buffer, expert_indices, logical_scores, drain_core
+    )
+
+    tt_mapping = _upload_mapping(mesh_device, experts_per_device)
+
+    # Validation rejects every malformed sparse input before program creation, so only
+    # rank and the expert-count dimension of these small device-resident weights matter.
+    dummy_weight = torch.zeros([1, 1, experts_per_device, 1, 32, 128], dtype=torch.bfloat16)
+    tt_weight = ttnn.from_torch(
+        dummy_weight,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    created_tensors = [tt_sparse, tt_indices, tt_scores, tt_scalar_scores, tt_mapping, tt_weight]
+
+    def upload(host_tensor, dtype, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG):
+        tensor = _upload_tensor(mesh_device, host_tensor, dtype, memory_config, layout)
+        created_tensors.append(tensor)
+        return tensor
+
+    def sharded(host_tensor, dtype, shard_shape, core=drain_core):
+        return upload(
+            host_tensor,
+            dtype,
+            memory_config=create_sharded_memory_config(core, shard_shape, dtype),
+        )
+
+    def invoke(indices_tensor, scores_tensor):
+        return ttnn.experimental.moe_compute(
+            tt_sparse,
+            indices_tensor,
+            scores_tensor,
+            tt_mapping,
+            tt_weight,
+            tt_weight,
+            **_moe_kwargs(output_height_shard_dim, intermediate_size, True),
+        )
+
+    def assert_rejected(indices_tensor, scores_tensor, message):
+        cache_entries_before = mesh_device.num_program_cache_entries()
+        with expect_error(RuntimeError, message):
+            invoke(indices_tensor, scores_tensor)
+        assert mesh_device.num_program_cache_entries() == cache_entries_before
+
+    def zeros(shape, dtype=torch.bfloat16):
+        return torch.zeros(shape, dtype=dtype)
+
+    def score_case(tensor, message):
+        return tt_indices, tensor, message
+
+    def indices_case(tensor, message):
+        return tensor, tt_scores, message
+
+    malformed_cases = [
+        score_case(upload(zeros([1, tokens, k, 2]), ttnn.bfloat16), r"trailing singleton"),
+        score_case(upload(zeros([1, tokens + 1, k]), ttnn.bfloat16), r"routing-score token dimension"),
+        score_case(upload(zeros([1, tokens, k + 1]), ttnn.bfloat16), r"routing-score K dimension"),
+        (
+            upload(zeros([1, tokens + 1, k], torch.int32), ttnn.uint16),
+            upload(zeros([1, tokens + 1, k]), ttnn.bfloat16),
+            r"trailing token dimension must match the activation token count",
+        ),
+        # The volume still equals tokens*K, but trailing [1,K] is not [tokens,K].
+        (
+            upload(expert_indices.reshape(2, 1, k), ttnn.uint16),
+            upload(logical_scores.reshape(2, 1, k), ttnn.bfloat16),
+            r"trailing token dimension must match the activation token count",
+        ),
+        score_case(upload(logical_scores.float(), ttnn.float32), r"tilize_expert_scores_tensor must be BFLOAT16"),
+        indices_case(upload(expert_indices, ttnn.uint32), r"tilize_expert_indices_tensor must be UINT16"),
+        score_case(upload(logical_scores, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT), r"scores_tensor must be ROW_MAJOR"),
+        indices_case(upload(expert_indices, ttnn.uint16, layout=ttnn.TILE_LAYOUT), r"indices_tensor must be ROW_MAJOR"),
+        score_case(upload(logical_scores, ttnn.bfloat16), r"must use HEIGHT_SHARDED memory layout"),
+        score_case(sharded(logical_scores, ttnn.bfloat16, [tokens + 1, k]), r"scores_tensor shard shape must be"),
+        score_case(
+            sharded(logical_scores.unsqueeze(-1), ttnn.bfloat16, [tokens * k + 1, 1]),
+            r"scores_tensor shard shape must be",
+        ),
+        indices_case(sharded(expert_indices, ttnn.uint16, [tokens + 1, k]), r"indices_tensor shard shape must be"),
+        score_case(
+            sharded(logical_scores, ttnn.bfloat16, [tokens, k], other_core),
+            r"must be placed on the selected tilize drain core",
+        ),
+        indices_case(
+            sharded(expert_indices, ttnn.uint16, [tokens, k], other_core),
+            r"must be placed on the selected tilize drain core",
+        ),
+        indices_case(upload(expert_indices.flatten(), ttnn.uint16), r"indices_tensor must be rank 2, 3, or 4"),
+        score_case(upload(zeros([1, 1, 1, tokens, k, 1]), ttnn.bfloat16), r"scores_tensor must be rank 2 through 5"),
+        score_case(upload(logical_scores.unsqueeze(-2), ttnn.bfloat16), r"trailing singleton"),
+    ]
+    for indices_tensor, scores_tensor, message in malformed_cases:
+        assert_rejected(indices_tensor, scores_tensor, message)
+
+    for tensor in created_tensors:
+        ttnn.deallocate(tensor)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -295,7 +295,8 @@ void kernel_main() {
     // Aligned page sizes
     constexpr uint32_t aligned_indices_page_size = get_named_compile_time_arg_val("aligned_indices_page_size");
     constexpr uint32_t aligned_mapping_page_size = get_named_compile_time_arg_val("aligned_mapping_page_size");
-    constexpr uint32_t aligned_scores_page_size = get_named_compile_time_arg_val("aligned_scores_page_size");
+    constexpr uint32_t score_token_stride = get_named_compile_time_arg_val("score_token_stride");
+    constexpr uint32_t score_k_stride = get_named_compile_time_arg_val("score_k_stride");
 
     // General info
     constexpr uint32_t tokens = get_named_compile_time_arg_val("tokens");
@@ -487,7 +488,7 @@ void kernel_main() {
     if (!is_drain_tilize_core) {
         // Calculate the byte offset for this core's token range within the indices/scores buffers
         uint32_t token_byte_offset_indices = core_token_start * aligned_indices_page_size;
-        uint32_t token_byte_offset_scores = core_token_start * aligned_scores_page_size;
+        uint32_t token_byte_offset_scores = core_token_start * score_token_stride;
         uint32_t num_tokens_this_core = core_token_end - core_token_start;
 
         // Get local CB addresses (same relative address as drain core)
@@ -510,7 +511,7 @@ void kernel_main() {
             noc_obj.async_read(
                 UnicastEndpoint{},
                 CoreLocalMem<uint32_t>(local_scores_addr),
-                num_tokens_this_core * aligned_scores_page_size,
+                num_tokens_this_core * score_token_stride,
                 {.noc_x = drain_core_noc_x, .noc_y = drain_core_noc_y, .addr = local_scores_addr},
                 {});
         }
@@ -592,7 +593,7 @@ void kernel_main() {
         }
 
         const uint16_t* token_indices = reinterpret_cast<const uint16_t*>(indices_base + t * aligned_indices_page_size);
-        const uint16_t* token_scores = reinterpret_cast<const uint16_t*>(scores_base + t * aligned_scores_page_size);
+        const uint32_t token_scores_base = scores_base + t * score_token_stride;
 
         // Defer pointer calculation until we know token is activated
         uint32_t* expert_activation_l1_ptr = nullptr;
@@ -619,7 +620,8 @@ void kernel_main() {
 
                     // Write k-index and score for this expert
                     expert_activation_l1_ptr[1 + e] = k;
-                    expert_activation_l1_ptr[1 + experts_per_device + e] = static_cast<uint32_t>(token_scores[k]);
+                    const uint16_t score = *reinterpret_cast<const uint16_t*>(token_scores_base + k * score_k_stride);
+                    expert_activation_l1_ptr[1 + experts_per_device + e] = static_cast<uint32_t>(score);
 
                     // Write to e_t buffer (16B aligned entries for NOC DMA compatibility)
                     const uint32_t e_t_offset =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -126,7 +126,8 @@ void kernel_main() {
     // Aligned page sizes
     constexpr uint32_t aligned_indices_page_size = get_named_compile_time_arg_val("aligned_indices_page_size");
     constexpr uint32_t aligned_mapping_page_size = get_named_compile_time_arg_val("aligned_mapping_page_size");
-    constexpr uint32_t aligned_scores_page_size = get_named_compile_time_arg_val("aligned_scores_page_size");
+    constexpr uint32_t score_token_stride = get_named_compile_time_arg_val("score_token_stride");
+    constexpr uint32_t score_k_stride = get_named_compile_time_arg_val("score_k_stride");
 
     // General info
     constexpr uint32_t tokens = get_named_compile_time_arg_val("tokens");
@@ -342,7 +343,7 @@ void kernel_main() {
         }
 
         const uint16_t* token_indices = reinterpret_cast<const uint16_t*>(indices_base + t * aligned_indices_page_size);
-        const uint16_t* token_scores = reinterpret_cast<const uint16_t*>(scores_base + t * aligned_scores_page_size);
+        const uint32_t token_scores_base = scores_base + t * score_token_stride;
 
         // Track if this token is activated for any local expert
         uint32_t* brisc_activation_l1_ptr = nullptr;
@@ -369,7 +370,8 @@ void kernel_main() {
 
                     // Write k-index and score for this expert
                     brisc_activation_l1_ptr[1 + e] = k;
-                    brisc_activation_l1_ptr[1 + experts_per_device + e] = static_cast<uint32_t>(token_scores[k]);
+                    const uint16_t score = *reinterpret_cast<const uint16_t*>(token_scores_base + k * score_k_stride);
+                    brisc_activation_l1_ptr[1 + experts_per_device + e] = static_cast<uint32_t>(score);
 
                     // Write to BRISC's e_t buffer (16B aligned entries)
                     const uint32_t brisc_e_t_offset =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -18,11 +18,237 @@
 
 #include <umd/device/types/arch.hpp>
 
+#include <limits>
+
 namespace ttnn::experimental::prim {
 namespace detail {
 
 constexpr auto TOKEN_SIZE = 32;  // This does not mean we only support 32 tokens, just hardcoding the shared buffer size
 constexpr auto DOUBLE_BUFFER_SIZE = 2;
+
+uint32_t get_total_tokens(const ttnn::Shape& input_shape) {
+    TT_FATAL(
+        input_shape.rank() >= 3 && input_shape.rank() <= 4,
+        "moe_compute: tilize_input_tensor must be rank 3 or 4 [...,tokens,hidden]; got {}",
+        input_shape);
+
+    const uint64_t hidden_size = input_shape[-1];
+    TT_FATAL(
+        hidden_size > 0, "moe_compute: tilize_input_tensor hidden dimension must be positive; got {}", input_shape);
+    const uint64_t volume = input_shape.volume();
+    TT_FATAL(
+        volume % hidden_size == 0,
+        "moe_compute: tilize_input_tensor volume {} is not divisible by hidden dimension {}; got {}",
+        volume,
+        hidden_size,
+        input_shape);
+    const uint64_t physical_rows = volume / hidden_size;
+    const uint64_t total_tokens = static_cast<uint64_t>(input_shape[0]) * input_shape[1];
+    TT_FATAL(
+        physical_rows == total_tokens,
+        "moe_compute: tilize_input_tensor {} has {} physical rows but dimensions 0*1 specify {} tokens; the "
+        "optional rank-4 dimension must be 1",
+        input_shape,
+        physical_rows,
+        total_tokens);
+    TT_FATAL(
+        total_tokens > 0 && total_tokens <= std::numeric_limits<uint32_t>::max(),
+        "moe_compute: total token count must fit uint32_t and be positive; got {}",
+        total_tokens);
+    return static_cast<uint32_t>(total_tokens);
+}
+
+MoEScoreInputOrganization derive_score_input_organization(
+    const ttnn::Shape& indices_shape, const ttnn::Shape& scores_shape) {
+    const auto indices_rank = indices_shape.rank();
+    const auto scores_rank = scores_shape.rank();
+    TT_FATAL(
+        indices_rank >= 2 && indices_rank <= 4,
+        "moe_compute: tilize_expert_indices_tensor must be rank 2, 3, or 4 with trailing [tokens,K]; got {}",
+        indices_shape);
+    TT_FATAL(
+        scores_rank >= 2 && scores_rank <= 5,
+        "moe_compute: tilize_expert_scores_tensor must be rank 2 through 5 and match indices exactly or add one "
+        "trailing 1; got {}",
+        scores_shape);
+
+    const bool scalar_page = scores_rank == indices_rank + 1;
+    TT_FATAL(
+        scores_rank == indices_rank || scalar_page,
+        "moe_compute: unsupported or ambiguous routing-score organization: scores must equal indices {} or add one "
+        "trailing singleton; got {}",
+        indices_shape,
+        scores_shape);
+    TT_FATAL(
+        !scalar_page || scores_shape[-1] == 1,
+        "moe_compute: ScalarPageK routing scores require one trailing singleton after K; got scores {} for indices "
+        "{}",
+        scores_shape,
+        indices_shape);
+    const auto organization =
+        scalar_page ? MoEScoreInputOrganization::ScalarPageK : MoEScoreInputOrganization::ContiguousK;
+    const uint32_t organization_trailing_dims = scalar_page ? 1 : 0;
+    const char* organization_name = scalar_page ? "ScalarPageK" : "ContiguousK";
+
+    TT_FATAL(
+        scores_shape[scores_rank - 2 - organization_trailing_dims] == indices_shape[-2],
+        "moe_compute: {} routing-score token dimension must match indices; got scores shape {} and indices shape {}",
+        organization_name,
+        scores_shape,
+        indices_shape);
+    TT_FATAL(
+        scores_shape[scores_rank - 1 - organization_trailing_dims] == indices_shape[-1],
+        "moe_compute: {} routing-score K dimension must match indices; got scores shape {} and indices shape {}",
+        organization_name,
+        scores_shape,
+        indices_shape);
+    for (uint32_t dim = 0; dim + 2 < indices_rank; ++dim) {
+        TT_FATAL(
+            scores_shape[dim] == indices_shape[dim],
+            "moe_compute: {} scores must match all indices dimensions before the optional trailing singleton; "
+            "scores {} and indices {} differ at dimension {}",
+            organization_name,
+            scores_shape,
+            indices_shape,
+            dim);
+    }
+    return organization;
+}
+
+void validate_device_row_major_tensor(
+    const ttnn::Tensor& tensor,
+    const char* tensor_name,
+    tt::tt_metal::DataType expected_dtype,
+    const char* expected_dtype_name) {
+    TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "moe_compute: {} must be a device tensor", tensor_name);
+    TT_FATAL(tensor.buffer() != nullptr, "moe_compute: {} must have an allocated device buffer", tensor_name);
+    TT_FATAL(
+        tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+        "moe_compute: {} must be ROW_MAJOR; got {}",
+        tensor_name,
+        tensor.layout());
+    TT_FATAL(
+        tensor.dtype() == expected_dtype,
+        "moe_compute: {} must be {}; got {}",
+        tensor_name,
+        expected_dtype_name,
+        tensor.dtype());
+}
+
+void validate_sparse_tensor_placement(
+    const ttnn::Tensor& tensor,
+    const char* tensor_name,
+    ttnn::MeshDevice* expected_device,
+    const CoreRangeSet& expected_drain_grid,
+    uint32_t expected_shard_height,
+    uint32_t expected_shard_width,
+    uint32_t element_size) {
+    TT_FATAL(tensor.device() == expected_device, "moe_compute: {} must share tilize_input_tensor's mesh", tensor_name);
+
+    const auto& memory_config = tensor.memory_config();
+    TT_FATAL(
+        memory_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        "moe_compute: {} must use HEIGHT_SHARDED memory layout; got {}",
+        tensor_name,
+        memory_config.memory_layout());
+    TT_FATAL(
+        memory_config.buffer_type() == tt::tt_metal::BufferType::L1,
+        "moe_compute: {} must reside in L1; got buffer type {}",
+        tensor_name,
+        memory_config.buffer_type());
+    TT_FATAL(memory_config.shard_spec().has_value(), "moe_compute: {} needs an explicit shard spec", tensor_name);
+
+    const auto& shard_spec = memory_config.shard_spec().value();
+    TT_FATAL(
+        shard_spec.grid.num_cores() == 1,
+        "moe_compute: {} must be height-sharded on one core; got {}",
+        tensor_name,
+        shard_spec.grid.num_cores());
+    TT_FATAL(
+        shard_spec.grid == expected_drain_grid,
+        "moe_compute: {} must be placed on the selected tilize drain core {}; got {}",
+        tensor_name,
+        expected_drain_grid,
+        shard_spec.grid);
+    TT_FATAL(
+        shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR,
+        "moe_compute: {} shard orientation must be ROW_MAJOR; got {}",
+        tensor_name,
+        shard_spec.orientation);
+    TT_FATAL(
+        shard_spec.shape[0] == expected_shard_height && shard_spec.shape[1] == expected_shard_width,
+        "moe_compute: {} shard shape must be [{}, {}]; got [{}, {}]",
+        tensor_name,
+        expected_shard_height,
+        expected_shard_width,
+        shard_spec.shape[0],
+        shard_spec.shape[1]);
+
+    const auto& buffer = *tensor.buffer();
+    const uint64_t expected_page_size = static_cast<uint64_t>(expected_shard_width) * element_size;
+    TT_FATAL(
+        expected_page_size <= std::numeric_limits<uint32_t>::max(),
+        "moe_compute: {} row byte size ({}) exceeds uint32_t",
+        tensor_name,
+        expected_page_size);
+    TT_FATAL(
+        buffer.num_pages() == expected_shard_height,
+        "moe_compute: {} needs {} row pages for shard [{},{}]; got {}",
+        tensor_name,
+        expected_shard_height,
+        expected_shard_height,
+        expected_shard_width,
+        buffer.num_pages());
+    TT_FATAL(
+        buffer.page_size() == expected_page_size,
+        "moe_compute: {} page size must be {} bytes for width {}; got {} (unsupported stride)",
+        tensor_name,
+        expected_page_size,
+        expected_shard_width,
+        buffer.page_size());
+    const uint64_t expected_aligned_page_size_64 =
+        tt::align(expected_page_size, static_cast<uint64_t>(tt::tt_metal::hal::get_l1_alignment()));
+    TT_FATAL(
+        expected_aligned_page_size_64 <= std::numeric_limits<uint32_t>::max(),
+        "moe_compute: {} aligned row stride ({}) exceeds uint32_t",
+        tensor_name,
+        expected_aligned_page_size_64);
+    const uint32_t expected_aligned_page_size = static_cast<uint32_t>(expected_aligned_page_size_64);
+    TT_FATAL(
+        buffer.aligned_page_size() == expected_aligned_page_size,
+        "moe_compute: {} aligned row stride must be {} bytes; got {} bytes",
+        tensor_name,
+        expected_aligned_page_size,
+        buffer.aligned_page_size());
+    const uint64_t expected_logical_size = static_cast<uint64_t>(expected_shard_height) * expected_page_size;
+    TT_FATAL(
+        expected_logical_size <= std::numeric_limits<uint32_t>::max(),
+        "moe_compute: {} logical buffer size ({}) exceeds uint32_t",
+        tensor_name,
+        expected_logical_size);
+    TT_FATAL(
+        buffer.size() == expected_logical_size,
+        "moe_compute: {} logical size must be {} bytes ({} rows of {}); got {} (unsupported padding/width)",
+        tensor_name,
+        expected_logical_size,
+        expected_shard_height,
+        expected_page_size,
+        buffer.size());
+
+    // Buffer::size() is logical bytes; L1 allocation consumes aligned_page_size() per row.
+    const uint64_t expected_physical_span = static_cast<uint64_t>(expected_shard_height) * expected_aligned_page_size;
+    TT_FATAL(
+        expected_physical_span <= std::numeric_limits<uint32_t>::max(),
+        "moe_compute: {} aligned physical span ({}) exceeds the 32-bit L1 address contract",
+        tensor_name,
+        expected_physical_span);
+    TT_FATAL(
+        buffer.aligned_size() == expected_physical_span,
+        "moe_compute: {} aligned span must be {} bytes; got {} (unsupported allocation/stride)",
+        tensor_name,
+        expected_physical_span,
+        buffer.aligned_size());
+}
 
 }  // namespace detail
 MoEComputeDeviceOperation::program_factory_t MoEComputeDeviceOperation::select_program_factory(
@@ -38,42 +264,91 @@ void MoEComputeDeviceOperation::validate_on_program_cache_hit(
 void MoEComputeDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     // Tilize
-    TT_FATAL(
-        tensor_args.tilize_input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR,
-        "Input tensor must be in row major layout");
-    TT_FATAL(
-        tensor_args.tilize_input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16, "Input tensor must be bfloat16");
-    TT_FATAL(
-        tensor_args.tilize_expert_indices_tensor.dtype() == tt::tt_metal::DataType::UINT16,
-        "Indices tensor must be uint16");
+    detail::validate_device_row_major_tensor(
+        tensor_args.tilize_input_tensor, "tilize_input_tensor", tt::tt_metal::DataType::BFLOAT16, "BFLOAT16");
+    detail::validate_device_row_major_tensor(
+        tensor_args.tilize_expert_indices_tensor,
+        "tilize_expert_indices_tensor",
+        tt::tt_metal::DataType::UINT16,
+        "UINT16");
+    detail::validate_device_row_major_tensor(
+        tensor_args.tilize_expert_scores_tensor,
+        "tilize_expert_scores_tensor",
+        tt::tt_metal::DataType::BFLOAT16,
+        "BFLOAT16");
 
-    // Input tensor rank guards. Exact ranks are enforced where every caller agrees; lenient
-    // minimum ranks are used for the token/index/score tensors, which legitimately arrive as
-    // rank-3 from some dispatch paths and rank-4 from others (the op only indexes [0]/[1]/[-1]).
+    // Input tensor rank and score-organization guards. Indices legitimately arrive as rank 2,
+    // 3, or 4. Scores must be either the exact same shape (ContiguousK) or that shape plus one
+    // trailing singleton dimension (ScalarPageK); matching relative shapes makes inference
+    // unambiguous even when K itself is one.
     const auto rank_of = [](const ttnn::Tensor& t) { return t.logical_shape().rank(); };
+    const auto& tilize_input_shape = tensor_args.tilize_input_tensor.logical_shape();
+    const auto& indices_shape = tensor_args.tilize_expert_indices_tensor.logical_shape();
+    const auto& scores_shape = tensor_args.tilize_expert_scores_tensor.logical_shape();
+    const uint32_t total_tokens = detail::get_total_tokens(tilize_input_shape);
+    const auto score_input_organization = detail::derive_score_input_organization(indices_shape, scores_shape);
     TT_FATAL(
-        rank_of(tensor_args.tilize_input_tensor) >= 3,
-        "tilize_input_tensor must be rank >= 3 ([..., tokens, hidden]); got rank {}",
-        rank_of(tensor_args.tilize_input_tensor));
+        score_input_organization == args.score_input_organization,
+        "moe_compute: derived routing-score organization ({}) does not match the cached operation attribute ({}); "
+        "this indicates an invalid program-cache key",
+        static_cast<uint32_t>(score_input_organization),
+        static_cast<uint32_t>(args.score_input_organization));
+
+    const uint32_t indices_tokens = indices_shape[-2];
+    const uint32_t selected_experts_k = indices_shape[-1];
     TT_FATAL(
-        rank_of(tensor_args.tilize_expert_indices_tensor) >= 2,
-        "tilize_expert_indices_tensor must be rank >= 2 ([..., tokens, K]); got rank {}",
-        rank_of(tensor_args.tilize_expert_indices_tensor));
+        indices_tokens > 0,
+        "moe_compute: tilize_expert_indices_tensor trailing token dimension must be positive; got shape {}",
+        indices_shape);
     TT_FATAL(
-        rank_of(tensor_args.tilize_expert_scores_tensor) >= 2,
-        "tilize_expert_scores_tensor must be rank >= 2 ([..., tokens, K]); got rank {}",
-        rank_of(tensor_args.tilize_expert_scores_tensor));
+        selected_experts_k > 0,
+        "moe_compute: tilize_expert_indices_tensor K must be positive; got shape {}",
+        indices_shape);
+    TT_FATAL(
+        indices_tokens == total_tokens,
+        "moe_compute: tilize_expert_indices_tensor trailing token dimension must match the activation token count; "
+        "got indices shape {} (tokens={}) and activation shape {} (tokens={})",
+        indices_shape,
+        indices_tokens,
+        tilize_input_shape,
+        total_tokens);
+    const uint64_t expected_sparse_volume = static_cast<uint64_t>(total_tokens) * selected_experts_k;
+    TT_FATAL(
+        indices_shape.volume() == expected_sparse_volume,
+        "moe_compute: tilize_expert_indices_tensor must contain exactly one K-wide row per activation token; got "
+        "shape {} (trailing tokens={}, volume={}) for activation shape {} (flattened tokens={}) and K={} "
+        "(expected volume={})",
+        indices_shape,
+        indices_tokens,
+        indices_shape.volume(),
+        tilize_input_shape,
+        total_tokens,
+        selected_experts_k,
+        expected_sparse_volume);
+    TT_FATAL(
+        scores_shape.volume() == expected_sparse_volume,
+        "moe_compute: routing scores must contain exactly tokens*K logical elements; got scores shape {} (volume={}) "
+        "and indices shape {} for tokens={} K={} (expected volume={})",
+        scores_shape,
+        scores_shape.volume(),
+        indices_shape,
+        total_tokens,
+        selected_experts_k,
+        expected_sparse_volume);
+
     TT_FATAL(
         rank_of(tensor_args.tilize_expert_mapping_tensor) == 2,
-        "tilize_expert_mapping_tensor must be rank 2 ([num_devices, experts]); got rank {}",
+        "moe_compute: tilize_expert_mapping_tensor must be rank 2 ([num_devices, experts]); got rank {}",
         rank_of(tensor_args.tilize_expert_mapping_tensor));
     TT_FATAL(
         rank_of(tensor_args.matmul_w0_w1_tensor) == 6,
-        "matmul_w0_w1_tensor must be rank 6 ([num_cores, L, E, groups_per_core, K, 4*TILE_SIZE]); got rank {}",
+        "moe_compute: matmul_w0_w1_tensor must be rank 6 ([num_cores, L, E, groups_per_core, K, "
+        "4*TILE_SIZE]); got rank {}",
         rank_of(tensor_args.matmul_w0_w1_tensor));
     TT_FATAL(
         rank_of(tensor_args.matmul_w2_tensor) == 6,
-        "matmul_w2_tensor must be rank 6 ([num_cores, L, E, groups_per_core, N, 4*TILE_SIZE]); got rank {}",
+        "moe_compute: matmul_w2_tensor must be rank 6 ([num_cores, L, E, groups_per_core, N, 4*TILE_SIZE]); got "
+        "rank {}",
         rank_of(tensor_args.matmul_w2_tensor));
 
     // When has_bias=True, dm0 derives per-expert byte strides using ceil((K+1)/W0W1_TXN)*W0W1_TXN and
@@ -108,8 +383,6 @@ void MoEComputeDeviceOperation::validate_on_program_cache_miss(
     }
 
     // validate that 32 (token dim) * output_shard_width * output_shard_height >= total tokens
-    const auto& tilize_input_shape = tensor_args.tilize_input_tensor.logical_shape();
-    const auto total_tokens = tilize_input_shape[0] * tilize_input_shape[1];
     const auto combine_token_parallel_cores = args.num_token_parallel_cores;
     const auto combine_data_parallel_cores = args.num_data_parallel_cores;
 
@@ -204,17 +477,59 @@ void MoEComputeDeviceOperation::validate_on_program_cache_miss(
         args.num_shared_experts_per_device,
         experts_per_device);
 
-    // Validate that dynamic core placement succeeds for this hidden size and combine grid.
-    // mux_core_range_set comes from combine_params when in Full mode; ComputeOnly uses an empty set.
+    // Validate that dynamic core placement succeeds and bind the sparse tensors to the selected
+    // drain core before any program is created. mux_core_range_set comes from combine_params when
+    // in Full mode; ComputeOnly uses an empty set.
     const CoreRangeSet validate_mux_cores =
         args.combine_params.has_value() ? args.combine_params->mux_core_range_set : CoreRangeSet{};
-    ttnn::operations::ccl::common::select_moe_compute_cores(
+    const auto core_selection = ttnn::operations::ccl::common::select_moe_compute_cores(
         mesh_device,
         combine_token_parallel_cores,
         combine_data_parallel_cores,
         hidden_size,
         validate_mux_cores,
         args.bh_ring_size);
+    TT_FATAL(
+        !core_selection.tilize_cores.empty(),
+        "moe_compute: core placement returned no tilize drain core for the requested configuration");
+    const CoreCoord drain_core = core_selection.tilize_cores.front();
+    const CoreCoord worker_grid_size = mesh_device->compute_with_storage_grid_size();
+    TT_FATAL(
+        drain_core.x < worker_grid_size.x && drain_core.y < worker_grid_size.y,
+        "moe_compute: selected tilize drain core {} is outside worker grid {}",
+        drain_core,
+        worker_grid_size);
+    const CoreRangeSet drain_grid = CoreRangeSet({CoreRange(drain_core, drain_core)});
+
+    detail::validate_sparse_tensor_placement(
+        tensor_args.tilize_expert_indices_tensor,
+        "tilize_expert_indices_tensor",
+        mesh_device,
+        drain_grid,
+        total_tokens,
+        selected_experts_k,
+        sizeof(uint16_t));
+
+    const uint64_t score_shard_height_64 = args.score_input_organization == MoEScoreInputOrganization::ScalarPageK
+                                               ? static_cast<uint64_t>(total_tokens) * selected_experts_k
+                                               : total_tokens;
+    TT_FATAL(
+        score_shard_height_64 <= std::numeric_limits<uint32_t>::max(),
+        "moe_compute: routing-score shard height ({}) exceeds uint32_t for tokens={} K={} organization={}",
+        score_shard_height_64,
+        total_tokens,
+        selected_experts_k,
+        static_cast<uint32_t>(args.score_input_organization));
+    const uint32_t score_shard_width =
+        args.score_input_organization == MoEScoreInputOrganization::ScalarPageK ? 1u : selected_experts_k;
+    detail::validate_sparse_tensor_placement(
+        tensor_args.tilize_expert_scores_tensor,
+        "tilize_expert_scores_tensor",
+        mesh_device,
+        drain_grid,
+        static_cast<uint32_t>(score_shard_height_64),
+        score_shard_width,
+        sizeof(bfloat16));
 }
 
 MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::compute_output_specs(
@@ -226,9 +541,7 @@ MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::comput
     auto* mesh_device = tilize_input_tensor.device();
 
     uint32_t experts_per_device = tensor_args.matmul_w0_w1_tensor.logical_shape()[2];
-    uint32_t total_tokens =
-        tilize_input_shape[0] *
-        tilize_input_shape[1];  // tokens_per_device from input, total tokens across all dispatch devices
+    const uint32_t total_tokens = detail::get_total_tokens(tilize_input_shape);
 
     const uint32_t hidden_size = tilize_input_shape[-1];
 
@@ -430,9 +743,12 @@ std::vector<ttnn::Tensor> moe_compute(
 
     const auto& input_shape = tilize_input_tensor.tensor_spec().logical_shape();
     const auto& indices_shape = tilize_expert_indices_tensor.tensor_spec().logical_shape();
+    const auto& scores_shape = tilize_expert_scores_tensor.tensor_spec().logical_shape();
+    const uint32_t total_tokens = ttnn::experimental::prim::detail::get_total_tokens(input_shape);
+    const auto score_input_organization =
+        ttnn::experimental::prim::detail::derive_score_input_organization(indices_shape, scores_shape);
     const uint32_t hidden_size = input_shape[-1];
     const uint32_t select_experts_k = indices_shape[-1];
-    const uint32_t total_tokens = input_shape[0] * input_shape[1];
 
     const auto& num_token_parallel_cores = output_height_shard_dim;
 
@@ -582,6 +898,7 @@ std::vector<ttnn::Tensor> moe_compute(
             .path = compute_only ? experimental::prim::MoEComputePath::ComputeOnly
                                  : (full_local ? experimental::prim::MoEComputePath::FullLocal
                                                : experimental::prim::MoEComputePath::FullCcl),
+            .score_input_organization = score_input_organization,
             .bh_ring_size = ring_n,
             .combine_params = combine_params,
             .activation_type = activation_type.value_or(experimental::prim::detail::MoEActivationFunction::SILU)},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -27,6 +27,12 @@ namespace ttnn::experimental::prim {
 //   no global semaphores; op emits 5 tensors instead of 6 (matmul_output is the final output).
 enum class MoEComputePath : uint8_t { FullCcl = 0, FullLocal = 2, ComputeOnly = 1 };
 
+// Physical organization of the row-major routing-score tensor. This is derived
+// from the exact score/indices shapes at the public operation boundary; it is an
+// operation attribute so the program cache compiles separate, branch-free
+// kernels for the two addressing contracts.
+enum class MoEScoreInputOrganization : uint8_t { ContiguousK = 0, ScalarPageK = 1 };
+
 struct MoEComputeParams {
     // MoE compute attributes
     uint32_t layer_id = 0;
@@ -41,6 +47,8 @@ struct MoEComputeParams {
     uint32_t num_data_parallel_cores = 0;
 
     MoEComputePath path = MoEComputePath::FullCcl;
+
+    MoEScoreInputOrganization score_input_organization = MoEScoreInputOrganization::ContiguousK;
 
     // Ring size in matmul cores. On WH this is always 12 (DRAM banks), so keep the
     // field initializer at the WH-neutral default. On BH, invoke() resolves this to
@@ -65,7 +73,7 @@ struct MoEComputeParams {
     auto attributes() const {
         using ttsl::reflection::Attribute;
         std::vector<std::tuple<std::string, Attribute>> attrs;
-        attrs.reserve(11);
+        attrs.reserve(12);
         attrs.emplace_back("layer_id", layer_id);
         attrs.emplace_back("output_height_shard_dim", output_height_shard_dim);
         attrs.emplace_back("intermediate_size", intermediate_size);
@@ -74,6 +82,7 @@ struct MoEComputeParams {
         attrs.emplace_back("num_token_parallel_cores", num_token_parallel_cores);
         attrs.emplace_back("num_data_parallel_cores", num_data_parallel_cores);
         attrs.emplace_back("path", static_cast<uint32_t>(path));
+        attrs.emplace_back("score_input_organization", static_cast<uint32_t>(score_input_organization));
         attrs.emplace_back("bh_ring_size", bh_ring_size);
         attrs.emplace_back("combine_params", combine_params);
         attrs.emplace_back("activation_type", static_cast<uint32_t>(activation_type));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <limits>
 #include <numeric>
 #include <tuple>
 #include <utility>
@@ -315,6 +316,19 @@ MoEComputeMeshWorkloadFactory::create_at(
     // physical experts per device, replicated shared experts are counted per device
     uint32_t experts_per_device = tensor_args.matmul_w0_w1_tensor.logical_shape()[2];
     uint32_t selected_experts_k = tilize_indices_shape[-1];
+
+    const uint64_t score_token_stride_64 =
+        args.score_input_organization == MoEScoreInputOrganization::ScalarPageK
+            ? static_cast<uint64_t>(selected_experts_k) * tilize_input_scores_aligned_page_size
+            : tilize_input_scores_aligned_page_size;
+    TT_FATAL(
+        score_token_stride_64 <= std::numeric_limits<uint32_t>::max(),
+        "moe_compute: routing-score token stride ({}) exceeds uint32_t",
+        score_token_stride_64);
+    const uint32_t score_token_stride = static_cast<uint32_t>(score_token_stride_64);
+    const uint32_t score_k_stride = args.score_input_organization == MoEScoreInputOrganization::ScalarPageK
+                                        ? tilize_input_scores_aligned_page_size
+                                        : sizeof(uint16_t);
 
     // Output/Combine input core dims, for core selection. These are top-level (lifted) so they
     // remain valid even when combine_params is nullopt (ComputeOnly mode).
@@ -868,7 +882,8 @@ MoEComputeMeshWorkloadFactory::create_at(
         {"aligned_input_page_size", tilize_input_aligned_page_size},
         {"aligned_indices_page_size", tilize_indices_aligned_page_size},
         {"aligned_mapping_page_size", tilize_mapping_aligned_page_size},
-        {"aligned_scores_page_size", tilize_input_scores_aligned_page_size},
+        {"score_token_stride", score_token_stride},
+        {"score_k_stride", score_k_stride},
 
         // General info
         {"tokens", tokens},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -84,8 +84,11 @@ void bind_moe_compute(nb::module_& mod) {
           dim and ``total_tokens`` from its first two dims.
         - ``tilize_expert_indices_tensor``: Per-token selected expert ids;
           ``select_experts_k`` is inferred from its last dim.
-        - ``tilize_expert_scores_tensor``: Per-token routing scores (gates) applied to
-          the expert outputs.
+        - ``tilize_expert_scores_tensor``: Per-token BF16 routing scores (gates), in
+          ROW_MAJOR layout. The organization is inferred without ambiguity from the
+          exact shapes: either the same ``[..., tokens, K]`` shape as expert indices
+          (contiguous K lanes in one row) or that shape plus a trailing singleton
+          dimension, ``[..., tokens, K, 1]`` (one aligned scalar page per K lane).
         - ``tilize_expert_mapping_tensor``: The expert → device mapping that tells the
           kernel which experts are resident locally.
 
@@ -300,6 +303,8 @@ void bind_get_moe_tilize_drain_core(nb::module_& mod) {
         Return the drain tilize core for moe_compute (``tilize_cores[0]``).
 
         Expert indices and scores tensors must be HEIGHT_SHARDED to this core in L1.
+        Indices use shard shape ``[tokens, K]``. Scores use ``[tokens, K]`` for
+        contiguous-K input or ``[tokens * K, 1]`` for scalar-page-K input.
         ``hidden_size`` must match the model hidden dimension because tilize core placement
         depends on ``hidden_tiles = hidden_size // 32``.
         Pass the same ``mux_core_range_set`` used by ``moe_compute`` when fabric mux cores are reserved.


### PR DESCRIPTION
This does not change the behavior or output semantics of existing valid
`[..., tokens, K]` `moe_compute` calls. It allows the same logical `tokens × K`
routing scores, presented as `[..., tokens, K, 1]` scalar pages, to use the op
directly without a frontend reshape, permute, slice, concat, or repack. The
existing contiguous-K path keeps the same API and compile-time addressing;
malformed inputs may now fail earlier because the host validation is stricter.

## Root cause

`moe_compute` currently assumes the routing scores for one token are stored as
K contiguous BF16 values in one aligned row:

```text
score_addr(token, k) =
    scores_base + token * aligned_scores_page_size + k * sizeof(bfloat16)
```

That is correct for scores shaped `[..., tokens, K]`.

A contiguous tensor with semantic shape `[1,K,T,1]` appears in TTNN order as
`[1,T,K,1]`. In that organization, each K lane is a separate aligned width-one
row. The current address advances into row padding after lane zero instead of
advancing to the next scalar page.

The non-drain tilize cores also copy only one aligned score page per token, so
changing only the drain-core load would leave the other cores incorrect.

## Fix

Accept exactly two score organizations, derived from their complete shape
relationship with the selected-expert IDs:

- `ContiguousK`: the score shape exactly equals the ID shape
  `[..., tokens, K]`.
- `ScalarPageK`: the score shape exactly equals the ID shape plus one trailing
  singleton dimension, `[..., tokens, K, 1]`.

All other rank or shape relationships are rejected as unsupported or ambiguous.
No public API parameter is added.

The organization is included in the operation attributes so the program cache
compiles separate kernels with these constants:

```text
ContiguousK:
    score_token_stride = aligned_scores_page_size
    score_k_stride     = sizeof(bfloat16)

ScalarPageK:
    score_token_stride = K * aligned_scores_page_size
    score_k_stride     = aligned_scores_page_size
```

Both tilize metadata paths then use:

```text
score_addr(token, k) =
    scores_base + token * score_token_stride + k * score_k_stride
```

The existing contiguous-K path remains branch-free inside the K loop.

Non-drain cores copy `num_tokens_this_core * score_token_stride` bytes beginning
at `core_token_start * score_token_stride`. Scalar pages are adjacent in the
height-sharded allocation, so this remains one contiguous NoC transfer per core
token range rather than K transfers per token.

Host validation now checks the exact score/ID shape and volume relationship,
ROW_MAJOR BF16/UINT16 types, one-core HEIGHT_SHARDED L1 placement on the selected
tilize drain core, organization-specific shard shape, and exact page, stride,
logical-size, and aligned-span contracts. The same validation runs on
program-cache hits.

## Test

Adds `test_moe_compute_score_organization.py` with:

- token counts `{1,2,31,32,33}` × K values `{2,4,6,8}`;
- identical logical values in both physical organizations;
- distinct nonzero, signed/zero, non-normalized, normalized, and one-hot-by-lane
  scores;
- exact BF16 score bits and K index checked for every selected lane;
- valid ComputeOnly and FullLocal paths;
- cold program creation and cache hits with changed sparse, ID, score, and output
  addresses;
- graph capture rejecting standalone reshape, slice, concat, or permute
  dispatch; and
- host-side rejection coverage for malformed rank/shape/volume, dtype, layout,
  shard shape, and drain-core placement.

## Validation

- The negative validation suite passed all malformed-input cases.
- The full 20-case token/K matrix passed for both score organizations.
- Cold invocation, program-cache hits, and changed input/output addresses
  passed.
- Scalar-page graph traces contained `ttnn.experimental.moe_compute` and no
  standalone reshape, slice, concat, or permute operation.

For `(tokens=33,K=8)`, 10 comparisons determined essentially no performance difference.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/moe-compute-scalar-page-scores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/moe-compute-scalar-page-scores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/moe-compute-scalar-page-scores)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/moe-compute-scalar-page-scores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/moe-compute-scalar-page-scores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/moe-compute-scalar-page-scores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/moe-compute-scalar-page-scores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/moe-compute-scalar-page-scores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/moe-compute-scalar-page-scores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/moe-compute-scalar-page-scores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/moe-compute-scalar-page-scores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/moe-compute-scalar-page-scores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/moe-compute-scalar-page-scores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/moe-compute-scalar-page-scores)
