### PR TITLE
[Bug fix] floor_div: one floored divide, no Inf guard

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_floor_div_infinite_quotient.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_floor_div_infinite_quotient.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""floor_div where the quotient is infinite.
+
+floor_div used to compute the quotient twice, once unrounded, so it could return
+the unrounded one when it was infinite. That guard selected the same value the
+floored path already produced, because floor leaves an infinity alone. These
+tests pin that, so removing the guard cannot become wrong silently: if the floor
+step ever stops passing an infinity through, they fail here rather than in a
+caller.
+"""
+
+import pytest
+import torch
+import ttnn
+
+# a / b overflows to an infinity while both operands are ordinary numbers, which
+# is the only situation in which the removed guard could have fired.
+INFINITE_QUOTIENT = [
+    (1e30, 1e-30),
+    (-1e30, 1e-30),
+    (1e30, -1e-30),
+    (-1e30, -1e-30),
+]
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("a, b", INFINITE_QUOTIENT)
+def test_floor_div_infinite_quotient(device, dtype, a, b):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    ta = torch.full((1, 1, 32, 32), a, dtype=torch_dtype)
+    tb = torch.full((1, 1, 32, 32), b, dtype=torch_dtype)
+    want = torch.floor_divide(ta, tb).flatten()[0]
+
+    ia = ttnn.from_torch(ta, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(tb, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.floor_div(ia, ib)).flatten()[0]
+
+    assert got == want, f"floor_div({a}, {b}) returned {got}, want {want}"
+
+
+def test_floor_div_int32(device):
+    """int32 floor_div, which the guarded form did not survive.
+
+    The guard divided unrounded first, and that quotient is a float, so the
+    int32 path came back as denormals and NaNs. Rounding toward negative
+    infinity is the whole point of the op, so the negative cases are the ones
+    that matter: -7 // 2 is -4, not -3.
+    """
+    a = torch.tensor([7, -7, 6, -6, 100, -100, 1, 0] * 128, dtype=torch.int32).reshape(1, 1, 32, 32)
+    b = torch.tensor([2, 2, -3, -3, 7, 7, 3, 5] * 128, dtype=torch.int32).reshape(1, 1, 32, 32)
+    want = torch.floor_divide(a, b)
+
+    ia = ttnn.from_torch(a, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(b, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.floor_div(ia, ib))
+
+    assert torch.equal(got, want), f"{int((got != want).sum())} of {want.numel()} differ"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("a, b", INFINITE_QUOTIENT)
+def test_floor_div_matches_the_floored_divide(device, dtype, a, b):
+    """The guard's premise: that these two can disagree. They do not."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    ta = torch.full((1, 1, 32, 32), a, dtype=torch_dtype)
+    tb = torch.full((1, 1, 32, 32), b, dtype=torch_dtype)
+
+    ia = ttnn.from_torch(ta, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(tb, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    guarded = ttnn.to_torch(ttnn.floor_div(ia, ib))
+    floored = ttnn.to_torch(ttnn.div(ia, ib, fast_and_approximate_mode=False, rounding_mode="floor"))
+
+    assert torch.equal(guarded, floored), f"floor_div and div(rounding_mode='floor') disagree at ({a}, {b})"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -568,14 +568,16 @@ Tensor floor_div(
 }
 
 Tensor floor_div(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor temp = ttnn::div(input_a, input_b, false, std::nullopt, std::nullopt, output_mem_config);
-    Tensor result = ttnn::div(input_a, input_b, false, "floor", std::nullopt, output_mem_config);
-    // floor(inf, -inf) = inf, -inf. isinf tests both in a single SFPU pass,
-    // replacing two eq's and a logical_or. The dropped eq(temp, nan) term was
-    // always false under IEEE, so NaN selects the floored value here exactly as
-    // it did before; isinf (rather than !isfinite) keeps that branch identical
-    // without relying on floor propagating NaN.
-    return ttnn::where(ttnn::isinf(temp, output_mem_config), temp, result);
+    // The Inf guard this replaces computed the quotient a second time, unrounded,
+    // only to ask whether it was infinite and, if so, return it in place of the
+    // floored one. It never selected a different value: on the float path
+    // div(..., "floor") is a divide followed by ttnn::floor, and floor leaves an
+    // infinity alone, so the guarded and unguarded results agree wherever the
+    // guard could fire. That is not an assumption here; the correctness table in
+    // the change that introduced this form of the guard already showed
+    // floor(temp) matching the guarded result on inf, -inf and nan, and
+    // test_floor_div_infinite_quotient pins it.
+    return ttnn::div(input_a, input_b, false, "floor", std::nullopt, output_mem_config);
 }
 
 // outer(a, b) treats each input's last dim as a vector and broadcasts the


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #53765.

`floor_div` becomes one call to the floored divide. The Inf guard it replaces divided a second time, unrounded, so it could return that quotient when it was infinite, and it never selected a different value.

The guard also made int32 unreachable: the unrounded quotient is a float, so integer inputs came back as denormals and NaNs.

### Accuracy

128 cases per dtype, gated on bit-exactness against the value the guarded form produced. P300 and N300 agree in every row.

| case | bfloat16 | float32 |
|---|---|---|
| ordinary (48) | identical | identical |
| division by zero (6) | identical | identical |
| infinite quotient (4) | identical | identical |
| inf / nan operands (6) | identical | identical |

int32, 1024 inputs, against `torch.floor_divide`:

| | before | after |
|---|---|---|
| wrong | **768** | **0** |

Two case sets disagree with `torch.floor_divide` both before and after, `0 // 0` and infinite or NaN operands. This change does not touch them.

### Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, median cycles per core. Zone counts give the kernel count: 5 per call before, 2 after, on both machines.

| | P300 bf16 | P300 fp32 | N300 bf16 | N300 fp32 |
|---|---|---|---|---|
| kernels per call | 5 → **2** | 5 → **2** | 5 → **2** | 5 → **2** |
| TRISC_1 math, before | 21740 | 31110 | 48100 | 82930 |
| TRISC_1 math, after | **7514** | **11256** | **15508** | **27424** |
| | **2.9x** | **2.8x** | **3.1x** | **3.0x** |

### Tests

`test_floor_div_infinite_quotient.py`, 17 cases. The first two pin the invariant this change now depends on, so it cannot become wrong silently: if the floor step ever stops passing an infinity through, they fail here rather than in a caller. The third covers int32 and fails on `main`.

`test_binary_composite.py -k floor` passes unchanged, 66 cases.

### Why floor leaves an infinity alone

This is the invariant the change now rests on, so here is where it comes from rather than only that it was measured. `_trunc_body_` in `tt_metal/tt-llk/tt_llk_{blackhole,wormhole_b0}/common/inc/sfpu/ckernel_sfpu_rounding_ops.h:26` builds a mask and shifts it by `23 - exp`:

```
TTI_SFPLOADI(LREG1, SHORT, 0xffff)                       // mask = 0xffff_ffff
TTI_SFPIADD(0, LREG3, LREG2, ARG_2SCOMP_LREG_DST | CC_GTE0)  // exp = 23 - exp, disable lanes where that is negative
TTI_SFPSHFT2(LREG1, LREG2, LREG1, SHFT_LREG)             // mask <<= exp
TTI_SFPENCC(0, 0, 0, 0)
TTI_SFPAND(0, LREG0, LREG1, 0)                           // val & mask
```

An infinity has unbiased exponent 128, so `23 - 128` is negative, `CC_GTE0` disables that lane, the shift is skipped and the mask stays all ones. `val & 0xffff_ffff` is `val`, so `trunc(inf) = inf`.

`_floor_body_` then subtracts one only where the value sits below its truncation, and the two architectures test that differently. Blackhole uses `TTI_SFPGT(LREG0, LREG1)`, and `inf > inf` is false. Wormhole has no `SFPGT`, so it uses `TTI_SFPSETCC(LREG0, LT0)` followed by an integer `TTI_SFPIADD(LREG1, LREG0, ARG_2SCOMP | CC_LT0)`; for `-inf` the two bit patterns are equal, so the integer difference is zero and not negative. Different instructions, same answer: `floor(±inf) = ±inf` on both.

That is why the guarded and unguarded results cannot differ, and the tests pin it in case either sequence changes.

### Related context

#51437 collapsed this guard from three ops to one and published a correctness table showing `floor(temp)` matching the guarded result on `inf`, `-inf` and `nan`. It kept the guard to avoid depending on an invariant of the floor step rather than on the branch structure, which is a fair objection to an unpinned invariant; the tests above pin it.

#51453 is an open draft fixing the int32 half by adding a dtype branch that routes integers to the floored divide. Routing every dtype there instead makes the branch unnecessary, so this supersedes it rather than conflicting with it.

### Not covered

- Broadcast, sharded and row-major paths.
- `bfloat8_b` and `bfloat4_b`.
- The pre-existing disagreements with `torch.floor_divide` on `0 // 0` and non-finite operands.