### PR TITLE
[skip ci] ci: anchor the wheel-artifact match when reusing a run's build

### DIFF
--- a/.github/actions/download-artifacts-from-run/action.yml
+++ b/.github/actions/download-artifacts-from-run/action.yml
@@ -107,7 +107,7 @@ runs:
         fi
 
         # Find wheel artifact
-        WHEEL_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "ttnn-dist|ttnn" | head -1 || true)
+        WHEEL_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "^ttnn-dist" | head -1 || true)
 
         # Find packages artifact (optional)
         PACKAGES_ARTIFACT=$(echo "$ARTIFACTS" | grep -E "packages-" | head -1 || true)


### PR DESCRIPTION
`download-artifacts-from-run` picks the wheel with an unanchored `grep -E "ttnn-dist|ttnn"`. Any run that also published per-leg `power-report-ttnn *` artifacts hands back one of those instead of the wheel.

Against run 32264767730's 81 artifacts:

```
picked:   power-report-ttnn fused group 2 [bh_p150b_civ2]
correct:  ttnn-dist-inplace-cp310-Release-profiler-0b3d5ab9acd-32264767730
```

The wheel download is non-fatal (`WARNING: Failed to download wheel artifact`), so this surfaces later as a missing wheel rather than a clear error.

Verified in run [32281747838](https://github.com/tenstorrent/tt-metal/actions/runs/32281747838), which reused that build end to end with the fix applied: `download-artifacts` succeeded, the build job skipped, and all three test legs passed against the reused binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/fix-wheel-artifact-anchor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/fix-wheel-artifact-anchor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/fix-wheel-artifact-anchor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/fix-wheel-artifact-anchor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/fix-wheel-artifact-anchor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/fix-wheel-artifact-anchor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/fix-wheel-artifact-anchor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/fix-wheel-artifact-anchor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/fix-wheel-artifact-anchor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/fix-wheel-artifact-anchor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/fix-wheel-artifact-anchor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/fix-wheel-artifact-anchor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/fix-wheel-artifact-anchor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/fix-wheel-artifact-anchor)