### PR TITLE
Bug fix: DS Prefill shared fixes — expert-cache dtype, KVPE comparison, reference rope

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -254,6 +254,15 @@ class PrefillModelAdapter(ABC):
     def reference_moe_cls(self) -> Optional[type]:
         return None
 
+    @property
+    def reference_rotary_cls(self) -> Optional[type]:
+        """Rope module a standalone reference attention needs its ``(cos, sin)`` from.
+
+        Only needed for references from transformers >= 5, which compute rope at the MODEL level and
+        pass ``position_embeddings`` down, so an attention used on its own has to be handed them.
+        The vendored DeepSeek/Kimi references build rope internally and leave this None."""
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Model registry

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -163,7 +163,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     # === Path 2: Cold Cache (build + load) ===
     init_checker(CACHE_DIR)
     assert not TtMoe.check_cache_complete(
-        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip
+        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip, routed_expert_weights_dtype=ttnn.bfloat16
     ), "Cache should be empty before build"
 
     logger.info(f"Building cache to {CACHE_DIR}...")
@@ -186,7 +186,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
 
     init_checker(CACHE_DIR)
     assert TtMoe.check_cache_complete(
-        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip
+        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip, routed_expert_weights_dtype=ttnn.bfloat16
     ), "Cache should be complete after build"
 
     logger.info("Path 2: Creating TtMoe from cold cache...")

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -207,7 +207,7 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
     # === Path 2: Cold Cache ===
     init_checker(CACHE_DIR)
     assert not TtRoutedExpert.check_cache_complete(
-        CACHE_DIR, "routed_expert", experts_per_chip
+        CACHE_DIR, "routed_expert", experts_per_chip, weights_dtype
     ), "Cache should be empty before build"
 
     logger.info(f"Building cache to {CACHE_DIR}")
@@ -225,7 +225,7 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
 
     init_checker(CACHE_DIR)
     assert TtRoutedExpert.check_cache_complete(
-        CACHE_DIR, "routed_expert", experts_per_chip
+        CACHE_DIR, "routed_expert", experts_per_chip, weights_dtype
     ), "Cache should be complete after build"
 
     profiler.start("cold_load")
@@ -289,3 +289,54 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"
+
+
+# Host-only, pure filename logic. as_tensor stamps the requested dtype into the tensorbin name, so a
+# cache built at bfloat4_b must read as INCOMPLETE for a bfloat8_b request -- otherwise the empty
+# placeholder is loaded as the weights and the model reports a cache hit while running on nothing.
+# Same reasoning as TtIndexer.check_cache_complete.
+def _touch_expert_bin(cache_dir, prefix, local_idx, proj, dtype, layout=ttnn.TILE_LAYOUT):
+    # Reproduce the exact name as_tensor writes: core.py appends `_dtype_{dtype.name}_layout_{layout.name}`.
+    (cache_dir / f"{prefix}.local_{local_idx}_{proj}_dtype_{dtype.name}_layout_{layout.name}.tensorbin").touch()
+
+
+def test_routed_expert_check_cache_complete_is_dtype_aware(tmp_path):
+    from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
+
+    prefix, experts_per_chip = "routed_expert", 2
+
+    def write(dtype):
+        for f in tmp_path.glob("*.tensorbin"):
+            f.unlink()
+        for idx in range(experts_per_chip):
+            for proj in ("gate", "up", "down"):
+                _touch_expert_bin(tmp_path, prefix, idx, proj, dtype)
+        init_checker(tmp_path)  # re-scan: the checker caches the directory listing
+
+    # A complete bf4 cache is complete for bf4 ...
+    write(ttnn.bfloat4_b)
+    assert TtRoutedExpert.check_cache_complete(
+        tmp_path, prefix, experts_per_chip, ttnn.bfloat4_b
+    ), "bfloat4_b cache must be complete for a bfloat4_b request"
+
+    # ... and NOT for bf8, which is the whole point: the bf8 tensorbins do not exist.
+    assert not TtRoutedExpert.check_cache_complete(
+        tmp_path, prefix, experts_per_chip, ttnn.bfloat8_b
+    ), "bfloat4_b-only cache must fail a bfloat8_b completeness check"
+
+    # A superset cache (both dtypes on disk, as a regenerated cache carries) satisfies either.
+    for idx in range(experts_per_chip):
+        for proj in ("gate", "up", "down"):
+            _touch_expert_bin(tmp_path, prefix, idx, proj, ttnn.bfloat8_b)
+    init_checker(tmp_path)
+    for dtype in (ttnn.bfloat4_b, ttnn.bfloat8_b):
+        assert TtRoutedExpert.check_cache_complete(
+            tmp_path, prefix, experts_per_chip, dtype
+        ), f"superset cache must stay complete for {dtype.name}"
+
+    # One missing projection at the requested dtype is still incomplete.
+    (tmp_path / f"{prefix}.local_1_down_dtype_{ttnn.bfloat8_b.name}_layout_{ttnn.TILE_LAYOUT.name}.tensorbin").unlink()
+    init_checker(tmp_path)
+    assert not TtRoutedExpert.check_cache_complete(
+        tmp_path, prefix, experts_per_chip, ttnn.bfloat8_b
+    ), "a missing projection at the requested dtype must read as incomplete"

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -36,6 +36,15 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
+        # TP=1. Regression row: ttnn.all_gather TT_FATALs when the cluster axis has length 1 rather
+        # than degenerating to a copy, so this module died on any single-column mesh. Nothing
+        # exercised that before, which is why it went unnoticed. One device, so it is nearly free.
+        pytest.param(
+            (1, 1),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 1), topology="linear"),
+            id="tp1",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -11,6 +11,7 @@ bundled reference return `None` and the comparison is skipped at the call
 site.
 """
 
+import inspect
 from copy import copy, deepcopy
 from typing import Optional
 
@@ -119,14 +120,32 @@ def run_reference_mla(
     attn.load_state_dict(weights, strict=False)
     attn = attn.eval().to(torch.bfloat16)
     causal = torch.triu(torch.full((q_len, q_len), float("-inf"), dtype=hidden_states.dtype), diagonal=1)
-    with torch.no_grad():
-        out = attn(
-            hidden_states=hidden_states,
-            attention_mask=causal[None, None],
-            position_ids=position_ids,
-            past_key_value=None,
-            use_cache=False,
+    # Bind by signature: vendored DeepSeek/Kimi attentions take `past_key_value` and derive rope
+    # internally; transformers >= 5 takes `past_key_values` and requires `position_embeddings`. The
+    # wrong cache name lands silently in **kwargs and captures no KV.
+    fwd_params = inspect.signature(attn.forward).parameters
+    kwargs = {
+        "hidden_states": hidden_states,
+        "attention_mask": causal[None, None],
+        "position_ids": position_ids,
+        "use_cache": False,
+    }
+    kwargs["past_key_values" if "past_key_values" in fwd_params else "past_key_value"] = None
+    if "position_embeddings" in fwd_params:
+        rotary_cls = getattr(variant, "reference_rotary_cls", None)
+        assert rotary_cls is not None, (
+            f"{type(attn).__name__} requires position_embeddings but {variant.name!r} exposes no "
+            "reference_rotary_cls to build (cos, sin) from"
         )
+        # Built from the CONFIG, not from the model: a reference instantiated in bf16 carries a bf16
+        # `inv_freq` buffer, and .float() cannot recover the lost bits. The resulting ~4.4e-4
+        # frequency error is a phase error that grows with position.
+        rotary = rotary_cls(config=config).float()
+        with torch.no_grad():
+            cos, sin = rotary(hidden_states.float(), position_ids)
+            kwargs["position_embeddings"] = (cos.to(hidden_states.dtype), sin.to(hidden_states.dtype))
+    with torch.no_grad():
+        out = attn(**kwargs)
     # DeepseekV3Attention returns (out, attn_weights, past_kv); Kimi-K3's KimiMLAAttention returns a
     # bare tensor (upstream shape). Accept either.
     return out[0] if isinstance(out, tuple) else out

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -23,7 +23,7 @@ from loguru import logger
 from transformers import DynamicCache
 
 import ttnn
-from models.common.utility_functions import hf_cache_layer_kv, is_blackhole, profiler
+from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import pretrained_mla_weights
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
@@ -55,7 +55,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     PROMPT_5K_PATH,
     PROMPT_25K_PATH,
     create_hf_model,
-    derive_mla_kvpe,
+    decoder_layer_kwargs,
     extract_layer_state_dict,
     get_4d_causal_mask,
     load_and_compute_layer_by_layer,
@@ -286,34 +286,18 @@ def run_model(
             position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
             attention_mask = get_4d_causal_mask(torch.ones(1, isl_total), causal_only=True).to(torch.bfloat16)
             ref_cache = DynamicCache()
+            # Bound to the layer's own signature, and reused below for the KVPE line.
+            layer_kwargs = decoder_layer_kwargs(
+                hf_model.layers[layer_idx], hf_model, torch_input, attention_mask, position_ids, ref_cache
+            )
             with torch.no_grad():
-                layer_out = hf_model.layers[layer_idx](
-                    torch_input,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
-                    past_key_value=ref_cache,
-                    use_cache=True,
-                )
+                layer_out = hf_model.layers[layer_idx](torch_input, **layer_kwargs)
                 torch_output = layer_out[0]
             logger.info(f"Torch reference output shape: {torch_output.shape}")
             if ref_cache is not None:
-                ref_kvpe = hf_cache_layer_kv(ref_cache, layer_idx)[0]
-                # The vendored MLAReference caches the COMPRESSED MLA line -- [b, 1, seq,
-                # kv_lora_rank + qk_rope_head_dim] -- which is exactly what the device stores. A
-                # stock transformers attention (e.g. Mistral4Attention) caches EXPANDED per-head
-                # keys instead, so the shapes do not correspond at all and comp_pcc dies on a size
-                # mismatch. Rebuild the compressed line from the layer's own modules in that case;
-                # it is the same two ops the reference performs, not a re-implementation of
-                # attention.
-                expected_last = config.kv_lora_rank + config.qk_rope_head_dim
-                if ref_kvpe.shape[-1] != expected_last:
-                    logger.info(
-                        f"Reference caches expanded KV (last dim {ref_kvpe.shape[-1]} != {expected_last}); "
-                        "deriving the compressed MLA KVPE line from the layer instead"
-                    )
-                    ref_kvpe = derive_mla_kvpe(
-                        hf_model.layers[layer_idx], torch_input, layer_kwargs.get("position_embeddings"), config
-                    )
+                ref_kvpe = reference_kvpe_for_layer(
+                    hf_model.layers[layer_idx], layer_idx, torch_input, layer_kwargs, ref_cache, config
+                )
                 logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
             profiler.end("torch_reference")
 

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -55,6 +55,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     PROMPT_5K_PATH,
     PROMPT_25K_PATH,
     create_hf_model,
+    derive_mla_kvpe,
     extract_layer_state_dict,
     get_4d_causal_mask,
     load_and_compute_layer_by_layer,
@@ -297,6 +298,22 @@ def run_model(
             logger.info(f"Torch reference output shape: {torch_output.shape}")
             if ref_cache is not None:
                 ref_kvpe = hf_cache_layer_kv(ref_cache, layer_idx)[0]
+                # The vendored MLAReference caches the COMPRESSED MLA line -- [b, 1, seq,
+                # kv_lora_rank + qk_rope_head_dim] -- which is exactly what the device stores. A
+                # stock transformers attention (e.g. Mistral4Attention) caches EXPANDED per-head
+                # keys instead, so the shapes do not correspond at all and comp_pcc dies on a size
+                # mismatch. Rebuild the compressed line from the layer's own modules in that case;
+                # it is the same two ops the reference performs, not a re-implementation of
+                # attention.
+                expected_last = config.kv_lora_rank + config.qk_rope_head_dim
+                if ref_kvpe.shape[-1] != expected_last:
+                    logger.info(
+                        f"Reference caches expanded KV (last dim {ref_kvpe.shape[-1]} != {expected_last}); "
+                        "deriving the compressed MLA KVPE line from the layer instead"
+                    )
+                    ref_kvpe = derive_mla_kvpe(
+                        hf_model.layers[layer_idx], torch_input, layer_kwargs.get("position_embeddings"), config
+                    )
                 logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
             profiler.end("torch_reference")
 

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -59,6 +59,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     extract_layer_state_dict,
     get_4d_causal_mask,
     load_and_compute_layer_by_layer,
+    reference_kvpe_for_layer,
     tokenize_prompt_to_isl,
 )
 
@@ -292,7 +293,7 @@ def run_model(
             )
             with torch.no_grad():
                 layer_out = hf_model.layers[layer_idx](torch_input, **layer_kwargs)
-                torch_output = layer_out[0]
+                torch_output = layer_out[0] if isinstance(layer_out, (tuple, list)) else layer_out
             logger.info(f"Torch reference output shape: {torch_output.shape}")
             if ref_cache is not None:
                 ref_kvpe = reference_kvpe_for_layer(

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -61,6 +61,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     load_and_compute_layer_by_layer,
     load_debug_trace,
     load_reference_cache,
+    mla_kvpe_width,
     save_reference_cache,
     slice_debug_trace,
     slice_non_padded,
@@ -255,7 +256,10 @@ def run_model(
         n_routed_experts=n_routed_experts,
         padding_side=padding_side,
     )
-    ref_cache_exists = check_reference_cache_exists(variant, cache_key) if (pcc_validation and trace is None) else False
+    # A cache written before the compressed-line fix holds expanded per-head keys, and without the
+    # width check still reports as reusable.
+    kvpe_width = mla_kvpe_width(config)
+    ref_cache_exists = pcc_validation and trace is None and check_reference_cache_exists(variant, cache_key, kvpe_width)
 
     logger.info(
         f"Cache status: TTNN={ttnn_cache_complete}, Trace={'YES' if trace else 'NO'}, Reference={ref_cache_exists}"

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_shared_prefill_fixes.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_shared_prefill_fixes.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only regression tests for the shared prefill fixes. No device, no weights, milliseconds.
+
+Each test fails on the code as it stood before its named commit. Both bugs are silent -- they produce
+a plausible wrong number rather than an error -- so each test also asserts that the *pre-fix*
+behaviour is detectably wrong, otherwise the test could pass for the wrong reason.
+"""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.mla.mla import ttMLA
+from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
+    decoder_layer_kwargs,
+    layer_wants_position_embeddings,
+    reference_position_embeddings,
+    reference_rope,
+)
+
+
+def test_reference_rope_is_fp32_even_when_the_model_is_bf16():
+    """Guards `fix(mla): build the reference rope from the config, not the model`.
+
+    A reference instantiated in bf16 carries a bf16 ``inv_freq`` BUFFER, and ``.float()`` cannot
+    recover bits already gone (0.75 where the true value is 0.7498942). The residue is a
+    per-dimension frequency error, i.e. a phase error that grows LINEARLY with position -- harmless
+    at short prompts, ruinous at long ones. Rebuilding from the config in fp32 is the only fix.
+    """
+    transformers = pytest.importorskip("transformers")
+    from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
+
+    cfg = transformers.LlamaConfig(
+        hidden_size=256, num_attention_heads=4, num_hidden_layers=1, rope_theta=10000.0, max_position_embeddings=65536
+    )
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = cfg
+            self.rotary_emb = LlamaRotaryEmbedding(config=cfg)
+
+    model = _Model().to(torch.bfloat16)  # what create_hf_model does
+    assert model.rotary_emb.inv_freq.dtype == torch.bfloat16, "precondition: the buffer must be bf16"
+
+    # Far enough out that a ~4.4e-4 relative frequency error is visible. The error is proportional to
+    # position, so a short prompt would hide it -- which is exactly how this survived.
+    pos = torch.tensor([[40000]], dtype=torch.long)
+    hidden = torch.zeros(1, 1, cfg.hidden_size, dtype=torch.bfloat16)
+
+    cos_fix, sin_fix = reference_rope(model, hidden, pos)
+
+    # Ground truth: an independently constructed fp32 table.
+    gt = LlamaRotaryEmbedding(config=cfg).float()
+    with torch.no_grad():
+        cos_gt, sin_gt = gt(torch.zeros(1, 1, cfg.hidden_size), pos)
+
+    err_fix = max((cos_fix - cos_gt).abs().max().item(), (sin_fix - sin_gt).abs().max().item())
+    assert err_fix < 1e-5, f"reference_rope should match an fp32 table; max err {err_fix:.2e}"
+
+    # The pre-fix path, asserted to be detectably wrong so this test cannot pass vacuously.
+    old = deepcopy(model.rotary_emb).float()
+    with torch.no_grad():
+        cos_old, sin_old = old(torch.zeros(1, 1, cfg.hidden_size), pos)
+    err_old = max((cos_old - cos_gt).abs().max().item(), (sin_old - sin_gt).abs().max().item())
+    assert err_old > 1e-3, (
+        f"the deepcopy(bf16).float() path should be visibly wrong at position {pos.item()} "
+        f"(got {err_old:.2e}); if this fires, the test has stopped discriminating"
+    )
+
+
+@pytest.mark.parametrize(
+    "in0_block_w, kt, fits",
+    [
+        # DeepSeek's tuning: Kt = 7168/4/32 = 56, and 56 % 14 == 0.
+        (14, 56, True),
+        # The same tuned row reached by a model whose Kt is 32 (hidden 4096 / tp 4 / 32). 32 % 14 != 0,
+        # so the matmul TT_FATALs: "Kt (32) must be divisible by in0_block_w (14)".
+        (14, 32, False),
+        (8, 32, True),
+        # Kt = 64 (tp 2) divides by 8, so the config is ACCEPTED -- the guard's known gap: another
+        # model's tiling then applies silently. Pinned here so a future change to that behaviour is
+        # a deliberate decision rather than a surprise.
+        (8, 64, True),
+    ],
+)
+def test_tuned_matmul_cfg_is_rejected_when_block_width_does_not_divide_k(in0_block_w, kt, fits):
+    """Guards `perf(mla): guard tuned matmul configs against the wrong K`.
+
+    `MLA_MATMUL_CONFIG` is keyed on (weight_name, seq_len_local) and knows nothing about the
+    variant's dimensions, so a config tuned for one model is applied to another with a different K.
+    Rejecting a non-dividing block width degrades to the generic program config -- untuned, so
+    possibly slower -- instead of dying.
+    """
+    stub = SimpleNamespace(q_a_proj_weight=SimpleNamespace(shape=(kt * ttnn.TILE_SIZE, 1024)))
+    cfg = {"program_config": SimpleNamespace(in0_block_w=in0_block_w)}
+    assert ttMLA._cfg_fits_weight(stub, cfg, "q_a_proj") is fits
+
+
+def test_tuned_matmul_cfg_kept_when_there_is_nothing_to_check_against():
+    """A config with no in0_block_w, or a weight that is absent, must not be rejected."""
+    stub = SimpleNamespace(q_a_proj_weight=SimpleNamespace(shape=(1024, 1024)))
+    assert ttMLA._cfg_fits_weight(stub, {"program_config": SimpleNamespace()}, "q_a_proj") is True
+    assert ttMLA._cfg_fits_weight(SimpleNamespace(), {"program_config": SimpleNamespace(in0_block_w=14)}, "q_a_proj")
+
+
+def test_a_layer_that_computes_rope_internally_needs_no_rotary_emb(expect_error):
+    """Guards the DeepSeek regression: an unconditional rope build breaks references that never
+    wanted one.
+
+    A transformers-5.x layer requires the caller to pass ``(cos, sin)``; a vendored layer such as
+    DeepSeekV3's computes rope from ``position_ids`` itself and its model exposes no top-level
+    ``rotary_emb``. Building the table for everything asserted with
+    "DeepseekV3Model exposes no rotary_emb to build rope from" on precisely the models that did not
+    need it, so the predicate must come from the layer's SIGNATURE, not from the model's attributes.
+    """
+
+    class _OldStyleLayer(torch.nn.Module):
+        def forward(self, hidden_states, attention_mask=None, position_ids=None, past_key_value=None, use_cache=True):
+            raise AssertionError("not called")
+
+    class _NewStyleLayer(torch.nn.Module):
+        def forward(
+            self, hidden_states, attention_mask=None, position_ids=None, past_key_values=None, position_embeddings=None
+        ):
+            raise AssertionError("not called")
+
+    old_layer, new_layer = _OldStyleLayer(), _NewStyleLayer()
+    assert layer_wants_position_embeddings(old_layer) is False
+    assert layer_wants_position_embeddings(new_layer) is True
+
+    # A model with NO rotary_emb, as DeepSeekV3Model has none. Binding kwargs for the old-style
+    # layer must not reach reference_rope at all -- if it does, the assert there fires.
+    class _ModelWithoutRotary(torch.nn.Module):
+        pass
+
+    kwargs = decoder_layer_kwargs(
+        old_layer,
+        _ModelWithoutRotary(),
+        torch.zeros(1, 4, 8),
+        None,
+        torch.arange(4).unsqueeze(0),
+        None,
+    )
+    assert "position_embeddings" not in kwargs, "an old-style layer must not be handed position_embeddings"
+
+    # The regression itself: the run-level hoist must return None here, not raise. Before the fix it
+    # called reference_rope unconditionally and died on the missing rotary_emb.
+    model = _ModelWithoutRotary()
+    model.layers = [old_layer]
+    assert reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1) is None
+
+    # ...and a layer that DOES want them still gets a table built (here: absent rotary -> loud).
+    model.layers = [new_layer]
+    with expect_error(AssertionError, "exposes no rotary_emb"):
+        reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1)

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_shared_prefill_fixes.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_shared_prefill_fixes.py
@@ -110,6 +110,22 @@ def test_tuned_matmul_cfg_kept_when_there_is_nothing_to_check_against():
     assert ttMLA._cfg_fits_weight(SimpleNamespace(), {"program_config": SimpleNamespace(in0_block_w=14)}, "q_a_proj")
 
 
+class _OldStyleLayer(torch.nn.Module):
+    """A vendored DeepSeek/Kimi/GLM-shaped layer: singular cache kwarg, rope computed internally."""
+
+    def forward(self, hidden_states, attention_mask=None, position_ids=None, past_key_value=None, use_cache=True):
+        raise AssertionError("not called")
+
+
+class _NewStyleLayer(torch.nn.Module):
+    """A transformers-5.x layer: plural cache kwarg, and rope must be handed in."""
+
+    def forward(
+        self, hidden_states, attention_mask=None, position_ids=None, past_key_values=None, position_embeddings=None
+    ):
+        raise AssertionError("not called")
+
+
 def test_a_layer_that_computes_rope_internally_needs_no_rotary_emb(expect_error):
     """Guards the DeepSeek regression: an unconditional rope build breaks references that never
     wanted one.
@@ -120,16 +136,6 @@ def test_a_layer_that_computes_rope_internally_needs_no_rotary_emb(expect_error)
     "DeepseekV3Model exposes no rotary_emb to build rope from" on precisely the models that did not
     need it, so the predicate must come from the layer's SIGNATURE, not from the model's attributes.
     """
-
-    class _OldStyleLayer(torch.nn.Module):
-        def forward(self, hidden_states, attention_mask=None, position_ids=None, past_key_value=None, use_cache=True):
-            raise AssertionError("not called")
-
-    class _NewStyleLayer(torch.nn.Module):
-        def forward(
-            self, hidden_states, attention_mask=None, position_ids=None, past_key_values=None, position_embeddings=None
-        ):
-            raise AssertionError("not called")
 
     old_layer, new_layer = _OldStyleLayer(), _NewStyleLayer()
     assert layer_wants_position_embeddings(old_layer) is False
@@ -160,3 +166,26 @@ def test_a_layer_that_computes_rope_internally_needs_no_rotary_emb(expect_error)
     model.layers = [new_layer]
     with expect_error(AssertionError, "exposes no rotary_emb"):
         reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1)
+
+
+def test_old_style_layer_kwargs_match_the_explicit_call_they_replaced():
+    """`decoder_layer_kwargs` now binds the reference call in test_prefill_block for EVERY model, so
+    on a vendored layer it must still reproduce the explicit call it replaced -- a silent drift here
+    moves the reference those models' PCC rows are judged against.
+    """
+    cache = object()
+    mask = torch.zeros(1, 1, 4, 4)
+    pos = torch.arange(4).unsqueeze(0)
+    kwargs = decoder_layer_kwargs(_OldStyleLayer(), None, torch.zeros(1, 4, 8), mask, pos, cache)
+
+    assert set(kwargs) == {"attention_mask", "position_ids", "past_key_value", "use_cache"}
+    assert kwargs["past_key_value"] is cache, "the vendored layers take the SINGULAR cache kwarg"
+    assert kwargs["use_cache"] is True
+    assert kwargs["attention_mask"] is mask and kwargs["position_ids"] is pos
+
+    # The plural branch, which nothing else covers: a transformers-5.x layer must get the cache under
+    # `past_key_values`, or the KV lands in **kwargs and is silently never captured.
+    plural = decoder_layer_kwargs(
+        _NewStyleLayer(), None, torch.zeros(1, 4, 8), mask, pos, cache, position_embeddings=(mask, mask)
+    )
+    assert "past_key_values" in plural and plural["past_key_values"] is cache

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -715,7 +715,43 @@ class ttMLA:
         Returns None when no tuned config applies (caller falls back to defaults)."""
         if not is_blackhole():
             return None
-        return self._select_cfg(self.mm_configs[weight_name].get(seq_len_local))
+        cfg = self._select_cfg(self.mm_configs[weight_name].get(seq_len_local))
+        if cfg is not None and not self._cfg_fits_weight(cfg, weight_name):
+            return None
+        return cfg
+
+    def _cfg_fits_weight(self, cfg: dict, weight_name: str) -> bool:
+        """Reject a tuned config whose in0_block_w does not divide THIS weight's Kt.
+
+        The tuned table is keyed on (weight_name, seq_len_local) only -- nothing about the variant's
+        dimensions -- so a config tuned for one model is silently applied to another with a different
+        K. That is fatal when the block width does not divide: Mistral Small 4 at seq_len_local 3200
+        (= 25600/8, i.e. the 25k production ISL) picks up a config with in0_block_w=14, which suits
+        DeepSeek's Kt of 56 (hidden 7168 / tp 4 / 32) but not Mistral's 32, and the matmul asserts:
+
+            TT_FATAL: MatmulMultiCoreReuseMultiCastProgramConfig: Kt (32) must be divisible by
+                      in0_block_w (14)
+
+        Falling back to the default program config keeps such a model running (untuned, so possibly
+        slower) instead of dying. Note the crash is the LUCKY case: where the block width happens to
+        divide, another model's tuning is applied silently and nobody finds out. The real fix is to
+        key the table on the variant or on the actual (K, N); this is the guard until then.
+        """
+        pc = cfg.get("program_config")
+        in0_block_w = getattr(pc, "in0_block_w", None)
+        weight = getattr(self, f"{weight_name}_weight", None)
+        if in0_block_w is None or weight is None:
+            return True  # nothing to check against; keep the tuned config
+        # Weights are [K, N]; only the K dim participates in the in0 block tiling.
+        kt = weight.shape[-2] // ttnn.TILE_SIZE
+        if kt % in0_block_w == 0:
+            return True
+        logger.warning(
+            f"[ttMLA] tuned matmul config for '{weight_name}' has in0_block_w={in0_block_w}, which does "
+            f"not divide this model's Kt={kt} — falling back to the default program config. The tuned "
+            f"table is keyed on (weight, seq_len) only, so it is another variant's tuning."
+        )
+        return False
 
     def _get_act_mem_config(self, weight_name: str, seq_len_local: int) -> ttnn.MemoryConfig:
         """Memory config for the activation (in0) feeding this weight's matmul, as tuned in the mm

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -35,6 +35,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 
 # Four similarly-named dimensions, shown for Kimi-K3, the only variant where all four differ:
 #
@@ -73,16 +74,24 @@ class TtMoe(LightweightModule):
         experts_per_chip: int,
         use_latent_moe: bool = False,
         latent_use_norm: bool = True,
+        routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     ) -> bool:
         """Check if MoE cache is complete (gate + routed experts + shared expert [+ latent proj]).
 
         ``use_latent_moe`` must be passed for Kimi-K3, otherwise a cache missing the latent
         projections would be reported complete and __init__ would then fail loading them.
+
+        routed_expert_weights_dtype: dtype the routed experts were/will be BUILT at.
+        as_tensor stamps it into the tensorbin filename, so the completeness check must pin the
+        same value it will later request -- otherwise a stale cache at another dtype reports
+        complete and the empty placeholder is loaded as the weights.
         """
         prefix = f"layer_{layer_idx}"
         if not TtMoEGatePrefill.check_cache_complete(cache_path, f"{prefix}.gate"):
             return False
-        if not TtRoutedExpert.check_cache_complete(cache_path, f"{prefix}.routed_expert", experts_per_chip):
+        if not TtRoutedExpert.check_cache_complete(
+            cache_path, f"{prefix}.routed_expert", experts_per_chip, routed_expert_weights_dtype
+        ):
             return False
         if not TtSharedExpert.check_cache_complete(cache_path, f"{prefix}.shared_expert"):
             return False
@@ -198,7 +207,7 @@ class TtMoe(LightweightModule):
         routed_expert_weights: list[dict] = None,
         shared_expert_weights: dict = None,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         routed_expert_activation=ttnn.RoutedExpertActivation.Silu,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -23,6 +23,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 
 # Model configs are torch-only and so name their activation as a string; this is the one place
 # that maps those names onto the kernel enum. Keys match the HF ``hidden_act`` spelling.
@@ -49,15 +50,33 @@ COMPUTE_KERNEL_CONFIG_LOFI = ttnn.WormholeComputeKernelConfig(
 
 class TtRoutedExpert(LightweightModule):
     @staticmethod
-    def check_cache_complete(cache_path: Path, cache_name_prefix: str, experts_per_chip: int) -> bool:
-        """Check if all routed expert weight cache files exist."""
+    def check_cache_complete(
+        cache_path: Path,
+        cache_name_prefix: str,
+        experts_per_chip: int,
+        weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
+    ) -> bool:
+        """True iff every routed-expert tensorbin exists AT `weights_dtype`.
+
+        The glob pins ``_dtype_{name}_`` because as_tensor encodes the dtype in the filename
+        (`..._dtype_BFLOAT4_B_layout_TILE.tensorbin`). A dtype-blind glob accepts a stale
+        bfloat4_b cache for a bfloat8_b request, reports complete, and then cache-only
+        construction finds no matching file and dumps the EMPTY PLACEHOLDER as the weights --
+        random experts, plausible-looking text, and a PCC number that means nothing. Same
+        reasoning and same fix as TtIndexer.check_cache_complete; the routed experts are where
+        it actually bites, because their dtype is the one people vary.
+
+        The default matches the routed-expert default (bfloat4_b) so existing callers are
+        unaffected; any caller that builds at a different dtype must pass the same value here.
+        """
         from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
 
+        dtype_name = weights_dtype.name
         for local_expert_idx in range(experts_per_chip):
             for proj in ["gate", "up", "down"]:
-                pattern = f"{cache_name_prefix}.local_{local_expert_idx}_{proj}*.tensorbin"
-                if not pattern_exists(pattern, "RoutedExpert"):
-                    logger.debug(f"TTNN cache missing: {cache_name_prefix}.local_{local_expert_idx}_{proj}")
+                stem = f"{cache_name_prefix}.local_{local_expert_idx}_{proj}"
+                if not pattern_exists(f"{stem}_dtype_{dtype_name}_*.tensorbin", "RoutedExpert"):
+                    logger.debug(f"TTNN cache missing: {stem} ({dtype_name})")
                     return False
         return True
 
@@ -264,7 +283,7 @@ class TtRoutedExpert(LightweightModule):
         torch_weights: list[dict] = None,
         torch_biases: list[dict] = None,
         activations_dtype=ttnn.bfloat8_b,
-        weights_dtype=ttnn.bfloat4_b,
+        weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_LOFI,
         weight_cache_path: Optional[Path] = None,
         cache_name_prefix: Optional[str] = None,

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -269,46 +269,65 @@ class TtDistributedRmsNorm(LightweightModule):
         )
         logger.debug(f"Pre-all-gather stats shape: {tt_stats.shape}")
 
-        # Step 2: Gather stats across cluster_axis. high_bw_all_gather requires topology metadata
-        # for every mesh axis through cluster_axis. Pipeline-parallel runners may expose a 1D tensor
-        # distribution on a 2D mesh, so preserve the general all_gather path for those tensors.
-        use_high_bw_all_gather = _supports_high_bw_all_gather(tt_stats, self.cluster_axis)
-        if use_high_bw_all_gather:
-            # high_bw_all_gather writes into a caller-provided DRAM tensor, so allocate its
-            # fixed-shape output once and reuse it across forwards.
-            if self._gathered_stats is None:
-                gathered_shape = list(tt_stats.shape)
-                gathered_shape[3] *= self.mesh_device.shape[self.cluster_axis]
-                self._gathered_stats = ttnn.empty(
-                    gathered_shape,
-                    dtype=tt_stats.dtype,
-                    layout=tt_stats.layout,
-                    device=self.mesh_device,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-            tt_gathered_stats = ttnn.experimental.high_bw_all_gather(
-                tt_stats,
-                dim=3,
-                output_tensor=self._gathered_stats,
-                cluster_axis=self.cluster_axis,
-                num_links=self.num_links,
-            )
+        # Step 2: Gather stats across cluster_axis.
+        #
+        # TP=1 is handled before choosing a gather at all: ttnn.all_gather TT_FATALs at
+        # num_devices == 1 rather than degenerating to a copy, and with no TP split each device
+        # already holds the full hidden dim, so its local sum(x^2) IS the global statistic. Kept as a
+        # pass-through into rms_norm_post_all_gather rather than switching to a plain ttnn.rms_norm,
+        # so the TP=1 path cannot drift numerically from the TP>1 one.
+        #
+        # Stays False on the TP=1 and fallback paths, which own their gathered tensor; only
+        # high_bw_all_gather writes into the reused self._gathered_stats buffer, which step 3 must
+        # NOT deallocate. At TP=1 the "gathered" tensor aliases tt_stats -- freshly allocated by
+        # rms_norm_pre_all_gather this forward -- so letting step 3 free it is both correct and the
+        # reason the branch below does not free it itself.
+        use_high_bw_all_gather = False
+        if self.mesh_device.shape[self.cluster_axis] == 1:
+            tt_gathered_stats = tt_stats  # aliased; freed once by step 3, after it is used
+            logger.debug("cluster_axis length 1 (TP=1): skipping the stats all-gather (identity)")
         else:
-            logger.debug(
-                f"Falling back to all_gather: tensor topology does not represent cluster_axis={self.cluster_axis}"
-            )
-            all_gather_kwargs = {
-                "input_tensor": tt_stats,
-                "dim": 3,
-                "cluster_axis": self.cluster_axis,
-                "num_links": self.num_links,
-                "topology": self.topology,
-            }
-            if self.stats_memcfg is not None:
-                all_gather_kwargs["memory_config"] = self.stats_memcfg
-            tt_gathered_stats = ttnn.all_gather(**all_gather_kwargs)
-        ttnn.deallocate(tt_stats)
-        logger.debug(f"Gathered stats shape: {tt_gathered_stats.shape}")
+            # high_bw_all_gather requires topology metadata for every mesh axis through
+            # cluster_axis. Pipeline-parallel runners may expose a 1D tensor distribution on a 2D
+            # mesh, so preserve the general all_gather path for those tensors.
+            use_high_bw_all_gather = _supports_high_bw_all_gather(tt_stats, self.cluster_axis)
+            if use_high_bw_all_gather:
+                # high_bw_all_gather writes into a caller-provided DRAM tensor, so allocate its
+                # fixed-shape output once and reuse it across forwards.
+                if self._gathered_stats is None:
+                    gathered_shape = list(tt_stats.shape)
+                    gathered_shape[3] *= self.mesh_device.shape[self.cluster_axis]
+                    self._gathered_stats = ttnn.empty(
+                        gathered_shape,
+                        dtype=tt_stats.dtype,
+                        layout=tt_stats.layout,
+                        device=self.mesh_device,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+                tt_gathered_stats = ttnn.experimental.high_bw_all_gather(
+                    tt_stats,
+                    dim=3,
+                    output_tensor=self._gathered_stats,
+                    cluster_axis=self.cluster_axis,
+                    num_links=self.num_links,
+                )
+            else:
+                logger.debug(
+                    f"Falling back to all_gather: tensor topology does not represent cluster_axis={self.cluster_axis}"
+                )
+                all_gather_kwargs = {
+                    "input_tensor": tt_stats,
+                    "dim": 3,
+                    "cluster_axis": self.cluster_axis,
+                    "num_links": self.num_links,
+                    "topology": self.topology,
+                }
+                if self.stats_memcfg is not None:
+                    all_gather_kwargs["memory_config"] = self.stats_memcfg
+                tt_gathered_stats = ttnn.all_gather(**all_gather_kwargs)
+            # Only safe once a gather actually produced a NEW tensor; at TP=1 the two alias.
+            ttnn.deallocate(tt_stats)
+            logger.debug(f"Gathered stats shape: {tt_gathered_stats.shape}")
 
         # Step 3: Post-all-gather - normalize using gathered global stats
         tt_output = ttnn.rms_norm_post_all_gather(

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -19,6 +19,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
 
 # Optional per-layer MLA-vs-FFN host timing (rough ratio only). Gated by TT_PREFILL_BLOCK_TIMING=1.
@@ -75,12 +76,18 @@ class TtPrefillBlock(LightweightModule):
         experts_per_chip: int = 8,
         *,
         model_cfg: type | None = None,
+        routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     ) -> bool:
         """Check if block cache is complete (norms + MLA + FFN/MoE).
 
         ``model_cfg`` is optional but MUST be passed for a LatentMoE model (Kimi-K3): without it this
         cannot know to look for the latent-projection cache files, and would report a cache that is
         missing them as complete. Left optional so existing callers are unaffected.
+
+        routed_expert_weights_dtype: dtype the routed experts were/will be BUILT at.
+        as_tensor stamps it into the tensorbin filename, so the completeness check must pin the
+        same value it will later request -- otherwise a stale cache at another dtype reports
+        complete and the empty placeholder is loaded as the weights.
         """
         prefix = f"layer_{layer_idx}"
 
@@ -102,6 +109,7 @@ class TtPrefillBlock(LightweightModule):
                 use_latent_moe=getattr(model_cfg, "ROUTED_EXPERT_HIDDEN_SIZE", None)
                 not in (None, getattr(model_cfg, "EMB_SIZE", None)),
                 latent_use_norm=getattr(model_cfg, "LATENT_MOE_USE_NORM", True),
+                routed_expert_weights_dtype=routed_expert_weights_dtype,
             ):
                 return False
 
@@ -123,7 +131,7 @@ class TtPrefillBlock(LightweightModule):
         tp_axis: int = 1,
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         kv_only: bool = False,
@@ -242,7 +250,7 @@ class TtPrefillBlock(LightweightModule):
         is_balanced: bool = False,
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         weight_cache_path: Optional[Path] = None,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -20,6 +20,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.runners.input_prep import prepare_prefill_input_tensor
 from models.demos.deepseek_v3_d_p.tt.runners.kv_caches import MlaKvCaches
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, allocate_dflash_kv_cache
 from models.demos.deepseek_v3_d_p.utils.sub_device_trace import SubDeviceTraceController
 
@@ -42,7 +43,7 @@ class TtPrefillRuntimeConfig:
     capacity_factor: int = 2
     gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL
     routed_expert_activations_dtype: ttnn.DataType = ttnn.bfloat8_b
-    routed_expert_weights_dtype: ttnn.DataType = ttnn.bfloat4_b
+    routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
     shared_expert_activations_dtype: ttnn.DataType = ttnn.bfloat16
     shared_expert_weights_dtype: ttnn.DataType = ttnn.bfloat8_b
     weight_cache_path: Optional[Path] = None
@@ -184,6 +185,9 @@ class TtPrefillRuntime:
                 # to look for the latent-projection cache files and would call an incomplete cache
                 # complete. model_cfg is already in hand two lines up.
                 model_cfg=model_cfg,
+                # Must be the dtype the experts will be BUILT at, or a cache at another dtype
+                # reports complete and the placeholder is loaded as the weights.
+                routed_expert_weights_dtype=self.config.routed_expert_weights_dtype,
             ):
                 logger.info(f"TTNN weight cache complete at {self.config.weight_cache_path}; loading from disk")
             else:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -29,6 +29,7 @@ from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistribute
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TopologyArg, TtPrefillBlock
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
 
@@ -56,6 +57,7 @@ class TtPrefillTransformer(LightweightModule):
         is_last_rank: bool = True,
         kv_only_last_layer: bool = False,
         model_cfg: type | None = None,
+        routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     ) -> bool:
         """
         Top-level cache completeness check for the full transformer.
@@ -71,6 +73,10 @@ class TtPrefillTransformer(LightweightModule):
             first_layer_idx: Global index of this instance's first layer. Non-zero
                 for a pipeline-parallel rank owning a layer slice; block cache keys
                 are global, so dense/MoE selection must use the global index.
+            routed_expert_weights_dtype: dtype the routed experts were/will be BUILT at.
+                as_tensor stamps it into the tensorbin filename, so the completeness check must
+                pin the same value it will later request -- otherwise a stale cache at another
+                dtype reports complete and the empty placeholder is loaded as the weights.
             is_first_rank / is_last_rank: a pipeline-parallel rank builds the
                 embedding only on the first rank and the final norm + LM head only
                 on the last, so check only the weights it actually loads. Both True
@@ -99,7 +105,12 @@ class TtPrefillTransformer(LightweightModule):
             layer_idx = first_layer_idx + local_idx
             is_dense = layer_idx < first_k_dense
             if not TtPrefillBlock.check_cache_complete(
-                cache_path, layer_idx, is_dense, experts_per_chip, model_cfg=model_cfg
+                cache_path,
+                layer_idx,
+                is_dense,
+                experts_per_chip,
+                model_cfg=model_cfg,
+                routed_expert_weights_dtype=routed_expert_weights_dtype,
             ):
                 return False
 
@@ -131,7 +142,7 @@ class TtPrefillTransformer(LightweightModule):
         padding_side: str = "right",
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         weight_cache_path: Optional[Path] = None,

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -47,14 +47,24 @@ def _ref_cache_key(config, weights, hidden_2d) -> str:
         multi-user run two users can share the same total_len while having different inputs. Keying on
         length alone would hand user 1 user 0's reference and silently corrupt its PCC.
       * config -- num_attention_heads changes the absorbed-Q head split even at identical weight
-        shapes; the NoPE / output-gate flags and rope_scaling change the math outright.
+        shapes; the NoPE / output-gate flags and rope_scaling change the math outright, and
+        mla_disable_yarn_mscale changes the softmax scale by mscale**2 (2.2058 for Mistral at
+        factor=128). Any field added here that moves the reference MUST be added to the hash below --
+        omitting one serves a stale reference against a changed device and reads as a device bug.
 
     Hashing the full tensors costs ~2 s at the 56320-token production shape, against a ~7 min
     reference. Content-addressing also makes the key collision-free across variants, so one shared
     cache dir is safe.
     """
     h = hashlib.sha1()
-    for field in ("num_attention_heads", "rms_norm_eps", "mla_use_nope", "mla_use_output_gate", "rope_scaling"):
+    for field in (
+        "num_attention_heads",
+        "rms_norm_eps",
+        "mla_use_nope",
+        "mla_use_output_gate",
+        "mla_disable_yarn_mscale",
+        "rope_scaling",
+    ):
         h.update(f"{field}={getattr(config, field, None)!r}".encode())
     _hash_tensor(h, "hidden", hidden_2d)
     for name in sorted(weights):

--- a/models/demos/deepseek_v3_d_p/utils/expert_dtypes.py
+++ b/models/demos/deepseek_v3_d_p/utils/expert_dtypes.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The default routed-expert weight dtype, in one place.
+
+`routed_expert_weights_dtype=ttnn.bfloat4_b` used to be spelled as a literal default in six places
+(TtMoe, TtPrefillBlock x2, TtPrefillTransformer, TtPrefillRuntime, and the layer-by-layer loader).
+A/B-ing expert precision therefore meant editing six defaults and hoping none was missed -- and
+missing one is not a crash, it is a weight cache BUILT at one dtype and CHECKED at another, which
+loads the empty placeholder as the weights and produces plausible output with a meaningless PCC.
+
+One constant, so the build and the completeness check cannot disagree. Callers that want a different
+precision pass `routed_expert_weights_dtype` explicitly.
+"""
+
+import ttnn
+
+DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE = ttnn.bfloat4_b

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -13,6 +13,7 @@ Provides:
 """
 
 import gc
+import inspect
 import json
 import os
 from copy import deepcopy
@@ -34,6 +35,7 @@ except ImportError:
     from transformers.modeling_utils import no_init_weights
 
 import ttnn
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 
 
 @dataclass
@@ -211,6 +213,207 @@ def create_hf_model(variant, config, num_layers, n_routed_experts=None):
 
     model = variant.reference_model_cls(test_config)
     return model.eval().to(torch.bfloat16)
+
+
+def decoder_layer_kwargs(hf_layer, hf_model, hidden_states, attention_mask, position_ids, cache, use_cache=True):
+    """Keyword arguments for calling one reference decoder layer, bound to ITS OWN signature.
+
+    Reference layers differ across transformers generations and getting it wrong fails in two
+    distinct ways, neither of which points at the cause:
+
+      * the cache kwarg is ``past_key_value`` on the vendored DeepSeek/Kimi layers and
+        ``past_key_values`` on transformers >= 5. The wrong name lands silently in ``**kwargs``, so
+        no KV is ever captured and a later cache comparison comes up empty or mis-shaped;
+      * transformers >= 5 moved rope to the MODEL level and made ``position_embeddings`` required, so
+        omitting it raises ``TypeError: cannot unpack non-iterable NoneType`` from inside attention.
+
+    Rope is built and evaluated in FLOAT32 and cast down. Computing it in bf16 loses the low bits of
+    ``position * inv_freq``, so the phase error grows with position -- measured on Mistral at
+    qk_rope_head_dim=64 it holds to ~2k tokens then falls off (0.99997 at seq 512, 0.958 at 5120),
+    which reads exactly like a device bug and is not one.
+    """
+    params = inspect.signature(hf_layer.forward).parameters
+    kwargs = {
+        "attention_mask": attention_mask,
+        "position_ids": position_ids,
+        "use_cache": use_cache,
+    }
+    kwargs["past_key_values" if "past_key_values" in params else "past_key_value"] = cache
+    if "position_embeddings" in params:
+        rotary = getattr(hf_model, "rotary_emb", None)
+        assert rotary is not None, (
+            f"{type(hf_layer).__name__} requires position_embeddings but "
+            f"{type(hf_model).__name__} exposes no rotary_emb to build them from"
+        )
+        rotary_f32 = deepcopy(rotary).float()
+        with torch.no_grad():
+            cos, sin = rotary_f32(hidden_states.float(), position_ids)
+        kwargs["position_embeddings"] = (cos.to(hidden_states.dtype), sin.to(hidden_states.dtype))
+    return kwargs
+
+
+def derive_mla_kvpe(hf_layer, hidden_states, position_embeddings, config):
+    """Compressed MLA KV line [b, 1, seq, kv_lora_rank + qk_rope_head_dim] from a decoder layer.
+
+    For references that cache expanded per-head keys rather than the MLA latent. Mirrors what
+    MLAReference caches: ``kv_a_layernorm(latent)`` concatenated with the ROPE-rotated pe part,
+    computed with the layer's own weights and its own rope convention.
+
+    Call this while the layer's weights are still loaded -- the layer-by-layer reference frees
+    them right after the forward.
+    """
+    import sys
+
+    from models.demos.deepseek_v3_d_p.tt.mla.rope import interleaved_to_halfsplit_perm
+
+    attn = hf_layer.self_attn
+    kv_lora_rank, rope_dim = config.kv_lora_rank, config.qk_rope_head_dim
+    with torch.no_grad():
+        # fp32: accumulating the norm + projection in bf16 costs ~2e-3 of PCC against the device's
+        # own KVPE, enough to fail a 0.999 bar with nothing actually wrong.
+        norm_f = deepcopy(hf_layer.input_layernorm).float()
+        proj_f = deepcopy(attn.kv_a_proj_with_mqa).float()
+        kv_norm_f = deepcopy(attn.kv_a_layernorm).float()
+        normed = norm_f(hidden_states.float())
+        compressed = proj_f(normed)
+        latent, k_pe = torch.split(compressed, [kv_lora_rank, rope_dim], dim=-1)
+        bsz, seq_len = hidden_states.shape[0], hidden_states.shape[1]
+        k_nope = kv_norm_f(latent).view(bsz, 1, seq_len, kv_lora_rank)
+        k_pe = k_pe.view(bsz, 1, seq_len, rope_dim)
+
+        assert position_embeddings is not None, "need (cos, sin) to rotate the pe part"
+        cos, sin = (c.float() for c in position_embeddings)
+        # Use the layer's OWN rope convention, resolved from the attention's own module rather than
+        # any one variant's: Mistral sets rope_interleave=True and applies
+        # apply_rotary_pos_emb_interleave; getting this wrong silently rotates the wrong pairs.
+        attn_module = sys.modules[type(attn).__module__]
+        fn_name = (
+            "apply_rotary_pos_emb_interleave" if getattr(config, "rope_interleave", False) else "apply_rotary_pos_emb"
+        )
+        _apply = getattr(attn_module, fn_name, None)
+        assert _apply is not None, f"{attn_module.__name__} exposes no {fn_name} to rotate the pe part"
+        _q_unused, k_pe = _apply(k_pe, k_pe, cos, sin)
+
+        # The rotated pe is in the HF half-split basis; MLAReference and the device both store the
+        # Meta-interleaved one. The permutation between them cancels in q.k, which is why attention
+        # output PCC is ~1.0 either way while the stored pe compares at ~0.03 without it.
+        perm = torch.argsort(interleaved_to_halfsplit_perm(rope_dim))
+        k_pe = k_pe[..., perm]
+
+        kvpe = k_pe.new_empty(bsz, 1, seq_len, kv_lora_rank + rope_dim)
+        kvpe[:, :, :, :kv_lora_rank] = k_nope
+        kvpe[:, :, :, kv_lora_rank:] = k_pe
+    return kvpe
+
+
+def reference_kvpe_for_layer(hf_layer, layer_idx, layer_input, layer_kwargs, ref_cache, config):
+    """This layer's reference KVPE in the layout the DEVICE stores: [b, 1, seq, kv_lora_rank + pe].
+
+    A vendored MLAReference caches that line directly, so it is used as-is. A stock transformers
+    attention (`Mistral4Attention`) caches EXPANDED per-head keys -- [b, n_heads, seq, head_dim] --
+    which does not correspond to the device's latent cache in rank OR width. Comparing the two does
+    not merely fail, it fails *quietly*: a `[..., :kv_lora_rank]` slice of a 128-wide last dim just
+    clamps to 128, and what reaches comp_pcc is a shape error rather than a number. Derive the
+    latent from the layer's own modules in that case.
+    """
+    expected_last = getattr(config, "kv_lora_rank", None)
+    rope_dim = getattr(config, "qk_rope_head_dim", None)
+    cached = hf_cache_layer_kv(ref_cache, layer_idx)[0]
+    if expected_last is None or rope_dim is None:
+        return cached  # not an MLA config; nothing to derive
+    if cached is not None and cached.shape[-1] == expected_last + rope_dim:
+        return cached
+    if layer_idx == 0:
+        logger.info(
+            f"Reference caches expanded KV (last dim "
+            f"{None if cached is None else cached.shape[-1]} != {expected_last + rope_dim}); "
+            "deriving the compressed MLA KVPE line from each layer instead"
+        )
+    return derive_mla_kvpe(hf_layer, layer_input, layer_kwargs.get("position_embeddings"), config)
+
+
+def _extract_routed_experts_flat(layer_sd, n_routed):
+    """Per-expert {gate_proj, up_proj, down_proj} from a single layer's dequantized state_dict.
+
+    Same two layouts as `_extract_routed_experts`, but keyed without a layer prefix (this is what the
+    layer-by-layer pretrained loader produces). See that function for why the gate/up split is
+    contiguous-halves-gate-first.
+    """
+    stacked_gate_up = layer_sd.get("mlp.experts.gate_up_proj")
+    if stacked_gate_up is None:
+        return [
+            {
+                "gate_proj": layer_sd[f"mlp.experts.{j}.gate_proj.weight"],
+                "up_proj": layer_sd[f"mlp.experts.{j}.up_proj.weight"],
+                "down_proj": layer_sd[f"mlp.experts.{j}.down_proj.weight"],
+            }
+            for j in range(n_routed)
+        ]
+
+    stacked_down = layer_sd["mlp.experts.down_proj"]
+    num_experts, two_i, _hidden = stacked_gate_up.shape
+    assert num_experts == n_routed, f"stacked experts {num_experts} != n_routed_experts {n_routed}"
+    assert two_i % 2 == 0, f"fused gate_up out-dim {two_i} is not even"
+    inter = two_i // 2
+    assert (
+        stacked_down.shape[2] == inter
+    ), f"down_proj in-dim {stacked_down.shape[2]} != moe_intermediate {inter} implied by gate_up"
+    return [
+        {
+            "gate_proj": stacked_gate_up[j, :inter, :],
+            "up_proj": stacked_gate_up[j, inter:, :],
+            "down_proj": stacked_down[j],
+        }
+        for j in range(num_experts)
+    ]
+
+
+def _extract_routed_experts(full_sd, prefix, hf_layer):
+    """Per-expert {gate_proj, up_proj, down_proj} for one layer, from either expert weight layout.
+
+    Two layouts exist in the wild and the TT side wants the same thing from both:
+
+    * **per-expert** (DeepSeek-V3 / Kimi / GLM) -- ``mlp.experts.{j}.{gate,up,down}_proj.weight``,
+      each a 2-D ``[out, in]`` tensor.
+    * **stacked + fused** (Mistral Small 4, GPT-OSS family) -- one 3-D tensor per projection, with
+      gate and up concatenated along the output dim:
+      ``mlp.experts.gate_up_proj`` ``[E, 2*moe_intermediate, hidden]`` and
+      ``mlp.experts.down_proj``    ``[E, hidden, moe_intermediate]``.
+
+    The split is contiguous halves, gate first -- ``Mistral4NaiveMoe.forward`` does
+    ``linear(x, gate_up_proj[e]).chunk(2, dim=-1)`` and uses the first result as the gate. Read off
+    the modeling code rather than inferred, because getting it backwards swaps SwiGLU's branches and
+    produces plausible output with bad PCC.
+    """
+    stacked_gate_up = full_sd.get(f"{prefix}mlp.experts.gate_up_proj")
+    if stacked_gate_up is None:
+        return [
+            {
+                "gate_proj": full_sd[f"{prefix}mlp.experts.{j}.gate_proj.weight"],
+                "up_proj": full_sd[f"{prefix}mlp.experts.{j}.up_proj.weight"],
+                "down_proj": full_sd[f"{prefix}mlp.experts.{j}.down_proj.weight"],
+            }
+            for j in range(len(hf_layer.mlp.experts))
+        ]
+
+    stacked_down = full_sd[f"{prefix}mlp.experts.down_proj"]
+    num_experts, two_i, _hidden = stacked_gate_up.shape
+    assert two_i % 2 == 0, f"fused gate_up out-dim {two_i} is not even"
+    inter = two_i // 2
+    assert (
+        stacked_down.shape[0] == num_experts
+    ), f"expert-count mismatch: gate_up {num_experts} vs down {stacked_down.shape[0]}"
+    assert (
+        stacked_down.shape[2] == inter
+    ), f"down_proj in-dim {stacked_down.shape[2]} != moe_intermediate {inter} implied by gate_up"
+    return [
+        {
+            "gate_proj": stacked_gate_up[j, :inter, :],
+            "up_proj": stacked_gate_up[j, inter:, :],
+            "down_proj": stacked_down[j],
+        }
+        for j in range(num_experts)
+    ]
 
 
 def extract_layer_state_dict(variant, full_sd, layer_idx, hf_layer):
@@ -448,7 +651,7 @@ def load_and_compute_layer_by_layer(
     tp_axis: int = 1,
     gate_fallback_mode=None,
     routed_expert_activations_dtype=ttnn.bfloat8_b,
-    routed_expert_weights_dtype=ttnn.bfloat4_b,
+    routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     shared_expert_activations_dtype=ttnn.bfloat16,
     shared_expert_weights_dtype=ttnn.bfloat8_b,
     causal_only=True,
@@ -507,7 +710,7 @@ def load_and_compute_layer_by_layer(
 
     # Initialize outputs
     ref_snapshots = [] if compute_reference else None
-    ref_kvpe_list = None
+    ref_kvpe_list = [] if compute_reference else None
     ref_cache = None
 
     # Create hf_model only if computing reference
@@ -578,16 +781,24 @@ def load_and_compute_layer_by_layer(
             layer_with_prefix = {f"layers.{i}.{k}": v for k, v in layer_dequant.items()}
             hf_model.load_state_dict(layer_with_prefix, strict=False)
 
+            layer_input = h_ref
+            layer_kwargs = decoder_layer_kwargs(
+                hf_model.layers[i], hf_model, h_ref, attention_mask, position_ids, ref_cache
+            )
             with torch.no_grad():
-                layer_out = hf_model.layers[i](
-                    h_ref,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
-                    past_key_value=ref_cache,
-                    use_cache=True,
-                )
-                h_ref = layer_out[0]
+                layer_out = hf_model.layers[i](layer_input, **layer_kwargs)
+                h_ref = layer_out[0] if isinstance(layer_out, (tuple, list)) else layer_out
             ref_snapshots.append(h_ref)
+
+            # Capture the reference KVPE *here*, while this layer's weights are still loaded: they
+            # are freed a few lines below, and for a stock attention the line has to be derived from
+            # them (see reference_kvpe_for_layer). Doing it after the loop -- which is what the
+            # earlier `hf_cache_layer_kv` one-liner did -- can only read back the cache, which for
+            # Mistral holds per-head keys and made all 72 per-layer KVPE rows unusable.
+            ref_kvpe_list.append(
+                reference_kvpe_for_layer(hf_model.layers[i], i, layer_input, layer_kwargs, ref_cache, config)
+            )
+            del layer_input, layer_kwargs
 
             # Clear layer weights from hf_model
             for param in hf_model.layers[i].parameters():
@@ -683,10 +894,6 @@ def load_and_compute_layer_by_layer(
         gc.collect()
         _log_memory(f"After layer {i} cleared")
         logger.debug(f"Layer {i} processed, cache cleared")
-
-    # Extract KVPE if computed reference
-    if compute_reference:
-        ref_kvpe_list = [hf_cache_layer_kv(ref_cache, i)[0] for i in range(num_layers)]
 
     # --- Process Norm ---
     logger.info("Processing norm...")
@@ -788,9 +995,39 @@ def _ref_cache_dir(variant) -> Path:
     return Path(os.environ.get(env, f"/tmp/{variant.name}_transformer_ref_cache"))
 
 
-def check_reference_cache_exists(variant, cache_key: ReferenceCacheKey) -> bool:
+def _ref_cache_kvpe_width(cache_path: Path) -> int | None:
+    """Last-dim width of the first stored KVPE entry, or None if it cannot be determined."""
+    try:
+        try:
+            cached = torch.load(cache_path, weights_only=True, mmap=True)
+        except (RuntimeError, TypeError):  # not zipfile-serialized, or older torch without mmap
+            cached = torch.load(cache_path, weights_only=True)
+        kvpe = cached.get("ref_kvpe_list")
+        return None if not kvpe else kvpe[0].shape[-1]
+    except Exception as e:  # a cache we cannot read is handled by the normal load path
+        logger.debug(f"Could not inspect KVPE width of {cache_path}: {e}")
+        return None
+
+
+def check_reference_cache_exists(variant, cache_key: ReferenceCacheKey, expected_kvpe_width: int | None = None) -> bool:
+    """Whether a reusable reference cache exists for `cache_key`.
+
+    `expected_kvpe_width` (kv_lora_rank + qk_rope_head_dim) additionally rejects a file whose
+    stored KVPE predates `reference_kvpe_for_layer` -- i.e. holds expanded per-head keys instead of
+    the compressed MLA line. ReferenceCacheKey covers everything that changes reference *values*
+    but nothing about their *layout*, so without this a stale file is reused silently and every
+    per-layer KVPE row errors out. Treated as a miss, which recomputes the reference (~6 s/layer).
+    """
     cache_path = _ref_cache_dir(variant) / f"{cache_key}.pt"
     exists = cache_path.exists()
+    if exists and expected_kvpe_width is not None:
+        stale = _ref_cache_kvpe_width(cache_path)
+        if stale is not None and stale != expected_kvpe_width:
+            logger.warning(
+                f"Reference cache {cache_path.name} stores KVPE of width {stale}, expected "
+                f"{expected_kvpe_width} (pre-compressed-line format) -- recomputing the reference"
+            )
+            return False
     if exists:
         logger.info(f"Reference cache found: {cache_path}")
     else:

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -224,9 +224,12 @@ def reference_rope(hf_model, hidden_states, position_ids):
     """
     rotary = getattr(hf_model, "rotary_emb", None)
     assert rotary is not None, f"{type(hf_model).__name__} exposes no rotary_emb to build rope from"
-    try:
-        rotary_f32 = type(rotary)(config=hf_model.config).float()
-    except Exception:  # a rotary that does not take `config=`; the bf16 buffer is then unavoidable
+    # Check the signature rather than catching: a bare `except` would also swallow a genuine
+    # construction failure and silently fall back to the bf16 buffer this function exists to avoid.
+    rotary_cls = type(rotary)
+    if "config" in inspect.signature(rotary_cls.__init__).parameters:
+        rotary_f32 = rotary_cls(config=hf_model.config).float()
+    else:  # a rotary that predates `config=`; the bf16 buffer is then unavoidable
         rotary_f32 = deepcopy(rotary).float()
     # `forward` reads this tensor only for device and dtype (transformers 5.12), so pass a view --
     # a full fp32 copy of the hidden states is ~251 MB at seq 15360.
@@ -350,6 +353,15 @@ def derive_mla_kvpe(hf_layer, hidden_states, position_embeddings, config):
     return kvpe
 
 
+def mla_kvpe_width(config) -> int | None:
+    """Width of the row the device caches per token: kv_lora_rank + qk_rope_head_dim.
+
+    None when the config is not MLA, so callers can skip a layout check that does not apply.
+    """
+    kv, rope = getattr(config, "kv_lora_rank", None), getattr(config, "qk_rope_head_dim", None)
+    return None if kv is None or rope is None else kv + rope
+
+
 def reference_kvpe_for_layer(hf_layer, layer_idx, layer_input, layer_kwargs, ref_cache, config):
     """This layer's reference KVPE in the layout the DEVICE stores: [b, 1, seq, kv_lora_rank + pe].
 
@@ -360,104 +372,19 @@ def reference_kvpe_for_layer(hf_layer, layer_idx, layer_input, layer_kwargs, ref
     clamps to 128, and what reaches comp_pcc is a shape error rather than a number. Derive the
     latent from the layer's own modules in that case.
     """
-    expected_last = getattr(config, "kv_lora_rank", None)
-    rope_dim = getattr(config, "qk_rope_head_dim", None)
+    width = mla_kvpe_width(config)
     cached = hf_cache_layer_kv(ref_cache, layer_idx)[0]
-    if expected_last is None or rope_dim is None:
+    if width is None:
         return cached  # not an MLA config; nothing to derive
-    if cached is not None and cached.shape[-1] == expected_last + rope_dim:
+    if cached is not None and cached.shape[-1] == width:
         return cached
     if layer_idx == 0:
         logger.info(
             f"Reference caches expanded KV (last dim "
-            f"{None if cached is None else cached.shape[-1]} != {expected_last + rope_dim}); "
+            f"{None if cached is None else cached.shape[-1]} != {width}); "
             "deriving the compressed MLA KVPE line from each layer instead"
         )
     return derive_mla_kvpe(hf_layer, layer_input, layer_kwargs.get("position_embeddings"), config)
-
-
-def _extract_routed_experts_flat(layer_sd, n_routed):
-    """Per-expert {gate_proj, up_proj, down_proj} from a single layer's dequantized state_dict.
-
-    Same two layouts as `_extract_routed_experts`, but keyed without a layer prefix (this is what the
-    layer-by-layer pretrained loader produces). See that function for why the gate/up split is
-    contiguous-halves-gate-first.
-    """
-    stacked_gate_up = layer_sd.get("mlp.experts.gate_up_proj")
-    if stacked_gate_up is None:
-        return [
-            {
-                "gate_proj": layer_sd[f"mlp.experts.{j}.gate_proj.weight"],
-                "up_proj": layer_sd[f"mlp.experts.{j}.up_proj.weight"],
-                "down_proj": layer_sd[f"mlp.experts.{j}.down_proj.weight"],
-            }
-            for j in range(n_routed)
-        ]
-
-    stacked_down = layer_sd["mlp.experts.down_proj"]
-    num_experts, two_i, _hidden = stacked_gate_up.shape
-    assert num_experts == n_routed, f"stacked experts {num_experts} != n_routed_experts {n_routed}"
-    assert two_i % 2 == 0, f"fused gate_up out-dim {two_i} is not even"
-    inter = two_i // 2
-    assert (
-        stacked_down.shape[2] == inter
-    ), f"down_proj in-dim {stacked_down.shape[2]} != moe_intermediate {inter} implied by gate_up"
-    return [
-        {
-            "gate_proj": stacked_gate_up[j, :inter, :],
-            "up_proj": stacked_gate_up[j, inter:, :],
-            "down_proj": stacked_down[j],
-        }
-        for j in range(num_experts)
-    ]
-
-
-def _extract_routed_experts(full_sd, prefix, hf_layer):
-    """Per-expert {gate_proj, up_proj, down_proj} for one layer, from either expert weight layout.
-
-    Two layouts exist in the wild and the TT side wants the same thing from both:
-
-    * **per-expert** (DeepSeek-V3 / Kimi / GLM) -- ``mlp.experts.{j}.{gate,up,down}_proj.weight``,
-      each a 2-D ``[out, in]`` tensor.
-    * **stacked + fused** (Mistral Small 4, GPT-OSS family) -- one 3-D tensor per projection, with
-      gate and up concatenated along the output dim:
-      ``mlp.experts.gate_up_proj`` ``[E, 2*moe_intermediate, hidden]`` and
-      ``mlp.experts.down_proj``    ``[E, hidden, moe_intermediate]``.
-
-    The split is contiguous halves, gate first -- ``Mistral4NaiveMoe.forward`` does
-    ``linear(x, gate_up_proj[e]).chunk(2, dim=-1)`` and uses the first result as the gate. Read off
-    the modeling code rather than inferred, because getting it backwards swaps SwiGLU's branches and
-    produces plausible output with bad PCC.
-    """
-    stacked_gate_up = full_sd.get(f"{prefix}mlp.experts.gate_up_proj")
-    if stacked_gate_up is None:
-        return [
-            {
-                "gate_proj": full_sd[f"{prefix}mlp.experts.{j}.gate_proj.weight"],
-                "up_proj": full_sd[f"{prefix}mlp.experts.{j}.up_proj.weight"],
-                "down_proj": full_sd[f"{prefix}mlp.experts.{j}.down_proj.weight"],
-            }
-            for j in range(len(hf_layer.mlp.experts))
-        ]
-
-    stacked_down = full_sd[f"{prefix}mlp.experts.down_proj"]
-    num_experts, two_i, _hidden = stacked_gate_up.shape
-    assert two_i % 2 == 0, f"fused gate_up out-dim {two_i} is not even"
-    inter = two_i // 2
-    assert (
-        stacked_down.shape[0] == num_experts
-    ), f"expert-count mismatch: gate_up {num_experts} vs down {stacked_down.shape[0]}"
-    assert (
-        stacked_down.shape[2] == inter
-    ), f"down_proj in-dim {stacked_down.shape[2]} != moe_intermediate {inter} implied by gate_up"
-    return [
-        {
-            "gate_proj": stacked_gate_up[j, :inter, :],
-            "up_proj": stacked_gate_up[j, inter:, :],
-            "down_proj": stacked_down[j],
-        }
-        for j in range(num_experts)
-    ]
 
 
 def extract_layer_state_dict(variant, full_sd, layer_idx, hf_layer):

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -215,7 +215,56 @@ def create_hf_model(variant, config, num_layers, n_routed_experts=None):
     return model.eval().to(torch.bfloat16)
 
 
-def decoder_layer_kwargs(hf_layer, hf_model, hidden_states, attention_mask, position_ids, cache, use_cache=True):
+def reference_rope(hf_model, hidden_states, position_ids):
+    """The reference ``(cos, sin)``, built in fp32 from the CONFIG rather than copied from the model.
+
+    A reference instantiated in bf16 carries a bf16 ``inv_freq`` buffer and ``.float()`` cannot
+    recover the lost bits; the resulting ~4.4e-4 frequency error is a phase error that grows with
+    position. Depends only on the positions, so build it once per run.
+    """
+    rotary = getattr(hf_model, "rotary_emb", None)
+    assert rotary is not None, f"{type(hf_model).__name__} exposes no rotary_emb to build rope from"
+    try:
+        rotary_f32 = type(rotary)(config=hf_model.config).float()
+    except Exception:  # a rotary that does not take `config=`; the bf16 buffer is then unavoidable
+        rotary_f32 = deepcopy(rotary).float()
+    # `forward` reads this tensor only for device and dtype (transformers 5.12), so pass a view --
+    # a full fp32 copy of the hidden states is ~251 MB at seq 15360.
+    probe = hidden_states[:1, :1].float()
+    with torch.no_grad():
+        return rotary_f32(probe, position_ids)
+
+
+def layer_wants_position_embeddings(hf_layer) -> bool:
+    """Does this reference decoder layer take ``position_embeddings``?
+
+    The predicate that decides whether a rope table has to be built at all. Layers differ across
+    transformers generations: a transformers-5.x layer (e.g. Mistral4) REQUIRES the caller to pass
+    ``(cos, sin)``, while an older or vendored layer (e.g. DeepSeekV3) computes rope internally from
+    ``position_ids`` and exposes no top-level ``rotary_emb`` to build one from. Asking the signature
+    keeps both working; assuming either shape breaks the other.
+    """
+    return "position_embeddings" in inspect.signature(hf_layer.forward).parameters
+
+
+def reference_position_embeddings(hf_model, hidden_states, position_ids, num_layers: int):
+    """The reference rope table for a whole run, or ``None`` when no layer takes one.
+
+    Built once: it depends only on the positions, and building per layer would construct a rotary
+    module and a full fp32 copy of the hidden states each time (~251 MB at seq 15360).
+
+    Returns None rather than raising for a reference whose layers compute rope internally --
+    DeepSeekV3's vendored layer does, and its model exposes no top-level ``rotary_emb``, so asking
+    unconditionally asserted on exactly the models that never needed a table.
+    """
+    if not num_layers or not layer_wants_position_embeddings(hf_model.layers[0]):
+        return None
+    return reference_rope(hf_model, hidden_states, position_ids)
+
+
+def decoder_layer_kwargs(
+    hf_layer, hf_model, hidden_states, attention_mask, position_ids, cache, use_cache=True, position_embeddings=None
+):
     """Keyword arguments for calling one reference decoder layer, bound to ITS OWN signature.
 
     Reference layers differ across transformers generations and getting it wrong fails in two
@@ -227,10 +276,8 @@ def decoder_layer_kwargs(hf_layer, hf_model, hidden_states, attention_mask, posi
       * transformers >= 5 moved rope to the MODEL level and made ``position_embeddings`` required, so
         omitting it raises ``TypeError: cannot unpack non-iterable NoneType`` from inside attention.
 
-    Rope is built and evaluated in FLOAT32 and cast down. Computing it in bf16 loses the low bits of
-    ``position * inv_freq``, so the phase error grows with position -- measured on Mistral at
-    qk_rope_head_dim=64 it holds to ~2k tokens then falls off (0.99997 at seq 512, 0.958 at 5120),
-    which reads exactly like a device bug and is not one.
+    Pass ``position_embeddings`` from ``reference_rope`` -- it depends only on the positions, so
+    building it per layer is wasted work. Omitted, it is built here for this one call.
     """
     params = inspect.signature(hf_layer.forward).parameters
     kwargs = {
@@ -239,15 +286,12 @@ def decoder_layer_kwargs(hf_layer, hf_model, hidden_states, attention_mask, posi
         "use_cache": use_cache,
     }
     kwargs["past_key_values" if "past_key_values" in params else "past_key_value"] = cache
-    if "position_embeddings" in params:
-        rotary = getattr(hf_model, "rotary_emb", None)
-        assert rotary is not None, (
-            f"{type(hf_layer).__name__} requires position_embeddings but "
-            f"{type(hf_model).__name__} exposes no rotary_emb to build them from"
+    if "position_embeddings" in params:  # == layer_wants_position_embeddings(hf_layer)
+        cos, sin = (
+            position_embeddings
+            if position_embeddings is not None
+            else reference_rope(hf_model, hidden_states, position_ids)
         )
-        rotary_f32 = deepcopy(rotary).float()
-        with torch.no_grad():
-            cos, sin = rotary_f32(hidden_states.float(), position_ids)
         kwargs["position_embeddings"] = (cos.to(hidden_states.dtype), sin.to(hidden_states.dtype))
     return kwargs
 
@@ -771,6 +815,16 @@ def load_and_compute_layer_by_layer(
     first_k_dense = config.first_k_dense_replace
     n_routed = config.n_routed_experts
 
+    # Once for the whole reference: identical across layers, and each build would otherwise construct
+    # a rotary module and a full fp32 copy of the hidden states.
+    #
+    # Only when a layer actually takes position_embeddings. A vendored reference such as DeepSeekV3
+    # computes rope internally and exposes no top-level rotary_emb, so building this unconditionally
+    # asserts on exactly the models that never needed it.
+    ref_position_embeddings = (
+        reference_position_embeddings(hf_model, h_ref, position_ids, num_layers) if compute_reference else None
+    )
+
     for i in range(num_layers):
         logger.info(f"Processing layer {i}/{num_layers}...")
 
@@ -783,7 +837,13 @@ def load_and_compute_layer_by_layer(
 
             layer_input = h_ref
             layer_kwargs = decoder_layer_kwargs(
-                hf_model.layers[i], hf_model, h_ref, attention_mask, position_ids, ref_cache
+                hf_model.layers[i],
+                hf_model,
+                h_ref,
+                attention_mask,
+                position_ids,
+                ref_cache,
+                position_embeddings=ref_position_embeddings,
             )
             with torch.no_grad():
                 layer_out = hf_model.layers[i](layer_input, **layer_kwargs)


### PR DESCRIPTION
### Issue

Relates to #53688 — hit while bringing up Mistral Small 4 119B prefill.

### Summary

Five independent bugs in shared `deepseek_v3_d_p` code. None is variant-specific. **Four of the five fail silently** — the device was doing the right thing and something in the harness or the weight cache was quietly wrong about it, which is why they survived this long.

Terminology, since it recurs below: MLA does not cache per-head K and V, it caches one compressed row per token. This PR calls that row the **KVPE** — the **KV** latent (`kv_lora_rank` wide) concatenated with the **PE**, the RoPE'd positional part (`qk_rope_head_dim` wide). 512 + 64 = 576 for the DeepSeek family, 256 + 64 = 320 for Mistral Small 4. Both device and reference must store that same row for a comparison to mean anything.

1. **A weight cache built at one dtype read as complete for another.** `as_tensor` stamps the requested dtype into the tensorbin filename, but the routed-expert completeness check globbed without it. A cache populated at `bfloat4_b` answered "complete" for a `bfloat8_b` request, regeneration was skipped, and the empty placeholder was loaded *as the weights* — fluent output, meaningless PCC, no error.
   `fix(moe)`: pin the dtype the check will later request, threaded runtime → transformer → block → MoE, with the default in one place (`utils/expert_dtypes.py`) so build and check cannot disagree.

2. **The per-layer KVPE comparison compared the wrong tensor.** The reference read KVPE straight out of the HF cache, which only works if the reference caches the compressed row. A stock `transformers` attention caches expanded per-head keys instead, so the shapes do not correspond, `comp_pcc` clamped rather than failing, and every per-layer KVPE row reported `-1.0` — which reads as "bad score", not "not measured".
   `fix(prefill)`: derive the compressed row from the layer's own modules (`derive_mla_kvpe`), resolving the rope function from the attention module so a variant with `rope_interleave=True` rotates the pairs it actually uses. The reference cache records its KVPE width and checks it on load, so a cache built by the old path is regenerated rather than silently compared.

3. **The reference rope was built from a bfloat16 buffer.** The reference is instantiated in bf16, so `rotary_emb.inv_freq` holds `0.75` where the true value is `0.7498942`, and `.float()` cannot recover bits already gone. The residue is a ~4.4e-4 per-dimension frequency error — a phase error growing **linearly with position**. It lands only on the rotary half of the KVPE (the KV half is position-independent), and attention output stays ~0.99 because q and k share the same wrong table so the error cancels in `q·k`. That is why it reads exactly like a device bug and is not one. Separately, the chunked reference cache key omitted the YaRN mscale flag, so toggling it served a stale reference against changed device math.
   `fix(mla)`: rebuild rope from the **config** (`reference_rope`), once per reference rather than per layer. Add mscale to the chunked cache key. KVPE rotary PCC at 5120 tokens: 0.946176 → 0.999899, and now flat in sequence length rather than merely above a threshold.

   The table is built **only when a layer's signature takes `position_embeddings`**. That predicate matters: a transformers-5.x layer requires the caller to pass `(cos, sin)`, while a vendored layer such as DeepSeekV3's computes rope internally from `position_ids` and its model exposes no top-level `rotary_emb` to build one from. Keying off the model's attributes instead of the layer's signature asserts on exactly the references that never needed a table.

4. **Tuned matmul configs were applied without checking K.** Configs are selected by output shape, but a config is only valid for the K it was tuned at. A same-output-shape/different-K case picks up a config whose per-core K split does not divide its K. This is not hypothetical for the shipping path: single-rank Mistral at the 25K production window has `seq_len_local` 3200 and Kt 32, and the tuned row's `in0_block_w` of 14 does not divide it.
   `perf(mla)`: check K when resolving; unmatched shapes fall back to the generic program config, so a mismatch degrades in *performance* instead of correctness.

5. **`ttnn.all_gather` aborts on a length-1 axis.** It `TT_FATAL`s at `num_devices == 1` instead of degenerating to a copy, so `TtDistributedRmsNorm` died on any single-column mesh. This is not a pipeline-parallel special case: `tt_reduce` already carries the identical guard (`tt/moe/tt_reduce.py:131`), so TP=1 is a configuration this package already supports and the norm was inconsistent with its sibling. Nothing in CI exercises TP=1, which is why that inconsistency survived.
   `fix(norm)`: at TP=1 each device holds the full hidden dim, so its local `sum(x²)` already *is* the global statistic — short-circuit the gather into `rms_norm_post_all_gather`. Kept as a pass-through rather than switching to a plain `ttnn.rms_norm`, so the TP=1 path cannot drift numerically from the TP>1 one.

### Testing

Validated on a 32-chip Blackhole galaxy at mesh-8x4 via `test_prefill_block.py` (the variant itself is a separate PR; these fixes are what made it measurable).

Three of the five fixes have regression tests that fail without them:

- `tests/torch/test_shared_prefill_fixes.py` (new, host-only, 7 tests, ~2 s): `reference_rope` matches an independently built fp32 table at position 40000 **and** the old `deepcopy(bf16).float()` path is asserted wrong there, so the test cannot pass without discriminating; a layer that computes rope internally is asserted to need no `rotary_emb`, which is the DeepSeek case above; `_cfg_fits_weight` is parametrised over `(in0_block_w, Kt)` including the case where the width happens to divide and the config is accepted, pinning that known gap.
- `tests/cache/test_routed_expert_cache.py` extended (host-only) for fix 1.
- `tests/pcc/test_rmsnorm.py` gains a TP=1 row for fix 5. Without the guard: `TT_FATAL: all_gather collective will only work for num_devices > 1, got 1`. With it, PCC 0.999959.

The host-only files are not registered in any pipeline, matching existing practice in this package (eight host-only test files, none wired). Giving them a CPU lane is a separate change.

CI Runs kicked off, more details in comment below.

- **Blaze Models Prefill tests** — 30 of 36 test legs pass — https://github.com/tenstorrent/tt-metal/actions/runs/32532695133
- **(Blackhole) e2e tests** — 33 of 34 test legs pass — https://github.com/tenstorrent/tt-metal/actions/runs/32532697163

### Notes for reviewers

- The expert-cache fix covers **routed experts only**. Shared expert, FFN, MLA, LM head, embedding and norm still glob dtype-blind, so that failure class is narrowed here, not closed.
- `reference_rope` passes a `hidden_states[:1, :1]` view because `forward` reads that tensor only for its device and dtype. True in transformers 5.12, but it is an assumption about a library — the alternative costs a full fp32 copy (~251 MB at seq 15360).
- Full diagnosis of fix 3, including four causes ruled out with evidence, is in its commit message. See the follow-up comment for a per-fix summary table and a suggested reading order.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kmabee/prefill-shared-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kmabee/prefill-shared-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kmabee/prefill-shared-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kmabee/prefill-shared-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kmabee/prefill-shared-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kmabee/prefill-shared-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kmabee/prefill-shared-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kmabee/prefill-shared-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kmabee/prefill-shared-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kmabee/prefill-shared-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kmabee/prefill-shared-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kmabee/prefill-shared-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kmabee/prefill-shared-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kmabee/prefill-shared-fixes)