### PR TITLE
[Bug fix] div_no_nan: fuse into the divide kernel

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_by_infinity.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_by_infinity.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""div where an operand is infinite.
+
+With fp32 destination accumulation the quotient is refined by a residual step,
+and that step cannot be formed when the divisor is infinite: the quotient is
+already zero, so the residual is 0 * inf. These pin the cases where the
+refinement used to turn a correct zero into a NaN.
+"""
+
+import pytest
+import torch
+import ttnn
+
+INF = float("inf")
+
+# finite / infinite, which is a signed zero, and the cases either side of it.
+CASES = [
+    (1.0, INF),
+    (2.0, INF),
+    (-3.0, INF),
+    (1.0, -INF),
+    (-1.0, -INF),
+    (0.0, INF),
+    (-0.0, INF),
+    (1e30, INF),
+    (1e-30, INF),
+    (INF, INF),
+    (-INF, INF),
+    (INF, 2.0),
+    (-INF, 2.0),
+]
+
+
+@pytest.mark.parametrize("a, b", CASES)
+def test_div_by_infinity_fp32(device, a, b):
+    ta = torch.full((1, 1, 32, 32), a, dtype=torch.float32)
+    tb = torch.full((1, 1, 32, 32), b, dtype=torch.float32)
+    want = (ta / tb).flatten()[0]
+
+    ia = ttnn.from_torch(ta, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(tb, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.divide(ia, ib)).flatten()[0]
+
+    if torch.isnan(want):
+        assert torch.isnan(got), f"div({a}, {b}) returned {got}, want nan"
+    else:
+        assert got == want, f"div({a}, {b}) returned {got}, want {want}"
+
+
+# The sign of the zero is not asserted above. It is wrong for a negative
+# dividend, and that is not this code path: an ordinary multiply loses it too,
+# ttnn.multiply(-3.0, 0.0) returns +0 where torch returns -0, while a plain
+# round trip through from_torch/to_torch preserves -0. Asserting it here would
+# be testing that separate defect.

--- a/tests/ttnn/unit_tests/operations/eltwise/test_div_no_nan_fused.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_div_no_nan_fused.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""div_no_nan, which is the divide with one arm replaced.
+
+The contract is that a zero divisor yields zero, including for a zero dividend,
+where the plain divide yields NaN. Everything else is the quotient.
+"""
+
+import pytest
+import torch
+import ttnn
+
+ZERO_DIVISOR = [1.0, -1.0, 0.0, -0.0, 7.0, -7.0, 1e30, 1e-30]
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("a", ZERO_DIVISOR)
+def test_div_no_nan_zero_divisor(device, dtype, a):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    ta = torch.full((1, 1, 32, 32), a, dtype=torch_dtype)
+    tb = torch.zeros((1, 1, 32, 32), dtype=torch_dtype)
+
+    ia = ttnn.from_torch(ta, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(tb, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.div_no_nan(ia, ib))
+
+    assert torch.equal(got, torch.zeros_like(got)), f"div_no_nan({a}, 0) returned {got.flatten()[0]}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_div_no_nan_matches_divide_away_from_zero(device, dtype):
+    """Away from a zero divisor it is exactly the divide, which is the point of
+    sharing the kernel rather than guarding one with a where."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    a = (torch.rand((1, 1, 32, 32), dtype=torch.float32) * 200 - 100).to(torch_dtype)
+    b = (torch.rand((1, 1, 32, 32), dtype=torch.float32) + 0.5).to(torch_dtype)
+
+    ia = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    assert torch.equal(ttnn.to_torch(ttnn.div_no_nan(ia, ib)), ttnn.to_torch(ttnn.divide(ia, ib)))
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_div_no_nan_by_infinity(device, dtype):
+    """A zero divisor is the only case the op overrides, so an infinite divisor
+    still gives the quotient, which is zero rather than NaN."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    ta = torch.full((1, 1, 32, 32), 2.0, dtype=torch_dtype)
+    tb = torch.full((1, 1, 32, 32), float("inf"), dtype=torch_dtype)
+
+    ia = ttnn.from_torch(ta, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ib = ttnn.from_torch(tb, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.div_no_nan(ia, ib)).flatten()[0]
+
+    assert got == 0.0, f"div_no_nan(2, inf) returned {got}"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -187,12 +187,19 @@ inline void calculate_sfpu_binary_div(const uint dst_index_in0, const uint dst_i
         }
 
         v_if(in1 == 0) {
-            v_if(in0 == 0) { result = std::numeric_limits<float>::quiet_NaN(); }
-            v_else {
-                result = std::numeric_limits<float>::infinity();
-                result = sfpi::copysgn(result, in0);
+            if constexpr (BINOP == BinaryOp::DIV_NO_NAN) {
+                // div_no_nan is defined by this arm: a zero divisor yields zero,
+                // for a zero dividend too. Everything above it is the ordinary
+                // quotient, which is why the two share one kernel.
+                result = 0.0f;
+            } else {
+                v_if(in0 == 0) { result = std::numeric_limits<float>::quiet_NaN(); }
+                v_else {
+                    result = std::numeric_limits<float>::infinity();
+                    result = sfpi::copysgn(result, in0);
+                }
+                v_endif;
             }
-            v_endif;
         }
         v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -170,10 +170,18 @@ inline void calculate_sfpu_binary_div(const uint dst_index_in0, const uint dst_i
             // If in0*r = +/-inf, then the residual e = in0 - (+/-inf)*in1 = -/+inf and
             // result + e*r = inf + (-inf) = NaN, which would corrupt IEEE overflow behavior.
             v_if(sfpi::exexp(result, sfpi::ExponentMode::Biased) != 255) {
-                // Residual (Markstein) refinement removes the double-rounding of in0 * round(1/in1).
-                // The residual subtraction is exact under Sterbenz's lemma.
-                sfpi::vFloat e = in0 - result * in1;
-                result = result + e * r;
+                // The residual is equally unusable when in1 is non-finite, and that case
+                // reaches here because the quotient is finite rather than in spite of it:
+                // r = 1/inf = 0 and result = in0 * 0 = 0, so result * in1 is 0 * inf, the
+                // residual is NaN and the refinement destroys a correct zero. The guard is
+                // about whether the residual can be formed, not about the quotient's size.
+                v_if(sfpi::exexp(in1, sfpi::ExponentMode::Biased) != 255) {
+                    // Residual (Markstein) refinement removes the double-rounding of in0 * round(1/in1).
+                    // The residual subtraction is exact under Sterbenz's lemma.
+                    sfpi::vFloat e = in0 - result * in1;
+                    result = result + e * r;
+                }
+                v_endif;
             }
             v_endif;
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -189,12 +189,19 @@ inline void calculate_sfpu_binary_div(
         }
 
         v_if(in1 == 0) {
-            v_if(in0 == 0) { result = std::numeric_limits<float>::quiet_NaN(); }
-            v_else {
-                result = std::numeric_limits<float>::infinity();
-                result = sfpi::copysgn(result, in0);
+            if constexpr (BINOP == BinaryOp::DIV_NO_NAN) {
+                // div_no_nan is defined by this arm: a zero divisor yields zero,
+                // for a zero dividend too. Everything above it is the ordinary
+                // quotient, which is why the two share one kernel.
+                result = 0.0f;
+            } else {
+                v_if(in0 == 0) { result = std::numeric_limits<float>::quiet_NaN(); }
+                v_else {
+                    result = std::numeric_limits<float>::infinity();
+                    result = sfpi::copysgn(result, in0);
+                }
+                v_endif;
             }
-            v_endif;
         }
         v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -172,10 +172,18 @@ inline void calculate_sfpu_binary_div(
             // If in0*r = +/-inf, then the residual e = in0 - (+/-inf)*in1 = -/+inf and
             // result + e*r = inf + (-inf) = NaN, which would corrupt IEEE overflow behavior.
             v_if(sfpi::exexp(result, sfpi::ExponentMode::Biased) != 255) {
-                // Residual (Markstein) refinement removes the double-rounding of in0 * round(1/in1).
-                // The residual subtraction is exact under Sterbenz's lemma.
-                sfpi::vFloat e = in0 - result * in1;
-                result = result + e * r;
+                // The residual is equally unusable when in1 is non-finite, and that case
+                // reaches here because the quotient is finite rather than in spite of it:
+                // r = 1/inf = 0 and result = in0 * 0 = 0, so result * in1 is 0 * inf, the
+                // residual is NaN and the refinement destroys a correct zero. The guard is
+                // about whether the residual can be formed, not about the quotient's size.
+                v_if(sfpi::exexp(in1, sfpi::ExponentMode::Biased) != 255) {
+                    // Residual (Markstein) refinement removes the double-rounding of in0 * round(1/in1).
+                    // The residual subtraction is exact under Sterbenz's lemma.
+                    sfpi::vFloat e = in0 - result * in1;
+                    result = result + e * r;
+                }
+                v_endif;
             }
             v_endif;
         }

--- a/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary_sfpu.h
@@ -62,6 +62,18 @@ ALWI void div_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 #endif
 }
 
+ALWI void div_no_nan_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_sfpu_binary_div,
+        (APPROX, ckernel::BinaryOp::DIV_NO_NAN, 8 /* ITERATIONS */, DST_ACCUM_MODE),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
 ALWI void mul_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
 #ifdef ARCH_QUASAR
     MATH((SFPU_BINARY_CALL(

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -360,6 +360,7 @@ enum class BinaryOp : std::uint8_t
     REMAINDER_INT32  = 40,
     REMAINDER_UINT32 = 41,
     FMOD_INT32       = 42,
+    DIV_NO_NAN       = 43,
 };
 
 enum class PackMode : std::uint8_t

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -342,6 +342,7 @@ enum class BinaryOp : std::uint8_t
     REMAINDER_INT32  = 40,
     REMAINDER_UINT32 = 41,
     FMOD_INT32       = 42,
+    DIV_NO_NAN       = 43,
 };
 
 enum class PackMode : std::uint8_t

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
@@ -54,6 +54,7 @@ std::span<const DataType> supported_tensor_a_dtypes(BinaryOpType op) {
         case BinaryOpType::POWER:
         case BinaryOpType::XLOGY:
         case BinaryOpType::ATAN2:
+        case BinaryOpType::DIV_NO_NAN:
         case BinaryOpType::HYPOT: return float_only;
         case BinaryOpType::WHERE_TST:
         case BinaryOpType::WHERE_TTS: return where;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -23,6 +23,7 @@ enum class BinaryOpType {
     LOGICAL_OR,
     LOGICAL_XOR,
     LDEXP,
+    DIV_NO_NAN,
     LOGADDEXP2,
     DIV,
     DIV_FLOOR,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -403,11 +403,11 @@ Tensor div_no_nan(
 }
 
 Tensor div_no_nan(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    if (input_a.dtype() == DataType::FLOAT32 && input_b.dtype() == DataType::FLOAT32) {
-        // Not using SFPU div op here since inf/nan handling is not required
-        Tensor div_result = ttnn::multiply(input_a, ttnn::reciprocal(input_b), std::nullopt, output_mem_config);
-        return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0.0f, div_result);
-    }
+    // float32 used to take reciprocal + multiply here instead of the SFPU divide,
+    // to keep div(a, +-inf) from coming back NaN. That was a property of the
+    // divide kernel's residual refinement rather than of this op, and it is
+    // fixed in the commit before this one; the divide is both a kernel cheaper
+    // and closer to the exact quotient, since reciprocal + multiply rounds twice.
     Tensor div_result = ttnn::divide(input_a, input_b, std::nullopt, output_mem_config);
     return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0.0f, div_result);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -404,12 +404,22 @@ Tensor div_no_nan(
 
 Tensor div_no_nan(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     // float32 used to take reciprocal + multiply here instead of the SFPU divide,
-    // to keep div(a, +-inf) from coming back NaN. That was a property of the
-    // divide kernel's residual refinement rather than of this op, and it is
-    // fixed in the commit before this one; the divide is both a kernel cheaper
-    // and closer to the exact quotient, since reciprocal + multiply rounds twice.
-    Tensor div_result = ttnn::divide(input_a, input_b, std::nullopt, output_mem_config);
-    return ttnn::where(ttnn::eqz(input_b, output_mem_config), 0.0f, div_result);
+    // to keep div(a, +-inf) from coming back NaN. That was a property of the divide
+    // kernel's residual refinement rather than of this op, and it is fixed, so both
+    // dtypes now reach the same kernel. The zero-divisor arm is the only thing that
+    // separates div_no_nan from divide, and it lives inside that kernel rather than
+    // in an eqz and a where over the whole tensor.
+    return ttnn::detail::invoke_binary_ng(
+        input_a,
+        input_b,
+        binary::BinaryOpType::DIV_NO_NAN,
+        std::nullopt,
+        output_mem_config,
+        std::nullopt,
+        {},
+        {},
+        {},
+        std::nullopt);
 }
 
 Tensor prelu(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -61,6 +61,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case MINIMUM:
         case XLOGY:
         case ATAN2:
+        case DIV_NO_NAN:
         case POWER:
         case WHERE_TST:
         case WHERE_TTS:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -366,6 +366,13 @@ OpConfig::OpConfig(
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::DIV_NO_NAN:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::DIV_NO_NAN;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         case BinaryOpType::ATAN2:
             if (is_sfpu_op()) {
                 binary_op = SfpuBinaryOp::ATAN2;
@@ -501,6 +508,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
+        case DIV_NO_NAN: return {"div_binary_tile_init();", "div_no_nan_binary_tile"};
         case LT:
             if (int_data_format) {
                 return {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -79,6 +79,7 @@ struct OpConfig {
         MINIMUM,
         XLOGY,
         ATAN2,
+        DIV_NO_NAN,
         LT,
         GT,
         GE,


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #53770.

`div_no_nan` becomes one kernel. The arm that separates it from the divide is a zero divisor yielding zero, and `calculate_sfpu_binary_div` is already templated on `BinaryOp` without using it, so the two share the whole kernel and differ only inside `v_if(in1 == 0)`.

The float32 special case, `reciprocal + multiply` instead of the divide, goes with it. It was there to avoid `div(a, ±inf)` returning NaN, which is fixed in the first commit.

**This depends on that fix and cannot land without it.** The first commit here is the same change as #53768; if that lands first, this rebases to the two commits that follow it. Without it, routing float32 through the divide reintroduces the NaN that the `reciprocal + multiply` route was written to dodge.

### Accuracy

Three case sets per dtype, on P300 and N300, gated on bit-exactness against what the composite returned.

| case | bfloat16 | float32 |
|---|---|---|
| ordinary (48) | identical | identical |
| zero divisor (8) | identical | identical |
| non-finite operand (8) | identical | identical |

float32 additionally gets closer to the exact quotient, because `reciprocal + multiply` rounds twice. Over 64 pairs the divide is never further and is closer in 14, with the maximum absolute error halving, 1.63e-04 to 8.14e-05. Against `a / b` with the zero arm applied, float32 goes from 14 of 48 ordinary cases differing to 6, which is what bfloat16 already had.

### Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, median cycles per core on the math thread. Zone counts give the kernel count.

| | P300 bf16 | P300 fp32 | N300 bf16 | N300 fp32 |
|---|---|---|---|---|
| kernels per call | 3 → **1** | 4 → **1** | 3 → **1** | 4 → **1** |
| TRISC_1, before | 12330 | 20416 | 27012 | 52704 |
| TRISC_1, after | **5039** | **8976** | **10392** | **21169** |
| | **2.4x** | **2.3x** | **2.6x** | **2.5x** |

### Tests

`test_div_no_nan_fused.py`, 20 cases: a zero divisor over eight dividends including zero and the extremes, equality with the divide away from zero, and an infinite divisor. `test_div_by_infinity.py`, 13 cases, of which 9 fail on `main`.

194 existing div tests across `test_binary_composite.py`, `test_binary_fp32.py` and `test_binaryng_fp32.py` pass unchanged.

### Related context

#52153 lists `div_no_nan` for migration to a device op. #48240 item 20 reports the tensor-scalar overload ignoring `output_mem_config`; that overload is already single-dispatch and is untouched here.

#52094 reports `div` returning `0` for `|b| >= 2^126`. That is the reciprocal underflowing and is not addressed by any commit here.

### Not covered

- The tensor-scalar overload.
- `bfloat8_b` and `bfloat4_b`, and the sharded and broadcast paths.
- The non-finite cases where the op already disagreed with `a / b`, identical before and after.
