### PR TITLE
Prune `tt-metal-l2-nightly`

### DIFF
--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -91,7 +91,7 @@
 
 - name: ttnn nightly experimental tests (blackhole)
   # Host-IOMMU tests are selected by the viommu job below and excluded from these non-IOMMU SKUs.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance" -m "not requires_host_iommu" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not (moe_grouped_topk and in_fp32)" -m "not requires_host_iommu" --timeout=600'
   skus:
     bh_p100:
       timeout: 60

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -79,7 +79,7 @@
 
 - name: ttnn nightly experimental tests (wormhole)
   # test_moe_grouped_topk hangs on Wormhole (TODO: file issue + restore). Exclude on WH only.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_moe_grouped_topk" -m "not requires_host_iommu" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_moe_grouped_topk and not deepseek_prefill_extract and not deepseek_prefill_insert and not x_tile" -m "not requires_host_iommu" --timeout=600'
   skus:
     wh_n150_civ2:
       timeout: 65
@@ -91,7 +91,7 @@
 
 - name: ttnn nightly experimental tests (blackhole)
   # Host-IOMMU tests are selected by the viommu job below and excluded from these non-IOMMU SKUs.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not (moe_grouped_topk and in_fp32)" -m "not requires_host_iommu" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not (moe_grouped_topk and in_fp32) and not deepseek_prefill_extract and not deepseek_prefill_insert and not x_tile and not (per_token_cast and ROW_MAJOR) and not scales_narrow_to_bf16 and not (token_count_aware_cast_back and False)" -m "not requires_host_iommu" --timeout=600'
   skus:
     bh_p100:
       timeout: 60

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -79,7 +79,7 @@
 
 - name: ttnn nightly experimental tests (wormhole)
   # test_moe_grouped_topk hangs on Wormhole (TODO: file issue + restore). Exclude on WH only.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_moe_grouped_topk and not deepseek_prefill_extract and not deepseek_prefill_insert and not x_tile" -m "not requires_host_iommu" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_moe_grouped_topk" -m "not requires_host_iommu" --timeout=600'
   skus:
     wh_n150_civ2:
       timeout: 65
@@ -91,7 +91,7 @@
 
 - name: ttnn nightly experimental tests (blackhole)
   # Host-IOMMU tests are selected by the viommu job below and excluded from these non-IOMMU SKUs.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not (moe_grouped_topk and in_fp32) and not deepseek_prefill_extract and not deepseek_prefill_insert and not x_tile and not (per_token_cast and ROW_MAJOR) and not scales_narrow_to_bf16 and not (token_count_aware_cast_back and False)" -m "not requires_host_iommu" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance" -m "not requires_host_iommu" --timeout=600'
   skus:
     bh_p100:
       timeout: 60

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ci_pruning.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ci_pruning.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collection-time pruning rules for the deepseek_prefill nightly suites.
+
+Every rule lives here so a change to what CI covers is one edit instead of one
+edit per decorator; `conftest.py` owns the `uncollect_if` marker that applies
+them. Predicates only prune in CI - a local run still collects everything.
+"""
+
+import ttnn
+
+
+def _ci_only(pred):
+    """Wrap `pred` so it prunes in CI and is a no-op everywhere else."""
+
+    def uncollect_if(**params):
+        if not (params["is_ci_env"] or params["is_ci_v2_env"]):
+            return False
+        return pred(**params)
+
+    return uncollect_if
+
+
+# Whole module: the op has no production counterpart.
+no_production_counterpart = _ci_only(lambda **params: True)
+
+# Blackhole prefill always hands the cast a tile-layout input.
+bh_row_major_input = _ci_only(lambda **params: params["is_bh"] and params["input_layout"] == ttnn.ROW_MAJOR_LAYOUT)
+
+# Blackhole prefill keeps the scales at fp32.
+bh_narrow_scales_to_bf16 = _ci_only(lambda **params: params["is_bh"] and params["narrow_scales_to_bf16"])
+
+# Blackhole prefill reads the scales back from the packed metadata, never precomputed.
+bh_scales_not_from_metadata = _ci_only(lambda **params: params["is_bh"] and not params["scales_from_metadata"])
+
+# fp32 logits cover the pre-#51009 host-typecast gate contract; production feeds bf16 directly.
+bh_fp32_input = _ci_only(lambda **params: params["is_bh"] and params["input_dtype"] == ttnn.float32)
+
+# The routed expert is always fed a row-major activation in production.
+tiled_x_input = _ci_only(lambda **params: not params["x_row_major"])

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/conftest.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/conftest.py
@@ -12,7 +12,7 @@ def pytest_configure(config):
         "markers",
         "uncollect_if(pred): deselect parametrized cases for which pred(**params) returns True. "
         "pred receives the test's collection-time param values as keyword args, plus "
-        "is_ci_env / is_ci_v2_env / is_bh.",
+        "is_ci_env / is_ci_v2_env / is_bh. Rules live in ci_pruning.py.",
     )
 
 
@@ -21,6 +21,7 @@ def pytest_collection_modifyitems(config, items):
     is_ci_v2_env = "TT_GH_CI_INFRA" in os.environ
     is_bh = is_blackhole()
     kept = []
+    deselected = []
     for item in items:
         marker = item.get_closest_marker("uncollect_if")
         if marker is None:
@@ -30,6 +31,10 @@ def pytest_collection_modifyitems(config, items):
         params.setdefault("is_ci_env", is_ci_env)
         params.setdefault("is_ci_v2_env", is_ci_v2_env)
         params.setdefault("is_bh", is_bh)
-        if not marker.kwargs["pred"](**params):
+        if marker.kwargs["pred"](**params):
+            deselected.append(item)
+        else:
             kept.append(item)
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
     items[:] = kept

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/conftest.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/conftest.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from models.common.utility_functions import is_blackhole
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "uncollect_if(pred): deselect parametrized cases for which pred(**params) returns True. "
+        "pred receives the test's collection-time param values as keyword args, plus "
+        "is_ci_env / is_ci_v2_env / is_bh.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    is_ci_env = os.getenv("CI") == "true"
+    is_ci_v2_env = "TT_GH_CI_INFRA" in os.environ
+    is_bh = is_blackhole()
+    kept = []
+    for item in items:
+        marker = item.get_closest_marker("uncollect_if")
+        if marker is None:
+            kept.append(item)
+            continue
+        params = dict(getattr(getattr(item, "callspec", None), "params", {}))
+        params.setdefault("is_ci_env", is_ci_env)
+        params.setdefault("is_ci_v2_env", is_ci_v2_env)
+        params.setdefault("is_bh", is_bh)
+        if not marker.kwargs["pred"](**params):
+            kept.append(item)
+    items[:] = kept

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
@@ -15,18 +15,10 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
 
-def _ci_unsupported_param_combos(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    return True
-
-
-pytestmark = pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
+pytestmark = pytest.mark.uncollect_if(pred=ci_pruning.no_production_counterpart)
 
 
 GLOBAL_ROWS = 64

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
@@ -17,6 +17,18 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+def _ci_unsupported_param_combos(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    return True
+
+
+pytestmark = pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
+
+
 GLOBAL_ROWS = 64
 HIDDEN_DIM = 128
 NUM_EXPERTS = 8

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
@@ -15,18 +15,10 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
 
-def _ci_unsupported_param_combos(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    return True
-
-
-pytestmark = pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
+pytestmark = pytest.mark.uncollect_if(pred=ci_pruning.no_production_counterpart)
 
 
 GLOBAL_ROWS = 128

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
@@ -17,6 +17,18 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+def _ci_unsupported_param_combos(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    return True
+
+
+pytestmark = pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
+
+
 GLOBAL_ROWS = 128
 HIDDEN_DIM = 64
 LOCAL_ROWS = 64

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -18,6 +18,7 @@ from loguru import logger
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from tests.ttnn.utils_for_testing import comp_pcc, assert_equal
+from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
 pytestmark = pytest.mark.use_module_device
 
@@ -106,20 +107,7 @@ def assert_quality(result, ref, *, pcc_threshold, rtol, atol, label=""):
 # ---------------------------------------------------------------------------
 
 
-def _ci_unsupported_param_combos_cast_to_fp8_scale(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    is_bh = params["is_bh"]
-    input_layout = params["input_layout"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_cast_to_fp8_scale)
+@pytest.mark.uncollect_if(pred=ci_pruning.bh_row_major_input)
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
 def test_cast_to_fp8_scale(device, dtype, input_layout):
@@ -144,20 +132,7 @@ def test_cast_to_fp8_scale(device, dtype, input_layout):
     assert_equal(scale, ref)
 
 
-def _ci_unsupported_param_combos_cast_to_fp8_scale_values(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    is_bh = params["is_bh"]
-    input_layout = params["input_layout"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_cast_to_fp8_scale_values)
+@pytest.mark.uncollect_if(pred=ci_pruning.bh_row_major_input)
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("shape", SHAPES)
@@ -191,20 +166,7 @@ def test_cast_to_fp8_scale_values(device, dtype, shape, input_layout):
     assert_quality(scale, ref, pcc_threshold=0.999, rtol=1e-2, atol=1e-9, label=f"scale {dtype} shape={shape}")
 
 
-def _ci_unsupported_param_combos_power_of_two_scale_for_sparse_kv(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    is_bh = params["is_bh"]
-    input_layout = params["input_layout"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_power_of_two_scale_for_sparse_kv)
+@pytest.mark.uncollect_if(pred=ci_pruning.bh_row_major_input)
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("shape", [(1, 512), (30, 512), (2, 3, 32, 512)])
@@ -284,20 +246,7 @@ def test_cast_to_fp8_power_of_two_scale_e4m3fn_boundary(device):
 # ---------------------------------------------------------------------------
 
 
-def _ci_unsupported_param_combos_cast_back_dequant(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    is_bh = params["is_bh"]
-    narrow_scales_to_bf16 = params["narrow_scales_to_bf16"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if is_bh and narrow_scales_to_bf16:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_cast_back_dequant)
+@pytest.mark.uncollect_if(pred=ci_pruning.bh_narrow_scales_to_bf16)
 @pytest.mark.parametrize("narrow_scales_to_bf16", [False, True], ids=["scales_kept_at_fp32", "scales_narrow_to_bf16"])
 @pytest.mark.parametrize("out_dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("shape", SHAPES)
@@ -353,20 +302,7 @@ def test_cast_back_dequant(device, out_dtype, shape, narrow_scales_to_bf16):
 # ---------------------------------------------------------------------------
 
 
-def _ci_unsupported_param_combos_round_trip_random(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    is_bh = params["is_bh"]
-    input_layout = params["input_layout"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_round_trip_random)
+@pytest.mark.uncollect_if(pred=ci_pruning.bh_row_major_input)
 # Output layout is always ROW_MAJOR.
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
@@ -437,20 +373,7 @@ def _pack_scale_metadata(input_scale):
     return meta
 
 
-def _ci_unsupported_param_combos_token_count_aware_cast_back(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    is_bh = params["is_bh"]
-    scales_from_metadata = params["scales_from_metadata"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if is_bh and not scales_from_metadata:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_token_count_aware_cast_back)
+@pytest.mark.uncollect_if(pred=ci_pruning.bh_scales_not_from_metadata)
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("scales_from_metadata", [False, True])
 @pytest.mark.parametrize("label, counts", TOKEN_COUNT_AWARE_CASES, ids=[c[0] for c in TOKEN_COUNT_AWARE_CASES])

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -106,6 +106,20 @@ def assert_quality(result, ref, *, pcc_threshold, rtol, atol, label=""):
 # ---------------------------------------------------------------------------
 
 
+def _ci_unsupported_param_combos_cast_to_fp8_scale(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    is_bh = params["is_bh"]
+    input_layout = params["input_layout"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_cast_to_fp8_scale)
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
 def test_cast_to_fp8_scale(device, dtype, input_layout):
@@ -130,6 +144,20 @@ def test_cast_to_fp8_scale(device, dtype, input_layout):
     assert_equal(scale, ref)
 
 
+def _ci_unsupported_param_combos_cast_to_fp8_scale_values(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    is_bh = params["is_bh"]
+    input_layout = params["input_layout"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_cast_to_fp8_scale_values)
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("shape", SHAPES)
@@ -163,6 +191,20 @@ def test_cast_to_fp8_scale_values(device, dtype, shape, input_layout):
     assert_quality(scale, ref, pcc_threshold=0.999, rtol=1e-2, atol=1e-9, label=f"scale {dtype} shape={shape}")
 
 
+def _ci_unsupported_param_combos_power_of_two_scale_for_sparse_kv(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    is_bh = params["is_bh"]
+    input_layout = params["input_layout"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_power_of_two_scale_for_sparse_kv)
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("shape", [(1, 512), (30, 512), (2, 3, 32, 512)])
@@ -242,6 +284,20 @@ def test_cast_to_fp8_power_of_two_scale_e4m3fn_boundary(device):
 # ---------------------------------------------------------------------------
 
 
+def _ci_unsupported_param_combos_cast_back_dequant(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    is_bh = params["is_bh"]
+    narrow_scales_to_bf16 = params["narrow_scales_to_bf16"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if is_bh and narrow_scales_to_bf16:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_cast_back_dequant)
 @pytest.mark.parametrize("narrow_scales_to_bf16", [False, True], ids=["scales_kept_at_fp32", "scales_narrow_to_bf16"])
 @pytest.mark.parametrize("out_dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("shape", SHAPES)
@@ -297,6 +353,20 @@ def test_cast_back_dequant(device, out_dtype, shape, narrow_scales_to_bf16):
 # ---------------------------------------------------------------------------
 
 
+def _ci_unsupported_param_combos_round_trip_random(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    is_bh = params["is_bh"]
+    input_layout = params["input_layout"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if is_bh and input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_round_trip_random)
 # Output layout is always ROW_MAJOR.
 @pytest.mark.parametrize("input_layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
@@ -367,6 +437,20 @@ def _pack_scale_metadata(input_scale):
     return meta
 
 
+def _ci_unsupported_param_combos_token_count_aware_cast_back(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    is_bh = params["is_bh"]
+    scales_from_metadata = params["scales_from_metadata"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if is_bh and not scales_from_metadata:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_token_count_aware_cast_back)
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("scales_from_metadata", [False, True])
 @pytest.mark.parametrize("label, counts", TOKEN_COUNT_AWARE_CASES, ids=[c[0] for c in TOKEN_COUNT_AWARE_CASES])

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
@@ -45,6 +45,20 @@ SCORE_FUNCS = ["sigmoid", "sqrtsoftplus"]
 INPUT_DTYPES = [ttnn.float32, ttnn.bfloat16]
 INPUT_DTYPE_IDS = ["in_fp32", "in_bf16"]
 
+
+def _ci_unsupported_param_combos_moe_grouped_topk(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    is_bh = params["is_bh"]
+    input_dtype = params["input_dtype"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if is_bh and input_dtype == ttnn.float32:
+        return True
+    return False
+
+
 # Selected-weight PCC thresholds
 WEIGHTS_PCC_THRESHOLD_FP32 = 0.96
 WEIGHTS_PCC_THRESHOLD_BF16 = 0.85
@@ -52,6 +66,7 @@ WEIGHTS_PCC_THRESHOLD_BF16 = 0.85
 BIASED_PCC_THRESHOLD = 0.999
 
 
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_moe_grouped_topk)
 @pytest.mark.parametrize("input_dtype", INPUT_DTYPES, ids=INPUT_DTYPE_IDS)
 @pytest.mark.parametrize("score_func", SCORE_FUNCS)
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
@@ -22,6 +22,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     grouped_gate_golden_act,
     score_activation,
 )
+from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
 
 TEST_PARAMS = [(1, 1, 1), (1, 1, 33), (1, 1, 128), (1, 1, 3200)]
@@ -46,19 +47,6 @@ INPUT_DTYPES = [ttnn.float32, ttnn.bfloat16]
 INPUT_DTYPE_IDS = ["in_fp32", "in_bf16"]
 
 
-def _ci_unsupported_param_combos_moe_grouped_topk(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    is_bh = params["is_bh"]
-    input_dtype = params["input_dtype"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if is_bh and input_dtype == ttnn.float32:
-        return True
-    return False
-
-
 # Selected-weight PCC thresholds
 WEIGHTS_PCC_THRESHOLD_FP32 = 0.96
 WEIGHTS_PCC_THRESHOLD_BF16 = 0.85
@@ -66,7 +54,7 @@ WEIGHTS_PCC_THRESHOLD_BF16 = 0.85
 BIASED_PCC_THRESHOLD = 0.999
 
 
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_moe_grouped_topk)
+@pytest.mark.uncollect_if(pred=ci_pruning.bh_fp32_input)
 @pytest.mark.parametrize("input_dtype", INPUT_DTYPES, ids=INPUT_DTYPE_IDS)
 @pytest.mark.parametrize("score_func", SCORE_FUNCS)
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -26,6 +26,7 @@ from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM2
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SILU, ACTIVATION_SITU, TorchExpert
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from tests.ttnn.utils_for_testing import comp_pcc
+from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
 
 SINGLE_CHIP_MESH_PARAMS = [
@@ -306,19 +307,7 @@ def _isl_params(active_sweep, only_models=None):
     return params
 
 
-def _ci_unsupported_param_combos_functional(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    x_row_major = params["x_row_major"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if x_row_major is False:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_functional)
+@pytest.mark.uncollect_if(pred=ci_pruning.tiled_x_input)
 @pytest.mark.parametrize("allocated_tokens, active_tokens, emb_dim, hidden_dim", _isl_params(_ISL_FUNCTIONAL_SWEEP))
 @pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
 def test_single_routed_expert_functional(
@@ -339,19 +328,7 @@ def test_single_routed_expert_functional(
     )
 
 
-def _ci_unsupported_param_combos_isl_sweep(**params):
-    is_ci_env = params["is_ci_env"]
-    is_ci_v2_env = params["is_ci_v2_env"]
-    x_row_major = params["x_row_major"]
-
-    if not (is_ci_env or is_ci_v2_env):
-        return False
-    if x_row_major is False:
-        return True
-    return False
-
-
-@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_isl_sweep)
+@pytest.mark.uncollect_if(pred=ci_pruning.tiled_x_input)
 @pytest.mark.parametrize(
     "allocated_tokens, active_tokens, emb_dim, hidden_dim",
     _isl_params(_ISL_EXHAUSTIVE_SWEEP, only_models=_ISL_EXHAUSTIVE_MODELS),

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -306,6 +306,19 @@ def _isl_params(active_sweep, only_models=None):
     return params
 
 
+def _ci_unsupported_param_combos_functional(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    x_row_major = params["x_row_major"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if x_row_major is False:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_functional)
 @pytest.mark.parametrize("allocated_tokens, active_tokens, emb_dim, hidden_dim", _isl_params(_ISL_FUNCTIONAL_SWEEP))
 @pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
 def test_single_routed_expert_functional(
@@ -326,6 +339,19 @@ def test_single_routed_expert_functional(
     )
 
 
+def _ci_unsupported_param_combos_isl_sweep(**params):
+    is_ci_env = params["is_ci_env"]
+    is_ci_v2_env = params["is_ci_v2_env"]
+    x_row_major = params["x_row_major"]
+
+    if not (is_ci_env or is_ci_v2_env):
+        return False
+    if x_row_major is False:
+        return True
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos_isl_sweep)
 @pytest.mark.parametrize(
     "allocated_tokens, active_tokens, emb_dim, hidden_dim",
     _isl_params(_ISL_EXHAUSTIVE_SWEEP, only_models=_ISL_EXHAUSTIVE_MODELS),


### PR DESCRIPTION
### Issues
https://github.com/tenstorrent/tt-metal/issues/53390

### PR Category
CI test pruning

### Summary
Drops `deepseek_prefill` nightly cases that exercise configurations production never runs. The filtering is done in Python at collection time, so the cases are *uncollected* rather than skipped, and `tests/pipeline_reorg/ops_unit_tests.yaml` keeps its baseline `-k` filters instead of growing a long deselect expression.

**≈55 min of L2-nightly wall clock saved: 3:02:15 → 2:07:42 (−29.9%)** across the seven `ttnn nightly experimental` jobs — or **−23.2% (≈34 min)** on the conservative read that drops the one noisy SKU. Collected tests fall 534 → 302 on both Blackhole SKUs. Per-job breakdown, run links and caveats under **Runtime impact** below.

**What is dropped — in CI only; a local run still collects everything:**

| Suite | Dropped | Rationale |
| --- | --- | --- |
| `test_deepseek_prefill_insert.py` | whole suite | op has no production counterpart |
| `test_deepseek_prefill_extract.py` | whole suite | op has no production counterpart |
| `test_single_routed_expert.py` | `x_tile` in both ISL sweeps | the routed expert is always fed a row-major activation |
| `test_moe_grouped_topk.py` | `in_fp32`, Blackhole | fp32 logits cover the pre-#51009 host-typecast gate contract; production feeds bf16 directly |
| `test_deepseek_prefill_per_token_cast.py` | `ROW_MAJOR_LAYOUT` input, Blackhole (4 test functions) | BH prefill always casts a tile-layout input |
| `test_deepseek_prefill_per_token_cast.py` | `scales_narrow_to_bf16`, Blackhole | BH keeps the scales at fp32 |
| `test_deepseek_prefill_per_token_cast.py` | precomputed scales, Blackhole | BH reads the scales back from the packed metadata |

**How it works — two new files, both under the `deepseek_prefill` test directory:**

- `conftest.py` — registers and applies an `uncollect_if(pred=...)` marker in `pytest_collection_modifyitems`. The predicate receives the case's collection-time params plus `is_ci_env` / `is_ci_v2_env` / `is_bh`; dropped items are reported through `pytest_deselected`. Same marker contract as `models/demos/deepseek_v3_d_p/tests/conftest.py`.
- `ci_pruning.py` — the six pruning rules, each defined once and shared by every decorator that needs it.

**Resulting counts in the `ttnn nightly experimental` job:**

| SKU | before | after |
| --- | --- | --- |
| `wh_n150_civ2` | 265 | 161 |
| `wh_n300_civ2` | 131 | 91 |
| `bh_p100` | 534 | 302 |
| `bh_p150b_civ2` | 534 | 302 |

Per-test before/after listing: https://claude.ai/code/artifact/92a0f490-0b04-4535-85c7-878e380aefff

### Runtime impact

**≈55 min saved across the seven `ttnn nightly experimental` jobs: 3:02:15 → 2:07:42 (−29.9%)**, matching the collected-count reduction above.

Job wall clock (includes per-job setup, unlike the test-step figures used in #53530 / #54314):

| Job | Before (avg of 2) | After | Delta |
| --- | ---: | ---: | ---: |
| `experimental (wormhole) [wh_n150_civ2]` | 48:38 | 37:30 | −22.9% |
| `experimental (wormhole) [wh_n300_civ2]` | 45:16 | 30:20 | −33.0% |
| `experimental (blackhole) [bh_p100]` | 37:11 | 16:16 | −56.3% |
| `experimental (blackhole) [bh_p150b_civ2]` | 36:14 | 28:27 | −21.5% |
| `experimental (blackhole - viommu)` | 5:21 | 5:33 | +3.6% |
| `generalized MoE gate op [wh_n150_civ2]` | 5:10 | 5:02 | −2.7% |
| `generalized MoE gate op [bh_p150b_civ2]` | 4:23 | 4:34 | +4.2% |
| **Total** | **3:02:15** | **2:07:42** | **−29.9%** |

Before: main runs [32944286374](https://github.com/tenstorrent/tt-metal/actions/runs/32944286374) (`3900b5ea463`) and [32722618739](https://github.com/tenstorrent/tt-metal/actions/runs/32722618739) (`298d4ef6798`), both verified to predate the merge commit `ee660b0ccd6`.
After: [32954712849](https://github.com/tenstorrent/tt-metal/actions/runs/32954712849), this branch's own dispatch.

Two caveats on those numbers:

- **The "after" is the branch run, not post-merge main.** The `experimental` category is not in every scheduled nightly: of the eight most recent main runs, it executed in four — all of them *before* the merge — and in none of the three since. So a main-to-main comparison is not yet possible, and the pruning only pays off on nightlies that actually select this category.
- **`bh_p100` is noisy and carries the largest delta.** Its two pre-merge samples were 21:19 and 53:04 — a 2.5× spread — so the −56.3% on that row is not trustworthy on its own. Excluding it, the remaining six jobs give **2:25:04 → 1:51:26, −23.2%** (≈34 min), which is the conservative read.

The collected-count reduction in the table above is the stronger evidence: it is deterministic, independent of machine load, and shows 534 → 302 on both Blackhole SKUs.

### Validation
`tt-metal-l2-nightly` dispatched on this branch with `additional_test_categories=experimental` (both archs, all other categories off), which runs the `ttnn nightly experimental` entries that own these suites: https://github.com/tenstorrent/tt-metal/actions/runs/32954712849

### Notes for reviewers
The pruning rules are the reviewable part — every entry in the table above is a claim that the configuration is not used in production. Predicate selection was verified on Blackhole to be id-identical to the equivalent `-k` selection.

