### PR TITLE
Bump fmt to 12.2.0

### DIFF
--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -121,7 +121,7 @@ cpack_add_component(tracy GROUP metalium)
 
 cpack_add_component_group(metalium-dev)
 cpack_add_component(metalium-dev DEPENDS metalium GROUP metalium-dev DESCRIPTION "TT-Metalium SDK")
-cpack_add_component(fmt-core GROUP metalium-dev)
+cpack_add_component(fmt_core GROUP metalium-dev)
 cpack_add_component(enchantum GROUP metalium-dev)
 cpack_add_component(umd-dev GROUP metalium-dev)
 cpack_add_component(spdlog-dev GROUP metalium-dev)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -199,7 +199,14 @@ CPMAddPackage(
 # fmt : https://github.com/fmtlib/fmt
 ############################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0 OPTIONS "CMAKE_MESSAGE_LOG_LEVEL NOTICE")
+CPMAddPackage(
+    NAME fmt
+    GITHUB_REPOSITORY fmtlib/fmt
+    GIT_TAG 12.2.0
+    OPTIONS
+        "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+        "FMT_INSTALL ON"
+)
 
 ############################################################################################################################
 # range-v3 : https://github.com/ericniebler/range-v3
@@ -415,7 +422,8 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${DEFAULT_COMPONENT_NAME})
 CPMAddPackage(
     NAME tt-logger
     GITHUB_REPOSITORY tenstorrent/tt-logger
-    GIT_TAG cfc210a071c0236b4bb272af0659b99c7a13021f # TEMPORARY: tt-logger fmt-12.2.0 PR head, for CI validation only. Revert to a VERSION x.y.z pin once tenstorrent/tt-logger#31 merges and a release is tagged.
+    GIT_TAG
+        e11fb3267582477803a8a9c8175b6454e073e110 # TEMPORARY: tt-logger fmt-12.2.0 PR head, for CI validation only. Revert to a VERSION x.y.z pin once tenstorrent/tt-logger#31 merges and a release is tagged.
     OPTIONS
         "TT_LOGGER_INSTALL ON"
         "TT_LOGGER_BUILD_TESTING OFF"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -199,7 +199,7 @@ CPMAddPackage(
 # fmt : https://github.com/fmtlib/fmt
 ############################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4 OPTIONS "CMAKE_MESSAGE_LOG_LEVEL NOTICE")
+CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0 OPTIONS "CMAKE_MESSAGE_LOG_LEVEL NOTICE")
 
 ############################################################################################################################
 # range-v3 : https://github.com/ericniebler/range-v3
@@ -415,7 +415,7 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${DEFAULT_COMPONENT_NAME})
 CPMAddPackage(
     NAME tt-logger
     GITHUB_REPOSITORY tenstorrent/tt-logger
-    VERSION 1.1.8
+    GIT_TAG cfc210a071c0236b4bb272af0659b99c7a13021f # TEMPORARY: tt-logger fmt-12.2.0 PR head, for CI validation only. Revert to a VERSION x.y.z pin once tenstorrent/tt-logger#31 merges and a release is tagged.
     OPTIONS
         "TT_LOGGER_INSTALL ON"
         "TT_LOGGER_BUILD_TESTING OFF"

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -66,7 +66,7 @@ CPMAddPackage(NAME reflect GITHUB_REPOSITORY boost-ext/reflect GIT_TAG v1.2.6)
 # fmt : https://github.com/fmtlib/fmt
 ############################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4)
+CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0)
 
 ############################################################################################################################
 # magic_enum : https://github.com/Neargye/magic_enum

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -66,7 +66,7 @@ CPMAddPackage(NAME reflect GITHUB_REPOSITORY boost-ext/reflect GIT_TAG v1.2.6)
 # fmt : https://github.com/fmtlib/fmt
 ############################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0)
+CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 12.2.0 OPTIONS "FMT_INSTALL ON")
 
 ############################################################################################################################
 # magic_enum : https://github.com/Neargye/magic_enum

--- a/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
+++ b/tt_metal/api/tt-metalium/experimental/context/metal_env.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <umd/device/types/arch.hpp>

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -16,6 +16,7 @@
 #include <hostdevcommon/fabric_common.h>
 #include <tt-metalium/distributed_context.hpp>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <cstdint>
 #include <functional>
 #include <ostream>
 #include <optional>

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <filesystem>

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <unordered_map>

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <span>
 
 #include <tt-metalium/program.hpp>

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/experimental/blaze/named_kernel_args.hpp>
 #include <tt_stl/small_vector.hpp>
 
+#include <cstdint>
 #include <functional>
 
 // UMD: re-exports CoreType (used in SemaphoreDescriptor::core_type member).

--- a/tt_metal/api/tt-metalium/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/tensor/host_tensor.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/buffer.hpp>
 

--- a/tt_metal/api/tt-metalium/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/tensor/mesh_tensor.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <tt-metalium/hal_types.hpp>
 
 #include <tt-metalium/tensor/tensor_types.hpp>


### PR DESCRIPTION
## What
Bumps the `fmt` (fmtlib/fmt) dependency from `11.1.4` to `12.2.0`, plus temporary dependency pins so CI actually exercises the new fmt version end-to-end:

1. **fmt 11.1.4 -> 12.2.0** in `third_party/CMakeLists.txt` and `tt-train/cmake/dependencies.cmake`, with `FMT_INSTALL ON` added to both calls (fmt 12 defaults `FMT_INSTALL` off when built as a subproject, which drops `fmt-header-only` from any export set and breaks spdlog's `install(EXPORT)` at configure time).
2. **TEMPORARY (CI validation only):** `tt-logger` CPM pin changed from `VERSION 1.1.8` to `GIT_TAG e11fb3267582477803a8a9c8175b6454e073e110` — the head of the (unmerged) tt-logger fmt-bump PR. **Must be reverted to a proper `VERSION x.y.z` pin once tenstorrent/tt-logger#31 merges and a new tt-logger version is tagged/released.**
3. **TEMPORARY (CI validation only):** `tt_metal/third_party/umd` submodule pointer moved from `67b3c0da` (main) to `1b6c8206` — the head of the (unmerged) tt-umd fmt-bump PR. **Must be reverted to point at a proper commit on tt-umd `main` once tenstorrent/tt-umd#3198 merges.**

> **Reviewer note:** items 2 and 3 point at unmerged branches and are NOT the intended final state — do not merge this PR as-is without reverting them to release/main pins after the linked PRs land.

## Context
This is 1 of 3 coordinated PRs aligning the `fmt` version to 12.2.0 across the stack:
- tt-umd: https://github.com/tenstorrent/tt-umd/pull/3198
- tt-logger: https://github.com/tenstorrent/tt-logger/pull/31
- tt-metal: this PR

## Risk / validation
- fmt 11 -> 12 is a **major version bump** per fmtlib's semver and may include breaking API changes — see the 12.0.0 changelog at https://github.com/fmtlib/fmt/releases. tt-metal has **not** been built locally to verify compilation; CI is expected to be the real validation for this change.
- fmt release tags have no `v` prefix, so `12.2.0` is the correct tag form (consistent with the previous `11.1.4` pin).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bump-fmt-12.2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bump-fmt-12.2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bump-fmt-12.2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bump-fmt-12.2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bump-fmt-12.2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bump-fmt-12.2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bump-fmt-12.2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bump-fmt-12.2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bump-fmt-12.2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bump-fmt-12.2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bump-fmt-12.2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bump-fmt-12.2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bump-fmt-12.2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bump-fmt-12.2.0)