### PR TITLE
Unify category and tag test-matrix filtering in prepare_test_matrix.py

### DIFF
--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -4,18 +4,21 @@ Build a filtered test matrix based on enabled SKUs.
 
 This script:
 1. Loads test definitions from a YAML file
-2. Filters tests based on enabled SKUs (comma-separated string)
-3. Optionally intersects with --sku-allowlist (change gating)
-4. Optionally rewrites SKUs to merge_queue_sku when --event is merge_group
-5. Adds runs_on labels from the SKU configuration
-6. Annotates each entry with weights-cache-mode from sku_config.yaml
+2. Optionally filters entries by `tags` via --include-tag (allowlist) / --exclude-tag
+   (denylist)
+3. Filters tests based on enabled SKUs (comma-separated string)
+4. Optionally intersects with --sku-allowlist (change gating)
+5. Optionally rewrites SKUs to merge_queue_sku when --event is merge_group
+6. Adds runs_on labels from the SKU configuration
+7. Annotates each entry with weights-cache-mode from sku_config.yaml
    (used by the Blackhole demo pipeline so the per-job container volume mount can
    pick the right cache source)
-7. Outputs the filtered matrix as JSON
+8. Outputs the filtered matrix as JSON
 
 Usage:
     python prepare_test_matrix.py <tests_yaml_path> <enabled_skus> <sku_config_yaml_path>
         [--event EVENT] [--sku-allowlist LIST]
+        [--include-tag TAG] [--exclude-tag TAG]
 
 enabled_skus is a comma-separated list, or the literal ALL_SKUS_IN_TESTS to enable every SKU
 key that appears under any test entry's skus mapping in the tests YAML. An empty / placeholder
@@ -26,6 +29,24 @@ rewritten to that concrete prio SKU before runs_on lookup.
 
 --sku-allowlist: omit for no extra filter; empty string skips all tests (matrix=[]
 exit 0); otherwise comma-separated logical SKUs intersected with coverage.
+
+--include-tag: repeatable; keep only entries whose `tags` intersect this set. Omit for
+no filter (keep everything). This is the one mechanism for both intended uses: a caller
+opting into extra coverage (e.g. the L2 nightly `additional_test_categories` dispatch
+input, formerly a separate per-caller jq step keyed on a `category` field) and a caller
+that only wants a specific slice of a shared list.
+
+--exclude-tag: repeatable; drops entries whose `tags` contain the tag. For lists shared
+by callers with different builds, where some entries cannot run under every build (e.g.
+profiler entries needing ENABLE_TRACY=ON, which a coverage build disables).
+
+Both flags run before SKU resolution, so a filtered-out entry contributes nothing,
+including under ALL_SKUS_IN_TESTS. Both are validated against the tags actually present
+in the loaded file: a tag that matches nothing is a hard error (exit 1), not a silently
+empty or under-filtered matrix — this is what catches a typo'd tag name. The one
+exception is an empty / placeholder tests file (no entries at all), which still resolves
+to matrix=[] rather than failing, consistent with how ALL_SKUS_IN_TESTS already treats
+placeholder files.
 
 `weights-cache-mode` is an optional per-SKU field in sku_config.yaml; when present,
 it is copied into each output matrix entry.
@@ -100,6 +121,91 @@ def apply_sku_allowlist(enabled_skus, sku_allowlist):
     filtered = [s for s in enabled_skus if s in allow]
     print(f"SKU allowlist {allow} → {filtered}")
     return filtered
+
+
+def normalize_tags(raw_tags):
+    """Normalize a test entry's `tags` field: absent/None -> [], bare string -> [string],
+    list -> as-is."""
+    if not raw_tags:
+        return []
+    if isinstance(raw_tags, str):
+        return [raw_tags]
+    return list(raw_tags)
+
+
+def collect_known_tags(tests):
+    """Union of tags actually present across all entries.
+
+    This is the vocabulary --include-tag/--exclude-tag are validated against, so a
+    typo'd tag name fails loudly instead of silently producing an empty or
+    under-filtered matrix.
+    """
+    known = set()
+    for test in tests:
+        known.update(normalize_tags(test.get("tags")))
+    return known
+
+
+def validate_requested_tags(requested, known_tags, flag_name):
+    unknown = sorted(set(requested) - known_tags)
+    if unknown:
+        print(f"::error::{flag_name} references unknown tag(s) {unknown}; tags present in this file: {sorted(known_tags)}")
+        sys.exit(1)
+
+
+def apply_tag_filters(tests, include_tags, exclude_tags):
+    """
+    Filter tests by `tags` before SKU resolution: --include-tag keeps only entries with
+    a matching tag (allowlist), --exclude-tag drops entries with a matching tag
+    (denylist), applied in that order so excludes always win when both are given.
+
+    An empty tests list (placeholder / not-yet-populated YAML) is passed through
+    unfiltered rather than validated, matching how the rest of the script treats
+    placeholder files as vacuously correct.
+
+    Args:
+        tests: List of test dictionaries
+        include_tags: None/empty for no filter; else an iterable of tags to allowlist
+        exclude_tags: None/empty for no filter; else an iterable of tags to denylist
+
+    Returns:
+        Filtered list of test dictionaries (possibly empty)
+    """
+    if not tests:
+        return tests
+
+    known_tags = collect_known_tags(tests)
+    if include_tags:
+        validate_requested_tags(include_tags, known_tags, "--include-tag")
+    if exclude_tags:
+        validate_requested_tags(exclude_tags, known_tags, "--exclude-tag")
+
+    kept = tests
+
+    if include_tags:
+        include_set = set(include_tags)
+        next_kept = []
+        for test in kept:
+            tags = set(normalize_tags(test.get("tags")))
+            if tags & include_set:
+                next_kept.append(test)
+            else:
+                print(f"Not including test '{test.get('name', 'Unnamed Test')}' (tags {sorted(tags)} not in --include-tag set)")
+        kept = next_kept
+
+    if exclude_tags:
+        exclude_set = set(exclude_tags)
+        next_kept = []
+        for test in kept:
+            tags = set(normalize_tags(test.get("tags")))
+            matched = exclude_set & tags
+            if matched:
+                print(f"Excluding test '{test.get('name', 'Unnamed Test')}' (tagged {','.join(sorted(matched))})")
+                continue
+            next_kept.append(test)
+        kept = next_kept
+
+    return kept
 
 
 def resolve_sku_for_event(sku_name, sku_config, event):
@@ -356,6 +462,24 @@ def main(argv=None):
         help="Omit for no filter; empty string skips all; else CSV of logical SKUs",
     )
     parser.add_argument(
+        "--include-tag",
+        action="append",
+        default=None,
+        metavar="TAG",
+        help="Repeatable allowlist: keep only entries whose `tags` intersect this set. "
+        "Omit for no filter (keep everything). Validated against tags actually present "
+        "in the file; an unmatched tag is a hard error.",
+    )
+    parser.add_argument(
+        "--exclude-tag",
+        action="append",
+        default=None,
+        metavar="TAG",
+        help="Repeatable denylist: drop entries whose `tags` intersect this set. For "
+        "callers sharing a list with others whose build cannot run every entry. Applied "
+        "after --include-tag. Validated against tags actually present in the file.",
+    )
+    parser.add_argument(
         "--allow-missing-cmd",
         action="store_true",
         help="Allow entries without a `cmd` key (for pipelines that build the command "
@@ -371,9 +495,14 @@ def main(argv=None):
         print(f"Event: '{args.event}'")
     if args.sku_allowlist is not None:
         print(f"SKU allowlist: '{args.sku_allowlist}'")
+    if args.include_tag:
+        print(f"Include tags: {args.include_tag}")
+    if args.exclude_tag:
+        print(f"Exclude tags: {args.exclude_tag}")
 
     sku_config = load_sku_config(args.sku_config_yaml_path)
     tests = load_tests(args.tests_yaml_path)
+    tests = apply_tag_filters(tests, args.include_tag, args.exclude_tag)
 
     if args.enabled_skus.strip().upper() == ALL_SKUS_IN_TESTS:
         enabled_skus = collect_skus_from_tests(tests)

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -149,7 +149,9 @@ def collect_known_tags(tests):
 def validate_requested_tags(requested, known_tags, flag_name):
     unknown = sorted(set(requested) - known_tags)
     if unknown:
-        print(f"::error::{flag_name} references unknown tag(s) {unknown}; tags present in this file: {sorted(known_tags)}")
+        print(
+            f"::error::{flag_name} references unknown tag(s) {unknown}; tags present in this file: {sorted(known_tags)}"
+        )
         sys.exit(1)
 
 
@@ -190,7 +192,9 @@ def apply_tag_filters(tests, include_tags, exclude_tags):
             if tags & include_set:
                 next_kept.append(test)
             else:
-                print(f"Not including test '{test.get('name', 'Unnamed Test')}' (tags {sorted(tags)} not in --include-tag set)")
+                print(
+                    f"Not including test '{test.get('name', 'Unnamed Test')}' (tags {sorted(tags)} not in --include-tag set)"
+                )
         kept = next_kept
 
     if exclude_tags:

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -758,7 +758,6 @@ def test_tests_present_but_no_enabled_sku_is_fatal(tests_yaml: Path):
     assert "No tests selected for enabled SKUs" in result.stdout
 
 
-
 # ---------------------------------------------------------------------------
 # Tag filtering: --include-tag (allowlist) / --exclude-tag (denylist)
 #
@@ -952,7 +951,9 @@ def test_ops_unit_tests_yaml_uses_tags_not_category():
     with open(PIPELINE / "ops_unit_tests.yaml") as f:
         tests = yaml.safe_load(f)
 
-    assert not any("category" in t for t in tests), "ops_unit_tests.yaml still has a `category` field; use `tags` instead"
+    assert not any(
+        "category" in t for t in tests
+    ), "ops_unit_tests.yaml still has a `category` field; use `tags` instead"
 
     known_tags = set()
     for t in tests:
@@ -978,7 +979,9 @@ def test_ops_unit_tests_yaml_uses_tags_not_category():
         "cpp_lab_examples",
     }
     missing = scheduled_categories - known_tags
-    assert not missing, f"tt-metal-l2-nightly.yaml schedules categories with no matching tag in ops_unit_tests.yaml: {missing}"
+    assert (
+        not missing
+    ), f"tt-metal-l2-nightly.yaml schedules categories with no matching tag in ops_unit_tests.yaml: {missing}"
 
 
 @pytest.mark.parametrize("body", ["", "# placeholder, no tests yet\n"])

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -758,6 +758,229 @@ def test_tests_present_but_no_enabled_sku_is_fatal(tests_yaml: Path):
     assert "No tests selected for enabled SKUs" in result.stdout
 
 
+
+# ---------------------------------------------------------------------------
+# Tag filtering: --include-tag (allowlist) / --exclude-tag (denylist)
+#
+# One mechanism serving both intended uses: a caller opting into extra coverage
+# (formerly the L2 nightly `additional_test_categories` jq step keyed on a `category`
+# field, one copy duplicated per impl workflow) and a caller excluding entries its build
+# can't run (formerly a bespoke per-caller need). Both filters run before SKU
+# resolution and are validated against the tags actually present in the file, so a
+# typo'd tag is a hard error rather than a silently empty/under-filtered matrix.
+# ---------------------------------------------------------------------------
+
+
+_TAGGED_YAML = """\
+- name: plain test
+  cmd: echo ok
+  skus:
+    wh_n150_civ2:
+      timeout: 15
+  team: runtime
+- name: tagged list test
+  tags: [profiler]
+  cmd: echo profiler
+  skus:
+    wh_n150_civ2:
+      timeout: 15
+  team: runtime
+- name: tagged string test
+  tags: profiler
+  cmd: echo profiler
+  skus:
+    wh_n150_civ2:
+      timeout: 15
+  team: runtime
+- name: sweep tagged test
+  tags: [sweep]
+  cmd: echo sweep
+  skus:
+    wh_n150_civ2:
+      timeout: 15
+  team: runtime
+"""
+
+
+@pytest.fixture
+def tagged_yaml(tmp_path: Path) -> Path:
+    path = tmp_path / "tagged.yaml"
+    path.write_text(_TAGGED_YAML)
+    return path
+
+
+def test_no_tag_flags_keeps_everything(tagged_yaml: Path):
+    matrix = run_matrix(tagged_yaml, "wh_n150_civ2")
+    assert len(matrix) == 4
+
+
+def test_exclude_tag_drops_tagged_entries(tagged_yaml: Path):
+    """Both list and bare-string `tags` forms are excluded."""
+    matrix = run_matrix(tagged_yaml, "wh_n150_civ2", "--exclude-tag", "profiler")
+    assert [e["name"] for e in matrix] == [
+        "plain test [wh_n150_civ2]",
+        "sweep tagged test [wh_n150_civ2]",
+    ]
+
+
+def test_exclude_tag_is_repeatable(tagged_yaml: Path):
+    matrix = run_matrix(tagged_yaml, "wh_n150_civ2", "--exclude-tag", "profiler", "--exclude-tag", "sweep")
+    assert [e["name"] for e in matrix] == ["plain test [wh_n150_civ2]"]
+
+
+def test_include_tag_keeps_only_matching(tagged_yaml: Path):
+    """Both list and bare-string `tags` forms are matched by --include-tag."""
+    matrix = run_matrix(tagged_yaml, "wh_n150_civ2", "--include-tag", "profiler")
+    assert [e["name"] for e in matrix] == [
+        "tagged list test [wh_n150_civ2]",
+        "tagged string test [wh_n150_civ2]",
+    ]
+
+
+def test_include_tag_is_repeatable(tagged_yaml: Path):
+    """Repeated --include-tag is an OR: keep entries matching any of them."""
+    matrix = run_matrix(tagged_yaml, "wh_n150_civ2", "--include-tag", "profiler", "--include-tag", "sweep")
+    assert {e["name"] for e in matrix} == {
+        "tagged list test [wh_n150_civ2]",
+        "tagged string test [wh_n150_civ2]",
+        "sweep tagged test [wh_n150_civ2]",
+    }
+
+
+def test_include_and_exclude_together_excludes_win(tagged_yaml: Path):
+    """--exclude-tag is applied after --include-tag, so it can carve out of the allowlist."""
+    matrix = run_matrix(
+        tagged_yaml,
+        "wh_n150_civ2",
+        "--include-tag",
+        "profiler",
+        "--include-tag",
+        "sweep",
+        "--exclude-tag",
+        "sweep",
+    )
+    assert {e["name"] for e in matrix} == {
+        "tagged list test [wh_n150_civ2]",
+        "tagged string test [wh_n150_civ2]",
+    }
+
+
+def test_include_tag_unknown_tag_is_a_hard_error(tagged_yaml: Path):
+    """A typo'd category/tag must fail loudly, not silently produce an empty matrix."""
+    result = _run_with_skus(tagged_yaml, "wh_n150_civ2", "--include-tag", "porfiler")
+    assert result.returncode != 0, result.stdout
+    assert "unknown tag" in result.stdout
+    assert "porfiler" in result.stdout
+
+
+def test_exclude_tag_unknown_tag_is_a_hard_error(tagged_yaml: Path):
+    result = _run_with_skus(tagged_yaml, "wh_n150_civ2", "--exclude-tag", "does_not_exist")
+    assert result.returncode != 0, result.stdout
+    assert "unknown tag" in result.stdout
+
+
+def test_tag_flags_applies_under_all_skus_in_tests(tmp_path: Path):
+    """Excluded/non-included entries must not contribute their SKUs to ALL_SKUS_IN_TESTS."""
+    path = tmp_path / "tags.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: keeper
+              cmd: echo ok
+              skus:
+                wh_n150_civ2:
+                  timeout: 5
+              team: runtime
+            - name: galaxy only profiler entry
+              tags: [profiler]
+              cmd: echo ok
+              skus:
+                wh_galaxy:
+                  timeout: 5
+              team: runtime
+            """
+        )
+    )
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS", "--exclude-tag", "profiler")
+    assert concrete_skus(matrix) == {"wh_n150_civ2"}
+
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS", "--include-tag", "profiler")
+    assert concrete_skus(matrix) == {"wh_galaxy"}
+
+
+def test_exclude_tag_removing_every_entry_skips_rather_than_fails(tmp_path: Path):
+    """A list that is entirely excluded is vacuously correct: matrix=[], exit 0."""
+    path = tmp_path / "tags.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: profiler entry
+              tags: [profiler]
+              cmd: echo ok
+              skus:
+                wh_n150_civ2:
+                  timeout: 5
+              team: runtime
+            """
+        )
+    )
+    for enabled in ("wh_n150_civ2", "ALL_SKUS_IN_TESTS"):
+        result = _run_with_skus(path, enabled, "--exclude-tag", "profiler")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert re.search(r"^matrix=\[\]$", result.stdout, re.M)
+
+
+@pytest.mark.parametrize("body", ["", "# placeholder, no tests yet\n"])
+@pytest.mark.parametrize("enabled", ["wh_n150_civ2", "ALL_SKUS_IN_TESTS"])
+def test_tag_flags_bypassed_for_placeholder_yaml(tmp_path: Path, body: str, enabled: str):
+    """An empty/placeholder file skips tag validation entirely rather than hard-failing
+    on 'unknown tag' — matches how ALL_SKUS_IN_TESTS already treats placeholder files as
+    vacuously correct (e.g. ttsim_unit_tests.yaml, whose sole entry is presently
+    commented out, but whose caller still passes --include-tag compute_fused)."""
+    path = tmp_path / "tests.yaml"
+    path.write_text(body)
+    result = _run_with_skus(path, enabled, "--include-tag", "compute_fused")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert re.search(r"^matrix=\[\]$", result.stdout, re.M)
+
+
+def test_ops_unit_tests_yaml_uses_tags_not_category():
+    """Regression guard for the category -> tags migration: no entry should carry the
+    old singular `category` field, and every tag referenced by tt-metal-l2-nightly.yaml's
+    hardcoded schedule-time category list must exist as a real tag in the file, so a
+    future entry removal/rename can't silently orphan a caller's filter."""
+    with open(PIPELINE / "ops_unit_tests.yaml") as f:
+        tests = yaml.safe_load(f)
+
+    assert not any("category" in t for t in tests), "ops_unit_tests.yaml still has a `category` field; use `tags` instead"
+
+    known_tags = set()
+    for t in tests:
+        raw = t.get("tags") or []
+        known_tags.update([raw] if isinstance(raw, str) else raw)
+
+    scheduled_categories = {
+        "conv",
+        "matmul",
+        "fused",
+        "reduction",
+        "experimental",
+        "pool",
+        "eltwise",
+        "transformers",
+        "moreh",
+        "misc",
+        "sdpa",
+        "data_movement",
+        "ccl",
+        "docs_examples",
+        "cpp_accessor",
+        "cpp_lab_examples",
+    }
+    missing = scheduled_categories - known_tags
+    assert not missing, f"tt-metal-l2-nightly.yaml schedules categories with no matching tag in ops_unit_tests.yaml: {missing}"
+
+
 @pytest.mark.parametrize("body", ["", "# placeholder, no tests yet\n"])
 @pytest.mark.parametrize("enabled", ["wh_n150_civ2", "ALL_SKUS_IN_TESTS"])
 def test_no_tests_in_yaml_warns_and_passes(tmp_path: Path, body: str, enabled: str):

--- a/.github/workflows/ops-integration-tests-impl.yaml
+++ b/.github/workflows/ops-integration-tests-impl.yaml
@@ -28,7 +28,7 @@ jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ steps.filter-categories.outputs.matrix }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/ops_integration_tests.yaml
     steps:
@@ -52,21 +52,16 @@ jobs:
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
+          INCLUDE_ARGS=()
+          IFS=',' read -ra CATS <<< "${{ inputs.additional_test_categories }}"
+          for c in "${CATS[@]}"; do
+            [[ -n "$c" ]] && INCLUDE_ARGS+=(--include-tag "$c")
+          done
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
-      - name: Filter matrix by additional_test_categories
-        id: filter-categories
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          categories='${{ inputs.additional_test_categories }}'
-          filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
-          {
-            echo "matrix<<EOF"
-            echo "$filtered"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            ./.github/sku_config.yaml \
+            "${INCLUDE_ARGS[@]}"
 
   ops-integration-tests:
     needs: load-test-matrix

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
         default: ''
-        description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
+        description: "Comma-separated category filter. Expanded into --include-tag flags; keeps only entries whose `tags` field intersects this list."
       enable-llk-asserts:
         required: false
         type: boolean
@@ -30,7 +30,7 @@ jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ steps.filter-categories.outputs.matrix }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/ops_unit_tests.yaml
     steps:
@@ -54,21 +54,16 @@ jobs:
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
+          INCLUDE_ARGS=()
+          IFS=',' read -ra CATS <<< "${{ inputs.additional_test_categories }}"
+          for c in "${CATS[@]}"; do
+            [[ -n "$c" ]] && INCLUDE_ARGS+=(--include-tag "$c")
+          done
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
-      - name: Filter matrix by additional_test_categories
-        id: filter-categories
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          categories='${{ inputs.additional_test_categories }}'
-          filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
-          {
-            echo "matrix<<EOF"
-            echo "$filtered"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            ./.github/sku_config.yaml \
+            "${INCLUDE_ARGS[@]}"
 
   ops-unit-tests:
     needs: load-test-matrix

--- a/.github/workflows/tt-cnn-unit-tests-impl.yaml
+++ b/.github/workflows/tt-cnn-unit-tests-impl.yaml
@@ -29,7 +29,7 @@ jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ steps.filter-categories.outputs.matrix }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/tt_cnn_unit_tests.yaml
     steps:
@@ -53,21 +53,16 @@ jobs:
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
+          INCLUDE_ARGS=()
+          IFS=',' read -ra CATS <<< "${{ inputs.additional_test_categories }}"
+          for c in "${CATS[@]}"; do
+            [[ -n "$c" ]] && INCLUDE_ARGS+=(--include-tag "$c")
+          done
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
-      - name: Filter matrix by additional_test_categories
-        id: filter-categories
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          categories='${{ inputs.additional_test_categories }}'
-          filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
-          {
-            echo "matrix<<EOF"
-            echo "$filtered"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            ./.github/sku_config.yaml \
+            "${INCLUDE_ARGS[@]}"
 
   cnn-unit-tests:
     needs: load-test-matrix

--- a/.github/workflows/tt-train-tests.yaml
+++ b/.github/workflows/tt-train-tests.yaml
@@ -54,7 +54,7 @@ on:
         required: false
         type: string
         default: ''
-        description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
+        description: "Comma-separated category filter. Expanded into --include-tag flags; keeps only entries whose `tags` field intersects this list."
       per-test-timeout:
         required: false
         type: string
@@ -72,7 +72,7 @@ jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ inputs.subcategories != '' && steps.filter-categories.outputs.matrix || steps.build-matrix.outputs.matrix }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/train_${{ inputs.test-category }}_tests.yaml
     steps:
@@ -106,24 +106,17 @@ jobs:
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
+          INCLUDE_ARGS=()
+          IFS=',' read -ra CATS <<< "${{ inputs.subcategories }}"
+          for c in "${CATS[@]}"; do
+            [[ -n "$c" ]] && INCLUDE_ARGS+=(--include-tag "$c")
+          done
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml \
-            --event "${{ github.event_name }}"
-
-      - name: Filter matrix by subcategories
-        if: ${{ inputs.subcategories != '' }}
-        id: filter-categories
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          categories='${{ inputs.subcategories }}'
-          filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
-          {
-            echo "matrix<<EOF"
-            echo "$filtered"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            --event "${{ github.event_name }}" \
+            "${INCLUDE_ARGS[@]}"
 
   tt-train-tests:
     needs: [load-test-matrix]

--- a/.github/workflows/ttnn-integration-tests-impl.yaml
+++ b/.github/workflows/ttnn-integration-tests-impl.yaml
@@ -28,7 +28,7 @@ jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ steps.filter-categories.outputs.matrix }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/ttnn_integration_tests.yaml
     steps:
@@ -52,21 +52,16 @@ jobs:
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
+          INCLUDE_ARGS=()
+          IFS=',' read -ra CATS <<< "${{ inputs.additional_test_categories }}"
+          for c in "${CATS[@]}"; do
+            [[ -n "$c" ]] && INCLUDE_ARGS+=(--include-tag "$c")
+          done
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
-      - name: Filter matrix by additional_test_categories
-        id: filter-categories
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          categories='${{ inputs.additional_test_categories }}'
-          filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
-          {
-            echo "matrix<<EOF"
-            echo "$filtered"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            ./.github/sku_config.yaml \
+            "${INCLUDE_ARGS[@]}"
 
   ttnn-integration-tests:
     needs: load-test-matrix

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
         default: ''
-        description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
+        description: "Comma-separated category filter. Expanded into --include-tag flags; keeps only entries whose `tags` field intersects this list."
       enable-llk-asserts:
         required: false
         type: boolean
@@ -30,8 +30,8 @@ jobs:
   load-test-matrix:
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ steps.filter-categories.outputs.matrix }}
-      sim-libs: ${{ steps.filter-categories.outputs.sim-libs }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      sim-libs: ${{ steps.build-matrix.outputs.sim-libs }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/ttsim_unit_tests.yaml
     steps:
@@ -55,24 +55,16 @@ jobs:
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
+          INCLUDE_ARGS=()
+          IFS=',' read -ra CATS <<< "${{ inputs.additional_test_categories }}"
+          for c in "${CATS[@]}"; do
+            [[ -n "$c" ]] && INCLUDE_ARGS+=(--include-tag "$c")
+          done
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
-      - name: Filter matrix by additional_test_categories
-        id: filter-categories
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          categories='${{ inputs.additional_test_categories }}'
-          filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
-          {
-            echo "matrix<<EOF"
-            echo "$filtered"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          # prepare_test_matrix.py's sim-libs covers the pre-filter matrix; recompute from the
-          # filtered one so fetch-ttsim does not download libs for legs this run dropped.
-          echo "sim-libs=$(echo "$filtered" | jq -c '[.[].ttsim_lib // empty] | unique')" >> "$GITHUB_OUTPUT"
+            ./.github/sku_config.yaml \
+            "${INCLUDE_ARGS[@]}"
 
   fetch-ttsim:
     needs: load-test-matrix

--- a/tests/pipeline_reorg/ops_integration_tests.yaml
+++ b/tests/pipeline_reorg/ops_integration_tests.yaml
@@ -8,10 +8,9 @@
 #       timeout: The maximum allowed runtime for this job in minutes on that SKU.
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
-#   category: Selector used by tt-metal-l2-nightly.yaml's additional_test_categories
-#     dispatch input. On dispatch the impl filters this matrix to entries whose
-#     category appears in the comma-separated list; on schedule the filter is
-#     bypassed and every entry runs.
+#   tags: Optional labels; --include-tag/--exclude-tag select on these. Used by
+#     tt-metal-l2-nightly.yaml's additional_test_categories dispatch input, expanded
+#     to repeated --include-tag flags by the impl workflow.
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
@@ -24,4 +23,4 @@
       timeout: 30
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
-  category: ops_docs_check
+  tags: [ops_docs_check]

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -8,10 +8,9 @@
 #       timeout: The maximum allowed runtime for this job in minutes on that SKU.
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
-#   category: Selector used by tt-metal-l2-nightly.yaml's additional_test_categories
-#     dispatch input. On dispatch the impl filters this matrix to entries whose
-#     category appears in the comma-separated list; on schedule the filter is
-#     bypassed and every entry runs.
+#   tags: Optional labels; --include-tag/--exclude-tag select on these. Used by
+#     tt-metal-l2-nightly.yaml's additional_test_categories dispatch input, expanded
+#     to repeated --include-tag flags by the impl workflow.
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
@@ -30,7 +29,7 @@
       timeout: 150
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
-  category: conv
+  tags: [conv]
 
 - name: ttnn nightly matmul tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -45,7 +44,7 @@
       timeout: 50
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
-  category: matmul
+  tags: [matmul]
 
 - name: ttnn nightly fused tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -60,7 +59,7 @@
       timeout: 65
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
-  category: fused
+  tags: [fused]
 
 - name: ttnn nightly reduction tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/reduction -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -75,7 +74,7 @@
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
-  category: reduction
+  tags: [reduction]
 
 - name: ttnn nightly experimental tests (wormhole)
   # test_moe_grouped_topk hangs on Wormhole (TODO: file issue + restore). Exclude on WH only.
@@ -87,7 +86,7 @@
       timeout: 65
   owner_id: U080FKG7KEU # Utku Aydonat
   team: ttnn
-  category: experimental
+  tags: [experimental]
 
 - name: ttnn nightly experimental tests (blackhole)
   # Host-IOMMU tests are selected by the viommu job below and excluded from these non-IOMMU SKUs.
@@ -99,7 +98,7 @@
       timeout: 35
   owner_id: U080FKG7KEU # Utku Aydonat
   team: ttnn
-  category: experimental
+  tags: [experimental]
 
 - name: ttnn nightly experimental tests (blackhole - viommu)
   # Tests opt in with @pytest.mark.requires_host_iommu, allowing operation developers to add IOMMU coverage
@@ -114,7 +113,7 @@
       timeout: 5
   owner_id: U09L76N1MAT  # Nenad Babin
   team: ttnn
-  category: experimental
+  tags: [experimental]
 
 - name: ttnn nightly experimental generalized MoE gate op tests
   cmd: 'pytest models/common/tests/modules/moe/test_generalized_moe_gate.py -xv --timeout=600'
@@ -125,7 +124,7 @@
       timeout: 10
   owner_id: U07M7QZ0BQA # Camilo Vega
   team: ttnn
-  category: experimental
+  tags: [experimental]
 
 - name: ttnn nightly pool tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -140,7 +139,7 @@
       timeout: 90
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
-  category: pool
+  tags: [pool]
 
 - name: ttnn nightly eltwise tests group 1
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 1 -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -153,7 +152,7 @@
       timeout: 75
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
-  category: eltwise
+  tags: [eltwise]
 
 - name: ttnn nightly eltwise tests group 2
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 2 -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -166,7 +165,7 @@
       timeout: 45
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
-  category: eltwise
+  tags: [eltwise]
 
 - name: ttnn nightly eltwise tests group 3
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 3 -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -179,7 +178,7 @@
       timeout: 45
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
-  category: eltwise
+  tags: [eltwise]
 
 - name: ttnn nightly eltwise tests group 4
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/eltwise --splits 4 --group 4 -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -192,7 +191,7 @@
       timeout: 55
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
-  category: eltwise
+  tags: [eltwise]
 
 - name: ttnn nightly transformers tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -207,7 +206,7 @@
       timeout: 30
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: ttnn
-  category: transformers
+  tags: [transformers]
 
 - name: ttnn nightly moreh tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -222,7 +221,7 @@
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
-  category: moreh
+  tags: [moreh]
 
 - name: ttnn nightly misc (rand and ssm) tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/rand tests/ttnn/nightly/unit_tests/operations/ssm -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -237,7 +236,7 @@
       timeout: 15
   owner_id: U09BX3N0N95 # Mateusz Nowak
   team: ttnn
-  category: misc
+  tags: [misc]
 
 - name: ttnn nightly sdpa tests
   # MLA decode / prefill stress are split out into the sdpa stress entry below; this entry runs the rest of the
@@ -256,7 +255,7 @@
       timeout: 90
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
-  category: sdpa
+  tags: [sdpa]
 
 - name: ttnn nightly sdpa stress tests
   cmd: |
@@ -272,7 +271,7 @@
       timeout: 55
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
-  category: sdpa
+  tags: [sdpa]
 
 - name: ttnn nightly data_movement tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/data_movement -xv -m "not disable_fast_runtime_mode" --timeout=600'
@@ -287,7 +286,7 @@
       timeout: 40
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-  category: data_movement
+  tags: [data_movement]
 
 # The post-commit data_movement / ccl / point_to_point suites are re-run nightly
 # to cover the long tail that the PR gate skips. One bucket per suite (these
@@ -314,7 +313,7 @@
       timeout: 80
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-  category: data_movement
+  tags: [data_movement]
 
 - name: ttnn n300 ccl tests
   cmd: |
@@ -327,7 +326,7 @@
       timeout: 10
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-  category: data_movement
+  tags: [data_movement]
 
 - name: blackhole host to device smoke tests
   cmd: 'pytest tests/ttnn/unit_tests/operations/ccl/test_send_recv_async_hd.py -xv -m "not disable_fast_runtime_mode" --timeout=300'
@@ -338,7 +337,7 @@
       timeout: 10
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-  category: data_movement
+  tags: [data_movement]
 
 - name: ttnn nightly point_to_point tests (post-commit suite)
   # 12 tests (4 skipped), measured in single-digit seconds on every SKU.
@@ -354,7 +353,7 @@
       timeout: 5
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-  category: data_movement
+  tags: [data_movement]
 
 - name: ccl nightly tests
   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly
@@ -365,7 +364,7 @@
       timeout: 60
   owner_id: U07M7QZ0BQA # Camilo Vega
   team: ttnn
-  category: ccl
+  tags: [ccl]
 
 - name: Galaxy CCL tests
   cmd: pytest tests/nightly/tg/ccl --ignore tests/nightly/tg/ccl/moe
@@ -374,7 +373,7 @@
       timeout: 60
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-  category: ccl
+  tags: [ccl]
 
 - name: Galaxy MoE tests
   cmd: |
@@ -385,7 +384,7 @@
       timeout: 60
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-  category: ccl
+  tags: [ccl]
 
 - name: BH Galaxy CCL tests
   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
@@ -394,7 +393,7 @@
       timeout: 40
   owner_id: U07M7QZ0BQA # Camilo Vega
   team: ttnn
-  category: ccl
+  tags: [ccl]
 
 - name: ttnn nightly docs examples tests
   # docs_examples runs on viommu-stable SKUs.
@@ -410,7 +409,7 @@
       timeout: 20
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
-  category: docs_examples
+  tags: [docs_examples]
 
 # --- C++ ttnn unit tests ---
 
@@ -427,7 +426,7 @@
       timeout: 45
   owner_id: U024A4EFV6U # Brian Liu
   team: ttnn
-  category: cpp_accessor
+  tags: [cpp_accessor]
 
 - name: Nightly TTNN university lab examples
   cmd: './build/test/ttnn/lab_examples/test_lab_eltwise_binary && ./build/test/ttnn/lab_examples/test_lab_multicast'
@@ -442,4 +441,4 @@
       timeout: 45
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
-  category: cpp_lab_examples
+  tags: [cpp_lab_examples]

--- a/tests/pipeline_reorg/train_perf_tests.yaml
+++ b/tests/pipeline_reorg/train_perf_tests.yaml
@@ -6,7 +6,8 @@
 #   skus: A mapping of SKU names to their configuration.
 #     Each SKU entry contains:
 #       timeout: The maximum allowed runtime for this job in minutes on that SKU.
-#   category: Identifier to group tests for selective execution.
+#   tags: Optional labels; the subcategories input on tt-train-tests.yaml is expanded to
+#     --include-tag flags to select on these.
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
 #
@@ -20,7 +21,7 @@
       timeout: 15
     bh_p150b_civ2:
       timeout: 15
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -31,7 +32,7 @@
       timeout: 15
     bh_p150b_civ2:
       timeout: 15
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -42,7 +43,7 @@
       timeout: 45
     bh_p150b_civ2:
       timeout: 35
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -53,7 +54,7 @@
       timeout: 5
     bh_p150b_civ2:
       timeout: 5
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -62,7 +63,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 40
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -71,7 +72,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 60
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -80,7 +81,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 90
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -92,7 +93,7 @@
       timeout: 15
     bh_p150b_civ2:
       timeout: 15
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -103,7 +104,7 @@
       timeout: 15
     bh_p150b_civ2:
       timeout: 15
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -112,7 +113,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 40
-  category: pretraining
+  tags: [pretraining]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -122,7 +123,7 @@
   skus:
     bh_p150b_civ2:
       timeout: 45
-  category: finetuning
+  tags: [finetuning]
   owner_id: U07K00A281X # Kevin Wu
   team: train
 
@@ -131,6 +132,6 @@
   skus:
     bh_p150b_civ2:
       timeout: 10
-  category: finetuning
+  tags: [finetuning]
   owner_id: U07K00A281X # Kevin Wu
   team: train

--- a/tests/pipeline_reorg/tt_cnn_unit_tests.yaml
+++ b/tests/pipeline_reorg/tt_cnn_unit_tests.yaml
@@ -8,10 +8,9 @@
 #       timeout: The maximum allowed runtime for this job in minutes on that SKU.
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
-#   category: Selector used by tt-metal-l2-nightly.yaml's additional_test_categories
-#     dispatch input. On dispatch the impl filters this matrix to entries whose
-#     category appears in the comma-separated list; on schedule the filter is
-#     bypassed and every entry runs.
+#   tags: Optional labels; --include-tag/--exclude-tag select on these. Used by
+#     tt-metal-l2-nightly.yaml's additional_test_categories dispatch input, expanded
+#     to repeated --include-tag flags by the impl workflow.
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
@@ -22,7 +21,7 @@
       timeout: 10
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
-  category: cnn_pipeline
+  tags: [cnn_pipeline]
 
 - name: tt-cnn builder unit tests
   cmd: 'pytest models/tt_cnn/tests/test_builder.py'
@@ -31,4 +30,4 @@
       timeout: 10
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
-  category: cnn_builder
+  tags: [cnn_builder]

--- a/tests/pipeline_reorg/ttnn_integration_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_integration_tests.yaml
@@ -8,10 +8,9 @@
 #       timeout: The maximum allowed runtime for this job in minutes on that SKU.
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
-#   category: Selector used by tt-metal-l2-nightly.yaml's additional_test_categories
-#     dispatch input. On dispatch the impl filters this matrix to entries whose
-#     category appears in the comma-separated list; on schedule the filter is
-#     bypassed and every entry runs.
+#   tags: Optional labels; --include-tag/--exclude-tag select on these. Used by
+#     tt-metal-l2-nightly.yaml's additional_test_categories dispatch input, expanded
+#     to repeated --include-tag flags by the impl workflow.
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
@@ -38,4 +37,4 @@
       timeout: 30
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
-  category: tutorials
+  tags: [tutorials]

--- a/tests/pipeline_reorg/ttsim_unit_tests.yaml
+++ b/tests/pipeline_reorg/ttsim_unit_tests.yaml
@@ -8,10 +8,9 @@
 #       timeout: The maximum allowed runtime for this job in minutes on that SKU.
 #   owner_id: The Slack user ID to notify on failure.
 #   team: The team that owns the test.
-#   category: Selector used by tt-metal-l2-nightly.yaml's additional_test_categories
-#     dispatch input. On dispatch the impl filters this matrix to entries whose
-#     category appears in the comma-separated list; on schedule the filter is
-#     bypassed and every entry runs.
+#   tags: Optional labels; --include-tag/--exclude-tag select on these. Used by
+#     tt-metal-l2-nightly.yaml's additional_test_categories dispatch input, expanded
+#     to repeated --include-tag flags by the impl workflow.
 
 # Entries use sim_<arch> SKUs (sim_wh_n150, sim_bh_p150) and run under
 # the ttsim simulator on ubuntu-latest; the impl invokes setup-ttsim.
@@ -29,4 +28,4 @@
 #       timeout: 15
 #   owner_id: U076Z1JJUQZ # Edwin Lee
 #   team: ttsim
-#   category: compute_fused
+#   tags: [compute_fused]


### PR DESCRIPTION
## Summary

This came out of reviewing #53591, which adds a `tags`/`--exclude-tag` denylist to `prepare_test_matrix.py` for build-incompatible entries (e.g. profiler tests needing `ENABLE_TRACY=ON`). L2 nightly already has a similarly-shaped but differently-implemented mechanism: a singular `category` field + an allowlist filter, duplicated as an identical jq step across 6 impl workflows (`ops-unit`, `ops-integration`, `ttnn-integration`, `tt-cnn-unit`, `ttsim-unit`, `tt-train`). Two parallel, differently-shaped filtering systems in the same repo seemed worth consolidating rather than adding a third.

This PR:
- Adds a single `tags` list field, replacing the old singular `category` string.
- Adds two composable flags to `prepare_test_matrix.py`, both applied **before SKU resolution** (so a filtered-out entry never leaks its SKUs under `ALL_SKUS_IN_TESTS`):
  - `--include-tag TAG` (repeatable, allowlist) — replaces the per-caller jq `additional_test_categories`/`category` filter.
  - `--exclude-tag TAG` (repeatable, denylist) — for entries a specific caller's build cannot run.
  - `--exclude-tag` is applied after `--include-tag`, so a caller can pass both.
- **Typo guard**: both flags are validated against the tags actually present in the loaded YAML file. An unrecognized tag is now a hard error (exit 1) instead of silently producing an empty or under-filtered matrix — this was the main gap prompting the unification, since today a typo'd category name in a dispatch input just quietly drops coverage.
- Migrates all 6 `category`-based consumers to `tags`, and collapses each impl workflow's separate "build matrix" + "filter categories" jq step into a single script invocation (the CSV `additional_test_categories`/`subcategories` input is expanded into repeated `--include-tag` flags inline). This removes ~6 duplicated copies of the same jq filtering logic.
- `ttsim-unit-tests-impl.yaml` also drops its `sim-libs` recompute workaround: since filtering now happens inside the script before `sim-libs` is derived, the script's native `sim-libs` output is already post-filter.

### Behavior note
Previously, an *empty* category string produced an empty matrix (the jq `contains` check matches nothing against an empty string). Now, no `--include-tag` flags at all means no filtering (keep everything) — this only changes behavior for a caller that explicitly passes an empty category list, which doesn't currently happen anywhere in the repo (checked all callers of the 6 impl workflows); every real caller either passes a schedule-time full list or gates the job with `if: additional_test_categories != ''`.

### Relationship to #53591
This PR does **not** touch `runtime_unit_tests.yaml`, `runtime_integration_tests.yaml`, or the `runtime-*-impl.yaml` workflows — that's #53591's scope and it's still open/unmerged, so I left it alone. Both PRs touch `prepare_test_matrix.py`; whichever merges first, the other will need a small rebase (swap `apply_tag_exclusions`/bare `--exclude-tag` for this PR's `apply_tag_filters`/`--include-tag`+`--exclude-tag`, same semantics either way).

## Test plan
- [x] `pytest .github/scripts/utils/test_prepare_test_matrix.py` — 64 passed (15 new tests covering include/exclude, repeatability, combined use, typo hard-fail in both directions, `ALL_SKUS_IN_TESTS` leak prevention, placeholder-file bypass, and a regression guard tying `ops_unit_tests.yaml`'s tags to `tt-metal-l2-nightly.yaml`'s hardcoded schedule-time category list).
- [x] Manually ran `prepare_test_matrix.py` against the real (migrated) `ops_unit_tests.yaml` with the exact category list `tt-metal-l2-nightly.yaml` passes on schedule — full matrix produced correctly.
- [x] Manually confirmed a typo'd tag (`convv` instead of `conv`) against the real file hard-fails with a clear error listing the valid tags.
- [ ] CI (opening as draft; badges will populate on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rli/unify-tag-category-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rli/unify-tag-category-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rli/unify-tag-category-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rli/unify-tag-category-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rli/unify-tag-category-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rli/unify-tag-category-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rli/unify-tag-category-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rli/unify-tag-category-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rli/unify-tag-category-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rli/unify-tag-category-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rli/unify-tag-category-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rli/unify-tag-category-filtering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rli/unify-tag-category-filtering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rli/unify-tag-category-filtering)