### PR TITLE
[Quasar] Migrate sub_bcast_col unpack onto the BFD allocator

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -12,7 +12,10 @@
  * LLK UNPACK AB SUB BCAST COL CUSTOM - SDPA specialized blocked sub path
  *************************************************************************/
 
-inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
+// operandB is accepted for cross-arch API parity (Quasar programs a SrcB buffer descriptor at init);
+// on Blackhole the SrcB descriptor is not programmed here, so it is unused.
+inline void llk_unpack_AB_sub_bcast_col_init_custom(
+    const std::uint32_t operandA, [[maybe_unused]] const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
     _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_common_api.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
@@ -17,20 +18,32 @@
 /**
  * @brief Init the unpacker for the SDPA blocked bcast-col SUB path.
  *
+ * Allocates and programs a buffer descriptor for each unpacker from the per-TRISC BFD partition
+ * (operandA -> UNPACKER0 -> SrcA, operandB -> UNPACKER1 -> SrcB); the DFB ids are used only to fetch
+ * buffer info, never as BFD ids. One init burns two unpack-partition ids, so the standard wrap
+ * contract applies: re-init before every re-execute.
+ *
  * @param operandA: DFB id of srcA; its tile shape is validated (32x32 or 16x32 tiles).
+ * @param operandB: DFB id of srcB (the reused bcast-col operand).
  * @note Run before @ref llk_unpack_AB_sub_bcast_col_custom on this thread.
  */
-inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
+inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
+
+    llk_unpack_program_bfd<ckernel::trisc::BfdResource::Unp0>(operandA_id);
+    llk_unpack_program_bfd<ckernel::trisc::BfdResource::Unp1>(operandB_id);
+
     _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
 }
 
 /**
  * @brief SDPA blocked bcast-col unpack: one reused SrcB tile + ct_dim SrcA tiles.
  *
- * operand_id doubles as the buffer-descriptor id (operandA -> UNPACKER0 -> SrcA,
- * operandB -> UNPACKER1 -> SrcB); L1 tile indices are derived from the operand's dataflow buffer.
+ * The buffer descriptors come from the allocator (programmed in the matching init: operandA ->
+ * UNPACKER0 -> SrcA, operandB -> UNPACKER1 -> SrcB); the DFB ids here only drive the L1 tile-index
+ * math off the operand's dataflow buffer.
  *
  * @param operandA: DFB id of srcA (the block of ct_dim column tiles).
  * @param operandB: DFB id of srcB (the single bcast-col tile, reused).
@@ -56,5 +69,11 @@ inline void llk_unpack_AB_sub_bcast_col_custom(
     const std::uint32_t l1_tile_idx_b =
         local_dfb_interface_b.tc_slots[local_dfb_interface_b.tc_idx].rd_entry_idx + tile_index_b;
 
-    _llk_unpack_AB_sub_bcast_col_custom_(operandA_id, operandB_id, l1_tile_idx_a, l1_tile_idx_b, ct_dim, tensor_shape);
+    _llk_unpack_AB_sub_bcast_col_custom_(
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+        l1_tile_idx_a,
+        l1_tile_idx_b,
+        ct_dim,
+        tensor_shape);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/experimental/llk_unpack_AB_sub_bcast_col_custom_api.h
@@ -12,7 +12,10 @@
  * LLK UNPACK AB SUB BCAST COL CUSTOM - SDPA specialized blocked sub path
  *************************************************************************/
 
-inline void llk_unpack_AB_sub_bcast_col_init_custom(const std::uint32_t operandA) {
+// operandB is accepted for cross-arch API parity (Quasar programs a SrcB buffer descriptor at init);
+// on Wormhole the SrcB descriptor is not programmed here, so it is unused.
+inline void llk_unpack_AB_sub_bcast_col_init_custom(
+    const std::uint32_t operandA, [[maybe_unused]] const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
     _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);

--- a/tt_metal/hw/inc/api/compute/experimental/indexer_mul_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/indexer_mul_custom.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common.h"
 
 // Blackhole-only: the math LLK lives only in the Blackhole llk_lib and indexer_score is a BH op.
@@ -25,15 +26,21 @@ namespace ckernel {
 // head h, so cb_qk must be head-major). Reuses the SDPA blocked-sub unpack (op-agnostic). Pair with
 // mul_bcast_cols_init_short_custom.
 
-ALWI void mul_bcast_cols_init_short_custom(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
+ALWI void mul_bcast_cols_init_short_custom(
+    std::uint32_t icb0, std::uint32_t icb1, std::uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1, call_line);
     MATH((llk_math_eltwise_binary_mul_bcast_cols_init_custom(icb0, icb1)));
-    UNPACK((llk_unpack_AB_sub_bcast_col_init_custom(icb0)));
+    UNPACK((llk_unpack_AB_sub_bcast_col_init_custom(icb0, icb1)));
 }
 
 // itile0 = base SrcA (qk) tile of head h's column run (ct_dim consecutive tiles); itile1 = w[h].
 ALWI void mul_tiles_bcast_cols_custom(
-    uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t ct_dim) {
+    std::uint32_t icb0,
+    std::uint32_t icb1,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst,
+    std::uint32_t ct_dim) {
     MATH((llk_math_eltwise_binary_mul_bcast_cols_custom(idst, ct_dim)));
     UNPACK((llk_unpack_AB_sub_bcast_col_custom(icb0, icb1, itile0, itile1, ct_dim)));
 }

--- a/tt_metal/hw/inc/api/compute/experimental/sdpa_sub_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/sdpa_sub_custom.h
@@ -25,7 +25,7 @@ ALWI void sub_bcast_cols_init_short_custom(
     std::uint32_t icb0, std::uint32_t icb1, std::uint32_t ct_dim, std::uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1, call_line);
     MATH((llk_math_eltwise_binary_sub_bcast_cols_init_custom<MATH_FIDELITY>(icb0, icb1)));
-    UNPACK((llk_unpack_AB_sub_bcast_col_init_custom(icb0)));
+    UNPACK((llk_unpack_AB_sub_bcast_col_init_custom(icb0, icb1)));
 }
 
 ALWI void sub_tiles_bcast_cols_custom(


### PR DESCRIPTION
The SDPA blocked bcast-col SUB metal wrapper was the last caller still using the pre-#52762 coupling where the DFB operand id doubled as the buffer-descriptor id. Allocate and program the SrcA (Unp0) and SrcB (Unp1) buffer descriptors at init via llk_unpack_program_bfd, then read them back with bfd_current at execute, matching the reduce/matmul unpack paths.

The Quasar metal init now takes (operandA, operandB); the shared compute-API shims (sdpa_sub_custom.h, indexer_mul_custom.h) forward icb1, and the Blackhole/Wormhole wrappers accept operandB as a parity [[maybe_unused]] param (no allocator on those arches, behavior unchanged).

Verified: unit_tests_llk ComputeSubBcastColCustom PASSES on 1x3 Quasar emulation, all cases including the 16x32 tiny-tile shapes.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-sub-bcast-col-bfd-alloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/quasar-sub-bcast-col-bfd-alloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-sub-bcast-col-bfd-alloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/quasar-sub-bcast-col-bfd-alloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/quasar-sub-bcast-col-bfd-alloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/quasar-sub-bcast-col-bfd-alloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/quasar-sub-bcast-col-bfd-alloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/quasar-sub-bcast-col-bfd-alloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/quasar-sub-bcast-col-bfd-alloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/quasar-sub-bcast-col-bfd-alloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/quasar-sub-bcast-col-bfd-alloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/quasar-sub-bcast-col-bfd-alloc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/quasar-sub-bcast-col-bfd-alloc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/quasar-sub-bcast-col-bfd-alloc)