### PR TITLE
Fix multicast destination core calculation in semaphore tests

### DIFF
--- a/tests/tt_metal/tt_metal/noc_debugging/test_reads_writes.cpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/test_reads_writes.cpp
@@ -312,8 +312,7 @@ void RunSemaphoreIncMulticastTest(
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    uint32_t num_dest_cores =
-        (mcast_end_virtual.x - mcast_start_virtual.x + 1) * (mcast_end_virtual.y - mcast_start_virtual.y + 1);
+    uint32_t num_dest_cores = CoreRange(mcast_start, mcast_end).size();
 
     constexpr uint32_t buffer_page_size = 64;
     distributed::DeviceLocalBufferConfig l1_config{
@@ -1138,8 +1137,7 @@ void RunMcastTest(
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
     tt_metal::Program program = tt_metal::CreateProgram();
 
-    uint32_t num_dest_cores =
-        (mcast_end_virtual.x - mcast_start_virtual.x + 1) * (mcast_end_virtual.y - mcast_start_virtual.y + 1);
+    uint32_t num_dest_cores = CoreRange(mcast_start, mcast_end).size();
 
     constexpr uint32_t buffer_page_size = 64;
     constexpr uint32_t buffer_size = buffer_page_size;


### PR DESCRIPTION
Replacing multicast core count to incorporate BH correctly.

Closes #53711.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/fix_multicast_search_range_noc_debug_tool_tests)