### PR TITLE
Expand PCH coverage: shared test PCHs and distributed.hpp in PCHFull (~11% less clean-build CPU)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,47 @@ target_link_libraries(
         TT::Metalium
 )
 
+# Test-wide precompiled header: extends TT::CommonPCH's content with gtest/gmock and the
+# heavy tt-metalium headers that nearly every test TU parses (host_api/distributed/
+# metal_context/tt_cluster). Compiled once and reused by the test targets below in place
+# of metal_common_pch, which lacks all of these.
+add_library(metal_test_pch STATIC)
+add_library(TT::TestPCH ALIAS metal_test_pch)
+file(GENERATE OUTPUT metal_test_pch.cpp CONTENT "/*dummy test pch file*/\n")
+target_sources(metal_test_pch PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/metal_test_pch.cpp)
+target_precompile_headers(
+    metal_test_pch
+    PUBLIC
+        <fmt/core.h>
+        <fmt/format.h>
+        <nlohmann/json.hpp>
+        <algorithm>
+        <cstddef>
+        <cstdint>
+        <functional>
+        <map>
+        <memory>
+        <optional>
+        <tuple>
+        <unordered_map>
+        <variant>
+        <vector>
+        <reflect>
+        <tt_stl/reflection.hpp>
+        <gtest/gtest.h>
+        <gmock/gmock.h>
+        <tt-metalium/host_api.hpp>
+        <tt-metalium/tt_metal.hpp>
+        <tt-metalium/distributed.hpp>
+        <tt-metalium/mesh_device.hpp>
+        ${PROJECT_SOURCE_DIR}/tt_metal/impl/context/metal_context.hpp
+        ${PROJECT_SOURCE_DIR}/tt_metal/llrt/tt_cluster.hpp
+)
+target_link_libraries(metal_test_pch PRIVATE test_common_libs)
+if(COMMAND tt_disable_ccache_for_pch)
+    tt_disable_ccache_for_pch(metal_test_pch)
+endif()
+
 if(TT_METAL_BUILD_TESTS)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_metal)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/scale_out)

--- a/tests/tt_metal/multihost/fabric_tests/CMakeLists.txt
+++ b/tests/tt_metal/multihost/fabric_tests/CMakeLists.txt
@@ -86,3 +86,8 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}/tests
         ${PROJECT_SOURCE_DIR}/tests/tt_metal/multihost
 )
+
+# Reuse the shared test PCH (gtest + heavy tt-metalium headers).
+foreach(_mh_target IN ITEMS multi_host_fabric mesh_socket_components test_mesh_socket_main)
+    target_precompile_headers(${_mh_target} REUSE_FROM metal_test_pch)
+endforeach()

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/CMakeLists.txt
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/CMakeLists.txt
@@ -32,3 +32,7 @@ endfunction()
 setup_metal_pipeline_test(unit_tests_single_host_pipeline single_host_pipeline_tests.cpp)
 # Metal-level multi-host pipeline test (closet box + single galaxy)
 setup_metal_pipeline_test(unit_tests_pipeline multi_host_pipeline.cpp)
+
+# Reuse the shared test PCH (gtest + heavy tt-metalium headers).
+target_precompile_headers(unit_tests_single_host_pipeline REUSE_FROM metal_test_pch)
+target_precompile_headers(unit_tests_pipeline REUSE_FROM metal_test_pch)

--- a/tests/tt_metal/test_utils/CMakeLists.txt
+++ b/tests/tt_metal/test_utils/CMakeLists.txt
@@ -14,7 +14,13 @@ target_link_libraries(
         gtest
         gtest_main
 )
-target_precompile_headers(unit_tests_gha_annotation REUSE_FROM metal_test_pch)
+# NOTE: deliberately metal_common_pch, not metal_test_pch. metal_test_pch is compiled with
+# TT::Metalium's usage requirements (TRACY_IMPORTS, the tt-metalium/ include dirs) and its
+# contents #include <tt-metalium/...>. REUSE_FROM does not propagate those to the consumer, so a
+# target that doesn't link Metalium can neither validate the .gch (-Winvalid-pch) nor fall back to
+# parsing the header textually. This test links only TT::STL + gtest and includes no Metalium
+# headers; keep it on the common PCH rather than linking Metalium just to satisfy the PCH.
+target_precompile_headers(unit_tests_gha_annotation REUSE_FROM metal_common_pch)
 set_target_properties(
     unit_tests_gha_annotation
     PROPERTIES

--- a/tests/tt_metal/test_utils/CMakeLists.txt
+++ b/tests/tt_metal/test_utils/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
         gtest
         gtest_main
 )
-target_precompile_headers(unit_tests_gha_annotation REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_gha_annotation REUSE_FROM metal_test_pch)
 set_target_properties(
     unit_tests_gha_annotation
     PROPERTIES

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -293,3 +293,20 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/test/tt_metal/tt_fabric
 )
+
+# Reuse the shared test PCH (gtest + heavy tt-metalium headers) for all targets in this dir.
+foreach(
+    _fabric_test_target
+    IN
+    ITEMS
+        fabric_unit_tests
+        test_physical_discovery
+        test_system_health_smoke
+        test_fabric_smoke
+        test_tt_fabric
+        bench_unicast
+        test_addrgen_write
+        test_bandwidth_telemetry_validation
+)
+    target_precompile_headers(${_fabric_test_target} REUSE_FROM metal_test_pch)
+endforeach()

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -13,7 +13,7 @@ include(sources.cmake)
 add_executable(unit_tests_legacy)
 target_sources(unit_tests_legacy PRIVATE ${UNIT_TESTS_LEGACY_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_legacy)
-target_precompile_headers(unit_tests_legacy REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_legacy REUSE_FROM metal_test_pch)
 target_link_libraries(unit_tests_legacy PUBLIC test_metal_common_libs)
 target_include_directories(
     unit_tests_legacy
@@ -34,7 +34,7 @@ list(APPEND METAL_TEST_TARGETS unit_tests_legacy)
 
 # Standalone test_clean_init executable (not a gtest - requires custom main with skip-teardown handling)
 add_executable(test_clean_init test_clean_init.cpp)
-target_precompile_headers(test_clean_init REUSE_FROM metal_common_pch)
+target_precompile_headers(test_clean_init REUSE_FROM metal_test_pch)
 target_link_libraries(test_clean_init PUBLIC Metalium::Metal)
 target_include_directories(
     test_clean_init

--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(
 )
 
 TT_ENABLE_UNITY_BUILD(unit_tests_api_lib)
-target_precompile_headers(unit_tests_api_lib REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_api_lib REUSE_FROM metal_test_pch)
 
 # Create the test executable
 add_executable(unit_tests_api)
@@ -67,7 +67,7 @@ target_link_libraries(
         Boost::smart_ptr
 )
 TT_ENABLE_UNITY_BUILD(unit_tests_tensor_lib)
-target_precompile_headers(unit_tests_tensor_lib REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_tensor_lib REUSE_FROM metal_test_pch)
 
 add_executable(unit_tests_tensor)
 target_link_libraries(unit_tests_tensor PRIVATE unit_tests_tensor_lib)
@@ -90,7 +90,7 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}
 )
 target_link_libraries(unit_tests_per_core_allocation PRIVATE test_metal_common_libs)
-target_precompile_headers(unit_tests_per_core_allocation REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_per_core_allocation REUSE_FROM metal_test_pch)
 set_target_properties(
     unit_tests_per_core_allocation
     PROPERTIES
@@ -116,7 +116,7 @@ target_link_libraries(
         test_metal_common_libs
         Boost::smart_ptr
 )
-target_precompile_headers(dfb_init_timing_bench REUSE_FROM metal_common_pch)
+target_precompile_headers(dfb_init_timing_bench REUSE_FROM metal_test_pch)
 set_target_properties(
     dfb_init_timing_bench
     PROPERTIES
@@ -143,7 +143,7 @@ if(TT_METAL_USE_EMULE)
             ${TT_EMULE_PATH}/include
     )
     target_link_libraries(unit_tests_fiber_asan PRIVATE test_metal_common_libs)
-    target_precompile_headers(unit_tests_fiber_asan REUSE_FROM metal_common_pch)
+    target_precompile_headers(unit_tests_fiber_asan REUSE_FROM metal_test_pch)
     target_link_options(unit_tests_fiber_asan PRIVATE -rdynamic)
     set_target_properties(
         unit_tests_fiber_asan

--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(noc_estimator)
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_data_movement)
-target_precompile_headers(unit_tests_data_movement REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_data_movement REUSE_FROM metal_test_pch)
 
 target_link_libraries(unit_tests_data_movement PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -9,7 +9,7 @@ function(create_unit_test_executable)
 
     # Enable unity build for the executable
     TT_ENABLE_UNITY_BUILD(${exec_name})
-    target_precompile_headers(${exec_name} REUSE_FROM metal_common_pch)
+    target_precompile_headers(${exec_name} REUSE_FROM metal_test_pch)
 
     # Link libraries
     target_link_libraries(
@@ -48,7 +48,7 @@ add_executable(unit_tests_inspector ${UNIT_TESTS_INSPECTOR_SRC})
 
 # Enable unity build for the executable
 TT_ENABLE_UNITY_BUILD(unit_tests_inspector)
-target_precompile_headers(unit_tests_inspector REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_inspector REUSE_FROM metal_test_pch)
 
 # Link libraries
 target_link_libraries(

--- a/tests/tt_metal/tt_metal/deployment/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/deployment/CMakeLists.txt
@@ -3,7 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_deployment ${UNIT_TESTS_DEPLOYMENT_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_deployment)
-target_precompile_headers(unit_tests_deployment REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_deployment REUSE_FROM metal_test_pch)
 
 target_link_libraries(unit_tests_deployment PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -5,7 +5,7 @@ include(sources.cmake)
 add_library(unit_tests_device_smoke OBJECT)
 add_library(TT::Metalium::Test::Device::Smoke ALIAS unit_tests_device_smoke)
 TT_ENABLE_UNITY_BUILD(unit_tests_device_smoke)
-target_precompile_headers(unit_tests_device_smoke REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_device_smoke REUSE_FROM metal_test_pch)
 target_sources(unit_tests_device_smoke PRIVATE ${UNIT_TESTS_DEVICE_SMOKE_SOURCES})
 target_include_directories(
     unit_tests_device_smoke

--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -5,7 +5,7 @@ include(sources.cmake)
 add_library(unit_tests_dispatch_smoke OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Smoke ALIAS unit_tests_dispatch_smoke)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_smoke)
-target_precompile_headers(unit_tests_dispatch_smoke REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_dispatch_smoke REUSE_FROM metal_test_pch)
 target_sources(unit_tests_dispatch_smoke PRIVATE ${UNIT_TESTS_DISPATCH_SMOKE_SOURCES})
 target_include_directories(
     unit_tests_dispatch_smoke
@@ -22,7 +22,7 @@ target_link_libraries(unit_tests_dispatch_smoke PRIVATE test_metal_common_libs)
 add_library(unit_tests_dispatch_basic OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Basic ALIAS unit_tests_dispatch_basic)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_basic)
-target_precompile_headers(unit_tests_dispatch_basic REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_dispatch_basic REUSE_FROM metal_test_pch)
 target_sources(unit_tests_dispatch_basic PRIVATE ${UNIT_TESTS_DISPATCH_BASIC_SOURCES})
 target_include_directories(
     unit_tests_dispatch_basic
@@ -38,7 +38,7 @@ target_link_libraries(unit_tests_dispatch_basic PRIVATE test_metal_common_libs)
 add_library(unit_tests_dispatch_slow OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Slow ALIAS unit_tests_dispatch_slow)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_slow)
-target_precompile_headers(unit_tests_dispatch_slow REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_dispatch_slow REUSE_FROM metal_test_pch)
 target_sources(unit_tests_dispatch_slow PRIVATE ${UNIT_TESTS_DISPATCH_SLOW_SOURCES})
 target_include_directories(
     unit_tests_dispatch_slow

--- a/tests/tt_metal/tt_metal/eth/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/eth/CMakeLists.txt
@@ -9,7 +9,7 @@ function(create_unit_test_executable)
 
     # Enable unity build for the executable
     TT_ENABLE_UNITY_BUILD(${exec_name})
-    target_precompile_headers(${exec_name} REUSE_FROM metal_common_pch)
+    target_precompile_headers(${exec_name} REUSE_FROM metal_test_pch)
 
     # Link libraries
     target_link_libraries(${exec_name} PRIVATE test_metal_common_libs)

--- a/tests/tt_metal/tt_metal/integration/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/integration/CMakeLists.txt
@@ -3,7 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_integration ${UNIT_TESTS_INTEGRATION_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_integration)
-target_precompile_headers(unit_tests_integration REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_integration REUSE_FROM metal_test_pch)
 
 target_link_libraries(unit_tests_integration PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/jit_build/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/jit_build/CMakeLists.txt
@@ -3,7 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_jit_build ${UNIT_TESTS_JIT_BUILD_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_jit_build)
-target_precompile_headers(unit_tests_jit_build REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_jit_build REUSE_FROM metal_test_pch)
 
 target_link_libraries(unit_tests_jit_build PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/lightmetal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/lightmetal/CMakeLists.txt
@@ -3,7 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_lightmetal ${UNIT_TESTS_LIGHTMETAL_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_lightmetal)
-target_precompile_headers(unit_tests_lightmetal REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_lightmetal REUSE_FROM metal_test_pch)
 
 target_link_libraries(
     unit_tests_lightmetal

--- a/tests/tt_metal/tt_metal/llk/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/llk/CMakeLists.txt
@@ -3,7 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_llk ${UNIT_TESTS_LLK_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_llk)
-target_precompile_headers(unit_tests_llk REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_llk REUSE_FROM metal_test_pch)
 
 target_link_libraries(unit_tests_llk PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/misc/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/misc/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(unit_tests_misc ${UNIT_TESTS_MISC_SRC})
 
 # Enable unity build for the executable
 TT_ENABLE_UNITY_BUILD(unit_tests_misc)
-target_precompile_headers(unit_tests_misc REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_misc REUSE_FROM metal_test_pch)
 
 # Link libraries
 target_link_libraries(

--- a/tests/tt_metal/tt_metal/noc/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/noc/CMakeLists.txt
@@ -3,7 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_noc ${UNIT_TESTS_NOC_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_noc)
-target_precompile_headers(unit_tests_noc REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_noc REUSE_FROM metal_test_pch)
 
 target_link_libraries(unit_tests_noc PUBLIC test_metal_common_libs)
 

--- a/tests/tt_metal/tt_metal/noc_debugging/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/noc_debugging/CMakeLists.txt
@@ -4,7 +4,7 @@ include(sources.cmake)
 add_executable(unit_tests_noc_debugging ${UNIT_TESTS_NOC_DEBUGGING_SRC})
 
 TT_ENABLE_UNITY_BUILD(unit_tests_noc_debugging)
-target_precompile_headers(unit_tests_noc_debugging REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_noc_debugging REUSE_FROM metal_test_pch)
 
 target_link_libraries(unit_tests_noc_debugging PRIVATE test_metal_common_libs)
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
     string(REPLACE "wormhole" "wormhole_b0" TEST_TARGET ${TEST_TARGET})
 
     add_executable(${TEST_TARGET} ${TEST_SRC})
-    target_precompile_headers(${TEST_TARGET} REUSE_FROM metal_common_pch)
+    target_precompile_headers(${TEST_TARGET} REUSE_FROM metal_test_pch)
     target_link_libraries(${TEST_TARGET} PRIVATE test_metal_common_libs)
 
     if(${TEST_SRC} STREQUAL "dispatch/test_pgm_dispatch.cpp")

--- a/tests/tt_metal/tt_metal/sfpi/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/sfpi/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(unit_tests_sfpi_lib OBJECT)
 add_library(TT::Metalium::Test::SFPI ALIAS unit_tests_sfpi_lib)
 
 target_sources(unit_tests_sfpi_lib PRIVATE ${UNIT_TESTS_SFPI_SOURCES})
-target_precompile_headers(unit_tests_sfpi_lib REUSE_FROM metal_common_pch)
+target_precompile_headers(unit_tests_sfpi_lib REUSE_FROM metal_test_pch)
 target_include_directories(
     unit_tests_sfpi_lib
     BEFORE

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -1,5 +1,47 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/test/ttnn)
 
+# TTNN test PCH: TTNN::PCHFull's content plus gtest/gmock and the heavy tensor/distributed
+# headers every ttnn gtest TU parses. Compiled once, reused by the test targets below.
+add_library(ttnn_test_pch STATIC)
+add_library(TTNN::TestPCH ALIAS ttnn_test_pch)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ttnn_test_pch.cpp CONTENT "/*dummy ttnn test pch file*/\n")
+target_sources(ttnn_test_pch PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/ttnn_test_pch.cpp)
+target_precompile_headers(
+    ttnn_test_pch
+    PUBLIC
+        <fmt/core.h>
+        <fmt/format.h>
+        <nlohmann/json.hpp>
+        <algorithm>
+        <cstddef>
+        <cstdint>
+        <functional>
+        <map>
+        <memory>
+        <optional>
+        <tuple>
+        <unordered_map>
+        <variant>
+        <vector>
+        <gtest/gtest.h>
+        <gmock/gmock.h>
+        <tt-metalium/host_api.hpp>
+        <tt-metalium/distributed.hpp>
+        <ttnn/device_operation.hpp>
+        <ttnn/operation.hpp>
+        <ttnn/tensor/tensor.hpp>
+        <ttnn/types.hpp>
+)
+target_link_libraries(
+    ttnn_test_pch
+    PUBLIC
+        test_common_libs
+        TTNN::CPP
+)
+if(COMMAND tt_disable_ccache_for_pch)
+    tt_disable_ccache_for_pch(ttnn_test_pch)
+endif()
+
 add_library(test_common_utils STATIC)
 # PRIVATE so consumers that link `test_common_utils` do not also recompile this
 # source file into their own OBJECT library (which would produce duplicate
@@ -12,7 +54,7 @@ target_link_libraries(
         test_common_libs
         TTNN::CPP
 )
-tt_reuse_precompile_headers(test_common_utils TTNN::PCHFull)
+tt_reuse_precompile_headers(test_common_utils TTNN::TestPCH)
 
 function(setup_ttnn_test_target target_name)
     target_link_libraries(
@@ -27,7 +69,7 @@ function(setup_ttnn_test_target target_name)
             ${PROJECT_SOURCE_DIR}/tests
             ${CMAKE_CURRENT_SOURCE_DIR}
     )
-    tt_reuse_precompile_headers(${target_name} TTNN::PCHFull)
+    tt_reuse_precompile_headers(${target_name} TTNN::TestPCH)
 endfunction()
 
 # unit_tests_ttnn
@@ -52,7 +94,7 @@ target_link_libraries(
         test_common_utils
         TTNN::CPP
 )
-tt_reuse_precompile_headers(unit_tests_ttnn_smoke TTNN::PCHFull)
+tt_reuse_precompile_headers(unit_tests_ttnn_smoke TTNN::TestPCH)
 
 add_library(unit_tests_ttnn_basic OBJECT)
 add_library(TTNN::Test::Basic ALIAS unit_tests_ttnn_basic)
@@ -66,7 +108,7 @@ target_link_libraries(
         test_common_utils
         TTNN::CPP
 )
-tt_reuse_precompile_headers(unit_tests_ttnn_basic TTNN::PCHFull)
+tt_reuse_precompile_headers(unit_tests_ttnn_basic TTNN::TestPCH)
 
 add_executable(unit_tests_ttnn)
 target_link_libraries(
@@ -88,7 +130,7 @@ target_link_libraries(
         test_common_libs
         TTNN::CPP
 )
-tt_reuse_precompile_headers(unit_tests_ttnn_ccl_lib TTNN::PCHFull)
+tt_reuse_precompile_headers(unit_tests_ttnn_ccl_lib TTNN::TestPCH)
 
 add_executable(unit_tests_ttnn_ccl)
 target_link_libraries(unit_tests_ttnn_ccl PRIVATE TTNN::Test::CCL)
@@ -110,7 +152,7 @@ target_link_libraries(
         test_common_libs
         TTNN::CPP
 )
-tt_reuse_precompile_headers(unit_tests_ttnn_ccl_ops_lib TTNN::PCHFull)
+tt_reuse_precompile_headers(unit_tests_ttnn_ccl_ops_lib TTNN::TestPCH)
 
 add_executable(unit_tests_ttnn_ccl_ops)
 target_link_libraries(unit_tests_ttnn_ccl_ops PRIVATE TTNN::Test::CCL::Ops)

--- a/tt-train/sources/examples/graph_capture/CMakeLists.txt
+++ b/tt-train/sources/examples/graph_capture/CMakeLists.txt
@@ -4,3 +4,5 @@ set(SOURCES main.cpp)
 
 add_executable(graph_capture ${SOURCES})
 target_link_libraries(graph_capture PRIVATE ttml)
+
+target_precompile_headers(graph_capture REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/linear_regression/CMakeLists.txt
+++ b/tt-train/sources/examples/linear_regression/CMakeLists.txt
@@ -3,3 +3,5 @@ project(linear_regression)
 set(SOURCES main.cpp)
 add_executable(linear_regression ${SOURCES})
 target_link_libraries(linear_regression PRIVATE ttml)
+
+target_precompile_headers(linear_regression REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/linear_regression_ddp/CMakeLists.txt
+++ b/tt-train/sources/examples/linear_regression_ddp/CMakeLists.txt
@@ -3,3 +3,5 @@ project(linear_regression_ddp)
 set(SOURCES main.cpp)
 add_executable(linear_regression_ddp ${SOURCES})
 target_link_libraries(linear_regression_ddp PRIVATE ttml)
+
+target_precompile_headers(linear_regression_ddp REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/linear_regression_tp_dp/CMakeLists.txt
+++ b/tt-train/sources/examples/linear_regression_tp_dp/CMakeLists.txt
@@ -3,3 +3,5 @@ project(linear_regression_tp_dp)
 set(SOURCES main.cpp)
 add_executable(linear_regression_tp_dp ${SOURCES})
 target_link_libraries(linear_regression_tp_dp PRIVATE ttml)
+
+target_precompile_headers(linear_regression_tp_dp REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/mnist_mlp/CMakeLists.txt
+++ b/tt-train/sources/examples/mnist_mlp/CMakeLists.txt
@@ -13,3 +13,5 @@ add_executable(mnist_mlp ${SOURCES})
 target_link_libraries(mnist_mlp PRIVATE ttml)
 target_compile_definitions(mnist_mlp PRIVATE MNIST_DATA_LOCATION="${mnist_dataset_SOURCE_DIR}/")
 add_definitions(-DCONFIGS_FOLDER="${TT_TRAIN_SOURCE_DIR}/configs")
+
+target_precompile_headers(mnist_mlp REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/nano_gpt/CMakeLists.txt
+++ b/tt-train/sources/examples/nano_gpt/CMakeLists.txt
@@ -68,3 +68,8 @@ if(NOT EXISTS "${SHAKESPEARE_FILE}")
 else()
     message(STATUS "Shakespeare text file already exists at ${SHAKESPEARE_FILE}, skipping download.")
 endif()
+
+target_precompile_headers(nano_gpt REUSE_FROM ttml_pch)
+target_precompile_headers(llama_inference REUSE_FROM ttml_pch)
+target_precompile_headers(nano_gpt_aggregator REUSE_FROM ttml_pch)
+target_precompile_headers(nano_gpt_optimizer REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/rng_simd/CMakeLists.txt
+++ b/tt-train/sources/examples/rng_simd/CMakeLists.txt
@@ -8,3 +8,5 @@ target_link_libraries(
         ttml
         Threads::Threads
 )
+
+target_precompile_headers(rng_simd REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/sample_app/CMakeLists.txt
+++ b/tt-train/sources/examples/sample_app/CMakeLists.txt
@@ -4,3 +4,5 @@ set(SOURCES main.cpp)
 
 add_executable(sample_app ${SOURCES})
 target_link_libraries(sample_app PRIVATE ttml)
+
+target_precompile_headers(sample_app REUSE_FROM ttml_pch)

--- a/tt-train/sources/examples/simple_cnn/CMakeLists.txt
+++ b/tt-train/sources/examples/simple_cnn/CMakeLists.txt
@@ -4,3 +4,5 @@ set(SOURCES main.cpp)
 
 add_executable(simple_cnn ${SOURCES})
 target_link_libraries(simple_cnn PRIVATE ttml)
+
+target_precompile_headers(simple_cnn REUSE_FROM ttml_pch)

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -524,6 +524,33 @@ install(
 
 target_include_directories(_ttml PUBLIC ${PROJECT_SOURCE_DIR})
 
+# _ttml cannot REUSE_FROM ttml_pch (nanobind_add_module alters its compile flags),
+# so it gets its own PCH covering nanobind plus the heavy ttml umbrella headers.
+if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+    target_precompile_headers(
+        _ttml
+        PRIVATE
+            <fmt/core.h>
+            <fmt/format.h>
+            <nlohmann/json.hpp>
+            <memory>
+            <optional>
+            <string>
+            <unordered_map>
+            <variant>
+            <vector>
+            <nanobind/nanobind.h>
+            <nanobind/stl/optional.h>
+            <nanobind/stl/shared_ptr.h>
+            <nanobind/stl/string.h>
+            <nanobind/stl/vector.h>
+            core/ttnn_all_includes.hpp
+    )
+    if(COMMAND tt_disable_ccache_for_pch)
+        tt_disable_ccache_for_pch(_ttml)
+    endif()
+endif()
+
 # CPack configuration for creating ttml deb package
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_NAME "ttml")

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -526,7 +526,9 @@ target_include_directories(_ttml PUBLIC ${PROJECT_SOURCE_DIR})
 
 # _ttml cannot REUSE_FROM ttml_pch (nanobind_add_module alters its compile flags),
 # so it gets its own PCH covering nanobind plus the heavy ttml umbrella headers.
-if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+# Only when ccache is off: as its own PCH provider the target would need
+# tt_disable_ccache_for_pch, which would disable ccache for all of its TUs.
+if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS AND NOT ENABLE_CCACHE)
     target_precompile_headers(
         _ttml
         PRIVATE

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -524,35 +524,6 @@ install(
 
 target_include_directories(_ttml PUBLIC ${PROJECT_SOURCE_DIR})
 
-# _ttml cannot REUSE_FROM ttml_pch (nanobind_add_module alters its compile flags),
-# so it gets its own PCH covering nanobind plus the heavy ttml umbrella headers.
-# Only when ccache is off: as its own PCH provider the target would need
-# tt_disable_ccache_for_pch, which would disable ccache for all of its TUs.
-if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS AND NOT ENABLE_CCACHE)
-    target_precompile_headers(
-        _ttml
-        PRIVATE
-            <fmt/core.h>
-            <fmt/format.h>
-            <nlohmann/json.hpp>
-            <memory>
-            <optional>
-            <string>
-            <unordered_map>
-            <variant>
-            <vector>
-            <nanobind/nanobind.h>
-            <nanobind/stl/optional.h>
-            <nanobind/stl/shared_ptr.h>
-            <nanobind/stl/string.h>
-            <nanobind/stl/vector.h>
-            core/ttnn_all_includes.hpp
-    )
-    if(COMMAND tt_disable_ccache_for_pch)
-        tt_disable_ccache_for_pch(_ttml)
-    endif()
-endif()
-
 # CPack configuration for creating ttml deb package
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_NAME "ttml")

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -163,6 +163,7 @@ target_link_libraries(
         ttml
         TTNN::TTNN
 )
+target_precompile_headers(swiglu_fusion_benchmark REUSE_FROM ttml_pch)
 
 add_executable(moe_ffn_swiglu_benchmark benchmark/moe_ffn_swiglu_benchmark.cpp)
 target_link_libraries(
@@ -171,6 +172,7 @@ target_link_libraries(
         ttml
         TTNN::TTNN
 )
+target_precompile_headers(moe_ffn_swiglu_benchmark REUSE_FROM ttml_pch)
 ############################################################################################################################
 # Benchmark tests (using Google Benchmark)
 # Only available when building via tt-metal (Build from tt-train would require adding new dependency)
@@ -200,5 +202,6 @@ if(TARGET benchmark::benchmark)
                 benchmark::benchmark
         )
         target_include_directories(${BENCH_TARGET} PRIVATE "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>")
+        target_precompile_headers(${BENCH_TARGET} REUSE_FROM ttml_pch)
     endforeach()
 endif()

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -62,6 +62,9 @@ target_precompile_headers(
         # Volatile TTNN headers — only for targets that actually include these
         <ttnn/device_operation.hpp>
         <ttnn/operation.hpp>
+        # Profiling shows distributed.hpp reaching many op TUs (via types.hpp/
+        # global_circular_buffer.hpp) at ~1.4s per parse; precompile it too.
+        <tt-metalium/distributed.hpp>
 )
 target_link_libraries(
     ttnn_pch_full
@@ -396,6 +399,50 @@ if(WITH_PYTHON_BINDINGS)
 
     # .. set important linker flags
     nanobind_link_options(ttnn)
+
+    # Precompile the headers that dominate parse time in the ~300 *_nanobind.cpp TUs
+    # (nanobind + ttnn operation/tensor headers). The ttnn target cannot REUSE_FROM
+    # TTNN::PCHFull because nanobind_opt_size/nanobind_compile_options alter its flags,
+    # so it gets its own PCH.
+    if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+        target_precompile_headers(
+            ttnn
+            PRIVATE
+                <fmt/core.h>
+                <fmt/format.h>
+                <nlohmann/json.hpp>
+                <algorithm>
+                <cstddef>
+                <cstdint>
+                <functional>
+                <map>
+                <memory>
+                <optional>
+                <tuple>
+                <unordered_map>
+                <variant>
+                <vector>
+                <nanobind/nanobind.h>
+                <nanobind/operators.h>
+                <nanobind/stl/array.h>
+                <nanobind/stl/optional.h>
+                <nanobind/stl/shared_ptr.h>
+                <nanobind/stl/string.h>
+                <nanobind/stl/variant.h>
+                <nanobind/stl/vector.h>
+                <ttnn-nanobind/small_vector_caster.hpp>
+                <ttnn-nanobind/span_caster.hpp>
+                <ttnn-nanobind/export_enum.hpp>
+                <ttnn-nanobind/bind_function.hpp>
+                <ttnn/device_operation.hpp>
+                <ttnn/operation.hpp>
+                <ttnn/types.hpp>
+                <ttnn/tensor/tensor.hpp>
+        )
+        if(COMMAND tt_disable_ccache_for_pch)
+            tt_disable_ccache_for_pch(ttnn)
+        endif()
+    endif()
 
     if(TT_INSTALL)
         install(TARGETS ttnn EXPORT TT-NN LIBRARY COMPONENT ttnn-runtime)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -400,53 +400,6 @@ if(WITH_PYTHON_BINDINGS)
     # .. set important linker flags
     nanobind_link_options(ttnn)
 
-    # Precompile the headers that dominate parse time in the ~300 *_nanobind.cpp TUs
-    # (nanobind + ttnn operation/tensor headers). The ttnn target cannot REUSE_FROM
-    # TTNN::PCHFull because nanobind_opt_size/nanobind_compile_options alter its flags,
-    # so it gets its own PCH. Since the target is its own PCH provider, Clang+ccache
-    # correctness requires tt_disable_ccache_for_pch on it — which would disable ccache
-    # for ALL of its TUs, a bad trade on warm-cache (CI) builds. So only enable this
-    # PCH when ccache is off: cold/local builds get the PCH win, CI keeps ccache.
-    if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS AND NOT ENABLE_CCACHE)
-        target_precompile_headers(
-            ttnn
-            PRIVATE
-                <fmt/core.h>
-                <fmt/format.h>
-                <nlohmann/json.hpp>
-                <algorithm>
-                <cstddef>
-                <cstdint>
-                <functional>
-                <map>
-                <memory>
-                <optional>
-                <tuple>
-                <unordered_map>
-                <variant>
-                <vector>
-                <nanobind/nanobind.h>
-                <nanobind/operators.h>
-                <nanobind/stl/array.h>
-                <nanobind/stl/optional.h>
-                <nanobind/stl/shared_ptr.h>
-                <nanobind/stl/string.h>
-                <nanobind/stl/variant.h>
-                <nanobind/stl/vector.h>
-                <ttnn-nanobind/small_vector_caster.hpp>
-                <ttnn-nanobind/span_caster.hpp>
-                <ttnn-nanobind/export_enum.hpp>
-                <ttnn-nanobind/bind_function.hpp>
-                <ttnn/device_operation.hpp>
-                <ttnn/operation.hpp>
-                <ttnn/types.hpp>
-                <ttnn/tensor/tensor.hpp>
-        )
-        if(COMMAND tt_disable_ccache_for_pch)
-            tt_disable_ccache_for_pch(ttnn)
-        endif()
-    endif()
-
     if(TT_INSTALL)
         install(TARGETS ttnn EXPORT TT-NN LIBRARY COMPONENT ttnn-runtime)
     endif()

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -403,8 +403,11 @@ if(WITH_PYTHON_BINDINGS)
     # Precompile the headers that dominate parse time in the ~300 *_nanobind.cpp TUs
     # (nanobind + ttnn operation/tensor headers). The ttnn target cannot REUSE_FROM
     # TTNN::PCHFull because nanobind_opt_size/nanobind_compile_options alter its flags,
-    # so it gets its own PCH.
-    if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+    # so it gets its own PCH. Since the target is its own PCH provider, Clang+ccache
+    # correctness requires tt_disable_ccache_for_pch on it — which would disable ccache
+    # for ALL of its TUs, a bad trade on warm-cache (CI) builds. So only enable this
+    # PCH when ccache is off: cold/local builds get the PCH win, CI keeps ccache.
+    if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS AND NOT ENABLE_CCACHE)
         target_precompile_headers(
             ttnn
             PRIVATE


### PR DESCRIPTION
## Summary

Clean-build profiling with ClangBuildAnalyzer showed the most expensive headers in the build (gtest/gmock, `host_api.hpp`, `distributed.hpp`, `metal_context.hpp`, `tt_cluster.hpp`) being re-parsed in hundreds of test TUs whose PCH (`metal_common_pch`) contained none of them. This PR expands PCH coverage where the profile says it matters most:

- **`metal_test_pch`** — new shared test PCH (TT::CommonPCH content + gtest/gmock + the heavy tt-metalium headers). All metal/fabric/multihost test targets switch to it from `metal_common_pch`, which contained neither gtest nor any metalium header.
- **`ttnn_test_pch`** — same idea for the ttnn gtests (TTNN::PCHFull content + gtest/gmock + tensor/distributed headers).
- **tt-train examples/benchmarks** — `REUSE_FROM ttml_pch` (they previously had no PCH).
- **`TTNN::PCHFull` += `<tt-metalium/distributed.hpp>`** — the profile shows it reaching many op TUs via `types.hpp`/`global_circular_buffer.hpp` at ~1.4 s per parse (362 inclusions repo-wide, 496 s total).

Both new PCH providers follow the existing dummy-source pattern (`tt_disable_ccache_for_pch` on Clang), so ccache/CI behavior is unchanged.

Earlier revisions of this branch also gave the `ttnn`/`_ttml` nanobind modules their own PCHs; that was dropped — as their own PCH providers they would need ccache disabled target-wide, which regresses warm-cache CI builds, and gating on ccache wasn't worth the config-dependent complexity.

## Measured impact

Clean build, clang-20, all cores (`--build-all`), measured via `time` + ClangBuildAnalyzer:

| Configuration | CPU time (user) | Frontend parse |
|---|---|---|
| main | 377.6 min | 196 min |
| this PR | 334.6 min | 158 min |

**~11% less CPU on a clean build**; run-to-run noise measured at ~±10 CPU-min via an A/A run. Wall-time gains scale with available parallelism. No functional changes — build-system only.

## Test plan

- [x] Full clean `--build-all` of this exact branch content with zero errors (1765 TUs)
- [x] Smoke-ran built test binaries (`unit_tests_gha_annotation` 10/10 passed; ttnn/api gtest executables enumerate correctly)
- [ ] CI

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/pch-compile-time)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/pch-compile-time)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/pch-compile-time)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/pch-compile-time)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/pch-compile-time)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/pch-compile-time)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/pch-compile-time)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/pch-compile-time)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/pch-compile-time)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/pch-compile-time)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/pch-compile-time)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/pch-compile-time)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/pch-compile-time)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/pch-compile-time)