### PR TITLE
sanity-tests: route t3000-sanity-tests through wh-skus, add wh_llmbox variants

### DIFF
--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -319,8 +319,8 @@ jobs:
           wh_skus=()
           bh_skus=()
           sim_skus=()
-          # wh-skus / bh-skus are per-arch lists: pass these to an impl whose tests yaml
-          # only ever defines SKUs of that one architecture (t3000-sanity-tests, umd-sanity-tests).
+          # wh-skus / bh-skus are per-arch lists: pass these to an impl when this pipeline
+          # must restrict a multi-architecture tests YAML to one architecture (umd-sanity-tests).
           # sanity-skus is the union of every enabled arch's list below: pass this to an impl
           # whose tests yaml spans multiple architectures in one file (ttnn-sanity-tests,
           # ops-sanity-tests, blackhole-multi-card-fast-sanity-tests). prepare_test_matrix.py

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -327,22 +327,42 @@ jobs:
           # intersects whichever list it's given against each test's own `skus:` map, so handing
           # a wider list than a given tests yaml needs is safe -- SKUs the yaml doesn't reference
           # simply produce no matrix rows for that impl.
+          #
+          # Both lists include every wh_*/bh_* SKU in .github/sku_config.yaml except:
+          #   - Galaxy SKUs (wh_galaxy*, bh_galaxy*) -- a separate pipeline (galaxy-sanity.yaml).
+          #   - bh_sc* -- exabox multihost SKUs, used by shield/scaleout, not sanity.
+          #   - cpu_medium -- not a wh/bh hardware SKU.
+          #   - *_prio SKUs -- merge_group-only aliases; sku_config.yaml itself says not to
+          #     list these in a tests yaml's skus map.
           if [[ "$run_wormhole" == "true" ]]; then
             wh_skus+=(
-              "wh_n300_civ2"
               "wh_llmbox"
+              "wh_llmbox_perf"
+              "wh_n150"
+              "wh_n300"
+              "wh_n150_civ2"
+              "wh_n300_civ2"
               "wh_llmbox_civ2"
               "wh_llmbox_civ2_viommu"
-              "wh_llmbox_perf"
+              "wh_n300_perf"
             )
             sanity_skus+=("${wh_skus[@]}")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
             bh_skus+=(
-              "bh_p150b_civ2"
+              "bh_p100"
+              "bh_p100_perf"
+              "bh_p100a_civ2_viommu"
               "bh_p150b_civ2_viommu"
-              "bh_quietbox_2"
+              "bh_p150b_civ2"
+              "bh_p150"
+              "bh_p150_perf"
+              "bh_loudbox"
               "bh_p300"
+              "bh_p300_viommu"
+              "bh_loudbox_civ2_viommu"
+              "bh_quietbox_2"
+              "bh_quietbox_2_iommu"
             )
             sanity_skus+=("${bh_skus[@]}")
           fi

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -319,12 +319,31 @@ jobs:
           wh_skus=()
           bh_skus=()
           sim_skus=()
+          # wh-skus / bh-skus are per-arch lists: pass these to an impl whose tests yaml
+          # only ever defines SKUs of that one architecture (t3000-sanity-tests, umd-sanity-tests).
+          # sanity-skus is the union of every enabled arch's list below: pass this to an impl
+          # whose tests yaml spans multiple architectures in one file (ttnn-sanity-tests,
+          # ops-sanity-tests, blackhole-multi-card-fast-sanity-tests). prepare_test_matrix.py
+          # intersects whichever list it's given against each test's own `skus:` map, so handing
+          # a wider list than a given tests yaml needs is safe -- SKUs the yaml doesn't reference
+          # simply produce no matrix rows for that impl.
           if [[ "$run_wormhole" == "true" ]]; then
-            wh_skus+=("wh_n300_civ2")
+            wh_skus+=(
+              "wh_n300_civ2"
+              "wh_llmbox"
+              "wh_llmbox_civ2"
+              "wh_llmbox_civ2_viommu"
+              "wh_llmbox_perf"
+            )
             sanity_skus+=("${wh_skus[@]}")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
-            bh_skus+=("bh_p150b_civ2" "bh_p150b_civ2_viommu" "bh_quietbox_2" "bh_p300")
+            bh_skus+=(
+              "bh_p150b_civ2"
+              "bh_p150b_civ2_viommu"
+              "bh_quietbox_2"
+              "bh_p300"
+            )
             sanity_skus+=("${bh_skus[@]}")
           fi
           if [[ "$run_sim" == "true" ]]; then
@@ -373,7 +392,10 @@ jobs:
     uses: ./.github/workflows/t3000-sanity-tests-impl.yaml
     with:
       summary-scope: ${{ inputs.platform }}
-      enabled-skus: "wh_llmbox_civ2"
+      # t3000_sanity_tests.yaml today only defines wh_llmbox_civ2; the other wh-skus
+      # entries (wh_n300_civ2, wh_llmbox, wh_llmbox_civ2_viommu, wh_llmbox_perf) simply
+      # produce no matrix rows here until/unless a test entry references them.
+      enabled-skus: ${{ needs.generate-sku-matrix.outputs.wh-skus }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -392,10 +392,13 @@ jobs:
     uses: ./.github/workflows/t3000-sanity-tests-impl.yaml
     with:
       summary-scope: ${{ inputs.platform }}
-      # t3000_sanity_tests.yaml today only defines wh_llmbox_civ2; the other wh-skus
-      # entries (wh_n300_civ2, wh_llmbox, wh_llmbox_civ2_viommu, wh_llmbox_perf) simply
-      # produce no matrix rows here until/unless a test entry references them.
-      enabled-skus: ${{ needs.generate-sku-matrix.outputs.wh-skus }}
+      # sanity-skus, same as ttnn-sanity-tests/ops-sanity-tests/blackhole-multi-card-fast-sanity-tests.
+      # t3000_sanity_tests.yaml today only defines wh_llmbox_civ2; every other SKU in the
+      # list (wh_n300_civ2, wh_llmbox, wh_llmbox_civ2_viommu, wh_llmbox_perf, and any bh_*/sim_*
+      # entries) simply produces no matrix row here until/unless a test entry references it.
+      # The job's own `if:` above still gates on run-wormhole, so this never fires with a
+      # SKU set lacking a wh_llmbox entry.
+      enabled-skus: ${{ needs.generate-sku-matrix.outputs.sanity-skus }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -350,9 +350,6 @@ jobs:
           fi
           if [[ "$run_blackhole" == "true" ]]; then
             bh_skus+=(
-              "bh_p100"
-              "bh_p100_perf"
-              "bh_p100a_civ2_viommu"
               "bh_p150b_civ2_viommu"
               "bh_p150b_civ2"
               "bh_p150"

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -347,7 +347,12 @@ jobs:
             sanity_skus+=("${bh_skus[@]}")
           fi
           if [[ "$run_sim" == "true" ]]; then
-            sim_skus+=("sim_wh_n150" "sim_wh_galaxy" "sim_bh_p150" "sim_bh_galaxy")
+            sim_skus+=(
+              "sim_wh_n150"
+              "sim_wh_galaxy"
+              "sim_bh_p150"
+              "sim_bh_galaxy"
+            )
             sanity_skus+=("${sim_skus[@]}")
           fi
 


### PR DESCRIPTION
## Summary
`t3000-sanity-tests` was the only sanity impl hardcoding its `enabled-skus` (`"wh_llmbox_civ2"`) instead of consuming `generate-sku-matrix`'s output like every other impl. This PR:

- Switches `t3000-sanity-tests` to `needs.generate-sku-matrix.outputs.sanity-skus`, matching `ttnn-sanity-tests`/`ops-sanity-tests`/`blackhole-multi-card-fast-sanity-tests`.
- Broadens `wh_skus`/`bh_skus` in `generate-sku-matrix` to every wh_*/bh_* SKU in `.github/sku_config.yaml`, **except**: Galaxy SKUs (separate pipeline), `bh_sc*` (exabox multihost, used by shield/scaleout), `cpu_medium` (not a wh/bh hardware SKU), and `*_prio` SKUs (merge_group-only aliases). `bh_p100`/`bh_p100_perf`/`bh_p100a_civ2_viommu` are also excluded on purpose — see below.
- Reformats `wh_skus`/`bh_skus`/`sim_skus` one-entry-per-line with a comment explaining the `wh-skus`/`bh-skus` (per-arch subset) vs `sanity-skus` (union across enabled arches) distinction.

`prepare_test_matrix.py` intersects whichever list it's given against each test's own `skus:` map, so a wider enabled-skus list than a given tests yaml needs is always safe — unreferenced SKUs simply produce no matrix rows.

## Why `bh_p100` family is excluded
Investigated why `bh_p100`/`bh_p100a_civ2_viommu` aren't already scheduled anywhere in the sanity pipeline. It's intentional, not a gap: [#48183](https://github.com/tenstorrent/tt-metal/pull/48183) ("Pipeline reorg: Blackhole sanity") deliberately moved P100-family tests out of the sanity pipeline into `tt-metal-l2-nightly.yaml` — "to respect the frequency at which p100 jobs are automatically triggered." That coverage is live today as `ttnn-p100-tests`/`umd-p100-tests` in `tt-metal-l2-nightly.yaml`, gated to schedule/nightly cadence rather than every sanity trigger. Keeping this PR aligned with that decision rather than fighting it.

## Test plan
- [x] YAML parses cleanly; local `prepare_test_matrix.py` dry runs confirm matrix output for `ttnn`/`ops`/`t3000`/`umd`/`blackhole-multi-card` is unchanged from before this PR (same `(name, sku)` sets).
- [x] Manual `workflow_dispatch` run, Wormhole-only, `t3000-sanity-tests` only: [32388110989](https://github.com/tenstorrent/tt-metal/actions/runs/32388110989) — passed.
- [x] Manual `workflow_dispatch` run, full default inputs (Wormhole+Blackhole+Sim, all suites): [32395851702](https://github.com/tenstorrent/tt-metal/actions/runs/32395851702) — passing, no failures across ttnn/t3000/ops/umd/ttsim/runtime-sim/blackhole-multi-card as legs complete.

## Note for a follow-up
`t3000-fast-tests.yaml` has its own separate hardcoded `enabled-skus: "wh_llmbox_civ2"` call to the same impl, outside this workflow's `generate-sku-matrix` — intentionally left untouched here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanity/t3000-wh-llmbox-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanity/t3000-wh-llmbox-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanity/t3000-wh-llmbox-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanity/t3000-wh-llmbox-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanity/t3000-wh-llmbox-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanity/t3000-wh-llmbox-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanity/t3000-wh-llmbox-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanity/t3000-wh-llmbox-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanity/t3000-wh-llmbox-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanity/t3000-wh-llmbox-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanity/t3000-wh-llmbox-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanity/t3000-wh-llmbox-skus)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanity/t3000-wh-llmbox-skus)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanity/t3000-wh-llmbox-skus)