### PR TITLE
generate_rank_bindings: fix unconditional throw in --all-solutions path

### DIFF
--- a/tools/scaleout/src/generate_rank_bindings.cpp
+++ b/tools/scaleout/src/generate_rank_bindings.cpp
@@ -979,7 +979,11 @@ int main(int argc, char** argv) {
                     ++emitted;
 
                     std::vector<RankBindingConfig> rank_bindings = extract_rank_bindings(
-                        psd, *solution, mesh_graphs_for_extract, /*per_part_local_to_global_mesh_ids=*/{});
+                        psd,
+                        *solution,
+                        mesh_graphs_for_extract,
+                        /*per_part_local_to_global_mesh_ids=*/{},
+                        /*emit_local_mesh_ids_for_mgd_partition=*/false);
 
                     const std::set<std::string> hosts = solution_host_set(rank_bindings);
                     if (args.distinct_host_sets && !seen_host_sets.insert(hosts).second) {


### PR DESCRIPTION
The streaming enumeration path calls `extract_rank_bindings` with an empty `per_part_local_to_global_mesh_ids` while `emit_local_mesh_ids_for_mgd_partition` keeps its default of `true`:

```cpp
std::vector<RankBindingConfig> rank_bindings = extract_rank_bindings(
    psd, *solution, mesh_graphs_for_extract, /*per_part_local_to_global_mesh_ids=*/{});
```

That trips the guard requiring `per_part_local_to_global_mesh_ids.size() == 1`, so **every `--all-solutions` run throws on its first solution**, independent of topology or cluster size. Still present at the current tip of `ridvan/gen-rank-bindings-all-solutions` (`23a1da8`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/fix-all-solutions-extract-rank-bindings-guard)