### PR TITLE
[skip ci] Notify Slack automatically when Sanity tests fail on main

### DIFF
--- a/.github/actions/resolve-slack-mentions/action.yml
+++ b/.github/actions/resolve-slack-mentions/action.yml
@@ -1,0 +1,160 @@
+name: 'Resolve Slack mentions for GitHub users'
+description: >
+  Resolves a list of GitHub logins to Slack mentions ("<@ID>", falling back to
+  "@login" when no match is found) by fetching the full Slack workspace member
+  list and fuzzy-matching on real name / display name / username. Single
+  source of truth for this resolution algorithm so any fix to the matching
+  logic or the hardcoded override map only needs to be made once.
+
+inputs:
+  github-logins:
+    description: 'JSON array of GitHub logins to resolve, e.g. ["octocat","hubot"]'
+    required: true
+  slack-bot-token:
+    description: 'Slack bot token with users:read scope'
+    required: true
+  github-token:
+    description: 'GitHub token used to look up each login''s display name'
+    required: true
+
+outputs:
+  mentions-json:
+    description: 'JSON object mapping each input login to its resolved Slack mention text'
+    value: ${{ steps.resolve.outputs.mentions_json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve
+      id: resolve
+      shell: bash
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        GITHUB_LOGINS_JSON: ${{ inputs.github-logins }}
+      run: |
+        set -euo pipefail
+
+        LOGINS=$(echo "$GITHUB_LOGINS_JSON" | jq -r 'unique | .[]')
+
+        echo "Fetching all Slack users..."
+        TEMP_USERS_FILE=$(mktemp)
+        echo "[]" > "$TEMP_USERS_FILE"
+        CURSOR=""
+        while true; do
+          if [ -n "$CURSOR" ]; then
+            API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
+          else
+            API_URL="https://slack.com/api/users.list?limit=1000"
+          fi
+
+          USER_SEARCH_RESPONSE=$(curl -s -X GET \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "$API_URL")
+
+          RESPONSE_FILE=$(mktemp)
+          echo "$USER_SEARCH_RESPONSE" > "$RESPONSE_FILE"
+
+          if [ "$(jq -r '.ok' "$RESPONSE_FILE")" = "true" ]; then
+            MERGE_FILE=$(mktemp)
+            jq -s '.[0] + .[1]' "$TEMP_USERS_FILE" <(jq '.members' "$RESPONSE_FILE") > "$MERGE_FILE"
+            mv "$MERGE_FILE" "$TEMP_USERS_FILE"
+            CURSOR=$(jq -r '.response_metadata.next_cursor // ""' "$RESPONSE_FILE")
+            rm -f "$RESPONSE_FILE"
+            if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
+              break
+            fi
+          else
+            ERROR_MSG=$(jq -r '.error // "Unknown error"' "$RESPONSE_FILE")
+            echo "::warning::Failed to fetch Slack users: $ERROR_MSG"
+            rm -f "$RESPONSE_FILE"
+            break
+          fi
+        done
+        SLACK_USERS_FILE="${RUNNER_TEMP}/slack_users.json"
+        mv "$TEMP_USERS_FILE" "$SLACK_USERS_FILE"
+        echo "Fetched $(jq '. | length' "$SLACK_USERS_FILE") Slack users"
+
+        # Hardcoded overrides for known GitHub<->Slack mismatches, then fuzzy match.
+        find_slack_user_id() {
+          local full_name="$1"
+          local github_username="$2"
+          local USERS_FILE="$3"
+
+          case "$github_username" in
+            "mradosavljevicTT") echo "U0837MYG788"; return 0 ;;
+            "nsextonTT") echo "U08TVGQGGAE"; return 0 ;;
+            "ncvetkovicTT") echo "U07AUABTEP6"; return 0 ;;
+            "jvegaTT") echo "U07M7QZ0BQA"; return 0 ;;
+          esac
+
+          USER_ID=$(jq -r --arg name "$full_name" \
+            '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' "$USERS_FILE" | head -n1)
+
+          if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+            USER_ID=$(jq -r --arg name "$full_name" \
+              '.[] | select(.profile.display_name == $name) | .id' "$USERS_FILE" | head -n1)
+          fi
+
+          if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+            USER_ID=$(jq -r --arg username "$github_username" \
+              '.[] | select(.name == $username or .profile.display_name == $username) | .id' "$USERS_FILE" | head -n1)
+          fi
+
+          if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+            IFS=' ' read -ra NAME_WORDS <<< "$full_name"
+            for word in "${NAME_WORDS[@]}"; do
+              if [ ${#word} -ge 3 ]; then
+                WORD_MATCHES=$(jq -r --arg word "$word" \
+                  '.[] | select(
+                    (.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
+                    (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
+                    (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))
+                  ) | .id + "|" + (.real_name // .profile.real_name // .name)' "$USERS_FILE")
+
+                if [ -n "$WORD_MATCHES" ]; then
+                  MATCH_COUNT=$(echo "$WORD_MATCHES" | wc -l)
+                  if [ "$MATCH_COUNT" -eq 1 ]; then
+                    USER_ID=$(echo "$WORD_MATCHES" | cut -d'|' -f1)
+                    break
+                  fi
+                fi
+              fi
+            done
+          fi
+
+          if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+            echo "$USER_ID"
+          else
+            echo ""
+          fi
+        }
+
+        MENTIONS_JSON="{}"
+        while IFS= read -r gh_user; do
+          [ -z "$gh_user" ] && continue
+
+          USER_DATA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/users/$gh_user" 2>/dev/null || echo "{}")
+          USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+          [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ] && USER_NAME="$gh_user"
+
+          SLACK_ID=$(find_slack_user_id "$USER_NAME" "$gh_user" "$SLACK_USERS_FILE")
+
+          if [ -n "$SLACK_ID" ]; then
+            MENTION="<@$SLACK_ID>"
+            echo "Resolved @$gh_user -> Slack <@$SLACK_ID>"
+          else
+            MENTION="@$gh_user"
+            echo "Could not resolve @$gh_user to Slack, using GitHub username fallback"
+          fi
+
+          MENTIONS_JSON=$(echo "$MENTIONS_JSON" | jq --arg login "$gh_user" --arg mention "$MENTION" '. + {($login): $mention}')
+        done <<< "$LOGINS"
+
+        {
+          echo 'mentions_json<<EOF'
+          echo "$MENTIONS_JSON"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/resolve-slack-mentions/action.yml
+++ b/.github/actions/resolve-slack-mentions/action.yml
@@ -38,49 +38,35 @@ runs:
         LOGINS=$(echo "$GITHUB_LOGINS_JSON" | jq -r 'unique | .[]')
 
         echo "Fetching all Slack users..."
-        TEMP_USERS_FILE=$(mktemp)
-        echo "[]" > "$TEMP_USERS_FILE"
+        SLACK_USERS_FILE="${RUNNER_TEMP}/slack_users.json"
+        PAGES_FILE=$(mktemp)
         CURSOR=""
         while true; do
-          if [ -n "$CURSOR" ]; then
-            API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
-          else
-            API_URL="https://slack.com/api/users.list?limit=1000"
+          RESPONSE=$(curl -s \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            "https://slack.com/api/users.list?limit=1000${CURSOR:+&cursor=$CURSOR}")
+
+          if [ "$(jq -r '.ok' <<< "$RESPONSE")" != "true" ]; then
+            echo "::warning::Failed to fetch Slack users: $(jq -r '.error // "Unknown error"' <<< "$RESPONSE")"
+            break
           fi
 
-          USER_SEARCH_RESPONSE=$(curl -s -X GET \
-            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-            -H "Content-Type: application/json" \
-            "$API_URL")
-
-          RESPONSE_FILE=$(mktemp)
-          echo "$USER_SEARCH_RESPONSE" > "$RESPONSE_FILE"
-
-          if [ "$(jq -r '.ok' "$RESPONSE_FILE")" = "true" ]; then
-            MERGE_FILE=$(mktemp)
-            jq -s '.[0] + .[1]' "$TEMP_USERS_FILE" <(jq '.members' "$RESPONSE_FILE") > "$MERGE_FILE"
-            mv "$MERGE_FILE" "$TEMP_USERS_FILE"
-            CURSOR=$(jq -r '.response_metadata.next_cursor // ""' "$RESPONSE_FILE")
-            rm -f "$RESPONSE_FILE"
-            if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
-              break
-            fi
-          else
-            ERROR_MSG=$(jq -r '.error // "Unknown error"' "$RESPONSE_FILE")
-            echo "::warning::Failed to fetch Slack users: $ERROR_MSG"
-            rm -f "$RESPONSE_FILE"
+          jq '.members' <<< "$RESPONSE" >> "$PAGES_FILE"
+          CURSOR=$(jq -r '.response_metadata.next_cursor // ""' <<< "$RESPONSE")
+          if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
             break
           fi
         done
-        SLACK_USERS_FILE="${RUNNER_TEMP}/slack_users.json"
-        mv "$TEMP_USERS_FILE" "$SLACK_USERS_FILE"
-        echo "Fetched $(jq '. | length' "$SLACK_USERS_FILE") Slack users"
+        # Flatten the per-page member arrays into one; an error before any page
+        # was fetched leaves an empty file, which becomes [].
+        jq -s 'add // []' "$PAGES_FILE" > "$SLACK_USERS_FILE"
+        rm -f "$PAGES_FILE"
+        echo "Fetched $(jq 'length' "$SLACK_USERS_FILE") Slack users"
 
         # Hardcoded overrides for known GitHub<->Slack mismatches, then fuzzy match.
         find_slack_user_id() {
           local full_name="$1"
           local github_username="$2"
-          local USERS_FILE="$3"
 
           case "$github_username" in
             "mradosavljevicTT") echo "U0837MYG788"; return 0 ;;
@@ -89,20 +75,17 @@ runs:
             "jvegaTT") echo "U07M7QZ0BQA"; return 0 ;;
           esac
 
-          USER_ID=$(jq -r --arg name "$full_name" \
-            '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' "$USERS_FILE" | head -n1)
+          # Exact-match tiers, first hit wins: real name, then display name ==
+          # full name, then Slack username / display name == GitHub login.
+          USER_ID=$(jq -r --arg name "$full_name" --arg login "$github_username" '
+            map(select(.real_name == $name or .profile.real_name == $name))
+            + map(select(.profile.display_name == $name))
+            + map(select(.name == $login or .profile.display_name == $login))
+            | .[0].id // ""' "$SLACK_USERS_FILE")
 
-          if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-            USER_ID=$(jq -r --arg name "$full_name" \
-              '.[] | select(.profile.display_name == $name) | .id' "$USERS_FILE" | head -n1)
-          fi
-
-          if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-            USER_ID=$(jq -r --arg username "$github_username" \
-              '.[] | select(.name == $username or .profile.display_name == $username) | .id' "$USERS_FILE" | head -n1)
-          fi
-
-          if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+          # Fuzzy fallback: any >=3-char word of the full name that matches
+          # exactly one Slack user (an ambiguous word is never trusted).
+          if [ -z "$USER_ID" ]; then
             IFS=' ' read -ra NAME_WORDS <<< "$full_name"
             for word in "${NAME_WORDS[@]}"; do
               if [ ${#word} -ge 3 ]; then
@@ -111,7 +94,7 @@ runs:
                     (.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
                     (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
                     (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))
-                  ) | .id + "|" + (.real_name // .profile.real_name // .name)' "$USERS_FILE")
+                  ) | .id + "|" + (.real_name // .profile.real_name // .name)' "$SLACK_USERS_FILE")
 
                 if [ -n "$WORD_MATCHES" ]; then
                   MATCH_COUNT=$(echo "$WORD_MATCHES" | wc -l)
@@ -124,11 +107,7 @@ runs:
             done
           fi
 
-          if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
-            echo "$USER_ID"
-          else
-            echo ""
-          fi
+          echo "$USER_ID"
         }
 
         MENTIONS_JSON="{}"
@@ -140,7 +119,7 @@ runs:
           USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
           [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ] && USER_NAME="$gh_user"
 
-          SLACK_ID=$(find_slack_user_id "$USER_NAME" "$gh_user" "$SLACK_USERS_FILE")
+          SLACK_ID=$(find_slack_user_id "$USER_NAME" "$gh_user")
 
           if [ -n "$SLACK_ID" ]; then
             MENTION="<@$SLACK_ID>"

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -17,8 +17,12 @@ on:
         type: boolean
         default: true
 
-# One group per run so a duplicate workflow_run delivery (GitHub occasionally
-# sends these) or a re-dispatch of the same run can't race and post twice.
+# Serializes processing of the SAME underlying run (e.g. a duplicate
+# workflow_run delivery GitHub occasionally sends, or a re-dispatch of the
+# same run) so the idempotency-marker check-and-claim below is race-free.
+# NOTE: this only serializes -- a queued duplicate still runs afterwards, it
+# does not by itself prevent a second Slack post. That guarantee comes from
+# the commit-status marker claimed in "Check and claim idempotency marker".
 concurrency:
   group: sanity-tests-slack-notify-${{ github.event.workflow_run.id || github.event.inputs.run_id }}
   cancel-in-progress: false
@@ -27,6 +31,8 @@ permissions:
   actions: read
   contents: read
   pull-requests: read
+  # Needed for the idempotency marker: a commit status on the failing head_sha.
+  statuses: write
 
 jobs:
   notify:
@@ -35,16 +41,26 @@ jobs:
     # bound the whole job well under GitHub's long default so a stalled
     # request can't occupy the runner indefinitely.
     timeout-minutes: 10
-    # Only act on a real failed push run, or an explicit manual test/replay.
     #
-    # _auto-retry-post-commit.yaml automatically re-runs a failed "Sanity tests"
-    # push run up to MAX_ATTEMPTS=3, and workflow_run:completed fires once per
-    # attempt (hours apart) -- so without the run_attempt gate below, a single
-    # real break would post to Slack up to 3 separate times (the concurrency
-    # group only dedupes truly-concurrent deliveries of the same id, not
-    # sequential ones hours apart). Gating on the final attempt mirrors that
-    # retrier's own MAX_ATTEMPTS so we only ever act once retries are exhausted.
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'push' && github.event.workflow_run.run_attempt >= 3) }}
+    # ============================ FINALITY GATE =============================
+    # _auto-retry-post-commit.yaml only re-runs a "Sanity tests" push run when
+    # ALL of: run_attempt < MAX_ATTEMPTS (3); it was originally push-triggered;
+    # AND conclusion == 'failure'. That third condition means cancelled /
+    # timed_out / startup_failure / etc. are NEVER retried, at ANY attempt
+    # number -- not just the last one. So "no further attempt is coming" (the
+    # exact moment we must notify) is:
+    #
+    #   is_final_red_state =
+    #     conclusion != 'success'
+    #     && (conclusion != 'failure' || run_attempt >= 3)
+    #
+    # A 'failure' only becomes final once the retry budget (3, MUST stay in
+    # sync with MAX_ATTEMPTS in _auto-retry-post-commit.yaml) is exhausted;
+    # every other non-success conclusion is final immediately, even at
+    # attempt 1. The previous gate (`conclusion == 'failure' && attempt >= 3`)
+    # silently never notified for any of those other terminal conclusions, at
+    # any attempt number.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion != 'success' && (github.event.workflow_run.conclusion != 'failure' || github.event.workflow_run.run_attempt >= 3)) }}
     steps:
       - name: Resolve run context
         id: context
@@ -62,17 +78,22 @@ jobs:
               dryRun = process.env.DISPATCH_DRY_RUN !== 'false';
               run = (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId })).data;
 
-              // A manual replay/test must target a real "Sanity tests" push-on-main
-              // failure -- otherwise this would confidently post a Slack message
-              // built from an unrelated or successful run. Check the workflow file
-              // path, not `run.name`: sanity-tests.yaml sets a dynamic `run-name`
-              // (e.g. "Sanity tests (push) SKUs[WH,Sim]"), so an exact-name check
-              // would reject every real run, including the one this validates against.
+              // A manual replay/test must target a run the automated path would
+              // itself act on -- otherwise this would confidently post a Slack
+              // message built from an unrelated or successful run. Check the
+              // workflow file path, not `run.name`: sanity-tests.yaml sets a
+              // dynamic `run-name` (e.g. "Sanity tests (push) SKUs[WH,Sim]"), so
+              // an exact-name check would reject every real run, including the
+              // one this validates against. The conclusion check mirrors the
+              // is_final_red_state formula above (not just 'failure') so the
+              // newly-covered terminal conclusions can be replayed too.
+              const isFinalRedState = run.conclusion !== 'success' &&
+                (run.conclusion !== 'failure' || run.run_attempt >= 3);
               const problems = [];
               if (run.path !== '.github/workflows/sanity-tests.yaml') problems.push(`workflow is "${run.path}", not "sanity-tests.yaml"`);
               if (run.event !== 'push') problems.push(`event is "${run.event}", not "push"`);
               if (run.head_branch !== 'main') problems.push(`head_branch is "${run.head_branch}", not "main"`);
-              if (run.conclusion !== 'failure') problems.push(`conclusion is "${run.conclusion}", not "failure"`);
+              if (!isFinalRedState) problems.push(`conclusion "${run.conclusion}" at attempt ${run.run_attempt} is not a final red state (see workflow header)`);
               if (problems.length > 0) {
                 core.setFailed(`run_id ${runId} is not a valid target to replay: ${problems.join('; ')}.`);
                 return;
@@ -88,8 +109,74 @@ jobs:
             core.setOutput('html_url', run.html_url);
             core.setOutput('dry_run', String(dryRun));
 
+      - name: Check and claim idempotency marker
+        id: claim
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        with:
+          # ========================= IDEMPOTENCY MARKER =======================
+          # workflow_run deliveries can be duplicated, and a human can press
+          # "Re-run" in the UI after attempt 3, producing attempt 4/5/... which
+          # still satisfies the finality gate above. To guarantee at most one
+          # Slack post per broken head_sha, we keep a durable marker in GitHub
+          # itself (not Slack, not an external store): a commit status on the
+          # run's head_sha under a fixed, private context string.
+          #
+          # Claim-then-act: this runs BEFORE any expensive work (commit walk,
+          # PR resolution, mention lookup) so a serialized duplicate (queued
+          # behind the first by the concurrency group above) sees the claim and
+          # skips instead of redoing everything and re-posting.
+          #   - marker state 'success'          -> already notified; skip.
+          #   - absent, or 'pending' (a prior attempt claimed but never
+          #     finished, e.g. Slack was down) -> (re)claim with 'pending' and
+          #     proceed. Only a finalized 'success' permanently blocks a future
+          #     post, so a genuine posting failure stays retryable.
+          #
+          # workflow_dispatch (manual test/replay) never reads or writes this
+          # marker: it must always be replayable for testing, and must not be
+          # blocked by, or interfere with, the automated path's dedupe state.
+          #
+          # Accepted residual risk: a crash between "Slack accepted the post"
+          # and "marker finalized to success" (see the last step) could allow
+          # one duplicate post if a duplicate delivery also arrives in that
+          # window. That failure mode is one extra Slack message -- not worth
+          # a two-phase commit to close.
+          script: |
+            const MARKER_CONTEXT = 'sanity-tests-slack-notify';
+
+            if (context.eventName === 'workflow_dispatch') {
+              core.info('workflow_dispatch replay: idempotency marker intentionally not consulted.');
+              core.setOutput('already_notified', 'false');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const headSha = process.env.HEAD_SHA;
+
+            const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+              owner, repo, ref: headSha, per_page: 100,
+            });
+            const marker = statuses.find(s => s.context === MARKER_CONTEXT);
+
+            if (marker && marker.state === 'success') {
+              core.info(`head_sha ${headSha} was already notified (marker set ${marker.updated_at}); skipping.`);
+              core.setOutput('already_notified', 'true');
+              return;
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: headSha,
+              state: 'pending',
+              context: MARKER_CONTEXT,
+              description: `Slack notification claimed by run ${context.runId}`,
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });
+            core.setOutput('already_notified', 'false');
+
       - name: Find culprit PRs since last green run
         id: culprits
+        if: steps.claim.outputs.already_notified != 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           CURRENT_RUN_NUMBER: ${{ steps.context.outputs.run_number }}
@@ -227,6 +314,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Compose and send Slack message
+        id: send
         if: steps.culprits.outputs.should_notify == 'true'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
@@ -280,6 +368,34 @@ jobs:
             exit 1
           fi
 
+      # Default step semantics: this only runs if every previous step
+      # succeeded -- in particular, only after "Compose and send Slack
+      # message" actually completed (a real post, or a dry-run summary). Real
+      # non-dry-run sends only reach here once Slack accepted the message.
+      # If that step failed (e.g. Slack API down), the marker stays 'pending'
+      # and the head_sha remains claimable by a later duplicate delivery or a
+      # manual replay. Never runs for workflow_dispatch, matching "claim" above.
+      - name: Finalize idempotency marker
+        if: github.event_name != 'workflow_dispatch' && steps.culprits.outputs.should_notify == 'true' && steps.context.outputs.dry_run != 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: process.env.HEAD_SHA,
+              state: 'success',
+              context: 'sanity-tests-slack-notify',
+              description: `Slack notification posted by run ${context.runId}`,
+              target_url: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });
+
       - name: Skip notification
-        if: steps.culprits.outputs.should_notify != 'true'
-        run: echo "Not a fresh green->red transition (or no baseline run found) -- nothing to notify. See the 'Find culprit PRs' step log for why."
+        if: steps.claim.outputs.already_notified == 'true' || steps.culprits.outputs.should_notify != 'true'
+        run: |
+          if [ "${{ steps.claim.outputs.already_notified }}" = "true" ]; then
+            echo "This commit was already notified about (idempotency marker present) -- nothing to do."
+          else
+            echo "Not a fresh green->red transition (or no baseline run found) -- nothing to notify. See the 'Find culprit PRs' step log for why."
+          fi

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -90,17 +90,36 @@ jobs:
               per_page: 100,
             });
 
-            const prevGood = runsResp.workflow_runs
-              .filter(r => r.run_number < currentRunNumber && r.conclusion === 'success')
+            // The run immediately before this one in the push-run sequence (not
+            // necessarily run_number - 1, since schedule/dispatch runs of the same
+            // workflow interleave and also consume run_numbers).
+            const immediatelyPrior = runsResp.workflow_runs
+              .filter(r => r.run_number < currentRunNumber && r.conclusion !== null)
               .sort((a, b) => b.run_number - a.run_number)[0];
 
-            if (!prevGood) {
-              core.warning('No previous successful "Sanity tests" push run found on main within the last 100 runs; skipping.');
-              core.setOutput('found_baseline', 'false');
+            if (!immediatelyPrior) {
+              core.warning('No previous completed "Sanity tests" push run found on main within the last 100 runs; skipping.');
+              core.setOutput('should_notify', 'false');
               return;
             }
 
-            core.setOutput('found_baseline', 'true');
+            if (immediatelyPrior.conclusion !== 'success') {
+              // main is still red from an earlier, already-reported break: diffing from
+              // the last GREEN run here would re-list the original culprit every time,
+              // plus every author who has merged on top of the still-broken main since --
+              // none of whom asked to be blamed for someone else's unresolved failure.
+              // Stay silent until a run actually goes green -> red again.
+              core.info(`Previous push run (#${immediatelyPrior.run_number}) also did not succeed (${immediatelyPrior.conclusion}); ` +
+                `main is still red from an earlier break. Not re-notifying to avoid repeat/duplicate pings.`);
+              core.setOutput('should_notify', 'false');
+              return;
+            }
+
+            // immediatelyPrior succeeded, so this is a fresh green->red transition:
+            // it doubles as both the "is this new" signal and the diff baseline.
+            const prevGood = immediatelyPrior;
+
+            core.setOutput('should_notify', 'true');
             core.setOutput('prev_run_url', prevGood.html_url);
             core.setOutput('prev_run_number', String(prevGood.run_number));
 
@@ -151,7 +170,7 @@ jobs:
 
       - name: Resolve Slack mentions for culprits
         id: mentions
-        if: steps.culprits.outputs.found_baseline == 'true'
+        if: steps.culprits.outputs.should_notify == 'true'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
           GH_TOKEN: ${{ github.token }}
@@ -285,7 +304,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Compose and send Slack message
-        if: steps.culprits.outputs.found_baseline == 'true'
+        if: steps.culprits.outputs.should_notify == 'true'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
           SLACK_CHANNEL_ID: "C05GRJC4J4A" # #tt-metal-pipelines
@@ -341,6 +360,6 @@ jobs:
             exit 1
           fi
 
-      - name: No baseline found
-        if: steps.culprits.outputs.found_baseline != 'true'
-        run: echo "No previous successful run to diff against -- nothing to notify."
+      - name: Skip notification
+        if: steps.culprits.outputs.should_notify != 'true'
+        run: echo "Not a fresh green->red transition (or no baseline run found) -- nothing to notify. See the 'Find culprit PRs' step log for why."

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -54,14 +54,13 @@ jobs:
           DISPATCH_DRY_RUN: ${{ github.event.inputs.dry_run }}
         with:
           script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            let runId, headSha, runNumber, htmlUrl, dryRun;
+            const { owner, repo } = context.repo;
+            let run, dryRun;
 
             if (context.eventName === 'workflow_dispatch') {
-              runId = Number(process.env.DISPATCH_RUN_ID);
+              const runId = Number(process.env.DISPATCH_RUN_ID);
               dryRun = process.env.DISPATCH_DRY_RUN !== 'false';
-              const { data: run } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+              run = (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId })).data;
 
               // A manual replay/test must target a real "Sanity tests" push-on-main
               // failure -- otherwise this would confidently post a Slack message
@@ -75,23 +74,15 @@ jobs:
                 core.setFailed(`run_id ${runId} is not a valid target to replay: ${problems.join('; ')}.`);
                 return;
               }
-
-              headSha = run.head_sha;
-              runNumber = run.run_number;
-              htmlUrl = run.html_url;
             } else {
-              runId = context.payload.workflow_run.id;
-              headSha = context.payload.workflow_run.head_sha;
-              runNumber = context.payload.workflow_run.run_number;
-              htmlUrl = context.payload.workflow_run.html_url;
+              run = context.payload.workflow_run;
               dryRun = false;
             }
 
-            core.info(`run=${runId} sha=${headSha} number=${runNumber} dryRun=${dryRun}`);
-            core.setOutput('run_id', String(runId));
-            core.setOutput('head_sha', headSha);
-            core.setOutput('run_number', String(runNumber));
-            core.setOutput('html_url', htmlUrl);
+            core.info(`run=${run.id} sha=${run.head_sha} number=${run.run_number} dryRun=${dryRun}`);
+            core.setOutput('head_sha', run.head_sha);
+            core.setOutput('run_number', String(run.run_number));
+            core.setOutput('html_url', run.html_url);
             core.setOutput('dry_run', String(dryRun));
 
       - name: Find culprit PRs since last green run
@@ -212,6 +203,8 @@ jobs:
 
             core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} between #${prevGood.run_number} and #${currentRunNumber}`);
             core.setOutput('entries', JSON.stringify(entries));
+            core.setOutput('logins_json',
+              JSON.stringify([...new Set(entries.map(e => e.authorLogin).filter(l => l !== null))].sort()));
 
       - name: Checkout resolve-slack-mentions action
         if: steps.culprits.outputs.should_notify == 'true'
@@ -221,25 +214,12 @@ jobs:
           sparse-checkout: .github/actions/resolve-slack-mentions
           sparse-checkout-cone-mode: true
 
-      - name: Collect culprit logins
-        id: logins
-        if: steps.culprits.outputs.should_notify == 'true'
-        env:
-          ENTRIES_JSON: ${{ steps.culprits.outputs.entries }}
-        run: |
-          set -euo pipefail
-          {
-            echo 'logins_json<<EOF'
-            echo "$ENTRIES_JSON" | jq -c '[.[].authorLogin | select(. != null)] | unique'
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
       - name: Resolve Slack mentions for culprits
         id: mentions
         if: steps.culprits.outputs.should_notify == 'true'
         uses: ./.github/actions/resolve-slack-mentions
         with:
-          github-logins: ${{ steps.logins.outputs.logins_json }}
+          github-logins: ${{ steps.culprits.outputs.logins_json }}
           slack-bot-token: ${{ secrets.CODEOWNERS_PING_BOT }}
           github-token: ${{ github.token }}
 
@@ -258,7 +238,7 @@ jobs:
 
           LINES=$(echo "$ENTRIES_JSON" | jq -r --argjson mentions "$MENTIONS_JSON" '
             .[] | (if .authorLogin != null then ($mentions[.authorLogin] // ("@" + .authorLogin)) else "(unknown author)" end) as $who
-            | "\($who) <\(.url)|\(if .type == "pr" then "#\(.number) - \(.title)" else "\(.title)" end)> broke sanity."
+            | "\($who) <\(.url)|\(if .type == "pr" then "#\(.number) - \(.title)" else .title end)> broke sanity."
           ')
 
           TEXT="${LINES}"$'\n'"Failing run on that commit: ${FAILING_RUN_URL}"$'\n'"Previous passing run: ${PREV_RUN_URL}"$'\n'"Please fix."
@@ -281,16 +261,13 @@ jobs:
             exit 0
           fi
 
-          PAYLOAD_FILE=$(mktemp)
-          jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "$TEXT" \
-            '{channel: $channel, text: $text, unfurl_links: true, unfurl_media: true}' > "$PAYLOAD_FILE"
-
-          SLACK_RESPONSE=$(curl -s --max-time 30 -X POST \
-            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-            -H "Content-type: application/json" \
-            -d @"$PAYLOAD_FILE" \
-            "https://slack.com/api/chat.postMessage")
-          rm -f "$PAYLOAD_FILE"
+          SLACK_RESPONSE=$(jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "$TEXT" \
+            '{channel: $channel, text: $text, unfurl_links: true, unfurl_media: true}' |
+            curl -s --max-time 30 -X POST \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-type: application/json" \
+              -d @- \
+              "https://slack.com/api/chat.postMessage")
 
           if [ "$(echo "$SLACK_RESPONSE" | jq -r '.ok')" = "true" ]; then
             echo "Slack notification sent successfully"

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -31,6 +31,10 @@ permissions:
 jobs:
   notify:
     runs-on: ubuntu-slim
+    # Several unbounded network calls (Slack pagination, GitHub API) below --
+    # bound the whole job well under GitHub's long default so a stalled
+    # request can't occupy the runner indefinitely.
+    timeout-minutes: 10
     # Only act on a real failed push run, or an explicit manual test/replay.
     #
     # _auto-retry-post-commit.yaml automatically re-runs a failed "Sanity tests"
@@ -209,140 +213,35 @@ jobs:
             core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} between #${prevGood.run_number} and #${currentRunNumber}`);
             core.setOutput('entries', JSON.stringify(entries));
 
-      - name: Resolve Slack mentions for culprits
-        id: mentions
+      - name: Checkout resolve-slack-mentions action
+        if: steps.culprits.outputs.should_notify == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 5
+        with:
+          sparse-checkout: .github/actions/resolve-slack-mentions
+          sparse-checkout-cone-mode: true
+
+      - name: Collect culprit logins
+        id: logins
         if: steps.culprits.outputs.should_notify == 'true'
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
-          GH_TOKEN: ${{ github.token }}
           ENTRIES_JSON: ${{ steps.culprits.outputs.entries }}
         run: |
           set -euo pipefail
-
-          LOGINS=$(echo "$ENTRIES_JSON" | jq -r '[.[].authorLogin | select(. != null)] | unique | .[]')
-
-          echo "Fetching all Slack users..."
-          TEMP_USERS_FILE=$(mktemp)
-          echo "[]" > "$TEMP_USERS_FILE"
-          CURSOR=""
-          while true; do
-            if [ -n "$CURSOR" ]; then
-              API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
-            else
-              API_URL="https://slack.com/api/users.list?limit=1000"
-            fi
-
-            USER_SEARCH_RESPONSE=$(curl -s -X GET \
-              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-              -H "Content-Type: application/json" \
-              "$API_URL")
-
-            RESPONSE_FILE=$(mktemp)
-            echo "$USER_SEARCH_RESPONSE" > "$RESPONSE_FILE"
-
-            if [ "$(jq -r '.ok' "$RESPONSE_FILE")" = "true" ]; then
-              MERGE_FILE=$(mktemp)
-              jq -s '.[0] + .[1]' "$TEMP_USERS_FILE" <(jq '.members' "$RESPONSE_FILE") > "$MERGE_FILE"
-              mv "$MERGE_FILE" "$TEMP_USERS_FILE"
-              CURSOR=$(jq -r '.response_metadata.next_cursor // ""' "$RESPONSE_FILE")
-              rm -f "$RESPONSE_FILE"
-              if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
-                break
-              fi
-            else
-              ERROR_MSG=$(jq -r '.error // "Unknown error"' "$RESPONSE_FILE")
-              echo "::warning::Failed to fetch Slack users: $ERROR_MSG"
-              rm -f "$RESPONSE_FILE"
-              break
-            fi
-          done
-          SLACK_USERS_FILE="${RUNNER_TEMP}/slack_users.json"
-          mv "$TEMP_USERS_FILE" "$SLACK_USERS_FILE"
-          echo "Fetched $(jq '. | length' "$SLACK_USERS_FILE") Slack users"
-
-          # Same resolution algorithm as .github/workflows/notify-slack-on-mention.yaml
-          # (hardcoded overrides for known GitHub<->Slack mismatches, then fuzzy match).
-          find_slack_user_id() {
-            local full_name="$1"
-            local github_username="$2"
-            local USERS_FILE="$3"
-
-            case "$github_username" in
-              "mradosavljevicTT") echo "U0837MYG788"; return 0 ;;
-              "nsextonTT") echo "U08TVGQGGAE"; return 0 ;;
-              "ncvetkovicTT") echo "U07AUABTEP6"; return 0 ;;
-              "jvegaTT") echo "U07M7QZ0BQA"; return 0 ;;
-            esac
-
-            USER_ID=$(jq -r --arg name "$full_name" \
-              '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' "$USERS_FILE" | head -n1)
-
-            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-              USER_ID=$(jq -r --arg name "$full_name" \
-                '.[] | select(.profile.display_name == $name) | .id' "$USERS_FILE" | head -n1)
-            fi
-
-            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-              USER_ID=$(jq -r --arg username "$github_username" \
-                '.[] | select(.name == $username or .profile.display_name == $username) | .id' "$USERS_FILE" | head -n1)
-            fi
-
-            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
-              IFS=' ' read -ra NAME_WORDS <<< "$full_name"
-              for word in "${NAME_WORDS[@]}"; do
-                if [ ${#word} -ge 3 ]; then
-                  WORD_MATCHES=$(jq -r --arg word "$word" \
-                    '.[] | select(
-                      (.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
-                      (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
-                      (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))
-                    ) | .id + "|" + (.real_name // .profile.real_name // .name)' "$USERS_FILE")
-
-                  if [ -n "$WORD_MATCHES" ]; then
-                    MATCH_COUNT=$(echo "$WORD_MATCHES" | wc -l)
-                    if [ "$MATCH_COUNT" -eq 1 ]; then
-                      USER_ID=$(echo "$WORD_MATCHES" | cut -d'|' -f1)
-                      break
-                    fi
-                  fi
-                fi
-              done
-            fi
-
-            if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
-              echo "$USER_ID"
-            else
-              echo ""
-            fi
-          }
-
-          MENTIONS_JSON="{}"
-          while IFS= read -r gh_user; do
-            [ -z "$gh_user" ] && continue
-
-            USER_DATA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/users/$gh_user" 2>/dev/null || echo "{}")
-            USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
-            [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ] && USER_NAME="$gh_user"
-
-            SLACK_ID=$(find_slack_user_id "$USER_NAME" "$gh_user" "$SLACK_USERS_FILE")
-
-            if [ -n "$SLACK_ID" ]; then
-              MENTION="<@$SLACK_ID>"
-              echo "Resolved @$gh_user -> Slack <@$SLACK_ID>"
-            else
-              MENTION="@$gh_user"
-              echo "Could not resolve @$gh_user to Slack, using GitHub username fallback"
-            fi
-
-            MENTIONS_JSON=$(echo "$MENTIONS_JSON" | jq --arg login "$gh_user" --arg mention "$MENTION" '. + {($login): $mention}')
-          done <<< "$LOGINS"
-
           {
-            echo 'mentions_json<<EOF'
-            echo "$MENTIONS_JSON"
+            echo 'logins_json<<EOF'
+            echo "$ENTRIES_JSON" | jq -c '[.[].authorLogin | select(. != null)] | unique'
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve Slack mentions for culprits
+        id: mentions
+        if: steps.culprits.outputs.should_notify == 'true'
+        uses: ./.github/actions/resolve-slack-mentions
+        with:
+          github-logins: ${{ steps.logins.outputs.logins_json }}
+          slack-bot-token: ${{ secrets.CODEOWNERS_PING_BOT }}
+          github-token: ${{ github.token }}
 
       - name: Compose and send Slack message
         if: steps.culprits.outputs.should_notify == 'true'
@@ -351,7 +250,7 @@ jobs:
           SLACK_CHANNEL_ID: "C05GRJC4J4A" # #tt-metal-pipelines
           DRY_RUN: ${{ steps.context.outputs.dry_run }}
           ENTRIES_JSON: ${{ steps.culprits.outputs.entries }}
-          MENTIONS_JSON: ${{ steps.mentions.outputs.mentions_json }}
+          MENTIONS_JSON: ${{ steps.mentions.outputs.mentions-json }}
           FAILING_RUN_URL: ${{ steps.context.outputs.html_url }}
           PREV_RUN_URL: ${{ steps.culprits.outputs.prev_run_url }}
         run: |

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -64,9 +64,12 @@ jobs:
 
               // A manual replay/test must target a real "Sanity tests" push-on-main
               // failure -- otherwise this would confidently post a Slack message
-              // built from an unrelated or successful run.
+              // built from an unrelated or successful run. Check the workflow file
+              // path, not `run.name`: sanity-tests.yaml sets a dynamic `run-name`
+              // (e.g. "Sanity tests (push) SKUs[WH,Sim]"), so an exact-name check
+              // would reject every real run, including the one this validates against.
               const problems = [];
-              if (run.name !== 'Sanity tests') problems.push(`workflow is "${run.name}", not "Sanity tests"`);
+              if (run.path !== '.github/workflows/sanity-tests.yaml') problems.push(`workflow is "${run.path}", not "sanity-tests.yaml"`);
               if (run.event !== 'push') problems.push(`event is "${run.event}", not "push"`);
               if (run.head_branch !== 'main') problems.push(`head_branch is "${run.head_branch}", not "main"`);
               if (run.conclusion !== 'failure') problems.push(`conclusion is "${run.conclusion}", not "failure"`);

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -1,0 +1,346 @@
+name: "Sanity tests - Slack break notification"
+
+on:
+  workflow_run:
+    workflows: ["Sanity tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Sanity tests run ID to process (for testing/re-sending)"
+        required: true
+        type: string
+      dry_run:
+        description: "Log the resolved Slack message instead of posting it"
+        required: false
+        type: boolean
+        default: true
+
+# One group per run so a duplicate workflow_run delivery (GitHub occasionally
+# sends these) or a re-dispatch of the same run can't race and post twice.
+concurrency:
+  group: sanity-tests-slack-notify-${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-slim
+    # Only act on a real failed push run, or an explicit manual test/replay.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'push') }}
+    steps:
+      - name: Resolve run context
+        id: context
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          DISPATCH_RUN_ID: ${{ github.event.inputs.run_id }}
+          DISPATCH_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            let runId, headSha, runNumber, htmlUrl, dryRun;
+
+            if (context.eventName === 'workflow_dispatch') {
+              runId = Number(process.env.DISPATCH_RUN_ID);
+              dryRun = process.env.DISPATCH_DRY_RUN !== 'false';
+              const { data: run } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+              headSha = run.head_sha;
+              runNumber = run.run_number;
+              htmlUrl = run.html_url;
+            } else {
+              runId = context.payload.workflow_run.id;
+              headSha = context.payload.workflow_run.head_sha;
+              runNumber = context.payload.workflow_run.run_number;
+              htmlUrl = context.payload.workflow_run.html_url;
+              dryRun = false;
+            }
+
+            core.info(`run=${runId} sha=${headSha} number=${runNumber} dryRun=${dryRun}`);
+            core.setOutput('run_id', String(runId));
+            core.setOutput('head_sha', headSha);
+            core.setOutput('run_number', String(runNumber));
+            core.setOutput('html_url', htmlUrl);
+            core.setOutput('dry_run', String(dryRun));
+
+      - name: Find culprit PRs since last green run
+        id: culprits
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          CURRENT_RUN_NUMBER: ${{ steps.context.outputs.run_number }}
+          CURRENT_HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const currentRunNumber = Number(process.env.CURRENT_RUN_NUMBER);
+            const currentHeadSha = process.env.CURRENT_HEAD_SHA;
+
+            const { data: runsResp } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: 'sanity-tests.yaml',
+              branch: 'main',
+              event: 'push',
+              per_page: 100,
+            });
+
+            const prevGood = runsResp.workflow_runs
+              .filter(r => r.run_number < currentRunNumber && r.conclusion === 'success')
+              .sort((a, b) => b.run_number - a.run_number)[0];
+
+            if (!prevGood) {
+              core.warning('No previous successful "Sanity tests" push run found on main within the last 100 runs; skipping.');
+              core.setOutput('found_baseline', 'false');
+              return;
+            }
+
+            core.setOutput('found_baseline', 'true');
+            core.setOutput('prev_run_url', prevGood.html_url);
+            core.setOutput('prev_run_number', String(prevGood.run_number));
+
+            const { data: cmp } = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: prevGood.head_sha,
+              head: currentHeadSha,
+            });
+
+            const entries = [];
+            const seenPrNumbers = new Set();
+
+            for (const commit of cmp.commits) {
+              const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: commit.sha,
+              });
+
+              if (pulls.length > 0) {
+                for (const pr of pulls) {
+                  if (seenPrNumbers.has(pr.number)) continue;
+                  seenPrNumbers.add(pr.number);
+                  entries.push({
+                    type: 'pr',
+                    number: pr.number,
+                    url: pr.html_url,
+                    title: pr.title,
+                    authorLogin: pr.user ? pr.user.login : null,
+                  });
+                }
+              } else {
+                // No associated PR (direct push, or API lag right after merge) --
+                // fall back to the commit's own author so a culprit is never silently dropped.
+                entries.push({
+                  type: 'commit',
+                  sha: commit.sha,
+                  url: commit.html_url,
+                  title: commit.commit.message.split('\n')[0],
+                  authorLogin: commit.author ? commit.author.login : null,
+                });
+              }
+            }
+
+            core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} between #${prevGood.run_number} and #${currentRunNumber}`);
+            core.setOutput('entries', JSON.stringify(entries));
+
+      - name: Resolve Slack mentions for culprits
+        id: mentions
+        if: steps.culprits.outputs.found_baseline == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
+          GH_TOKEN: ${{ github.token }}
+          ENTRIES_JSON: ${{ steps.culprits.outputs.entries }}
+        run: |
+          set -euo pipefail
+
+          LOGINS=$(echo "$ENTRIES_JSON" | jq -r '[.[].authorLogin | select(. != null)] | unique | .[]')
+
+          echo "Fetching all Slack users..."
+          TEMP_USERS_FILE=$(mktemp)
+          echo "[]" > "$TEMP_USERS_FILE"
+          CURSOR=""
+          while true; do
+            if [ -n "$CURSOR" ]; then
+              API_URL="https://slack.com/api/users.list?limit=1000&cursor=$CURSOR"
+            else
+              API_URL="https://slack.com/api/users.list?limit=1000"
+            fi
+
+            USER_SEARCH_RESPONSE=$(curl -s -X GET \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json" \
+              "$API_URL")
+
+            RESPONSE_FILE=$(mktemp)
+            echo "$USER_SEARCH_RESPONSE" > "$RESPONSE_FILE"
+
+            if [ "$(jq -r '.ok' "$RESPONSE_FILE")" = "true" ]; then
+              MERGE_FILE=$(mktemp)
+              jq -s '.[0] + .[1]' "$TEMP_USERS_FILE" <(jq '.members' "$RESPONSE_FILE") > "$MERGE_FILE"
+              mv "$MERGE_FILE" "$TEMP_USERS_FILE"
+              CURSOR=$(jq -r '.response_metadata.next_cursor // ""' "$RESPONSE_FILE")
+              rm -f "$RESPONSE_FILE"
+              if [ -z "$CURSOR" ] || [ "$CURSOR" = "null" ]; then
+                break
+              fi
+            else
+              ERROR_MSG=$(jq -r '.error // "Unknown error"' "$RESPONSE_FILE")
+              echo "::warning::Failed to fetch Slack users: $ERROR_MSG"
+              rm -f "$RESPONSE_FILE"
+              break
+            fi
+          done
+          SLACK_USERS_FILE="${RUNNER_TEMP}/slack_users.json"
+          mv "$TEMP_USERS_FILE" "$SLACK_USERS_FILE"
+          echo "Fetched $(jq '. | length' "$SLACK_USERS_FILE") Slack users"
+
+          # Same resolution algorithm as .github/workflows/notify-slack-on-mention.yaml
+          # (hardcoded overrides for known GitHub<->Slack mismatches, then fuzzy match).
+          find_slack_user_id() {
+            local full_name="$1"
+            local github_username="$2"
+            local USERS_FILE="$3"
+
+            case "$github_username" in
+              "mradosavljevicTT") echo "U0837MYG788"; return 0 ;;
+              "nsextonTT") echo "U08TVGQGGAE"; return 0 ;;
+              "ncvetkovicTT") echo "U07AUABTEP6"; return 0 ;;
+              "jvegaTT") echo "U07M7QZ0BQA"; return 0 ;;
+            esac
+
+            USER_ID=$(jq -r --arg name "$full_name" \
+              '.[] | select(.real_name == $name or .profile.real_name == $name) | .id' "$USERS_FILE" | head -n1)
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              USER_ID=$(jq -r --arg name "$full_name" \
+                '.[] | select(.profile.display_name == $name) | .id' "$USERS_FILE" | head -n1)
+            fi
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              USER_ID=$(jq -r --arg username "$github_username" \
+                '.[] | select(.name == $username or .profile.display_name == $username) | .id' "$USERS_FILE" | head -n1)
+            fi
+
+            if [ -z "$USER_ID" ] || [ "$USER_ID" = "null" ]; then
+              IFS=' ' read -ra NAME_WORDS <<< "$full_name"
+              for word in "${NAME_WORDS[@]}"; do
+                if [ ${#word} -ge 3 ]; then
+                  WORD_MATCHES=$(jq -r --arg word "$word" \
+                    '.[] | select(
+                      (.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
+                      (.profile.real_name // "" | ascii_downcase | contains($word | ascii_downcase)) or
+                      (.profile.display_name // "" | ascii_downcase | contains($word | ascii_downcase))
+                    ) | .id + "|" + (.real_name // .profile.real_name // .name)' "$USERS_FILE")
+
+                  if [ -n "$WORD_MATCHES" ]; then
+                    MATCH_COUNT=$(echo "$WORD_MATCHES" | wc -l)
+                    if [ "$MATCH_COUNT" -eq 1 ]; then
+                      USER_ID=$(echo "$WORD_MATCHES" | cut -d'|' -f1)
+                      break
+                    fi
+                  fi
+                fi
+              done
+            fi
+
+            if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+              echo "$USER_ID"
+            else
+              echo ""
+            fi
+          }
+
+          MENTIONS_JSON="{}"
+          while IFS= read -r gh_user; do
+            [ -z "$gh_user" ] && continue
+
+            USER_DATA=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/users/$gh_user" 2>/dev/null || echo "{}")
+            USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+            [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ] && USER_NAME="$gh_user"
+
+            SLACK_ID=$(find_slack_user_id "$USER_NAME" "$gh_user" "$SLACK_USERS_FILE")
+
+            if [ -n "$SLACK_ID" ]; then
+              MENTION="<@$SLACK_ID>"
+              echo "Resolved @$gh_user -> Slack <@$SLACK_ID>"
+            else
+              MENTION="@$gh_user"
+              echo "Could not resolve @$gh_user to Slack, using GitHub username fallback"
+            fi
+
+            MENTIONS_JSON=$(echo "$MENTIONS_JSON" | jq --arg login "$gh_user" --arg mention "$MENTION" '. + {($login): $mention}')
+          done <<< "$LOGINS"
+
+          {
+            echo 'mentions_json<<EOF'
+            echo "$MENTIONS_JSON"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compose and send Slack message
+        if: steps.culprits.outputs.found_baseline == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CODEOWNERS_PING_BOT }}
+          SLACK_CHANNEL_ID: "C05GRJC4J4A" # #tt-metal-pipelines
+          DRY_RUN: ${{ steps.context.outputs.dry_run }}
+          ENTRIES_JSON: ${{ steps.culprits.outputs.entries }}
+          MENTIONS_JSON: ${{ steps.mentions.outputs.mentions_json }}
+          FAILING_RUN_URL: ${{ steps.context.outputs.html_url }}
+          PREV_RUN_URL: ${{ steps.culprits.outputs.prev_run_url }}
+        run: |
+          set -euo pipefail
+
+          LINES=$(echo "$ENTRIES_JSON" | jq -r --argjson mentions "$MENTIONS_JSON" '
+            .[] | (if .authorLogin != null then ($mentions[.authorLogin] // ("@" + .authorLogin)) else "(unknown author)" end) as $who
+            | "\($who) <\(.url)|\(if .type == "pr" then "#\(.number) - \(.title)" else "\(.title)" end)> broke sanity."
+          ')
+
+          TEXT="${LINES}"$'\n'"Failing run on that commit: ${FAILING_RUN_URL}"$'\n'"Previous passing run: ${PREV_RUN_URL}"$'\n'"Please fix."
+
+          # Neutralize Slack broadcast mentions, out of caution -- text here is
+          # machine-built from PR titles/authors, not raw user content.
+          TEXT=$(echo "$TEXT" | sed 's/<!here>/\&lt;!here\&gt;/g; s/<!channel>/\&lt;!channel\&gt;/g; s/<!everyone>/\&lt;!everyone\&gt;/g')
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN -- would send to channel ${SLACK_CHANNEL_ID}:"
+            echo "---"
+            echo "$TEXT"
+            echo "---"
+            {
+              echo '### Dry-run Slack message (not sent)'
+              echo '```'
+              echo "$TEXT"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          PAYLOAD_FILE=$(mktemp)
+          jq -n --arg channel "$SLACK_CHANNEL_ID" --arg text "$TEXT" \
+            '{channel: $channel, text: $text, unfurl_links: true, unfurl_media: true}' > "$PAYLOAD_FILE"
+
+          SLACK_RESPONSE=$(curl -s --max-time 30 -X POST \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-type: application/json" \
+            -d @"$PAYLOAD_FILE" \
+            "https://slack.com/api/chat.postMessage")
+          rm -f "$PAYLOAD_FILE"
+
+          if [ "$(echo "$SLACK_RESPONSE" | jq -r '.ok')" = "true" ]; then
+            echo "Slack notification sent successfully"
+          else
+            ERROR=$(echo "$SLACK_RESPONSE" | jq -r '.error // "unknown error"')
+            echo "::error::Failed to send Slack notification: $ERROR"
+            exit 1
+          fi
+
+      - name: No baseline found
+        if: steps.culprits.outputs.found_baseline != 'true'
+        run: echo "No previous successful run to diff against -- nothing to notify."

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -32,7 +32,15 @@ jobs:
   notify:
     runs-on: ubuntu-slim
     # Only act on a real failed push run, or an explicit manual test/replay.
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'push') }}
+    #
+    # _auto-retry-post-commit.yaml automatically re-runs a failed "Sanity tests"
+    # push run up to MAX_ATTEMPTS=3, and workflow_run:completed fires once per
+    # attempt (hours apart) -- so without the run_attempt gate below, a single
+    # real break would post to Slack up to 3 separate times (the concurrency
+    # group only dedupes truly-concurrent deliveries of the same id, not
+    # sequential ones hours apart). Gating on the final attempt mirrors that
+    # retrier's own MAX_ATTEMPTS so we only ever act once retries are exhausted.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'push' && github.event.workflow_run.run_attempt >= 3) }}
     steps:
       - name: Resolve run context
         id: context
@@ -50,6 +58,20 @@ jobs:
               runId = Number(process.env.DISPATCH_RUN_ID);
               dryRun = process.env.DISPATCH_DRY_RUN !== 'false';
               const { data: run } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
+
+              // A manual replay/test must target a real "Sanity tests" push-on-main
+              // failure -- otherwise this would confidently post a Slack message
+              // built from an unrelated or successful run.
+              const problems = [];
+              if (run.name !== 'Sanity tests') problems.push(`workflow is "${run.name}", not "Sanity tests"`);
+              if (run.event !== 'push') problems.push(`event is "${run.event}", not "push"`);
+              if (run.head_branch !== 'main') problems.push(`head_branch is "${run.head_branch}", not "main"`);
+              if (run.conclusion !== 'failure') problems.push(`conclusion is "${run.conclusion}", not "failure"`);
+              if (problems.length > 0) {
+                core.setFailed(`run_id ${runId} is not a valid target to replay: ${problems.join('; ')}.`);
+                return;
+              }
+
               headSha = run.head_sha;
               runNumber = run.run_number;
               htmlUrl = run.html_url;
@@ -90,34 +112,46 @@ jobs:
               per_page: 100,
             });
 
-            // The run immediately before this one in the push-run sequence (not
-            // necessarily run_number - 1, since schedule/dispatch runs of the same
-            // workflow interleave and also consume run_numbers).
-            const immediatelyPrior = runsResp.workflow_runs
-              .filter(r => r.run_number < currentRunNumber && r.conclusion !== null)
-              .sort((a, b) => b.run_number - a.run_number)[0];
+            // Walk backwards (by run_number, not necessarily run_number - 1, since
+            // schedule/dispatch runs of the same workflow interleave and also
+            // consume run_numbers) to find the most recent MEANINGFUL prior state:
+            //  - a still-in-progress run (e.g. mid auto-retry-attempt) makes the
+            //    true completion order ambiguous -- abstain rather than silently
+            //    skip past it and risk misattributing to the wrong set of authors.
+            //  - cancelled/skipped runs carry no real red/green signal -- skip over
+            //    them and keep looking, so they can't permanently swallow a break.
+            //  - success -> this is a fresh green->red transition; use it as baseline.
+            //  - failure (or any other bad terminal conclusion) -> main was already
+            //    red before us; stay silent to avoid re-notifying / re-blaming.
+            const candidates = runsResp.workflow_runs
+              .filter(r => r.run_number < currentRunNumber)
+              .sort((a, b) => b.run_number - a.run_number);
 
-            if (!immediatelyPrior) {
-              core.warning('No previous completed "Sanity tests" push run found on main within the last 100 runs; skipping.');
+            let prevGood = null;
+            for (const run of candidates) {
+              if (run.status !== 'completed') {
+                core.info(`Push run #${run.run_number} is still in progress; completion order is ambiguous. Abstaining.`);
+                core.setOutput('should_notify', 'false');
+                return;
+              }
+              if (run.conclusion === 'cancelled' || run.conclusion === 'skipped') {
+                core.info(`Push run #${run.run_number} was ${run.conclusion} (no real signal); looking further back.`);
+                continue;
+              }
+              if (run.conclusion === 'success') {
+                prevGood = run;
+              } else {
+                core.info(`Push run #${run.run_number} also did not succeed (${run.conclusion}); ` +
+                  `main is still red from an earlier break. Not re-notifying to avoid repeat/duplicate pings.`);
+              }
+              break;
+            }
+
+            if (!prevGood) {
+              core.warning('No usable previous "Sanity tests" push run found on main (either none within the last 100 runs, or main is still red from an earlier break); skipping.');
               core.setOutput('should_notify', 'false');
               return;
             }
-
-            if (immediatelyPrior.conclusion !== 'success') {
-              // main is still red from an earlier, already-reported break: diffing from
-              // the last GREEN run here would re-list the original culprit every time,
-              // plus every author who has merged on top of the still-broken main since --
-              // none of whom asked to be blamed for someone else's unresolved failure.
-              // Stay silent until a run actually goes green -> red again.
-              core.info(`Previous push run (#${immediatelyPrior.run_number}) also did not succeed (${immediatelyPrior.conclusion}); ` +
-                `main is still red from an earlier break. Not re-notifying to avoid repeat/duplicate pings.`);
-              core.setOutput('should_notify', 'false');
-              return;
-            }
-
-            // immediatelyPrior succeeded, so this is a fresh green->red transition:
-            // it doubles as both the "is this new" signal and the diff baseline.
-            const prevGood = immediatelyPrior;
 
             core.setOutput('should_notify', 'true');
             core.setOutput('prev_run_url', prevGood.html_url);
@@ -129,6 +163,13 @@ jobs:
               base: prevGood.head_sha,
               head: currentHeadSha,
             });
+
+            // PR titles and commit subjects are attacker-controlled (anyone who can
+            // open a PR) and end up inside Slack `<url|label>` mrkdwn links below --
+            // must be entity-escaped the same way notify-slack-on-mention.yaml
+            // escapes user-supplied text, or a crafted title could break out of the
+            // link syntax or smuggle in a broadcast mention like <!subteam^...>.
+            const escapeSlack = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
             const entries = [];
             const seenPrNumbers = new Set();
@@ -148,7 +189,7 @@ jobs:
                     type: 'pr',
                     number: pr.number,
                     url: pr.html_url,
-                    title: pr.title,
+                    title: escapeSlack(pr.title),
                     authorLogin: pr.user ? pr.user.login : null,
                   });
                 }
@@ -159,7 +200,7 @@ jobs:
                   type: 'commit',
                   sha: commit.sha,
                   url: commit.html_url,
-                  title: commit.commit.message.split('\n')[0],
+                  title: escapeSlack(commit.commit.message.split('\n')[0]),
                   authorLogin: commit.author ? commit.author.login : null,
                 });
               }


### PR DESCRIPTION
## Summary

Automatically posts to `#tt-metal-pipelines` when "Sanity tests" breaks on `main`, tagging the responsible PR author(s) — the same triage Borys currently does by hand. Adds `.github/workflows/sanity-tests-slack-notify.yaml` (`workflow_run`-triggered, doesn't touch `sanity-tests.yaml`) plus a shared `.github/actions/resolve-slack-mentions` action.

## How it works

- Fires once per real break: waits for the repo's auto-retry to exhaust its 3 attempts, and only acts on a fresh green→red transition (not every subsequent still-red run).
- Diffs commits since the last green run, resolves each to its PR/author (falls back to the commit's own author if no PR).
- Resolves GitHub logins to Slack mentions, then posts: `<author> <PR> broke sanity. Failing run ... Previous passing run ... Please fix.`
- Manual `workflow_dispatch` replay (validated against the real target run) with `dry_run` (default `true`) for safe testing.

## Why not the existing regression-detection systems

`aggregate-workflow-data.yaml` already monitors this workflow but classifies a single push-triggered failure as "no regression" (confirmed in its own logs for the incident this fixes). `ci-failure-triage.md` doesn't cover this workflow and disables Slack during its pilot. This is a small deterministic workflow rather than an LLM/agentic one, since the merge queue means the diff window is almost always exactly one PR.

## Known limitations

- If an older, still-in-progress push run finishes out of order and later turns out to be green, this workflow may have already abstained for a later red run rather than notify — favors missing a notification over misattributing one.
- The `concurrency` group serializes duplicate `workflow_run` deliveries for the same run but doesn't fully dedupe a queued rerun.

## Test plan

- [x] `actionlint` clean.
- [ ] Dry-run replay against the real historical incident to confirm it reconstructs the same attribution (PR #53464 / Nachiket Kapre) Borys posted by hand: `gh workflow run sanity-tests-slack-notify.yaml --ref wilder/sanity-tests-slack-notify -f run_id=32282881530 -f dry_run=true`
- [ ] One live dispatch to confirm `CODEOWNERS_PING_BOT` can post in `#tt-metal-pipelines`.
- [ ] Let it prove itself on the next real break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/sanity-tests-slack-notify)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/sanity-tests-slack-notify)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/sanity-tests-slack-notify)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/sanity-tests-slack-notify)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/sanity-tests-slack-notify)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/sanity-tests-slack-notify)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/sanity-tests-slack-notify)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/sanity-tests-slack-notify)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/sanity-tests-slack-notify)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/sanity-tests-slack-notify)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/sanity-tests-slack-notify)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/sanity-tests-slack-notify)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/sanity-tests-slack-notify)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/sanity-tests-slack-notify)
