### PR TITLE
[Cleanup] Deprecated `MeshCommandQueue::ShardDataTransfer` removal

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -26,6 +26,7 @@
 #include <tt-metalium/mesh_trace_id.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/shard_data_transfer.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 
 namespace tt::tt_metal {
@@ -40,10 +41,6 @@ class MeshDevice;
 class MeshWorkload;
 }  // namespace distributed
 struct ProgramCommandSequence;
-namespace experimental {
-
-class ShardDataTransferHelper;
-}  // namespace experimental
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal::distributed {
@@ -56,8 +53,6 @@ struct MeshCoreDataReadDescriptor;
 
 using MeshCompletionReaderVariant =
     std::variant<MeshBufferReadDescriptor, MeshReadEventDescriptor, MeshCoreDataReadDescriptor>;
-
-class ShardDataTransfer;
 
 // THREAD SAFETY: All methods are thread safe.
 class MeshCommandQueue {
@@ -142,36 +137,6 @@ public:
     virtual void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) = 0;
     virtual void record_end() = 0;
     virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
-};
-
-// Specifies host data to be written to or read from a MeshBuffer shard.
-class ShardDataTransfer {
-private:
-    MeshCoordinate shard_coord_;
-    void* host_data_ = nullptr;
-    std::optional<BufferRegion> region_;
-    std::shared_ptr<experimental::PinnedMemory> pinned_memory_ = nullptr;
-    friend class experimental::ShardDataTransferHelper;
-
-public:
-    explicit ShardDataTransfer(const MeshCoordinate& shard_coord) : shard_coord_(shard_coord) {}
-
-    MeshCoordinate shard_coord() const { return shard_coord_; }
-    void* host_data() const { return host_data_; }
-    std::optional<BufferRegion> region() const { return region_; }
-
-    ShardDataTransfer& shard_coord(const MeshCoordinate& shard_coord) {
-        shard_coord_ = shard_coord;
-        return *this;
-    }
-    ShardDataTransfer& host_data(void* host_data) {
-        host_data_ = host_data;
-        return *this;
-    }
-    ShardDataTransfer& region(std::optional<BufferRegion> region) {
-        region_ = region;
-        return *this;
-    }
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -100,14 +100,14 @@ public:
     // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
     virtual void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
         bool blocking) = 0;
 
     // MeshBuffer Read APIs
     virtual void enqueue_read_mesh_buffer(
         void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) = 0;
     virtual void enqueue_read_shards(
-        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking) = 0;
     // TODO: does "enqueue" make sense anymore? Return the object by value instead.

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -80,13 +80,6 @@ public:
     virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
     virtual void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) = 0;
 
-    // Specifies host data to be written to or read from a MeshBuffer shard.
-    struct [[deprecated("Use distributed::ShardDataTransfer instead.")]] ShardDataTransfer {
-        MeshCoordinate shard_coord;
-        void* host_data = nullptr;
-        std::optional<BufferRegion> region;
-    };
-
     // MeshBuffer Write APIs
     virtual void enqueue_write_shard_to_sub_grid(
         const MeshBuffer& buffer,
@@ -114,23 +107,6 @@ public:
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking) = 0;
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    [[deprecated("Use enqueue_write_shards with distributed::ShardDataTransfer instead.")]]
-    void enqueue_write_shards(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
-        bool blocking);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
     // MeshBuffer Read APIs
     virtual void enqueue_read_mesh_buffer(
@@ -145,23 +121,6 @@ public:
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) = 0;
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    [[deprecated("Use enqueue_read_shards with distributed::ShardDataTransfer instead.")]]
-    void enqueue_read_shards(
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        bool blocking);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
     // MeshTensor Read/Write APIs
     tt::tt_metal::HostTensor enqueue_read_tensor(const tt::tt_metal::MeshTensor& device_tensor, bool blocking = true);
@@ -196,22 +155,6 @@ private:
 
 public:
     explicit ShardDataTransfer(const MeshCoordinate& shard_coord) : shard_coord_(shard_coord) {}
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    explicit ShardDataTransfer(const MeshCommandQueue::ShardDataTransfer& shard_data_transfer) :
-        shard_coord_(shard_data_transfer.shard_coord),
-        host_data_(shard_data_transfer.host_data),
-        region_(shard_data_transfer.region) {}
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
     MeshCoordinate shard_coord() const { return shard_coord_; }
     void* host_data() const { return host_data_; }

--- a/tt_metal/api/tt-metalium/shard_data_transfer.hpp
+++ b/tt_metal/api/tt-metalium/shard_data_transfer.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+
+namespace tt::tt_metal::experimental {
+class PinnedMemory;
+class ShardDataTransferHelper;
+}  // namespace tt::tt_metal::experimental
+
+namespace tt::tt_metal::distributed {
+
+// Specifies host data to be written to or read from a MeshBuffer shard.
+class ShardDataTransfer {
+private:
+    MeshCoordinate shard_coord_;
+    void* host_data_ = nullptr;
+    std::optional<BufferRegion> region_;
+    std::shared_ptr<experimental::PinnedMemory> pinned_memory_ = nullptr;
+    friend class experimental::ShardDataTransferHelper;
+
+public:
+    explicit ShardDataTransfer(const MeshCoordinate& shard_coord) : shard_coord_(shard_coord) {}
+
+    MeshCoordinate shard_coord() const { return shard_coord_; }
+    void* host_data() const { return host_data_; }
+    std::optional<BufferRegion> region() const { return region_; }
+
+    ShardDataTransfer& shard_coord(const MeshCoordinate& shard_coord) {
+        shard_coord_ = shard_coord;
+        return *this;
+    }
+    ShardDataTransfer& host_data(void* host_data) {
+        host_data_ = host_data;
+        return *this;
+    }
+    ShardDataTransfer& region(std::optional<BufferRegion> region) {
+        region_ = region;
+        return *this;
+    }
+};
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/shard_data_transfer.hpp
+++ b/tt_metal/api/tt-metalium/shard_data_transfer.hpp
@@ -21,6 +21,7 @@ namespace tt::tt_metal::distributed {
 class ShardDataTransfer {
 private:
     MeshCoordinate shard_coord_;
+    // TODO: consider making host data const when it's only read from.
     void* host_data_ = nullptr;
     std::optional<BufferRegion> region_;
     std::shared_ptr<experimental::PinnedMemory> pinned_memory_ = nullptr;

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -404,32 +404,4 @@ void MeshCommandQueueBase::enqueue_read(
     this->enqueue_read_shards_nolock(shard_data_transfers, buffer, blocking, std::move(memory_pins));
 }
 
-void MeshCommandQueue::enqueue_write_shards(
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
-    bool blocking) {
-    std::vector<distributed::ShardDataTransfer> distributed_shard_data_transfers;
-    distributed_shard_data_transfers.reserve(shard_data_transfers.size());
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        distributed_shard_data_transfers.push_back(distributed::ShardDataTransfer{shard_data_transfer.shard_coord}
-                                                       .host_data(shard_data_transfer.host_data)
-                                                       .region(shard_data_transfer.region));
-    }
-    this->enqueue_write_shards(mesh_buffer, distributed_shard_data_transfers, blocking);
-}
-
-void MeshCommandQueue::enqueue_read_shards(
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    bool blocking) {
-    std::vector<distributed::ShardDataTransfer> distributed_shard_data_transfers;
-    distributed_shard_data_transfers.reserve(shard_data_transfers.size());
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        distributed_shard_data_transfers.push_back(distributed::ShardDataTransfer{shard_data_transfer.shard_coord}
-                                                       .host_data(shard_data_transfer.host_data)
-                                                       .region(shard_data_transfer.region));
-    }
-    this->enqueue_read_shards(distributed_shard_data_transfers, mesh_buffer, blocking);
-}
-
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -220,9 +220,8 @@ void MeshCommandQueueBase::enqueue_read_mesh_buffer(
         auto lock = lock_api_function_();
         this->read_sharded_buffer(*buffer, host_data);
     } else {
-        std::vector<distributed::ShardDataTransfer> shard_data_transfers = {
-            distributed::ShardDataTransfer{MeshCoordinate::zero_coordinate(buffer->device()->shape().dims())}.host_data(
-                host_data)};
+        std::vector<ShardDataTransfer> shard_data_transfers = {
+            ShardDataTransfer{MeshCoordinate::zero_coordinate(buffer->device()->shape().dims())}.host_data(host_data)};
         // enqueue_read_shards will call lock_api_function_(), no need to call it here
         this->enqueue_read_shards(shard_data_transfers, buffer, blocking);
     }
@@ -230,7 +229,7 @@ void MeshCommandQueueBase::enqueue_read_mesh_buffer(
 
 void MeshCommandQueueBase::enqueue_write_shards_nolock(
     MeshBuffer& buffer,
-    const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+    const std::vector<ShardDataTransfer>& shard_data_transfers,
     bool blocking,
     const tt::tt_metal::CoreRangeSet* logical_core_filter) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
@@ -287,7 +286,7 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
 
 void MeshCommandQueueBase::enqueue_write_shards(
     const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+    const std::vector<ShardDataTransfer>& shard_data_transfers,
     bool blocking) {
     auto lock = lock_api_function_();
     this->enqueue_write_shards_nolock(*mesh_buffer, shard_data_transfers, blocking, nullptr);
@@ -305,12 +304,12 @@ void MeshCommandQueueBase::enqueue_write_with_core_filter(
     const tt::tt_metal::CoreRangeSet* logical_core_filter) {
     auto lock = lock_api_function_();
     // Iterate over global coordinates; skip host-remote coordinates, as per `host_buffer` configuration.
-    std::vector<distributed::ShardDataTransfer> shard_data_transfers;
+    std::vector<ShardDataTransfer> shard_data_transfers;
     shard_data_transfers.reserve(host_buffer.shard_coords().size());
     for (const auto& host_buffer_coord : host_buffer.shard_coords()) {
         auto buf = host_buffer.get_shard(host_buffer_coord);
         if (buf.has_value()) {
-            auto shard_data_transfer = distributed::ShardDataTransfer{MeshCoordinate(host_buffer_coord)}
+            auto shard_data_transfer = ShardDataTransfer{MeshCoordinate(host_buffer_coord)}
                                            .host_data(buf->view_bytes().data())
                                            .region(BufferRegion(0, buf->view_bytes().size()));
             experimental::ShardDataTransferSetPinnedMemory(
@@ -323,7 +322,7 @@ void MeshCommandQueueBase::enqueue_write_with_core_filter(
 }
 
 void MeshCommandQueueBase::enqueue_read_shards_nolock(
-    const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+    const std::vector<ShardDataTransfer>& shard_data_transfers,
     const std::shared_ptr<MeshBuffer>& buffer,
     bool blocking,
     std::vector<MemoryPin> memory_pins) {
@@ -360,7 +359,7 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
 }
 
 void MeshCommandQueueBase::enqueue_read_shards(
-    const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+    const std::vector<ShardDataTransfer>& shard_data_transfers,
     const std::shared_ptr<MeshBuffer>& mesh_buffer,
     bool blocking) {
     auto lock = lock_api_function_();
@@ -373,7 +372,7 @@ void MeshCommandQueueBase::enqueue_read(
     const std::optional<std::unordered_set<MeshCoordinate>>& shards,
     bool blocking) {
     auto lock = lock_api_function_();
-    std::vector<distributed::ShardDataTransfer> shard_data_transfers;
+    std::vector<ShardDataTransfer> shard_data_transfers;
     shard_data_transfers.reserve(buffer->device()->shape().mesh_size());
     // For non-blocking reads, capture a MemoryPin for each shard so the host
     // buffer stays alive until the async reader thread finishes the memcpy
@@ -393,7 +392,7 @@ void MeshCommandQueueBase::enqueue_read(
             if (!blocking) {
                 memory_pins.push_back(buf->pin());
             }
-            auto xfer = distributed::ShardDataTransfer{coord}
+            auto xfer = ShardDataTransfer{coord}
                             .host_data(buf->view_bytes().data())
                             .region(BufferRegion(0, buf->view_bytes().size()));
             experimental::ShardDataTransferSetPinnedMemory(xfer, experimental::HostBufferGetPinnedMemory(*buf));

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -71,14 +71,14 @@ private:
 
     // Must be called with lock_api_function_() held.
     void enqueue_read_shards_nolock(
-        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking,
         std::vector<MemoryPin> memory_pins = {});
     // Must be called with lock_api_function_() held.
     void enqueue_write_shards_nolock(
         MeshBuffer& mesh_buffer,
-        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
         bool blocking,
         const tt::tt_metal::CoreRangeSet* logical_core_filter = nullptr);
 
@@ -115,7 +115,7 @@ public:
         const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) override;
     void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
         bool blocking) override;
     void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
@@ -125,7 +125,7 @@ public:
     // MeshBuffer Read APIs
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) override;
     void enqueue_read_shards(
-        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const std::vector<ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking) override;
     void enqueue_read(

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -155,6 +155,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/shape.hpp
     api/tt-metalium/shape2d.hpp
     api/tt-metalium/shape_base.hpp
+    api/tt-metalium/shard_data_transfer.hpp
     api/tt-metalium/sub_device.hpp
     api/tt-metalium/sub_device_types.hpp
     api/tt-metalium/system_mesh.hpp


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

`MeshCommandQueue::ShardDataTransfer` was deprecated in favor of `distributed::ShardDataTransfer` 7 months ago in https://github.com/tenstorrent/tt-metal/pull/28957

Our deprecation window is only 1 month, so we can remove it now.

Also, `distributed::ShardDataTransfer` is moved into a separate file to declutter _mesh_command_queue.hpp_

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-ShardDataTransfer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-ShardDataTransfer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-ShardDataTransfer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-ShardDataTransfer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-ShardDataTransfer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-ShardDataTransfer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-ShardDataTransfer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-ShardDataTransfer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-ShardDataTransfer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-ShardDataTransfer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-ShardDataTransfer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-ShardDataTransfer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-ShardDataTransfer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-ShardDataTransfer)