### PR TITLE
[Do not merge] cross-arch re-verification scaffold for #53399 (untilize codegen L1 budgeting, a2cb3b0c)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -3009,3 +3009,75 @@ def test_pc_untilize_codegen(device, tensor_shape):
             base_count = device.cache_entries_counter.total
         else:
             assert device.cache_entries_counter.total == base_count, "program cache entries differ on same configs"
+
+
+def test_untilize_codegen_with_resident_l1_buffers(device):
+    """Regression: the codegen CB plan must be budgeted against LIVE L1 occupancy.
+
+    Statically allocated CBs grow upward from the allocator's base L1 address while L1 tensors are
+    allocated downward from the top of L1, so the space actually available to a program's CBs is
+    lowest_occupied_compute_l1_address() - base, not the whole of L1. The codegen path originally
+    planned against the whole of L1, which is only correct on an otherwise-idle device; with a
+    model's weights/trace buffers resident in L1 it planned a CB region that overlapped them and
+    ProgramImpl::validate_circular_buffer_region() aborted the run with
+
+        Statically allocated circular buffers in program N clash with L1 buffers on core range ...
+
+    rather than degrading to a shallower CB plan (or falling back to native). Seen end-to-end on
+    Gemma-3-4B in trace mode; reproduced here at the op level by pinning a persistent interleaved
+    L1 tensor before untilizing.
+    """
+    torch.manual_seed(42)
+
+    TILE_BYTES = 2048  # bfloat16 tile
+    info = ttnn._ttnn.reports.get_device_info(device)
+
+    # Wt wide enough that the whole-of-L1 budget selects a double-buffered CB plan, but still
+    # inside the gate's wide-chunk threshold (2 * Wt * 2048 <= 800_000 => Wt <= 195). Two tile
+    # rows keep this on the row-parallel writer, whose CB plan is sized by Wt.
+    wt = 192
+    height_tiles = 2
+    single_buffer_bytes = 2 * wt * TILE_BYTES  # cb_in + cb_out, one slot each
+    double_in_bytes = 3 * wt * TILE_BYTES  # 2x cb_in + 1x cb_out
+
+    # cb_limit is exactly the whole-of-L1 budget the buggy plan used: worker L1 minus the base.
+    if info.cb_limit < double_in_bytes:
+        pytest.skip(f"needs at least {double_in_bytes} B of CB space, device offers {info.cb_limit} B")
+
+    # Leave a headroom window that fits the single-buffer plan but NOT the double-buffered one, so
+    # the only non-clashing plan is unambiguous and an unbudgeted build provably overruns it.
+    headroom_target = single_buffer_bytes + 64 * 1024
+    tiles_per_bank = (info.cb_limit - headroom_target) // TILE_BYTES
+    if tiles_per_bank <= 0:
+        pytest.skip("device L1 is too small to leave a meaningful headroom window")
+
+    # Built before the L1 reservation so that any device-side tilize in from_torch runs with the
+    # usual amount of L1 available; only the untilize under test should see the pressure.
+    # untilize only relayouts values, so the input is its own golden.
+    input_torch_tensor = torch.randn([1, 1, 32 * height_tiles, 32 * wt], dtype=torch.bfloat16)
+    input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Interleaved L1 spreads pages round-robin over every bank, so tiles_per_bank tiles per bank
+    # pushes the lowest occupied L1 address down on all of them. Allocated directly on device: the
+    # contents are irrelevant, only the occupancy matters.
+    resident = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32 * tiles_per_bank, 32 * info.l1_num_banks]),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        device,
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+    )
+    try:
+        # Guard against a vacuous pass: if the reservation did not land where intended there is no
+        # L1 pressure left to regress against.
+        actual_headroom = resident.buffer_address() - info.address_at_first_l1_cb_buffer
+        assert single_buffer_bytes <= actual_headroom < double_in_bytes, (
+            f"resident L1 buffer left {actual_headroom} B above the CB base; the test needs it in "
+            f"[{single_buffer_bytes}, {double_in_bytes}) so that only the single-buffer CB plan fits"
+        )
+
+        output = ttnn.untilize(input_ttnn_tensor)
+
+        assert_equal(input_torch_tensor, ttnn.to_torch(output))
+    finally:
+        ttnn.deallocate(resident)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -3011,8 +3011,9 @@ def test_pc_untilize_codegen(device, tensor_shape):
             assert device.cache_entries_counter.total == base_count, "program cache entries differ on same configs"
 
 
+@pytest.mark.parametrize("warmup", [False, True], ids=["cold", "warmup_then_constrain"])
 @pytest.mark.parametrize("headroom_regime", ["shallower_cb_plan", "no_cb_plan_fits"])
-def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime):
+def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime, warmup):
     """Regression: the codegen CB plan must be budgeted against LIVE L1 occupancy.
 
     Statically allocated CBs grow upward from the allocator's base L1 address while L1 tensors are
@@ -3034,9 +3035,11 @@ def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime):
       - no_cb_plan_fits: not even the single-buffered codegen plan fits, so the program factory
         must build the native-equivalent program instead of failing.
 
-    This asserts only on the result, never on which implementation served it: the choice is made
-    inside the program factory (once per program-cache miss, against one L1 snapshot) precisely so
-    that no observer outside it -- including this test -- has to reason about live L1 state.
+    This asserts only on the result, never on which implementation served it.
+
+    warmup=True first untilizes with free L1 (caches a roomier plan), deallocates that
+    output, then constrains L1. The CB-tier / Native-block-split is in the program-cache
+    key, so the second call must miss and rebuild rather than clash.
     """
     torch.manual_seed(42)
 
@@ -3078,6 +3081,11 @@ def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime):
     # untilize only relayouts values, so the input is its own golden.
     input_torch_tensor = torch.randn([1, 1, 32 * height_tiles, 32 * wt], dtype=torch.bfloat16)
     input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    if warmup:
+        warmup_output = ttnn.untilize(input_ttnn_tensor)
+        assert_equal(input_torch_tensor, ttnn.to_torch(warmup_output))
+        ttnn.deallocate(warmup_output)
 
     # Interleaved L1 spreads pages round-robin over every bank, so tiles_per_bank tiles per bank
     # pushes the lowest occupied L1 address down on all of them. Allocated directly on device: the

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -3011,7 +3011,8 @@ def test_pc_untilize_codegen(device, tensor_shape):
             assert device.cache_entries_counter.total == base_count, "program cache entries differ on same configs"
 
 
-def test_untilize_codegen_with_resident_l1_buffers(device):
+@pytest.mark.parametrize("headroom_regime", ["shallower_cb_plan", "no_cb_plan_fits"])
+def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime):
     """Regression: the codegen CB plan must be budgeted against LIVE L1 occupancy.
 
     Statically allocated CBs grow upward from the allocator's base L1 address while L1 tensors are
@@ -3026,6 +3027,16 @@ def test_untilize_codegen_with_resident_l1_buffers(device):
     rather than degrading to a shallower CB plan (or falling back to native). Seen end-to-end on
     Gemma-3-4B in trace mode; reproduced here at the op level by pinning a persistent interleaved
     L1 tensor before untilizing.
+
+    Two regimes, both of which must simply produce the right answer:
+      - shallower_cb_plan: enough headroom for the single-buffered codegen plan but not the
+        double-buffered one, so the program factory must degrade the tier it picks.
+      - no_cb_plan_fits: not even the single-buffered codegen plan fits, so the program factory
+        must build the native-equivalent program instead of failing.
+
+    This asserts only on the result, never on which implementation served it: the choice is made
+    inside the program factory (once per program-cache miss, against one L1 snapshot) precisely so
+    that no observer outside it -- including this test -- has to reason about live L1 state.
     """
     torch.manual_seed(42)
 
@@ -3044,9 +3055,20 @@ def test_untilize_codegen_with_resident_l1_buffers(device):
     if info.cb_limit < double_in_bytes:
         pytest.skip(f"needs at least {double_in_bytes} B of CB space, device offers {info.cb_limit} B")
 
-    # Leave a headroom window that fits the single-buffer plan but NOT the double-buffered one, so
-    # the only non-clashing plan is unambiguous and an unbudgeted build provably overruns it.
-    headroom_target = single_buffer_bytes + 64 * 1024
+    if headroom_regime == "shallower_cb_plan":
+        # A headroom window that fits the single-buffer plan but NOT the double-buffered one, so
+        # the only non-clashing codegen plan is unambiguous and an unbudgeted build provably
+        # overruns it.
+        headroom_target = single_buffer_bytes + 64 * 1024
+        expected_headroom = (single_buffer_bytes, double_in_bytes)
+    else:
+        # Below every codegen tier, so the factory has to hand off to native. Still generous
+        # enough for native's own blocked CBs, which it sizes against the same live L1 space.
+        headroom_target = 256 * 1024
+        if headroom_target >= single_buffer_bytes:
+            pytest.skip("device L1 headroom cannot be driven below the smallest codegen CB plan")
+        expected_headroom = (0, single_buffer_bytes)
+
     tiles_per_bank = (info.cb_limit - headroom_target) // TILE_BYTES
     if tiles_per_bank <= 0:
         pytest.skip("device L1 is too small to leave a meaningful headroom window")
@@ -3071,9 +3093,10 @@ def test_untilize_codegen_with_resident_l1_buffers(device):
         # Guard against a vacuous pass: if the reservation did not land where intended there is no
         # L1 pressure left to regress against.
         actual_headroom = resident.buffer_address() - info.address_at_first_l1_cb_buffer
-        assert single_buffer_bytes <= actual_headroom < double_in_bytes, (
-            f"resident L1 buffer left {actual_headroom} B above the CB base; the test needs it in "
-            f"[{single_buffer_bytes}, {double_in_bytes}) so that only the single-buffer CB plan fits"
+        low, high = expected_headroom
+        assert low <= actual_headroom < high, (
+            f"resident L1 buffer left {actual_headroom} B above the CB base; the {headroom_regime} "
+            f"regime needs it in [{low}, {high})"
         )
 
         output = ttnn.untilize(input_ttnn_tensor)

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -8,8 +8,14 @@
 
 #pragma once
 
-#include "ttnn/tensor/types.hpp"
+#include <cmath>
+#include <optional>
+#include <set>
+
+#include <tt_stl/assert.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/math.hpp>
+#include "ttnn/tensor/types.hpp"
 
 namespace ttnn {
 
@@ -104,18 +110,20 @@ inline NcoresWH compute_ncores_wh(size_t grid_area, uint32_t nblocks, uint32_t w
     return NcoresWH{ncores, nblocks_per_core, total_blocks_width, total_blocks_height, single_block_size};
 }
 
-inline NcoresWHsb compute_ncores_wh_sb(
+// Non-throwing: returns nullopt when no sub-block assignment satisfies the L1-derived
+// single_block_size_limit (or the limit is invalid). The throwing wrapper below is the
+// factory entry point; hash-time callers must use this so a tight-L1 miss does not
+// TT_FATAL / backtrace on every dispatch.
+inline std::optional<NcoresWHsb> try_compute_ncores_wh_sb(
     size_t grid_area, uint32_t nblocks, uint32_t width_tiles, uint32_t height_tiles, uint32_t single_block_size_limit) {
-    // check single_block_size_limit is valid
-    TT_FATAL(single_block_size_limit >= 1, "single_block_size_limit must be at least 1");
-    // Compute grid area and initial blocks-per-core using integer math.
+    if (single_block_size_limit < 1) {
+        return std::nullopt;
+    }
     uint32_t nblocks_per_core = (grid_area == 0) ? 1 : (nblocks + grid_area - 1) / grid_area;
-    // Calculate ncores using single_block_size_limit.
     uint32_t total_blocks_width = tt::div_up(width_tiles, single_block_size_limit);
     uint32_t total_blocks_height = tt::div_up(height_tiles, single_block_size_limit);
     uint32_t total_blocks = total_blocks_width * total_blocks_height;
     uint32_t ncores = total_blocks;
-    // If ncores is smaller than grid_area, return an NcoresWH constructed using these values.
     if (ncores < grid_area) {
         return NcoresWHsb{
             ncores,
@@ -125,11 +133,6 @@ inline NcoresWHsb compute_ncores_wh_sb(
             single_block_size_limit,
             single_block_size_limit};
     }
-    // single_block_size = n * single_sub_block_size
-    // Conditions: (1) single_sub_block_size < single_block_size_limit
-    //             (2) Maximize total_blocks_sb (computed by single_block_size)
-    //             (3) Minimize n (prefer smaller n for tie-breaker)
-    //             (4) blocks_row_cliff < single_sub_block_size_limit
     uint32_t single_block_size = 0;
     uint32_t opt_n = 0;
     uint32_t single_sub_block_size = 0;
@@ -144,7 +147,6 @@ inline NcoresWHsb compute_ncores_wh_sb(
             uint32_t total_blocks_sb = total_blocks_width_sb * total_blocks_height_sb;
             uint32_t full_cores_per_row = width_tiles / tmp_single_block_size;
             uint32_t cliff_nblocks_row = width_tiles - full_cores_per_row * tmp_single_block_size;
-            // Select for max total_blocks_sb, for tie-break: prefer smaller n
             if (total_blocks_sb <= grid_area && cliff_nblocks_row < single_block_size_limit &&
                 (opt_n == 0 || total_blocks_sb > opt_ncores_sb || (total_blocks_sb == opt_ncores_sb && n < opt_n))) {
                 opt_n = n;
@@ -155,9 +157,8 @@ inline NcoresWHsb compute_ncores_wh_sb(
         }
     }
 
-    // If no solution found, use single_block_size_limit
     if (opt_n == 0) {
-        TT_FATAL(false, "No solution found for single_block_size");
+        return std::nullopt;
     }
 
     total_blocks_width = tt::div_up(width_tiles, single_block_size);
@@ -166,6 +167,13 @@ inline NcoresWHsb compute_ncores_wh_sb(
     ncores = (nblocks_per_core == 0) ? nblocks : total_blocks;
     return NcoresWHsb{
         ncores, nblocks_per_core, total_blocks_width, total_blocks_height, single_block_size, single_sub_block_size};
+}
+
+inline NcoresWHsb compute_ncores_wh_sb(
+    size_t grid_area, uint32_t nblocks, uint32_t width_tiles, uint32_t height_tiles, uint32_t single_block_size_limit) {
+    auto result = try_compute_ncores_wh_sb(grid_area, nblocks, width_tiles, height_tiles, single_block_size_limit);
+    TT_FATAL(result.has_value(), "No solution found for single_block_size");
+    return *result;
 }
 
 inline BlockSplitWH split_blocks_for_tilize_wh(

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -166,6 +166,7 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     untilize/device/factories/untilize_multi_core_program_factory.cpp
     untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
     untilize/codegen/untilize_codegen_device_operation.cpp
+    untilize/codegen/untilize_codegen_cb_plan.cpp
     untilize/codegen/untilize_codegen_program_factory.cpp
     untilize/codegen/untilize_codegen_supported.cpp
     untilize/untilize.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.cpp
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "untilize_codegen_cb_plan.hpp"
+
+#include <algorithm>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim::untilize_codegen_detail {
+
+uint32_t compute_block_ct_dim(uint32_t wt, bool fp32) {
+    uint32_t max_bct = fp32 ? 4 : 8;
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (wt % bct == 0) {
+            return bct;
+        }
+    }
+    return 1;
+}
+
+uint32_t choose_2d_ncol(uint32_t total_tile_rows, uint32_t wt, uint32_t valid_cores) {
+    if (total_tile_rows >= valid_cores || wt < 2) {
+        return 1;
+    }
+    uint32_t max_ncol = std::min(valid_cores / total_tile_rows, wt);
+    uint32_t best = 1;
+    for (uint32_t d = 2; d <= max_ncol; ++d) {
+        if (wt % d == 0) {
+            best = d;
+        }
+    }
+    return best;
+}
+
+std::optional<CbPlan> plan_cb_depths(
+    uint64_t usable_l1, uint32_t pages_per_unit, uint32_t page_size, uint32_t block_units) {
+    uint64_t p = pages_per_unit;
+    uint64_t ts = page_size;
+    uint64_t double_both = (2 * p + 2 * p) * ts;
+    uint64_t double_in = (2 * p + p) * ts;
+    uint64_t single_both = (p + p) * ts;
+    if (double_both <= usable_l1) {
+        return CbPlan{static_cast<uint32_t>(2 * p), static_cast<uint32_t>(2 * p), pages_per_unit};
+    }
+    if (double_in <= usable_l1) {
+        return CbPlan{static_cast<uint32_t>(2 * p), pages_per_unit, pages_per_unit};
+    }
+    if (single_both <= usable_l1) {
+        return CbPlan{pages_per_unit, pages_per_unit, block_units};
+    }
+    return std::nullopt;
+}
+
+namespace {
+
+bool needs_dst_accum(DataType dtype) {
+    return dtype == DataType::FLOAT32 || dtype == DataType::INT32 || dtype == DataType::UINT32;
+}
+
+struct PaddedGrid {
+    uint32_t wt;
+    uint32_t total_tile_rows;
+    bool tile_aligned;
+};
+
+PaddedGrid padded_grid(const Tensor& input) {
+    const auto& padded_shape = input.padded_shape();
+    uint32_t rank = padded_shape.rank();
+    uint32_t w = padded_shape[-1];
+    uint32_t h = padded_shape[-2];
+    uint32_t nc = 1;
+    for (uint32_t i = 0; i + 2 < rank; ++i) {
+        nc *= padded_shape[i];
+    }
+    uint32_t wt = w / TILE_WIDTH;
+    uint32_t ht = h / TILE_HEIGHT;
+    const auto& logical_shape = input.logical_shape();
+    bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
+    return PaddedGrid{wt, nc * ht, tile_aligned};
+}
+
+struct PagesAndBlock {
+    uint32_t pages_per_unit;
+    uint32_t block_units;
+};
+
+PagesAndBlock pages_for_builder(const Tensor& input, bool fp32) {
+    auto g = padded_grid(input);
+    auto* device = input.device();
+    auto grid = device->compute_with_storage_grid_size();
+    uint32_t valid_cores = static_cast<uint32_t>(grid.x) * static_cast<uint32_t>(grid.y);
+
+    if (!g.tile_aligned) {
+        return {g.wt, compute_block_ct_dim(g.wt, fp32)};
+    }
+    if (g.total_tile_rows == 1 && g.wt > 1) {
+        auto [_num_cores, _core_range, cg1, cg2, tpc1, tpc2] =
+            tt::tt_metal::split_work_to_cores(grid, g.wt, /*row_wise=*/true);
+        uint32_t max_tpc = std::max(tpc1, cg2.empty() ? 0u : tpc2);
+        return {max_tpc, compute_block_ct_dim(max_tpc, fp32)};
+    }
+    if (g.wt > 1) {
+        uint32_t ncol = choose_2d_ncol(g.total_tile_rows, g.wt, valid_cores);
+        if (ncol >= 2) {
+            uint32_t tpc = g.wt / ncol;
+            return {tpc, compute_block_ct_dim(tpc, fp32)};
+        }
+    }
+    return {g.wt, compute_block_ct_dim(g.wt, fp32)};
+}
+
+CodegenCbPlan tier_from_depths(const CbPlan& plan, uint32_t pages_per_unit) {
+    if (plan.cb_in_depth == 2 * pages_per_unit && plan.cb_out_depth == 2 * pages_per_unit) {
+        return CodegenCbPlan::DoubleBoth;
+    }
+    if (plan.cb_in_depth == 2 * pages_per_unit && plan.cb_out_depth == pages_per_unit) {
+        return CodegenCbPlan::DoubleIn;
+    }
+    return CodegenCbPlan::SingleBoth;
+}
+
+NativeCacheIdentity identity_from_ncores(
+    const ttnn::NcoresWHsb& sb, uint32_t width_tiles, uint32_t height_tiles) {
+    NativeCacheIdentity id;
+    id.enough_space_height = false;
+    id.split_valid = true;
+    id.ncores = sb.ncores;
+    id.nblocks_per_core = sb.nblocks_per_core;
+    id.single_block_size = sb.single_block_size;
+    if (id.single_block_size == 0) {
+        id.split_valid = false;
+        return id;
+    }
+    uint32_t total_blocks_width = sb.total_blocks_width;
+    uint32_t total_blocks_height = sb.total_blocks_height;
+    id.full_cores_per_row = width_tiles / id.single_block_size;
+    id.has_cliff_row = (id.full_cores_per_row < total_blocks_width);
+    id.full_cores_per_col = height_tiles / id.single_block_size;
+    id.has_cliff_col = (id.full_cores_per_col < total_blocks_height);
+    id.single_block_size_cliff_row = width_tiles - (id.full_cores_per_row * id.single_block_size);
+    id.single_block_size_cliff_col = height_tiles - (id.full_cores_per_col * id.single_block_size);
+    id.single_sub_block_size = sb.single_sub_block_size;
+    return id;
+}
+
+NativeCacheIdentity block_split_identity(
+    uint32_t grid_area,
+    uint32_t nblocks,
+    uint32_t width_tiles,
+    uint32_t height_tiles,
+    uint32_t cb_block_size_limit) {
+    auto wh = ttnn::compute_ncores_wh(grid_area, nblocks, width_tiles, height_tiles);
+    ttnn::NcoresWHsb sb{
+        wh.ncores,
+        wh.nblocks_per_core,
+        wh.total_blocks_width,
+        wh.total_blocks_height,
+        wh.single_block_size,
+        wh.single_block_size};
+    if (cb_block_size_limit >= 1 && wh.single_block_size > cb_block_size_limit) {
+        auto maybe = ttnn::try_compute_ncores_wh_sb(
+            grid_area, nblocks, width_tiles, height_tiles, cb_block_size_limit);
+        if (!maybe.has_value()) {
+            NativeCacheIdentity sentinel;
+            sentinel.enough_space_height = false;
+            sentinel.split_valid = false;
+            return sentinel;
+        }
+        sb = *maybe;
+    }
+    return identity_from_ncores(sb, width_tiles, height_tiles);
+}
+
+}  // namespace
+
+ChosenCodegenCbPlan choose_codegen_cb_plan(
+    const UntilizeCodegenOperationAttributes& attrs, const UntilizeCodegenTensorArgs& tensor_args) {
+    const Tensor& input = tensor_args.input;
+    auto out_spec = UntilizeCodegenDeviceOperation::compute_output_specs(attrs, tensor_args);
+    DataType in_dtype = input.dtype();
+    DataType out_dtype = out_spec.data_type();
+    bool fp32 = needs_dst_accum(in_dtype);
+    auto in_fmt = datatype_to_dataformat_converter(in_dtype);
+    auto out_fmt = datatype_to_dataformat_converter(out_dtype);
+    uint32_t tile_size_for_planning = std::max(tt::tile_size(in_fmt), tt::tile_size(out_fmt));
+    uint64_t usable_l1 = ttnn::operations::data_movement::get_max_l1_space(input);
+    auto pages = pages_for_builder(input, fp32);
+    auto depths = plan_cb_depths(usable_l1, pages.pages_per_unit, tile_size_for_planning, pages.block_units);
+    if (!depths.has_value()) {
+        return ChosenCodegenCbPlan{CodegenCbPlan::Native, std::nullopt};
+    }
+    return ChosenCodegenCbPlan{tier_from_depths(*depths, pages.pages_per_unit), depths};
+}
+
+NativeCacheIdentity native_cache_identity(
+    const UntilizeCodegenOperationAttributes& attrs,
+    const UntilizeCodegenTensorArgs& tensor_args,
+    CodegenCbPlan plan) {
+    (void)attrs;
+    NativeCacheIdentity zeros;
+    if (plan != CodegenCbPlan::Native) {
+        return zeros;
+    }
+
+    namespace dm = ttnn::operations::data_movement;
+    const Tensor& input = tensor_args.input;
+    auto in_fmt = datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(in_fmt);
+    uint32_t num_tiles_per_row = input.padded_shape()[-1] / TILE_WIDTH;
+    const bool enough_space_height =
+        dm::is_enough_space(input, single_tile_size, single_tile_size, num_tiles_per_row);
+    if (enough_space_height) {
+        NativeCacheIdentity id;
+        id.enough_space_height = true;
+        return id;
+    }
+
+    auto out_spec = UntilizeCodegenDeviceOperation::compute_output_specs(attrs, tensor_args);
+    auto out_fmt = datatype_to_dataformat_converter(out_spec.data_type());
+    uint32_t output_single_tile_size = tt::tile_size(out_fmt);
+    uint32_t max_l1_size = dm::get_max_l1_space(input);
+    uint32_t denom = single_tile_size + output_single_tile_size;
+    uint32_t cb_block_size_limit = denom == 0 ? 0 : max_l1_size / denom;
+
+    const auto& logical_shape = input.logical_shape();
+    const bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
+    auto* device = input.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+
+    if (tile_aligned) {
+        uint32_t a_tile_width = input.tensor_spec().tile().get_width();
+        uint32_t a_tile_height = input.tensor_spec().tile().get_height();
+        uint32_t width_tiles = input.padded_shape()[-1] / a_tile_width;
+        uint32_t height_tiles = input.padded_shape()[-2] / a_tile_height;
+        uint32_t nblocks = (input.padded_shape()[-1] * input.padded_shape()[-2]) / (a_tile_height * a_tile_width);
+        uint32_t grid_area = static_cast<uint32_t>(grid_size.x) * static_cast<uint32_t>(grid_size.y);
+        return block_split_identity(grid_area, nblocks, width_tiles, height_tiles, cb_block_size_limit);
+    }
+
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet available_grid(default_cores);
+    uint32_t width_tiles = input.padded_shape()[-1] / TILE_WIDTH;
+    uint32_t height_tiles = input.padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t nblocks =
+        (input.padded_shape()[-1] * input.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
+    return block_split_identity(
+        available_grid.num_cores(), nblocks, width_tiles, height_tiles, cb_block_size_limit);
+}
+
+}  // namespace ttnn::prim::untilize_codegen_detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_cb_plan.hpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "untilize_codegen_device_operation.hpp"
+
+namespace ttnn::prim::untilize_codegen_detail {
+
+enum class CodegenCbPlan : uint8_t { DoubleBoth, DoubleIn, SingleBoth, Native };
+
+struct CbPlan {
+    uint32_t cb_in_depth;
+    uint32_t cb_out_depth;
+    uint32_t read_batch;
+};
+
+std::optional<CbPlan> plan_cb_depths(
+    uint64_t usable_l1, uint32_t pages_per_unit, uint32_t page_size, uint32_t block_units);
+
+uint32_t compute_block_ct_dim(uint32_t wt, bool fp32);
+uint32_t choose_2d_ncol(uint32_t total_tile_rows, uint32_t wt, uint32_t valid_cores);
+
+struct ChosenCodegenCbPlan {
+    CodegenCbPlan tier;
+    std::optional<CbPlan> depths;
+};
+
+// Live-L1 CB tier for this (already output-allocated) dispatch. Output tile size comes from
+// UntilizeCodegenDeviceOperation::compute_output_specs so bf8_b->bf16 demotion is not copied.
+ChosenCodegenCbPlan choose_codegen_cb_plan(
+    const UntilizeCodegenOperationAttributes& attrs, const UntilizeCodegenTensorArgs& tensor_args);
+
+// Discrete native-fallback identity hashed with the codegen tier. Zeros when tier is not Native
+// or when enough_space_height is true. split_valid is false when the block split has no solution
+// (sentinel: forces a cache miss so create_descriptor can TT_FATAL as the factory does today).
+struct NativeCacheIdentity {
+    bool enough_space_height = false;
+    bool split_valid = true;
+    uint32_t ncores = 0;
+    uint32_t nblocks_per_core = 0;
+    uint32_t single_block_size = 0;
+    uint32_t single_block_size_cliff_row = 0;
+    uint32_t single_block_size_cliff_col = 0;
+    bool has_cliff_row = false;
+    bool has_cliff_col = false;
+    uint32_t full_cores_per_row = 0;
+    uint32_t full_cores_per_col = 0;
+    uint32_t single_sub_block_size = 0;
+};
+
+NativeCacheIdentity native_cache_identity(
+    const UntilizeCodegenOperationAttributes& attrs,
+    const UntilizeCodegenTensorArgs& tensor_args,
+    CodegenCbPlan plan);
+
+}  // namespace ttnn::prim::untilize_codegen_detail

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_device_operation.cpp
@@ -10,6 +10,9 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "untilize_codegen_supported.hpp"
+#include "untilize_codegen_cb_plan.hpp"
+
+#include <tt_stl/reflection.hpp>
 
 namespace ttnn::prim {
 
@@ -63,6 +66,30 @@ UntilizeCodegenDeviceOperation::spec_return_value_t UntilizeCodegenDeviceOperati
 UntilizeCodegenDeviceOperation::tensor_return_value_t UntilizeCodegenDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
+}
+
+ttsl::hash::hash_t UntilizeCodegenDeviceOperation::compute_program_hash(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto chosen = untilize_codegen_detail::choose_codegen_cb_plan(operation_attributes, tensor_args);
+    const auto native =
+        untilize_codegen_detail::native_cache_identity(operation_attributes, tensor_args, chosen.tier);
+    return ttsl::hash::hash_objects_with_default_seed(
+        ttsl::hash::type_hash<UntilizeCodegenDeviceOperation>,
+        operation_attributes,
+        tensor_args,
+        chosen.tier,
+        native.enough_space_height,
+        native.split_valid,
+        native.ncores,
+        native.nblocks_per_core,
+        native.single_block_size,
+        native.single_block_size_cliff_row,
+        native.single_block_size_cliff_col,
+        native.has_cliff_row,
+        native.has_cliff_col,
+        native.full_cores_per_row,
+        native.full_cores_per_col,
+        native.single_sub_block_size);
 }
 
 Tensor untilize_codegen(const Tensor& input, tt::tt_metal::MemoryConfig output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_device_operation.hpp
@@ -37,6 +37,8 @@ struct UntilizeCodegenDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 Tensor untilize_codegen(const Tensor& input, tt::tt_metal::MemoryConfig output_mem_config);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
@@ -22,6 +22,7 @@
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp"
+#include "untilize_codegen_cb_plan.hpp"
 #include "untilize_codegen_device_operation.hpp"
 #include "untilize_codegen_supported.hpp"
 
@@ -47,79 +48,10 @@ bool needs_dst_accum(DataType dtype) {
     return dtype == DataType::FLOAT32 || dtype == DataType::INT32 || dtype == DataType::UINT32;
 }
 
-// Mirrors compute_untilize.cpp's compute_num_blocks_per_column: the largest bct <= max_bct
-// that evenly divides wt. The host must replicate this to size CB depths in the same units
-// the kernel will actually consume per pack_untilize_block call.
-uint32_t compute_block_ct_dim(uint32_t wt, bool fp32) {
-    uint32_t max_bct = fp32 ? 4 : 8;
-    for (uint32_t bct = max_bct; bct >= 1; --bct) {
-        if (wt % bct == 0) {
-            return bct;
-        }
-    }
-    return 1;
-}
-
-struct CbPlan {
-    uint32_t cb_in_depth;
-    uint32_t cb_out_depth;
-    uint32_t read_batch;
-};
-
-// Mirrors codegen_common.factory.cb_policy.plan_cb_depths exactly: 3-tier asymmetric CB
-// depth selection (double-buffer both -> double-buffer input only -> single-buffer both).
-//
-// `usable_l1` is the budget measured ONCE per program build by create_descriptor (see
-// kUsableL1Note there): the L1 gap actually free below whatever buffers are already resident,
-// not the whole-core L1 size. Statically allocated CBs grow up from the allocator base while
-// L1 buffers grow down from the top, so planning against total L1 is what let a program whose
-// CBs overlap a resident trace/weight buffer get built at all -- it then died later in
-// ProgramImpl::validate_circular_buffer_region() with "Statically allocated circular buffers
-// ... clash with L1 buffers".
-//
-// Tightening the budget cannot change any plan that previously worked: the three tiers are
-// strictly ordered by size, the live gap is always <= the whole-L1 budget, so the only plans
-// that differ are exactly those the old budget accepted but the allocator would have rejected.
-//
-// The Python source has no 4th "chunked" tier -- it raises when even the single-buffer plan
-// overflows. Returning nullopt instead lets create_descriptor build a native-equivalent
-// program for that case rather than failing the op; the codegen builders themselves still have
-// no depth below single-buffer to fall back to (compute_untilize.cpp reserves a full unit in
-// cb_out per pass), which is exactly why the fallback has to be a different program.
-std::optional<CbPlan> plan_cb_depths(
-    uint64_t usable_l1, uint32_t pages_per_unit, uint32_t page_size, uint32_t block_units) {
-    uint64_t p = pages_per_unit;
-    uint64_t ts = page_size;
-    uint64_t double_both = (2 * p + 2 * p) * ts;
-    uint64_t double_in = (2 * p + p) * ts;
-    uint64_t single_both = (p + p) * ts;
-    if (double_both <= usable_l1) {
-        return CbPlan{static_cast<uint32_t>(2 * p), static_cast<uint32_t>(2 * p), pages_per_unit};
-    }
-    if (double_in <= usable_l1) {
-        return CbPlan{static_cast<uint32_t>(2 * p), pages_per_unit, pages_per_unit};
-    }
-    if (single_both <= usable_l1) {
-        return CbPlan{pages_per_unit, pages_per_unit, block_units};
-    }
-    return std::nullopt;
-}
-
-// Mirrors spec.py's _choose_2d_ncol: largest divisor of wt (>=2) so that every tile-row x
-// column-block unit still gets its own core; returns 1 ("don't use the 2D path") otherwise.
-uint32_t choose_2d_ncol(uint32_t total_tile_rows, uint32_t wt, uint32_t valid_cores) {
-    if (total_tile_rows >= valid_cores || wt < 2) {
-        return 1;
-    }
-    uint32_t max_ncol = std::min(valid_cores / total_tile_rows, wt);
-    uint32_t best = 1;
-    for (uint32_t d = 2; d <= max_ncol; ++d) {
-        if (wt % d == 0) {
-            best = d;
-        }
-    }
-    return best;
-}
+using untilize_codegen_detail::CbPlan;
+using untilize_codegen_detail::choose_2d_ncol;
+using untilize_codegen_detail::compute_block_ct_dim;
+using untilize_codegen_detail::plan_cb_depths;
 
 // DRAM-interleaved tile CBs must step at the device's real DRAM page pitch, not the raw tile
 // byte size (a no-op for bf16/bf8_b tile sizes, both already multiples of every supported
@@ -575,30 +507,22 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     a.out_elem_size = output.element_size();
     a.in_buf = input.buffer();
     a.out_buf = output.buffer();
-    // kUsableL1Note: THE single live-L1 decision point for this op.
+    // kUsableL1Note: live-L1 is sampled here on a cache MISS so every builder plans against one
+    // snapshot (get_max_l1_space: lowest_occupied_compute_l1_address ?: l1_size_per_core, minus
+    // allocator base). The SAME chooser (choose_codegen_cb_plan) also runs on every dispatch from
+    // compute_program_hash, so a later occupancy change that crosses a CB tier (or Native
+    // block-split) is a new cache key rather than a hit with a frozen plan.
     //
-    // Sampled exactly here, once, and threaded through CommonArgs so every builder plans against
-    // one consistent snapshot. get_max_l1_space() is the same helper the native untilize path
-    // uses: (lowest_occupied_compute_l1_address ?: l1_size_per_core) - allocator base, i.e. the
-    // gap between where statically allocated CBs start growing up and where the lowest resident
-    // L1 buffer sits. Taken after create_output_tensors() has already allocated the output, so it
-    // accounts for that too.
-    //
-    // Cost on the hot path: zero. create_descriptor runs only on a program-cache MISS. Every
-    // builder below (and every native factory the fallback can delegate to) emits
-    // emplace_runtime_args with a Buffer* first argument on every core, so buffer bindings are
-    // always populated and resolve; cache HITS therefore take apply_descriptor's
-    // apply_resolved_bindings path, which patches addresses in the cached Program without ever
-    // calling create_descriptor again. (The one exception is the opt-in
-    // ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK build, OFF by default, which re-invokes
-    // create_descriptor on every hit purely to diff it -- see the note in create_descriptor's
-    // tail.)
-    //
-    // No previously-working program changes shape because of this. plan_cb_depths' three tiers
-    // are strictly ordered by size and the live gap is always <= the whole-L1 budget it used
-    // before, so the only plans that differ are exactly the ones the allocator would have
-    // rejected anyway in ProgramImpl::validate_circular_buffer_region().
+    // get_max_l1_space is therefore on the untilize-codegen hot path (hash), not miss-only: it
+    // takes the allocator mutex and walks the L1 free list per sub-device. create_descriptor
+    // itself still runs only on a miss; cache hits patch addresses via apply_resolved_bindings
+    // (except ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK, OFF by default).
     a.usable_l1 = ttnn::operations::data_movement::get_max_l1_space(input);
+
+    auto chosen = untilize_codegen_detail::choose_codegen_cb_plan(operation_attributes, tensor_args);
+    if (chosen.tier == untilize_codegen_detail::CodegenCbPlan::Native) {
+        return build_native_equivalent(operation_attributes, input, output);
+    }
 
     // Wt/Ht/NC are derived from the PADDED (physical, tile-aligned) shape, which the reader/
     // compute stages need regardless of dispatch branch below (even the with-unpadding path

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
@@ -5,6 +5,10 @@
 #include "untilize_codegen_program_factory.hpp"
 
 #include <algorithm>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <variant>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
@@ -13,7 +17,11 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/small_vector.hpp>
 
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
+#include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp"
 #include "untilize_codegen_device_operation.hpp"
 #include "untilize_codegen_supported.hpp"
 
@@ -29,7 +37,6 @@ constexpr const char* kKernelDir = "ttnn/cpp/ttnn/operations/data_movement/until
 constexpr uint32_t kCbIn = tt::CBIndex::c_0;
 constexpr uint32_t kCbOut = tt::CBIndex::c_16;
 constexpr uint32_t kSeqIdentity = 0;  // mirrors common/templates/sequencers.h SEQ_IDENTITY
-using ttnn::operations::data_movement::untilize_codegen::usable_l1_bytes;
 
 std::string kernel_path(const char* name) { return std::string(kKernelDir) + "/" + name; }
 
@@ -60,20 +67,32 @@ struct CbPlan {
 };
 
 // Mirrors codegen_common.factory.cb_policy.plan_cb_depths exactly: 3-tier asymmetric CB
-// depth selection (double-buffer both -> double-buffer input only -> single-buffer both),
-// budgeted against the device's actual usable-L1 (queried, not a hardcoded constant -- see
-// usable_l1_bytes()). The Python source has no 4th "chunked" tier -- it raises when even the
-// single-buffer plan overflows, because the caller (ops/untilize/untilize.py's wide-tensor
-// guard, transcribed into supported_by_codegen's wide-chunk-threshold check) is expected to
-// have already routed such shapes away from this builder entirely. Fail the same way rather
-// than inventing an untraceable fallback depth.
-CbPlan plan_cb_depths(const IDevice* device, uint32_t pages_per_unit, uint32_t page_size, uint32_t block_units) {
+// depth selection (double-buffer both -> double-buffer input only -> single-buffer both).
+//
+// `usable_l1` is the budget measured ONCE per program build by create_descriptor (see
+// kUsableL1Note there): the L1 gap actually free below whatever buffers are already resident,
+// not the whole-core L1 size. Statically allocated CBs grow up from the allocator base while
+// L1 buffers grow down from the top, so planning against total L1 is what let a program whose
+// CBs overlap a resident trace/weight buffer get built at all -- it then died later in
+// ProgramImpl::validate_circular_buffer_region() with "Statically allocated circular buffers
+// ... clash with L1 buffers".
+//
+// Tightening the budget cannot change any plan that previously worked: the three tiers are
+// strictly ordered by size, the live gap is always <= the whole-L1 budget, so the only plans
+// that differ are exactly those the old budget accepted but the allocator would have rejected.
+//
+// The Python source has no 4th "chunked" tier -- it raises when even the single-buffer plan
+// overflows. Returning nullopt instead lets create_descriptor build a native-equivalent
+// program for that case rather than failing the op; the codegen builders themselves still have
+// no depth below single-buffer to fall back to (compute_untilize.cpp reserves a full unit in
+// cb_out per pass), which is exactly why the fallback has to be a different program.
+std::optional<CbPlan> plan_cb_depths(
+    uint64_t usable_l1, uint32_t pages_per_unit, uint32_t page_size, uint32_t block_units) {
     uint64_t p = pages_per_unit;
     uint64_t ts = page_size;
     uint64_t double_both = (2 * p + 2 * p) * ts;
     uint64_t double_in = (2 * p + p) * ts;
     uint64_t single_both = (p + p) * ts;
-    uint64_t usable_l1 = usable_l1_bytes(device);
     if (double_both <= usable_l1) {
         return CbPlan{static_cast<uint32_t>(2 * p), static_cast<uint32_t>(2 * p), pages_per_unit};
     }
@@ -83,15 +102,7 @@ CbPlan plan_cb_depths(const IDevice* device, uint32_t pages_per_unit, uint32_t p
     if (single_both <= usable_l1) {
         return CbPlan{pages_per_unit, pages_per_unit, block_units};
     }
-    TT_THROW(
-        "untilize codegen: single-buffer CB plan exceeds L1 and cannot be reduced without chunking "
-        "(pages_per_unit={}, page_size={}, minimum_bytes={}, budget={}); supported_by_codegen() should "
-        "have routed this shape to native",
-        pages_per_unit,
-        page_size,
-        single_both,
-        usable_l1);
-    return CbPlan{};
+    return std::nullopt;
 }
 
 // Mirrors spec.py's _choose_2d_ncol: largest divisor of wt (>=2) so that every tile-row x
@@ -174,18 +185,24 @@ struct CommonArgs {
     uint32_t out_elem_size;
     bool fp32;
     uint32_t max_bct;
+    // Live L1 headroom, sampled once in create_descriptor -- see kUsableL1Note.
+    uint64_t usable_l1;
 };
 
 // Per-tile-row split (build_untilize_tile's default path / _build_untilize_tile_cliff).
 // Splits total_tile_rows across up to the device's core grid; an uneven split produces a
 // second ("cliff") compute-kernel core group with its own per-core tile-row count.
-ProgramDescriptor build_main_split(const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows) {
+std::optional<ProgramDescriptor> build_main_split(const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows) {
     auto grid = a.device->compute_with_storage_grid_size();
     auto [_num_cores, core_range, cg1, cg2, tpc1, tpc2] =
         tt::tt_metal::split_work_to_cores(grid, total_tile_rows, /*row_wise=*/true);
 
     uint32_t block_ct_dim = compute_block_ct_dim(wt, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, wt, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, wt, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     // Row stride used both as the writer's TensorAccessor page pitch and the CB byte stride
     // between physical tile-rows: the FULL padded row (Wt tiles wide), never the logical
@@ -241,14 +258,18 @@ ProgramDescriptor build_main_split(const CommonArgs& a, uint32_t wt, uint32_t to
 
 // Column-parallel split (_build_untilize_column_parallel): single tile-row, Wt>1 -- splits
 // tile-COLUMNS across cores instead of tile-rows.
-ProgramDescriptor build_column_parallel(const CommonArgs& a, uint32_t wt) {
+std::optional<ProgramDescriptor> build_column_parallel(const CommonArgs& a, uint32_t wt) {
     auto grid = a.device->compute_with_storage_grid_size();
     auto [_num_cores, core_range, cg1, cg2, tpc1, tpc2] =
         tt::tt_metal::split_work_to_cores(grid, wt, /*row_wise=*/true);
 
     uint32_t max_tpc = std::max(tpc1, cg2.empty() ? 0u : tpc2);
     uint32_t block_ct_dim = compute_block_ct_dim(max_tpc, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, max_tpc, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, max_tpc, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     uint32_t full_stick_size = wt * TILE_WIDTH * a.out_elem_size;
 
@@ -304,7 +325,8 @@ ProgramDescriptor build_column_parallel(const CommonArgs& a, uint32_t wt) {
 // 2D (tile-row x column-block) split (_build_untilize_2d_column): raises core utilization
 // when total_tile_rows alone would leave cores idle. Every one of total_tile_rows*ncol cores
 // owns exactly one (tile-row, column-block) unit of tpc = Wt/ncol tiles.
-ProgramDescriptor build_2d_column(const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows, uint32_t ncol) {
+std::optional<ProgramDescriptor> build_2d_column(
+    const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows, uint32_t ncol) {
     uint32_t tpc = wt / ncol;
     uint32_t num_units = total_tile_rows * ncol;
 
@@ -313,7 +335,11 @@ ProgramDescriptor build_2d_column(const CommonArgs& a, uint32_t wt, uint32_t tot
         tt::tt_metal::split_work_to_cores(grid, num_units, /*row_wise=*/true);
 
     uint32_t block_ct_dim = compute_block_ct_dim(tpc, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, tpc, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, tpc, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     uint32_t full_stick_size = wt * TILE_WIDTH * a.out_elem_size;
     uint32_t col_chunk_bytes = tpc * TILE_WIDTH * a.out_elem_size;
@@ -377,7 +403,7 @@ uint32_t count_valid_sticks(uint32_t start, uint32_t count, uint32_t batch_h, ui
 // writer additionally skips physical pad sticks and writes only the unpadded row width, producing
 // the compact output UntilizeCodegenDeviceOperation::compute_output_specs's non-aligned branch
 // declares. Cliff-capable (two compute kernels), same as build_main_split.
-ProgramDescriptor build_with_unpadding(
+std::optional<ProgramDescriptor> build_with_unpadding(
     const CommonArgs& a,
     uint32_t wt,
     uint32_t total_tile_rows,
@@ -389,7 +415,11 @@ ProgramDescriptor build_with_unpadding(
         tt::tt_metal::split_work_to_cores(grid, total_tile_rows, /*row_wise=*/true);
 
     uint32_t block_ct_dim = compute_block_ct_dim(wt, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, wt, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, wt, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     uint32_t unpadded_row_bytes = w_unpadded * a.out_elem_size;
     uint32_t padded_row_bytes = wt * TILE_WIDTH * a.out_elem_size;
@@ -446,6 +476,82 @@ ProgramDescriptor build_with_unpadding(
     return desc;
 }
 
+// Last-resort builder for the rare case where NO codegen CB plan fits the L1 that is actually
+// free right now (see kUsableL1Note): build the program the native untilize op would have built
+// for this very same (input -> output) pair, and let prim::untilize_codegen run that instead.
+//
+// This is a program-level fallback, deliberately NOT a routing-level one. supported_by_codegen()
+// is evaluated independently at three sites (ttnn::untilize's routing gate,
+// untilize_force_codegen's TT_FATAL, and validate_on_program_cache_miss) and is only self-
+// consistent because it is a pure function of static properties; teaching it about live L1
+// occupancy is what made routing say "yes" and validate then TT_FATAL on the same tensor. Here
+// the decision is made once, after the op has committed to codegen and after its output tensor
+// is allocated, so there is no second observer to disagree with.
+//
+// Delegating (rather than duplicating native's kernels) keeps the two in lockstep by
+// construction. It is sound because the output tensor the codegen op already allocated is
+// byte-identical in spec to the one native would allocate for the same case:
+//   - tile-aligned  -> UntilizeDeviceOperation::compute_output_specs (same logical shape, same
+//     ROW_MAJOR page config, same dtype demotion bf8_b->bf16, same padded shape carried through)
+//   - non-aligned   -> UntilizeWithUnpaddingDeviceOperation::compute_output_specs with
+//     output_tensor_end = logical_shape - 1, i.e. the compact interleaved spec, which is exactly
+//     what UntilizeCodegenDeviceOperation::compute_output_specs's non-aligned branch declares.
+// The native factories only read `output` (buffer address, spec) to emit their descriptor, so
+// handing them the already-allocated tensor is exactly what their own op would have done.
+ProgramDescriptor build_native_equivalent(
+    const UntilizeCodegenOperationAttributes& operation_attributes, const Tensor& input, const Tensor& output) {
+    namespace dm = ttnn::operations::data_movement;
+
+    // Several native factories take `UntilizeTensorReturnValue&` (non-const). A Tensor is a
+    // shallow, refcounted handle, so this copy aliases the same buffer the op allocated.
+    Tensor out = output;
+
+    const bool fp32_dest_acc_en = input.dtype() == DataType::INT32 || input.dtype() == DataType::UINT32 ||
+                                  input.dtype() == DataType::FLOAT32;
+    auto in_fmt = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(in_fmt);
+    uint32_t num_tiles_per_row = input.padded_shape()[-1] / TILE_WIDTH;
+    // Same derivation the native free functions do before calling their prim; note this is itself
+    // a live-L1 query (get_max_l1_space), consistent with the snapshot taken in create_descriptor.
+    const bool enough_space_height =
+        dm::is_enough_space(input, single_tile_size, single_tile_size, num_tiles_per_row);
+
+    const auto& logical_shape = input.logical_shape();
+    const bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
+
+    if (!tile_aligned) {
+        ttnn::Shape output_tensor_end(ttsl::SmallVector<uint32_t>(logical_shape.rank(), 0));
+        int logical_rank = static_cast<int>(logical_shape.rank());
+        for (int index = -1; index >= -logical_rank; --index) {
+            output_tensor_end[index] = logical_shape[index] - 1;
+        }
+        UntilizeWithUnpaddingParams params{
+            .output_tensor_end = output_tensor_end,
+            .output_mem_config = operation_attributes.output_mem_config,
+            .use_multicore = true,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .enough_space_height = enough_space_height,
+            .sub_core_grids = std::nullopt};
+        auto pf = UntilizeWithUnpaddingDeviceOperation::select_program_factory(params, input);
+        return std::visit(
+            [&](auto&& factory) { return std::decay_t<decltype(factory)>::create_descriptor(params, input, out); }, pf);
+    }
+
+    UntilizeOperationAttributes attrs{
+        .output_mem_config = operation_attributes.output_mem_config,
+        .use_multicore = true,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .sub_core_grids = std::nullopt,
+        .enough_space_height = enough_space_height,
+        // supported_by_codegen() rejects sharded output, so the sharded pf_type branches are
+        // unreachable here; pass false to match what untilize_native would compute.
+        .pf_type = dm::get_pf_type(/*output_is_sharded=*/false, input)};
+    UntilizeTensorArgs args{.input = input};
+    auto pf = UntilizeDeviceOperation::select_program_factory(attrs, args);
+    return std::visit(
+        [&](auto&& factory) { return std::decay_t<decltype(factory)>::create_descriptor(attrs, args, out); }, pf);
+}
+
 }  // namespace
 
 ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
@@ -469,6 +575,30 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     a.out_elem_size = output.element_size();
     a.in_buf = input.buffer();
     a.out_buf = output.buffer();
+    // kUsableL1Note: THE single live-L1 decision point for this op.
+    //
+    // Sampled exactly here, once, and threaded through CommonArgs so every builder plans against
+    // one consistent snapshot. get_max_l1_space() is the same helper the native untilize path
+    // uses: (lowest_occupied_compute_l1_address ?: l1_size_per_core) - allocator base, i.e. the
+    // gap between where statically allocated CBs start growing up and where the lowest resident
+    // L1 buffer sits. Taken after create_output_tensors() has already allocated the output, so it
+    // accounts for that too.
+    //
+    // Cost on the hot path: zero. create_descriptor runs only on a program-cache MISS. Every
+    // builder below (and every native factory the fallback can delegate to) emits
+    // emplace_runtime_args with a Buffer* first argument on every core, so buffer bindings are
+    // always populated and resolve; cache HITS therefore take apply_descriptor's
+    // apply_resolved_bindings path, which patches addresses in the cached Program without ever
+    // calling create_descriptor again. (The one exception is the opt-in
+    // ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK build, OFF by default, which re-invokes
+    // create_descriptor on every hit purely to diff it -- see the note in create_descriptor's
+    // tail.)
+    //
+    // No previously-working program changes shape because of this. plan_cb_depths' three tiers
+    // are strictly ordered by size and the live gap is always <= the whole-L1 budget it used
+    // before, so the only plans that differ are exactly the ones the allocator would have
+    // rejected anyway in ProgramImpl::validate_circular_buffer_region().
+    a.usable_l1 = ttnn::operations::data_movement::get_max_l1_space(input);
 
     // Wt/Ht/NC are derived from the PADDED (physical, tile-aligned) shape, which the reader/
     // compute stages need regardless of dispatch branch below (even the with-unpadding path
@@ -485,7 +615,13 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     uint32_t ht = h / TILE_HEIGHT;
     uint32_t total_tile_rows = nc * ht;
 
-    (void)operation_attributes;
+    // Each branch below picks the codegen builder this shape belongs to, exactly as before. The
+    // only new behaviour is that a builder may decline (nullopt) when its CB plan does not fit the
+    // L1 that is free right now, in which case we emit the native-equivalent program instead of
+    // failing the op. Under the opt-in ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK build this function
+    // is re-invoked on cache hits and diffed against the cached descriptor; if L1 occupancy has
+    // changed enough since the miss to flip a tier, that check can report a spurious mismatch.
+    // That build is a debug aid (OFF by default) and never runs in production dispatch.
 
     // Non-tile-aligned logical shapes (bf16 only -- see supported_by_codegen) route through the
     // with-unpadding builder instead of build_untilize_tile's variants. h == ht * TILE_HEIGHT
@@ -494,11 +630,17 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     const auto& logical_shape = input.logical_shape();
     bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
     if (!tile_aligned) {
-        return build_with_unpadding(a, wt, total_tile_rows, logical_shape[-2], logical_shape[-1], h);
+        if (auto desc = build_with_unpadding(a, wt, total_tile_rows, logical_shape[-2], logical_shape[-1], h)) {
+            return std::move(*desc);
+        }
+        return build_native_equivalent(operation_attributes, input, output);
     }
 
     if (total_tile_rows == 1 && wt > 1) {
-        return build_column_parallel(a, wt);
+        if (auto desc = build_column_parallel(a, wt)) {
+            return std::move(*desc);
+        }
+        return build_native_equivalent(operation_attributes, input, output);
     }
 
     auto grid = a.device->compute_with_storage_grid_size();
@@ -506,10 +648,16 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     if (wt > 1) {
         uint32_t ncol = choose_2d_ncol(total_tile_rows, wt, valid_cores);
         if (ncol >= 2) {
-            return build_2d_column(a, wt, total_tile_rows, ncol);
+            if (auto desc = build_2d_column(a, wt, total_tile_rows, ncol)) {
+                return std::move(*desc);
+            }
+            return build_native_equivalent(operation_attributes, input, output);
         }
     }
-    return build_main_split(a, wt, total_tile_rows);
+    if (auto desc = build_main_split(a, wt, total_tile_rows)) {
+        return std::move(*desc);
+    }
+    return build_native_equivalent(operation_attributes, input, output);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
@@ -14,6 +14,11 @@ struct UntilizeCodegenOperationAttributes;
 struct UntilizeCodegenTensorArgs;
 
 struct UntilizeCodegenProgramFactory {
+    // Builds the codegen untilize program for the (already validated, already output-allocated)
+    // case. This is also the op's ONLY live-L1 decision point: it samples the free L1 headroom
+    // once and, if no codegen CB plan fits below the resident L1 buffers, emits the native
+    // untilize program for the same tensors instead of failing. Runs only on a program-cache
+    // miss; cache hits patch the cached program's buffer addresses without re-entering here.
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeCodegenOperationAttributes& operation_attributes,
         const UntilizeCodegenTensorArgs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
@@ -14,11 +14,10 @@ struct UntilizeCodegenOperationAttributes;
 struct UntilizeCodegenTensorArgs;
 
 struct UntilizeCodegenProgramFactory {
-    // Builds the codegen untilize program for the (already validated, already output-allocated)
-    // case. This is also the op's ONLY live-L1 decision point: it samples the free L1 headroom
-    // once and, if no codegen CB plan fits below the resident L1 buffers, emits the native
-    // untilize program for the same tensors instead of failing. Runs only on a program-cache
-    // miss; cache hits patch the cached program's buffer addresses without re-entering here.
+    // Builds the codegen untilize program (or native-equivalent) for the already-validated,
+    // already output-allocated case. Live L1 is sampled on every dispatch in
+    // compute_program_hash (choose_codegen_cb_plan) so a CB-tier / Native-block-split change
+    // is a cache miss. create_descriptor itself still runs only on a miss.
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeCodegenOperationAttributes& operation_attributes,
         const UntilizeCodegenTensorArgs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
@@ -14,7 +14,20 @@
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device) {
-    return device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    // Same accounting as ProgramImpl::validate_circular_buffer_region(): statically allocated CBs
+    // grow upward from the allocator's base L1 address, L1 buffers are allocated downward from the
+    // top of L1, and that validator TT_THROWs as soon as the CB region end passes
+    // lowest_occupied_compute_l1_address(). Budget against the same frontier so a plan this gate
+    // accepts is one the program validator will accept too. Mirrors get_max_l1_space() in
+    // data_movement/common/common.cpp.
+    //
+    // std::nullopt means nothing is resident in L1 yet, in which case the whole region above the
+    // base is available.
+    const uint32_t base = device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    const auto lowest_occupied = device->lowest_occupied_compute_l1_address();
+    const uint32_t ceiling =
+        lowest_occupied.has_value() ? static_cast<uint32_t>(*lowest_occupied) : device->l1_size_per_core();
+    return ceiling > base ? ceiling - base : 0;
 }
 
 // Correctness scope of the ported builders: TILE input, interleaved (non-sharded) input AND
@@ -49,18 +62,42 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
     constexpr uint32_t kTileSize = 2048;  // bf16/bf8_b only in this scope
     constexpr uint64_t kWideChunkThreshold = 800'000;
 
+    auto* device = input.device();
+
+    // plan_cb_depths()'s floor tier: cb_in + cb_out at a single slot each. The factory has no
+    // smaller plan to degrade to below this and TT_THROWs instead, so anything that does not clear
+    // the floor has to be routed to native from here rather than aborting inside program creation.
+    //
+    // usable_l1_bytes() is budgeted against LIVE L1 occupancy, so this check is not a static
+    // shape property: the same shape can clear it on an idle device and fail it alongside a
+    // model's resident weight/trace buffers. That is deliberate -- it is the same budget
+    // ProgramImpl::validate_circular_buffer_region() will hold the resulting program to.
+    auto min_cb_plan_fits = [&](uint32_t pages_per_unit) {
+        return 2ull * pages_per_unit * kTileSize <= usable_l1_bytes(device);
+    };
+
     // Mirrors build_column_parallel + plan_cb_depths: that builder's CB plan is sized by the
-    // busiest core's tile count, not by Wt, and plan_cb_depths() TT_FATALs once even the
-    // single-buffer plan (cb_in + cb_out, one slot per tile each) exceeds the L1 budget. Reject
-    // here so "auto" falls back to native instead of aborting inside program creation.
+    // busiest core's tile count, not by Wt.
     auto column_parallel_plan_fits = [&](uint32_t wt) {
-        auto* device = input.device();
         auto grid = device->compute_with_storage_grid_size();
         auto split = tt::tt_metal::split_work_to_cores(grid, wt, /*row_wise=*/true);
         uint32_t max_tiles_per_core =
             std::max(std::get<4>(split), std::get<3>(split).empty() ? 0u : std::get<5>(split));
-        return 2ull * max_tiles_per_core * kTileSize <= usable_l1_bytes(device);
+        return min_cb_plan_fits(max_tiles_per_core);
     };
+
+    // Wt / total_tile_rows are derived from the PADDED shape (Wt/Ht are physical, tile-grid
+    // quantities), matching how the program factory itself derives them -- including for the
+    // with-unpadding builder, which reads the full physical tile grid and only differs in its
+    // writer.
+    const auto& padded_shape = input.padded_shape();
+    uint32_t rank = padded_shape.rank();
+    uint32_t wt = padded_shape[-1] / tt::constants::TILE_WIDTH;
+    uint32_t nc = 1;
+    for (uint32_t i = 0; i + 2 < rank; ++i) {
+        nc *= padded_shape[i];
+    }
+    uint32_t total_tile_rows = nc * (padded_shape[-2] / tt::constants::TILE_HEIGHT);
 
     const auto& logical = input.logical_shape();
     const bool tile_aligned =
@@ -78,36 +115,32 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
         // slice/untilize/concat cascade outside this port's scope. Uses ceil(W/TILE_W) since W is
         // not tile-aligned here.
         uint32_t wt_ceil = (logical[-1] + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
-        return 2ull * wt_ceil * kTileSize <= kWideChunkThreshold;
+        if (2ull * wt_ceil * kTileSize > kWideChunkThreshold) {
+            return false;
+        }
+        // build_with_unpadding plans its CBs on the physical Wt.
+        return min_cb_plan_fits(wt);
     }
 
     // Tile-aligned path: mirrors ops/untilize/untilize.py's wide-tensor guard for
     // build_untilize_tile -- a multi-tile-row input wide enough that a single tile-row would
     // overflow the slice+concat chunking threshold (~800KB for two double-buffered CBs at
     // 2048B/tile) is routed to a slice -> untilize -> concat cascade over unrelated builder
-    // entries, out of scope here. Computed from the PADDED shape (Wt/Ht are physical, tile-grid
-    // quantities), matching how the program factory itself derives Wt/total_tile_rows.
-    const auto& padded_shape = input.padded_shape();
-    uint32_t rank = padded_shape.rank();
-    uint32_t w = padded_shape[-1];
-    uint32_t h = padded_shape[-2];
-    uint32_t wt = w / tt::constants::TILE_WIDTH;
-    uint32_t nc = 1;
-    for (uint32_t i = 0; i + 2 < rank; ++i) {
-        nc *= padded_shape[i];
-    }
-    uint32_t total_tile_rows = nc * (h / tt::constants::TILE_HEIGHT);
+    // entries, out of scope here.
     if (total_tile_rows > 1 && 2ull * wt * kTileSize > kWideChunkThreshold) {
         return false;
     }
     // A single tile-row skips the chunk cascade (build_column_parallel splits Wt across the grid
     // in one dispatch instead), so it is bounded by that builder's own per-core plan, not by the
     // whole-row threshold above.
-    if (total_tile_rows == 1 && wt > 1 && !column_parallel_plan_fits(wt)) {
-        return false;
+    if (total_tile_rows == 1 && wt > 1) {
+        return column_parallel_plan_fits(wt);
     }
 
-    return true;
+    // build_2d_column plans on wt/ncol and build_main_split on wt, so Wt bounds both. (ncol lives
+    // in the factory's anonymous namespace; using the looser bound here can only over-route to
+    // native, never under-route into a plan the factory cannot build.)
+    return min_cb_plan_fits(wt);
 }
 
 bool supported_execution_controls(bool use_multicore, const std::optional<CoreRangeSet>& sub_core_grids) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
@@ -14,20 +14,7 @@
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device) {
-    // Same accounting as ProgramImpl::validate_circular_buffer_region(): statically allocated CBs
-    // grow upward from the allocator's base L1 address, L1 buffers are allocated downward from the
-    // top of L1, and that validator TT_THROWs as soon as the CB region end passes
-    // lowest_occupied_compute_l1_address(). Budget against the same frontier so a plan this gate
-    // accepts is one the program validator will accept too. Mirrors get_max_l1_space() in
-    // data_movement/common/common.cpp.
-    //
-    // std::nullopt means nothing is resident in L1 yet, in which case the whole region above the
-    // base is available.
-    const uint32_t base = device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-    const auto lowest_occupied = device->lowest_occupied_compute_l1_address();
-    const uint32_t ceiling =
-        lowest_occupied.has_value() ? static_cast<uint32_t>(*lowest_occupied) : device->l1_size_per_core();
-    return ceiling > base ? ceiling - base : 0;
+    return device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
 }
 
 // Correctness scope of the ported builders: TILE input, interleaved (non-sharded) input AND
@@ -62,42 +49,20 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
     constexpr uint32_t kTileSize = 2048;  // bf16/bf8_b only in this scope
     constexpr uint64_t kWideChunkThreshold = 800'000;
 
-    auto* device = input.device();
-
-    // plan_cb_depths()'s floor tier: cb_in + cb_out at a single slot each. The factory has no
-    // smaller plan to degrade to below this and TT_THROWs instead, so anything that does not clear
-    // the floor has to be routed to native from here rather than aborting inside program creation.
-    //
-    // usable_l1_bytes() is budgeted against LIVE L1 occupancy, so this check is not a static
-    // shape property: the same shape can clear it on an idle device and fail it alongside a
-    // model's resident weight/trace buffers. That is deliberate -- it is the same budget
-    // ProgramImpl::validate_circular_buffer_region() will hold the resulting program to.
-    auto min_cb_plan_fits = [&](uint32_t pages_per_unit) {
-        return 2ull * pages_per_unit * kTileSize <= usable_l1_bytes(device);
-    };
-
     // Mirrors build_column_parallel + plan_cb_depths: that builder's CB plan is sized by the
-    // busiest core's tile count, not by Wt.
+    // busiest core's tile count, not by Wt. A case whose single-buffer plan (cb_in + cb_out, one
+    // slot per tile each) cannot fit even an empty core's L1 is out of scope for every codegen
+    // builder no matter what else is resident, so reject it here and let "auto" pick native.
+    // This is a static bound only -- whether the plan fits the L1 that is actually free right now
+    // is decided once, inside the program factory (see UntilizeCodegenProgramFactory).
     auto column_parallel_plan_fits = [&](uint32_t wt) {
+        auto* device = input.device();
         auto grid = device->compute_with_storage_grid_size();
         auto split = tt::tt_metal::split_work_to_cores(grid, wt, /*row_wise=*/true);
         uint32_t max_tiles_per_core =
             std::max(std::get<4>(split), std::get<3>(split).empty() ? 0u : std::get<5>(split));
-        return min_cb_plan_fits(max_tiles_per_core);
+        return 2ull * max_tiles_per_core * kTileSize <= usable_l1_bytes(device);
     };
-
-    // Wt / total_tile_rows are derived from the PADDED shape (Wt/Ht are physical, tile-grid
-    // quantities), matching how the program factory itself derives them -- including for the
-    // with-unpadding builder, which reads the full physical tile grid and only differs in its
-    // writer.
-    const auto& padded_shape = input.padded_shape();
-    uint32_t rank = padded_shape.rank();
-    uint32_t wt = padded_shape[-1] / tt::constants::TILE_WIDTH;
-    uint32_t nc = 1;
-    for (uint32_t i = 0; i + 2 < rank; ++i) {
-        nc *= padded_shape[i];
-    }
-    uint32_t total_tile_rows = nc * (padded_shape[-2] / tt::constants::TILE_HEIGHT);
 
     const auto& logical = input.logical_shape();
     const bool tile_aligned =
@@ -115,32 +80,36 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
         // slice/untilize/concat cascade outside this port's scope. Uses ceil(W/TILE_W) since W is
         // not tile-aligned here.
         uint32_t wt_ceil = (logical[-1] + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
-        if (2ull * wt_ceil * kTileSize > kWideChunkThreshold) {
-            return false;
-        }
-        // build_with_unpadding plans its CBs on the physical Wt.
-        return min_cb_plan_fits(wt);
+        return 2ull * wt_ceil * kTileSize <= kWideChunkThreshold;
     }
 
     // Tile-aligned path: mirrors ops/untilize/untilize.py's wide-tensor guard for
     // build_untilize_tile -- a multi-tile-row input wide enough that a single tile-row would
     // overflow the slice+concat chunking threshold (~800KB for two double-buffered CBs at
     // 2048B/tile) is routed to a slice -> untilize -> concat cascade over unrelated builder
-    // entries, out of scope here.
+    // entries, out of scope here. Computed from the PADDED shape (Wt/Ht are physical, tile-grid
+    // quantities), matching how the program factory itself derives Wt/total_tile_rows.
+    const auto& padded_shape = input.padded_shape();
+    uint32_t rank = padded_shape.rank();
+    uint32_t w = padded_shape[-1];
+    uint32_t h = padded_shape[-2];
+    uint32_t wt = w / tt::constants::TILE_WIDTH;
+    uint32_t nc = 1;
+    for (uint32_t i = 0; i + 2 < rank; ++i) {
+        nc *= padded_shape[i];
+    }
+    uint32_t total_tile_rows = nc * (h / tt::constants::TILE_HEIGHT);
     if (total_tile_rows > 1 && 2ull * wt * kTileSize > kWideChunkThreshold) {
         return false;
     }
     // A single tile-row skips the chunk cascade (build_column_parallel splits Wt across the grid
     // in one dispatch instead), so it is bounded by that builder's own per-core plan, not by the
     // whole-row threshold above.
-    if (total_tile_rows == 1 && wt > 1) {
-        return column_parallel_plan_fits(wt);
+    if (total_tile_rows == 1 && wt > 1 && !column_parallel_plan_fits(wt)) {
+        return false;
     }
 
-    // build_2d_column plans on wt/ncol and build_main_split on wt, so Wt bounds both. (ncol lives
-    // in the factory's anonymous namespace; using the looser bound here can only over-route to
-    // native, never under-route into a plan the factory cannot build.)
-    return min_cb_plan_fits(wt);
+    return true;
 }
 
 bool supported_execution_controls(bool use_multicore, const std::optional<CoreRangeSet>& sub_core_grids) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
@@ -18,9 +18,16 @@ class IDevice;
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 // Mirrors codegen builder_utils.USABLE_L1: the CB budget every codegen builder plans against.
-// Queried from the device's actual L1 budget (total L1 minus the allocator's reserved base)
-// rather than a hardcoded constant, so the gate and the factory can never disagree with what
-// the allocator will actually hand out. Shared between the two so they stay in lockstep.
+// Queried from the device's *live* L1 occupancy rather than a hardcoded constant, so the gate
+// and the factory can never disagree with what the allocator will actually hand out. Shared
+// between the two so they stay in lockstep.
+//
+// Statically allocated CBs grow upward from the allocator's base L1 address; L1 tensors are
+// allocated downward from the top of L1. The budget is therefore the gap between the two, i.e.
+// lowest_occupied_compute_l1_address() - base -- the exact quantity
+// ProgramImpl::validate_circular_buffer_region() checks the CB region end against. Budgeting
+// against total L1 instead would ignore buffers already resident in L1 (model weights, trace
+// buffers) and plan a CB region that provably clashes with them.
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device);
 
 // Correctness-only: true iff the codegen build_untilize_tile path can produce a bit-exact

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
@@ -18,21 +18,29 @@ class IDevice;
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 // Mirrors codegen builder_utils.USABLE_L1: the CB budget every codegen builder plans against.
-// Queried from the device's *live* L1 occupancy rather than a hardcoded constant, so the gate
-// and the factory can never disagree with what the allocator will actually hand out. Shared
-// between the two so they stay in lockstep.
+// Queried from the device's static L1 budget (total L1 minus the allocator's reserved base)
+// rather than a hardcoded constant, so the gate and the factory can never disagree with what
+// the allocator will actually hand out. Shared between the two so they stay in lockstep.
 //
-// Statically allocated CBs grow upward from the allocator's base L1 address; L1 tensors are
-// allocated downward from the top of L1. The budget is therefore the gap between the two, i.e.
-// lowest_occupied_compute_l1_address() - base -- the exact quantity
-// ProgramImpl::validate_circular_buffer_region() checks the CB region end against. Budgeting
-// against total L1 instead would ignore buffers already resident in L1 (model weights, trace
-// buffers) and plan a CB region that provably clashes with them.
+// Deliberately a STATIC device property: it must not consult live L1 occupancy (see
+// supported_by_codegen below). How much of this budget is actually free at program-build time
+// is the program factory's business, via get_max_l1_space() -- it is the only place that can
+// observe it once, consistently.
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device);
 
 // Correctness-only: true iff the codegen build_untilize_tile path can produce a bit-exact
 // result for this (input, output_mem_config) case. Consulted by the free function's forced
 // "codegen" branch and by prim::untilize_codegen's validate -- never gated on performance.
+//
+// MUST stay a pure function of static tensor/memory-config properties (layout, dtype, shape,
+// sharding, and static device geometry). It is evaluated independently at three call sites --
+// ttnn::untilize's routing gate, detail::untilize_force_codegen's TT_FATAL, and
+// UntilizeCodegenDeviceOperation::validate_on_program_cache_miss -- at different moments in the
+// same dispatch, and those sites are only consistent with each other because the answer cannot
+// change between them. Making it depend on mutable device state (e.g. live L1 occupancy, which
+// the op's own create_output_tensors() moves by allocating the output) breaks that invariant:
+// routing sees true, dispatches to codegen, and validate then TT_FATALs on the same tensor.
+// Live-L1 accounting belongs in the program factory, which decides once per cache miss.
 bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);
 
 // Every codegen builder places work over the full compute-with-storage grid and has no


### PR DESCRIPTION
## Not for merge — cross-arch verification scaffold for #53399

This branch is #53399's current head commit (`a2cb3b0c0d`) under a `port/*` name so that
`tt-dm-codegen`'s cross-arch verification can dispatch against it. #53399 itself is refused by
`cross_arch.guard_ref` (`head branch 'fix/untilize-codegen-l1-overlap' is not a port/* branch`) and
carries no `codegen-port-results:v2` block, which is where `dispatch` reads the op and manifest
from. No code differs between this branch and #53399.

**Close this once the runs are collected.** The results belong on #53399.

## What is being re-verified

This is a second re-verify of the same question #53420 answered at `68f60f8e`: whether #53399's
change to the untilize codegen CB budget — from the whole of L1 above the allocator base to the gap
actually free below resident L1 buffers (`get_max_l1_space`), declining (`std::nullopt`) into a
native-equivalent program instead of aborting when no codegen CB plan fits — silently changes any
result on the untilize codegen sweep #50178 shipped against.

#53399 has moved since that re-verify: `a2cb3b0c` adds a hash-key follow-up requested in review
(hashing the codegen CB tier / native block-split identity into the program cache key, on top of the
`68f60f8e` live-L1 budget) to close a cache-staleness gap the reviewer raised. It touches the cache
key, not the budget arithmetic itself, but a program-hash change is exactly the kind of thing that
can silently perturb which cached program a case resolves to — so the sweep is re-run rather than
assumed unaffected.

Each dispatched run covers, on its arch:

- the 112-config perf sweep (wall leg un-profiled, device leg under tracy), native vs ported;
- a bit-exact forced-native vs forced-codegen compare over the same case set;
- the op's in-tree unit tests, including `test_untilize_codegen_with_resident_l1_buffers` (both the
  `shallower_cb_plan` and `no_cb_plan_fits` headroom regimes, and the warmup parametrization if
  present);
- `tests/ttnn/nightly/unit_tests/operations/data_movement/test_untilize_codegen_routing.py`.

Baseline is #50178 (local wormhole_b0 gate at wall 1.015 / device-vs-native 1.220 /
device-vs-generic-op 0.988, last collected CI rows at `3c131242`) and the prior re-verify at
`68f60f8e` from #53420/#53399 (wormhole_b0/N300 [run 32065863722](https://github.com/tenstorrent/tt-metal/actions/runs/32065863722),
blackhole/P150 [run 32065876271](https://github.com/tenstorrent/tt-metal/actions/runs/32065876271) —
device time median 0.285x/0.260x, worst 0.866x/0.799x ported/native).

## About the block below

Seeded from #50178 / #53420 so `dispatch` can resolve the op and `collect` has somewhere to write.
The correctness tallies and the one-shot generic-op parity record are inherited from that port and
carry their own commit; `perf` is empty and carries no `cross_arch` runs yet, exactly as a fresh
scaffold should — every performance number that appears here comes from the runs this PR dispatches.
`pins` point at this branch and commit.

<!-- codegen-port-results:v2
{
  "arch": "wormhole_b0",
  "cross_arch": {
    "flags": [
      "blackhole: 1 case(s) miss wall-clock parity in CI while still beating native on device \u2014 `[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` (4 more cleared on retest)",
      "blackhole: `[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 inconclusive over 5 window(s), wall ratio now 0.927 ported/native",
      "blackhole: `[1, 188, 200]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.922 ported/native",
      "blackhole: `[12, 63, 172]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.980 ported/native",
      "blackhole: `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.997 ported/native",
      "blackhole: `[211, 244]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.825 ported/native",
      "blackhole: retest of `[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **inconclusive** (median wall ratio 0.927 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[1, 188, 200]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.922 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[12, 63, 172]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.980 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.997 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[211, 244]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.825 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: 1 case(s) miss wall-clock parity in CI while still beating native on device \u2014 `[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` (5 more cleared on retest)",
      "wormhole_b0: `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.978 ported/native",
      "wormhole_b0: `[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 inconclusive over 5 window(s), wall ratio now 0.837 ported/native",
      "wormhole_b0: `[2, 32, 32]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.959 ported/native",
      "wormhole_b0: `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.958 ported/native",
      "wormhole_b0: `[32, 64]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.992 ported/native",
      "wormhole_b0: `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.991 ported/native",
      "wormhole_b0: retest of `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.978 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **inconclusive** (median wall ratio 0.837 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[2, 32, 32]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.959 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.958 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[32, 64]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.992 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.991 ported/native, was flagged at CI's original measurement)"
    ],
    "runs": {
      "blackhole": {
        "run_conclusion": "success",
        "run_id": 32297316426,
        "sha": "a2cb3b0c0d0e4b22ad0762f345ecf1ef5727bf2a",
        "state": "collected",
        "url": "https://github.com/tenstorrent/tt-metal/actions/runs/32297316426"
      },
      "wormhole_b0": {
        "run_conclusion": "success",
        "run_id": 32297304723,
        "sha": "a2cb3b0c0d0e4b22ad0762f345ecf1ef5727bf2a",
        "state": "collected",
        "url": "https://github.com/tenstorrent/tt-metal/actions/runs/32297304723"
      }
    }
  },
  "measurements": {
    "correctness": {
      "failing": 0,
      "implemented_passing": 112,
      "not_started": 0,
      "proven_infeasible": 0,
      "routing": 96
    },
    "parity": {
      "arch": "wormhole_b0",
      "ratio": 0.9876412123113003,
      "sha": "33658abe7786b16a3910c317c29d4f570879f8a8"
    },
    "perf": {
      "blackhole": {
        "board": {
          "arch_env": "blackhole",
          "device_arch": "Arch.BLACKHOLE",
          "labels": [
            "tt-ubuntu-2204-P150b-viommu-stable"
          ],
          "name": "P150",
          "pci": [
            {
              "device": "0xb140",
              "subsystem_device": "0x0041"
            }
          ],
          "runner": "tt-ubuntu-2204-p150b-viommu-stable-rxwdj-runner-rjcq7"
        },
        "config_count": 112,
        "demoted_count": 0,
        "demoted_worst_vs_native": null,
        "device_vs_native": 1.2497512437810945,
        "measured_at": "2026-08-19T20:52:21+00:00",
        "retest_verdicts": {
          "[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "inconclusive",
            "retest_windows": 5,
            "wall_native_us": 62.80000002334418,
            "wall_ported_us": 66.26999993386562,
            "wall_ratio": 1.0789567182469555
          },
          "[1, 188, 200]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 63.570000065737986,
            "wall_ported_us": 59.27999995947175,
            "wall_ratio": 1.0842125446195758
          },
          "[12, 63, 172]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 65.48999999722582,
            "wall_ported_us": 62.090000028547365,
            "wall_ratio": 1.0203948436428696
          },
          "[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 80.86000002549554,
            "wall_ported_us": 66.14999983867165,
            "wall_ratio": 1.0031746074193264
          },
          "[211, 244]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 68.11000002926448,
            "wall_ported_us": 60.26000005476817,
            "wall_ratio": 1.2128429854231162
          }
        },
        "run_id": 32297316426,
        "sha": "a2cb3b0c0d0e4b22ad0762f345ecf1ef5727bf2a",
        "source": "ci",
        "wall_only_configs": [
          "[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile"
        ],
        "wall_ratio": 0.5399707622680164
      },
      "wormhole_b0": {
        "board": {
          "arch_env": "wormhole_b0",
          "device_arch": "Arch.WORMHOLE_B0",
          "labels": [
            "tt-ubuntu-2204-N300-viommu-stable"
          ],
          "name": "N300",
          "pci": [
            {
              "device": "0x401e",
              "subsystem_device": "0x0014"
            }
          ],
          "runner": "tt-ubuntu-2204-n300-viommu-stable-wnk2h-runner-ql72z"
        },
        "config_count": 112,
        "demoted_count": 0,
        "demoted_worst_vs_native": null,
        "device_vs_native": 1.1615326821938392,
        "measured_at": "2026-08-19T20:52:24+00:00",
        "retest_verdicts": {
          "[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 148.50000002297747,
            "wall_ported_us": 145.2700000754703,
            "wall_ratio": 1.0222344595981905
          },
          "[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "inconclusive",
            "retest_windows": 5,
            "wall_native_us": 105.35000001254957,
            "wall_ported_us": 112.12999993404082,
            "wall_ratio": 1.1949863898182398
          },
          "[2, 32, 32]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 148.5499999489548,
            "wall_ported_us": 144.91000001726206,
            "wall_ratio": 1.0422331107536844
          },
          "[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 141.75100000102248,
            "wall_ported_us": 135.8000001800974,
            "wall_ratio": 1.0438217953831581
          },
          "[32, 64]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 143.25000006465416,
            "wall_ported_us": 140.87999988987576,
            "wall_ratio": 1.0079267613349732
          },
          "[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 112.05999999219785,
            "wall_ported_us": 106.23999992276367,
            "wall_ratio": 1.0085755310504234
          }
        },
        "run_id": 32297304723,
        "sha": "a2cb3b0c0d0e4b22ad0762f345ecf1ef5727bf2a",
        "source": "ci",
        "wall_only_configs": [
          "[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile"
        ],
        "wall_ratio": 0.8084469496166462
      }
    }
  },
  "op": "untilize",
  "pins": {
    "codegen_commit": "7f2930ff75da8e4731e7d5cf7d730a77aaec3b62",
    "ttmetal_branch": "port/untilize-l1-budget-reverify-20260819T201021Z",
    "ttmetal_commit": "a2cb3b0c0d0e4b22ad0762f345ecf1ef5727bf2a"
  }
}
-->

Related: #53399, #53420, #50178

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260819T201021Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:port/untilize-l1-budget-reverify-20260819T201021Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260819T201021Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:port/untilize-l1-budget-reverify-20260819T201021Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260819T201021Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:port/untilize-l1-budget-reverify-20260819T201021Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260819T201021Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:port/untilize-l1-budget-reverify-20260819T201021Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260819T201021Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:port/untilize-l1-budget-reverify-20260819T201021Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260819T201021Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:port/untilize-l1-budget-reverify-20260819T201021Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260819T201021Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:port/untilize-l1-budget-reverify-20260819T201021Z)

<!-- codegen-port-cross-arch:begin -->

### Cross-arch verification

| arch | commit | run | state |
|---|---|---|---|
| `blackhole` | `a2cb3b0c` | [32297316426](https://github.com/tenstorrent/tt-metal/actions/runs/32297316426) | collected |
| `wormhole_b0` | `a2cb3b0c` | [32297304723](https://github.com/tenstorrent/tt-metal/actions/runs/32297304723) | collected |

**Flagged — a CI result contradicts a local measurement on the same arch.** Reported only: no verdict here changes because of it.

- blackhole: 1 case(s) miss wall-clock parity in CI while still beating native on device — `[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` (4 more cleared on retest)
- blackhole: `[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — inconclusive over 5 window(s), wall ratio now 0.927 ported/native
- blackhole: `[1, 188, 200]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.922 ported/native
- blackhole: `[12, 63, 172]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.980 ported/native
- blackhole: `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest — cleared over 5 window(s), wall ratio now 0.997 ported/native
- blackhole: `[211, 244]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.825 ported/native
- blackhole: retest of `[1, 12, 41, 119]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **inconclusive** (median wall ratio 0.927 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[1, 188, 200]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.922 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[12, 63, 172]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.980 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) — **cleared** (median wall ratio 0.997 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[211, 244]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.825 ported/native, was flagged at CI's original measurement)
- wormhole_b0: 1 case(s) miss wall-clock parity in CI while still beating native on device — `[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` (5 more cleared on retest)
- wormhole_b0: `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest — cleared over 5 window(s), wall ratio now 0.978 ported/native
- wormhole_b0: `[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — inconclusive over 5 window(s), wall ratio now 0.837 ported/native
- wormhole_b0: `[2, 32, 32]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest — cleared over 5 window(s), wall ratio now 0.959 ported/native
- wormhole_b0: `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.958 ported/native
- wormhole_b0: `[32, 64]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest — cleared over 5 window(s), wall ratio now 0.992 ported/native
- wormhole_b0: `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.991 ported/native
- wormhole_b0: retest of `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) — **cleared** (median wall ratio 0.978 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[2, 12, 73, 122]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **inconclusive** (median wall ratio 0.837 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[2, 32, 32]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) — **cleared** (median wall ratio 0.959 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.958 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[32, 64]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) — **cleared** (median wall ratio 0.992 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.991 ported/native, was flagged at CI's original measurement)

**Worst-case device time, ported / native** (lower is faster; `1.0` = no change)

| arch | | ratio | source |
|---|---|---:|---|
| `blackhole/P150` | `███████████████████·····` | 0.80x | ci ([run](https://github.com/tenstorrent/tt-metal/actions/runs/32297316426)) |
| `wormhole_b0/N300` | `█████████████████████···` | 0.86x | ci ([run](https://github.com/tenstorrent/tt-metal/actions/runs/32297304723)) |

<!-- codegen-port-cross-arch:end -->
