### PR TITLE
Runtime: Run TensixTestRandomizedProgram in package-and-release

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -237,6 +237,8 @@ runtime:
     wh_n150_civ2: 13
     bh_p150b_civ2: 13
     bh_loudbox: 5
+    wh_n150: 10
+    bh_p150: 10
     sim_wh_n150: 30
     sim_bh_p150: 30
     sim_wh_galaxy: 10

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -123,6 +123,18 @@ jobs:
       tier: "1"
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
 
+  # Release SKUs (wh_n150, bh_p150), not CI _civ2. Gated like release-demo-tests.
+  runtime-sanity-tests:
+    needs: [build-artifact]
+    if: ${{ inputs.tag-version != '' }}
+    secrets: inherit
+    uses: ./.github/workflows/runtime-sanity-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enabled-skus: wh_n150,bh_p150
+
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
   # expected-jobs is the union of single-host and exabox multihost legs so a
   # missing ai_job_summary artifact is reconciled as INFRA_FAILURE.

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -123,10 +123,12 @@ jobs:
       tier: "1"
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
 
-  # Release SKUs (wh_n150, bh_p150), not CI _civ2. Gated like release-demo-tests.
   runtime-sanity-tests:
     needs: [build-artifact]
     if: ${{ inputs.tag-version != '' }}
+    permissions:
+      contents: read
+      packages: read
     secrets: inherit
     uses: ./.github/workflows/runtime-sanity-tests-impl.yaml
     with:

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -26,6 +26,19 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
+# '*RandomProgram*' does not match TensixTestRandomizedProgram. Release SKUs
+# (wh_n150, bh_p150) are distinct from CI _civ2 SKUs so this leg only runs
+# when a caller enables them.
+- name: runtime_release_sanity_dispatch
+  cmd: TT_METAL_SEED=0 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='UnitMeshCQProgramFixture.TensixTestRandomizedProgram'
+  skus:
+    wh_n150:
+      timeout: 10
+    bh_p150:
+      timeout: 10
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
 # --- Device: init, cluster API, mock API (excluding NIGHTLY) ---
 - name: runtime_sanity_device
   cmd: ./build/test/tt_metal/unit_tests_device --gtest_filter='*:-*NIGHTLY*'

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -26,9 +26,7 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# '*RandomProgram*' does not match TensixTestRandomizedProgram. Release SKUs
-# (wh_n150, bh_p150) are distinct from CI _civ2 SKUs so this leg only runs
-# when a caller enables them.
+# --- Dispatch: randomized tensix programs (package-and-release health check) ---
 - name: runtime_release_sanity_dispatch
   cmd: TT_METAL_SEED=0 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='UnitMeshCQProgramFixture.TensixTestRandomizedProgram'
   skus:


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Today the only on-device coverage in package-and-release is the tier-1 model demos (models-owned) and the docker image smoke test, which is an `import ttnn` plus a single eltwise add on N150/N300. There is no runtime-owned test and nothing that exercises dispatch directly, so a dispatch or compile regression can ship without the pipeline noticing.

This adds a runtime sanity leg running `UnitMeshCQProgramFixture.TensixTestRandomizedProgram`: 100 randomized workloads with brisc + ncrisc + trisc kernels, so it covers compute rather than just data movement. This improves Runtime coverage and to check its state. 

### Notes for reviewers
- This needs its own entry in `runtime_sanity_tests.yaml`. The existing `runtime_sanity_dispatch` filter is `*RandomProgram*`, which does not match `TensixTestRandomizedProgram`.
- Uses the single-CQ fixture so the leg behaves the same on WH and BH. The multi-CQ fixture of the same name needs `TT_METAL_GTEST_NUM_HW_CQS=2` and skips on Blackhole.
- SKUs are `wh_n150` / `bh_p150`, which are the release SKUs, not the CI `_civ2` ones. The nightly runtime sanity and post-commit sanity matrices are unchanged; I confirmed this by running `prepare_test_matrix.py` for both SKU sets.
- `TT_METAL_SEED=0` is set explicitly. It is already the default, but pinning it keeps the release gate deterministic if that default ever changes.
- 10 min timeout, with matching `wh_n150` / `bh_p150` budgets added under `runtime -> sanity` in `time_budget.yaml` (`verify_time_budget.py` hard-fails on an unbudgeted SKU).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/release-runtime-sanity-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/release-runtime-sanity-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/release-runtime-sanity-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/release-runtime-sanity-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/release-runtime-sanity-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/release-runtime-sanity-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/release-runtime-sanity-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/release-runtime-sanity-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/release-runtime-sanity-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/release-runtime-sanity-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/release-runtime-sanity-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/release-runtime-sanity-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/release-runtime-sanity-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/release-runtime-sanity-dispatch)