### PR TITLE
[Quasar] Fixes the latent BFD id allocator race described in tenstorrent/tt-llk#1678.

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -7,6 +7,7 @@
 #include "internal/firmware_common.h"
 #include "risc_common.h"
 #include <tensix.h>
+#include <cstdint>
 #include "hostdev/dev_msgs.h"
 
 #include "tools/profiler/kernel_profiler.hpp"
@@ -22,37 +23,38 @@
 #endif
 #include "tt-metalium/circular_buffer_constants.h"
 #include "api/kernel_thread_globals.h"
+#include "llk_bfd_alloc.h"  // ckernel::trisc::BfdAllocatorState (definition of bfd_state below)
 
 // clang-format on
 
 #if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-thread_local uint32_t wIndex __attribute__((used));
-thread_local uint32_t stackSize __attribute__((used));
-thread_local uint32_t sums[SUM_COUNT] __attribute__((used));
-thread_local uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+thread_local std::uint32_t wIndex __attribute__((used));
+thread_local std::uint32_t stackSize __attribute__((used));
+thread_local std::uint32_t sums[SUM_COUNT] __attribute__((used));
+thread_local std::uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 }  // namespace kernel_profiler
 #endif
 
-thread_local uint32_t hw_thread_idx __attribute__((used));
-thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
-thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
-thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
+thread_local std::uint32_t hw_thread_idx __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
-thread_local uint32_t rta_count __attribute__((used));
-thread_local uint32_t crta_count __attribute__((used));
+thread_local std::uint32_t rta_count __attribute__((used));
+thread_local std::uint32_t crta_count __attribute__((used));
 #endif
 
-uint8_t my_logical_x_ __attribute__((used));
-uint8_t my_logical_y_ __attribute__((used));
-uint8_t my_relative_x_ __attribute__((used));
-uint8_t my_relative_y_ __attribute__((used));
+std::uint8_t my_logical_x_ __attribute__((used));
+std::uint8_t my_logical_y_ __attribute__((used));
+std::uint8_t my_relative_x_ __attribute__((used));
+std::uint8_t my_relative_y_ __attribute__((used));
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
 #if defined(UCK_CHLKC_PACK)
 thread_local LocalDFBInterface g_dfb_interface[dfb::MAX_ACTIVE_DFBS_PACK] __attribute__((used));
-thread_local uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used));
+thread_local std::uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used));
 #else
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
 #endif
@@ -76,11 +78,16 @@ namespace ckernel {
 #undef PTR_CONST
 
 // Flip between 0 and 1 to keep state between kernel calls
-thread_local uint32_t cfg_state_id __attribute__((used)) = 0;
-thread_local uint32_t op_info_offset __attribute__((used)) = 0;
+thread_local std::uint32_t cfg_state_id __attribute__((used)) = 0;
+thread_local std::uint32_t op_info_offset __attribute__((used)) = 0;
 namespace trisc {
 // Flip between 0 and 1 to keep dest pointer between kernel calls
-thread_local uint32_t dest_register_offset __attribute__((used)) = 0;
+thread_local std::uint32_t dest_register_offset __attribute__((used)) = 0;
+// BFD id allocator state (Quasar). Defined for all TRISC images alongside dest_register_offset;
+// thread_local so the host-threaded emulation gives each TRISC its own allocator (tt-llk#1678).
+// initialized=false is set explicitly (not left to .tbss zeroing) so the first bfd_alloc runs
+// lazy-init, which sets next to the partition base and current[] to BFD_ID_INVALID.
+thread_local BfdAllocatorState bfd_state __attribute__((used)) = {.next = 0, .current = {}, .initialized = false};
 }  // namespace trisc
 
 tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE);
@@ -103,29 +110,30 @@ void init_sync_registers() {
 
 inline void enable_cc_stack() {
 #if defined(UCK_CHLKC_MATH)
-    constexpr uint32_t SFPENCC_IMM12_BOTH = 3;
-    constexpr uint32_t SFPENCC_MOD1_EI_RI = 10;
+    constexpr std::uint32_t SFPENCC_IMM12_BOTH = 3;
+    constexpr std::uint32_t SFPENCC_MOD1_EI_RI = 10;
     TTI_SFPENCC(SFPENCC_IMM12_BOTH, SFPENCC_MOD1_EI_RI);  // Enable all the SFPU lanes
 #endif
 }
 
-extern "C" uint32_t _start1() {
+extern "C" std::uint32_t _start1() {
     configure_csr();
     // Raw read: hw_thread_idx has not been filled yet, and do_thread_crt1() below zeroes the .tbss
     // it lives in, so caching it any earlier would just be discarded.
-    uint32_t hartid = internal_::read_hw_thread_idx();
-    uint32_t neo_id = internal_::get_neo_id();
-    uint32_t trisc_id = internal_::get_trisc_id();
-    volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
-                                                       ->subordinate_sync.map[hartid];  // first entry is for NCRISC
+    std::uint32_t hartid = internal_::read_hw_thread_idx();
+    std::uint32_t neo_id = internal_::get_neo_id();
+    std::uint32_t trisc_id = internal_::get_trisc_id();
+    volatile tt_l1_ptr std::uint8_t* const trisc_run =
+        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
+             ->subordinate_sync.map[hartid];  // first entry is for NCRISC
 
     if (neo_id == 0) {
-        extern uint32_t __ldm_data_start[];
+        extern std::uint32_t __ldm_data_start[];
         do_crt1(__ldm_data_start);
         (*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[MaxDMProcessorsPerCoreType + trisc_id] =
             SHARED_GLOBALS_READY_GO;
     }
-    extern uint32_t __ldm_tdata_init[];
+    extern std::uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
     // .tbss has been zeroed: cache this thread's hw index.
     internal_::init_hw_thread_idx();
@@ -163,15 +171,15 @@ extern "C" uint32_t _start1() {
         // RUN_SYNC_MSG_DONE is signaled.
         {
             DeviceZoneScopedMainN("TRISC-FW");
-            uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
+            std::uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
             launch_msg_t* launch_msg = &(mailboxes->launch[launch_msg_rd_ptr]);
 
             uintptr_t kernel_config_base = launch_msg->kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-            uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base +
-                                                                    launch_msg->kernel_config.local_cb_offset);
-            uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
+            std::uint32_t tt_l1_ptr* dfb_l1_base =
+                (std::uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
+            std::uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
 #if defined(UCK_CHLKC_PACK)
             const DfbPackerRemapperRange packer_rmp = setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
 #else
@@ -180,15 +188,15 @@ extern "C" uint32_t _start1() {
 #endif
 
             // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when PR #38124 is merged
-            rta_l1_base =
-                (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset +
-                                      MEM_L1_UNCACHED_BASE);
-            crta_l1_base =
-                (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].crta_offset +
-                                      MEM_L1_UNCACHED_BASE);
+            rta_l1_base = (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                                     launch_msg->kernel_config.rta_offset[hartid].rta_offset +
+                                                     MEM_L1_UNCACHED_BASE);
+            crta_l1_base = (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                                      launch_msg->kernel_config.rta_offset[hartid].crta_offset +
+                                                      MEM_L1_UNCACHED_BASE);
             sem_l1_base[ProgrammableCoreType::TENSIX] =
-                (uint32_t tt_l1_ptr*)(kernel_config_base +
-                                      launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
+                (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                           launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
             // Initialize RTA count from L1 memory
             // Set to 0 if: 1. offset is sentinel (no args set)
@@ -220,7 +228,7 @@ extern "C" uint32_t _start1() {
             uintptr_t kernel_lma =
                 (kernel_config_base +
                  launch_msg->kernel_config.kernel_text_offset[hartid]);  // TODO verify if depends on kernel
-            auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
+            auto stack_free = reinterpret_cast<std::uint32_t (*)()>(kernel_lma)();
             record_stack_usage(stack_free);
             WAYPOINT("D");
             DEVICE_PRINT_KERNEL_FINISHED();
@@ -231,10 +239,10 @@ extern "C" uint32_t _start1() {
 #endif
 
             // Signal completion
-            DPRINT("SIGNALING COMPLETION {:x}\n", (uint32_t)*trisc_run);
+            DPRINT("SIGNALING COMPLETION {:x}\n", (std::uint32_t)*trisc_run);
             tensix_sync();
         }
         *trisc_run = RUN_SYNC_MSG_DONE;
-        DPRINT("COMPLETION SIGNED OFF {:x}\n", (uint32_t)*trisc_run);
+        DPRINT("COMPLETION SIGNED OFF {:x}\n", (std::uint32_t)*trisc_run);
     }
 }

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -85,8 +85,8 @@ namespace trisc {
 thread_local std::uint32_t dest_register_offset __attribute__((used)) = 0;
 // BFD id allocator state (Quasar). Defined for all TRISC images alongside dest_register_offset;
 // thread_local so the host-threaded emulation gives each TRISC its own allocator (tt-llk#1678).
-// initialized=false is set explicitly (not left to .tbss zeroing) so the first bfd_alloc runs
-// lazy-init, which sets next to the partition base and current[] to BFD_ID_INVALID.
+// do_thread_crt1 clears this per-thread state before first use; bfd_alloc then sets next to the
+// partition base and current[] to BFD_ID_INVALID on the first allocation.
 thread_local BfdAllocatorState bfd_state __attribute__((used)) = {.next = 0, .current = {}, .initialized = false};
 }  // namespace trisc
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
@@ -113,8 +113,8 @@ struct BfdAllocatorState
     bool initialized;                                                    // lazy init: globals are bss zero-init only, no dynamic init on device
 };
 
-// One instance per TRISC image. thread_local so the host-threaded emulation gives each Neo's
-// TRISC its own allocator, matching the per-TRISC physical partitioning of the BFD table. A
+// One instance per hardware TRISC thread (one per Neo and TRISC role). thread_local gives each Neo's
+// TRISC its own allocator, matching the per-TRISC partitioning of each Neo's BFD table. A
 // single shared instance races the id allocator two ways when num_threads > 1 (see tt-llk#1678):
 // an unfenced read-modify-write on next hands the same id to two threads, and the unfenced lazy
 // init lets one role hand out ids from another role's partition. Mirrors trisc::dest_register_offset:

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
@@ -113,8 +113,18 @@ struct BfdAllocatorState
     bool initialized;                                                    // lazy init: globals are bss zero-init only, no dynamic init on device
 };
 
-// One instance per TRISC binary (each TRISC compiles its own image with COMPILE_FOR_TRISC).
-inline BfdAllocatorState bfd_state; // zero-init; next initialized lazily to the partition base
+// One instance per TRISC image. thread_local so the host-threaded emulation gives each Neo's
+// TRISC its own allocator, matching the per-TRISC physical partitioning of the BFD table. A
+// single shared instance races the id allocator two ways when num_threads > 1 (see tt-llk#1678):
+// an unfenced read-modify-write on next hands the same id to two threads, and the unfenced lazy
+// init lets one role hand out ids from another role's partition. Mirrors trisc::dest_register_offset:
+// ENV_LLK_INFRA (standalone LLK infra, no firmware TU) uses a plain static; the metal build
+// declares it extern thread_local and defines it in firmware (tt_metal/hw/firmware/src/tt-2xx/trisc.cc).
+#ifdef ENV_LLK_INFRA
+static BfdAllocatorState bfd_state; // zero-init; next initialized lazily to the partition base
+#else
+extern thread_local BfdAllocatorState bfd_state; // defined in tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+#endif
 
 /**
  * @brief Allocate the next buffer descriptor id for this thread's partition and record it as the


### PR DESCRIPTION
bfd_state was a plain inline global, so in the host-threaded emulation a single allocator instance was shared across every Neo's TRISC and across TRISC roles. With num_threads > 1 this races two ways (tt-llk#1678):

  1. Unfenced read-modify-write on bfd_state.next hands the same id to two threads, which then program different descriptor table entries under it.
  2. Unfenced lazy init lets one role (e.g. TRISC2) observe initialized==true with next still in another role's range, handing out ids from TRISC0's partition and clobbering unpack descriptors.

Make bfd_state `inline thread_local` so each compute thread gets its own allocator, matching the per-TRISC physical partitioning of the BFD table. Mirrors the trisc::dest_register_offset pattern but stays header-local, so it is correct in both the emulation and ENV_LLK_INFRA builds without touching firmware. BfdAllocatorState is trivially default-constructible, so this uses static thread-init (no guard variable / __cxa_thread_atexit).

### PR Category
[#https://github.com/tenstorrent/tt-llk/issues/1678](https://github.com/tenstorrent/tt-llk/issues/1678)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/bfd-state-thread-local-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/bfd-state-thread-local-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/bfd-state-thread-local-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/bfd-state-thread-local-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/bfd-state-thread-local-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/bfd-state-thread-local-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/bfd-state-thread-local-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/bfd-state-thread-local-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/bfd-state-thread-local-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/bfd-state-thread-local-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/bfd-state-thread-local-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/bfd-state-thread-local-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/bfd-state-thread-local-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/bfd-state-thread-local-1678)