### PR TITLE
[Bug fix] Update tt-2xx get_timestamp and get_timestamp_32b

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -534,19 +534,28 @@ void zero_l1_buf(tt_l1_ptr uint32_t* buf, uint32_t size_bytes) {
     }
 }
 
-// Get the wall clock timestamp. Reading RISCV_DEBUG_REG_WALL_CLOCK_L samples/freezes (for readback)
-// upper 32 bits of the 64-bit timestamp. Upper 32 bits are read from RISCV_DEBUG_REG_WALL_CLOCK_H.
+// NOTE: Timestamps from different processors are NOT directly comparable. Do not subtract one
+// processor's value from another's without an explicit correlation step.
+//   * TRISC and DM sit in different clock domains running at different frequencies.
+//   * The TRISC clock counter is per-NEO. Empirically the four counters on different NEOs are
+//     synchronized, meaning if two TRISCs on different NEOs read their own counters at exactly
+//     the same time, the value will be the same.
+//   * The DM value is per-hart: rdcycle counts that core's own cycles since reset.
 inline uint64_t get_timestamp() {
-    volatile uint timestamp_low =
-        *reinterpret_cast<volatile uint tt_reg_ptr*>(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_0_REG_ADDR);
-    volatile uint timestamp_high =
-        *reinterpret_cast<volatile uint tt_reg_ptr*>(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_1_REG_ADDR);
-    return (((uint64_t)timestamp_high) << 32) | timestamp_low;
+#if defined(COMPILE_FOR_TRISC)
+    uint32_t timestamp_low = *reinterpret_cast<volatile uint32_t tt_reg_ptr*>(
+        LOCAL_REGS_BASE + NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_0_REG_OFFSET);
+    uint32_t timestamp_high = *reinterpret_cast<volatile uint32_t tt_reg_ptr*>(
+        LOCAL_REGS_BASE + NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_1_AT_REG_OFFSET);
+    return (static_cast<uint64_t>(timestamp_high) << 32) | timestamp_low;
+#else
+    uint64_t cycle;
+    asm volatile("rdcycle %0" : "=r"(cycle));
+    return cycle;
+#endif
 }
 
-// Get only the lower 32 bits of the wall clock timestamp
-inline uint32_t get_timestamp_32b() {
-    return *reinterpret_cast<volatile uint tt_reg_ptr*>(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_0_REG_ADDR);
-}
+// Lower 32 bits of the timestamp. Same cross-processor caveats as get_timestamp().
+inline uint32_t get_timestamp_32b() { return static_cast<uint32_t>(get_timestamp()); }
 
 #endif


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
Relates to #53559 
Currently, get_timestamp() reads the NEO 0 absolute addresses. This only works on DMs Quasar NEO clusters: TRISCs don't have access to these addresses, and the dispatch engine do not have NEOs so these addresses don't exist.
This PR updates get_timestamp() to read different sources, so it works on all nodes: on TRISCs, it reads the per-NEO wall clock counter. On DMs, it reads the per-hart cycle counter.

### Notes for reviewers
Since TRISCs and DMs are running at different clock speeds, and DM counters are per-hart, the values returned by get_timestamp() and get_timestamp_32b() on different processors are not directly comparable.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/timestamp-53559)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/timestamp-53559)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/timestamp-53559)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/timestamp-53559)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/timestamp-53559)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/timestamp-53559)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/timestamp-53559)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/timestamp-53559)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/timestamp-53559)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/timestamp-53559)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/timestamp-53559)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/timestamp-53559)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/timestamp-53559)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/timestamp-53559)