### PR TITLE
fix(eltwise): implement numerically stable logaddexp and logaddexp2

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_log1p.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_logaddexp_(sfpi::vFloat a, sfpi::vFloat b) {
+    // Numerically stable logaddexp: max(a,b) + log1p(exp(-|a-b|))
+    auto [min_val, max_val] = sfpi::min_max(a, b);
+    sfpi::vFloat diff = max_val - min_val;
+
+    // Compute exp(-diff). Since diff >= 0, this is always in (0, 1].
+    sfpi::vFloat neg_diff = -diff;
+    sfpi::vFloat exp_neg_diff = sfpi::exp(neg_diff);
+
+    // log1p(exp(-diff)) using the existing log1p implementation
+    sfpi::vFloat log1p_result = calculate_log1p_fp32<is_fp32_dest_acc_en>(exp_neg_diff);
+
+    return max_val + log1p_result;
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_logaddexp2_(sfpi::vFloat a, sfpi::vFloat b) {
+    // log2(2^a + 2^b) = logaddexp(a*ln2, b*ln2) / ln2
+    // Stable form: max(a,b) + log2(1 + 2^(-|a-b|))
+    //            = max(a,b) + log1p(2^(-|a-b|)) / ln2
+    auto [min_val, max_val] = sfpi::min_max(a, b);
+    sfpi::vFloat diff = max_val - min_val;
+
+    // 2^(-diff) = exp(-diff * ln2)
+    constexpr float LN2 = 0.6931471805599453f;
+    sfpi::vFloat neg_diff_ln2 = -diff * LN2;
+    sfpi::vFloat exp_neg_diff_ln2 = sfpi::exp(neg_diff_ln2);
+
+    sfpi::vFloat log1p_result = calculate_log1p_fp32<is_fp32_dest_acc_en>(exp_neg_diff_ln2);
+
+    // Divide by ln2 to convert from natural log to log2
+    constexpr float INV_LN2 = 1.4426950408889634f;
+    return max_val + log1p_result * INV_LN2;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_logaddexp(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = _sfpu_logaddexp_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_logaddexp2(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = _sfpu_logaddexp2_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_logaddexp_init() {
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_logaddexp2_init() {
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/logaddexp.h
+++ b/tt_metal/hw/inc/api/compute/logaddexp.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_logaddexp.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise logaddexp operation on two inputs: y = log(exp(x0) + exp(x1)).
+ * Uses the numerically stable identity: max(x0, x1) + log1p(exp(-|x0 - x1|)).
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void logaddexp_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_sfpu_logaddexp,
+        (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void logaddexp_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(unused, sfpu::calculate_sfpu_logaddexp_init, (APPROX, DST_ACCUM_MODE))));
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/logaddexp2.h
+++ b/tt_metal/hw/inc/api/compute/logaddexp2.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_logaddexp.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise logaddexp2 operation on two inputs: y = log2(2^x0 + 2^x1).
+ * Uses the numerically stable identity: max(x0, x1) + log2(1 + 2^(-|x0 - x1|)).
+ * Implemented as logaddexp(a*ln2, b*ln2) / ln2 for numerical stability.
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void logaddexp2_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_sfpu_logaddexp2,
+        (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void logaddexp2_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(unused, sfpu::calculate_sfpu_logaddexp2_init, (APPROX, DST_ACCUM_MODE))));
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -33,6 +33,8 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/compute_kernel_api.h
     inc/api/compute/add_int_sfpu.h
     inc/api/compute/atan2.h
+    inc/api/compute/logaddexp.h
+    inc/api/compute/logaddexp2.h
     inc/api/compute/bcast.h
     inc/api/compute/binary_bitwise_sfpu.h
     inc/api/compute/binary_comp.h

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -399,20 +399,12 @@ std::map<std::string, std::string> get_defines_fp32(
             op_name = "lcm_tile";
             break;
         case BinaryOpType::LOGADDEXP:
-            // PRE_IN0_0 ===> Applies prescaling for first input
-            // PRE_IN1_0 ====> Applies prescaling for second input
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP, std::vector<float>{0}, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", fmt::format("logaddexp_binary_tile_init();")});
+            op_name = "logaddexp_binary_tile";
             break;
         case BinaryOpType::LOGADDEXP2:
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN0_0"));
-            new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));
-            new_defines.insert({"BINOP_INIT", fmt::format("add_binary_tile_init();")});
-            op_name = "add_binary_tile";
-            new_defines.merge(get_defines(UnaryOpType::LOG2, std::nullopt, "0", idst1));
+            new_defines.insert({"BINOP_INIT", fmt::format("logaddexp2_binary_tile_init();")});
+            op_name = "logaddexp2_binary_tile";
             break;
         case BinaryOpType::LDEXP:
             new_defines.merge(get_defines(UnaryOpType::EXP2, std::nullopt, "PRE_IN1_0"));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -30,8 +30,6 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case MUL:
             return !fast_and_approximate_mode || (a == b && (a == FLOAT32 || a == INT32 || a == UINT32 || a == UINT16));
         case DIV: return !fast_and_approximate_mode || (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32);
-        case LOGADDEXP:
-        case LOGADDEXP2:
         case LDEXP:
         case BIAS_GELU:
         case HYPOT: return (a == FLOAT32 && b == FLOAT32);
@@ -64,6 +62,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case POWER:
         case WHERE_TST:
         case WHERE_TTS:
+        case LOGADDEXP:
+        case LOGADDEXP2:
         case ISCLOSE: return true;
         default: return false;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -247,19 +247,21 @@ OpConfig::OpConfig(
             process_rhs = unary::UnaryOpType::EXP2;
             binary_op = EnumT::MUL;
             break;
-        // log( exp(a) + exp(b) )
+        // log( exp(a) + exp(b) ) = max(a,b) + log1p(exp(-|a-b|))
         case BinaryOpType::LOGADDEXP:
-            process_lhs = unary::UnaryOpType::EXP;
-            process_rhs = unary::UnaryOpType::EXP;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
             break;
-        // log2( 2**a + 2**b )
+        // log2( 2**a + 2**b ) = max(a,b) + log2(1 + 2^(-|a-b|))
         case BinaryOpType::LOGADDEXP2:
-            process_lhs = unary::UnaryOpType::EXP2;
-            process_rhs = unary::UnaryOpType::EXP2;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG2;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP2;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
             break;
         case BinaryOpType::BITWISE_AND:
             if (is_sfpu_op()) {
@@ -501,6 +503,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
+        case LOGADDEXP: return {"logaddexp_binary_tile_init();", "logaddexp_binary_tile"};
+        case LOGADDEXP2: return {"logaddexp2_binary_tile_init();", "logaddexp2_binary_tile"};
         case LT:
             if (int_data_format) {
                 return {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -88,6 +88,8 @@ struct OpConfig {
         EQ,
         NE,
         ISCLOSE,
+        LOGADDEXP,
+        LOGADDEXP2,
     };
 
     template <class EnumT>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -23,6 +23,8 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/logaddexp.h"
+#include "api/compute/logaddexp2.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"


### PR DESCRIPTION
Fixes #52037

## Problem
The previous implementation of `ttnn.logaddexp` and `ttnn.logaddexp2` was composed as `log(exp(a) + exp(b))` and `log2(2^a + 2^b)`, which caused overflow to `inf` when inputs were large (`|a| > 88.7` for logaddexp).

## Solution
This PR implements the numerically stable identities as dedicated fused SFPU binary tile ops:
- `logaddexp(a, b) = max(a, b) + log1p(exp(-|a - b|))`
- `logaddexp2(a, b) = max(a, b) + log2(1 + 2^(-|a - b|))`

### Changes
- Added new fused SFPU binary tile ops for `LOGADDEXP` and `LOGADDEXP2`.
- Implemented `ckernel_sfpu_logaddexp.h` using the existing `log1p` SFPU op.
- Created `api/compute/logaddexp.h` and `api/compute/logaddexp2.h` wrappers.
- Registered the new ops in `binary_ng_utils` and `binary_op_utils`.
- Moved `LOGADDEXP`/`LOGADDEXP2` to the SFPU-true group in `binary_ng_device_operation`.
- Added the new headers to `sources.cmake` and `eltwise_binary_sfpu.cpp`.

Closes #52037