### PR TITLE
[Cleanup] Thread MetalContext& into DeviceCommand and alike

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -11,209 +11,220 @@
 #include <vector>
 
 #include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 
 namespace tt::tt_metal {
 
-TEST(DeviceCommandTest, CPU_AddDispatchWait) {
-    DeviceCommandCalculator calculator;
+// These are host-only command-layout checks, but they link into unit_tests_dispatch which runs against
+// hardware, so resolving the global MetalContext here is an acceptable single documented bridge.
+class DeviceCommandTest : public ::testing::Test {
+protected:
+    MetalContext& ctx_ = MetalContext::instance();
+};
+
+TEST_F(DeviceCommandTest, CPU_AddDispatchWait) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_wait();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_dispatch_wait(0, 0, 0, 0, 0);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchWaitWithPrefetchStall) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddDispatchWaitWithPrefetchStall) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_wait_with_prefetch_stall();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_dispatch_wait_with_prefetch_stall(0, 0, 0, 0, 0);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddPrefetchRelayLinear) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddPrefetchRelayLinear) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_prefetch_relay_linear();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_prefetch_relay_linear(0, 0, 0);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddData) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddData) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_data(32);
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     uint32_t data[1] = {};
     command.add_data(data, 4, 32);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchWriteLinear) {
+TEST_F(DeviceCommandTest, CPU_AddDispatchWriteLinear) {
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_linear<false, false>(5);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         command.add_dispatch_write_linear<false, false>(0, 0, 0, 5);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_linear<true, true>(5);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         uint32_t data[2] = {};
         command.add_dispatch_write_linear<true, true>(0, 0, 0, 5, data);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_linear<true, false>(5);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         command.add_dispatch_write_linear<true, false>(0, 0, 0, 5);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_linear<false, true>(5);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         uint32_t data[2] = {};
         command.add_dispatch_write_linear<false, true>(0, 0, 0, 5, data);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchGoSignalMcast) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddDispatchGoSignalMcast) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_go_signal_mcast();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_dispatch_go_signal_mcast(0, 0, 0, 0, 0, 0, DispatcherSelect::DISPATCH_MASTER);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddNotifyDispatchSGoSignalCmd) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddNotifyDispatchSGoSignalCmd) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_notify_dispatch_s_go_signal_cmd();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_notify_dispatch_s_go_signal_cmd(0, 0);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchSetNumWorkerSems) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddDispatchSetNumWorkerSems) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_set_num_worker_sems();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_dispatch_set_num_worker_sems(0, DispatcherSelect::DISPATCH_MASTER);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchSetSubDeviceWorkerCounts) {
+TEST_F(DeviceCommandTest, CPU_AddDispatchSetSubDeviceWorkerCounts) {
     constexpr uint32_t num_sub_devices = 3;
     std::array<uint32_t, num_sub_devices> workers_per_sub_device = {4, 7, 2};
 
-    DeviceCommandCalculator calculator;
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_set_sub_device_worker_counts(num_sub_devices);
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_dispatch_set_sub_device_worker_counts(
         ttsl::Span<const uint32_t>(workers_per_sub_device.data(), workers_per_sub_device.size()),
         DispatcherSelect::DISPATCH_MASTER);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchSetGoSignalNocData) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddDispatchSetGoSignalNocData) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_set_go_signal_noc_data(5);
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     vector_aligned<uint32_t> data(5);
     command.add_dispatch_set_go_signal_noc_data(data, DispatcherSelect::DISPATCH_MASTER);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchSetWriteOffsets) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddDispatchSetWriteOffsets) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_set_write_offsets(CQ_DISPATCH_MAX_WRITE_OFFSETS);
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     std::vector<uint32_t> offsets(CQ_DISPATCH_MAX_WRITE_OFFSETS, 0);
     command.add_dispatch_set_write_offsets(offsets);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchTerminate) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddDispatchTerminate) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_dispatch_terminate();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_dispatch_terminate();
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchWritePaged) {
+TEST_F(DeviceCommandTest, CPU_AddDispatchWritePaged) {
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_paged<false>(1, 5);
         // Do PCIE alignment for out-of-line data
         calculator.add_alignment();
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         command.add_dispatch_write_paged<false>(false, 0, 0, 0, 1, 5);
         command.align_write_offset();
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_paged<true>(1, 5);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         uint32_t data[2] = {};
         command.add_dispatch_write_paged<true>(false, 0, 0, 0, 1, 5, data);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
 }
 
-TEST(DeviceCommandTest, CPU_AddPrefetchRelayPaged) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddPrefetchRelayPaged) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_prefetch_relay_paged();
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     command.add_prefetch_relay_paged(0, 0, 0, 0, 0, 0);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, CPU_AddPrefetchRelayPagedPacked) {
-    DeviceCommandCalculator calculator;
+TEST_F(DeviceCommandTest, CPU_AddPrefetchRelayPagedPacked) {
+    DeviceCommandCalculator calculator(ctx_);
     calculator.add_prefetch_relay_paged_packed(1);
 
-    HostMemDeviceCommand command(calculator.write_offset_bytes());
+    HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
     std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds(1);
     command.add_prefetch_relay_paged_packed(0, sub_cmds, 1);
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
 template <typename T>
-class WritePackedCommandTest : public ::testing::Test {};
+class WritePackedCommandTest : public ::testing::Test {
+protected:
+    MetalContext& ctx_ = MetalContext::instance();
+};
 
 using TestTypes = testing::Types<CQDispatchWritePackedMulticastSubCmd, CQDispatchWritePackedUnicastSubCmd>;
 TYPED_TEST_SUITE(WritePackedCommandTest, TestTypes);
 
 TYPED_TEST(WritePackedCommandTest, CPU_AddDispatchWritePacked) {
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(this->ctx_);
         calculator.add_dispatch_write_packed<TypeParam>(2, 5, 100, /*no_stride*/ false);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(this->ctx_, calculator.write_offset_bytes());
         std::vector<TypeParam> sub_cmds(2);
         uint32_t data[1] = {};
         std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}, {data, 4}};
@@ -221,10 +232,10 @@ TYPED_TEST(WritePackedCommandTest, CPU_AddDispatchWritePacked) {
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(this->ctx_);
         calculator.add_dispatch_write_packed<TypeParam>(2, 5, 100, /*no_stride*/ true);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(this->ctx_, calculator.write_offset_bytes());
         std::vector<TypeParam> sub_cmds(2);
         uint32_t data[1] = {};
         std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}};
@@ -233,21 +244,21 @@ TYPED_TEST(WritePackedCommandTest, CPU_AddDispatchWritePacked) {
     }
 }
 
-TEST(DeviceCommandTest, CPU_AddDispatchWritePackedLarge) {
+TEST_F(DeviceCommandTest, CPU_AddDispatchWritePackedLarge) {
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_packed_large(1);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds(1);
         command.add_dispatch_write_packed_large(CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_UNKNOWN, 0, 1, sub_cmds);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(ctx_);
         calculator.add_dispatch_write_packed_large(1, 4);
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(ctx_, calculator.write_offset_bytes());
         std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds(1);
 
         uint8_t data[4] = {};
@@ -261,7 +272,7 @@ TEST(DeviceCommandTest, CPU_AddDispatchWritePackedLarge) {
 TYPED_TEST(WritePackedCommandTest, CPU_RandomAddDispatchWritePacked) {
     srand(0);
     for (size_t i = 0; i < 100; i++) {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(this->ctx_);
         uint32_t random_start = (rand() % 4) % 32;
         calculator.add_data(random_start);
         uint32_t num_sub_cmds = (rand() % 100) + 1;
@@ -284,7 +295,7 @@ TYPED_TEST(WritePackedCommandTest, CPU_RandomAddDispatchWritePacked) {
             data_collection.push_back({data, sub_cmd_sizeB});
         }
 
-        HostMemDeviceCommand command(calculator.write_offset_bytes());
+        HostMemDeviceCommand command(this->ctx_, calculator.write_offset_bytes());
         command.add_data(data, 0, random_start);
         uint32_t curr_sub_cmd_idx = 0;
         for (const auto& [sub_cmd_ct, payload_size] : packed_cmd_payloads) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -24,6 +24,7 @@
 
 #include "llrt/hal.hpp"
 #include "tt_metal/impl/context/metal_context.hpp"
+#include "tt_metal/impl/context/context_types.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include <variant>
 #include <llrt/tt_cluster.hpp>
@@ -651,6 +652,7 @@ namespace CommandBuilder {
 // Emits a single linear write, optionally multicast, with inline data
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_linear_write_command(
+    MetalContext& metal_ctx,
     const std::vector<uint32_t>& payload,
     const CoreRange& worker_range,
     bool is_mcast,
@@ -659,12 +661,12 @@ HostMemDeviceCommand build_linear_write_command(
     uint32_t xfer_size_bytes) {
     // Calculate the command size using DeviceCommandCalculator
     // Pre-calculate the exact size to allocate correct amount of memory in HostMemDeviceCommand buffer
-    DeviceCommandCalculator cmd_calc;
+    DeviceCommandCalculator cmd_calc(metal_ctx);
     cmd_calc.add_dispatch_write_linear<flush_prefetch, inline_data>(xfer_size_bytes);
     const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
     // Add the dispatch write linear command
     cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
@@ -682,6 +684,7 @@ HostMemDeviceCommand build_linear_write_command(
 // payload is already stitched together for all pages in the chunk
 template <bool inline_data>
 HostMemDeviceCommand build_paged_write_command(
+    MetalContext& metal_ctx,
     const std::vector<uint32_t>& payload,
     uint32_t base_addr,
     uint32_t page_size_bytes,
@@ -689,12 +692,12 @@ HostMemDeviceCommand build_paged_write_command(
     uint16_t start_page_cmd,
     bool is_dram) {
     // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
+    DeviceCommandCalculator cmd_calc(metal_ctx);
     cmd_calc.add_dispatch_write_paged<inline_data>(page_size_bytes, pages_in_chunk);
     const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
     // Add the dispatch write paged command
     cmd.add_dispatch_write_paged<inline_data>(
@@ -713,6 +716,7 @@ HostMemDeviceCommand build_paged_write_command(
 // Serializes a packed-unicast command including sub-command table
 // and optional replicated payloads when stride is enabled
 inline HostMemDeviceCommand build_packed_write_command(
+    MetalContext& metal_ctx,
     const std::vector<uint32_t>& payload,
     const std::vector<CQDispatchWritePackedUnicastSubCmd>& sub_cmds,
     uint32_t common_addr,
@@ -729,7 +733,7 @@ inline HostMemDeviceCommand build_packed_write_command(
     const uint32_t payload_bytes = tt::align(sizeof(CQDispatchCmd) + sub_cmds_bytes, l1_alignment) + data_bytes;
 
     // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
+    DeviceCommandCalculator cmd_calc(metal_ctx);
     cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
         num_sub_cmds,        // num_sub_cmds
         payload_size_bytes,  // packed_data_sizeB
@@ -739,7 +743,7 @@ inline HostMemDeviceCommand build_packed_write_command(
     const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
     // Build data_collection pointing to the payload
     std::vector<std::pair<const void*, uint32_t>> data_collection;
@@ -912,6 +916,7 @@ inline std::vector<CQDispatchWritePackedUnicastSubCmd> build_sub_cmds(
 // even one alignment unit does not fit. A caller that gets 0 must not emit the command: a packed write of no payload
 // makes the dispatcher issue zero-length NOC writes, which the watcher NOC sanitizer stops the device for.
 inline uint32_t clamp_to_max_fetch(
+    MetalContext& metal_ctx,
     uint32_t max_fetch_bytes,
     uint32_t xfer_size_bytes,
     uint32_t num_sub_cmds,
@@ -922,7 +927,7 @@ inline uint32_t clamp_to_max_fetch(
     // size reports what both commands would occupy together -- the measurement then only grows as the loop below tries
     // smaller transfers, no size ever looks like it fits, and the loop walks the transfer down to nothing.
     const auto command_size_bytes = [&](uint32_t payload_bytes) {
-        DeviceCommandCalculator cmd_calc;
+        DeviceCommandCalculator cmd_calc(metal_ctx);
         cmd_calc.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
             num_sub_cmds,   // num_sub_cmds
             payload_bytes,  // packed_data_sizeB
@@ -1301,6 +1306,9 @@ protected:
         uint32_t num_iterations,
         bool wait_for_completion = true,
         bool wait_for_host_writes = false) {
+        tt::tt_metal::MetalContext& metal_ctx =
+            tt::tt_metal::MetalContext::instance(tt::tt_metal::extract_context_id(device_));
+
         // PHASE 2: Calculate total command buffer size
         uint64_t per_iter_total = 0;
         for (const auto& cmd : commands_per_iteration) {
@@ -1308,7 +1316,7 @@ protected:
         }
 
         // For the barrier wait command
-        DeviceCommandCalculator cmd_calc;
+        DeviceCommandCalculator cmd_calc(metal_ctx);
         cmd_calc.add_dispatch_wait();
 
         const uint64_t total_cmd_bytes = num_iterations * per_iter_total + cmd_calc.write_offset_bytes();
@@ -1327,7 +1335,7 @@ protected:
         // 2. Writing (HugepageDeviceCommand):
         //    - wraps a pointer that points directly to the issue queue memory (cmd_buffer_base)
         //    - the loop below copies staged commands into the issue queue memory
-        HugepageDeviceCommand dc(cmd_buffer_base, total_cmd_bytes);
+        HugepageDeviceCommand dc(metal_ctx, cmd_buffer_base, total_cmd_bytes);
 
         // Store the size of each command entry (per-chunk)
         std::vector<uint32_t> entry_sizes;
@@ -1350,7 +1358,7 @@ protected:
         // Without this, there can be occasional timeouts in MetalContext::initialize_and_launch_firmware()
         // between test fixtures possibly because the previously issued commands
         // are not completed before next firmware launch
-        HostMemDeviceCommand cmd(cmd_calc.write_offset_bytes());
+        HostMemDeviceCommand cmd(metal_ctx, cmd_calc.write_offset_bytes());
         cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0, 0);
         dc.add_data(cmd.data(), cmd.size_bytes(), cmd.size_bytes());
         entry_sizes.push_back(cmd.size_bytes());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -15,6 +15,7 @@
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
+#include "tt_metal/impl/context/context_types.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include "tt_metal/impl/host_api/temp_quasar_api.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
@@ -136,17 +137,18 @@ namespace CommandBuilder {
 //  Builds a multi-transaction packed-large command
 //  payload spans map 1:1 with the sub-command list
 HostMemDeviceCommand build_packed_large_write_command(
+    MetalContext& metal_ctx,
     const std::vector<CQDispatchWritePackedLargeSubCmd>& sub_cmds,
     const std::vector<std::vector<uint32_t>>& payloads,
     uint32_t cumulative_payload_bytes,
     uint32_t l1_alignment) {
     // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
+    DeviceCommandCalculator cmd_calc(metal_ctx);
     cmd_calc.add_dispatch_write_packed_large(sub_cmds.size(), cumulative_payload_bytes);
     const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
     // Build data spans pointing to the generated payloads
     std::vector<ttsl::Span<const uint8_t>> data_spans;
@@ -171,17 +173,18 @@ HostMemDeviceCommand build_packed_large_write_command(
 //  Builds a multi-transaction packed-large unicast command
 //  payload spans map 1:1 with the sub-command list
 HostMemDeviceCommand build_packed_large_unicast_write_command(
+    MetalContext& metal_ctx,
     const std::vector<CQDispatchWritePackedLargeUnicastSubCmd>& sub_cmds,
     const std::vector<std::vector<uint32_t>>& payloads,
     uint32_t cumulative_payload_bytes,
     uint32_t l1_alignment) {
     // Calculate the command size
-    DeviceCommandCalculator cmd_calc;
+    DeviceCommandCalculator cmd_calc(metal_ctx);
     cmd_calc.add_dispatch_write_packed_large_unicast(sub_cmds.size(), cumulative_payload_bytes);
     const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(command_size_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
     // Build data spans pointing to the generated payloads
     std::vector<ttsl::Span<const uint8_t>> data_spans;
@@ -253,6 +256,7 @@ protected:
         uint32_t budget_bytes,
         Common::DeviceData& device_data) {
         const CoreCoord first_worker = worker_range.start_coord;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         for (uint32_t remaining_bytes = budget_bytes; remaining_bytes > 0;) {
             uint32_t xfer_size_bytes =
                 payload_generator_->get_random_size(MAX_XFER_SIZE_16B, bytes_per_16B_unit, remaining_bytes);
@@ -261,7 +265,7 @@ protected:
             std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
             Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, is_mcast_);
             commands.push_back(Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
-                payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes));
+                metal_ctx, payload, worker_range, is_mcast_, noc_xy, addr, xfer_size_bytes));
             remaining_bytes -= xfer_size_bytes;
         }
     }
@@ -299,7 +303,8 @@ public:
         Common::DeviceData device_data(
             device_, worker_range, l1_base, dram_base, nullptr, false, /*dram_data_size_words=*/0, cfg_);
 
-        DeviceCommandCalculator cmd_calc;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        DeviceCommandCalculator cmd_calc(metal_ctx);
         cmd_calc.add_dispatch_write_linear<flush_prefetch_, inline_data_>(0);
         const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - cmd_calc.write_offset_bytes();
         const uint32_t noc_xy = linear_write_noc_encoding(worker_range);
@@ -395,6 +400,7 @@ public:
         uint32_t remaining_pages = num_pages_;
         uint32_t absolute_start_page = 0;
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         // This loop generates commands, payloads, and updates expectations all at once
         // Each iteration represents one "chunk" that fits in max_payload_per_cmd_bytes
         while (remaining_pages > 0) {
@@ -439,7 +445,7 @@ public:
 
             // Create the HostMemDeviceCommand
             HostMemDeviceCommand cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
-                chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, is_dram_);
+                metal_ctx, chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, is_dram_);
 
             commands_per_iteration.push_back(std::move(cmd));
 
@@ -482,7 +488,8 @@ public:
         const tt::CoreType core_type = is_dram ? tt::CoreType::DRAM : tt::CoreType::WORKER;
         const uint32_t page_size_bytes = paged_write_page_size_bytes(get_page_size());
 
-        DeviceCommandCalculator cmd_calc;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        DeviceCommandCalculator cmd_calc(metal_ctx);
         cmd_calc.add_dispatch_write_paged<inline_data_>(page_size_bytes, 0);
         const uint32_t max_payload_per_cmd_bytes = max_fetch_bytes_ - cmd_calc.write_offset_bytes();
 
@@ -519,7 +526,9 @@ class DispatchPackedWriteTestFixture : public BaseDispatchTestFixture,
         uint32_t packed_write_max_unicast_sub_cmds,
         bool no_stride,
         uint32_t l1_alignment) {
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         return Common::PackedWriteUtils::clamp_to_max_fetch(
+            metal_ctx,
             max_fetch_bytes_,
             xfer_size_bytes,
             num_sub_cmds,
@@ -568,6 +577,7 @@ public:
         // Relevel once before generating commands
         device_data.relevel(tt::CoreType::WORKER);
         constexpr uint32_t payload_unit = sizeof(uint32_t);
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
 
         // Generate random-sized packed write commands until transfer_size_bytes_ is consumed
         // Each command is constrained by:
@@ -617,7 +627,7 @@ public:
             Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment);
 
             HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
-                payload, sub_cmds, common_addr, l1_alignment, packed_write_max_unicast_sub_cmds, no_stride);
+                metal_ctx, payload, sub_cmds, common_addr, l1_alignment, packed_write_max_unicast_sub_cmds, no_stride);
 
             // Add command to batch
             commands_per_iteration.push_back(std::move(cmd));
@@ -702,6 +712,7 @@ class DispatchPackedWriteLargeTestFixture : public DispatchPackedWriteTestFixtur
         // Track payload size for this command
         uint32_t cumulative_payload_bytes = 0;
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         for (int i = 0; i < max_transactions && remaining_bytes > 0; i++) {
             // Generate a random transfer size
             // We're first converting the max payload allowed by the packed large format into alignment units
@@ -717,7 +728,7 @@ class DispatchPackedWriteLargeTestFixture : public DispatchPackedWriteTestFixtur
             // Verify adding this transaction won't exceed max_fetch_bytes_
             // Use a projected command size to see if we would exceed the max_fetch_bytes_
             // We speculatively calculate the command size to ensure we don't overflow
-            DeviceCommandCalculator cmd_calc;
+            DeviceCommandCalculator cmd_calc(metal_ctx);
             cmd_calc.add_dispatch_write_packed_large(
                 transaction_sizes.size() + 1, cumulative_payload_bytes + xfer_size_bytes);
             const uint32_t projected_cmd_size = cmd_calc.write_offset_bytes();
@@ -778,6 +789,7 @@ protected:
         // Relevel once at start (all transactions target same fixed range)
         device_data.relevel(worker_range);
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         // This loop generates random-sized packed-large commands until remaining_bytes is exhausted
         while (remaining_bytes > 0) {
             const int max_transactions =
@@ -818,7 +830,7 @@ protected:
 
             // Create the HostMemDeviceCommand
             HostMemDeviceCommand cmd = CommandBuilder::build_packed_large_write_command(
-                sub_cmds, payloads, transaction_batch.total_payload_bytes, l1_alignment);
+                metal_ctx, sub_cmds, payloads, transaction_batch.total_payload_bytes, l1_alignment);
 
             log_info(
                 tt::LogTest,
@@ -878,6 +890,7 @@ class DispatchPackedWriteLargeUnicastTestFixture : public DispatchPackedWriteTes
 
         uint32_t cumulative_payload_bytes = 0;
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         for (int i = 0; i < max_transactions && remaining_bytes > 0; i++) {
             uint32_t max_allowed = dispatch_buffer_page_size_ * max_pages_per_transaction / l1_alignment;
             if (get_target_sub_cmds() != 0) {
@@ -888,7 +901,7 @@ class DispatchPackedWriteLargeUnicastTestFixture : public DispatchPackedWriteTes
                 payload_generator_->get_random_size(max_allowed, bytes_per_16B_unit, remaining_bytes);
 
             // Verify adding this transaction won't exceed max_fetch_bytes_
-            DeviceCommandCalculator cmd_calc;
+            DeviceCommandCalculator cmd_calc(metal_ctx);
             cmd_calc.add_dispatch_write_packed_large_unicast(
                 transaction_sizes.size() + 1, cumulative_payload_bytes + xfer_size_bytes);
             const uint32_t projected_cmd_size = cmd_calc.write_offset_bytes();
@@ -941,6 +954,7 @@ protected:
         std::vector<HostMemDeviceCommand> commands_per_iteration;
         uint32_t remaining_bytes = get_transfer_size_bytes();
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         // This loop generates random-sized packed-large unicast commands until remaining_bytes is exhausted
         while (remaining_bytes > 0) {
             const int max_transactions =
@@ -992,7 +1006,7 @@ protected:
 
             // Create the HostMemDeviceCommand
             HostMemDeviceCommand cmd = CommandBuilder::build_packed_large_unicast_write_command(
-                sub_cmds, payloads, transaction_batch.total_payload_bytes, l1_alignment);
+                metal_ctx, sub_cmds, payloads, transaction_batch.total_payload_bytes, l1_alignment);
 
             log_info(
                 tt::LogTest,
@@ -1120,9 +1134,10 @@ public:
 
         // Append terminate command as its own page
         {
-            DeviceCommandCalculator calc;
+            auto& metal_ctx = MetalContext::instance(extract_context_id(this->device_));
+            DeviceCommandCalculator calc(metal_ctx);
             calc.add_dispatch_terminate();
-            HostMemDeviceCommand term_cmd(calc.write_offset_bytes());
+            HostMemDeviceCommand term_cmd(metal_ctx, calc.write_offset_bytes());
             term_cmd.add_dispatch_terminate();
             append_dispatch_payload(raw, term_cmd);
         }
@@ -1270,9 +1285,16 @@ protected:
         // stress stream overwrites before validation.
         constexpr uint32_t filler_page_size = 16;
         const std::vector<uint32_t> filler_payload(filler_page_size / sizeof(uint32_t), 0xA5A5A5A5);
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         for (uint32_t page = 1; page < dispatch_cb_pages; ++page) {
             HostMemDeviceCommand prefix_cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
-                filler_payload, base_addr, filler_page_size, /*pages_in_chunk=*/1, /*start_page_cmd=*/0, is_dram);
+                metal_ctx,
+                filler_payload,
+                base_addr,
+                filler_page_size,
+                /*pages_in_chunk=*/1,
+                /*start_page_cmd=*/0,
+                is_dram);
             const auto* prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(prefix_cmd.data());
             TT_FATAL(
                 tt::align(prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
@@ -1287,7 +1309,13 @@ protected:
         const uint32_t crossing_page_size = dispatch_cb_page_size;
         const std::vector<uint32_t> crossing_payload(crossing_page_size / sizeof(uint32_t), 0x5A5A5A5A);
         HostMemDeviceCommand crossing_cmd = Common::CommandBuilder::build_paged_write_command<inline_data_>(
-            crossing_payload, base_addr, crossing_page_size, /*pages_in_chunk=*/1, /*start_page_cmd=*/0, is_dram);
+            metal_ctx,
+            crossing_payload,
+            base_addr,
+            crossing_page_size,
+            /*pages_in_chunk=*/1,
+            /*start_page_cmd=*/0,
+            is_dram);
         const auto* crossing_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(crossing_cmd.data());
         const uint32_t crossing_dispatch_payload_bytes = crossing_prefetch_cmd->relay_inline.length;
         TT_FATAL(
@@ -1324,10 +1352,11 @@ protected:
         // target the normal stream's initial destination but are not added to DeviceData.
         constexpr uint32_t filler_payload_size = 16;
         const std::vector<uint32_t> filler_payload(filler_payload_size / sizeof(uint32_t), 0xA5A5A5A5);
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         for (uint32_t page = 1; page < dispatch_cb_pages; ++page) {
             HostMemDeviceCommand filler_cmd =
                 Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
-                    filler_payload, worker_range, is_mcast, noc_xy, addr, filler_payload_size);
+                    metal_ctx, filler_payload, worker_range, is_mcast, noc_xy, addr, filler_payload_size);
             const auto* prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(filler_cmd.data());
             TT_FATAL(
                 tt::align(prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
@@ -1341,7 +1370,7 @@ protected:
         std::vector<uint32_t> crossing_payload = payload_generator_->generate_payload(crossing_payload_size);
         HostMemDeviceCommand crossing_cmd =
             Common::CommandBuilder::build_linear_write_command<flush_prefetch_, inline_data_>(
-                crossing_payload, worker_range, is_mcast, noc_xy, addr, crossing_payload_size);
+                metal_ctx, crossing_payload, worker_range, is_mcast, noc_xy, addr, crossing_payload_size);
         const auto* crossing_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(crossing_cmd.data());
         TT_FATAL(
             dispatch_cb_prefix_bytes + crossing_prefetch_cmd->relay_inline.length > dispatch_cb_size,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -14,6 +14,7 @@
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"
+#include "tt_metal/impl/context/context_types.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/host_api/temp_quasar_api.hpp"
@@ -165,17 +166,17 @@ class PrefetcherRingbufferReadTestFixture;
 // for testing purposes.
 namespace CommandBuilder {
 
-HostMemDeviceCommand build_dispatch_terminate(bool include_dispatch_s = true) {
+HostMemDeviceCommand build_dispatch_terminate(MetalContext& metal_ctx, bool include_dispatch_s = true) {
     bool dispatch_sub_enabled =
         MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() && include_dispatch_s;
-    DeviceCommandCalculator calc;
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_wait();
     calc.add_dispatch_terminate();
     if (dispatch_sub_enabled) {
         calc.add_dispatch_terminate();
     }
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
     cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0, 0);
     cmd.add_dispatch_terminate();
     if (dispatch_sub_enabled) {
@@ -185,22 +186,22 @@ HostMemDeviceCommand build_dispatch_terminate(bool include_dispatch_s = true) {
     return cmd;
 }
 
-HostMemDeviceCommand build_prefetch_terminate() {
-    DeviceCommandCalculator calc;
+HostMemDeviceCommand build_prefetch_terminate(MetalContext& metal_ctx) {
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_prefetch_terminate();
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
 
     cmd.add_prefetch_terminate();
 
     return cmd;
 }
 
-HostMemDeviceCommand build_dispatch_prefetch_stall() {
-    DeviceCommandCalculator calc;
+HostMemDeviceCommand build_dispatch_prefetch_stall(MetalContext& metal_ctx) {
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_wait_with_prefetch_stall();
     const uint32_t command_size_bytes = calc.write_offset_bytes();
-    HostMemDeviceCommand cmd(command_size_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
     cmd.add_dispatch_wait_with_prefetch_stall(
         CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER | CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY, 0, 0, 0, 0);
@@ -208,12 +209,12 @@ HostMemDeviceCommand build_dispatch_prefetch_stall() {
     return cmd;
 }
 
-HostMemDeviceCommand build_dispatch_write_offset(ttsl::Span<const uint32_t> write_offsets) {
-    DeviceCommandCalculator calc;
+HostMemDeviceCommand build_dispatch_write_offset(MetalContext& metal_ctx, ttsl::Span<const uint32_t> write_offsets) {
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_set_write_offsets(write_offsets.size());
     const uint32_t command_size_bytes = calc.write_offset_bytes();
 
-    HostMemDeviceCommand cmd(command_size_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
     cmd.add_dispatch_set_write_offsets(write_offsets);
 
@@ -221,13 +222,14 @@ HostMemDeviceCommand build_dispatch_write_offset(ttsl::Span<const uint32_t> writ
 }
 
 template <bool inline_data>
-HostMemDeviceCommand build_prefetch_relay_linear_host(uint32_t noc_xy, uint32_t addr, uint32_t data_size_bytes) {
-    DeviceCommandCalculator calc;
+HostMemDeviceCommand build_prefetch_relay_linear_host(
+    MetalContext& metal_ctx, uint32_t noc_xy, uint32_t addr, uint32_t data_size_bytes) {
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_write_linear_host();
     calc.add_prefetch_relay_linear();
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
     cmd.add_dispatch_write_host<inline_data>(
         false,            // flush_prefetch
         data_size_bytes,  // data_sizeB
@@ -243,12 +245,13 @@ HostMemDeviceCommand build_prefetch_relay_linear_host(uint32_t noc_xy, uint32_t 
 }
 
 template <bool inline_data>
-HostMemDeviceCommand build_relay_inline_host(const std::vector<uint32_t>& payload, uint32_t data_size_bytes) {
-    DeviceCommandCalculator calc;
+HostMemDeviceCommand build_relay_inline_host(
+    MetalContext& metal_ctx, const std::vector<uint32_t>& payload, uint32_t data_size_bytes) {
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_write_linear_host_event(data_size_bytes);
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
     cmd.add_dispatch_write_host<inline_data>(
         true,             // flush_prefetch
         data_size_bytes,  // data_sizeB
@@ -262,13 +265,13 @@ HostMemDeviceCommand build_relay_inline_host(const std::vector<uint32_t>& payloa
 
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_prefetch_relay_linear_read(
-    uint32_t noc_xy, uint32_t dst_addr, uint32_t src_addr, uint32_t transfer_size) {
-    DeviceCommandCalculator calc;
+    MetalContext& metal_ctx, uint32_t noc_xy, uint32_t dst_addr, uint32_t src_addr, uint32_t transfer_size) {
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_write_linear<flush_prefetch, inline_data>(transfer_size);
     calc.add_prefetch_relay_linear();
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
     cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
         0,              // num_mcast_dests
         noc_xy,         // NOC coordinates
@@ -285,6 +288,7 @@ HostMemDeviceCommand build_prefetch_relay_linear_read(
 
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_prefetch_relay_paged(
+    MetalContext& metal_ctx,
     uint32_t noc_xy,
     uint32_t addr,
     uint32_t start_page,
@@ -292,14 +296,14 @@ HostMemDeviceCommand build_prefetch_relay_paged(
     uint32_t page_size_bytes,
     uint32_t pages_in_chunk,
     uint32_t length_adjust = 0) {
-    DeviceCommandCalculator calc;
+    DeviceCommandCalculator calc(metal_ctx);
     uint32_t transfer_size = page_size_bytes * pages_in_chunk;
     calc.add_dispatch_write_linear<flush_prefetch, inline_data>(transfer_size);
     calc.add_prefetch_relay_paged();
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
 
     cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
         0,              // num_mcast_dests
@@ -317,19 +321,20 @@ HostMemDeviceCommand build_prefetch_relay_paged(
 
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_prefetch_relay_paged_packed(
+    MetalContext& metal_ctx,
     const std::vector<CQPrefetchRelayPagedPackedSubCmd>& sub_cmds,
     uint32_t noc_xy,
     uint32_t addr,
     uint32_t total_length) {
     const uint32_t n_sub_cmds = sub_cmds.size();
     // Calculate the command size using DeviceCommandCalculator
-    DeviceCommandCalculator calc;
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_write_linear<flush_prefetch, inline_data>(total_length);
     calc.add_prefetch_relay_paged_packed(n_sub_cmds);
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
 
     cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
         0,             // num_mcast_dests
@@ -347,6 +352,7 @@ HostMemDeviceCommand build_prefetch_relay_paged_packed(
 
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_prefetch_relay_linear_packed(
+    MetalContext& metal_ctx,
     const std::vector<CQPrefetchRelayLinearPackedSubCmd>& sub_cmds,
     uint32_t src_noc_xy,
     uint32_t dst_noc_xy,
@@ -354,13 +360,13 @@ HostMemDeviceCommand build_prefetch_relay_linear_packed(
     uint32_t total_length) {
     const uint32_t n_sub_cmds = sub_cmds.size();
     // Calculate the command size using DeviceCommandCalculator
-    DeviceCommandCalculator calc;
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_write_linear<flush_prefetch, inline_data>(total_length);
     calc.add_prefetch_relay_linear_packed(n_sub_cmds);
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
 
     cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
         0,             // num_mcast_dests
@@ -378,6 +384,7 @@ HostMemDeviceCommand build_prefetch_relay_linear_packed(
 
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_prefetch_relay_linear_packed_h(
+    MetalContext& metal_ctx,
     const std::vector<CQPrefetchRelayLinearPackedSubCmd>& sub_cmds,
     uint32_t src_noc_xy,
     uint32_t dst_noc_xy,
@@ -385,13 +392,13 @@ HostMemDeviceCommand build_prefetch_relay_linear_packed_h(
     uint32_t total_length) {
     const uint32_t n_sub_cmds = sub_cmds.size();
     // Calculate the command size using DeviceCommandCalculator
-    DeviceCommandCalculator calc;
+    DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_write_linear<flush_prefetch, inline_data>(total_length);
     calc.add_prefetch_relay_linear_packed_h(n_sub_cmds);
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
 
     cmd.add_dispatch_write_linear<flush_prefetch, inline_data>(
         0,             // num_mcast_dests
@@ -409,6 +416,7 @@ HostMemDeviceCommand build_prefetch_relay_linear_packed_h(
 
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_prefetch_ringbuffer_relay(
+    MetalContext& metal_ctx,
     const std::vector<CQPrefetchRelayRingbufferSubCmd>& sub_cmds,
     const std::vector<uint32_t>& lengths,
     Common::DeviceData& device_data,
@@ -524,8 +532,9 @@ protected:
     // Hooks that differ between FD and SD execution. Overridden in SDPrefetchTestBase /
     // SDPrefetchHostTestFixture so the test bodies can be written once.
     virtual void append_terminate_commands(std::vector<HostMemDeviceCommand>& cmds) {
-        cmds.push_back(CommandBuilder::build_dispatch_terminate());
-        cmds.push_back(CommandBuilder::build_prefetch_terminate());
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        cmds.push_back(CommandBuilder::build_dispatch_terminate(metal_ctx));
+        cmds.push_back(CommandBuilder::build_prefetch_terminate(metal_ctx));
     }
     virtual void* get_completion_queue_buffer() { return mgr_->get_completion_queue_ptr(fdcq_->id()); }
     virtual uint32_t get_completion_queue_buffer_size() { return mgr_->get_completion_queue_size(fdcq_->id()); }
@@ -619,9 +628,10 @@ protected:
         std::vector<uint32_t> payload = payload_generator_->generate_payload(xfer_size_bytes);
 
         // PHASE 1: Generate terminate command metadata
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         std::vector<HostMemDeviceCommand> work_cmds;
         work_cmds.push_back(Common::CommandBuilder::build_linear_write_command<true, true>(
-            payload, worker_range, false, noc_xy, l1_addr, xfer_size_bytes));
+            metal_ctx, payload, worker_range, false, noc_xy, l1_addr, xfer_size_bytes));
 
         std::vector<HostMemDeviceCommand> terminate_cmds;
         append_terminate_commands(terminate_cmds);
@@ -680,16 +690,17 @@ public:
             }
         }
 
-        DeviceCommandCalculator wait_calc;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        DeviceCommandCalculator wait_calc(metal_ctx);
         wait_calc.add_dispatch_wait();
-        HostMemDeviceCommand wait_cmd(wait_calc.write_offset_bytes());
+        HostMemDeviceCommand wait_cmd(metal_ctx, wait_calc.write_offset_bytes());
         wait_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0, 0, 0, 0);
         const uint8_t* wptr = reinterpret_cast<const uint8_t*>(wait_cmd.data());
         exec_buf_data.insert(exec_buf_data.end(), wptr, wptr + wait_cmd.size_bytes());
 
-        DeviceCommandCalculator exec_buf_end_calc;
+        DeviceCommandCalculator exec_buf_end_calc(metal_ctx);
         exec_buf_end_calc.add_prefetch_exec_buf_end();
-        HostMemDeviceCommand exec_terminate(exec_buf_end_calc.write_offset_bytes());
+        HostMemDeviceCommand exec_terminate(metal_ctx, exec_buf_end_calc.write_offset_bytes());
         exec_terminate.add_prefetch_exec_buf_end();
         const uint8_t* tptr = reinterpret_cast<const uint8_t*>(exec_terminate.data());
         exec_buf_data.insert(exec_buf_data.end(), tptr, tptr + exec_terminate.size_bytes());
@@ -746,12 +757,13 @@ private:
         const uint32_t num_pages = fixture.build_and_write_exec_buf_to_dram(commands_per_iteration, num_iterations);
 
         // 4. Reserve and Write exec_buff command
-        DeviceCommandCalculator exec_buf_calc;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        DeviceCommandCalculator exec_buf_calc(metal_ctx);
         exec_buf_calc.add_prefetch_exec_buf();
         uint32_t cmd_size = exec_buf_calc.write_offset_bytes();
         void* cmd_buffer_base = mgr_->issue_queue_reserve(cmd_size, fdcq_->id());
         // Use DeviceCommand helper (HugepageDeviceCommand) to write to the issue queue memory
-        HugepageDeviceCommand exec_cmd(cmd_buffer_base, cmd_size);
+        HugepageDeviceCommand exec_cmd(metal_ctx, cmd_buffer_base, cmd_size);
         exec_cmd.add_prefetch_exec_buf(
             fixture.compute_exec_buf_base_addr(), fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
 
@@ -819,8 +831,9 @@ public:
             uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
 
             // Relay paged from prefetcher -> linear write from dispatcher to L1
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
             HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
-                noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
+                metal_ctx, noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
 
             // Shadow model updated per page
             for (uint32_t page = 0; page < pages_in_chunk; ++page) {
@@ -899,12 +912,13 @@ public:
             const uint16_t start_page_cmd = absolute_start_page % num_banks_;
 
             //  Step 1: Paged Write of host data to DRAM banks by dispatcher cmd
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
             HostMemDeviceCommand cmd_dispatch_dram = Common::CommandBuilder::build_paged_write_command<hugepage_write_>(
-                chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, true);
+                metal_ctx, chunk_payload, base_addr, page_size_bytes, pages_in_chunk, start_page_cmd, true);
             commands_per_iteration.push_back(std::move(cmd_dispatch_dram));
 
             // Followed by stall to avoid RAW hazard
-            HostMemDeviceCommand cmd_stall = CommandBuilder::build_dispatch_prefetch_stall();
+            HostMemDeviceCommand cmd_stall = CommandBuilder::build_dispatch_prefetch_stall(metal_ctx);
             commands_per_iteration.push_back(std::move(cmd_stall));
 
             uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
@@ -912,7 +926,7 @@ public:
             // Step 2: Paged Read of DRAM banks by prefetcher, relay data to dispatcher for linear write to L1
             HostMemDeviceCommand cmd_prefetch =
                 CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
-                    noc_xy, l1_addr, start_page_cmd, base_addr, page_size_bytes, pages_in_chunk);
+                    metal_ctx, noc_xy, l1_addr, start_page_cmd, base_addr, page_size_bytes, pages_in_chunk);
             commands_per_iteration.push_back(std::move(cmd_prefetch));
 
             for (uint32_t page = 0; page < pages_in_chunk; ++page) {
@@ -983,8 +997,9 @@ public:
         // Update Common::DeviceData for linear write
         Common::DeviceDataUpdater::update_linear_write(payload, device_data_, worker_range, is_mcast_);
         // Create the HostMemDeviceCommand
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         HostMemDeviceCommand cmd = Common::CommandBuilder::build_linear_write_command<flush_prefetch, inline_data>(
-            payload, worker_range, is_mcast_, noc_xy, addr, length);
+            metal_ctx, payload, worker_range, is_mcast_, noc_xy, addr, length);
 
         cmds_.push_back(std::move(cmd));
     }
@@ -999,7 +1014,8 @@ public:
         const bool inline_data = true;
 
         // Calculate size of a single merged entry of all lengths
-        DeviceCommandCalculator cmd_calc;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        DeviceCommandCalculator cmd_calc(metal_ctx);
         for (const auto length : lengths) {
             cmd_calc.add_dispatch_write_linear<flush_prefetch, inline_data>(length);
         }
@@ -1007,7 +1023,7 @@ public:
         const uint32_t command_size_bytes = cmd_calc.write_offset_bytes();
 
         // Create the HostMemDeviceCommand for single merged entry
-        HostMemDeviceCommand cmd(command_size_bytes);
+        HostMemDeviceCommand cmd(metal_ctx, command_size_bytes);
 
         // Add all lengths into single cmd
         for (const auto length : lengths) {
@@ -1051,8 +1067,9 @@ public:
         std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds =
             build_packed(lengths, device_data_, log_packed_read_page_size, n_sub_cmds);
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged_packed<flush_prefetch, inline_data>(
-            sub_cmds, noc_xy, l1_addr, total_length);
+            metal_ctx, sub_cmds, noc_xy, l1_addr, total_length);
 
         cmds_.push_back(std::move(cmd));
     }
@@ -1079,8 +1096,9 @@ public:
         // Capture address before updating device_data
         uint32_t l1_addr = device_data_.get_result_data_addr(worker, 0);
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch, inline_data>(
-            noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
+            metal_ctx, noc_xy, l1_addr, start_page, base_addr, page_size_bytes, pages_in_chunk);
 
         for (uint32_t page = 0; page < pages_in_chunk; ++page) {
             const uint32_t page_id = start_page + page;
@@ -1128,8 +1146,15 @@ public:
         Common::DeviceDataUpdater::update_packed_write(payload, device_data_, worker_cores, info_.l1_alignment_);
 
         // Build Command
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
-            payload, sub_cmds, addr, info_.l1_alignment_, info_.packed_write_max_unicast_sub_cmds_, no_stride);
+            metal_ctx,
+            payload,
+            sub_cmds,
+            addr,
+            info_.l1_alignment_,
+            info_.packed_write_max_unicast_sub_cmds_,
+            no_stride);
 
         cmds_.push_back(std::move(cmd));
     }
@@ -1166,12 +1191,13 @@ public:
         device_data_.pad(worker, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
 
         // Barrier/stall to avoid RAW hazards
-        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall(metal_ctx);
         cmds_.push_back(std::move(stall_cmd));
 
         // Blit: dispatcher linear write (dest) + relay linear read (src)
         HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_linear_read<flush_prefetch, inline_data>(
-            noc_xy, dst_addr, src_addr, length);
+            metal_ctx, noc_xy, dst_addr, src_addr, length);
 
         cmds_.push_back(std::move(cmd));
     }
@@ -1184,7 +1210,8 @@ public:
         DeviceDataUpdater::update_host_data(device_data_, payload, length);
 
         // Create the HostMemDeviceCommand with pre-calculated size
-        HostMemDeviceCommand cmd = CommandBuilder::build_relay_inline_host<inline_data>(payload, length);
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        HostMemDeviceCommand cmd = CommandBuilder::build_relay_inline_host<inline_data>(metal_ctx, payload, length);
 
         cmds_.push_back(std::move(cmd));
 
@@ -1241,8 +1268,9 @@ protected:
             uint32_t data_size_words = payload_generator_->get_rand<uint32_t>(0, max_limit - 1) * count + 1;
             uint32_t data_size_bytes = data_size_words * sizeof(uint32_t);
 
-            HostMemDeviceCommand cmd =
-                CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(noc_xy, l1_base, data_size_bytes);
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+            HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(
+                metal_ctx, noc_xy, l1_base, data_size_bytes);
 
             commands_per_iteration.push_back(std::move(cmd));
 
@@ -1479,8 +1507,9 @@ protected:
             std::vector<CQPrefetchRelayPagedPackedSubCmd> sub_cmds =
                 build_sub_cmds(lengths, device_data, packed_read_page_size, n_sub_cmds);
 
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
             HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged_packed<flush_prefetch_, inline_data_>(
-                sub_cmds, noc_xy, l1_addr, total_length);
+                metal_ctx, sub_cmds, noc_xy, l1_addr, total_length);
 
             commands_per_iteration.push_back(std::move(cmd));
             remaining_bytes -= total_length;
@@ -1639,7 +1668,8 @@ public:
         // Skipping CQ_DISPATCH_CMD_DELAY from the legacy test here
         helper.add_unicast_write(worker_range, 1024);
         // Barrier/stall to avoid RAW hazards
-        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall(metal_ctx);
         commands_per_iteration.push_back(std::move(stall_cmd));
         uint32_t length_bytes = 32;
         uint32_t offset_words = device_data.size_at(worker_range.start_coord, 0) - (length_bytes / sizeof(uint32_t));
@@ -1736,9 +1766,10 @@ protected:
 
             const std::vector<CQPrefetchRelayLinearPackedSubCmd> sub_cmds = build_sub_cmds(lengths, addresses);
 
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
             HostMemDeviceCommand cmd =
                 CommandBuilder::build_prefetch_relay_linear_packed<flush_prefetch_, inline_data_>(
-                    sub_cmds, src_noc_xy, dst_noc_xy, dram_dest_addr, total_length);
+                    metal_ctx, sub_cmds, src_noc_xy, dst_noc_xy, dram_dest_addr, total_length);
 
             commands_per_iteration.push_back(std::move(cmd));
 
@@ -1917,8 +1948,17 @@ public:
             // We build the sub commands to relay them from the ringbuffer to the dispatcher
             std::vector<CQPrefetchRelayRingbufferSubCmd> sub_cmds = build_sub_cmds(lengths, n_sub_cmds);
 
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
             HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_ringbuffer_relay<flush_prefetch_, inline_data_>(
-                sub_cmds, lengths, device_data, *this, noc_xy, l1_addr, total_length, ringbuffer_read_page_size_log2);
+                metal_ctx,
+                sub_cmds,
+                lengths,
+                device_data,
+                *this,
+                noc_xy,
+                l1_addr,
+                total_length,
+                ringbuffer_read_page_size_log2);
 
             commands_per_iteration.push_back(std::move(cmd));
             remaining_bytes -= total_length;
@@ -1957,6 +1997,7 @@ namespace CommandBuilder {
 
 template <bool flush_prefetch, bool inline_data>
 HostMemDeviceCommand build_prefetch_ringbuffer_relay(
+    MetalContext& metal_ctx,
     const std::vector<CQPrefetchRelayRingbufferSubCmd>& sub_cmds,
     const std::vector<uint32_t>& lengths,
     Common::DeviceData& device_data,
@@ -1967,7 +2008,7 @@ HostMemDeviceCommand build_prefetch_ringbuffer_relay(
     uint32_t ringbuffer_read_page_size_log2) {
     const uint32_t n_sub_cmds = sub_cmds.size();
     // Calculate the command size using DeviceCommandCalculator
-    DeviceCommandCalculator calc;
+    DeviceCommandCalculator calc(metal_ctx);
     for (uint32_t i = 0; i < n_sub_cmds; i++) {
         calc.add_prefetch_paged_to_ringbuffer();
     }
@@ -1977,7 +2018,7 @@ HostMemDeviceCommand build_prefetch_ringbuffer_relay(
     const uint32_t total_cmd_bytes = calc.write_offset_bytes();
 
     // Create the HostMemDeviceCommand with pre-calculated size
-    HostMemDeviceCommand cmd(total_cmd_bytes);
+    HostMemDeviceCommand cmd(metal_ctx, total_cmd_bytes);
 
     // First, we populate the ringbuffer
     fixture.populate_ringbuffer_from_dram(cmd, lengths, device_data, ringbuffer_read_page_size_log2, n_sub_cmds);
@@ -2093,12 +2134,13 @@ public:
             uint32_t dram_addr =
                 dest_device_data.get_result_data_addr(dest_dram_logical_core, dest_dram_bank_id, tt::CoreType::DRAM);
 
-            DeviceCommandCalculator calc;
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+            DeviceCommandCalculator calc(metal_ctx);
             calc.add_dispatch_write_linear<false, false>(length);
             const uint32_t dispatch_cmd_size = calc.write_offset_bytes();
 
             // Create the HostMemDeviceCommand with pre-calculated size
-            HostMemDeviceCommand cmd1(dispatch_cmd_size);
+            HostMemDeviceCommand cmd1(metal_ctx, dispatch_cmd_size);
 
             cmd1.add_dispatch_write_linear<false, false>(
                 0,          // num_mcast_dests
@@ -2132,11 +2174,11 @@ public:
 
             // Create the relay linear H command as a separate command as it must be
             // the only entry in fetchQ
-            DeviceCommandCalculator calc2;
+            DeviceCommandCalculator calc2(metal_ctx);
             calc2.add_prefetch_relay_linear_h();
             const uint32_t relay_cmd_size = calc2.write_offset_bytes();
 
-            HostMemDeviceCommand cmd2(relay_cmd_size);
+            HostMemDeviceCommand cmd2(metal_ctx, relay_cmd_size);
             cmd2.add_prefetch_relay_linear_h(src_noc_xy_addr, length, src_addr);
 
             uint32_t length_words = length / sizeof(uint32_t);
@@ -2250,11 +2292,12 @@ public:
             const std::vector<CQPrefetchRelayLinearPackedSubCmd> sub_cmds = build_sub_cmds(lengths, addresses);
 
             // Command 1: Dispatch write linear (RELAY_INLINE_NOFLUSH) - sent as separate fetchQ entry
-            DeviceCommandCalculator calc1;
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+            DeviceCommandCalculator calc1(metal_ctx);
             calc1.add_dispatch_write_linear<flush_prefetch_, inline_data_>(total_length);
             const uint32_t dispatch_cmd_size = calc1.write_offset_bytes();
 
-            HostMemDeviceCommand cmd1(dispatch_cmd_size);
+            HostMemDeviceCommand cmd1(metal_ctx, dispatch_cmd_size);
             cmd1.add_dispatch_write_linear<flush_prefetch_, inline_data_>(
                 0,               // num_mcast_dests
                 dst_noc_xy,      // NOC coordinates for DESTINATION (dispatcher writes here)
@@ -2265,11 +2308,11 @@ public:
             commands_per_iteration.push_back(std::move(cmd1));
 
             // Command 2: Relay linear packed H - must be standalone entry in fetchQ
-            DeviceCommandCalculator calc2;
+            DeviceCommandCalculator calc2(metal_ctx);
             calc2.add_prefetch_relay_linear_packed_h(sub_cmds.size());
             const uint32_t relay_cmd_size = calc2.write_offset_bytes();
 
-            HostMemDeviceCommand cmd2(relay_cmd_size);
+            HostMemDeviceCommand cmd2(metal_ctx, relay_cmd_size);
             cmd2.add_prefetch_relay_linear_packed_h(src_noc_xy, total_length, sub_cmds, sub_cmds.size());
             commands_per_iteration.push_back(std::move(cmd2));
 
@@ -2331,8 +2374,9 @@ protected:
         device_data.pad(worker_core, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
 
         // Build command (dispatcher linear write (dest) + relay linear read (src))
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_linear_read<flush_prefetch_, inline_data_>(
-            noc_xy, dst_addr, src_addr, data_size_bytes);
+            metal_ctx, noc_xy, dst_addr, src_addr, data_size_bytes);
 
         remaining_bytes -= data_size_bytes;
         return cmd;
@@ -2380,8 +2424,9 @@ protected:
         // Calculate absolute address for command
         uint32_t cmd_base_addr = dram_base_ + random_offset;
         uint32_t addr = device_data.get_result_data_addr(worker_core, 0);
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
-            noc_xy, addr, start_page, cmd_base_addr, page_size, pages, length_adjust);
+            metal_ctx, noc_xy, addr, start_page, cmd_base_addr, page_size, pages, length_adjust);
 
         // Update Common::DeviceData for paged read
         uint32_t page_size_words = page_size / sizeof(uint32_t);
@@ -2450,8 +2495,9 @@ protected:
                     Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, false);
 
                     // Build the command: Dispatch Write Linear (Unicast) wrapped in Prefetch Relay Inline
+                    auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
                     HostMemDeviceCommand cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
-                        payload, worker_range, false, noc_xy, addr, xfer_size_bytes);
+                        metal_ctx, payload, worker_range, false, noc_xy, addr, xfer_size_bytes);
 
                     remaining_bytes -= xfer_size_bytes;
                     return cmd;
@@ -2508,7 +2554,9 @@ protected:
                         }
                     }
 
+                    auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
                     xfer_size_bytes = Common::PackedWriteUtils::clamp_to_max_fetch(
+                        metal_ctx,
                         max_fetch_bytes_,
                         xfer_size_bytes,
                         num_sub_cmds,
@@ -2527,7 +2575,13 @@ protected:
 
                     // Build Command
                     HostMemDeviceCommand cmd = Common::CommandBuilder::build_packed_write_command(
-                        payload, sub_cmds, addr, l1_alignment_, packed_write_max_unicast_sub_cmds_, no_stride);
+                        metal_ctx,
+                        payload,
+                        sub_cmds,
+                        addr,
+                        l1_alignment_,
+                        packed_write_max_unicast_sub_cmds_,
+                        no_stride);
 
                     remaining_bytes -= xfer_size_bytes;
                     return cmd;
@@ -2838,8 +2892,9 @@ public:
         }
 
         // Terminate: dispatch_wait + dispatch_terminate + prefetch_terminate (shared by both paths).
-        write_cmd(CommandBuilder::build_dispatch_terminate(/*include_dispatch_s*/ false));
-        write_cmd(CommandBuilder::build_prefetch_terminate());
+        auto& metal_ctx = MetalContext::instance(extract_context_id(this->device_));
+        write_cmd(CommandBuilder::build_dispatch_terminate(metal_ctx, /*include_dispatch_s*/ false));
+        write_cmd(CommandBuilder::build_prefetch_terminate(metal_ctx));
 
         if (Common::is_quasar_cq_dram_backed()) {
             // Flush all DRAM command writes so the kernel sees them when it starts.
@@ -2990,9 +3045,10 @@ private:
         const std::function<void(const HostMemDeviceCommand&, bool)>& write_cmd) {
         const uint32_t num_pages = this->build_and_write_exec_buf_to_dram(commands_per_iteration, num_iterations);
 
-        DeviceCommandCalculator exec_buf_calc;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(this->device_));
+        DeviceCommandCalculator exec_buf_calc(metal_ctx);
         exec_buf_calc.add_prefetch_exec_buf();
-        HostMemDeviceCommand exec_cmd(exec_buf_calc.write_offset_bytes());
+        HostMemDeviceCommand exec_cmd(metal_ctx, exec_buf_calc.write_offset_bytes());
         exec_cmd.add_prefetch_exec_buf(
             this->compute_exec_buf_base_addr(), this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
         write_cmd(exec_cmd, /*stall*/ true);
@@ -3202,8 +3258,9 @@ protected:
                 device_, worker_range, l1_base, dram_base_, nullptr, false, get_dram_data_size_words(), cfg_);
             const uint32_t page_size_words = page_size / sizeof(uint32_t);
             const uint32_t l1_addr = device_data.get_result_data_addr(first_worker, 0);
+            auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
             HostMemDeviceCommand cmd = CommandBuilder::build_prefetch_relay_paged<flush_prefetch_, inline_data_>(
-                noc_xy, l1_addr, /*start_page=*/0, dram_base_, page_size, /*pages_in_chunk=*/1);
+                metal_ctx, noc_xy, l1_addr, /*start_page=*/0, dram_base_, page_size, /*pages_in_chunk=*/1);
 
             const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(/*bank_id=*/0);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
@@ -3275,9 +3332,10 @@ protected:
         }
         serialized_bytes *= get_num_iterations();
 
-        DeviceCommandCalculator wait_calc;
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
+        DeviceCommandCalculator wait_calc(metal_ctx);
         wait_calc.add_dispatch_wait();
-        DeviceCommandCalculator exec_buf_end_calc;
+        DeviceCommandCalculator exec_buf_end_calc(metal_ctx);
         exec_buf_end_calc.add_prefetch_exec_buf_end();
         serialized_bytes += wait_calc.write_offset_bytes() + exec_buf_end_calc.write_offset_bytes();
 
@@ -3328,10 +3386,11 @@ protected:
 
         constexpr uint32_t filler_payload_size = 16;
         const std::vector<uint32_t> filler_payload(filler_payload_size / sizeof(uint32_t), 0xA5A5A5A5);
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         std::vector<HostMemDeviceCommand> commands;
         for (uint32_t page = 1; page < dispatch_cb_pages - 3; ++page) {
             HostMemDeviceCommand filler_cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
-                filler_payload, worker_range, /*is_mcast=*/false, noc_xy, source_addr, filler_payload_size);
+                metal_ctx, filler_payload, worker_range, /*is_mcast=*/false, noc_xy, source_addr, filler_payload_size);
             const auto* prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(filler_cmd.data());
             TT_FATAL(
                 tt::align(prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
@@ -3344,7 +3403,7 @@ protected:
         const uint32_t crossing_payload_size = dispatch_cb_page_size;
         std::vector<uint32_t> crossing_payload = payload_generator_->generate_payload(crossing_payload_size);
         HostMemDeviceCommand seed_cmd = Common::CommandBuilder::build_linear_write_command<true, true>(
-            crossing_payload, worker_range, /*is_mcast=*/false, noc_xy, source_addr, crossing_payload_size);
+            metal_ctx, crossing_payload, worker_range, /*is_mcast=*/false, noc_xy, source_addr, crossing_payload_size);
         const auto* seed_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(seed_cmd.data());
         TT_FATAL(
             tt::align(seed_prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == 2 * dispatch_cb_page_size,
@@ -3354,7 +3413,7 @@ protected:
         Common::DeviceDataUpdater::update_linear_write(crossing_payload, device_data, worker_range, /*is_mcast=*/false);
         commands.push_back(std::move(seed_cmd));
 
-        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall();
+        HostMemDeviceCommand stall_cmd = CommandBuilder::build_dispatch_prefetch_stall(metal_ctx);
         const auto* stall_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(stall_cmd.data());
         TT_FATAL(
             tt::align(stall_prefetch_cmd->relay_inline.length, dispatch_cb_page_size) == dispatch_cb_page_size,
@@ -3363,7 +3422,7 @@ protected:
 
         const uint32_t dst_addr = device_data.get_result_data_addr(first_worker, 0);
         HostMemDeviceCommand crossing_cmd = CommandBuilder::build_prefetch_relay_linear_read<false, false>(
-            noc_xy, dst_addr, source_addr, crossing_payload_size);
+            metal_ctx, noc_xy, dst_addr, source_addr, crossing_payload_size);
         const auto* crossing_prefetch_cmd = reinterpret_cast<const CQPrefetchCmd*>(crossing_cmd.data());
         TT_FATAL(
             crossing_prefetch_cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH,
@@ -3411,9 +3470,10 @@ protected:
         std::vector<uint32_t> payload = payload_generator_->generate_payload(transfer_size_bytes);
         Common::DeviceDataUpdater::update_linear_write(payload, device_data, worker_range, /*is_mcast=*/false);
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         std::vector<HostMemDeviceCommand> commands;
         commands.push_back(Common::CommandBuilder::build_linear_write_command<true, true>(
-            payload, worker_range, /*is_mcast=*/false, noc_xy, l1_addr, transfer_size_bytes));
+            metal_ctx, payload, worker_range, /*is_mcast=*/false, noc_xy, l1_addr, transfer_size_bytes));
 
         // Each command consumes one PrefetchQ entry. After prefetch_q_entries commands, the device consumer
         // has wrapped to the base and the host producer is at the limit. The extra command makes the host
@@ -3439,12 +3499,13 @@ protected:
         const CoreCoord first_virt_worker = device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
         const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
 
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         auto make_command = [&](const std::vector<uint32_t>& payload, uint32_t address) {
             return Common::CommandBuilder::build_linear_write_command<true, true>(
-                payload, worker_range, /*is_mcast=*/false, noc_xy, address, transfer_size_bytes);
+                metal_ctx, payload, worker_range, /*is_mcast=*/false, noc_xy, address, transfer_size_bytes);
         };
 
-        DeviceCommandCalculator barrier_calc;
+        DeviceCommandCalculator barrier_calc(metal_ctx);
         barrier_calc.add_dispatch_wait();
         const uint32_t barrier_bytes = barrier_calc.write_offset_bytes();
         const uint32_t issue_alignment = mgr_->is_dram_backed()
@@ -3579,6 +3640,7 @@ protected:
         // pages past the base, which we track so every iteration refills up to the boundary and wraps once.
         uint32_t write_offset_pages = 0;
         const uint32_t num_iterations = get_num_iterations();
+        auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
         for (uint32_t iter = 0; iter < num_iterations; ++iter) {
             // Phase 1: fill the ring up to exactly one page before the region end.
             const uint32_t fill_pages = total_pages - write_offset_pages - 1;
@@ -3601,8 +3663,8 @@ protected:
             std::vector<HostMemDeviceCommand> fillers;
             fillers.reserve(fill_pages);
             for (uint32_t page = 0; page < fill_pages; ++page) {
-                fillers.push_back(
-                    CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(noc_xy, l1_base, filler_size_bytes));
+                fillers.push_back(CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(
+                    metal_ctx, noc_xy, l1_base, filler_size_bytes));
                 DeviceDataUpdater::update_host_data(filler_expected, filler_data, filler_size_bytes);
                 pad_host_data(filler_expected);
             }
@@ -3633,8 +3695,8 @@ protected:
                 /*dram_data_size_words=*/0,
                 cfg_);
             std::vector<HostMemDeviceCommand> crossing_commands;
-            crossing_commands.push_back(
-                CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(noc_xy, l1_base, crossing_size_bytes));
+            crossing_commands.push_back(CommandBuilder::build_prefetch_relay_linear_host<inline_data_>(
+                metal_ctx, noc_xy, l1_base, crossing_size_bytes));
             DeviceDataUpdater::update_host_data(crossing_expected, crossing_data, crossing_size_bytes);
             pad_host_data(crossing_expected);
             const uint32_t crossing_pages =
@@ -3889,9 +3951,10 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
         device_, worker_range, l1_base, dram_base, nullptr, /*is_banked=*/false, /*dram_data_size_words=*/0, cfg_);
 
     // Find the maximum number of pages per command that fits within the configured max prefetch command size.
+    auto& metal_ctx = MetalContext::instance(extract_context_id(device_));
     uint32_t pages_per_cmd = 1U;
     for (uint32_t pages = 1U; pages <= requested_pages_per_cmd; ++pages) {
-        DeviceCommandCalculator calc;
+        DeviceCommandCalculator calc(metal_ctx);
         calc.add_dispatch_write_paged<hugepage_write_>(page_size_bytes, pages);
         if (calc.write_offset_bytes() > max_fetch_bytes_) {
             break;
@@ -3944,7 +4007,7 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
         const uint16_t start_page_cmd = absolute_start_page % num_banks_;
 
         HostMemDeviceCommand cmd_dispatch_dram = Common::CommandBuilder::build_paged_write_command<hugepage_write_>(
-            chunk_payload, base_addr, page_size_bytes, pages_per_cmd, start_page_cmd, /*is_dram=*/true);
+            metal_ctx, chunk_payload, base_addr, page_size_bytes, pages_per_cmd, start_page_cmd, /*is_dram=*/true);
         commands_per_iteration.push_back(std::move(cmd_dispatch_dram));
 
         absolute_start_page += pages_per_cmd;
@@ -3957,13 +4020,13 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     }
 
     // Barrier wait command (same rationale as BaseTestFixture::execute_generated_commands).
-    DeviceCommandCalculator barrier_calc;
+    DeviceCommandCalculator barrier_calc(metal_ctx);
     barrier_calc.add_dispatch_wait();
     const uint64_t total_cmd_bytes =
         (static_cast<uint64_t>(num_iterations) * per_iter_total) + barrier_calc.write_offset_bytes();
 
     void* cmd_buffer_base = mgr_->issue_queue_reserve(total_cmd_bytes, fdcq_->id());
-    HugepageDeviceCommand dc(cmd_buffer_base, total_cmd_bytes);
+    HugepageDeviceCommand dc(metal_ctx, cmd_buffer_base, total_cmd_bytes);
 
     std::vector<uint32_t> entry_sizes;
     entry_sizes.reserve((static_cast<size_t>(num_iterations) * commands_per_iteration.size()) + 1U);
@@ -3975,7 +4038,7 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
         }
     }
 
-    HostMemDeviceCommand barrier_cmd(barrier_calc.write_offset_bytes());
+    HostMemDeviceCommand barrier_cmd(metal_ctx, barrier_calc.write_offset_bytes());
     barrier_cmd.add_dispatch_wait(CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER, 0U, 0U, 0U, 0);
     dc.add_data(barrier_cmd.data(), barrier_cmd.size_bytes(), barrier_cmd.size_bytes());
     entry_sizes.push_back(barrier_cmd.size_bytes());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -167,8 +167,7 @@ class PrefetcherRingbufferReadTestFixture;
 namespace CommandBuilder {
 
 HostMemDeviceCommand build_dispatch_terminate(MetalContext& metal_ctx, bool include_dispatch_s = true) {
-    bool dispatch_sub_enabled =
-        MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() && include_dispatch_s;
+    bool dispatch_sub_enabled = metal_ctx.get_dispatch_query_manager().dispatch_s_enabled() && include_dispatch_s;
     DeviceCommandCalculator calc(metal_ctx);
     calc.add_dispatch_wait();
     calc.add_dispatch_terminate();

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1394,7 +1394,8 @@ void FDMeshCommandQueue::record_end() {
     }
     std::vector<uint32_t> exec_buf_end = {};
 
-    DeviceCommand command_sequence(MetalContext::instance().hal().get_alignment(HalMemType::HOST));
+    MetalContext& metal_ctx = MetalContext::instance(mesh_device_->impl().get_context_id());
+    DeviceCommand command_sequence(metal_ctx, metal_ctx.hal().get_alignment(HalMemType::HOST));
     command_sequence.add_prefetch_exec_buf_end();
 
     exec_buf_end.reserve(command_sequence.size_bytes() / sizeof(uint32_t));

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -38,9 +38,10 @@ void write_go_signal_sequence(
     bool send_unicasts,
     const program_dispatch::ProgramDispatchMetadata& dispatch_md,
     std::optional<uint32_t> config_ring_sync_count) {
-    const auto& hal = MetalContext::instance().hal();
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
+    const auto& hal = metal_ctx.hal();
     uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
-    DeviceCommandCalculator calculator;
+    DeviceCommandCalculator calculator(metal_ctx);
     if (config_ring_sync_count.has_value()) {
         calculator.add_dispatch_wait();
     }
@@ -56,7 +57,7 @@ void write_go_signal_sequence(
 
     auto sub_device_index = *sub_device_id;
 
-    HugepageDeviceCommand go_signal_cmd_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand go_signal_cmd_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
     if (not dispatch_md.prefetcher_cache_info.is_cached) {
         go_signal_cmd_sequence.add_prefetch_set_ringbuffer_offset(
@@ -115,13 +116,14 @@ void write_go_signal_sequence(
 
 void write_rt_profiler_flush(
     uint8_t cq_id, SubDeviceId sub_device_id, SystemMemoryManager& sysmem_manager, uint32_t wait_count) {
-    DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
+    DeviceCommandCalculator calculator(metal_ctx);
     calculator.add_dispatch_rt_profiler_flush();
     uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
 
-    HugepageDeviceCommand flush_cmd_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand flush_cmd_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     const uint32_t wait_stream = MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(*sub_device_id);
     flush_cmd_sequence.add_dispatch_rt_profiler_flush(wait_count, wait_stream);
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -688,7 +688,8 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
     ttsl::Span<const SubDeviceId> sub_device_ids) {
     TTZoneScopedD(DISPATCH);
     ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
-    const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
+    MetalContext& metal_ctx = tt::tt_metal::MetalContext::instance(context_id);
+    const auto& hal = metal_ctx.hal();
     const uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
     const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
@@ -719,14 +720,14 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
 
     // Issue wait commands once at the beginning if needed
     if (dispatch_params.issue_wait && num_worker_counters > 0) {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(metal_ctx);
         for (int i = 0; i < num_worker_counters; ++i) {
             calculator.add_dispatch_wait();
         }
 
         const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
         void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
-        HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+        HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
         for (const auto& sub_device_id : sub_device_ids) {
             auto offset_index = *sub_device_id;
@@ -764,10 +765,10 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
         }
 
         // Use calculator to compute command sequence size
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_write_packed_large_unicast(write_sub_cmds.size());
         void* cmd_region = sysmem_manager.issue_queue_reserve(calculator.write_offset_bytes(), dispatch_params.cq_id);
-        HugepageDeviceCommand command_sequence(cmd_region, calculator.write_offset_bytes());
+        HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, calculator.write_offset_bytes());
 
         // Add write packed large unicast command
         command_sequence.add_dispatch_write_packed_large_unicast(
@@ -794,7 +795,7 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
         }
 
         cmd_region = sysmem_manager.issue_queue_reserve(calculator.write_offset_bytes(), dispatch_params.cq_id);
-        HugepageDeviceCommand prefetch_command_sequence(cmd_region, calculator.write_offset_bytes());
+        HugepageDeviceCommand prefetch_command_sequence(metal_ctx, cmd_region, calculator.write_offset_bytes());
 
         // Add relay linear packed command
         if (dispatch_params.remote_chip) {
@@ -946,7 +947,8 @@ void issue_buffer_dispatch_command_sequence(
         use_pinned_memory ? dispatch_params.total_pages_to_write : dispatch_params.pages_per_txn;
     uint64_t data_size_bytes = uint64_t(num_pages_to_write) * dispatch_params.page_size_to_write;
 
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(dispatch_params.device));
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     if (dispatch_params.issue_wait) {
         for (int i = 0; i < num_worker_counters; ++i) {
             calculator.add_dispatch_wait();
@@ -973,7 +975,7 @@ void issue_buffer_dispatch_command_sequence(
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
 
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
     if (dispatch_params.issue_wait) {
         for (const auto& sub_device_id : sub_device_ids) {
@@ -1026,7 +1028,7 @@ void issue_buffer_dispatch_command_sequence(
         }
         const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
         void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
-        HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+        HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
         if (dispatch_params.remote_chip) {
             command_sequence.add_prefetch_relay_linear_h(
@@ -1118,7 +1120,8 @@ void write_sharded_buffer_to_core(
         issue_sharded_buffer_pinned_dispatch_command_sequence(
             src, buffer, dispatch_params, core_page_mapping, core, sub_device_ids);
     } else {
-        DeviceCommandCalculator calculator;
+        MetalContext& metal_ctx = MetalContext::instance(extract_context_id(buffer.device()));
+        DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_write_linear<true, false>(0);
         uint32_t data_offset_bytes = calculator.write_offset_bytes();
         update_offset_on_issue_wait_cmd(data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
@@ -1424,7 +1427,8 @@ void issue_read_buffer_dispatch_command_sequence(
     }
 
     ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
-    const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
+    MetalContext& metal_ctx = tt::tt_metal::MetalContext::instance(context_id);
+    const auto& hal = metal_ctx.hal();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
 
@@ -1464,7 +1468,7 @@ void issue_read_buffer_dispatch_command_sequence(
     }
 
     // Build calculator with the chosen path
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     for (uint32_t i = 0; i < num_worker_counters; ++i) {
         calculator.add_dispatch_wait();
     }
@@ -1486,7 +1490,7 @@ void issue_read_buffer_dispatch_command_sequence(
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
     uint32_t last_index = num_worker_counters - 1;
     // We only need the write barrier + prefetch stall for the last wait cmd

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -69,7 +69,8 @@ DeviceAddr add_bank_offset_to_address(IDevice* device, const CoreCoord& virtual_
 void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_params) {
     const uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
 
-    DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(dispatch_params.device));
+    DeviceCommandCalculator calculator(metal_ctx);
     for (uint32_t i = 0; i < num_worker_counters; ++i) {
         calculator.add_dispatch_wait();
     }
@@ -79,7 +80,7 @@ void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_p
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
     for (uint32_t i = 0; i < num_worker_counters; ++i) {
         const uint8_t offset_index = *dispatch_params.sub_device_ids[i];
@@ -172,7 +173,8 @@ void write_to_core_unchecked(
 
 void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_params) {
     const uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
-    DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(dispatch_params.device));
+    DeviceCommandCalculator calculator(metal_ctx);
     for (uint32_t i = 0; i < num_worker_counters - 1; ++i) {
         calculator.add_dispatch_wait();
     }
@@ -183,7 +185,7 @@ void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_par
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
     // We only need the write barrier + prefetch stall for the last wait cmd
     const uint32_t last_index = num_worker_counters - 1;

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -52,10 +52,10 @@ void read_cq_memory_for_dump(
     ChipId mmio_device_id,
     uint16_t channel,
     const SystemMemoryManager& sysmem_manager) {
-    auto& cluster = MetalContext::instance().get_cluster();
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
+    auto& cluster = metal_ctx.get_cluster();
     if (sysmem_manager.is_dram_backed()) {
-        const uint32_t dram_channel = MetalContext::instance()
-                                          .device_manager()
+        const uint32_t dram_channel = metal_ctx.device_manager()
                                           ->get_active_device(mmio_device_id)
                                           ->allocator_impl()
                                           ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
@@ -157,7 +157,7 @@ void wait_for_program_vector_to_arrive_and_compare_to_host_program_vector(
 }
 
 // Returns the number of bytes taken up by this dispatch command (including header).
-uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream& cq_file) {
+uint32_t dump_dispatch_cmd(MetalContext& metal_ctx, CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream& cq_file) {
     uint32_t stride = sizeof(CQDispatchCmd);  // Default stride is just the command
     CQDispatchCmdId cmd_id = cmd->base.cmd_id;
 
@@ -245,7 +245,7 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
                     num_sub_devices,
                     fmt::join(workers_per_sub_device, workers_per_sub_device + num_sub_devices, ", "));
                 stride += num_sub_devices * sizeof(uint32_t);
-                const uint32_t alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+                const uint32_t alignment = metal_ctx.hal().get_alignment(HalMemType::HOST);
                 stride = ((stride + alignment - 1) / alignment) * alignment;
                 break;
             }
@@ -268,9 +268,8 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
 }
 
 // Returns the number of bytes taken up by this prefetch command (including header).
-uint32_t dump_prefetch_cmd(CQPrefetchCmd* cmd, uint32_t cmd_addr, std::ofstream& iq_file) {
-    uint32_t stride =
-        MetalContext::instance().hal().get_alignment(HalMemType::HOST);  // Default stride matches alignment.
+uint32_t dump_prefetch_cmd(MetalContext& metal_ctx, CQPrefetchCmd* cmd, uint32_t cmd_addr, std::ofstream& iq_file) {
+    uint32_t stride = metal_ctx.hal().get_alignment(HalMemType::HOST);  // Default stride matches alignment.
     CQPrefetchCmdId cmd_id = cmd->base.cmd_id;
 
     if (cmd_id < CQ_PREFETCH_CMD_MAX_COUNT) {
@@ -367,10 +366,9 @@ void print_progress_bar(float progress, bool init = false) {
 
 void dump_completion_queue_entries(
     std::ofstream& cq_file, SystemMemoryManager& sysmem_manager, SystemMemoryCQInterface& cq_interface) {
-    ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
-        sysmem_manager.get_device_id());
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
+    ChipId mmio_device_id = metal_ctx.get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
+    uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(sysmem_manager.get_device_id());
     uint32_t completion_write_ptr =
         get_cq_completion_wr_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
         << 4;
@@ -422,7 +420,7 @@ void dump_completion_queue_entries(
                 }
                 cq_file << std::endl;
             }
-            uint32_t stride = dump_dispatch_cmd(cmd, page_addr, cq_file);
+            uint32_t stride = dump_dispatch_cmd(metal_ctx, cmd, page_addr, cq_file);
             // Completion Q is page-aligned
             uint32_t cmd_pages =
                 (stride + DispatchSettings::TRANSFER_PAGE_SIZE - 1) / DispatchSettings::TRANSFER_PAGE_SIZE;
@@ -465,10 +463,9 @@ void dump_completion_queue_entries(
 
 void dump_issue_queue_entries(
     std::ofstream& iq_file, SystemMemoryManager& sysmem_manager, SystemMemoryCQInterface& cq_interface) {
-    ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
-        sysmem_manager.get_device_id());
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
+    ChipId mmio_device_id = metal_ctx.get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
+    uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(sysmem_manager.get_device_id());
     // TODO: Issue Q read ptr is not prefetcly updated 0 try to read it out from chip on dump?
     uint32_t issue_read_ptr =
         get_cq_issue_rd_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size()) << 4;
@@ -495,7 +492,7 @@ void dump_issue_queue_entries(
         first_page_addr + DispatchSettings::TRANSFER_PAGE_SIZE - 1;  // To track offset of latest page read out
     read_cq_memory_for_dump(
         read_data.data(), read_data.size(), first_page_addr, mmio_device_id, channel, sysmem_manager);
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     for (uint32_t offset = 0; offset < issue_q_bytes;) {  // offset increments at end of loop
         uint32_t curr_addr = issue_q_base_addr + offset;
         uint32_t page_offset = curr_addr % DispatchSettings::TRANSFER_PAGE_SIZE;
@@ -532,7 +529,7 @@ void dump_issue_queue_entries(
                 iq_file << std::endl;
             }
 
-            uint32_t cmd_stride = dump_prefetch_cmd(cmd, curr_addr, iq_file);
+            uint32_t cmd_stride = dump_prefetch_cmd(metal_ctx, cmd, curr_addr, iq_file);
 
             // Check for a bad stride (happen to have a valid cmd_id, overwritten values, etc.)
             if (cmd_stride + offset >= issue_q_bytes || cmd_stride == 0 ||
@@ -571,7 +568,7 @@ void dump_issue_queue_entries(
                     if (dispatch_cmd->base.cmd_id < CQ_DISPATCH_CMD_MAX_COUNT) {
                         iq_file << "  ";
                         uint32_t dispatch_cmd_stride =
-                            dump_dispatch_cmd(dispatch_cmd, issue_q_base_addr + dispatch_offset, iq_file);
+                            dump_dispatch_cmd(metal_ctx, dispatch_cmd, issue_q_base_addr + dispatch_offset, iq_file);
                         dispatch_offset += dispatch_cmd_stride;
                         iq_file << std::endl;
                     } else {
@@ -609,10 +606,9 @@ void dump_command_queue_raw_data(
     SystemMemoryManager& sysmem_manager,
     SystemMemoryCQInterface& cq_interface,
     cq_queue_t queue_type) {
-    ChipId mmio_device_id =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
-        sysmem_manager.get_device_id());
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
+    ChipId mmio_device_id = metal_ctx.get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
+    uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(sysmem_manager.get_device_id());
 
     // The following variables depend on completion Q vs issue Q
     uint32_t write_ptr, read_ptr, base_addr, bytes_to_read = 0;

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -27,32 +27,6 @@ void DeviceCommand<hugepage_write>::init_from_context(MetalContext& ctx) {
 }
 
 template <bool hugepage_write>
-DeviceCommand<hugepage_write>::DeviceCommand(void* cmd_region, uint32_t cmd_sequence_sizeB) :
-    cmd_sequence_sizeB(cmd_sequence_sizeB), cmd_region(cmd_region) {
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    this->init_from_context(MetalContext::instance());
-    TT_FATAL(
-        cmd_sequence_sizeB % sizeof(uint32_t) == 0,
-        "Command sequence size B={} is not {}-byte aligned",
-        cmd_sequence_sizeB,
-        sizeof(uint32_t));
-}
-
-template <bool hugepage_write>
-template <bool hp_w, typename std::enable_if_t<!hp_w, int>>
-DeviceCommand<hugepage_write>::DeviceCommand(uint32_t cmd_sequence_sizeB) : cmd_sequence_sizeB(cmd_sequence_sizeB) {
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    this->init_from_context(MetalContext::instance());
-    TT_FATAL(
-        cmd_sequence_sizeB % sizeof(uint32_t) == 0,
-        "Command sequence size B={} is not {}-byte aligned",
-        cmd_sequence_sizeB,
-        sizeof(uint32_t));
-    this->cmd_region_vector.resize(cmd_sequence_sizeB / sizeof(uint32_t), 0);
-    this->cmd_region = this->cmd_region_vector.data();
-}
-
-template <bool hugepage_write>
 DeviceCommand<hugepage_write>::DeviceCommand(MetalContext& ctx) {
     this->init_from_context(ctx);
 }
@@ -1418,7 +1392,6 @@ uint32_t DeviceCommand<hugepage_write>::random_padding_value() {
 template class DeviceCommand<true>;
 template class DeviceCommand<false>;
 
-template DeviceCommand<false>::DeviceCommand(uint32_t);
 template DeviceCommand<false>::DeviceCommand(MetalContext&, uint32_t);
 
 template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -27,12 +27,6 @@ void DeviceCommand<hugepage_write>::init_from_context(MetalContext& ctx) {
 }
 
 template <bool hugepage_write>
-DeviceCommand<hugepage_write>::DeviceCommand() {
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    this->init_from_context(MetalContext::instance());
-}
-
-template <bool hugepage_write>
 DeviceCommand<hugepage_write>::DeviceCommand(void* cmd_region, uint32_t cmd_sequence_sizeB) :
     cmd_sequence_sizeB(cmd_sequence_sizeB), cmd_region(cmd_region) {
     // TODO(N2c/C3): remove once all callers pass a MetalContext.

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -20,8 +20,23 @@
 namespace tt::tt_metal {
 
 template <bool hugepage_write>
+void DeviceCommand<hugepage_write>::init_from_context(MetalContext& ctx) {
+    this->ctx_ = &ctx;
+    this->pcie_alignment = ctx.hal().get_alignment(HalMemType::HOST);
+    this->l1_alignment = ctx.hal().get_alignment(HalMemType::L1);
+}
+
+template <bool hugepage_write>
+DeviceCommand<hugepage_write>::DeviceCommand() {
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
+    this->init_from_context(MetalContext::instance());
+}
+
+template <bool hugepage_write>
 DeviceCommand<hugepage_write>::DeviceCommand(void* cmd_region, uint32_t cmd_sequence_sizeB) :
     cmd_sequence_sizeB(cmd_sequence_sizeB), cmd_region(cmd_region) {
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
+    this->init_from_context(MetalContext::instance());
     TT_FATAL(
         cmd_sequence_sizeB % sizeof(uint32_t) == 0,
         "Command sequence size B={} is not {}-byte aligned",
@@ -32,6 +47,38 @@ DeviceCommand<hugepage_write>::DeviceCommand(void* cmd_region, uint32_t cmd_sequ
 template <bool hugepage_write>
 template <bool hp_w, typename std::enable_if_t<!hp_w, int>>
 DeviceCommand<hugepage_write>::DeviceCommand(uint32_t cmd_sequence_sizeB) : cmd_sequence_sizeB(cmd_sequence_sizeB) {
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
+    this->init_from_context(MetalContext::instance());
+    TT_FATAL(
+        cmd_sequence_sizeB % sizeof(uint32_t) == 0,
+        "Command sequence size B={} is not {}-byte aligned",
+        cmd_sequence_sizeB,
+        sizeof(uint32_t));
+    this->cmd_region_vector.resize(cmd_sequence_sizeB / sizeof(uint32_t), 0);
+    this->cmd_region = this->cmd_region_vector.data();
+}
+
+template <bool hugepage_write>
+DeviceCommand<hugepage_write>::DeviceCommand(MetalContext& ctx) {
+    this->init_from_context(ctx);
+}
+
+template <bool hugepage_write>
+DeviceCommand<hugepage_write>::DeviceCommand(MetalContext& ctx, void* cmd_region, uint32_t cmd_sequence_sizeB) :
+    cmd_sequence_sizeB(cmd_sequence_sizeB), cmd_region(cmd_region) {
+    this->init_from_context(ctx);
+    TT_FATAL(
+        cmd_sequence_sizeB % sizeof(uint32_t) == 0,
+        "Command sequence size B={} is not {}-byte aligned",
+        cmd_sequence_sizeB,
+        sizeof(uint32_t));
+}
+
+template <bool hugepage_write>
+template <bool hp_w, typename std::enable_if_t<!hp_w, int>>
+DeviceCommand<hugepage_write>::DeviceCommand(MetalContext& ctx, uint32_t cmd_sequence_sizeB) :
+    cmd_sequence_sizeB(cmd_sequence_sizeB) {
+    this->init_from_context(ctx);
     TT_FATAL(
         cmd_sequence_sizeB % sizeof(uint32_t) == 0,
         "Command sequence size B={} is not {}-byte aligned",
@@ -48,6 +95,9 @@ DeviceCommand<hugepage_write>& DeviceCommand<hugepage_write>::operator=(const De
     }
     this->cmd_sequence_sizeB = other.cmd_sequence_sizeB;
     this->cmd_write_offsetB = other.cmd_write_offsetB;
+    this->ctx_ = other.ctx_;
+    this->pcie_alignment = other.pcie_alignment;
+    this->l1_alignment = other.l1_alignment;
     this->cmd_region_vector = other.cmd_region_vector;
     this->deepcopy(other);
     return *this;
@@ -57,6 +107,9 @@ template <bool hugepage_write>
 DeviceCommand<hugepage_write>& DeviceCommand<hugepage_write>::operator=(DeviceCommand&& other) noexcept {
     this->cmd_sequence_sizeB = other.cmd_sequence_sizeB;
     this->cmd_write_offsetB = other.cmd_write_offsetB;
+    this->ctx_ = other.ctx_;
+    this->pcie_alignment = other.pcie_alignment;
+    this->l1_alignment = other.l1_alignment;
     this->cmd_region_vector = std::move(other.cmd_region_vector);
     if constexpr (hugepage_write) {
         this->deepcopy(other);
@@ -71,6 +124,9 @@ template <bool hugepage_write>
 DeviceCommand<hugepage_write>::DeviceCommand(const DeviceCommand& other) :
     cmd_sequence_sizeB(other.cmd_sequence_sizeB),
     cmd_write_offsetB(other.cmd_write_offsetB),
+    ctx_(other.ctx_),
+    pcie_alignment(other.pcie_alignment),
+    l1_alignment(other.l1_alignment),
     cmd_region_vector(other.cmd_region_vector) {
     this->deepcopy(other);
 }
@@ -79,6 +135,9 @@ template <bool hugepage_write>
 DeviceCommand<hugepage_write>::DeviceCommand(DeviceCommand&& other) noexcept :
     cmd_sequence_sizeB(other.cmd_sequence_sizeB),
     cmd_write_offsetB(other.cmd_write_offsetB),
+    ctx_(other.ctx_),
+    pcie_alignment(other.pcie_alignment),
+    l1_alignment(other.l1_alignment),
     cmd_region_vector(std::move(other.cmd_region_vector)) {
     if constexpr (hugepage_write) {
         this->deepcopy(other);
@@ -112,13 +171,14 @@ void DeviceCommand<hugepage_write>::add_dispatch_wait(
     uint32_t flags, uint32_t address, uint32_t stream, uint32_t count, uint8_t cq_id, uint8_t dispatcher_type) {
     // If there are no stream registers (Quasar), translate stream flags to memory flags and calculate the L1 worker
     // completion counter address from the stream index.
-    if (!MetalContext::instance().hal().has_stream_registers() &&
+    TT_ASSERT(this->ctx_ != nullptr, "DeviceCommand used without a MetalContext");
+    const auto& ctx = *this->ctx_;
+    if (!ctx.hal().has_stream_registers() &&
         (flags & (CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM))) {
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
+        const auto& mem_map = ctx.dispatch_mem_map();
         const uint32_t first_stream = mem_map.get_dispatch_stream_index(0);
         const uint32_t completion_counter_offset = mem_map.get_completion_counter_offset(cq_id);
-        address = mem_map.get_dispatch_message_addr_start() +
-                  completion_counter_offset * MetalContext::instance().hal().get_alignment(HalMemType::L1) +
+        address = mem_map.get_dispatch_message_addr_start() + completion_counter_offset * this->l1_alignment +
                   mem_map.get_sync_offset(stream - first_stream);
         uint32_t new_flags = flags & ~(CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM);
         new_flags |= CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
@@ -1365,6 +1425,7 @@ template class DeviceCommand<true>;
 template class DeviceCommand<false>;
 
 template DeviceCommand<false>::DeviceCommand(uint32_t);
+template DeviceCommand<false>::DeviceCommand(MetalContext&, uint32_t);
 
 template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
 template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -28,10 +28,8 @@ namespace tt::tt_metal {
 template <bool hugepage_write = false>
 class DeviceCommand {
 public:
-    // Prefer DeviceCommand(MetalContext&). Legacy ctors resolve the global singleton and will be
-    // removed once all callers pass a MetalContext (N2c/C3).
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    DeviceCommand();
+    // Prefer DeviceCommand(MetalContext&). Legacy size/region ctors resolve the global singleton and will
+    // be removed once all callers pass a MetalContext (N2c/C3).
     // TODO(N2c/C3): remove once all callers pass a MetalContext.
     DeviceCommand(void* cmd_region, uint32_t cmd_sequence_sizeB);
     // TODO(N2c/C3): remove once all callers pass a MetalContext.

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -28,14 +28,6 @@ namespace tt::tt_metal {
 template <bool hugepage_write = false>
 class DeviceCommand {
 public:
-    // Prefer DeviceCommand(MetalContext&). Legacy size/region ctors resolve the global singleton and will
-    // be removed once all callers pass a MetalContext (N2c/C3).
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    DeviceCommand(void* cmd_region, uint32_t cmd_sequence_sizeB);
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    template <bool hp_w = hugepage_write, typename std::enable_if_t<!hp_w, int> = 0>
-    DeviceCommand(uint32_t cmd_sequence_sizeB);
-
     explicit DeviceCommand(MetalContext& ctx);
     DeviceCommand(MetalContext& ctx, void* cmd_region, uint32_t cmd_sequence_sizeB);
     template <bool hp_w = hugepage_write, typename std::enable_if_t<!hp_w, int> = 0>

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -28,11 +28,20 @@ namespace tt::tt_metal {
 template <bool hugepage_write = false>
 class DeviceCommand {
 public:
-    DeviceCommand() = default;
+    // Prefer DeviceCommand(MetalContext&). Legacy ctors resolve the global singleton and will be
+    // removed once all callers pass a MetalContext (N2c/C3).
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
+    DeviceCommand();
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
     DeviceCommand(void* cmd_region, uint32_t cmd_sequence_sizeB);
-
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
     template <bool hp_w = hugepage_write, typename std::enable_if_t<!hp_w, int> = 0>
     DeviceCommand(uint32_t cmd_sequence_sizeB);
+
+    explicit DeviceCommand(MetalContext& ctx);
+    DeviceCommand(MetalContext& ctx, void* cmd_region, uint32_t cmd_sequence_sizeB);
+    template <bool hp_w = hugepage_write, typename std::enable_if_t<!hp_w, int> = 0>
+    DeviceCommand(MetalContext& ctx, uint32_t cmd_sequence_sizeB);
 
     DeviceCommand& operator=(const DeviceCommand& other);
     DeviceCommand& operator=(DeviceCommand&& other) noexcept;
@@ -314,12 +323,14 @@ private:
         }
     }
 
+    void init_from_context(MetalContext& ctx);
+
     uint32_t cmd_sequence_sizeB = 0;
     void* cmd_region = nullptr;
     uint32_t cmd_write_offsetB = 0;
-    uint32_t pcie_alignment =
-        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
-    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+    MetalContext* ctx_ = nullptr;
+    uint32_t pcie_alignment = 0;
+    uint32_t l1_alignment = 0;
 
     vector_aligned<uint32_t> cmd_region_vector;
 };

--- a/tt_metal/impl/dispatch/device_command_calculator.cpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.cpp
@@ -12,10 +12,8 @@
 
 namespace tt::tt_metal {
 
-DeviceCommandCalculator::DeviceCommandCalculator(MetalContext& ctx) {
-    this->pcie_alignment = ctx.hal().get_alignment(HalMemType::HOST);
-    this->l1_alignment = ctx.hal().get_alignment(HalMemType::L1);
-}
+DeviceCommandCalculator::DeviceCommandCalculator(MetalContext& ctx) :
+    pcie_alignment(ctx.hal().get_alignment(HalMemType::HOST)), l1_alignment(ctx.hal().get_alignment(HalMemType::L1)) {}
 
 template <typename PackedSubCmd>
 uint32_t DeviceCommandCalculator::get_max_write_packed_sub_cmds(

--- a/tt_metal/impl/dispatch/device_command_calculator.cpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.cpp
@@ -12,13 +12,6 @@
 
 namespace tt::tt_metal {
 
-DeviceCommandCalculator::DeviceCommandCalculator() {
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    const auto& hal = MetalContext::instance().hal();
-    this->pcie_alignment = hal.get_alignment(HalMemType::HOST);
-    this->l1_alignment = hal.get_alignment(HalMemType::L1);
-}
-
 DeviceCommandCalculator::DeviceCommandCalculator(MetalContext& ctx) {
     this->pcie_alignment = ctx.hal().get_alignment(HalMemType::HOST);
     this->l1_alignment = ctx.hal().get_alignment(HalMemType::L1);

--- a/tt_metal/impl/dispatch/device_command_calculator.cpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.cpp
@@ -8,8 +8,21 @@
 
 #include "dispatch/kernels/cq_commands.hpp"
 #include "hal.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
+
+DeviceCommandCalculator::DeviceCommandCalculator() {
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
+    const auto& hal = MetalContext::instance().hal();
+    this->pcie_alignment = hal.get_alignment(HalMemType::HOST);
+    this->l1_alignment = hal.get_alignment(HalMemType::L1);
+}
+
+DeviceCommandCalculator::DeviceCommandCalculator(MetalContext& ctx) {
+    this->pcie_alignment = ctx.hal().get_alignment(HalMemType::HOST);
+    this->l1_alignment = ctx.hal().get_alignment(HalMemType::L1);
+}
 
 template <typename PackedSubCmd>
 uint32_t DeviceCommandCalculator::get_max_write_packed_sub_cmds(
@@ -50,8 +63,7 @@ void DeviceCommandCalculator::insert_write_packed_payloads(
     const uint32_t max_prefetch_command_size,
     const uint32_t packed_write_max_unicast_sub_cmds,
     std::vector<std::pair<uint32_t, uint32_t>>& packed_cmd_payloads) {
-    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    const uint32_t aligned_sub_cmd_sizeB = tt::align(sub_cmd_sizeB, l1_alignment);
+    const uint32_t aligned_sub_cmd_sizeB = tt::align(sub_cmd_sizeB, this->l1_alignment);
     const uint32_t max_packed_sub_cmds_per_cmd = get_max_write_packed_sub_cmds<PackedSubCmd>(
         aligned_sub_cmd_sizeB, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);
     uint32_t rem_num_sub_cmds = num_sub_cmds;
@@ -59,7 +71,7 @@ void DeviceCommandCalculator::insert_write_packed_payloads(
         const uint32_t num_sub_cmds_in_cmd = std::min(max_packed_sub_cmds_per_cmd, rem_num_sub_cmds);
         const uint32_t aligned_data_sizeB = aligned_sub_cmd_sizeB * num_sub_cmds_in_cmd;
         const uint32_t dispatch_cmd_sizeB =
-            tt::align(sizeof(CQDispatchCmd) + (num_sub_cmds_in_cmd * sizeof(PackedSubCmd)), l1_alignment);
+            tt::align(sizeof(CQDispatchCmd) + (num_sub_cmds_in_cmd * sizeof(PackedSubCmd)), this->l1_alignment);
         packed_cmd_payloads.emplace_back(num_sub_cmds_in_cmd, dispatch_cmd_sizeB + aligned_data_sizeB);
         rem_num_sub_cmds -= num_sub_cmds_in_cmd;
         this->add_dispatch_write_packed<PackedSubCmd>(

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -11,13 +11,21 @@
 
 #include <tt_stl/assert.hpp>
 #include "hal_types.hpp"
-#include "impl/context/metal_context.hpp"
 #include "tt_align.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 
 namespace tt::tt_metal {
+
+class MetalContext;
+
 class DeviceCommandCalculator {
 public:
+    // Prefer DeviceCommandCalculator(MetalContext&). Legacy default resolves the global singleton
+    // and will be removed once all callers pass a MetalContext (N2c/C3).
+    // TODO(N2c/C3): remove once all callers pass a MetalContext.
+    DeviceCommandCalculator();
+    explicit DeviceCommandCalculator(MetalContext& ctx);
+
     uint32_t write_offset_bytes() const { return this->cmd_write_offsetB; }
 
     void add_dispatch_wait() {
@@ -347,8 +355,7 @@ public:
 private:
     void add_prefetch_relay_inline() { this->cmd_write_offsetB += sizeof(CQPrefetchCmd); }
     uint32_t cmd_write_offsetB = 0;
-    uint32_t pcie_alignment =
-        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
-    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+    uint32_t pcie_alignment = 0;
+    uint32_t l1_alignment = 0;
 };
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -20,10 +20,6 @@ class MetalContext;
 
 class DeviceCommandCalculator {
 public:
-    // Prefer DeviceCommandCalculator(MetalContext&). Legacy default resolves the global singleton
-    // and will be removed once all callers pass a MetalContext (N2c/C3).
-    // TODO(N2c/C3): remove once all callers pass a MetalContext.
-    DeviceCommandCalculator();
     explicit DeviceCommandCalculator(MetalContext& ctx);
 
     uint32_t write_offset_bytes() const { return this->cmd_write_offsetB; }

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -76,27 +76,27 @@ void HWCommandQueue::terminate() {
     log_debug(tt::LogDispatch, "Terminating dispatch kernels for command queue {}", this->id_);
     // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_TERMINATE
     // CQ_PREFETCH_CMD_TERMINATE
-    uint32_t cmd_sequence_sizeB =
-        MetalContext::instance(this->device_->get_context_id()).hal().get_alignment(HalMemType::HOST);
+    MetalContext& metal_ctx = MetalContext::instance(this->device_->get_context_id());
+    uint32_t cmd_sequence_sizeB = metal_ctx.hal().get_alignment(HalMemType::HOST);
 
     // dispatch and prefetch terminate commands each needs to be a separate fetch queue entry
     void* cmd_region = this->manager_.issue_queue_reserve(cmd_sequence_sizeB, this->id_);
-    HugepageDeviceCommand dispatch_d_command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand dispatch_d_command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     dispatch_d_command_sequence.add_dispatch_terminate(DispatcherSelect::DISPATCH_MASTER);
     this->manager_.issue_queue_push_back(cmd_sequence_sizeB, this->id_);
     this->manager_.fetch_queue_reserve_back(this->id_);
     this->manager_.fetch_queue_write(cmd_sequence_sizeB, this->id_);
-    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+    if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
         // Terminate dispatch_s if enabled
         cmd_region = this->manager_.issue_queue_reserve(cmd_sequence_sizeB, this->id_);
-        HugepageDeviceCommand dispatch_s_command_sequence(cmd_region, cmd_sequence_sizeB);
+        HugepageDeviceCommand dispatch_s_command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
         dispatch_s_command_sequence.add_dispatch_terminate(DispatcherSelect::DISPATCH_SUBORDINATE);
         this->manager_.issue_queue_push_back(cmd_sequence_sizeB, this->id_);
         this->manager_.fetch_queue_reserve_back(this->id_);
         this->manager_.fetch_queue_write(cmd_sequence_sizeB, this->id_);
     }
     cmd_region = this->manager_.issue_queue_reserve(cmd_sequence_sizeB, this->id_);
-    HugepageDeviceCommand prefetch_command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand prefetch_command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     prefetch_command_sequence.add_prefetch_terminate();
     this->manager_.issue_queue_push_back(cmd_sequence_sizeB, this->id_);
     this->manager_.fetch_queue_reserve_back(this->id_);

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -54,7 +54,8 @@ void issue_record_event_commands(
     std::vector<uint32_t> event_payload(DispatchSettings::EVENT_PADDED_SIZE / sizeof(uint32_t), 0);
     event_payload[0] = event_id;
 
-    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    MetalContext& metal_ctx = MetalContext::instance(manager.get_context_id());
+    const uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     const uint32_t num_worker_counters = sub_device_ids.size();
     const uint32_t num_cqs_per_dispatch_core =
         MetalContext::instance().get_dispatch_query_manager().cq_dispatch_layout().num_cqs_per_core;
@@ -64,7 +65,7 @@ void issue_record_event_commands(
     // Calculate the packed event payload size
     uint32_t packed_event_payload_sizeB;
     {
-        tt::tt_metal::DeviceCommandCalculator event_payload_calculator;
+        tt::tt_metal::DeviceCommandCalculator event_payload_calculator(metal_ctx);
         event_payload_calculator.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
             num_dispatch_cores, DispatchSettings::EVENT_PADDED_SIZE, packed_write_max_unicast_sub_cmds, false);
         packed_event_payload_sizeB =
@@ -72,7 +73,7 @@ void issue_record_event_commands(
     }
 
     // Calculate the actual command size
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     for (uint32_t i = 0; i + 1 < num_worker_counters; ++i) {
         calculator.add_dispatch_wait();
     }
@@ -90,7 +91,7 @@ void issue_record_event_commands(
 
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
 
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
     for (uint32_t i = 0; i < num_worker_counters; ++i) {
         auto offset_index = *sub_device_ids[i];
@@ -161,13 +162,14 @@ void issue_record_event_commands(
 
 void issue_wait_for_event_commands(
     uint8_t cq_id, uint8_t event_cq_id, SystemMemoryManager& sysmem_manager, uint32_t event_id) {
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     calculator.add_dispatch_wait();
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
 
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     uint32_t completion_q0_last_event_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
         CommandQueueDeviceAddrType::COMPLETION_Q0_LAST_EVENT, cq_id);
     uint32_t completion_q1_last_event_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -541,17 +541,21 @@ uint32_t get_packed_write_max_unicast_sub_cmds(IDevice* device) {
 void insert_empty_program_dispatch_preamble_cmd(ProgramCommandSequence& program_command_sequence) {
     // Initialize an empty preamble command in the Program Dispatch Cmd Sequence, which will be
     // updated with the correct write offsets when the program is enqueued
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    TT_ASSERT(program_command_sequence.ctx != nullptr);
+    MetalContext& metal_ctx = *program_command_sequence.ctx;
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     calculator.add_dispatch_set_write_offsets(4);
     const uint32_t preamble_cmd_sizeB = calculator.write_offset_bytes();
-    program_command_sequence.preamble_command_sequence = HostMemDeviceCommand(preamble_cmd_sizeB);
+    program_command_sequence.preamble_command_sequence = HostMemDeviceCommand(metal_ctx, preamble_cmd_sizeB);
     static constexpr uint32_t write_offsets[4] = {0, 0, 0, 0};
     program_command_sequence.preamble_command_sequence.add_dispatch_set_write_offsets(write_offsets);
 }
 
 void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDeviceId sub_device_id) {
     // Initialize stall command sequences for this program.
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    TT_ASSERT(program_command_sequence.ctx != nullptr);
+    MetalContext& metal_ctx = *program_command_sequence.ctx;
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     calculator.add_dispatch_wait_with_prefetch_stall();
     const uint32_t uncached_stall_cmd_sizeB = calculator.write_offset_bytes();
     calculator.clear();
@@ -563,21 +567,21 @@ void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDevi
     // update_program_dispatch_commands/update_traced_program_dispatch_commands patch in the real completion
     // address for the enqueuing CQ before the sequence ever reaches hardware.
     program_command_sequence.stall_command_sequences[UncachedStallSequenceIdx] =
-        HostMemDeviceCommand(uncached_stall_cmd_sizeB);
+        HostMemDeviceCommand(metal_ctx, uncached_stall_cmd_sizeB);
     // Empty wait command initialized here. Will get updated when program is enqueued.
     program_command_sequence.stall_command_sequences[UncachedStallSequenceIdx].add_dispatch_wait_with_prefetch_stall(
         CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER | CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
         0,
-        MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(*sub_device_id),
+        metal_ctx.dispatch_mem_map().get_dispatch_stream_index(*sub_device_id),
         0,
         /*cq_id=*/0);
     // Empty wait command initialized here. Will get updated when program is enqueued.
     program_command_sequence.stall_command_sequences[CachedStallSequenceIdx] =
-        HostMemDeviceCommand(cached_stall_cmd_seqB);
+        HostMemDeviceCommand(metal_ctx, cached_stall_cmd_seqB);
     program_command_sequence.stall_command_sequences[CachedStallSequenceIdx].add_dispatch_wait(
         CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
         0,
-        MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(*sub_device_id),
+        metal_ctx.dispatch_mem_map().get_dispatch_stream_index(*sub_device_id),
         0,
         /*cq_id=*/0);
 }
@@ -626,6 +630,7 @@ void repoint_rta_data_into_command_stream(
 
 template <typename PackedSubCmd>
 void generate_runtime_args_cmds(
+    MetalContext& metal_ctx,
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
     std::vector<ProgramCommandSequence::RtaUpdate>& rta_updates,
     const uint32_t& l1_arg_base_addr,
@@ -666,7 +671,7 @@ void generate_runtime_args_cmds(
     constexpr bool unicast = std::is_same_v<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd>;
 
     uint32_t num_packed_cmds_in_seq = sub_cmds.size();
-    DeviceCommandCalculator calculator;
+    DeviceCommandCalculator calculator(metal_ctx);
     uint32_t max_packed_cmds = calculator.get_max_write_packed_sub_cmds<PackedSubCmd>(
         max_runtime_args_len,
         constants.max_prefetch_command_size,
@@ -680,22 +685,22 @@ void generate_runtime_args_cmds(
             num_packed_cmds_in_seq,
             max_packed_cmds);
     }
-    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     while (num_packed_cmds_in_seq != 0) {
         // Generate the device command
         uint32_t num_packed_cmds = std::min(num_packed_cmds_in_seq, max_packed_cmds);
         uint32_t rt_payload_sizeB =
             get_runtime_payload_sizeB(num_packed_cmds, max_runtime_args_len, unicast, no_stride);
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_write_packed<PackedSubCmd>(
             num_packed_cmds,
             max_runtime_args_len * sizeof(uint32_t),
             constants.packed_write_max_unicast_sub_cmds,
             no_stride);
-        auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
+        auto& command_obj = runtime_args_command_sequences.emplace_back(metal_ctx, calculator.write_offset_bytes());
         uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
         // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand.
-        if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+        if (metal_ctx.rtoptions().get_watcher_enabled()) {
             uint32_t total_words = (calculator.write_offset_bytes() - data_offset) / sizeof(uint32_t);
             uint32_t* command_start_ptr =
                 reinterpret_cast<uint32_t*>(command_obj.data()) + (data_offset / sizeof(uint32_t));
@@ -782,6 +787,7 @@ uint32_t max_cores_per_large_unicast_cmd(uint32_t rta_payload_sizeB, uint32_t ma
 // max_cores_per_large_unicast_cmd() per command, with each core's payload laid out
 // exactly as the packed path lays out its per-core data region so the RTA-update pointers stay valid.
 void generate_runtime_args_cmds_large_unicast(
+    MetalContext& metal_ctx,
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
     std::vector<ProgramCommandSequence::RtaUpdate>& rta_updates,
     uint32_t l1_arg_base_addr,
@@ -793,7 +799,7 @@ void generate_runtime_args_cmds_large_unicast(
         rt_args_data,
     uint32_t max_prefetch_command_size,
     uint32_t write_offset_index) {
-    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     // Device reads rta_payload_sizeB bytes per sub-command, then pads the read pointer to `alignment`, so
     // consecutive per-core payloads in the command stream are separated by this aligned size.
     const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
@@ -819,7 +825,7 @@ void generate_runtime_args_cmds_large_unicast(
             auto& buf = core_payloads[k];
             buf.assign(aligned_core_payload, 0);
             // With watcher off the buffer stays zero; mirrors the packed path.
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+            if (metal_ctx.rtoptions().get_watcher_enabled()) {
                 fill_runtime_args_watcher_pattern(
                     reinterpret_cast<uint32_t*>(buf.data()), aligned_core_payload / sizeof(uint32_t));
             }
@@ -834,9 +840,9 @@ void generate_runtime_args_cmds_large_unicast(
             data_collection[k] = tt::stl::Span<const uint8_t>(buf.data(), buf.size());
         }
 
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_write_packed_large_unicast(num_in_chunk, num_in_chunk * aligned_core_payload);
-        auto& command_obj = runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
+        auto& command_obj = runtime_args_command_sequences.emplace_back(metal_ctx, calculator.write_offset_bytes());
 
         std::vector<uint8_t*> data_collection_location;
         command_obj.add_dispatch_write_packed_large_unicast(
@@ -921,10 +927,12 @@ BatchedTransfers assemble_runtime_args_commands(
 
     program_command_sequence.runtime_args_command_sequences = {};
     uint32_t command_count = 0;
-    const DeviceCommandCalculator calculator;
+    TT_ASSERT(program_command_sequence.ctx != nullptr);
+    MetalContext& metal_ctx = *program_command_sequence.ctx;
+    const DeviceCommandCalculator calculator(metal_ctx);
 
     // Unique RTAs
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     for (uint32_t programmable_core_type_index = 0;
          programmable_core_type_index < hal.get_programmable_core_type_count();
          programmable_core_type_index++) {
@@ -1086,6 +1094,7 @@ BatchedTransfers assemble_runtime_args_commands(
                     // Per-core payload exceeds one dispatch page; the packed-write handler cannot span
                     // pages, so send these unique RTAs via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST.
                     generate_runtime_args_cmds_large_unicast(
+                        metal_ctx,
                         program_command_sequence.runtime_args_command_sequences,
                         program_command_sequence.rta_updates,
                         rta_offset,
@@ -1097,6 +1106,7 @@ BatchedTransfers assemble_runtime_args_commands(
                         get_dispatch_write_offset(programmable_core_type));
                 } else {
                     generate_runtime_args_cmds(
+                        metal_ctx,
                         program_command_sequence.runtime_args_command_sequences,
                         program_command_sequence.rta_updates,
                         rta_offset,
@@ -1187,6 +1197,7 @@ BatchedTransfers assemble_runtime_args_commands(
                     std::visit(
                         [&](auto&& sub_cmds) {
                             generate_runtime_args_cmds(
+                                metal_ctx,
                                 program_command_sequence.runtime_args_command_sequences,
                                 program_command_sequence.rta_updates,
                                 crta_offset,
@@ -2454,15 +2465,18 @@ void assemble_device_commands(
         *sub_device_id,
         use_prefetcher_cache ? "enabled" : "disabled");
 
+    TT_ASSERT(program_command_sequence.ctx != nullptr);
+    MetalContext& metal_ctx = *program_command_sequence.ctx;
+
     CommandConstants constants{};
     constants.noc_index = k_dispatch_downstream_noc;
-    constants.max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    constants.max_prefetch_command_size = metal_ctx.dispatch_mem_map().max_prefetch_command_size();
     constants.packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(mesh_device);
     BatchedTransfers batched_transfers =
         assemble_runtime_args_commands(program_command_sequence, program, mesh_device, constants);
 
     // Assemble config buffer
-    DeviceCommandCalculator program_config_buffer_calculator;
+    DeviceCommandCalculator program_config_buffer_calculator(metal_ctx);
 
     SemphoreCommandGenerator semaphore_command_generator;
     semaphore_command_generator.size_commands(
@@ -2486,7 +2500,7 @@ void assemble_device_commands(
         absolute_cross_node_config_transfers, program_config_buffer_calculator);
 
     program_command_sequence.program_config_buffer_command_sequence =
-        HostMemDeviceCommand(program_config_buffer_calculator.write_offset_bytes());
+        HostMemDeviceCommand(metal_ctx, program_config_buffer_calculator.write_offset_bytes());
     batched_transfer_generator.assemble_commands(
         program_command_sequence, program_command_sequence.program_config_buffer_command_sequence);
     absolute_cross_node_config_generator.assemble_commands(
@@ -2508,7 +2522,7 @@ void assemble_device_commands(
             "Expected Kernel Binary Buffer to be allocated for program.");
     }
     ProgramBinaryCommandGenerator program_binary_command_generator;
-    DeviceCommandCalculator program_binary_calculator;
+    DeviceCommandCalculator program_binary_calculator(metal_ctx);
     program_binary_command_generator.size_commands(
         mesh_device,
         program,
@@ -2518,7 +2532,7 @@ void assemble_device_commands(
         program_binary_calculator,
         use_prefetcher_cache);
     program_command_sequence.program_binary_command_sequence =
-        HostMemDeviceCommand(program_binary_calculator.write_offset_bytes());
+        HostMemDeviceCommand(metal_ctx, program_binary_calculator.write_offset_bytes());
     program_binary_command_generator.assemble_commands(
         program_command_sequence.program_binary_command_sequence, use_prefetcher_cache);
     TT_ASSERT(
@@ -2530,9 +2544,10 @@ void assemble_device_commands(
 
     // Assemble wait barrier command sequence
     {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_wait();
-        program_command_sequence.wait_barrier_command_sequence = HostMemDeviceCommand(calculator.write_offset_bytes());
+        program_command_sequence.wait_barrier_command_sequence =
+            HostMemDeviceCommand(metal_ctx, calculator.write_offset_bytes());
         // cq_id is unused here: add_dispatch_wait only consults it for WAIT_STREAM/CLEAR_STREAM waits, and this
         // is a plain barrier wait.
         program_command_sequence.wait_barrier_command_sequence.add_dispatch_wait(
@@ -2544,11 +2559,11 @@ void assemble_device_commands(
 
     // Assemble launch message
     LaunchMessageGenerator launch_message_generator;
-    DeviceCommandCalculator launch_message_calculator;
+    DeviceCommandCalculator launch_message_calculator(metal_ctx);
     launch_message_generator.construct_commands(
         mesh_device, program, launch_message_calculator, constants, sub_device_id);
     program_command_sequence.launch_msg_command_sequence =
-        HostMemDeviceCommand(launch_message_calculator.write_offset_bytes());
+        HostMemDeviceCommand(metal_ctx, launch_message_calculator.write_offset_bytes());
     launch_message_generator.assemble_commands(
         program_command_sequence, program_command_sequence.launch_msg_command_sequence, constants);
     TT_ASSERT(
@@ -2557,9 +2572,10 @@ void assemble_device_commands(
 
     // Assemble go signal
     GoSignalGenerator go_signal_generator;
-    DeviceCommandCalculator go_signal_calculator;
+    DeviceCommandCalculator go_signal_calculator(metal_ctx);
     go_signal_generator.size_commands(go_signal_calculator, sub_device_id, program_transfer_info);
-    program_command_sequence.go_msg_command_sequence = HostMemDeviceCommand(go_signal_calculator.write_offset_bytes());
+    program_command_sequence.go_msg_command_sequence =
+        HostMemDeviceCommand(metal_ctx, go_signal_calculator.write_offset_bytes());
     go_signal_generator.assemble_commands(
         program_command_sequence,
         program_command_sequence.go_msg_command_sequence,
@@ -2867,10 +2883,11 @@ void update_program_dispatch_commands(
     // Update prefetcher cache initialization
     if (cached_program_command_sequence.prefetcher_cache_used) {
         // reserve space for cache command
-        uint32_t pcie_alignment =
-            tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+        TT_ASSERT(cached_program_command_sequence.ctx != nullptr);
+        MetalContext& metal_ctx = *cached_program_command_sequence.ctx;
+        uint32_t pcie_alignment = metal_ctx.hal().get_alignment(tt::tt_metal::HalMemType::HOST);
         cached_program_command_sequence.program_binary_setup_prefetcher_cache_command =
-            HostMemDeviceCommand(tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
+            HostMemDeviceCommand(metal_ctx, tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
 
         auto is_cached = dispatch_md.prefetcher_cache_info.is_cached;
         auto cache_offset = dispatch_md.prefetcher_cache_info.offset;
@@ -3078,10 +3095,11 @@ void update_traced_program_dispatch_commands(
     // Update prefetcher cache initialization
     if (dispatch_md.send_binary && cached_program_command_sequence.prefetcher_cache_used) {
         // reserve space for cache command
-        uint32_t pcie_alignment =
-            tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+        TT_ASSERT(cached_program_command_sequence.ctx != nullptr);
+        MetalContext& metal_ctx = *cached_program_command_sequence.ctx;
+        uint32_t pcie_alignment = metal_ctx.hal().get_alignment(tt::tt_metal::HalMemType::HOST);
         cached_program_command_sequence.program_binary_setup_prefetcher_cache_command =
-            HostMemDeviceCommand(tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
+            HostMemDeviceCommand(metal_ctx, tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
 
         auto is_cached = dispatch_md.prefetcher_cache_info.is_cached;
         auto cache_offset = dispatch_md.prefetcher_cache_info.offset;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -750,11 +750,12 @@ void generate_runtime_args_cmds(
 // so a large per-core payload forces far fewer than 35 cores per command; exceeding it silently overflows
 // the eth cmddat queue and hangs the device. Returns >=1 (a single core's payload is L1-fit-checked at
 // finalize, so it is expected to fit).
-uint32_t max_cores_per_large_unicast_cmd(uint32_t rta_payload_sizeB, uint32_t max_prefetch_command_size) {
-    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+uint32_t max_cores_per_large_unicast_cmd(
+    MetalContext& metal_ctx, uint32_t rta_payload_sizeB, uint32_t max_prefetch_command_size) {
+    const uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
     for (uint32_t n = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS; n >= 1; --n) {
-        DeviceCommandCalculator calculator;
+        DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_write_packed_large_unicast(n, n * aligned_core_payload);
         if (calculator.write_offset_bytes() <= max_prefetch_command_size) {
             return n;
@@ -766,7 +767,7 @@ uint32_t max_cores_per_large_unicast_cmd(uint32_t rta_payload_sizeB, uint32_t ma
     // guard is a TT_ASSERT and compiles out in release builds). The kernel-side RTA ceiling
     // (validate_runtime_args_size) is set before the dispatch core type is known, so this is the first point
     // that can enforce the dispatch-core-specific prefetch command size.
-    DeviceCommandCalculator single_core;
+    DeviceCommandCalculator single_core(metal_ctx);
     single_core.add_dispatch_write_packed_large_unicast(1, aligned_core_payload);
     TT_FATAL(
         false,
@@ -805,7 +806,8 @@ void generate_runtime_args_cmds_large_unicast(
     const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
     const uint32_t count_word_offset = is_watcher_assert_enabled() ? 1 : 0;
     // Cap cores/command by the prefetcher command size, not just the sub-cmd count (see helper above).
-    const uint32_t max_cores_per_cmd = max_cores_per_large_unicast_cmd(rta_payload_sizeB, max_prefetch_command_size);
+    const uint32_t max_cores_per_cmd =
+        max_cores_per_large_unicast_cmd(metal_ctx, rta_payload_sizeB, max_prefetch_command_size);
 
     const uint32_t num_cores = sub_cmds.size();
     uint32_t offset_idx = 0;
@@ -946,7 +948,8 @@ BatchedTransfers assemble_runtime_args_commands(
                 if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
                     command_count += div_up(
                         num_sub_cmds,
-                        max_cores_per_large_unicast_cmd(kg->total_rta_size, constants.max_prefetch_command_size));
+                        max_cores_per_large_unicast_cmd(
+                            metal_ctx, kg->total_rta_size, constants.max_prefetch_command_size));
                 } else {
                     uint32_t max_runtime_args_len = kg->total_rta_size / sizeof(uint32_t);
                     uint32_t max_packed_cmds =
@@ -1667,13 +1670,14 @@ public:
         const CommandConstants& constants,
         DeviceCommandCalculator& calculator,
         bool using_prefetcher_cache) {
-        const auto& hal = MetalContext::instance().hal();
-        const uint32_t max_length_per_sub_cmd = MetalContext::instance().dispatch_mem_map().scratch_db_size() / 2;
+        MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+        const auto& hal = metal_ctx.hal();
+        const uint32_t max_length_per_sub_cmd = metal_ctx.dispatch_mem_map().scratch_db_size() / 2;
         const uint32_t max_paged_length_per_sub_cmd =
             max_length_per_sub_cmd / HostMemDeviceCommand::PROGRAM_PAGE_SIZE * HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
 
-        const uint32_t unicast_cmd_sequence_sizeB = [using_prefetcher_cache]() {
-            DeviceCommandCalculator calc;
+        const uint32_t unicast_cmd_sequence_sizeB = [using_prefetcher_cache, &metal_ctx]() {
+            DeviceCommandCalculator calc(metal_ctx);
             constexpr bool flush_prefetch = false;
             calc.add_dispatch_write_linear<flush_prefetch>(0);
             if (not using_prefetcher_cache) {
@@ -1723,7 +1727,7 @@ public:
                             },
                             cores);
                     }
-                    kernel_bins_unicast_cmds.emplace_back(unicast_cmd_sequence_sizeB);
+                    kernel_bins_unicast_cmds.emplace_back(metal_ctx, unicast_cmd_sequence_sizeB);
                     calculator.update_write_offset_bytes(unicast_cmd_sequence_sizeB);
                     constexpr bool flush_prefetch = false;
 
@@ -3458,7 +3462,8 @@ void reset_worker_dispatch_state_on_device(
     bool reset_launch_msg_state) {
     auto num_sub_devices = mesh_device->num_sub_devices();
 
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(manager.get_context_id());
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     if (reset_launch_msg_state) {
         for (int i = 0; i < num_sub_devices; ++i) {
             calculator.add_dispatch_go_signal_mcast();
@@ -3477,7 +3482,7 @@ void reset_worker_dispatch_state_on_device(
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
     if (reset_launch_msg_state) {
         if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
@@ -3544,14 +3549,15 @@ void set_num_worker_sems_on_dispatch(
     ttsl::Span<const uint32_t> workers_per_sub_device) {
     TT_ASSERT(num_worker_sems <= DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
     TT_ASSERT(workers_per_sub_device.size() == num_worker_sems);
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(manager.get_context_id());
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
         calculator.add_dispatch_set_num_worker_sems();
     }
     calculator.add_dispatch_set_sub_device_worker_counts(num_worker_sems);
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
         command_sequence.add_dispatch_set_num_worker_sems(num_worker_sems, DispatcherSelect::DISPATCH_SUBORDINATE);
         command_sequence.add_dispatch_set_sub_device_worker_counts(
@@ -3567,11 +3573,12 @@ void set_num_worker_sems_on_dispatch(
 
 void set_go_signal_noc_data_on_dispatch(
     const vector_aligned<uint32_t>& go_signal_noc_data, SystemMemoryManager& manager, uint8_t cq_id) {
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(manager.get_context_id());
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     calculator.add_dispatch_set_go_signal_noc_data(go_signal_noc_data.size());
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     DispatcherSelect dispatcher_for_go_signal =
         MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()
             ? DispatcherSelect::DISPATCH_SUBORDINATE
@@ -3585,7 +3592,8 @@ void set_go_signal_noc_data_on_dispatch(
 // Wait for number of workers to complete and then reset the counter on the device
 void reset_expected_num_workers_completed_on_device(
     Device* device, SubDeviceId sub_device_id, uint32_t num_expected_workers, uint8_t cq_id) {
-    tt::tt_metal::DeviceCommandCalculator calculator;
+    MetalContext& metal_ctx = MetalContext::instance(device->get_context_id());
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
     bool distributed_dispatcher =
         tt::tt_metal::MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
     if (distributed_dispatcher) {
@@ -3596,7 +3604,7 @@ void reset_expected_num_workers_completed_on_device(
     auto& manager = device->sysmem_manager();
     const auto cmd_sequence_sizeB = calculator.write_offset_bytes();
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     const auto populate_dispatch_wait_cmd = [&](DispatcherSelect dispatcher_type) {
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
@@ -3645,9 +3653,9 @@ void set_core_go_message_mapping_on_device(
     const std::vector<std::pair<CoreRangeSet, uint32_t>>& core_go_message_mapping,
     SystemMemoryManager& manager,
     uint8_t cq_id) {
-    tt::tt_metal::DeviceCommandCalculator calculator;
-    uint32_t go_msg_size =
-        MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+    MetalContext& metal_ctx = MetalContext::instance(device->get_context_id());
+    tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
+    uint32_t go_msg_size = metal_ctx.hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
     calculator.add_dispatch_write_linear<true, true>(go_msg_size);
     calculator.add_dispatch_wait();
 
@@ -3655,7 +3663,7 @@ void set_core_go_message_mapping_on_device(
     std::vector<CQDispatchWritePackedMulticastSubCmd> sub_cmds;
     std::vector<std::pair<uint32_t, uint32_t>> payload;
     uint32_t noc_index = k_dispatch_downstream_noc;
-    uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    uint32_t max_prefetch_command_size = metal_ctx.dispatch_mem_map().max_prefetch_command_size();
     uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 
     size_t num_core_ranges = 0;
@@ -3685,7 +3693,7 @@ void set_core_go_message_mapping_on_device(
 
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
-    HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
 
     const auto& compute_grid_size = device->compute_with_storage_grid_size();
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2423,7 +2423,7 @@ void ProgramImpl::generate_dispatch_commands(distributed::MeshDevice* mesh_devic
     if (!cached_program_command_sequences.contains(command_hash)) {
         // Programs currently only support spanning a single sub-device
         auto sub_device_id = this->determine_sub_device_ids(mesh_device).at(0);
-        ProgramCommandSequence program_command_sequence;
+        ProgramCommandSequence program_command_sequence{MetalContext::instance(extract_context_id(mesh_device))};
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id);
         program_dispatch::assemble_device_commands(
@@ -2464,7 +2464,7 @@ void ProgramImpl::generate_trace_dispatch_commands(distributed::MeshDevice* mesh
     if (!trace_cached_program_command_sequences.contains(command_hash)) {
         // Programs currently only support spanning a single sub-device
         auto sub_device_id = this->determine_sub_device_ids(mesh_device).at(0);
-        ProgramCommandSequence program_command_sequence;
+        ProgramCommandSequence program_command_sequence{MetalContext::instance(extract_context_id(mesh_device))};
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id);
         program_dispatch::assemble_device_commands(

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -22,7 +22,17 @@ constexpr uint32_t UncachedStallSequenceIdx = 0;
 constexpr uint32_t CachedStallSequenceIdx = 1;
 
 struct ProgramCommandSequence {
-    ProgramCommandSequence() = default;
+    explicit ProgramCommandSequence(MetalContext& metal_ctx) :
+        ctx(&metal_ctx),
+        preamble_command_sequence(metal_ctx),
+        stall_command_sequences{HostMemDeviceCommand(metal_ctx), HostMemDeviceCommand(metal_ctx)},
+        program_config_buffer_command_sequence(metal_ctx),
+        program_binary_setup_prefetcher_cache_command(metal_ctx),
+        program_binary_command_sequence(metal_ctx),
+        wait_barrier_command_sequence(metal_ctx),
+        launch_msg_command_sequence(metal_ctx),
+        go_msg_command_sequence(metal_ctx) {}
+
     ProgramCommandSequence(const ProgramCommandSequence&) = delete;
     ProgramCommandSequence& operator=(const ProgramCommandSequence&) = delete;
 
@@ -50,6 +60,8 @@ struct ProgramCommandSequence {
         LaunchMsgData(bool is_multicast, dev_msgs::launch_msg_t original_msg, dev_msgs::launch_msg_t::View msg_ptr) :
             is_multicast(is_multicast), original_msg(std::move(original_msg)), msg_ptr(msg_ptr) {}
     };
+
+    MetalContext* ctx = nullptr;
     HostMemDeviceCommand preamble_command_sequence;
     uint32_t current_stall_seq_idx = 0;
     HostMemDeviceCommand stall_command_sequences[2];

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -85,9 +85,10 @@ void issue_trace_commands(
     uint8_t cq_id,
     const DispatchArray<uint32_t>& expected_num_workers_completed,
     CoreCoord dispatch_core) {
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
     void* cmd_region = sysmem_manager.issue_queue_reserve(dispatch_md.cmd_sequence_sizeB, cq_id);
 
-    HugepageDeviceCommand command_sequence(cmd_region, dispatch_md.cmd_sequence_sizeB);
+    HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, dispatch_md.cmd_sequence_sizeB);
 
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
     if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Thread MetalContext& into DeviceCommand and alike.

DeviceCommand needs MetalContext for:

- pcie_alignment
- l1_alignment
- dispatch_mem_map

Passing an explicit reference so no reliance on implicit singleton is used, making it multi-context aware.

### Notes for reviewers
This PR aims at getting MetalContext passed correctly into DeviceCommand. Fixing other calls to MetalContext::instance() belongs to subsequent PRs.

- Why not MetalEnvImpl?
  - dispatch_mem_map is not part of MetalEnvImpl

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/device-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/device-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/device-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/device-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/device-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/device-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/device-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/device-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/device-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/device-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/device-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/device-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/device-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/device-command)