### PR TITLE
[Cleanup] Deprecating legacy `LaunchProgram` and `CompileProgram`

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -79,7 +79,7 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     const auto topology = fabric_context.get_fabric_topology();
     TT_FATAL(topology == Topology::Mesh, "Intermesh Routing tests need Dynamic Routing enabled.");
 
-    auto devices = fixture->get_devices();
+    const auto& devices = fixture->get_devices();
 
     // Synchronize seeds across hosts (sender and receiver must use the same seed for randomization)
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
@@ -158,8 +158,7 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Run sender program
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
 
     // Validate status of sender
     std::vector<uint32_t> sender_status;
@@ -200,7 +199,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
     TT_FATAL(topology == Topology::Mesh, "Intermesh Routing tests need Dynamic Routing enabled.");
-    auto devices = fixture->get_devices();
+    const auto& devices = fixture->get_devices();
 
     // Synchronize seeds across hosts (sender and receiver must use the same seed for randomization)
     uint32_t time_seed = 0;
@@ -248,8 +247,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
     auto recv_program = create_receiver_program(compile_time_args, receiver_runtime_args, receiver_logical_core);
 
     // Run receiver program
-    fixture->RunProgramNonblocking(receiver_device, *recv_program);
-    fixture->WaitForSingleProgramDone(receiver_device, *recv_program);
+    tt_metal::LaunchProgram(*receiver_device, std::move(*recv_program), /*wait_until_cores_done=*/true);
 
     // Validate status of the receiver
     std::vector<uint32_t> receiver_status;
@@ -306,7 +304,7 @@ void run_mcast_sender_step(
     );
     // Randomly select a mcast sender device
     auto sender_phys_id = control_plane.get_physical_chip_id_from_fabric_node_id(mcast_sender_node);
-    auto sender_device = fixture->get_device(sender_phys_id);
+    const auto& sender_device = fixture->get_device(sender_phys_id);
     const auto& worker_grid_size = sender_device->compute_with_storage_grid_size();
     // Randomly select a mcast sender core
     auto sender_x = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.x - 2)(global_rng);
@@ -366,8 +364,7 @@ void run_mcast_sender_step(
     tt_metal::SetRuntimeArgs(mcast_send_program, mcast_send_kernel, sender_logical_core, sender_runtime_args);
 
     log_debug(tt::LogTest, "Run Sender on: {}", sender_device->id());
-    fixture->RunProgramNonblocking(sender_device, mcast_send_program);
-    fixture->WaitForSingleProgramDone(sender_device, mcast_send_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(mcast_send_program), /*wait_until_cores_done=*/true);
 
     // Validate status of sender
     std::vector<uint32_t> sender_status;
@@ -463,12 +460,12 @@ void run_mcast_recv_step(
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
         log_debug(tt::LogTest, "Run receiver on: {}", dev->id());
-        fixture->RunProgramNonblocking(dev, *recv_program);
+        fixture->RunProgramNonblocking(dev, std::move(*recv_program));
     }
 
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
-        fixture->WaitForSingleProgramDone(dev, *recv_program);
+        fixture->WaitForSingleProgramDone(dev);
     }
     // Validate status of the receiver
     // Request test results from the sender host and ensure that they match

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -19,6 +19,7 @@
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
 #include <tt-metalium/allocator.hpp>
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "test_host_kernel_common.hpp"
 
@@ -134,33 +135,13 @@ public:
 
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void RunProgramNonblocking(
-        const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device, tt::tt_metal::Program& program) {
-        if (this->slow_dispatch_) {
-            tt::tt_metal::slow_dispatch::LaunchProgram(*device, program, false);
-        } else {
-            tt::tt_metal::distributed::MeshCommandQueue& cq = device->mesh_command_queue();
-            // Create a mesh workload from the program
-            auto& program_copy = program;
-            auto mesh_workload = tt::tt_metal::distributed::MeshWorkload();
-            mesh_workload.add_program(
-                tt::tt_metal::distributed::MeshCoordinateRange(
-                    tt::tt_metal::distributed::MeshCoordinate(0, 0), tt::tt_metal::distributed::MeshCoordinate(0, 0)),
-                std::move(program_copy));
-            tt::tt_metal::distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
-        }
+        const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device, tt::tt_metal::Program&& program) {
+        tt_metal::LaunchProgram(*device, std::move(program), /*wait_until_cores_done=*/false);
     }
 
     // NOLINTNEXTLINE(readability-make-member-function-const)
-    void WaitForSingleProgramDone(
-        const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device, tt::tt_metal::Program& program) {
-        if (this->slow_dispatch_) {
-            // Wait for the program to finish
-            tt::tt_metal::detail::WaitProgramDone(device->get_devices()[0], program);
-        } else {
-            // Wait for all programs on cq to finish
-            tt::tt_metal::distributed::MeshCommandQueue& cq = device->mesh_command_queue();
-            tt::tt_metal::distributed::Finish(cq);
-        }
+    void WaitForSingleProgramDone(const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device) {
+        tt::tt_metal::distributed::Finish(device->mesh_command_queue());
     }
 
     // Utility function reused across tests to get address params

--- a/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
@@ -141,16 +141,14 @@ void signal_worker_teardown(
 void wait_for_worker_complete(
     fabric_router_tests::BaseFabricFixture* fixture,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
-    tt_metal::Program& program,
     std::chrono::milliseconds timeout) {
-
     // Wait for the worker program to complete with timeout
     // This blocks until the program completes or timeout expires
 
     auto start = std::chrono::steady_clock::now();
 
     // Call the fixture's wait method to block until program completes
-    fixture->WaitForSingleProgramDone(device, program);
+    fixture->WaitForSingleProgramDone(device);
 
     auto elapsed = std::chrono::steady_clock::now() - start;
     if (elapsed > timeout) {

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -29,7 +29,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
@@ -140,7 +140,7 @@ static void build_and_enqueue(
         futures.emplace_back(tt::tt_metal::detail::async([&devices, &programs, i, enqueue_only]() {
             if constexpr (std::is_same_v<ProgramContainer, std::vector<Program*>>) {
                 if (!enqueue_only) {
-                    slow_dispatch::CompileProgram(*devices[i], *programs[i]);
+                    programs[i]->impl().compile(devices[i].get());
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range
@@ -148,7 +148,7 @@ static void build_and_enqueue(
                 tt::tt_metal::distributed::EnqueueMeshWorkload(devices[i]->mesh_command_queue(), mesh_workload, false);
             } else {
                 if (!enqueue_only) {
-                    slow_dispatch::CompileProgram(*devices[i], programs[i]);
+                    programs[i].impl().compile(devices[i].get());
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -303,16 +303,16 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
         log_info(tt::LogTest, "Run receiver on: {}", dev->get_device_ids()[0]);
-        fixture->RunProgramNonblocking(dev, *recv_program);
+        fixture->RunProgramNonblocking(dev, std::move(*recv_program));
     }
     log_info(tt::LogTest, "Run Sender on: {}", sender_device->get_device_ids()[0]);
-    fixture->RunProgramNonblocking(sender_device, sender_program);
+    fixture->RunProgramNonblocking(sender_device, std::move(sender_program));
 
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
-        fixture->WaitForSingleProgramDone(dev, *recv_program);
+        fixture->WaitForSingleProgramDone(dev);
     }
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    fixture->WaitForSingleProgramDone(sender_device);
 
     std::vector<uint32_t> sender_status;
     tt_metal::slow_dispatch::ReadFromL1(
@@ -504,10 +504,9 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
     // Launch sender and receiver programs and wait for them to finish
-    fixture->RunProgramNonblocking(receiver_device, receiver_program);
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
+    fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate the status and packets processed by sender and receiver
     std::vector<uint32_t> sender_status;
@@ -667,10 +666,9 @@ void run_unicast_test_bw_chips(
     tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
     // Launch sender and receiver programs and wait for them to finish
-    fixture->RunProgramNonblocking(receiver_device, receiver_program);
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
+    fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate the status and packets processed by sender and receiver
     std::vector<uint32_t> sender_status;
@@ -866,7 +864,6 @@ void RunTestMCastConnAPI(
     uint32_t bwd_hops) {
     tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
     tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
-    std::vector<tt_metal::Program> receiver_programs;
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
@@ -1053,21 +1050,18 @@ void RunTestMCastConnAPI(
                     .compile_args = compile_time_args});
 
             tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-            fixture->RunProgramNonblocking(receiver_device, receiver_program);
-            receiver_programs.push_back(std::move(receiver_program));
+            fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
             log_debug(tt::LogTest, "{} Rx Launched on physical device {}", routing_direction, physical_end_device_id);
         }
     }
 
     // Launch sender program and wait for sender to finish
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
 
     // Wait for receivers to finish
     for (const auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
-        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
-            auto receiver_device = fixture->get_device(physical_end_device_ids[i]);
-            fixture->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
+        for (auto physical_end_device_id : physical_end_device_ids) {
+            fixture->WaitForSingleProgramDone(fixture->get_device(physical_end_device_id));
         }
     }
     log_info(tt::LogTest, "All Receivers Finished");
@@ -1122,7 +1116,6 @@ void RunTest2DMCastConnAPI(
 
     tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
     tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
-    std::vector<tt_metal::Program> receiver_programs;
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
@@ -1598,18 +1591,15 @@ void RunTest2DMCastConnAPI(
                 .compile_args = compile_time_args});
 
         tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-        fixture->RunProgramNonblocking(receiver_device, receiver_program);
-        receiver_programs.push_back(std::move(receiver_program));
+        fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
         log_debug(tt::LogTest, "Rx Launched on physical device {}", physical_end_device_id);
     }
     // Launch sender program and wait for sender to finish
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
 
     // Wait for receivers to finish
-    for (uint32_t i = 0; i < rx_physical_device_ids.size(); i++) {
-        auto receiver_device = fixture->get_device(rx_physical_device_ids[i]);
-        fixture->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
+    for (auto rx_physical_device_id : rx_physical_device_ids) {
+        fixture->WaitForSingleProgramDone(fixture->get_device(rx_physical_device_id));
     }
     log_info(tt::LogTest, "All Receivers Finished");
 
@@ -1655,7 +1645,6 @@ void RunTest2DMCastConnAPI(
 void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32_t start_distance, uint32_t range) {
     tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
     tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
-    std::vector<tt_metal::Program> receiver_programs;
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
@@ -1812,24 +1801,20 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
 
             tt_metal::SetRuntimeArgs(
                 receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-            fixture->RunProgramNonblocking(receiver_device, receiver_program);
-            receiver_programs.push_back(std::move(receiver_program));
+            fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
             log_debug(tt::LogTest, "{} Rx Launched on physical device {}", routing_direction, physical_end_device_id);
         }
     }
 
     // Launch sender program and wait for sender to finish
-    fixture->RunProgramNonblocking(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
     log_info(tt::LogTest, "Sender Launched on physical device {}", src_phys_chip_id);
-
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
     log_info(tt::LogTest, "Sender Finished");
 
     // Wait for receivers to finish
     for (const auto& [routing_direction, physical_end_device_ids] : physical_end_device_ids_by_dir) {
-        for (uint32_t i = 0; i < physical_end_device_ids.size(); i++) {
-            auto receiver_device = fixture->get_device(physical_end_device_ids[i]);
-            fixture->WaitForSingleProgramDone(receiver_device, receiver_programs[i]);
+        for (auto physical_end_device_id : physical_end_device_ids) {
+            fixture->WaitForSingleProgramDone(fixture->get_device(physical_end_device_id));
         }
     }
     log_info(tt::LogTest, "All Receivers Finished");
@@ -1947,8 +1932,8 @@ void RunEDMConnectionStressTest(
     auto dst_physical_device_id =
         control_plane.get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id.value(), 1));
 
-    auto sender_device = fixture->get_device(src_physical_device_id);
-    auto receiver_device = fixture->get_device(dst_physical_device_id);
+    const auto& sender_device = fixture->get_device(src_physical_device_id);
+    const auto& receiver_device = fixture->get_device(dst_physical_device_id);
 
     // Set the destination address for fabric writes (constant for all workers)
     uint32_t fabric_write_dest_bank_addr = 0x50000;
@@ -2081,8 +2066,7 @@ void RunEDMConnectionStressTest(
             // Launch program and wait for completion
             auto start_time = std::chrono::high_resolution_clock::now();
             log_debug(tt::LogTest, "Launching program");
-            fixture->RunProgramNonblocking(sender_device, program);
-            fixture->WaitForSingleProgramDone(sender_device, program);
+            tt_metal::LaunchProgram(*sender_device, std::move(program), /*wait_until_cores_done=*/true);
             auto end_time = std::chrono::high_resolution_clock::now();
             auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
 
@@ -2269,12 +2253,11 @@ void FabricUnicastCommon(
             receiver_programs[recv_dev], receiver_kernel, receiver_logical_core, receiver_runtime_args);
     }
     for (auto& [recv_dev, receiver_program] : receiver_programs) {
-        fixture->RunProgramNonblocking(recv_dev, receiver_program);
+        fixture->RunProgramNonblocking(recv_dev, std::move(receiver_program));
     }
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
     for (auto& [recv_dev, receiver_program] : receiver_programs) {
-        fixture->WaitForSingleProgramDone(recv_dev, receiver_program);
+        fixture->WaitForSingleProgramDone(recv_dev);
     }
 
     std::vector<uint32_t> sender_status;
@@ -2603,10 +2586,9 @@ void UDMFabricUnicastCommon(
     }
 
     // Run programs
-    fixture->RunProgramNonblocking(receiver_device, receiver_program);
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
+    fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    fixture->WaitForSingleProgramDone(receiver_device);
 
     // Helper lambda to check test results for a given RISC
     auto check_risc_results = [&](const tt::tt_metal::CoreCoord& sender_core,
@@ -3014,12 +2996,12 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
 
     log_info(tt::LogTest, "All-to-all test starting");
     for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
-        fixture->RunProgramNonblocking(device_ptrs[dev_idx], programs[dev_idx]);
+        fixture->RunProgramNonblocking(device_ptrs[dev_idx], std::move(programs[dev_idx]));
     }
     log_info(tt::LogTest, "All-to-all test waiting for finish");
     // Wait for all devices to complete
     for (size_t dev_idx = 0; dev_idx < num_active_devices; dev_idx++) {
-        fixture->WaitForSingleProgramDone(device_ptrs[dev_idx], programs[dev_idx]);
+        fixture->WaitForSingleProgramDone(device_ptrs[dev_idx]);
     }
     log_info(tt::LogTest, "All-to-all test done");
 
@@ -3340,7 +3322,7 @@ void Fabric2DMulticastCommon(
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Build and launch receiver programs for all destination devices in the rectangular multicast region
-    std::vector<std::pair<std::shared_ptr<tt_metal::distributed::MeshDevice>, tt_metal::Program>> receiver_programs;
+    std::vector<std::shared_ptr<tt_metal::distributed::MeshDevice>> receiver_devices;
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
     for (auto physical_end_device_id : receiver_device_ids) {
         // auto recv_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(physical_end_device_id);
@@ -3359,15 +3341,14 @@ void Fabric2DMulticastCommon(
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = compile_time_args});
         tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-        fixture->RunProgramNonblocking(receiver_device, receiver_program);
-        receiver_programs.emplace_back(receiver_device, std::move(receiver_program));
+        fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+        receiver_devices.emplace_back(receiver_device);
     }
 
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
 
-    for (auto& [dev, prog] : receiver_programs) {
-        fixture->WaitForSingleProgramDone(dev, prog);
+    for (auto& dev : receiver_devices) {
+        fixture->WaitForSingleProgramDone(dev);
     }
 
     std::vector<uint32_t> sender_status;
@@ -3382,7 +3363,7 @@ void Fabric2DMulticastCommon(
     uint64_t sender_words =
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
-    for (auto& [dev, _] : receiver_programs) {
+    for (auto& dev : receiver_devices) {
         std::vector<uint32_t> recv_status;
         tt_metal::slow_dispatch::ReadFromL1(
             *dev,
@@ -3521,7 +3502,7 @@ void FabricMulticastCommon(
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Build and launch receiver programs for all destination devices in all configured directions
-    std::vector<std::pair<std::shared_ptr<tt_metal::distributed::MeshDevice>, tt_metal::Program>> receiver_programs;
+    std::vector<std::shared_ptr<tt_metal::distributed::MeshDevice>> receiver_devices;
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
     for (auto& [dir, start_distance, range] : dir_configs) {
         for (auto physical_end_device_id : physical_end_device_ids_by_dir[dir]) {
@@ -3540,16 +3521,15 @@ void FabricMulticastCommon(
                     .noc = tt_metal::NOC::RISCV_0_default,
                     .compile_args = compile_time_args});
             tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-            fixture->RunProgramNonblocking(receiver_device, receiver_program);
-            receiver_programs.emplace_back(receiver_device, std::move(receiver_program));
+            fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+            receiver_devices.emplace_back(receiver_device);
         }
     }
 
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
 
-    for (auto& [dev, prog] : receiver_programs) {
-        fixture->WaitForSingleProgramDone(dev, prog);
+    for (auto& dev : receiver_devices) {
+        fixture->WaitForSingleProgramDone(dev);
     }
 
     std::vector<uint32_t> sender_status;
@@ -3564,7 +3544,7 @@ void FabricMulticastCommon(
     uint64_t sender_words =
         ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
 
-    for (auto& [dev, _] : receiver_programs) {
+    for (auto& dev : receiver_devices) {
         std::vector<uint32_t> recv_status;
         tt_metal::slow_dispatch::ReadFromL1(
             *dev,
@@ -3811,7 +3791,7 @@ void FabricSparseMulticastCommon(
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
     // Build and launch receiver programs for all destination devices in all configured directions
-    std::vector<std::pair<std::shared_ptr<tt_metal::distributed::MeshDevice>, tt_metal::Program>> receiver_programs;
+    std::vector<std::shared_ptr<tt_metal::distributed::MeshDevice>> receiver_devices;
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
     for (auto& [dir, hops] : dir_configs) {
         for (auto physical_end_device_id : physical_end_device_ids_by_dir[dir]) {
@@ -3827,16 +3807,15 @@ void FabricSparseMulticastCommon(
                     .compile_args = compile_time_args});
 
             tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-            fixture->RunProgramNonblocking(receiver_device, receiver_program);
-            receiver_programs.emplace_back(receiver_device, std::move(receiver_program));
+            fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+            receiver_devices.emplace_back(receiver_device);
         }
     }
 
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
 
-    for (auto& [dev, prog] : receiver_programs) {
-        fixture->WaitForSingleProgramDone(dev, prog);
+    for (auto& dev : receiver_devices) {
+        fixture->WaitForSingleProgramDone(dev);
     }
 
     std::vector<uint32_t> sender_status;
@@ -3849,7 +3828,7 @@ void FabricSparseMulticastCommon(
         CoreType::WORKER);
     EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
 
-    for (auto& [dev, _] : receiver_programs) {
+    for (auto& dev : receiver_devices) {
         std::vector<uint32_t> recv_status;
         tt_metal::slow_dispatch::ReadFromL1(
             *dev,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -129,10 +129,10 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
     }
 
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
-        fixture->RunProgramNonblocking(devices[src_idx], programs[src_idx]);
+        fixture->RunProgramNonblocking(devices[src_idx], std::move(programs[src_idx]));
     }
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
-        fixture->WaitForSingleProgramDone(devices[src_idx], programs[src_idx]);
+        fixture->WaitForSingleProgramDone(devices[src_idx]);
     }
 
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
@@ -279,10 +279,10 @@ void RunSetUnicastRouteTest(
     }
 
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
-        fixture->RunProgramNonblocking(devices[src_idx], programs[src_idx]);
+        fixture->RunProgramNonblocking(devices[src_idx], std::move(programs[src_idx]));
     }
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
-        fixture->WaitForSingleProgramDone(devices[src_idx], programs[src_idx]);
+        fixture->WaitForSingleProgramDone(devices[src_idx]);
     }
 
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -593,7 +593,7 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
 
     log_info(LogTest, "Running programs");
     for (auto i = 0; i < devices.size(); i++) {
-        fixture->RunProgramNonblocking(devices[i], program_handles[i]);
+        fixture->RunProgramNonblocking(devices[i], std::move(program_handles[i]));
     }
 
     if (!test_config.terminate_from_kernel) {
@@ -629,8 +629,8 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     }
 
     log_info(LogTest, "Waiting for programs");
-    for (auto i = 0; i < devices.size(); i++) {
-        fixture->WaitForSingleProgramDone(devices[i], program_handles[i]);
+    for (const auto& device : devices) {
+        fixture->WaitForSingleProgramDone(device);
     }
 
     auto validate_worker_results = [&](tt::tt_metal::distributed::MeshDevice& device,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
@@ -786,16 +786,15 @@ void run_test_case(BaseFabricFixture& fixture, const TestCaseConfig& test_case) 
         const auto& receiver_device_context = receiver_device_context_entry.second;
         fixture.RunProgramNonblocking(
             receiver_device_context.receiver_mux_deployment.device,
-            *receiver_device_context.receiver_mux_deployment.program);
+            std::move(*receiver_device_context.receiver_mux_deployment.program));
     }
-    fixture.RunProgramNonblocking(sender_mux_deployment->device, *sender_mux_deployment->program);
-
-    fixture.WaitForSingleProgramDone(sender_mux_deployment->device, *sender_mux_deployment->program);
+    tt_metal::LaunchProgram(
+        *sender_mux_deployment->device,
+        std::move(*sender_mux_deployment->program),
+        /*wait_until_cores_done=*/true);
     for (const auto& receiver_device_context_entry : receiver_device_contexts.value()) {
         const auto& receiver_device_context = receiver_device_context_entry.second;
-        fixture.WaitForSingleProgramDone(
-            receiver_device_context.receiver_mux_deployment.device,
-            *receiver_device_context.receiver_mux_deployment.program);
+        fixture.WaitForSingleProgramDone(receiver_device_context.receiver_mux_deployment.device);
     }
 
     const uint64_t expected_bytes =

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -136,10 +136,9 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
     // Run programs
-    fixture->RunProgramNonblocking(receiver_device, receiver_program);
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
+    fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate results
     std::vector<uint32_t> sender_status;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
@@ -132,7 +132,7 @@ protected:
 
         // Create and launch program (note: correct argument order)
         program_ = create_traffic_generator_program(mesh_device_, worker_core, dest_node, memory_layout_);
-        this->RunProgramNonblocking(mesh_device_, *program_);
+        this->RunProgramNonblocking(mesh_device_, std::move(*program_));
 
         log_info(
             LogTest,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
@@ -115,7 +115,7 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_rt_args);
 
     // One receiver per writing chip; each polls its own offset (base + slot*payload).
-    std::vector<std::pair<std::shared_ptr<tt_metal::distributed::MeshDevice>, tt_metal::Program>> receiver_programs;
+    std::vector<std::shared_ptr<tt_metal::distributed::MeshDevice>> receiver_devices;
     std::vector<uint32_t> receiver_rt_args = {payload, num_packets, time_seed};
     for (uint32_t slot = 0; slot < num_dests; slot++) {
         auto receiver_device = fixture->get_device(writing_physical_devices[slot]);
@@ -138,14 +138,13 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
                 .noc = tt_metal::NOC::RISCV_0_default,
                 .compile_args = receiver_ct_args});
         tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_rt_args);
-        fixture->RunProgramNonblocking(receiver_device, receiver_program);
-        receiver_programs.emplace_back(receiver_device, std::move(receiver_program));
+        fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+        receiver_devices.push_back(receiver_device);
     }
 
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
-    for (auto& [dev, prog] : receiver_programs) {
-        fixture->WaitForSingleProgramDone(dev, prog);
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    for (const auto& dev : receiver_devices) {
+        fixture->WaitForSingleProgramDone(dev);
     }
 
     std::vector<uint32_t> sender_status;
@@ -158,7 +157,7 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
         CoreType::WORKER);
     EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
 
-    for (auto& [dev, _] : receiver_programs) {
+    for (const auto& dev : receiver_devices) {
         std::vector<uint32_t> recv_status;
         tt_metal::slow_dispatch::ReadFromL1(
             *dev,

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -344,10 +344,9 @@ UnicastTrafficResult run_unicast_traffic_bw_nodes(
     tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
 
     // Launch and wait
-    fixture->RunProgramNonblocking(receiver_device, receiver_program);
-    fixture->RunProgramNonblocking(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(sender_device, sender_program);
-    fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
+    fixture->RunProgramNonblocking(receiver_device, std::move(receiver_program));
+    tt_metal::LaunchProgram(*sender_device, std::move(sender_program), /*wait_until_cores_done=*/true);
+    fixture->WaitForSingleProgramDone(receiver_device);
 
     // Validate sender/receiver status
     std::vector<uint32_t> sender_status;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -267,10 +267,11 @@ void LogDfbInitTimingFromL1(
 }
 
 void LaunchAndLogDfbInitTiming(
-    IDevice* device, Program& program, const CoreCoord& core, const char* benchmark_name) {
-    ClearDfbInitTimingL1(device, core);
-    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
-    LogDfbInitTimingFromL1(device, core, benchmark_name, DfbInitTimingUsedSlotsMask(program, core));
+    DfbInitTimingBenchContext& ctx, Program&& program, const CoreCoord& core, const char* benchmark_name) {
+    ClearDfbInitTimingL1(ctx.device, core);
+    const uint16_t used_slots_mask = DfbInitTimingUsedSlotsMask(program, core);
+    LaunchProgram(*ctx.mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LogDfbInitTimingFromL1(ctx.device, core, benchmark_name, used_slots_mask);
 }
 }  // namespace
 
@@ -285,7 +286,6 @@ void LaunchAndLogDfbInitTiming(
 // Data movement is commented out in those kernels so measured time reflects DFB init overhead.
 void run_benchmark_case_base(DfbInitTimingBenchContext& ctx) {
     auto mesh_device = ctx.mesh_device;
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE = 1024;
@@ -362,11 +362,10 @@ void run_benchmark_case_base(DfbInitTimingBenchContext& ctx) {
     run_args.tensor_args.emplace(IN_TENSOR, experimental::TensorArgument{in_tensor});
     experimental::SetProgramRunArgs(program, run_args);
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseBase");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseBase");
 }
 
 void run_benchmark_case_two(DfbInitTimingBenchContext& ctx) {
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE  = 1024;
@@ -445,7 +444,7 @@ void run_benchmark_case_two(DfbInitTimingBenchContext& ctx) {
     };
     experimental::SetProgramRunArgs(program, run_args);
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseTwo");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseTwo");
 }
 
 // Worst-case DFB init benchmark.
@@ -468,7 +467,6 @@ void run_benchmark_case_two(DfbInitTimingBenchContext& ctx) {
 //   reader: 4 implicit reads per DFB per DM
 //   compute: 16 copy_tile+pop_front per Neo per DFB (4 ALL TCs × 4 entries)
 void run_benchmark_case_four(DfbInitTimingBenchContext& ctx) {
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE    = 1024;
@@ -536,7 +534,7 @@ void run_benchmark_case_four(DfbInitTimingBenchContext& ctx) {
     };
     experimental::SetProgramRunArgs(program, run_args);
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseFour");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseFour");
 }
 
 // Average-case-two DFB init benchmark.
@@ -555,7 +553,6 @@ void run_benchmark_case_four(DfbInitTimingBenchContext& ctx) {
 //   reader: 4 implicit reads per DFB per DM
 //   compute: 4 copy_tile+pop_front per Neo per DFB (eltwise_copy tile_regs pattern)
 void run_benchmark_case_three(DfbInitTimingBenchContext& ctx) {
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE    = 1024;
@@ -623,7 +620,7 @@ void run_benchmark_case_three(DfbInitTimingBenchContext& ctx) {
     };
     experimental::SetProgramRunArgs(program, run_args);
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseThree");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseThree");
 }
 
 // Worst-case-two DFB init benchmark.
@@ -654,7 +651,6 @@ void run_benchmark_case_three(DfbInitTimingBenchContext& ctx) {
 //   reader: 16 implicit reads per DFB per DM (single producer)
 //   compute: 16 copy_tile+pop_front per Neo per DFB across all 12 DFBs
 void run_benchmark_case_five(DfbInitTimingBenchContext& ctx) {
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE  = 1024;
@@ -749,7 +745,7 @@ void run_benchmark_case_five(DfbInitTimingBenchContext& ctx) {
     }
     experimental::SetProgramRunArgs(program, run_args);
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseFive");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseFive");
 }
 
 // Worst-case-three DFB init benchmark.
@@ -786,7 +782,6 @@ void run_benchmark_case_five(DfbInitTimingBenchContext& ctx) {
 // workaround where a default 2048 B unpack over-reads into the next ring slot.
 // Quasar copy_tile requires standard 32×32 tile geometry (narrow/partial tiles fault).
 void run_benchmark_case_seven(DfbInitTimingBenchContext& ctx) {
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE  = 2048;
@@ -915,7 +910,7 @@ void run_benchmark_case_seven(DfbInitTimingBenchContext& ctx) {
             .num_threads_per_cluster = 4,
         });
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSeven");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseSeven");
 }
 
 // BenchmarkWorstCaseFour — exhausts all 16 one-to-many remapper slots AND exercises
@@ -1103,7 +1098,7 @@ void run_benchmark_case_six(DfbInitTimingBenchContext& ctx) {
     TT_FATAL(neo0_e0->entry_size == ENTRY_SIZE, "Neo0 entry_size preflight mismatch");
     TT_FATAL(neo0_tc0->limit - neo0_tc0->base_addr == ENTRY_SIZE / 16u, "Neo0 ring_tiles preflight mismatch");
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSix");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseSix");
 }
 
 // Minimal 1Sx1A isolation variant of BenchmarkCaseSix for remapper debugging.
@@ -1198,7 +1193,7 @@ void run_benchmark_case_six_debug(DfbInitTimingBenchContext& ctx) {
     TT_FATAL(neo0_e0->entry_size == ENTRY_SIZE, "Neo0 entry_size preflight mismatch");
     TT_FATAL(neo0_tc0->limit - neo0_tc0->base_addr == ENTRY_SIZE / 16u, "Neo0 ring_tiles preflight mismatch");
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSixDebug");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseSixDebug");
 }
 
 // Same 1Sx1A topology as BenchmarkCaseSixDebug but with implicit_sync enabled.
@@ -1207,7 +1202,6 @@ void run_benchmark_case_six_debug(DfbInitTimingBenchContext& ctx) {
 // sync_threads(get_num_threads()) waits for all 6 launched DM harts even though
 // only DM4 issues the implicit read.
 void run_benchmark_case_six_debug_implicit_sync(DfbInitTimingBenchContext& ctx) {
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE  = 2048;
@@ -1262,12 +1256,11 @@ void run_benchmark_case_six_debug_implicit_sync(DfbInitTimingBenchContext& ctx) 
         ENTRY_SIZE,
         NUM_ENTRIES);
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSixDebugImplicitSync");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseSixDebugImplicitSync");
 }
 
 void run_benchmark_case_six_debug_implicit_sync_program_spec(DfbInitTimingBenchContext& ctx) {
     auto mesh_device = ctx.mesh_device;
-    IDevice* device = ctx.device;
     CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
 
     constexpr uint32_t ENTRY_SIZE = 2048;
@@ -1342,7 +1335,7 @@ void run_benchmark_case_six_debug_implicit_sync_program_spec(DfbInitTimingBenchC
     run_args.tensor_args.emplace(IN_TENSOR, experimental::TensorArgument{in_tensor});
     experimental::SetProgramRunArgs(program, run_args);
 
-    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSixDebugImplicitSyncProgramSpec");
+    LaunchAndLogDfbInitTiming(ctx, std::move(program), CoreCoord(0, 0), "BenchmarkCaseSixDebugImplicitSyncProgramSpec");
 }
 
 struct DfbInitTimingBenchCase {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -468,7 +468,7 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
         slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, slice);
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     // Verify (DM consumer only — Tensix consumer doesn't write DRAM).
     if (p.consumer_type == M2PorCType::DM) {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -437,7 +437,7 @@ TEST_F(UnitMeshFixture, AliasDFBAddressEquality1Sx1S) {
 
     Program program = MakeProgramFromSpec(this->device(), spec);
 
-    slow_dispatch::CompileProgram(this->device(), program);
+    program.impl().compile(&this->device());
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
@@ -771,7 +771,7 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryAddressEquality) {
 
     Program program = MakeProgramFromSpec(this->device(), spec);
 
-    slow_dispatch::CompileProgram(this->device(), program);
+    program.impl().compile(&this->device());
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -280,7 +280,7 @@ void run_alias_dfb_program(
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
@@ -614,7 +614,7 @@ TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> out_la, out_lb, out_ra, out_rb;
     slow_dispatch::ReadFromBuffer(left.out_a.mesh_buffer(), out_la);
@@ -874,7 +874,7 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -201,7 +201,10 @@ void run_borrowed_memory_dfb_program(
     // -----------------------------------------------------------------------
     // Create program and allocate tensors
     // -----------------------------------------------------------------------
-    Program program = MakeProgramFromSpec(mesh_device, spec);
+    auto device_range = distributed::MeshCoordinateRange(mesh_device.shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, MakeProgramFromSpec(mesh_device, spec));
+    Program& program = workload.get_programs().at(device_range);
 
     MeshTensor src_tensor = MeshTensor::allocate_on_device(mesh_device, src_spec);
     std::optional<MeshTensor> dst_tensor;
@@ -260,13 +263,11 @@ void run_borrowed_memory_dfb_program(
     std::iota(input.begin(), input.end(), 0u);
     slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, /*blocking=*/true);
 
     // Assert the borrowed tensor's L1 address was used for the DFB ring. For a borrowed DFB this
     // stays PINNED across a size override (no reallocation).
-    EXPECT_EQ(
-        program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
-        static_cast<uint32_t>(ring_tensor.address()));
+    EXPECT_EQ(program.impl().dataflow_buffers()[0]->uniform_alloc_addr(), static_cast<uint32_t>(ring_tensor.address()));
 
     if (cfg.num_entries_override.has_value()) {
         EXPECT_EQ(program.impl().dataflow_buffers()[0]->config.num_entries, *cfg.num_entries_override)
@@ -365,7 +366,10 @@ void run_update_address_test(
     spec.dataflow_buffers = {dfb_spec};
     spec.work_units       = {MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(mesh_device, spec);
+    auto device_range = distributed::MeshCoordinateRange(mesh_device.shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, MakeProgramFromSpec(mesh_device, spec));
+    Program& program = workload.get_programs().at(device_range);
 
     MeshTensor src_tensor = MeshTensor::allocate_on_device(mesh_device, src_spec);
     MeshTensor dst_tensor = MeshTensor::allocate_on_device(mesh_device, dst_spec);
@@ -401,11 +405,10 @@ void run_update_address_test(
         {experimental::TensorParamName{"dfb_ring_tensor"}, TensorArgument{ring_tensor_a}},
     };
     SetProgramRunArgs(program, params1);
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, /*blocking=*/true);
 
     EXPECT_EQ(
-        program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
-        static_cast<uint32_t>(ring_tensor_a.address()));
+        program.impl().dataflow_buffers()[0]->uniform_alloc_addr(), static_cast<uint32_t>(ring_tensor_a.address()));
     {
         std::vector<uint32_t> output;
         slow_dispatch::ReadFromBuffer(dst_tensor.mesh_buffer(), output);
@@ -448,11 +451,10 @@ void run_update_address_test(
                 {experimental::TensorParamName{"dfb_ring_tensor"}, TensorArgument{ring_tensor_b}},
             });
     }
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, /*blocking=*/true);
 
     EXPECT_EQ(
-        program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
-        static_cast<uint32_t>(ring_tensor_b.address()));
+        program.impl().dataflow_buffers()[0]->uniform_alloc_addr(), static_cast<uint32_t>(ring_tensor_b.address()));
     if (reentry_num_entries_override.has_value()) {
         EXPECT_EQ(program.impl().dataflow_buffers()[0]->config.num_entries, *reentry_num_entries_override)
             << "combined re-bind + resize: num_entries override was not applied";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -32,6 +32,7 @@
 
 #include "dfb_test_common.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "device_fixture.hpp"
 #include "llrt/rtoptions.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -181,7 +182,7 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     std::vector<DataT> result_init(expected_scalar_reads.size(), 0u);
     slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), result_l1_addr, result_init);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     tt_driver_atomics::mfence();
     std::vector<DataT> scalar_results;
@@ -471,7 +472,7 @@ void run_extent_probe(distributed::MeshDevice& mesh_device, const ExtentProbePar
     };
     m2::SetProgramRunArgs(program, run_args);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
     tt_driver_atomics::mfence();
 
     const CoreCoord core{0, 0};

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -303,7 +303,7 @@ TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
     }
     m2::SetProgramRunArgs(program, params);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         std::vector<uint32_t> got;
@@ -321,7 +321,10 @@ TEST_F(UnitMeshFixture, HalfGrid16Plus16DFBsOnDevice) {
     constexpr uint32_t per_half = 16;
     constexpr uint32_t touched_magic = 0xA11CED00u;
     m2::ProgramSpec spec = make_split_touch_spec(this->device(), per_half);
-    Program program = m2::MakeProgramFromSpec(this->device(), spec);
+    auto device_range = distributed::MeshCoordinateRange(this->device().shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, m2::MakeProgramFromSpec(this->device(), spec));
+    Program& program = workload.get_programs().at(device_range);
 
     expect_half_grid_slots_packed(program, per_half, is_quasar);
     expect_no_slot_collision_on_core(program, CoreCoord{0, 0});
@@ -339,7 +342,7 @@ TEST_F(UnitMeshFixture, HalfGrid16Plus16DFBsOnDevice) {
         {.kernel = m2::KernelSpecName{"cons_b"}, .runtime_arg_values = cons_rtas(m2::NodeCoord{1, 0})},
     };
     m2::SetProgramRunArgs(program, params);
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), workload, /*blocking=*/true);
 
     std::vector<uint32_t> left_slots(per_half), right_slots(per_half);
     for (uint32_t i = 0; i < per_half; ++i) {
@@ -449,7 +452,7 @@ TEST_F(UnitMeshFixture, HalfGridOnDeviceDataflow1DFBEach) {
     m2_writeshard_barrier_uint32(this->device(), in_a, input_a);
     m2_writeshard_barrier_uint32(this->device(), in_b, input_b);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
@@ -528,7 +531,9 @@ TEST_F(UnitMeshFixture, CoordinatorWorkerSlotReuseOnDevice) {
         {.kernel = m2::KernelSpecName{"worker_cons"}, .runtime_arg_values = std::move(worker_cons_rtas)},
     };
     m2::SetProgramRunArgs(program, params);
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    distributed::MeshWorkload coord_worker_workload;
+    coord_worker_workload.add_program(distributed::MeshCoordinateRange(this->device().shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), coord_worker_workload, /*blocking=*/true);
 
     expect_touch_results(
         this->device(),

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -6,6 +6,7 @@
 
 #include "dfb_test_common.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -126,7 +127,7 @@ static void run_a1_pipeline(distributed::MeshDevice& mesh_device, A1Transform tr
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -225,8 +226,10 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
+    distributed::MeshWorkload workload;
+    workload.add_program(distributed::MeshCoordinateRange(mesh_device.shape()), std::move(program));
     for (uint32_t iter = 0; iter < num_iterations; ++iter) {
-        slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+        distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, /*blocking=*/true);
     }
 
     std::vector<uint32_t> output;
@@ -362,7 +365,7 @@ TEST_F(UnitMeshFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -593,7 +596,7 @@ TEST_F(UnitMeshFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -6,6 +6,7 @@
 
 #include "dfb_test_common.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 #include <array>
 #include <map>
@@ -107,7 +108,7 @@ static void run_intra_tensix_dfb_program(
 
     slow_dispatch::WriteToL1(mesh_device, logical_core, dfb_l1_addr, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     // Packer increments each word by 1, then unpacker increments it by 1 → +2 per word.
     // This holds for every Neo's ring independently, so the entire L1 region is input + 2.
@@ -257,7 +258,7 @@ TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     EXPECT_NE(self_rc.config.intra_shadow_tc_id, self_tc);
     EXPECT_GE(self_rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -345,7 +346,7 @@ static void run_intra_tensix_dfb_program_2_0(
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_bytes / sizeof(uint32_t));
     slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> expected(input.size());
     std::transform(input.begin(), input.end(), expected.begin(), [](uint32_t v) { return v + 2; });
@@ -530,12 +531,14 @@ TEST_F(UnitMeshFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input_remapper);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input_remapper);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    // Ring L1 address is fixed by finalize, so read it while the program is still owned here: the launch moves
+    // the program into the workload, which invalidates program (and remapper_dfb) once the launch returns.
+    const uint32_t remapper_l1_addr = remapper_dfb->uniform_alloc_addr();
+
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     // Verify remapper ring L1: DM wrote input_remapper; Tensix consumed credits
     // (ALL pattern) but did not overwrite the ring's data.
-    const uint32_t remapper_l1_addr =
-        program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(*DFB_REMAPPER))->uniform_alloc_addr();
     std::vector<uint32_t> l1_remapper;
     slow_dispatch::ReadFromL1(this->device(), CoreCoord(0, 0), remapper_l1_addr, num_entries * entry_size, l1_remapper);
     EXPECT_EQ(input_remapper, l1_remapper) << "M2 DM->Tensix strided x ALL remapper ring L1 mismatch";
@@ -690,7 +693,7 @@ TEST_F(UnitMeshFixture, TensixIntraIsolatesOverlayTCs) {
     const auto before = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GE(before.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> scratch;
     slow_dispatch::ReadFromL1(

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -6,6 +6,7 @@
 
 #include "dfb_test_common.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -111,7 +112,7 @@ static void run_single_dfb_multicore_2_0(
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -217,7 +218,7 @@ static void run_concurrent_dfbs_program_2_0(
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -361,7 +362,7 @@ static void run_sequential_4_dfbs_2_0(
         m2_writeshard_barrier_uint32(mesh_device, in_tensors[i], inputs[i]);
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     for (uint32_t i = 0; i < 4; ++i) {
         std::vector<uint32_t> output;
@@ -554,7 +555,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
         slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), dfb_l1_addr, inputs[i]);
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         std::vector<uint32_t> output;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -542,7 +542,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
     // Pre-fill each DFB's L1 ring directly via uniform_alloc_addr after manual
     // finalize+allocate. No borrowed_from / ring tensor needed; the compute
     // kernel is TRISC-only and can't carry tensor bindings.
-    slow_dispatch::CompileProgram(this->device(), program);
+    program.impl().compile(&this->device());
     program.impl().finalize_dataflow_buffer_configs();
     program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -6,6 +6,7 @@
 
 #include "dfb_test_common.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -116,7 +117,10 @@ static void run_dfb_size_override_test(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
+    auto device_range = distributed::MeshCoordinateRange(mesh_device.shape());
+    distributed::MeshWorkload mesh_workload;
+    mesh_workload.add_program(device_range, experimental::MakeProgramFromSpec(mesh_device, spec));
+    Program& program = mesh_workload.get_programs().at(device_range);
 
     const auto input =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, workload * data_entry_size / sizeof(uint32_t));
@@ -168,7 +172,7 @@ static void run_dfb_size_override_test(
             tt_driver_atomics::mfence();
             ASSERT_EQ(rdback, input);
         }
-        slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+        distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), mesh_workload, /*blocking=*/true);
 
         std::vector<uint32_t> output;
         slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
@@ -11,6 +11,7 @@
 
 #include "dfb_test_common.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/tt_metal/test_kernels/dataflow/dfb_scoped_lock_cache_common.h"
 
 namespace tt::tt_metal {
@@ -186,7 +187,7 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(distributed::MeshDevice& me
         slow_dispatch::WriteToL1(mesh_device, core, ring_base, prefill);
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     // Kernels write their in-kernel verification read-back (via the non-cacheable alias so the result lands
     // in TL1) to the scratch region; the host reads it directly. Layout: handshake -> num_rounds words (one

--- a/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
@@ -22,12 +22,12 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -60,7 +60,7 @@ TEST_F(UnitMeshFixture, NocRead_L1_Misaligned_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -93,7 +93,7 @@ TEST_F(UnitMeshFixture, NocWrite_L1_Misaligned_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -128,7 +128,7 @@ TEST_F(UnitMeshFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -163,7 +163,7 @@ TEST_F(UnitMeshFixture, NocWrite_L1_Misaligned_Dest_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -219,7 +219,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_dst});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*DRAM source.*must be 32-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -276,7 +276,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_dst});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*DRAM source.*must be 64-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -320,7 +320,7 @@ TEST_F(UnitMeshFixture, NocWrite_DRAM_Misaligned_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_src});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*DRAM destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -395,7 +395,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
 
     // Must NOT abort. If the alignment mask regresses to something stricter than
     // 0x1F, this LaunchProgram SIGABRTs and the harness marks the test failed.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -467,7 +467,7 @@ TEST_F(UnitMeshFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
 
     // Must NOT abort. If the alignment mask regresses to something stricter than
     // 0x3F, this LaunchProgram SIGABRTs and the harness marks the test failed.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -517,7 +517,7 @@ TEST_F(UnitMeshFixture, NocRead_L1_Aligned_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {base});
 
     // Must NOT abort on the alignment check.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
@@ -11,9 +11,9 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -62,7 +62,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_ReserveWithoutPush) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
 }
 
@@ -103,7 +103,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_WaitWithoutPop) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
 }
 
@@ -150,7 +150,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_LookaheadReserve_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — lookahead over-reservation is correct on silicon.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -193,7 +193,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_Balanced_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -233,7 +233,7 @@ TEST_F(UnitMeshFixture, Dirty_CB_SkipEnv_Suppresses) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — the Dirty CB check is suppressed by the opt-out env var.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
@@ -11,9 +11,9 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -46,7 +46,7 @@ TEST_F(UnitMeshFixture, CB_Reservation_Overflow_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
 }
 
@@ -81,7 +81,7 @@ TEST_F(UnitMeshFixture, CB_Reservation_Overflow_AlwaysOn) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
 }
 
@@ -127,7 +127,7 @@ TEST_F(UnitMeshFixture, CB_Reservation_ExactCapacity_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
@@ -12,6 +12,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
@@ -20,7 +21,6 @@
 #include <tt-metalium/allocator.hpp>
 #include "impl/context/metal_context.hpp"
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -68,7 +68,7 @@ TEST_F(UnitMeshFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*\\[ASAN ERROR\\] Metadata Overflow.*");
 }
 
@@ -154,7 +154,7 @@ TEST_F(UnitMeshFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, args);
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*\\[ASAN ERROR\\] Metadata Overflow.*");
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -193,7 +193,7 @@ TEST_F(UnitMeshFixture, Metadata_CB_Tensor_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
@@ -9,12 +9,12 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -63,7 +63,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_Missing_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Race Condition: cb_pop_front.*called while a NoC read is still pending.*");
 }
 
@@ -121,7 +121,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {src_buf->address(), dst_buf->address()});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Race Condition: cb_pop_front.*called while a NoC read is still pending.*");
 }
 
@@ -171,7 +171,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_Present_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     // Must NOT abort.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -224,7 +224,7 @@ TEST_F(UnitMeshFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     // Must NOT abort — the single barrier cleared both in-flight reads.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
@@ -12,10 +12,10 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
 #include "impl/emulation/host_sanitizers.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -74,7 +74,7 @@ TEST_F(UnitMeshFixture, Tensor_Padding_Violation_SanityCheck) {
 
     // 3. The emulator should intercept the illegal write inside l1_ptr
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Tensor Padding Violation: Attempted to write to a padded memory region at address 0x.*");
 }
 

--- a/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
@@ -11,9 +11,9 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -44,7 +44,7 @@ TEST_F(UnitMeshFixture, Local_L1_Alignment_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Local L1 Alignment: Offset 0x5 must be 4-byte aligned.*");
 }
 

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -10,9 +10,9 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -45,7 +45,7 @@ TEST_F(UnitMeshFixture, Semaphore_Direct_Write_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Illegal Semaphore Access: Offset 0x.*is inside the reserved Semaphore region.*");
 }
 
@@ -83,7 +83,7 @@ TEST_F(UnitMeshFixture, Semaphore_OutsideRegion_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr});
 
     // Must NOT abort.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -100,7 +100,6 @@ TEST_F(UnitMeshFixture, Semaphore_OutsideRegion_NoViolation) {
 TEST_F(MeshDeviceFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
     uint32_t sem_id = CreateSemaphore(program, logical_core, /*initial_value=*/3);
@@ -128,7 +127,7 @@ TEST_F(MeshDeviceFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
 
     // Must NOT abort.
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*this->devices_.at(0), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -189,7 +188,7 @@ TEST_F(MeshDeviceFixture, Semaphore_RelayUnicast_NoViolation) {
     SetRuntimeArgs(program, sender_kernel, sender_core, {rx_virtual.x, rx_virtual.y});
 
     // Must NOT abort (and must not hang: the relay's value wakes the waiter).
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*this->devices_.at(0), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -226,7 +225,9 @@ TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
 
-    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*Out-of-Bounds Write.*");
+    EXPECT_DEATH(
+        LaunchProgram(*this->devices_.at(0), std::move(program), /*wait_until_cores_done=*/true),
+        ".*Out-of-Bounds Write.*");
     ::unsetenv("TT_METAL_EMULE_ASAN");
 }
 

--- a/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
@@ -12,9 +12,9 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -95,7 +95,7 @@ TEST_F(UnitMeshFixture, Object_Intent_Provenance_Violation_SanityCheck) {
 
     // 3. The sanitizer should catch that the execution sequence breached pointer provenance bounds
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Object Intent Violation: Attempted to modify memory belonging to an adjacent object context.*");
 }
 
@@ -162,7 +162,7 @@ TEST_F(UnitMeshFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr_a, addr_c - addr_a});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Object Intent Violation: Attempted to modify memory belonging to an adjacent object context.*");
 }
 
@@ -209,7 +209,7 @@ TEST_F(UnitMeshFixture, Object_Intent_Provenance_NoViolation_Control) {
 
     // Must NOT abort. If the sanitizer is over-eager, LaunchProgram will SIGABRT
     // and the test harness will mark this as failed.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 }
 
@@ -259,7 +259,7 @@ TEST_F(UnitMeshFixture, Object_Intent_IOArg_Exempt_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr_a, addr_b});
 
     // Must NOT abort — B was handed to the kernel as a runtime arg.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -324,7 +324,7 @@ TEST_F(UnitMeshFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — writing a globally-allocated CB the kernel owns is legitimate.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -384,7 +384,7 @@ TEST_F(UnitMeshFixture, Object_Intent_MultiKernel_Core_NoViolation) {
     SetRuntimeArgs(program, kernel_1, logical_core, {buffer_2->address()});
 
     // Must NOT abort — Object Intent no-ops on multi-kernel cores.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
@@ -13,9 +13,9 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -64,7 +64,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Violation_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*CB Boundary Violation: Attempted to access CB 0.*reserved.*");
 }
 
@@ -110,7 +110,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Violation_Read_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*CB Boundary Violation: Attempted to access CB 0.*Read window.*");
 }
 
@@ -166,7 +166,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*CB Boundary Violation: Attempted to access CB 0.*");
 }
 
@@ -225,7 +225,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_Wraparound_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Wrapped access is legal and the kernel exits flushed → no sanitizer fires.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -270,7 +270,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_NoActiveWindow_NoViolation) {
 
     // Must NOT abort. If the window check regresses to firing without an active
     // reservation/wait, LaunchProgram SIGABRTs and this test fails.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -318,7 +318,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Reuse of produced data is legal and the kernel exits flushed → no abort.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -375,7 +375,7 @@ TEST_F(UnitMeshFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — globally-allocated CBs are exempt from the boundary window check.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
@@ -63,7 +64,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_Gap_L1_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {oob_addr});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Out-of-Bounds Write: Attempted to access address.*not part of any allocated tensor.*");
 }
 
@@ -111,7 +112,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {oob_addr});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Out-of-Bounds Write: Attempted to access DRAM address.*not part of any allocated tensor.*");
 }
 
@@ -156,7 +157,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {past_addr});
 
     EXPECT_DEATH(
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true),
         ".*Out-of-Bounds Write: Attempted to access address.*not part of any allocated tensor.*");
 }
 
@@ -194,7 +195,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_L1_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the address is inside an allocated tensor.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -232,7 +233,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the offset is inside an allocated DRAM tensor.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -281,7 +282,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {poke_addr});
 
     // Must NOT abort — the address is inside a host-designated raw-L1 region.
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -45,7 +45,7 @@
 #include "impl/host_api/temp_quasar_api.hpp"  // for QuasarComputeConfig
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/tt_metal.hpp>  // for CompileProgram (JIT trigger)
+#include <tt-metalium/tt_metal.hpp>
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgsConfig / ArgConfig::RuntimePageSize
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
@@ -3940,7 +3940,7 @@ TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecWithTensorParameterSucceeds) 
 // TensorParameter JIT Smoke Tests (Gen1 / WH)
 // ============================================================================
 // Codegen-path smoke test for the Metal 2.0 TensorAccessor binding feature. Ends in
-// CompileProgram, so the auto-generated kernel_bindings_generated.h (with its `tensor::` namespace)
+// program.impl().compile, so the auto-generated kernel_bindings_generated.h (with its `tensor::` namespace)
 // must be syntactically valid and compose correctly with the rest of the kernel build. Doesn't
 // validate runtime behavior — catches regressions in codegen string-formatting, token type alias
 // generation, and include-path resolution.
@@ -3975,8 +3975,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // ----------------------------------------------------------------------------
@@ -4012,8 +4011,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // Compute-kernel counterpart. A scratchpad binding works on a compute kernel: scratchpad.h only
@@ -4040,8 +4038,7 @@ void kernel_main() {
         .scratchpad_spec_name = ScratchpadSpecName{"scratch"}, .accessor_name = "scratch"});
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // Compile-only: a range-based for loop over a Scratchpad must compile. Exercises begin()/end() and the
@@ -4074,8 +4071,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // ============================================================================
@@ -4083,7 +4079,7 @@ void kernel_main() {
 // ============================================================================
 //
 // Compiles a TT_KERNEL compute kernel through genfiles + the RISC-V compiler on a MOCK Wormhole
-// device (no silicon, no dispatch) via detail::CompileProgram. This is the only no-hardware
+// device (no silicon, no dispatch) via program.impl().compile. This is the only no-hardware
 // coverage that the generated kernel_main() shim is emitted on the COMPUTE (TRISC) compile path
 // and actually compiles: the on-hardware compute test (TtKernelNamedArgsLoopbackCompute) skips in
 // CI, and the shim unit tests only check the generated string, not its genfiles wiring.
@@ -4135,8 +4131,7 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("wu", node, {"compute", "consumer"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // ============================================================================
@@ -4171,8 +4166,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 TEST_F(ProgramSpecTestGen1, EmptyCompileTimeVarargsReadableFromKernel) {
@@ -4192,8 +4186,7 @@ void kernel_main() {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // Template accessor bounds-checks at compile time: size==1 but get_compile_time_vararg<1>()
@@ -4252,8 +4245,7 @@ void kernel_main() {}
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // Same stress as above, on a compute (TRISC) kernel — CTA varargs are available on DM and compute.
@@ -4289,8 +4281,7 @@ void kernel_main() {}
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute_kernel"})};
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 // CTA varargs are a positional prefix ahead of TensorBinding CTA payloads.
@@ -4341,8 +4332,7 @@ void kernel_main() {
     EXPECT_TRUE(args_config.test(tensor_accessor::ArgConfig::IsDram))
         << "positional compile_args[N] must be the tensor args_config after the CTA-vararg prefix";
 
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
 TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargsProducesDifferentKernelHash) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -19,6 +19,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -172,7 +173,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // -------------------------------------------------------
     // Dispatch
     // -------------------------------------------------------
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     // -------------------------------------------------------
     // Verify
@@ -310,7 +311,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     }
     detail::WriteToBuffer(input_buffer, input_data);
 
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output_data;
     detail::ReadFromBuffer(output_buffer, output_data);
@@ -390,7 +391,7 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     std::vector<uint32_t> zero_report(1, 0u);
     detail::WriteToDeviceL1(device, node, report_addr, zero_report);
 
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, report_addr, sizeof(uint32_t), reported);
@@ -476,7 +477,7 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
     }
     detail::WriteToBuffer(input_buffer, input_data);
 
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output_data;
     detail::ReadFromBuffer(output_buffer, output_data);
@@ -540,7 +541,7 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopbackCompute) {
     std::vector<uint32_t> zero_report(1, 0u);
     detail::WriteToDeviceL1(device, node, report_addr, zero_report);
 
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, report_addr, sizeof(uint32_t), reported);
@@ -566,7 +567,6 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopbackCompute) {
 
 TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     const NodeCoord node{0, 0};
 
@@ -620,7 +620,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
     };
 
     Program program = MakeProgramFromSpec(*mesh_device, spec);
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
     // If we got here, both kernels resolved their sem accessors to the same ID.
 }
 
@@ -649,7 +649,6 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
 
 TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     // Tensor: 8 pages × 1024 bytes (BFLOAT16, ROW_MAJOR, shape {8, 512} → page = row = 1024 B)
     constexpr uint32_t num_pages = 8;
@@ -747,7 +746,7 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
     // -------------------------------------------------------
     // Dispatch
     // -------------------------------------------------------
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     // -------------------------------------------------------
     // Verify
@@ -821,7 +820,7 @@ TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
     std::vector<uint32_t> zero_report(kNumReportWords, 0u);
     detail::WriteToDeviceL1(device, node, kReportAddr, zero_report);
 
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, kReportAddr, kNumReportWords * sizeof(uint32_t), reported);
@@ -941,7 +940,7 @@ TEST_F(ProgramSpecHWTest, ScratchpadWriteReadback) {
     detail::WriteToDeviceL1(device, node, kReportAddr, zero_report);
 
     // Dispatch via the slow-dispatch path (blocking — wait_until_cores_done defaults to true).
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> reported;
     detail::ReadFromDeviceL1(device, node, kReportAddr, sizeof(uint32_t), reported);
@@ -1104,7 +1103,10 @@ void kernel_main() {
         .relaxations = TensorSpecRelaxations{.dynamic_tensor_shape = true}}};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, MakeProgramFromSpec(*mesh_device, spec));
+    Program& program = workload.get_programs().at(device_range);
 
     // Consumer's per-node RTAs (re-supplied on every set/update in this test).
     auto consumer_args = [&]() {
@@ -1117,7 +1119,7 @@ void kernel_main() {
 
     // Blocking launch, then read back the seven staged words.
     auto launch_and_read = [&]() {
-        detail::LaunchProgram(device, program);
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
         std::vector<uint32_t> out;
         detail::ReadFromBuffer(output_buffer, out);
         EXPECT_GE(out.size(), 7u);
@@ -1287,7 +1289,10 @@ void kernel_main() {
     spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"pad"}, .size_per_node = kScratchpadBytes}};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, MakeProgramFromSpec(*mesh_device, spec));
+    Program& program = workload.get_programs().at(device_range);
 
     std::vector<uint32_t> expected_pattern(kNumElems);
     for (uint32_t i = 0; i < kNumElems; i++) {
@@ -1306,7 +1311,7 @@ void kernel_main() {
         params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"stage"}, .num_entries = dfb_num_entries});
         SetProgramRunArgs(program, params);
 
-        detail::LaunchProgram(device, program);
+        distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
 
         std::vector<uint32_t> out;
         detail::ReadFromBuffer(output_buffer, out);

--- a/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
@@ -24,7 +24,6 @@
 #include "jit_build/build.hpp"
 #include "jit_build/build_env_manager.hpp"
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -70,7 +69,7 @@ void kernel_main() {
 
     EXPECT_NO_THROW({
         CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
-        slow_dispatch::CompileProgram(this->device(), program);
+        program.impl().compile(&this->device());
     });
 
     fs::remove_all(include_dir);
@@ -117,7 +116,7 @@ void kernel_main() {
 
     EXPECT_NO_THROW({
         CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
-        slow_dispatch::CompileProgram(this->device(), program);
+        program.impl().compile(&this->device());
     });
 
     fs::remove_all(absolute_include_dir);
@@ -215,7 +214,7 @@ void kernel_main() {
             .compiler_include_paths = {include_dir},
         };
         auto kernel_handle = CreateKernelFromString(program, kernel_src, CoreCoord{0, 0}, config);
-        slow_dispatch::CompileProgram(this->device(), program);
+        program.impl().compile(&this->device());
 
         const uint32_t tensix_core_type =
             MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);

--- a/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
@@ -100,7 +100,7 @@ TEST_F(CrossNodeDFBFixture, ProgramCrossNodeDFBsAPI) {
         const uint8_t remote_dfb_id = experimental::CreateCrossNodeDFB(program, mesh_device.get(), mapping, 256, 4);
         EXPECT_EQ(remote_dfb_id, 0u);
 
-        slow_dispatch::CompileProgram(*mesh_device, program);
+        program.impl().compile(mesh_device.get());
         program.impl().finalize_offsets(mesh_device.get());
 
         const auto& hal = MetalContext::instance().hal();
@@ -121,7 +121,7 @@ TEST_F(CrossNodeDFBFixture, ProgramCrossNodeDFBsAPI) {
             tt::tt_metal::DataMovementConfig{
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = tt::tt_metal::NOC::RISCV_0_default});
         const uint8_t remote_dfb_id = experimental::CreateCrossNodeDFB(program, mesh_device.get(), mapping, 256, 4);
-        slow_dispatch::CompileProgram(*mesh_device, program);
+        program.impl().compile(mesh_device.get());
         program.impl().finalize_offsets(mesh_device.get());
 
         const uint32_t original_data_addr = program.impl().get_cross_node_dfb(remote_dfb_id).buffer_address();
@@ -152,7 +152,7 @@ TEST_F(CrossNodeDFBFixture, ProgramCrossNodeDFBsAPI) {
         const CoreRangeSet dummy_all_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0))).merge(dummy_receiver_cores);
         auto dummy_data = cross_node_dfb_test::make_cross_node_data_buffer(
             mesh_device.get(), dummy_all_cores, /*entry_size=*/256, /*num_entries=*/4);
-        slow_dispatch::CompileProgram(*mesh_device, program);
+        program.impl().compile(mesh_device.get());
         program.impl().finalize_offsets(mesh_device.get());
         EXPECT_THROW(
             experimental::UpdateDynamicCrossNodeDFBAddress(program, remote_dfb_id, *dummy_data), std::exception);
@@ -166,7 +166,7 @@ TEST_F(CrossNodeDFBFixture, ProgramCrossNodeDFBsAPI) {
             all_cores,
             tt::tt_metal::DataMovementConfig{
                 .processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc = tt::tt_metal::NOC::RISCV_0_default});
-        slow_dispatch::CompileProgram(*mesh_device, program);
+        program.impl().compile(mesh_device.get());
         program.impl().finalize_offsets(mesh_device.get());
         const auto& hal = MetalContext::instance().hal();
         uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -36,6 +36,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;
@@ -309,7 +310,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     };
     experimental::SetProgramRunArgs(program, params);
 
-    slow_dispatch::LaunchProgram(*mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dest_buffer_data;
     slow_dispatch::ReadFromBuffer(*output_dram_buffer, dest_buffer_data);

--- a/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
@@ -21,7 +21,6 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 // Access to internal API: ProgramImpl::finalize_offsets
 #include "impl/program/program_impl.hpp"
@@ -101,7 +100,7 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffersAPI) {
             std::exception);
         auto remote_cb =
             tt::tt_metal::experimental::CreateCircularBuffer(program, receiver_cores, global_cb_config, global_cb);
-        slow_dispatch::CompileProgram(*mesh_device, program);
+        program.impl().compile(mesh_device.get());
         program.impl().finalize_offsets(mesh_device.get());
         tt::tt_metal::experimental::UpdateDynamicCircularBufferAddress(program, remote_cb, global_cb);
         EXPECT_THROW(UpdateDynamicCircularBufferAddress(program, remote_cb, dummy_global_cb), std::exception);

--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -22,7 +22,6 @@
 #include "jit_build/build_env_manager.hpp"
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "impl/kernels/kernel.hpp"
 // Access to internal API: ProgramImpl::get_kernels
 #include "impl/program/program_impl.hpp"
@@ -42,7 +41,7 @@ TEST_F(MeshDeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentPr
         Program program = CreateProgram();
         KernelHandle kernel_handle_riscv_0 = CreateKernel(program, kernel_file, CoreCoord(0, 0), config_riscv_0);
         KernelHandle kernel_handle_riscv_1 = CreateKernel(program, kernel_file, CoreCoord(0, 0), config_riscv_1);
-        slow_dispatch::CompileProgram(*mesh_device, program);
+        program.impl().compile(mesh_device.get());
 
         const uint32_t tensix_core_type =
             MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);

--- a/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_creation.cpp
@@ -26,7 +26,6 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -97,7 +96,7 @@ TEST_F(MeshDispatchFixture, DISABLED_TensixIdleEthCreateKernelsOnDispatchCores) 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderMetalRootDir) {
     const std::string& kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
     create_kernel(kernel_file);
-    slow_dispatch::CompileProgram(this->device(), this->program_);
+    this->program_.impl().compile(&this->device());
 }
 
 TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderKernelRootDir) {
@@ -105,7 +104,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderKernelRootDir
     const std::string& new_kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/new_kernel.cpp";
     this->setup_kernel_dir(orig_kernel_file, new_kernel_file);
     this->create_kernel(new_kernel_file);
-    slow_dispatch::CompileProgram(this->device(), this->program_);
+    this->program_.impl().compile(&this->device());
     this->cleanup_kernel_dir();
 }
 
@@ -113,7 +112,7 @@ TEST_F(CompileProgramWithKernelPathEnvVarFixture, TensixKernelUnderMetalRootDirA
     const std::string& kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_push_4.cpp";
     this->setup_kernel_dir(kernel_file, kernel_file);
     this->create_kernel(kernel_file);
-    slow_dispatch::CompileProgram(this->device(), this->program_);
+    this->program_.impl().compile(&this->device());
     this->cleanup_kernel_dir();
 }
 

--- a/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_thread_sync.cpp
@@ -20,6 +20,7 @@
 #include "impl/context/metal_context.hpp"
 #include "device_fixture.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "metal2_host_api/test_helpers.hpp"
 
 namespace tt::tt_metal::experimental {
@@ -132,7 +133,7 @@ TEST_F(KernelThreadSyncTest, BarrierSynchronizesThreads) {
             make_run_params(KernelSpecName{cfg.name}, node, cfg.layout, kRounds, kSkewIters));
     }
     SetProgramRunArgs(program, params);
-    slow_dispatch::LaunchProgram(this->device(), program, true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     for (const auto& cfg : kernel_configs) {
         std::vector<uint32_t> observed;

--- a/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include "device_fixture.hpp"
 #include "impl/context/metal_context.hpp"
 #include "jit_build/build.hpp"
@@ -101,7 +102,7 @@ Program create_precompiled_program(
 
 // Snapshot of the process-wide srcs counter, which advances on every JitBuildState::compile()
 // call (the shared hot path of every jit_build* entry point). delta() > 0 after a
-// CompileProgram call means the JIT pipeline ran. Snapshotting (instead of resetting the
+// program.impl().compile call means the JIT pipeline ran. Snapshotting (instead of resetting the
 // telemetry singleton) keeps other tests sharing the same process unaffected.
 struct JitSrcsBaseline {
     uint32_t baseline = BuildCacheTelemetry::inst().get_srcs_count();
@@ -266,7 +267,6 @@ TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
         GTEST_SKIP() << "Fabric is active, so CreateKernel injects fabric defines that CompileKernelOffline "
                         "cannot reproduce; the offline bucket is keyed on a different compile hash.";
     }
-    auto* device = this->devices_.at(0)->get_devices().at(0);
 
     ScopedTempDir precompiled_root("tt_metal_precompiled_seed_hit");
     seed_precompiled_root(precompiled_root.path_, kReaderKernelPath, kReaderDmConfig);
@@ -276,7 +276,7 @@ TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(this->devices_.at(0).get()));
     EXPECT_EQ(jit_srcs.delta(), 0u);
 }
 
@@ -295,7 +295,6 @@ TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWit
     // hlk_desc contributions diverge, this test fails as `jit_srcs.delta() > 0` (runtime
     // falls through to JIT) rather than as a layout assertion, which is exactly the
     // failure mode that justifies surfacing CBCompileConfigsFromProgram in the public API.
-    auto* device = this->devices_.at(0)->get_devices().at(0);
 
     constexpr uint32_t kPageSize = 2048;
     constexpr DataFormat kCbFormat = DataFormat::Float16_b;
@@ -328,30 +327,28 @@ TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWit
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
-    EXPECT_NO_THROW(detail::CompileProgram(device, runtime_program));
+    EXPECT_NO_THROW(runtime_program.impl().compile(this->devices_.at(0).get()));
     EXPECT_EQ(jit_srcs.delta(), 0u);
 }
 
 TEST_F(AnyDispatchMeshDeviceFixture, RuntimeMissingPrecompiledFallsBackToJit) {
     const auto precompiled_config = make_precompiled_config(kMissingPrecompiledRoot, BinaryPolicy::JitCompile);
     Program program = create_precompiled_program(precompiled_config);
-    auto* device = this->devices_.at(0)->get_devices().at(0);
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+    EXPECT_NO_THROW(program.impl().compile(this->devices_.at(0).get()));
     EXPECT_GT(jit_srcs.delta(), 0u);
 }
 
 TEST_F(AnyDispatchMeshDeviceFixture, RuntimeMissingPrecompiledErrorsOnPolicyError) {
     const auto precompiled_config = make_precompiled_config(kMissingPrecompiledRoot, BinaryPolicy::Error);
     Program program = create_precompiled_program(precompiled_config);
-    auto* device = this->devices_.at(0)->get_devices().at(0);
 
     jit_build_cache_clear();
     JitSrcsBaseline jit_srcs;
     try {
-        detail::CompileProgram(device, program);
+        program.impl().compile(this->devices_.at(0).get());
         FAIL() << "Expected PrecompiledKernelNotFoundError";
     } catch (const experimental::PrecompiledKernelNotFoundError& ex) {
         EXPECT_EQ(ex.kernel_name(), kReaderKernelName);

--- a/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/kernels/kernel.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -26,7 +26,7 @@ TEST_F(UnitMeshFixture, StreamScratchRegisterTensixCores) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Execute the program
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 }
 
 // Test stream scratch register APIs on Erisc cores
@@ -54,7 +54,7 @@ TEST_F(UnitMeshFixture, StreamScratchRegisterEriscCores) {
         EthernetConfig{.noc = NOC::NOC_0});
 
     // Execute the program
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -45,6 +45,7 @@
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 #include "gtest/gtest.h"
 
@@ -176,7 +177,7 @@ TEST_F(UnitMeshFixture, ZeroMemoryApi) {
     params.tensor_args = {{OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{tensor}}};
     experimental::SetProgramRunArgs(program, params);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     // ----- Host verifies -----
     // L1: kernel reports its in-kernel verify result via the flag word.
@@ -280,7 +281,7 @@ TEST_F(UnitMeshFixture, ZeroMemoryApiBatchedL1) {
     params.tensor_args = {{OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{tensor}}};
     experimental::SetProgramRunArgs(program, params);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     // The batched producer's in-kernel verify is the primary signal: kStatusOk only if
     // every byte across all chunks is zero after the single barrier.

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -25,6 +25,7 @@
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
+#include "impl/program/program_impl.hpp"
 
 #include <umd/device/types/arch.hpp>
 
@@ -537,8 +538,7 @@ TEST(MetalContextIntegrationTest, MockMetal2ProgramCompileOnForeignMeshFails) {
     auto mesh_b = env_b.create_mesh_device(distributed::MeshDeviceConfig(distributed::MeshShape(1)));
 
     Program program = experimental::MakeProgramFromSpec(*mesh_a, MakeMinimalNoOpProgramSpec());
-    IDevice* foreign_device = mesh_b->get_devices().at(0);
-    EXPECT_THROW(detail::CompileProgram(foreign_device, program), std::runtime_error);
+    EXPECT_THROW(program.impl().compile(mesh_b.get()), std::runtime_error);
 }
 
 TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -18,7 +18,7 @@
 #include "tt_stl/assert.hpp"
 #include "fmt/format.h"
 
-// Access to internal API: BuildEnvManager, CompileProgram, get_kernel
+// Access to internal API: BuildEnvManager, ProgramImpl, get_kernel
 #include "jit_build/build_env_manager.hpp"
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
@@ -346,6 +346,8 @@ public:
         SetSingleDmPrintArgs(program, runtime_args);
 
         auto* device = mesh_device->get_devices()[0];
+        program.impl().compile(mesh_device.get());
+
         const auto& hal = tt::tt_metal::MetalContext::instance().hal();
         uint32_t tensix_core_type = hal.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::TENSIX);
         uint32_t dm_class_idx = enchantum::to_underlying(tt::tt_metal::HalProcessorClassType::DM);

--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -8,6 +8,7 @@
 #include <chrono>
 
 #include "tt_metal/tt_metal/deployment/deployment_common.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp"
 
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -286,7 +287,7 @@ static void wait_to_finish_eth_timeout_cores(
     }
 
     for (const auto& [dev, workload] : devices) {
-        detail::CompileProgram(dev->get_devices()[0], *programs[dev]);
+        programs[dev]->impl().compile(dev.get());
         devices[dev]->add_program(device_range, std::move(*programs[dev]));
     }
 

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 
 #include "impl/allocator/allocator.hpp"
 #include "impl/context/metal_context.hpp"
@@ -236,7 +237,7 @@ TEST_F(ServiceCoreSdFixture, PersistentServiceMultiCycle) {
         SetRuntimeArgs(
             prog, kernel, svc_core, {(uint32_t)stop_addr, (uint32_t)counter_addr, (uint32_t)service_done_addr});
 
-        tt::tt_metal::detail::CompileProgram(device, prog, /*force_slow_dispatch=*/true);
+        prog.impl().compile(device, /*force_slow_dispatch=*/true);
         tt::tt_metal::detail::WriteRuntimeArgsToDevice(device, prog, /*force_slow_dispatch=*/true);
         tt::tt_metal::detail::LaunchProgram(
             device, prog, /*wait_until_cores_done=*/false, /*force_slow_dispatch=*/true);

--- a/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
@@ -64,6 +64,7 @@
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include "common/env_lib.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
@@ -219,7 +220,7 @@ protected:
 TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
     const auto target = MetalContext::instance().get_cluster().get_target_device_type();
 
-    IDevice* dev = devices_[0]->get_devices()[0];
+    distributed::MeshDevice* device = devices_[0].get();
 
     if (use_mock_mode()) {
         TT_FATAL(
@@ -231,7 +232,7 @@ TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
         // does not steer CompileProgram), so a runner/arch mismatch would gate
         // e.g. Wormhole kernels against the Blackhole golden. Fail fast instead.
         const tt::ARCH expected_arch = get_mock_arch_from_env();
-        const tt::ARCH actual_arch = dev->arch();
+        const tt::ARCH actual_arch = device->arch();
         TT_FATAL(
             actual_arch == expected_arch,
             "CompileStressFixture requested arch '{}' but the attached device is '{}'.",
@@ -260,7 +261,7 @@ TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
     const uint32_t num_shared = static_cast<uint32_t>(std::floor(shared_fraction * target_num_kernels));
     const uint32_t num_private = target_num_kernels - num_shared;
 
-    CoreCoord compute_grid = dev->compute_with_storage_grid_size();
+    CoreCoord compute_grid = device->compute_with_storage_grid_size();
     const uint32_t grid_x = compute_grid.x;
     const uint32_t grid_y = compute_grid.y;
     const uint32_t cores_per_program = grid_x * grid_y;
@@ -306,7 +307,7 @@ TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
                 .set_page_size(tt::CBIndex::c_16, single_tile_size);
         CreateCircularBuffer(warmup, CoreCoord(0, 0), cb16);
         CreateKernel(warmup, kernel_path, CoreCoord(0, 0), ComputeConfig{.compile_args = {UINT32_MAX, private_seed}});
-        detail::CompileProgram(dev, warmup);
+        warmup.impl().compile(device);
     }
     log_info(LogTest, "Warmup compile done");
 
@@ -341,7 +342,7 @@ TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
     std::vector<std::future<void>> futures;
     futures.reserve(num_programs);
     for (auto& program : programs) {
-        futures.push_back(std::async(std::launch::async, [dev, &program] { detail::CompileProgram(dev, program); }));
+        futures.push_back(std::async(std::launch::async, [device, &program] { program.impl().compile(device); }));
     }
     for (auto& f : futures) {
         f.get();

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/mxfp4.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -184,7 +185,7 @@ static vector<uint32_t> run_mxfp4_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
     detail::ReadFromBuffer(dst_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/mxfp6.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -186,7 +187,7 @@ static vector<uint32_t> run_mxfp6_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
     detail::ReadFromBuffer(dst_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/mxfp8.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -189,7 +190,7 @@ static vector<uint32_t> run_mxfp8_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
     detail::ReadFromBuffer(dst_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/mxint.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
@@ -172,7 +173,7 @@ static vector<uint32_t> run_mxint_typecast(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
     detail::ReadFromBuffer(dst_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -227,7 +228,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
     };
     experimental::SetProgramRunArgs(program, params);
 
-    tt::tt_metal::detail::LaunchProgram(dev, program, true);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<std::uint32_t> result_vec;
     tt::tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -33,6 +33,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
@@ -622,8 +623,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
     };
     experimental::SetProgramRunArgs(program, params);
 
-    auto* dev = mesh_device->get_devices()[0];
-    tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, out_dram, zero_coord, false);
@@ -977,8 +977,7 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
     };
     experimental::SetProgramRunArgs(program, params);
 
-    auto* dev = mesh_device->get_devices()[0];
-    tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> out0_data;
     std::vector<uint32_t> out1_data;

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -11,6 +11,7 @@
 #include <random>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -977,13 +978,12 @@ std::vector<uint32_t> sfpu_quasar_run(
     const experimental::ProgramRunArgs& params,
     const std::vector<std::pair<std::shared_ptr<tt::tt_metal::Buffer>, const std::vector<uint32_t>*>>& inputs,
     const std::shared_ptr<tt::tt_metal::Buffer>& out_buf) {
-    auto* device = mesh_device->get_devices()[0];
     auto program = experimental::MakeProgramFromSpec(*mesh_device, spec);
     experimental::SetProgramRunArgs(program, params);
     for (const auto& [buf, data] : inputs) {
         tt_metal::detail::WriteToBuffer(buf, *data);
     }
-    tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
     std::vector<uint32_t> dest;
     tt_metal::detail::ReadFromBuffer(out_buf, dest);
     return dest;

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -41,10 +41,6 @@
 #include <tt-metalium/distributed.hpp>
 
 namespace tt::tt_metal {
-class IDevice;
-}  // namespace tt::tt_metal
-
-namespace tt::tt_metal {
 
 using std::map;
 using std::vector;
@@ -593,7 +589,10 @@ bool single_core_binary(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, experimental::MakeProgramFromSpec(*mesh_device, spec));
+    Program& program = workload.get_programs().at(device_range);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -625,10 +624,9 @@ bool single_core_binary(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    auto* dev = mesh_device->get_devices()[0];
     std::vector<uint32_t> first_result;
     for (uint32_t run = 0; run < num_runs; ++run) {
-        tt_metal::detail::LaunchProgram(dev, program, /*wait_until_cores_done=*/true);
+        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
         std::vector<uint32_t> packed_result;
         if (!read_and_validate_binary_result(cq, output_dram_buffer, zero_coord, stimulus, &packed_result)) {

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -37,6 +37,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <impl/context/metal_context.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "tt_metal/test_utils/df/float32.hpp"
@@ -281,7 +282,6 @@ void get_packed_tilized_input_output_pair(
 
 void run_single_core_unary_broadcast_quasar(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const UnaryBroadcastConfig& test_config) {
-    auto* device = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     constexpr uint32_t num_tiles = 32;
@@ -420,7 +420,7 @@ void run_single_core_unary_broadcast_quasar(
         in_t, out_t, num_tiles, test_config.broadcast_dim, packed_tilized_input, golden_packed_tilized_output);
     tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), packed_tilized_input);
 
-    tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dest_buffer_data;
     tt_metal::detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), dest_buffer_data);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -28,6 +28,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/impl/profiler/profiler_paths.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
 
 #include <thread>
 #include "impl/context/metal_context.hpp"
@@ -411,7 +412,7 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
     for (size_t i = 0; i < device_helper.devices.size(); i++) {
         const auto& device = device_helper.devices[i];
         try {
-            tt_metal::detail::CompileProgram(device.get(), programs[i]);
+            programs[i].impl().compile(device.get());
         } catch (std::exception& e) {
             log_error(tt::LogTest, "Failed to compile program on device {}: {}", i, e.what());
             throw e;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -60,7 +60,7 @@ void measure_latency(const std::string& kernel_name) {
     tt::tt_metal::detail::SetDeviceProfilerDir(kernel_name + "_microbenchmark");
     tt::tt_metal::detail::FreshProfilerDeviceLog();
     program.impl().compile(device);
-    tt_metal::detail::LaunchProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
     tt_metal::CloseDevice(device);
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <map>
 #include <string>
 #include <variant>
@@ -58,7 +59,7 @@ void measure_latency(const std::string& kernel_name) {
 
     tt::tt_metal::detail::SetDeviceProfilerDir(kernel_name + "_microbenchmark");
     tt::tt_metal::detail::FreshProfilerDeviceLog();
-    tt::tt_metal::detail::CompileProgram(device, program);
+    program.impl().compile(device);
     tt_metal::detail::LaunchProgram(device, program);
     tt_metal::CloseDevice(device);
 }

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -25,7 +25,11 @@ using namespace tt::tt_metal;
 TEST_F(UnitMeshFixture, AddTwoInts) {
     uint32_t l1_unreserved_base = this->device().allocator()->get_base_allocator_addr(HalMemType::L1);
 
-    Program program = CreateProgram();
+    auto device_range = distributed::MeshCoordinateRange(this->device().shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, CreateProgram());
+    Program& program = workload.get_programs().at(device_range);
+
     CoreCoord core = {0, 0};
     constexpr std::array<uint32_t, 2> first_runtime_args = {101, 202};
     constexpr std::array<uint32_t, 2> second_runtime_args = {303, 606};
@@ -41,7 +45,7 @@ TEST_F(UnitMeshFixture, AddTwoInts) {
 
     // First run
     SetRuntimeArgs(program, add_two_ints_kernel, core, first_runtime_args);
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), workload, /*blocking=*/true);
 
     std::vector<uint32_t> first_kernel_result;
     slow_dispatch::ReadFromL1(this->device(), core, l1_unreserved_base, sizeof(int), first_kernel_result);
@@ -49,7 +53,7 @@ TEST_F(UnitMeshFixture, AddTwoInts) {
 
     // Second run with updated args
     SetRuntimeArgs(program, add_two_ints_kernel, core, second_runtime_args);
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), workload, /*blocking=*/true);
 
     std::vector<uint32_t> second_kernel_result;
     slow_dispatch::ReadFromL1(this->device(), core, l1_unreserved_base, sizeof(int), second_kernel_result);

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
 
@@ -255,7 +256,7 @@ void run_bcast_test(distributed::MeshDevice& mesh_device, BcastDim::Enum bcast_d
     vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 10.0f, 0x1234);
     slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_vec);
 
-    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tilize_utils.hpp>
@@ -278,8 +279,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, BmmMultinode) {
         GTEST_SKIP() << "This test requires at least 2 worker nodes.";
     }
 
-    IDevice* dev = mesh_device.get_devices()[0];
-
     BmmParams p;
     p.Mt = 2; p.Kt = 2; p.Nt = 2;
     p.B_total = 2;      // total batches across both cores
@@ -335,7 +334,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, BmmMultinode) {
     detail::WriteToBuffer(*tensors.src0.mesh_buffer().get_reference_buffer(), src0_vec);
     detail::WriteToBuffer(*tensors.src1.mesh_buffer().get_reference_buffer(), src1_vec);
 
-    detail::LaunchProgram(dev, program, true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     detail::ReadFromBuffer(*tensors.dst.mesh_buffer().get_reference_buffer(), result_vec);

--- a/tests/tt_metal/tt_metal/test_compile_failure_drain.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_failure_drain.cpp
@@ -44,7 +44,7 @@
 #include <tt-metalium/tt_metal.hpp>
 
 #include "jit_build/build.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 
 namespace tt::tt_metal {
@@ -105,7 +105,7 @@ TEST_F(UnitMeshAnyDispatchFixture, CompileProgramWithFailingKernelThrowsCleanly)
         Program good = CreateProgram();
         add_tile_cbs(good, CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
         CreateKernel(good, kGoodComputeKernel, CoreCoord(0, 0), ComputeConfig{.compile_args = {1u, 0u}});
-        EXPECT_NO_THROW(slow_dispatch::CompileProgram(this->device(), good));
+        EXPECT_NO_THROW(good.impl().compile(&this->device()));
     }
 
     // Force every repro kernel to compile from scratch (see clear_kernel_cache) so the valid
@@ -144,7 +144,7 @@ TEST_F(UnitMeshAnyDispatchFixture, CompileProgramWithFailingKernelThrowsCleanly)
 
     // sync_build_steps drains all in-flight steps, then rethrows the compile failure
     // -> a clean exception. Without the drain: abandons in-flight steps -> UAF -> SIGSEGV.
-    EXPECT_THROW(slow_dispatch::CompileProgram(this->device(), program), std::exception);
+    EXPECT_THROW(program.impl().compile(&this->device()), std::exception);
 
     std::error_code ec;
     std::filesystem::remove_all(regression_tmp_dir(), ec);

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "common/device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #include <cstdint>
 #include <filesystem>
@@ -74,7 +73,7 @@ KernelCacheStatus CompileProgramTestWrapper(
             .get_device_build_env(device.build_id())
             .build_env.get_out_kernel_root_path());
 
-    slow_dispatch::CompileProgram(device, program);
+    program.impl().compile(&device);
 
     std::unordered_map<std::string, std::string> post_compile_kernel_to_hash_str = get_last_program_binary_path(
         program,

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -23,7 +23,6 @@
 #include "impl/kernels/kernel.hpp"
 #include "tt_memory.h"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <umd/device/types/arch.hpp>
 
 using std::vector;
@@ -142,7 +141,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
         auto mask = BuildEnvManager::get_instance(extract_context_id(device))
                         .get_device_build_env(device->build_id())
                         .build_key();
-        slow_dispatch::CompileProgram(*device, program);
+        program.impl().compile(device);
         compute_binaries.insert({mask, compute_kernel->binaries(mask)});
         TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
         brisc_binaries.insert({mask, riscv0_kernel->binaries(mask)});
@@ -184,7 +183,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
                     auto mask = BuildEnvManager::get_instance(extract_context_id(device))
                                     .get_device_build_env(device->build_id())
                                     .build_key();
-                    slow_dispatch::CompileProgram(*device, program);
+                    program.impl().compile(device);
                     uint32_t programmable_core_index = MetalContext::instance().hal().get_programmable_core_type_index(
                         HalProgrammableCoreType::TENSIX);
                     const KernelGroup* kernel_group = program.impl().kernels_on_core(core, programmable_core_index);

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -91,7 +91,10 @@ void check_semaphores_are_initialized(
 }  // namespace
 
 TEST_F(UnitMeshFixture, CoreRangeSet) {
-    Program program = CreateProgram();
+    auto device_range = distributed::MeshCoordinateRange(this->device().shape());
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, CreateProgram());
+    Program& program = workload.get_programs().at(device_range);
 
     CoreRange core_range_one({0, 0}, {1, 1});
     CoreRange core_range_two({2, 2}, {3, 3});
@@ -185,7 +188,7 @@ TEST_F(UnitMeshFixture, CoreRangeSet) {
              num_tiles});
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), workload, /*blocking=*/true);
 
     check_semaphores_are_initialized(this->device(), program, core_ranges, golden_sem_values);
 

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -162,7 +162,7 @@ TEST_F(UnitMeshFixture, CoreRangeSet) {
 
     check_program_is_mapped_to_correct_cores(program, core_ranges, compute_kernel_args);
 
-    slow_dispatch::CompileProgram(this->device(), program);
+    program.impl().compile(&this->device());
 
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 using std::vector;
 using namespace tt;
@@ -80,7 +81,7 @@ TEST_F(UnitMeshFixture, Datacopy) {
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 
 using std::vector;
@@ -82,7 +83,7 @@ TEST_F(UnitMeshFixture, DatacopyBfp8b) {
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 
 using std::vector;
@@ -88,7 +89,7 @@ TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
          (std::uint32_t)l1_dst_noc_xy.y,
          num_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -29,6 +29,7 @@
 #include <tt_stl/span.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -116,7 +117,7 @@ TEST_F(UnitMeshFixture, DramCopySticksMultiCore) {
             }
         }
 
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
         // std::vector<uint32_t> result_vec;
         // slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -57,7 +58,7 @@ TEST_F(UnitMeshFixture, DramLoopbackSingleCore) {
         core,
         {l1_buffer_addr, input_dram_buffer_addr, 0, output_dram_buffer_addr, 0, dram_buffer_size});
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*output_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -40,6 +40,7 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -296,7 +297,7 @@ TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
 
         tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_rt_args);
 
-        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
         std::vector<uint32_t> result_vec;
         slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 
 using std::vector;
@@ -110,7 +111,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
 
     SetRuntimeArgs(program, unary_writer_kernel, core, {(uint32_t)dst_dram_buffer->address(), 0, num_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 
@@ -116,7 +117,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
@@ -112,7 +113,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelSameRuntimeArgs) {
     set_rt_args(program, reader_kernel_id, all_cores, unary_reader_args);
     set_rt_args(program, writer_kernel_id, all_cores, unary_writer_args);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
@@ -167,7 +168,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelUniqueRuntimeArgs) {
         set_rt_args(program, writer_kernel_id, core_range, rt_args.at(core_range_idx++));
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec_1;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer_1, result_vec_1);

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 
 using std::vector;
@@ -218,7 +219,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
         *src1_dram_buffer,
         *dst_dram_buffer);
 
-    slow_dispatch::LaunchProgram(this->device(), program1, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program1), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> intermediate_result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, intermediate_result_vec);
@@ -242,7 +243,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
         *src1_dram_buffer,
         *dst_dram_buffer);
 
-    slow_dispatch::LaunchProgram(this->device(), program2, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program2), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
@@ -175,7 +176,7 @@ static void run_pack_relu_test(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    detail::LaunchProgram(dev, program, true);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     detail::ReadFromBuffer(dst_dram_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -36,7 +36,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -51,7 +51,6 @@ const uint32_t N_RANDS = 512;
 }  // namespace
 
 // Disabled because this test can hang the NoC due to hardware issues.
-// Uses slow_dispatch::LaunchProgram which requires slow dispatch mode
 TEST_F(UnitMeshFixture, DISABLED_StressNocMcast) {
     // Use default test parameters
     uint32_t time_secs = DEFAULT_SECONDS;
@@ -147,5 +146,5 @@ TEST_F(UnitMeshFixture, DISABLED_StressNocMcast) {
     }
     log_info(LogTest, "Running for {} seconds", time_secs);
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 }

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
 
@@ -124,7 +125,7 @@ TEST_F(UnitMeshFixture, TransposeHC) {
     SetRuntimeArgs(program, reader_kernel, core, {dram_buffer_src0_addr, 0U, W, H, C, HW, N, CHW});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0U, num_tensor_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_strided_dfb.cpp
@@ -18,6 +18,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/distributed.hpp>
@@ -116,8 +117,6 @@ void run_strided_dfb_copy_test(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     uint32_t num_dfb_entries,
     KernelBuilderFn kernel_builder_fn) {
-    auto* device = mesh_device->get_devices().at(0);
-
     MemoryConfig mem_config(TensorMemoryLayout::INTERLEAVED, params.buffer_type);
     tt::tt_metal::TensorSpec tensor_spec(
         params.tensor_shape, TensorLayout(params.dtype, PageConfig(params.layout), mem_config));
@@ -203,7 +202,7 @@ void run_strided_dfb_copy_test(
     // -----------------------------------------------------------------------
     // Dispatch and verify
     // -----------------------------------------------------------------------
-    detail::LaunchProgram(device, program);
+    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     const auto output_cpu = output_tensor.cpu(true);
     const auto output_shard = ttnn::distributed::get_device_tensors(output_cpu).front();

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -160,8 +160,10 @@ void ReadShard(Buffer& buffer, std::vector<DType>& host_buffer, const uint32_t& 
 
 // Launches all kernels on cores specified with kernels in the program.
 // All kernels on a given Tensix core must be launched.
+[[deprecated("Use distributed::EnqueueMeshWorkload instead. detail::LaunchProgram will be removed after 2026-09-20.")]]
 void LaunchProgram(
     IDevice* device, Program& program, bool wait_until_cores_done = true, bool force_slow_dispatch = false);
+[[deprecated("Use distributed::EnqueueMeshWorkload instead. detail::LaunchProgram will be removed after 2026-09-20.")]]
 void LaunchProgram(
     IDevice* device,
     const std::shared_ptr<Program>& program,

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -193,6 +193,7 @@ void WaitProgramDone(IDevice* device, Program& program, bool read_device_profile
  * a user wants to compile a program with Slow Dispatch Force Enabled (advanced feature, currently used internally to
  * launch Fast Dispatch Firmware and in the Device Performance Profiler)           | bool      | | No |
  */
+[[deprecated("Use MakeProgramFromSpec instead. CompileProgram will be removed after 2026-09-20.")]]
 void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
 /**

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -160,10 +160,10 @@ void ReadShard(Buffer& buffer, std::vector<DType>& host_buffer, const uint32_t& 
 
 // Launches all kernels on cores specified with kernels in the program.
 // All kernels on a given Tensix core must be launched.
-[[deprecated("Use distributed::EnqueueMeshWorkload instead. detail::LaunchProgram will be removed after 2026-09-20.")]]
+[[deprecated("Use distributed::EnqueueMeshWorkload instead. detail::LaunchProgram will be removed after 2026-09-21.")]]
 void LaunchProgram(
     IDevice* device, Program& program, bool wait_until_cores_done = true, bool force_slow_dispatch = false);
-[[deprecated("Use distributed::EnqueueMeshWorkload instead. detail::LaunchProgram will be removed after 2026-09-20.")]]
+[[deprecated("Use distributed::EnqueueMeshWorkload instead. detail::LaunchProgram will be removed after 2026-09-21.")]]
 void LaunchProgram(
     IDevice* device,
     const std::shared_ptr<Program>& program,
@@ -196,8 +196,8 @@ void WaitProgramDone(IDevice* device, Program& program, bool read_device_profile
  * launch Fast Dispatch Firmware and in the Device Performance Profiler)           | bool      | | No |
  */
 [[deprecated(
-    "Program is automatically compiled at the time of first enqueue. "
-    "CompileProgram will be removed after 2026-09-20.")]]
+    "Program is compiled automatically by the runtime infrastructure; this API is unnecessary. "
+    "CompileProgram will be removed after 2026-09-21.")]]
 void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
 /**

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -195,7 +195,9 @@ void WaitProgramDone(IDevice* device, Program& program, bool read_device_profile
  * a user wants to compile a program with Slow Dispatch Force Enabled (advanced feature, currently used internally to
  * launch Fast Dispatch Firmware and in the Device Performance Profiler)           | bool      | | No |
  */
-[[deprecated("Use MakeProgramFromSpec instead. CompileProgram will be removed after 2026-09-20.")]]
+[[deprecated(
+    "Program is automatically compiled at the time of first enqueue. "
+    "CompileProgram will be removed after 2026-09-20.")]]
 void CompileProgram(IDevice* device, Program& program, bool force_slow_dispatch = false);
 
 /**

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -53,6 +53,7 @@
 #include "dispatch/dispatch_mem_map.hpp"
 #include "distributed/mesh_device_impl.hpp"
 #include "llrt/hal.hpp"
+#include "program/program_impl.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/data_collector.hpp"
@@ -739,7 +740,7 @@ void RealtimeProfilerManager::initialize_devices(const std::shared_ptr<MeshDevic
             CreateKernel(
                 realtime_profiler_program, realtime_profiler_push_kernel_path, realtime_profiler_core, ncrisc_config);
 
-            tt::tt_metal::detail::CompileProgram(device, realtime_profiler_program, /*force_slow_dispatch=*/true);
+            realtime_profiler_program.impl().compile(device, /*force_slow_dispatch=*/true);
             ::tt::tt_metal::detail::WriteRuntimeArgsToDevice(
                 device, realtime_profiler_program, /*force_slow_dispatch=*/true);
             ::tt::tt_metal::detail::LaunchProgram(

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -10,6 +10,7 @@
 #include "tt_metal/fabric/fabric_builder.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
+#include "impl/program/program_impl.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 
 // hack for test_basic_fabric_apis.cpp
@@ -41,8 +42,7 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::
     builder.create_kernels();
 
     // Compile the program
-    tt::tt_metal::detail::CompileProgram(
-        device, *fabric_program_ptr, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
+    fabric_program_ptr->impl().compile(device, tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch());
 
     return fabric_program_ptr;
 }

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -35,6 +35,7 @@
 
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"  // DramConfig + CreateKernel(DramConfig)
+#include "impl/program/program_impl.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"  // receiver_socket_md (for L1 layout sizing)
 
@@ -615,7 +616,7 @@ void TensorPrefetcherManager::start() {
 
     // Launch programs (non-blocking — kernels park on the socket immediately).
     for (uint32_t d = 0; d < devices_.size(); ++d) {
-        ::tt::tt_metal::detail::CompileProgram(devices_[d], *programs_[d], /*force_slow_dispatch=*/true);
+        programs_[d]->impl().compile(devices_[d], /*force_slow_dispatch=*/true);
         ::tt::tt_metal::detail::WriteRuntimeArgsToDevice(devices_[d], *programs_[d], /*force_slow_dispatch=*/true);
         ::tt::tt_metal::detail::LaunchProgram(
             devices_[d], *programs_[d], /*wait_until_cores_done=*/false, /*force_slow_dispatch=*/true);

--- a/tt_metal/impl/dispatch/slow_dispatch.hpp
+++ b/tt_metal/impl/dispatch/slow_dispatch.hpp
@@ -112,8 +112,4 @@ inline bool ReadFromDRAMChannel(
         physical_device_from_unit_mesh(unit_mesh), dram_channel, address, host_buffer);
 }
 
-inline void LaunchProgram(distributed::MeshDevice& unit_mesh, Program& program, bool wait_until_cores_done) {
-    detail::LaunchProgram(physical_device_from_unit_mesh(unit_mesh), program, wait_until_cores_done);
-}
-
 }  // namespace tt::tt_metal::slow_dispatch

--- a/tt_metal/impl/dispatch/slow_dispatch.hpp
+++ b/tt_metal/impl/dispatch/slow_dispatch.hpp
@@ -112,10 +112,6 @@ inline bool ReadFromDRAMChannel(
         physical_device_from_unit_mesh(unit_mesh), dram_channel, address, host_buffer);
 }
 
-inline void CompileProgram(distributed::MeshDevice& unit_mesh, Program& program) {
-    detail::CompileProgram(physical_device_from_unit_mesh(unit_mesh), program);
-}
-
 inline void LaunchProgram(distributed::MeshDevice& unit_mesh, Program& program, bool wait_until_cores_done) {
     detail::LaunchProgram(physical_device_from_unit_mesh(unit_mesh), program, wait_until_cores_done);
 }

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -952,7 +952,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         if (MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Emule)
 #endif
         {
-            detail::CompileProgram(device, program);
+            program.impl().compile(device);
         }
         program.impl().finalize_dataflow_buffer_configs();
         if (!program.impl().is_finalized()) {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -53,6 +53,7 @@
 #include "profiler_types.hpp"
 #include "profiler_state_manager.hpp"
 #include "program.hpp"
+#include "program/program_impl.hpp"
 #include "kernels/kernel.hpp"
 #include "device/device_manager.hpp"
 #include "rtoptions.hpp"
@@ -426,8 +427,8 @@ void syncDeviceDevice(ChipId device_id_sender, ChipId device_id_receiver) {
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = ct_args});
 
         try {
-            detail::CompileProgram(device_sender, program_sender);
-            detail::CompileProgram(device_receiver, program_receiver);
+            program_sender.impl().compile(device_sender);
+            program_receiver.impl().compile(device_receiver);
         } catch (std::exception& e) {
             log_error(tt::LogMetal, "Failed compile: {}", e.what());
             throw e;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -52,6 +52,7 @@
 #include "impl/device/device_impl.hpp"
 #include "impl/memory_tracking/memory_stats_shm.hpp"
 #include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/mesh_workload.hpp"
 #include <unistd.h>
 #include "jit_build/build.hpp"
 #include <tt_stl/enum.hpp>
@@ -3054,6 +3055,12 @@ void detail::ProgramCompileGroup::clear() {
 bool detail::ProgramCompileGroup::contains(tt::tt_metal::IDevice* device) {
     std::lock_guard lock(mutex_);
     return program_device_map_.contains(device);
+}
+
+void LaunchProgram(distributed::MeshDevice& mesh_device, Program&& program, bool wait_until_cores_done) {
+    distributed::MeshWorkload workload;
+    workload.add_program(distributed::MeshCoordinateRange(mesh_device.shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, wait_until_cores_done);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -661,4 +661,9 @@ private:
 };
 
 }  // namespace detail
+
+// Launch `program` on every device in `mesh_device` via EnqueueMeshWorkload.
+// Takes ownership of `program`. When `wait_until_cores_done` is true, enqueue is blocking.
+void LaunchProgram(distributed::MeshDevice& mesh_device, Program&& program, bool wait_until_cores_done);
+
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

`LaunchProgram` and `CompileProgram` from _tt_metal/api/tt-metalium/tt_metal.hpp_ are not used externally, so they are deprecated:

1. `detail::LaunchProgram` in favor of using `MeshWorkload`.
  Internal `LaunchProgram` is added in _program_impl.hpp_ that uses `MeshWorkload`, making it compatible with both slow and fast dispatch. If there's interest, we can expose this convenience helper publicly.
  Note that a couple of calls to `detail::LaunchProgram` are left in the codebase where they pass `force_slow_dispatch = true`, because refactoring them would make this PR more complicated.

2. `detail::CompileProgram` without direct public alternative.
  All its usage was internal, and it's replaced with `ProgramImpl::compile`.
  Note that it's valid to pass `MeshDevice` instead of `Device` there, see this:
<details>
  <summary>explanation by AI</summary>
  
`MakeProgramFromSpec` and `MeshWorkloadImpl::compile` both call `compile_and_allocate` with a `MeshDevice`, which then calls `compile()`. The JIT work does not use `IDevice::id()` as a chip id.

What compile actually uses:

Call | MeshDevice | First physical device (get_devices()[0])
-- | -- | --
build_id() | reference_device()->id() = first chip | Device::build_id() = that chip’s id
extract_context_id() | mesh context | same, via Device::get_mesh_device()
arch() / is_initialized() | mesh implementations | same for a live unit mesh
id() | unique mesh id | chip id

`build_id()` and context drive the build env, kernel hash, ELF paths, watcher, and inspector. On a unit mesh those match `get_devices()[0]`.

`id()` is only used to key `sub_device_ids_`. Fast dispatch already looks that up with the mesh (`determine_sub_device_ids(mesh_device)`), so passing the mesh is the consistent key. Mixing compile(physical) with later `determine_sub_device_ids(mesh)` (or the reverse) just misses that cache and recomputes.

On a multi-chip mesh, `MeshDevice::build_id()` is always the reference (first) chip. That matches compiling against `get_devices()[0]`. It is not equivalent to compiling against some other chip if harvest masks differ.  
</details>

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-program-legacy-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-program-legacy-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-program-legacy-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-program-legacy-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-program-legacy-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-program-legacy-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-program-legacy-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-program-legacy-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-program-legacy-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-program-legacy-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-program-legacy-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-program-legacy-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-program-legacy-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-program-legacy-api)