### PR TITLE
[Bug fix] nextafter: step the bit pattern by one ULP toward the target

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_nextafter_neighbour.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_nextafter_neighbour.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""nextafter returns the adjacent representable value.
+
+The gate is bit-exactness against torch.nextafter, which is the op's own golden.
+Nothing weaker can test this: the answer differs from the input by one unit in
+the last place, so any tolerance that admits a near miss admits every miss.
+"""
+
+import pytest
+import torch
+import ttnn
+
+# Magnitudes spanning six decades either side of 1. The composite this replaced
+# stepped by FLT_EPSILON, which is one ULP only inside [1, 2), so it failed
+# everywhere except that band, in both directions.
+MAGNITUDES = [1e-6, 1e-3, 0.5, 1.0, 1.5, 3.0, 100.0, 1e4, 1e6]
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("magnitude", MAGNITUDES)
+@pytest.mark.parametrize("sign", [1.0, -1.0])
+@pytest.mark.parametrize("direction", [1.0, -1.0])
+def test_nextafter_steps_one_ulp(device, dtype, magnitude, sign, direction):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    a_val = sign * magnitude
+    b_val = a_val + direction * (magnitude * 10 + 1)
+
+    a = torch.full((1, 1, 32, 32), a_val, dtype=torch_dtype)
+    b = torch.full((1, 1, 32, 32), b_val, dtype=torch_dtype)
+    want = torch.nextafter(a, b).flatten()[0]
+
+    ia = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.nextafter(ia, ib)).flatten()[0]
+
+    assert got == want, f"nextafter({a_val}, {b_val}) returned {got}, want {want}"
+    # Stated separately because a result that fails to move and one that moves
+    # the wrong way are different defects, and the composite did both.
+    assert (got - a_val) * (b_val - a_val) > 0, f"nextafter({a_val}, {b_val}) did not step toward b"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_nextafter_equal_inputs_are_unchanged(device, dtype):
+    """IEEE-754: nextafter(x, x) is x, for every x."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    vals = torch.tensor(MAGNITUDES + [-m for m in MAGNITUDES], dtype=torch_dtype)
+    a = vals.repeat(32 * 32 // vals.numel() + 1)[: 32 * 32].reshape(1, 1, 32, 32)
+
+    ia = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.nextafter(ia, ia))
+
+    assert torch.equal(got, a), f"{int((got != a).sum())} of {got.numel()} changed"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_nextafter_from_infinity_is_the_largest_finite(device, dtype):
+    """One step down from infinity is the largest finite value, not infinity."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    for sign in (1.0, -1.0):
+        a = torch.full((1, 1, 32, 32), sign * float("inf"), dtype=torch_dtype)
+        b = torch.zeros((1, 1, 32, 32), dtype=torch_dtype)
+        want = torch.nextafter(a, b).flatten()[0]
+
+        ia = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        ib = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        got = ttnn.to_torch(ttnn.nextafter(ia, ib)).flatten()[0]
+
+        assert torch.isfinite(got), f"nextafter({sign} inf, 0) returned {got}"
+        assert got == want, f"nextafter({sign} inf, 0) returned {got}, want {want}"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_nextafter.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_nextafter.h
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// nextafter(a, b) is the representable value adjacent to a in the direction of
+// b, so it is defined on the bit pattern rather than on the value: step the
+// magnitude by one and put the sign back. That is one pass over dst, which is
+// why this does not decompose into arithmetic ops without either losing the
+// step at large magnitudes or overshooting at small ones.
+//
+// The step is one unit in the LAST place of the destination format, not of the
+// register. Registers are fp32 whatever dst holds, so a bfloat16 destination
+// steps by 0x10000, which is also exactly its smallest subnormal.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_nextafter_(sfpi::vFloat a, sfpi::vFloat b) {
+    constexpr int step = is_fp32_dest_acc_en ? 1 : 0x10000;
+    constexpr float infinity = std::numeric_limits<float>::infinity();
+
+    // The magnitude grows when the direction of travel agrees with the sign of
+    // a. Comparing signs through copysgn rather than the product a * (b - a)
+    // keeps it correct when that product would overflow or flush.
+    sfpi::vFloat d = b - a;
+    sfpi::vFloat toward = sfpi::copysgn(sfpi::vFloat(1.0f), a) * sfpi::copysgn(sfpi::vFloat(1.0f), d);
+
+    sfpi::vInt m = sfpi::as<sfpi::vInt>(sfpi::setsgn(a, 0));
+    v_if(toward > 0.0f) { m = m + step; }
+    v_else { m = m - step; }
+    v_endif;
+    sfpi::vFloat r = sfpi::copysgn(sfpi::as<sfpi::vFloat>(m), a);
+
+    // a infinite needs no case of its own: the magnitude of an infinity is the
+    // exponent field all ones with a zero mantissa, so one step down is the
+    // largest finite value, which is the answer, and one step up cannot be
+    // asked for because that would need b beyond infinity.
+
+    // a zero has no magnitude bits to walk down, and its neighbour in either
+    // direction is the smallest subnormal carrying the sign of b.
+    v_if(sfpi::setsgn(a, 0) == 0.0f) {
+        r = sfpi::copysgn(sfpi::as<sfpi::vFloat>(sfpi::vInt(step)), b);
+    }
+    v_endif;
+
+    // IEEE-754: nextafter(x, x) is x, for every x including the zeroes.
+    v_if(a == b) { r = b; }
+    v_endif;
+
+    sfpi::vFloat vinf = infinity;
+    v_if(sfpi::as<sfpi::vInt>(sfpi::setsgn(a, 0)) > sfpi::as<sfpi::vInt>(vinf)) { r = a; }
+    v_endif;
+    v_if(sfpi::as<sfpi::vInt>(sfpi::setsgn(b, 0)) > sfpi::as<sfpi::vInt>(vinf)) { r = b; }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::Nearest);
+    }
+
+    return r;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_nextafter(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_nextafter_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_nextafter_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_nextafter.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_nextafter.h
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// nextafter(a, b) is the representable value adjacent to a in the direction of
+// b, so it is defined on the bit pattern rather than on the value: step the
+// magnitude by one and put the sign back. That is one pass over dst, which is
+// why this does not decompose into arithmetic ops without either losing the
+// step at large magnitudes or overshooting at small ones.
+//
+// The step is one unit in the LAST place of the destination format, not of the
+// register. Registers are fp32 whatever dst holds, so a bfloat16 destination
+// steps by 0x10000, which is also exactly its smallest subnormal.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_nextafter_(sfpi::vFloat a, sfpi::vFloat b) {
+    constexpr int step = is_fp32_dest_acc_en ? 1 : 0x10000;
+    constexpr float infinity = std::numeric_limits<float>::infinity();
+
+    // The magnitude grows when the direction of travel agrees with the sign of
+    // a. Comparing signs through copysgn rather than the product a * (b - a)
+    // keeps it correct when that product would overflow or flush.
+    sfpi::vFloat d = b - a;
+    sfpi::vFloat toward = sfpi::copysgn(sfpi::vFloat(1.0f), a) * sfpi::copysgn(sfpi::vFloat(1.0f), d);
+
+    sfpi::vInt m = sfpi::as<sfpi::vInt>(sfpi::setsgn(a, 0));
+    v_if(toward > 0.0f) { m = m + step; }
+    v_else { m = m - step; }
+    v_endif;
+    sfpi::vFloat r = sfpi::copysgn(sfpi::as<sfpi::vFloat>(m), a);
+
+    // a infinite needs no case of its own: the magnitude of an infinity is the
+    // exponent field all ones with a zero mantissa, so one step down is the
+    // largest finite value, which is the answer, and one step up cannot be
+    // asked for because that would need b beyond infinity.
+
+    // a zero has no magnitude bits to walk down, and its neighbour in either
+    // direction is the smallest subnormal carrying the sign of b.
+    v_if(sfpi::setsgn(a, 0) == 0.0f) {
+        r = sfpi::copysgn(sfpi::as<sfpi::vFloat>(sfpi::vInt(step)), b);
+    }
+    v_endif;
+
+    // IEEE-754: nextafter(x, x) is x, for every x including the zeroes.
+    v_if(a == b) { r = b; }
+    v_endif;
+
+    sfpi::vFloat vinf = infinity;
+    v_if(sfpi::as<sfpi::vInt>(sfpi::setsgn(a, 0)) > sfpi::as<sfpi::vInt>(vinf)) { r = a; }
+    v_endif;
+    v_if(sfpi::as<sfpi::vInt>(sfpi::setsgn(b, 0)) > sfpi::as<sfpi::vInt>(vinf)) { r = b; }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::Nearest);
+    }
+
+    return r;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_nextafter(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_nextafter_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_nextafter_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/nextafter.h
+++ b/tt_metal/hw/inc/api/compute/nextafter.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_nextafter.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise nextafter operation on two inputs: y = the representable
+ * value adjacent to idst0 in the direction of idst1.
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void nextafter_binary_tile(std::uint32_t idst0, std::uint32_t idst1, std::uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_sfpu_nextafter,
+        (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void nextafter_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(unused, sfpu::calculate_sfpu_nextafter_init, (APPROX, DST_ACCUM_MODE))));
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -121,6 +121,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/isclose.h
     inc/api/compute/layernorm.h
     inc/api/compute/lcm.h
+    inc/api/compute/nextafter.h
     inc/api/compute/logsigmoid.h
     inc/api/compute/mask.h
     inc/api/compute/matmul.h

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
@@ -54,6 +54,7 @@ std::span<const DataType> supported_tensor_a_dtypes(BinaryOpType op) {
         case BinaryOpType::POWER:
         case BinaryOpType::XLOGY:
         case BinaryOpType::ATAN2:
+        case BinaryOpType::NEXTAFTER:
         case BinaryOpType::HYPOT: return float_only;
         case BinaryOpType::WHERE_TST:
         case BinaryOpType::WHERE_TTS: return where;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -23,6 +23,7 @@ enum class BinaryOpType {
     LOGICAL_OR,
     LOGICAL_XOR,
     LDEXP,
+    NEXTAFTER,
     LOGADDEXP2,
     DIV,
     DIV_FLOOR,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -31,23 +31,25 @@ namespace ttnn {
 using namespace operations;
 
 // nextafter
+//
+// The composite this replaces stepped by hal::get_eps(), which is FLT_EPSILON and
+// so is one ULP only inside [1, 2): above that band the step rounds straight back
+// to input_a and below it overshoots. It also stepped away from input_b rather
+// than toward it. Neither is reachable from arithmetic on the values, because the
+// neighbouring representable number is a property of the bit pattern, so this is a
+// fused kernel rather than a longer chain.
 Tensor nextafter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    const float eps = tt::tt_metal::hal::get_eps();
-    Tensor result(input_a);
-    {
-        Tensor eps_gt(input_a);
-        {
-            eps_gt = ttnn::where(
-                ttnn::gt(input_a, input_b, std::nullopt, output_mem_config),
-                ttnn::add(input_a, eps, std::nullopt, output_mem_config),
-                input_a);
-        }
-        result = ttnn::where(
-            ttnn::lt(input_a, input_b, std::nullopt, output_mem_config),
-            ttnn::subtract(input_a, eps, std::nullopt, output_mem_config),
-            eps_gt);
-    }
-    return result;
+    return ttnn::detail::invoke_binary_ng(
+        input_a,
+        input_b,
+        binary::BinaryOpType::NEXTAFTER,
+        std::nullopt,
+        output_mem_config,
+        std::nullopt,
+        {},
+        {},
+        {},
+        std::nullopt);
 }
 
 Tensor minimum(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -11,7 +11,6 @@
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/types.hpp"
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/hal.hpp>
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/eltwise/ternary/ternary.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -22,6 +22,7 @@
 #include "api/compute/binary_max_min.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/gcd.h"
 #include "api/compute/lcm.h"
 #include "api/compute/binary_comp.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -61,6 +61,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case MINIMUM:
         case XLOGY:
         case ATAN2:
+        case NEXTAFTER:
         case POWER:
         case WHERE_TST:
         case WHERE_TTS:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -373,6 +373,13 @@ OpConfig::OpConfig(
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::NEXTAFTER:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::NEXTAFTER;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         case BinaryOpType::WHERE_TTS:
             if (is_sfpu_op()) {
                 binary_op = SfpuBinaryOp::WHERE;
@@ -501,6 +508,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
+        case NEXTAFTER: return {"nextafter_binary_tile_init();", "nextafter_binary_tile"};
         case LT:
             if (int_data_format) {
                 return {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -79,6 +79,7 @@ struct OpConfig {
         MINIMUM,
         XLOGY,
         ATAN2,
+        NEXTAFTER,
         LT,
         GT,
         GE,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -20,6 +20,7 @@
 #include "api/compute/quantization.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "api/compute/bcast.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -25,6 +25,7 @@
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/nextafter.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "api/compute/bcast.h"


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #53760.

`nextafter` becomes a fused SFPU binary op that steps the magnitude bit pattern by one and restores the sign. The six-op composite goes away, so this is also a launch-count change: 6 kernels per call to 1.

The step is one unit in the last place of the **destination** format, not of the register. Registers are fp32 whatever `dst` holds, so a bfloat16 destination steps by `0x10000`, which is also exactly its smallest subnormal and so serves as both constants. Infinity needs no case of its own: one step down from the exponent field all ones is the largest finite value, which is the answer.

### Accuracy

Both architectures, both dtypes, against `torch.nextafter`, gated on bit-exactness. Wormhole B0 N300 and Blackhole P300 return identical counts, so the table is written once.

| case | before | after |
|---|---|---|
| step toward a larger `b` (18) | 18 wrong | **0** |
| step toward a smaller `b` (18) | 18 wrong | **0** |
| `a == b` (18) | 0 wrong | 0 wrong |
| zero / inf / nan (9), bfloat16 | 9 wrong | **5** |
| zero / inf / nan (9), float32 | 8 wrong | **3** |

What still differs is `nextafter(±0, b)`, whose answer is the smallest subnormal and which the hardware flushes to zero, in both dtypes. bfloat16 additionally loses NaN, which an ordinary `ttnn.mul(x, 1.0)` does too in that dtype.

### Cost

Device profiler, `TT_METAL_DEVICE_PROFILER=1`, `[1, 1, 512, 512]`, 33 invocations, median cycles per core. Zone counts give the launch count directly: 6 per call before, 1 after, on both machines. Cycles are per call, so the composite figure is its per-launch median times six.

| | BH bfloat16 | BH float32 | WH bfloat16 | WH float32 |
|---|---|---|---|---|
| launches per call | 6 → **1** | 6 → **1** | 6 → **1** | 6 → **1** |
| TRISC_1 math, before | 25158 | 40236 | 56040 | 109446 |
| TRISC_1 math, after | **5994** | **9230** | **11082** | **21352** |
| | **4.2x** | **4.4x** | **5.1x** | **5.1x** |

BRISC moves the same way, 29784 to 6610 on Blackhole bfloat16.

### Tests

`test_nextafter_neighbour.py`, 76 cases, passing on both machines:

- one ULP steps across nine magnitudes from `1e-6` to `1e6`, both signs, both directions, asserting bit-exactness and, separately, that the result moved toward `b` at all. All 72 fail on `main`.
- `nextafter(x, x) == x`.
- `nextafter(±inf, 0)` is the largest finite value, not infinity.

The existing coverage could not see this: `test_binary_composite.py:43` uses `compare_pcc` over `[-100, 100]`, where a one-ULP directional error does not move PCC off 1.0.

### Related context

#51218 item 1 reports the swapped `where` arms, which is one of the two defects fixed here. #49996 proposes exactly this fused kernel in its second section and measures the op at 6 launches; #52153 tracks `nextafter` for migration, as #32509 did before it.

#52668 fixes the same two defects by composing about twenty ttnn ops in place of the six, including `bitcast`, `full_like` and five `where`s. That is a larger launch count on the op #49996 measures as the most dispatch-bound composite in the set. The bit-level step is a single SFPU pass, so doing it in the kernel fixes the same values and removes the launches rather than adding to them.

### Not covered

- `bfloat8_b` and `bfloat4_b`, and the sharded and broadcast paths.
- Subnormal results, which the hardware flushes and this does not change.
- Quasar, which carries its own copy of the composite.
