### PR TITLE
Skip BH-routed topk cells on simulator runners (fix sim_bh_p150 sanity)

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -2,11 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 import torch
 
 import ttnn
-from models.common.utility_functions import comp_allclose_and_pcc, torch_random
+from models.common.utility_functions import comp_allclose_and_pcc, is_blackhole, torch_random
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 TEST_PADDING_VALUE = -42
@@ -458,6 +460,17 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     )
 
 
+# The BH-routed ttnn.topk path (topk_large_indices, engages for bf16 largest at k>64 or wide
+# non-pow2 widths) crashes the CI simulator's ttsim build (silent worker death ~9s in; see the
+# sanity break on 1dc0e9673b6). The same tests pass on BH silicon and on a current ttsim
+# (SFPLOADMACRO-capable). Skip the routed cells on simulator runners until the runner image
+# ships an updated ttsim.
+skip_routed_topk_on_sim = pytest.mark.skipif(
+    is_blackhole() and bool(os.environ.get("TT_METAL_SIMULATOR")),
+    reason="BH-routed topk crashes the CI ttsim build; passes on silicon and current ttsim",
+)
+
+
 @pytest.mark.parametrize("dim1", [1])
 @pytest.mark.parametrize("dim", [1])
 @pytest.mark.parametrize("largest", [True])
@@ -468,12 +481,14 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 #   (8192, 1024) k > 64 -> single-core, and Kt=32 exercises the multi-tile-k merge ramp
 #   bfloat8_b is paired with the large-k case: bfp8 unpack/pack reconfig plus the bfp8 L1 sizing
 #                path, which only matters when Kt is large
+
+
 @pytest.mark.parametrize(
     "dim2, k, dtype",
     [
         (8192, 50, ttnn.bfloat16),
-        (50257, 50, ttnn.bfloat16),
-        (8192, 1024, ttnn.bfloat16),
+        pytest.param(50257, 50, ttnn.bfloat16, marks=skip_routed_topk_on_sim),
+        pytest.param(8192, 1024, ttnn.bfloat16, marks=skip_routed_topk_on_sim),
         (8192, 1024, ttnn.bfloat8_b),
     ],
 )
@@ -547,6 +562,7 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
 @pytest.mark.parametrize("k", [50])
 @pytest.mark.parametrize("largest", [True])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@skip_routed_topk_on_sim
 def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     torch.manual_seed(2005)
     shape = [dim1, dim2]


### PR DESCRIPTION
### What

Fixes the `sim_bh_p150` sanity break introduced by #53464 ([failing run](https://github.com/tenstorrent/tt-metal/actions/runs/32282881530), [last passing](https://github.com/tenstorrent/tt-metal/actions/runs/32282876991)): skip the three routing-eligible `ttnn.topk` cells on simulator runners; all non-routing cells keep their simulator coverage, and everything keeps running on silicon.

### Root cause

#53464 routes large-k / wide-non-pow2 bf16 `ttnn.topk` shapes onto `topk_large_indices` on Blackhole — including a simulated Blackhole. The runner's pinned ttsim build crashes silently on the routed kernels (xdist worker "node down: Not properly terminated" ~9s into each of exactly the three routing-eligible cells; the non-routing twins — pow2 small-k and the `bfloat8_b` row — passed in the same run).

Verified locally:
- Same three tests **pass under a current ttsim** (ttsim-private @ `99205a71`, 2026-08-15) with the routed path confirmed engaged (routed kernels in the JIT cache), fast and slow dispatch.
- Same tests **pass on BH silicon** (5/5).
- With this change, the sim arm runs 2 passed / 3 skipped and the silicon arm 5 passed.

### Durable fix

Update the ttsim artifact the `setup-ttsim` action pins for `sim_bh_p150` to a build ≥ 2026-08-15 ttsim-private (the routed kernels' instruction mix — SFPLOADMACRO et al. — is handled there); then revert these skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/sanity-sim-skip-routed-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/sanity-sim-skip-routed-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/sanity-sim-skip-routed-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/sanity-sim-skip-routed-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/sanity-sim-skip-routed-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/sanity-sim-skip-routed-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/sanity-sim-skip-routed-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/sanity-sim-skip-routed-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/sanity-sim-skip-routed-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/sanity-sim-skip-routed-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/sanity-sim-skip-routed-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/sanity-sim-skip-routed-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/sanity-sim-skip-routed-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/sanity-sim-skip-routed-topk)