### PR TITLE
Include libtracy.so* in wheel lib_patterns to fix auditwheel repair failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["ls", "-hal", "runtime"], cwd=source_dir, env=build_env)
 
         # Copy needed C++ shared libraries and runtime assets into wheel (sfpi, FW etc)
-        lib_patterns = ["_ttnn.so", "_ttnncpp.so", "libtt_metal.so", "libtt-umd.so*", "libtt_stl.so"]
+        lib_patterns = ["_ttnn.so", "_ttnncpp.so", "libtt_metal.so", "libtt-umd.so*", "libtt_stl.so", "libtracy.so*"]
         runtime_patterns = [
             "hw/**/*",
         ]


### PR DESCRIPTION
## Problem

Wheel builds fail at the `auditwheel repair` step:

```
ValueError: Cannot repair wheel, because required library "libtracy.so.0.13.3" could not be located
```

Failing run: https://github.com/tenstorrent/tt-metal/actions/runs/32316451630/job/96269730051

## Root cause

Commit 502a0c61d3fc303a7d0cfa130a4f6cf010ce2a7b removed the absolute `${PROJECT_BINARY_DIR}/lib` entry from `INSTALL_RPATH` on the `tt_metal`/`ttnncpp`/`ttnn` targets, leaving only relocatable `$ORIGIN`-relative entries (`$ORIGIN/build/lib;$ORIGIN`). That change is correct and is intentionally **not** touched here.

The side effect: `TracyClient` (`libtracy.so.0.13.3`) is linked unconditionally as `DT_NEEDED` into `libtt_metal.so`/`_ttnn.so` — even with `CIBW_ENABLE_TRACY=OFF`, where it's built as a small no-op stub (see the comment block in `tt_metal/third_party/CMakeLists.txt` documenting exactly this class of problem). However, `setup.py`'s `lib_patterns` list — which selects the built shared libraries copied into the wheel's `build/lib` directory before `auditwheel repair` runs — did not include libtracy. Previously, auditwheel could still resolve it through the now-removed absolute build-dir RPATH entry pointing into the live build tree in the CI container. With only `$ORIGIN`-relative entries and no copy of libtracy at the location `$ORIGIN/build/lib` resolves to inside the wheel, auditwheel fails.

## Fix

Add `"libtracy.so*"` to `lib_patterns` in `setup.py` (glob-matched via `copy_tree_with_patterns` / `glob.glob`, same convention as the existing versioned `"libtt-umd.so*"` entry). The library is then already present at the wheel-relative path `$ORIGIN/build/lib` resolves to, so both `auditwheel repair` and the runtime dynamic linker find it.

This packaging-side fix is preferred over reverting the RPATH change: reintroducing `${PROJECT_BINARY_DIR}` into `INSTALL_RPATH` would embed a non-relocatable build-tree path in installed binaries, which 502a0c61 deliberately fixed. No CMakeLists.txt or RPATH settings are modified by this PR.

## Testing

Not build-tested in this environment — a full wheel build requires the complete tt-metal toolchain and hours of compilation. The change is a one-line addition to an existing glob list; reviewer should confirm the wheel-build CI job passes.

## Attribution

Investigated and fixed by an AI agent (BrAIn/Fable) at Wilder's request. Please have a human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/wheel-libtracy-auditwheel-repair)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/wheel-libtracy-auditwheel-repair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/wheel-libtracy-auditwheel-repair)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/wheel-libtracy-auditwheel-repair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/wheel-libtracy-auditwheel-repair)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/wheel-libtracy-auditwheel-repair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/wheel-libtracy-auditwheel-repair)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/wheel-libtracy-auditwheel-repair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/wheel-libtracy-auditwheel-repair)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/wheel-libtracy-auditwheel-repair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/wheel-libtracy-auditwheel-repair)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/wheel-libtracy-auditwheel-repair)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/wheel-libtracy-auditwheel-repair)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/wheel-libtracy-auditwheel-repair)