### PR TITLE
Reconcile the SwiGLU SFPU activations with tt-blaze

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_clamped_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_clamped_silu.h
@@ -18,8 +18,10 @@ static constexpr std::uint32_t FUSED_ACT_GELU = 4;
 static constexpr std::uint32_t FUSED_ACT_CLAMP_ONLY = 5;
 static constexpr std::uint32_t FUSED_ACT_SITU_GATE = 6;
 static constexpr std::uint32_t FUSED_ACT_SCALED_TANH = 7;
+static constexpr std::uint32_t FUSED_ACT_SILU_SCALED = 8;
 
-#ifdef TRISC_PACK
+// MATH as well as PACK: MatmulSwiGLU drives these from the math thread.
+#if defined(TRISC_PACK) || defined(TRISC_MATH)
 #include "ckernel_sfpu_sigmoid.h"
 
 namespace ckernel {
@@ -135,4 +137,4 @@ inline void calculate_scaled_tanh(std::uint32_t beta_bits, std::uint32_t beta_re
 
 }  // namespace sfpu
 }  // namespace ckernel
-#endif  // TRISC_PACK
+#endif  // TRISC_PACK || TRISC_MATH

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_silu_scaled.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_silu_scaled.h
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Scaled SiLU: dst = tail * silu(s*x), for broadcast scalars s and tail.
+//
+// SiLU is not scale-invariant, so a scalar belonging on the activation's INPUT
+// cannot be applied afterwards; s goes inside, tail outside.
+//
+// Requires the caller's silu_init: this shares calculate_silu's non-approx sigmoid.
+// Not TRISC_PACK-gated — callers invoke it from both MATH and PACK.
+
+#pragma once
+
+#include <cstdint>
+
+#if defined(COMPILE_FOR_TRISC)
+
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_sigmoid.h"  // _sfpu_sigmoid_
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// Clear HAS_TAIL_SCALE when a downstream op already applies s.
+template <bool is_fp32_dest_acc_en, bool HAS_TAIL_SCALE, bool HAS_POST_SCALE, int ITERATIONS>
+inline void calculate_silu_scaled(std::uint32_t scale_bits, std::uint32_t post_scale_bits) {
+    constexpr bool HAS_TAIL = HAS_TAIL_SCALE || HAS_POST_SCALE;
+    sfpi::vFloat s = sfpi::as<sfpi::vFloat>(sfpi::vInt(scale_bits));
+    sfpi::vFloat tail = s;
+    if constexpr (HAS_TAIL) {
+        if constexpr (HAS_TAIL_SCALE && HAS_POST_SCALE) {
+            tail = s * sfpi::as<sfpi::vFloat>(sfpi::vInt(post_scale_bits));
+        } else if constexpr (HAS_POST_SCALE) {
+            tail = sfpi::as<sfpi::vFloat>(sfpi::vInt(post_scale_bits));
+        }
+    }
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0] * s;
+
+        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        if constexpr (HAS_TAIL) {
+            result = result * tail;
+        }
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+
+// Template order mirrors llk_math_eltwise_unary_sfpu_silu.
+template <
+    bool APPROXIMATE,
+    bool is_fp32_dest_acc_en,
+    bool HAS_TAIL_SCALE = true,
+    bool HAS_POST_SCALE = false,
+    int ITERATIONS = 8>
+inline void llk_math_eltwise_unary_sfpu_silu_scaled(
+    std::uint32_t dst_index,
+    std::uint32_t scale_bits,
+    std::uint32_t post_scale_bits = 0,
+    VectorMode vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::calculate_silu_scaled<is_fp32_dest_acc_en, HAS_TAIL_SCALE, HAS_POST_SCALE, ITERATIONS>,
+        dst_index,
+        vector_mode,
+        scale_bits,
+        post_scale_bits);
+}
+
+}  // namespace ckernel
+
+#endif  // COMPILE_FOR_TRISC


### PR DESCRIPTION
### PR Category

LLK reconciliation (additive + drift fix)

### Summary

Brings the shared SwiGLU-family SFPU activations back in sync with tt-blaze, which has moved twice since the metal copy was taken. Both changes are verbatim ports of code running on Blackhole in blaze today.

- `ckernel_sfpu_silu_scaled.h` (new) — scaled SiLU, `dst = tail * silu(s*x)` for broadcast scalars. SiLU is not scale-invariant, so a scalar belonging on the activation's input cannot be applied afterwards: `s` goes inside, `tail` outside. Ported from `blaze/kernels/sfpu/silu_scaled.hpp` (tt-blaze#3061).
- `ckernel_sfpu_clamped_silu.h` — picks up the two deltas blaze added after this file was promoted: the `FUSED_ACT_SILU_SCALED = 8` fused-activation constant (tt-blaze#3061) and the MATH-thread guard widening (tt-blaze#2862), where MatmulSwiGLU drives these activations from the math thread rather than pack.

### Changes on top of the blaze source

1. **`std::uint32_t` + `<cstdint>`.** Repo convention on this path, matching the existing `ckernel_sfpu_clamped_silu.h`. The `fix-cstdint` hook also rewrites `uint dst_index` to `std::uint32_t dst_index`; the two spell the same type.
2. **Formatting.** clang-format wraps the `llk_math_eltwise_unary_sfpu_silu_scaled` parameter list; the code tokens are unchanged.

Verified code-token identical to the blaze sources modulo the above.

### Testing

No behavioral change to any existing metal caller: `FUSED_ACT_SILU_SCALED` is a new constant, the guard widening is additive (the block previously compiled on PACK only), and `ckernel_sfpu_silu_scaled.h` has no includers in metal yet. The only in-repo consumer of this header family is the LLK test `tt_metal/tt-llk/tests/sources/sfpu_clamped_silu_test.cpp`.

LLK test coverage for `silu_scaled` is not included here and is worth a follow-up, in line with the other experimental SFPU kernels that landed without tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/reconcile-silu-scaled)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/reconcile-silu-scaled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/reconcile-silu-scaled)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/reconcile-silu-scaled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/reconcile-silu-scaled)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/reconcile-silu-scaled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/reconcile-silu-scaled)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/reconcile-silu-scaled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/reconcile-silu-scaled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/reconcile-silu-scaled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/reconcile-silu-scaled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/reconcile-silu-scaled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/reconcile-silu-scaled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/reconcile-silu-scaled)