### PR TITLE
[Minimax M3] (8, 4) Mesh traceable chunked prefill

### DIFF
--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank_trace.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank_trace.yaml
@@ -1,0 +1,16 @@
+# REQUEST mode (unbounded, H2D-driven), 1 rank, trace serving. Same as pipeline_prefill_request_1rank.yaml
+# plus PREFILL_USE_TRACE. That flag must live in global_env, not the shell: ttrun forwards only TT_*/ARCH_*
+# (and PREFILL_MANIFEST/MODEL/MOCK_MIGRATION) to the rank, so a shell-set PREFILL_USE_TRACE never reaches the
+# runner and it silently serves eager. Model-agnostic — select the model with PREFILL_MANIFEST.
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
+global_env:
+  # XY sub-torus (both axes wrap); matches the [RING,RING] descriptor above. Needs #48711's 2d_torus_* modes.
+  PREFILL_FABRIC_MODE: "2d_torus_xy"
+  PREFILL_MAX_SEQ_LEN: "56320"
+  PREFILL_H2D_SERVICE_ID: "ds_prefill"
+  PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
+  LOGURU_LEVEL: "INFO"
+  PREFILL_USE_TRACE: "1"
+  PREFILL_TRACE_REGION_SIZE: "800000000"

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -208,9 +208,9 @@ def main():
         )
 
     ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
-    # PREFILL_TRACE_POOL needs a DRAM trace region to hold one captured trace per KV-length bucket;
+    # PREFILL_USE_TRACE needs a DRAM trace region to hold one captured trace per KV-length bucket;
     # default 0 leaves the eager path byte-identical (no region reserved).
-    _trace_region = int(os.getenv("PREFILL_TRACE_REGION", "0"))
+    _trace_region = int(os.getenv("PREFILL_TRACE_REGION_SIZE", "0"))
     mesh = ttnn.open_mesh_device(ttnn.MeshShape(rows, cols), trace_region_size=_trace_region)
     print(f"[prefill-pcc] mesh opened {tuple(mesh.shape)} ndev={mesh.get_num_devices()}", flush=True)
     try:
@@ -272,6 +272,7 @@ def main():
             print("[prefill-pcc] loading real bf16 weights + EP placement (slow: bf16 source read) ...", flush=True)
             state_dict = ModelArgs.load_state_dict(model_args.weights_path)
         num_users = int(os.getenv("PREFILL_NUM_USERS", "1"))
+        use_trace = os.getenv("PREFILL_USE_TRACE") == "1"
         cfg = TtPrefillRuntimeConfig(
             num_layers=num_layers,
             max_seq_len=total,
@@ -280,6 +281,7 @@ def main():
             num_users=num_users,
             expert_weight_dtype=expert_dtype,
             weight_cache_path=cache_path,
+            use_trace=use_trace,
         )
         runtime = TtPrefillRuntime(mesh, hf_config, state_dict, cfg)
         del state_dict
@@ -293,12 +295,12 @@ def main():
         print(f"[prefill-pcc] compiling ({num_layers}L, SP=8 × TP=4 + EP=32) ...", flush=True)
         runtime.compile(kv_cache)
 
-        # --- Request-mode WRITE+READ slot correctness (PREFILL_TWO_USER_PCC=1, PREFILL_NUM_USERS>=2):
-        # prefill each user into its own slot (the write/read slot is device-valued whenever num_users > 1),
-        # then PCC every user's cache vs the golden. A mis-targeted slot corrupts one user's KV -> its PCC
-        # craters. Same golden for all users, so each slot must match it independently.
-        if os.getenv("PREFILL_TWO_USER_PCC") == "1":
-            assert num_users >= 2, "PREFILL_TWO_USER_PCC needs PREFILL_NUM_USERS>=2"
+        # Request-mode eager path: more than one user prefills each into its own slot (the write/read slot
+        # is device-valued whenever num_users > 1), times the multi-user pass, then PCCs every slot against
+        # the golden unless PREFILL_SKIP_PCC is set. All slots share one golden, so a mis-targeted slot
+        # corrupts only that user's KV and craters only its PCC. The traced multi-user path is the trace pool
+        # below (PREFILL_USE_TRACE), so defer to it when set.
+        if num_users > 1 and not use_trace:
             two_padded = token_ids + [0] * (total - n_tokens)
             reps = int(os.getenv("PREFILL_TPS_ITERS", "3"))
             passes = []
@@ -315,65 +317,64 @@ def main():
                 passes.append(time.perf_counter() - t0)
                 tok = num_users * n_chunks * chunk
                 print(
-                    f"[prefill-pcc] TWO_USER eager pass {r}: {passes[-1] * 1000:.1f} ms "
+                    f"[prefill-pcc] {num_users}-user eager pass {r}: {passes[-1] * 1000:.1f} ms "
                     f"({tok / passes[-1]:.0f} tok/s, {num_users}u x {n_chunks} chunks)",
                     flush=True,
                 )
             steady = statistics.median(passes[1:]) if reps > 1 else passes[0]
             print(
-                f"[prefill-pcc] TWO_USER eager steady-state (pass>=1): {steady * 1000:.1f} ms/seq "
+                f"[prefill-pcc] {num_users}-user eager steady-state (pass>=1): {steady * 1000:.1f} ms/seq "
                 f"({num_users * n_chunks * chunk / steady:.0f} tok/s, {num_users}u)",
                 flush=True,
             )
-            for uid in range(num_users):
-                print(f"[prefill-pcc] --- user {uid} (slot {uid}) KV PCC vs golden ---", flush=True)
-                check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config, slot_id=uid)
+            if os.environ.get("PREFILL_SKIP_PCC") == "1":
+                print("[prefill-pcc] PREFILL_SKIP_PCC=1 -> skipping per-slot KV PCC", flush=True)
+            else:
+                for uid in range(num_users):
+                    print(f"[prefill-pcc] --- user {uid} (slot {uid}) KV PCC vs golden ---", flush=True)
+                    check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config, slot_id=uid)
             print("[prefill-pcc] DONE", flush=True)
             return 0
 
-        # --- Full per-chunk trace POOL (PREFILL_TRACE_POOL=1): capture one trace per chunk index, then
-        # replay the whole sequence R times. This is the pipeline design's correctness gate in isolation
-        # (single galaxy, no D2D): the replayed KV must match the golden as well as eager does, since the
-        # pool traces ARE the eager forward. Amortization shows as pass>=1 (post-capture) tok/s.
-        if os.getenv("PREFILL_TRACE_POOL") == "1":
+        # --- Serving-path trace (PREFILL_USE_TRACE=1): drive the runner's exact contract — capture_trace()
+        # once, then prefill_chunk() per chunk (which picks the depth bucket, re-targets the user slot, and
+        # replays). Exercises the same runtime code the real prefill_runner uses, so this isolation PCC/perf
+        # gate validates the served path, not a parallel API. Replay amortization shows as pass>=1 tok/s;
+        # num_users > 1 replays each user's slot from the one captured pool via the device-valued slot.
+        if use_trace:
             padded = token_ids + [0] * (total - n_tokens)
-            runtime.capture_prefill_trace_pool(kv_cache, slot_id=0, n_chunks=n_chunks, token_ids=padded)
-            repeats = int(os.getenv("PREFILL_TRACE_POOL_REPEATS", "3"))
-            # Request-mode: one captured bucket pool replayed once per active user, re-targeting the
-            # cache-read slot between users via kv_cache.set_read_user. The user count is NOT baked into
-            # the trace (prefill is per-user-per-chunk), so a load-varying 1..N users is just the replay
-            # count. The device-valued read slot this relies on is active because num_users > 1.
-            users = int(os.getenv("PREFILL_TRACE_POOL_USERS", "1"))
+            runtime.capture_trace(kv_cache)
+            repeats = int(os.getenv("PREFILL_TPS_ITERS", "3"))
             passes = []
             for r in range(repeats):
                 t0 = time.perf_counter()
-                for u in range(users):
-                    if users > 1:
-                        kv_cache.set_read_user(u)
+                for u in range(num_users):
                     for c in range(n_chunks):
-                        runtime.update_chunk_input(c, tokens=padded[c * chunk : (c + 1) * chunk])
-                        runtime.replay_chunk(c)
+                        a = c * chunk
+                        inp = runtime.make_chunk_input(padded[a : a + chunk])
+                        runtime.prefill_chunk(
+                            inp, kv_cache, slot_id=u, actual_start=a, actual_end=min(a + chunk, n_tokens), request_id=c
+                        )
                 ttnn.synchronize_device(mesh)
                 passes.append(time.perf_counter() - t0)
-                tok = users * n_chunks * chunk
+                tok = num_users * n_chunks * chunk
                 print(
-                    f"[prefill-pcc] TRACE_POOL pass {r}: {passes[-1] * 1000:.1f} ms "
-                    f"({tok / passes[-1]:.0f} tok/s, {users}u x {n_chunks} chunks)",
+                    f"[prefill-pcc] TRACE pass {r}: {passes[-1] * 1000:.1f} ms "
+                    f"({tok / passes[-1]:.0f} tok/s, {num_users}u x {n_chunks} chunks)",
                     flush=True,
                 )
             steady = statistics.median(passes[1:]) if repeats > 1 else passes[0]
             print(
-                f"[prefill-pcc] TRACE_POOL steady-state (pass>=1): {steady * 1000:.1f} ms/seq "
-                f"({users * n_chunks * chunk / steady:.0f} tok/s, {users}u)",
+                f"[prefill-pcc] TRACE steady-state (pass>=1): {steady * 1000:.1f} ms/seq "
+                f"({num_users * n_chunks * chunk / steady:.0f} tok/s, {num_users}u)",
                 flush=True,
             )
             if os.environ.get("PREFILL_SKIP_PCC") == "1":
                 print("[prefill-pcc] PREFILL_SKIP_PCC=1 -> skipping KV PCC (perf only)", flush=True)
-            elif users > 1:
-                # RB1 makes the KV-write slot device-valued too, so set_read_user re-targets BOTH read and
-                # write: each user's replay pass above fills its own slot from empty. PCC every user's slot
-                # vs the golden — a mis-targeted read or write corrupts that user's KV and craters its PCC.
-                for uid in range(users):
+            elif num_users > 1:
+                # Each user's replay fills its own slot via the device-valued read+write slot; PCC every
+                # slot vs the golden — a mis-targeted read or write corrupts that user's KV and craters it.
+                for uid in range(num_users):
                     print(f"[prefill-pcc] --- traced user {uid} (slot {uid}) KV PCC vs golden ---", flush=True)
                     check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config, slot_id=uid)
             else:

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -208,7 +208,10 @@ def main():
         )
 
     ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D)
-    mesh = ttnn.open_mesh_device(ttnn.MeshShape(rows, cols))
+    # PREFILL_TRACE_POOL needs a DRAM trace region to hold one captured trace per KV-length bucket;
+    # default 0 leaves the eager path byte-identical (no region reserved).
+    _trace_region = int(os.getenv("PREFILL_TRACE_REGION", "0"))
+    mesh = ttnn.open_mesh_device(ttnn.MeshShape(rows, cols), trace_region_size=_trace_region)
     print(f"[prefill-pcc] mesh opened {tuple(mesh.shape)} ndev={mesh.get_num_devices()}", flush=True)
     try:
         model_args = ModelArgs(mesh_device=mesh)  # HF_MODEL
@@ -288,6 +291,99 @@ def main():
 
         print(f"[prefill-pcc] compiling ({num_layers}L, SP=8 × TP=4 + EP=32) ...", flush=True)
         runtime.compile(kv_cache)
+
+        # --- Full per-chunk trace POOL (PREFILL_TRACE_POOL=1): capture one trace per chunk index, then
+        # replay the whole sequence R times. This is the pipeline design's correctness gate in isolation
+        # (single galaxy, no D2D): the replayed KV must match the golden as well as eager does, since the
+        # pool traces ARE the eager forward. Amortization shows as pass>=1 (post-capture) tok/s.
+        if os.getenv("PREFILL_TRACE_POOL") == "1":
+            padded = token_ids + [0] * (total - n_tokens)
+            runtime.capture_prefill_trace_pool(kv_cache, slot_id=0, n_chunks=n_chunks, token_ids=padded)
+            repeats = int(os.getenv("PREFILL_TRACE_POOL_REPEATS", "3"))
+            passes = []
+            for r in range(repeats):
+                t0 = time.perf_counter()
+                for c in range(n_chunks):
+                    runtime.update_chunk_input(c, tokens=padded[c * chunk : (c + 1) * chunk])
+                    runtime.replay_chunk(c)
+                ttnn.synchronize_device(mesh)
+                passes.append(time.perf_counter() - t0)
+                print(
+                    f"[prefill-pcc] TRACE_POOL pass {r}: {passes[-1] * 1000:.1f} ms "
+                    f"({n_chunks * chunk / passes[-1]:.0f} tok/s, {n_chunks} chunks)",
+                    flush=True,
+                )
+            steady = statistics.median(passes[1:]) if repeats > 1 else passes[0]
+            print(
+                f"[prefill-pcc] TRACE_POOL steady-state (pass>=1): {steady * 1000:.1f} ms/seq "
+                f"({n_chunks * chunk / steady:.0f} tok/s)",
+                flush=True,
+            )
+            if os.environ.get("PREFILL_SKIP_PCC") == "1":
+                print("[prefill-pcc] PREFILL_SKIP_PCC=1 -> skipping KV PCC (perf only)", flush=True)
+            else:
+                check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
+            runtime.release_trace_pool()
+            print("[prefill-pcc] DONE", flush=True)
+            return 0
+
+        # --- Device-only per-chunk rate via execute_trace (PREFILL_TRACE_REPLAY=1). Captures ONE chunk's
+        # forward and replays it, so per-op HOST dispatch is paid once at capture, not per iter — the replay
+        # wall is ~pure device time. This separates the device-collective cost (what a traced production run
+        # pays) from eager host-dispatch, which the eager loop below conflates. A trace is fixed to its
+        # captured KV offset (cached_len is host-side), so one capture serves one depth only:
+        #   default        -> capture at cached_len=0 (Cold-5k device rate)
+        #   TRACE_AT_LAST=1 -> eagerly pre-fill chunks 0..n-2 to build the KV, then capture the LAST chunk at
+        #                      cached_len=(n_chunks-1)*chunk (the true 5k@50k depth rate).
+        if os.getenv("PREFILL_TRACE_REPLAY") == "1":
+            padded = token_ids + [0] * (total - n_tokens)
+            at_last = os.getenv("PREFILL_TRACE_AT_LAST") == "1"
+            a_cap = (n_chunks - 1) * chunk if at_last else 0
+            if at_last:
+                for c in range(n_chunks - 1):  # eager pre-fill to build the accumulated KV up to a_cap
+                    a = c * chunk
+                    inp = runtime.make_chunk_input(padded[a : a + chunk])
+                    runtime.prefill_chunk(inp, kv_cache, slot_id=0, actual_start=a, actual_end=min(a + chunk, n_tokens))
+                ttnn.synchronize_device(mesh)
+            tokens = runtime.make_chunk_input(padded[a_cap : a_cap + chunk])  # persistent; embed reads, never frees
+
+            def _fwd():
+                x = runtime._embed_tokens(tokens)
+                return runtime.model.prefill_forward(
+                    x,
+                    rot_mats_global=runtime.rope_indexed,
+                    kv_cache=kv_cache,
+                    cached_len=a_cap,
+                    user_id=0,
+                    get_last_token=-1,
+                    skip_lm_head=True,
+                    indexed_rope=True,
+                    on_layer_complete=None,
+                )
+
+            o = _fwd()  # warmup after compile (stabilizes allocations before capture)
+            ttnn.synchronize_device(mesh)
+            if o is not None:
+                o.deallocate(True)
+            tid = ttnn.begin_trace_capture(mesh, cq_id=0)
+            o = _fwd()
+            ttnn.end_trace_capture(mesh, tid, cq_id=0)
+            ttnn.synchronize_device(mesh)
+            tr = []
+            for i in range(tps_iters):
+                t0 = time.perf_counter()
+                ttnn.execute_trace(mesh, tid, cq_id=0, blocking=True)
+                tr.append(time.perf_counter() - t0)
+            ttnn.synchronize_device(mesh)
+            m = statistics.median(tr)
+            print(
+                f"[prefill-pcc] TRACED CHUNK over {tps_iters} iters: {chunk} tok @ {a_cap} cache, {num_layers}L, "
+                f"SP={rows}×TP={cols} EP={rows * cols}, median {chunk / m:.1f} tok/s; "
+                f"wall median {m * 1000:.2f} ms [min {min(tr) * 1000:.2f}, max {max(tr) * 1000:.2f}]",
+                flush=True,
+            )
+            print("[prefill-pcc] DONE", flush=True)
+            return 0
 
         # --- throughput. Each iteration re-fills slot 0 (valid for the PCC check after the loop) and
         # times two distinct full-prefill passes, each with syncs placed so it pays for no extra barrier:

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -92,7 +92,7 @@ def plan(n_tokens, chunk_size, chunked):
     return n_chunks, chunk, n_chunks * chunk
 
 
-def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config):
+def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config, slot_id=0):
     """Per-layer K / V / index_k PCC: device cache (gather_layer) vs the golden trace. The device
     stores K / index_k Meta-RoPE swizzled over the rotary slice; the golden is HF half-split, so
     permute the golden's rotary slice (identity tail) before comparing. V is raw (no swizzle).
@@ -117,7 +117,7 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
     logger.info(f"[kv-pcc] per-layer K / V / index_k vs golden ({golden_dir}):")
     mins = {"k": 1.0, "v": 1.0, "index_k": 1.0}
     for L in range(num_layers):
-        dev_k, dev_v, dev_ik = runtime.gather_layer(kv_cache, slot_id=0, layer_idx=L, n_tokens=n_tokens)
+        dev_k, dev_v, dev_ik = runtime.gather_layer(kv_cache, slot_id=slot_id, layer_idx=L, n_tokens=n_tokens)
         with safe_open(str(kv_dir / f"layer_{L}.safetensors"), framework="pt") as h:
             keys = set(h.keys())
             g_k = h.get_tensor(f"key_cache_layer_{L}").float()[:, :, :n_tokens, :][..., src]  # HF -> Meta
@@ -271,12 +271,13 @@ def main():
             )
             print("[prefill-pcc] loading real bf16 weights + EP placement (slow: bf16 source read) ...", flush=True)
             state_dict = ModelArgs.load_state_dict(model_args.weights_path)
+        num_users = int(os.getenv("PREFILL_NUM_USERS", "1"))
         cfg = TtPrefillRuntimeConfig(
             num_layers=num_layers,
             max_seq_len=total,
             mesh_shape=(rows, cols),
             chunk_size=chunk,
-            num_users=1,
+            num_users=num_users,
             expert_weight_dtype=expert_dtype,
             weight_cache_path=cache_path,
         )
@@ -286,11 +287,49 @@ def main():
         # The runtime is stateless w.r.t. the cache (engine-owned model): allocate it here and pass it
         # into every runtime call (compile / prefill_chunk / gather_layer), mirroring the prefill engine.
         kv_cache = allocate_kv_caches(
-            mesh, num_layers=num_layers, max_seq_len=total, num_users=1, head_dim=hf_config.head_dim
+            mesh, num_layers=num_layers, max_seq_len=total, num_users=num_users, head_dim=hf_config.head_dim
         )
 
         print(f"[prefill-pcc] compiling ({num_layers}L, SP=8 × TP=4 + EP=32) ...", flush=True)
         runtime.compile(kv_cache)
+
+        # --- Request-mode WRITE+READ slot correctness (PREFILL_TWO_USER_PCC=1, PREFILL_NUM_USERS>=2):
+        # prefill each user into its own slot (device-valued write/read slot when PREFILL_DEVICE_SLOT_SLICE=1),
+        # then PCC every user's cache vs the golden. A mis-targeted slot corrupts one user's KV -> its PCC
+        # craters. Same golden for all users, so each slot must match it independently.
+        if os.getenv("PREFILL_TWO_USER_PCC") == "1":
+            assert num_users >= 2, "PREFILL_TWO_USER_PCC needs PREFILL_NUM_USERS>=2"
+            two_padded = token_ids + [0] * (total - n_tokens)
+            reps = int(os.getenv("PREFILL_TPS_ITERS", "3"))
+            passes = []
+            for r in range(reps):
+                t0 = time.perf_counter()
+                for uid in range(num_users):
+                    for c in range(n_chunks):
+                        a = c * chunk
+                        inp = runtime.make_chunk_input(two_padded[a : a + chunk])
+                        runtime.prefill_chunk(
+                            inp, kv_cache, slot_id=uid, actual_start=a, actual_end=min(a + chunk, n_tokens)
+                        )
+                ttnn.synchronize_device(mesh)
+                passes.append(time.perf_counter() - t0)
+                tok = num_users * n_chunks * chunk
+                print(
+                    f"[prefill-pcc] TWO_USER eager pass {r}: {passes[-1] * 1000:.1f} ms "
+                    f"({tok / passes[-1]:.0f} tok/s, {num_users}u x {n_chunks} chunks)",
+                    flush=True,
+                )
+            steady = statistics.median(passes[1:]) if reps > 1 else passes[0]
+            print(
+                f"[prefill-pcc] TWO_USER eager steady-state (pass>=1): {steady * 1000:.1f} ms/seq "
+                f"({num_users * n_chunks * chunk / steady:.0f} tok/s, {num_users}u)",
+                flush=True,
+            )
+            for uid in range(num_users):
+                print(f"[prefill-pcc] --- user {uid} (slot {uid}) KV PCC vs golden ---", flush=True)
+                check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config, slot_id=uid)
+            print("[prefill-pcc] DONE", flush=True)
+            return 0
 
         # --- Full per-chunk trace POOL (PREFILL_TRACE_POOL=1): capture one trace per chunk index, then
         # replay the whole sequence R times. This is the pipeline design's correctness gate in isolation
@@ -300,27 +339,43 @@ def main():
             padded = token_ids + [0] * (total - n_tokens)
             runtime.capture_prefill_trace_pool(kv_cache, slot_id=0, n_chunks=n_chunks, token_ids=padded)
             repeats = int(os.getenv("PREFILL_TRACE_POOL_REPEATS", "3"))
+            # Request-mode: one captured bucket pool replayed once per active user, re-targeting the
+            # cache-read slot between users via kv_cache.set_read_user. The user count is NOT baked into
+            # the trace (prefill is per-user-per-chunk), so a load-varying 1..N users is just the replay
+            # count. Requires PREFILL_DEVICE_SLOT_SLICE=1 (device-valued read slot).
+            users = int(os.getenv("PREFILL_TRACE_POOL_USERS", "1"))
             passes = []
             for r in range(repeats):
                 t0 = time.perf_counter()
-                for c in range(n_chunks):
-                    runtime.update_chunk_input(c, tokens=padded[c * chunk : (c + 1) * chunk])
-                    runtime.replay_chunk(c)
+                for u in range(users):
+                    if users > 1:
+                        kv_cache.set_read_user(u)
+                    for c in range(n_chunks):
+                        runtime.update_chunk_input(c, tokens=padded[c * chunk : (c + 1) * chunk])
+                        runtime.replay_chunk(c)
                 ttnn.synchronize_device(mesh)
                 passes.append(time.perf_counter() - t0)
+                tok = users * n_chunks * chunk
                 print(
                     f"[prefill-pcc] TRACE_POOL pass {r}: {passes[-1] * 1000:.1f} ms "
-                    f"({n_chunks * chunk / passes[-1]:.0f} tok/s, {n_chunks} chunks)",
+                    f"({tok / passes[-1]:.0f} tok/s, {users}u x {n_chunks} chunks)",
                     flush=True,
                 )
             steady = statistics.median(passes[1:]) if repeats > 1 else passes[0]
             print(
                 f"[prefill-pcc] TRACE_POOL steady-state (pass>=1): {steady * 1000:.1f} ms/seq "
-                f"({n_chunks * chunk / steady:.0f} tok/s)",
+                f"({users * n_chunks * chunk / steady:.0f} tok/s, {users}u)",
                 flush=True,
             )
             if os.environ.get("PREFILL_SKIP_PCC") == "1":
                 print("[prefill-pcc] PREFILL_SKIP_PCC=1 -> skipping KV PCC (perf only)", flush=True)
+            elif users > 1:
+                # RB1 makes the KV-write slot device-valued too, so set_read_user re-targets BOTH read and
+                # write: each user's replay pass above fills its own slot from empty. PCC every user's slot
+                # vs the golden — a mis-targeted read or write corrupts that user's KV and craters its PCC.
+                for uid in range(users):
+                    print(f"[prefill-pcc] --- traced user {uid} (slot {uid}) KV PCC vs golden ---", flush=True)
+                    check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config, slot_id=uid)
             else:
                 check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
             runtime.release_trace_pool()

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -294,7 +294,7 @@ def main():
         runtime.compile(kv_cache)
 
         # --- Request-mode WRITE+READ slot correctness (PREFILL_TWO_USER_PCC=1, PREFILL_NUM_USERS>=2):
-        # prefill each user into its own slot (device-valued write/read slot when PREFILL_DEVICE_SLOT_SLICE=1),
+        # prefill each user into its own slot (the write/read slot is device-valued whenever num_users > 1),
         # then PCC every user's cache vs the golden. A mis-targeted slot corrupts one user's KV -> its PCC
         # craters. Same golden for all users, so each slot must match it independently.
         if os.getenv("PREFILL_TWO_USER_PCC") == "1":
@@ -342,7 +342,7 @@ def main():
             # Request-mode: one captured bucket pool replayed once per active user, re-targeting the
             # cache-read slot between users via kv_cache.set_read_user. The user count is NOT baked into
             # the trace (prefill is per-user-per-chunk), so a load-varying 1..N users is just the replay
-            # count. Requires PREFILL_DEVICE_SLOT_SLICE=1 (device-valued read slot).
+            # count. The device-valued read slot this relies on is active because num_users > 1.
             users = int(os.getenv("PREFILL_TRACE_POOL_USERS", "1"))
             passes = []
             for r in range(repeats):
@@ -379,64 +379,6 @@ def main():
             else:
                 check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
             runtime.release_trace_pool()
-            print("[prefill-pcc] DONE", flush=True)
-            return 0
-
-        # --- Device-only per-chunk rate via execute_trace (PREFILL_TRACE_REPLAY=1). Captures ONE chunk's
-        # forward and replays it, so per-op HOST dispatch is paid once at capture, not per iter — the replay
-        # wall is ~pure device time. This separates the device-collective cost (what a traced production run
-        # pays) from eager host-dispatch, which the eager loop below conflates. A trace is fixed to its
-        # captured KV offset (cached_len is host-side), so one capture serves one depth only:
-        #   default        -> capture at cached_len=0 (Cold-5k device rate)
-        #   TRACE_AT_LAST=1 -> eagerly pre-fill chunks 0..n-2 to build the KV, then capture the LAST chunk at
-        #                      cached_len=(n_chunks-1)*chunk (the true 5k@50k depth rate).
-        if os.getenv("PREFILL_TRACE_REPLAY") == "1":
-            padded = token_ids + [0] * (total - n_tokens)
-            at_last = os.getenv("PREFILL_TRACE_AT_LAST") == "1"
-            a_cap = (n_chunks - 1) * chunk if at_last else 0
-            if at_last:
-                for c in range(n_chunks - 1):  # eager pre-fill to build the accumulated KV up to a_cap
-                    a = c * chunk
-                    inp = runtime.make_chunk_input(padded[a : a + chunk])
-                    runtime.prefill_chunk(inp, kv_cache, slot_id=0, actual_start=a, actual_end=min(a + chunk, n_tokens))
-                ttnn.synchronize_device(mesh)
-            tokens = runtime.make_chunk_input(padded[a_cap : a_cap + chunk])  # persistent; embed reads, never frees
-
-            def _fwd():
-                x = runtime._embed_tokens(tokens)
-                return runtime.model.prefill_forward(
-                    x,
-                    rot_mats_global=runtime.rope_indexed,
-                    kv_cache=kv_cache,
-                    cached_len=a_cap,
-                    user_id=0,
-                    get_last_token=-1,
-                    skip_lm_head=True,
-                    indexed_rope=True,
-                    on_layer_complete=None,
-                )
-
-            o = _fwd()  # warmup after compile (stabilizes allocations before capture)
-            ttnn.synchronize_device(mesh)
-            if o is not None:
-                o.deallocate(True)
-            tid = ttnn.begin_trace_capture(mesh, cq_id=0)
-            o = _fwd()
-            ttnn.end_trace_capture(mesh, tid, cq_id=0)
-            ttnn.synchronize_device(mesh)
-            tr = []
-            for i in range(tps_iters):
-                t0 = time.perf_counter()
-                ttnn.execute_trace(mesh, tid, cq_id=0, blocking=True)
-                tr.append(time.perf_counter() - t0)
-            ttnn.synchronize_device(mesh)
-            m = statistics.median(tr)
-            print(
-                f"[prefill-pcc] TRACED CHUNK over {tps_iters} iters: {chunk} tok @ {a_cap} cache, {num_layers}L, "
-                f"SP={rows}×TP={cols} EP={rows * cols}, median {chunk / m:.1f} tok/s; "
-                f"wall median {m * 1000:.2f} ms [min {min(tr) * 1000:.2f}, max {max(tr) * 1000:.2f}]",
-                flush=True,
-            )
             print("[prefill-pcc] DONE", flush=True)
             return 0
 

--- a/models/demos/minimax_m3/tests/unit/test_device_slot_slice.py
+++ b/models/demos/minimax_m3/tests/unit/test_device_slot_slice.py
@@ -1,0 +1,67 @@
+"""Byte-parity: device-valued slot select vs host-int slice.
+
+The chunked-prefill cache read (attention/prefill.py) slices one (user,layer) slot out of the
+packed cache with a host-int begin index, which bakes the slot into any captured trace. Request-mode
+tracing needs the slot to vary per replay, i.e. read from a device tensor. ttnn.slice's device-tensor
+path is a partition-select (slice_dim split into num_devices equal parts, one picked by the device
+begin) that only reshapes slice_dim, so it cannot also bound the row dim -> slot via the device
+partition-slice on dim 0, then the existing host-int slice bounds the row dim. This proves that
+two-step path is bit-identical to the single host-int slice for an arbitrary slot.
+"""
+
+import torch
+
+import ttnn
+
+
+def _run(mesh):
+    n_slots, max_rows, head_dim = 12, 256, 128
+    torch.manual_seed(0)
+    packed = torch.randn(n_slots, 1, max_rows, head_dim)
+    dev = ttnn.from_torch(
+        packed, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    failures = []
+    for slot in (0, 1, 5, n_slots - 1):
+        for n_rows in (32, 128, max_rows):
+            ref = ttnn.to_torch(ttnn.slice(dev, (slot, 0, 0, 0), (slot + 1, 1, n_rows, head_dim)))
+
+            start = ttnn.from_torch(
+                torch.tensor([slot, 0, 0, 0], dtype=torch.int32),
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=mesh,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            end = ttnn.from_torch(
+                torch.tensor([slot + 1, 1, max_rows, head_dim], dtype=torch.int32),
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=mesh,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            slot_full = ttnn.slice(dev, starts=start, ends=end, slice_dim=0, num_devices=n_slots)  # [1,1,max_rows,hd]
+            got = ttnn.to_torch(ttnn.slice(slot_full, (0, 0, 0, 0), (1, 1, n_rows, head_dim)))
+
+            max_abs = (ref - got).abs().max().item()
+            tag = f"slot={slot:2d} n_rows={n_rows:3d} shape={tuple(got.shape)} max_abs_diff={max_abs:.3e}"
+            print(("PASS " if max_abs == 0.0 else "FAIL ") + tag, flush=True)
+            if max_abs != 0.0:
+                failures.append(tag)
+    return failures
+
+
+def main():
+    mesh = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
+    try:
+        failures = _run(mesh)
+    finally:
+        ttnn.close_mesh_device(mesh)
+    if failures:
+        raise SystemExit(f"{len(failures)} byte-parity FAILURES: {failures}")
+    print("ALL PASS: device slot-slice == host-int slice (byte-parity)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/minimax_m3/tests/unit/test_device_slot_slice_trace.py
+++ b/models/demos/minimax_m3/tests/unit/test_device_slot_slice_trace.py
@@ -1,0 +1,93 @@
+"""Trace-replayability of the device-valued slot slice.
+
+Request-mode tracing needs one captured trace to serve any user: the slot begin rides a persistent
+device tensor, and updating that tensor between replays must re-target the slot WITHOUT recapture.
+The slice reader NoC-reads the start tensor at kernel runtime, so execute_trace should observe fresh
+contents. This proves it: capture the slice over a persistent start = slot A, replay -> slot A;
+copy_host_to_device the start = slot B, replay the SAME trace -> slot B.
+"""
+
+import torch
+
+import ttnn
+
+
+def main():
+    n_slots, rows, head_dim = 12, 256, 128
+    mesh = ttnn.open_mesh_device(ttnn.MeshShape(1, 1), trace_region_size=200_000_000)
+    try:
+        # Distinct per-slot contents so a mis-targeted slot is caught (slot k filled with value k).
+        packed = torch.arange(n_slots, dtype=torch.float32).view(n_slots, 1, 1, 1).expand(n_slots, 1, rows, head_dim)
+        dev = ttnn.from_torch(
+            packed.contiguous(),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        def host_ref(slot):
+            return ttnn.to_torch(ttnn.slice(dev, (slot, 0, 0, 0), (slot + 1, 1, rows, head_dim)))
+
+        slot_a, slot_b = 3, 9
+        start = ttnn.from_torch(
+            torch.tensor([slot_a, 0, 0, 0], dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        end = ttnn.from_torch(
+            torch.tensor([slot_a + 1, 1, rows, head_dim], dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        def sliced():
+            return ttnn.slice(dev, starts=start, ends=end, slice_dim=0, num_devices=n_slots)
+
+        sliced()  # warm compile before capture
+        tid = ttnn.begin_trace_capture(mesh, cq_id=0)
+        out = sliced()
+        ttnn.end_trace_capture(mesh, tid, cq_id=0)
+
+        def replay_and_check(expect_slot, tag):
+            ttnn.execute_trace(mesh, tid, cq_id=0, blocking=True)
+            got = ttnn.to_torch(out)
+            ref = host_ref(expect_slot)
+            max_abs = (got - ref).abs().max().item()
+            val = got.flatten()[0].item()
+            print(
+                f"{'PASS' if max_abs == 0.0 else 'FAIL'} {tag}: slot={expect_slot} first_val={val:.1f} max_abs_diff={max_abs:.3e}",
+                flush=True,
+            )
+            return max_abs == 0.0
+
+        ok = replay_and_check(slot_a, "replay@capture-slot")
+
+        # Re-target: overwrite the persistent start in place; the SAME trace must now read slot B.
+        host_start = ttnn.from_torch(
+            torch.tensor([slot_b, 0, 0, 0], dtype=torch.int32), dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
+        )
+        ttnn.copy_host_to_device_tensor(host_start, start)
+        ok &= replay_and_check(slot_b, "replay@updated-slot")
+
+        # Back to A to rule out a one-way latch.
+        host_start_a = ttnn.from_torch(
+            torch.tensor([slot_a, 0, 0, 0], dtype=torch.int32), dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
+        )
+        ttnn.copy_host_to_device_tensor(host_start_a, start)
+        ok &= replay_and_check(slot_a, "replay@back-to-A")
+
+        ttnn.release_trace(mesh, tid)
+    finally:
+        ttnn.close_mesh_device(mesh)
+    if not ok:
+        raise SystemExit("FAIL: persistent start tensor did not re-target the traced slice")
+    print("ALL PASS: one trace re-targets the slot via the persistent start tensor (request-mode ready)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/minimax_m3/tt/attention/kv_cache.py
+++ b/models/demos/minimax_m3/tt/attention/kv_cache.py
@@ -40,14 +40,13 @@ class MiniMaxKVCache(KvCaches):
     max_seq_len: int
     sp: int
 
-    # Device-valued slot metadata for request-mode tracing (populated only when num_users > 1). A captured trace
-    # reads these tensors by address, so an in-place host update (set_read_user) re-targets the user's slot
-    # WITHOUT recapture. `_slot_frozen` is set around trace capture so the captured forward only reads them
-    # (a host copy inside a trace is illegal); the warm forward pre-sets the values.
-    #   _read_slot_start   — cache-read partition-slice begin [slot,0,0,0], one per layer (prefill.py). The
-    #                        `_read_slot_end` companion is a constant (the reader ignores its value).
-    #   _write_slot        — KV-write user slot (update_padded_kv_cache tensor form); one scalar, all layers.
-    #   _write_kv_actual   — KV-write prior-length scalar, one per distinct depth (bucket); value == key.
+    # Device-valued slot metadata for request-mode tracing (populated only when num_users > 1). A captured
+    # trace reads these tensors by address, so set_read_user re-targets a user's slot in place without
+    # recapture; `_slot_frozen` blocks the host update during capture (a host copy inside a trace is illegal).
+    #   _read_slot_start — cache-read partition-slice begin [slot,0,0,0], one per layer. `_read_slot_end` is a
+    #                      constant companion (the reader ignores its value).
+    #   _write_slot      — KV-write user slot (update_padded_kv_cache tensor form); one scalar, all layers.
+    #   _write_kv_actual — KV-write prior-length scalar, one per distinct depth (bucket).
     _read_slot_start: dict = field(default_factory=dict, repr=False)
     _read_slot_end: object = field(default=None, repr=False)
     _write_slot: object = field(default=None, repr=False)
@@ -76,7 +75,6 @@ class MiniMaxKVCache(KvCaches):
 
     @staticmethod
     def _host_scalar(val):
-        # Host-side 1-element uint32 for the in-place copy_host_to_device update of a device scalar.
         return ttnn.from_torch(
             torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
             dtype=ttnn.uint32,
@@ -84,9 +82,8 @@ class MiniMaxKVCache(KvCaches):
         )
 
     def read_slot_start(self, layer_idx, slot, mesh_device):
-        """Persistent [slot,0,0,0] begin tensor for `layer_idx`, reused across chunks/users. Updated to
-        `slot` in place unless frozen; during trace capture the value is pre-set by the warm forward and
-        must be read as-is (a host copy inside a captured trace is illegal)."""
+        """Persistent [slot,0,0,0] begin tensor for `layer_idx`, reused across chunks/users. Re-targets to
+        `slot` in place unless frozen — during capture the warm forward's value must be read as-is."""
         t = self._read_slot_start.get(layer_idx)
         if t is None:
             self._read_slot_start[layer_idx] = t = self._begin_index_tensor([slot, 0, 0, 0], mesh_device)
@@ -115,8 +112,8 @@ class MiniMaxKVCache(KvCaches):
         return self._write_slot
 
     def write_kv_actual_tensor(self, kv_actual, mesh_device):
-        """Persistent prior-KV-length scalar, one per distinct depth (bucket). value == key, so it is never
-        updated after creation — each captured bucket reads its own depth, shared across users."""
+        """Persistent prior-KV-length scalar, keyed by depth (bucket), so it is never updated after creation —
+        each bucket reads its own depth and is shared across users (no set_read_user)."""
         t = self._write_kv_actual.get(kv_actual)
         if t is None:
             self._write_kv_actual[kv_actual] = t = self._meta_scalar(kv_actual, mesh_device)

--- a/models/demos/minimax_m3/tt/attention/kv_cache.py
+++ b/models/demos/minimax_m3/tt/attention/kv_cache.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 
@@ -14,6 +14,11 @@ from models.demos.common.prefill.adapter import KvCaches
 # round-robin across BH_NUM_DRAM_BANKS DRAM banks. The address-table builder must match both values.
 NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
 BH_NUM_DRAM_BANKS = 8
+
+# Request-mode device-valued slot metadata: same flag as the cache-read slot slice (prefill.py). When on,
+# the KV write takes update_padded_kv_cache's traceable tensor form so the write slot rides a device tensor
+# and a captured trace re-targets any user's slot. Default off = host-scalar write, unchanged.
+_DEVICE_SLOT_SLICE = os.environ.get("PREFILL_DEVICE_SLOT_SLICE", "0") == "1"
 
 
 @dataclass
@@ -39,6 +44,103 @@ class MiniMaxKVCache(KvCaches):
     num_layers: int
     max_seq_len: int
     sp: int
+
+    # Device-valued slot metadata for request-mode tracing (PREFILL_DEVICE_SLOT_SLICE=1). A captured trace
+    # reads these tensors by address, so an in-place host update (set_read_user) re-targets the user's slot
+    # WITHOUT recapture. `_slot_frozen` is set around trace capture so the captured forward only reads them
+    # (a host copy inside a trace is illegal); the warm forward pre-sets the values.
+    #   _read_slot_start   — cache-read partition-slice begin [slot,0,0,0], one per layer (prefill.py). The
+    #                        `_read_slot_end` companion is a constant (the reader ignores its value).
+    #   _write_slot        — KV-write user slot (update_padded_kv_cache tensor form); one scalar, all layers.
+    #   _write_kv_actual   — KV-write prior-length scalar, one per distinct depth (bucket); value == key.
+    _read_slot_start: dict = field(default_factory=dict, repr=False)
+    _read_slot_end: object = field(default=None, repr=False)
+    _write_slot: object = field(default=None, repr=False)
+    _write_kv_actual: dict = field(default_factory=dict, repr=False)
+    _slot_frozen: bool = field(default=False, repr=False)
+
+    def _begin_index_tensor(self, values, mesh_device):
+        return ttnn.from_torch(
+            torch.tensor(values, dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _meta_scalar(self, val, mesh_device):
+        # 1-element uint32 replicated-DRAM scalar; update_padded_kv_cache's tensor form reads element [0].
+        return ttnn.from_torch(
+            torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+    @staticmethod
+    def _host_scalar(val):
+        # Host-side 1-element uint32 for the in-place copy_host_to_device update of a device scalar.
+        return ttnn.from_torch(
+            torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+    def read_slot_start(self, layer_idx, slot, mesh_device):
+        """Persistent [slot,0,0,0] begin tensor for `layer_idx`, reused across chunks/users. Updated to
+        `slot` in place unless frozen; during trace capture the value is pre-set by the warm forward and
+        must be read as-is (a host copy inside a captured trace is illegal)."""
+        t = self._read_slot_start.get(layer_idx)
+        if t is None:
+            self._read_slot_start[layer_idx] = t = self._begin_index_tensor([slot, 0, 0, 0], mesh_device)
+        elif not self._slot_frozen:
+            ttnn.copy_host_to_device_tensor(
+                ttnn.from_torch(
+                    torch.tensor([slot, 0, 0, 0], dtype=torch.int32), dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
+                ),
+                t,
+            )
+        return t
+
+    def read_slot_end(self, max_rows, head_dim, mesh_device):
+        if self._read_slot_end is None:
+            self._read_slot_end = self._begin_index_tensor(
+                [self.num_users * self.num_layers, 1, max_rows, head_dim], mesh_device
+            )
+        return self._read_slot_end
+
+    def write_slot_tensor(self, slot_idx, mesh_device):
+        """Persistent user-slot scalar for the traceable KV write. Updated in place unless frozen."""
+        if self._write_slot is None:
+            self._write_slot = self._meta_scalar(slot_idx, mesh_device)
+        elif not self._slot_frozen:
+            ttnn.copy_host_to_device_tensor(self._host_scalar(slot_idx), self._write_slot)
+        return self._write_slot
+
+    def write_kv_actual_tensor(self, kv_actual, mesh_device):
+        """Persistent prior-KV-length scalar, one per distinct depth (bucket). value == key, so it is never
+        updated after creation — each captured bucket reads its own depth, shared across users."""
+        t = self._write_kv_actual.get(kv_actual)
+        if t is None:
+            self._write_kv_actual[kv_actual] = t = self._meta_scalar(kv_actual, mesh_device)
+        return t
+
+    def set_read_user(self, user_id):
+        """Point every device-valued slot tensor at `user_id` (read begins + the KV-write slot). Call before
+        replaying a captured trace for a different user (host update outside the trace). kv_actual is not
+        touched — depth is a per-bucket constant shared across users."""
+        for layer_idx, t in self._read_slot_start.items():
+            slot = user_id * self.num_layers + layer_idx
+            ttnn.copy_host_to_device_tensor(
+                ttnn.from_torch(
+                    torch.tensor([slot, 0, 0, 0], dtype=torch.int32), dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT
+                ),
+                t,
+            )
+        if self._write_slot is not None:
+            ttnn.copy_host_to_device_tensor(self._host_scalar(user_id), self._write_slot)
 
 
 def allocate_kv_caches(
@@ -112,23 +214,38 @@ def allocate_kv_caches(
     )
 
 
-def _write_one(cache, tensor, *, slot_idx, layer_idx, num_layers, kv_actual, sp_axis):
+def _write_one(kv_cache, cache, tensor, *, slot_idx, layer_idx, num_layers, kv_actual, sp_axis):
     """Write one SP-sharded chunk tensor into a packed cache via update_padded_kv_cache.
 
     The op requires TILE layout and input.dtype == cache.dtype, so cast a copy to the cache's dtype when
     needed (the original stays live for the attention op that follows). At ``kv_actual % 32 == 0`` chunk
     boundaries the per-device write offset is contiguous (block-cyclic degenerates to a reshape).
+
+    PREFILL_DEVICE_SLOT_SLICE=1 takes the op's traceable tensor form: slot/kv_actual are read on-device
+    from persistent scalars (kv_cache), so a captured trace re-targets the write slot per user.
     """
     src = tensor if tensor.dtype == cache.dtype else ttnn.typecast(tensor, cache.dtype)
-    ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
-        cache,
-        src,
-        slot_idx=slot_idx,
-        layer_idx=layer_idx,
-        num_layers=num_layers,
-        kv_actual_global=kv_actual,
-        cluster_axis=sp_axis,
-    )
+    if _DEVICE_SLOT_SLICE:
+        mesh_device = cache.device()
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            cache,
+            src,
+            kv_cache.write_slot_tensor(slot_idx, mesh_device),
+            kv_cache.write_kv_actual_tensor(kv_actual, mesh_device),
+            layer_idx=layer_idx,
+            num_layers=num_layers,
+            cluster_axis=sp_axis,
+        )
+    else:
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            cache,
+            src,
+            slot_idx=slot_idx,
+            layer_idx=layer_idx,
+            num_layers=num_layers,
+            kv_actual_global=kv_actual,
+            cluster_axis=sp_axis,
+        )
     if src is not tensor:
         src.deallocate(True)
 
@@ -141,6 +258,7 @@ def write_kv_chunk(kv_cache: MiniMaxKVCache, tt_k, tt_v, *, slot_idx, layer_idx,
     in place. ``kv_actual`` is the cumulative valid prefix before this chunk (0 for non-chunked).
     """
     _write_one(
+        kv_cache,
         kv_cache.k,
         tt_k,
         slot_idx=slot_idx,
@@ -150,6 +268,7 @@ def write_kv_chunk(kv_cache: MiniMaxKVCache, tt_k, tt_v, *, slot_idx, layer_idx,
         sp_axis=sp_axis,
     )
     _write_one(
+        kv_cache,
         kv_cache.v,
         tt_v,
         slot_idx=slot_idx,
@@ -167,6 +286,7 @@ def write_index_k_chunk(kv_cache: MiniMaxKVCache, tt_index_k, *, slot_idx, layer
     REPLICATED across the TP cols (so each col writes the same data into its replicated cache slot).
     """
     _write_one(
+        kv_cache,
         kv_cache.index_k,
         tt_index_k,
         slot_idx=slot_idx,

--- a/models/demos/minimax_m3/tt/attention/kv_cache.py
+++ b/models/demos/minimax_m3/tt/attention/kv_cache.py
@@ -15,11 +15,6 @@ from models.demos.common.prefill.adapter import KvCaches
 NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
 BH_NUM_DRAM_BANKS = 8
 
-# Request-mode device-valued slot metadata: same flag as the cache-read slot slice (prefill.py). When on,
-# the KV write takes update_padded_kv_cache's traceable tensor form so the write slot rides a device tensor
-# and a captured trace re-targets any user's slot. Default off = host-scalar write, unchanged.
-_DEVICE_SLOT_SLICE = os.environ.get("PREFILL_DEVICE_SLOT_SLICE", "0") == "1"
-
 
 @dataclass
 class MiniMaxKVCache(KvCaches):
@@ -45,7 +40,7 @@ class MiniMaxKVCache(KvCaches):
     max_seq_len: int
     sp: int
 
-    # Device-valued slot metadata for request-mode tracing (PREFILL_DEVICE_SLOT_SLICE=1). A captured trace
+    # Device-valued slot metadata for request-mode tracing (populated only when num_users > 1). A captured trace
     # reads these tensors by address, so an in-place host update (set_read_user) re-targets the user's slot
     # WITHOUT recapture. `_slot_frozen` is set around trace capture so the captured forward only reads them
     # (a host copy inside a trace is illegal); the warm forward pre-sets the values.
@@ -221,11 +216,11 @@ def _write_one(kv_cache, cache, tensor, *, slot_idx, layer_idx, num_layers, kv_a
     needed (the original stays live for the attention op that follows). At ``kv_actual % 32 == 0`` chunk
     boundaries the per-device write offset is contiguous (block-cyclic degenerates to a reshape).
 
-    PREFILL_DEVICE_SLOT_SLICE=1 takes the op's traceable tensor form: slot/kv_actual are read on-device
+    With more than one user this takes the op's traceable tensor form: slot/kv_actual are read on-device
     from persistent scalars (kv_cache), so a captured trace re-targets the write slot per user.
     """
     src = tensor if tensor.dtype == cache.dtype else ttnn.typecast(tensor, cache.dtype)
-    if _DEVICE_SLOT_SLICE:
+    if kv_cache.num_users > 1:
         mesh_device = cache.device()
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
             cache,

--- a/models/demos/minimax_m3/tt/attention/prefill.py
+++ b/models/demos/minimax_m3/tt/attention/prefill.py
@@ -28,12 +28,10 @@ from .weights import AttentionWeights
 
 
 def _slot_slice_device(packed, kv_cache, layer_idx, slot, n_rows, head_dim, mesh_device):
-    # ttnn.slice's device-tensor path is a partition-select: it splits slice_dim into num_devices
-    # equal parts and picks the one at the device-valued begin, reshaping ONLY slice_dim. num_devices
-    # = the slot count makes unit slices, so the begin tensor selects slot `slot` on dim 0 and a trace
-    # replays any user's slot. The row-count bound (dim 2, constant per KV-length bucket) stays a
-    # host-int slice, since the partition path cannot bound the other dims. The begin tensor is
-    # persistent (kv_cache) so a captured trace re-targets the slot by an in-place host update.
+    # ttnn.slice's device-tensor path is a partition-select: it splits slice_dim into num_devices equal
+    # parts and picks the one at the device-valued begin. num_devices = slot count makes unit slices, so the
+    # persistent begin tensor selects a slot on dim 0 and an in-place host update re-targets it under a trace.
+    # The row-count bound (dim 2) stays a host-int slice — the partition path cannot bound the other dims.
     n_slots = packed.shape[0]
     max_rows = packed.shape[2]
     start = kv_cache.read_slot_start(layer_idx, slot, mesh_device)
@@ -236,10 +234,9 @@ def attention_forward(
                     v_int = ttnn.to_memory_config(kv_cache.v, ttnn.DRAM_MEMORY_CONFIG)
                     ik_int = ttnn.to_memory_config(kv_cache.index_k, ttnn.DRAM_MEMORY_CONFIG)
                 with zone("slice", FINE):
-                    # With more than one user the slot has to vary per replay, so it rides a device
-                    # tensor that a host update re-targets; a captured trace would otherwise bake whichever
-                    # host int it saw. At one user every layer's slot is fixed, so the host int is already
-                    # correct and cheaper.
+                    # Multi-user: the slot varies per replay, so it rides a device tensor a host update
+                    # re-targets (a host int would be baked into the trace). At one user the slot is fixed,
+                    # so the host int is correct and cheaper.
                     if kv_cache.num_users > 1:
                         k_acc = _slot_slice_device(
                             k_int, kv_cache, layer_idx, slot, n_rows, config.head_dim, mesh_device

--- a/models/demos/minimax_m3/tt/attention/prefill.py
+++ b/models/demos/minimax_m3/tt/attention/prefill.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import os
-
 import ttnn
 from models.demos.minimax_m3.utils.profiler_utils import FINE, zone
 
@@ -27,11 +25,6 @@ from .operations import (
     split_qkv_heads_prefill,
 )
 from .weights import AttentionWeights
-
-
-# Select the cache slot with a device-valued begin index instead of a host int, so a captured
-# per-chunk trace can replay any user's slot (request mode). Default off = host-int slice, unchanged.
-_DEVICE_SLOT_SLICE = os.environ.get("PREFILL_DEVICE_SLOT_SLICE", "0") == "1"
 
 
 def _slot_slice_device(packed, kv_cache, layer_idx, slot, n_rows, head_dim, mesh_device):
@@ -243,7 +236,11 @@ def attention_forward(
                     v_int = ttnn.to_memory_config(kv_cache.v, ttnn.DRAM_MEMORY_CONFIG)
                     ik_int = ttnn.to_memory_config(kv_cache.index_k, ttnn.DRAM_MEMORY_CONFIG)
                 with zone("slice", FINE):
-                    if _DEVICE_SLOT_SLICE:
+                    # With more than one user the slot has to vary per replay, so it rides a device
+                    # tensor that a host update re-targets; a captured trace would otherwise bake whichever
+                    # host int it saw. At one user every layer's slot is fixed, so the host int is already
+                    # correct and cheaper.
+                    if kv_cache.num_users > 1:
                         k_acc = _slot_slice_device(
                             k_int, kv_cache, layer_idx, slot, n_rows, config.head_dim, mesh_device
                         )

--- a/models/demos/minimax_m3/tt/attention/prefill.py
+++ b/models/demos/minimax_m3/tt/attention/prefill.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import ttnn
 from models.demos.minimax_m3.utils.profiler_utils import FINE, zone
 
@@ -25,6 +27,26 @@ from .operations import (
     split_qkv_heads_prefill,
 )
 from .weights import AttentionWeights
+
+
+# Select the cache slot with a device-valued begin index instead of a host int, so a captured
+# per-chunk trace can replay any user's slot (request mode). Default off = host-int slice, unchanged.
+_DEVICE_SLOT_SLICE = os.environ.get("PREFILL_DEVICE_SLOT_SLICE", "0") == "1"
+
+
+def _slot_slice_device(packed, kv_cache, layer_idx, slot, n_rows, head_dim, mesh_device):
+    # ttnn.slice's device-tensor path is a partition-select: it splits slice_dim into num_devices
+    # equal parts and picks the one at the device-valued begin, reshaping ONLY slice_dim. num_devices
+    # = the slot count makes unit slices, so the begin tensor selects slot `slot` on dim 0 and a trace
+    # replays any user's slot. The row-count bound (dim 2, constant per KV-length bucket) stays a
+    # host-int slice, since the partition path cannot bound the other dims. The begin tensor is
+    # persistent (kv_cache) so a captured trace re-targets the slot by an in-place host update.
+    n_slots = packed.shape[0]
+    max_rows = packed.shape[2]
+    start = kv_cache.read_slot_start(layer_idx, slot, mesh_device)
+    end = kv_cache.read_slot_end(max_rows, head_dim, mesh_device)
+    slot_full = ttnn.slice(packed, starts=start, ends=end, slice_dim=0, num_devices=n_slots)
+    return ttnn.slice(slot_full, (0, 0, 0, 0), (1, 1, n_rows, head_dim))
 
 
 def attention_forward(
@@ -221,9 +243,20 @@ def attention_forward(
                     v_int = ttnn.to_memory_config(kv_cache.v, ttnn.DRAM_MEMORY_CONFIG)
                     ik_int = ttnn.to_memory_config(kv_cache.index_k, ttnn.DRAM_MEMORY_CONFIG)
                 with zone("slice", FINE):
-                    k_acc = ttnn.slice(k_int, (slot, 0, 0, 0), (slot + 1, 1, n_rows, config.head_dim))
-                    v_acc = ttnn.slice(v_int, (slot, 0, 0, 0), (slot + 1, 1, n_rows, config.head_dim))
-                    ik_acc = ttnn.slice(ik_int, (slot, 0, 0, 0), (slot + 1, 1, n_rows, config.head_dim))
+                    if _DEVICE_SLOT_SLICE:
+                        k_acc = _slot_slice_device(
+                            k_int, kv_cache, layer_idx, slot, n_rows, config.head_dim, mesh_device
+                        )
+                        v_acc = _slot_slice_device(
+                            v_int, kv_cache, layer_idx, slot, n_rows, config.head_dim, mesh_device
+                        )
+                        ik_acc = _slot_slice_device(
+                            ik_int, kv_cache, layer_idx, slot, n_rows, config.head_dim, mesh_device
+                        )
+                    else:
+                        k_acc = ttnn.slice(k_int, (slot, 0, 0, 0), (slot + 1, 1, n_rows, config.head_dim))
+                        v_acc = ttnn.slice(v_int, (slot, 0, 0, 0), (slot + 1, 1, n_rows, config.head_dim))
+                        ik_acc = ttnn.slice(ik_int, (slot, 0, 0, 0), (slot + 1, 1, n_rows, config.head_dim))
                 k_int.deallocate(True)
                 v_int.deallocate(True)
                 ik_int.deallocate(True)

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -468,9 +468,15 @@ class TtPrefillRuntime:
         ttnn.synchronize_device(mesh)
         if warm is not None:
             warm.deallocate(True)
+        # The warm forward has set the device slot metadata (read begins + KV-write slot/kv_actual) to
+        # slot_id; freeze them so the captured forward only reads (a host copy inside the trace would be
+        # illegal). A later replay for another user updates the slot via kv_cache.set_read_user, outside
+        # the trace.
+        kv_cache._slot_frozen = True
         tid = ttnn.begin_trace_capture(mesh, cq_id=0)
         out = self._trace_fwd(buf, cached_len, slot_id, kv_cache)
         ttnn.end_trace_capture(mesh, tid, cq_id=0)
+        kv_cache._slot_frozen = False
         ttnn.synchronize_device(mesh)
         if self._trace_pool is None:
             self._trace_pool = {}

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -109,8 +109,8 @@ class TtPrefillRuntime:
         self._on_layer_complete = None
         # Per-layer completion sink for pipelined prefill, registered via set_layer_completion_sink().
         self._layer_completion_sink = None
-        # Per-chunk metal-trace pool (c -> {tid, in, out, cached_len}) + its persistent input buffers,
-        # populated by capture_chunk_trace / capture_prefill_trace_pool. None until captured.
+        # Per-chunk metal-trace pool (c -> {tid, in, out, cached_len}) + its persistent input buffers.
+        # None until capture_trace().
         self._trace_pool = None
         self._trace_in = None
 
@@ -332,6 +332,23 @@ class TtPrefillRuntime:
             actual_start < actual_end <= actual_start + self.config.chunk_size
         ), f"[actual_start={actual_start}, actual_end={actual_end}) not within one chunk of {self.config.chunk_size}"
 
+        if self.config.use_trace and self._trace_pool is not None:
+            # Replay this chunk's captured bucket (selected by cache offset) instead of re-dispatching,
+            # after re-targeting the device-valued slot (num_users > 1) and refreshing the input in place.
+            # compile()'s warm sweep runs before capture, when the pool is empty, so it falls through to the
+            # eager path below — which is what warms the programs the capture then records.
+            assert skip_lm_head and get_last_token == -1, (
+                "use_trace captures the headless cache-fill forward; logits (skip_lm_head=False / "
+                "get_last_token>=0) are not on the traced path"
+            )
+            bucket = actual_start // self.config.chunk_size
+            assert bucket in self._trace_pool, f"no captured trace for cache offset {actual_start} (bucket {bucket})"
+            if kv_cache.num_users > 1:
+                kv_cache.set_read_user(slot_id)
+            self.update_chunk_input(bucket, activation=input_tensor)
+            ttnn.deallocate(input_tensor)
+            return self.replay_chunk(bucket)
+
         # First rank embeds the SP-sharded tokens. On a non-first rank the input is already the upstream
         # hidden state, fed straight in — the first decoder layer frees it, so don't deallocate it here.
         if self.config.is_first_rank:
@@ -404,17 +421,13 @@ class TtPrefillRuntime:
         self._layer_completion_sink = sink
 
     # --- Per-chunk metal-trace pool -------------------------------------------------------------------
-    # One trace per chunk INDEX, not one reusable trace: cached_len is a host scalar baked into each
-    # capture — it selects the RoPE start row, the KV-cache write offset, kv_len and the causal
-    # chunk_start, and (at cached_len==0) gates the no-cache op path — so a trace serves exactly its
-    # chunk index and slot. The win is amortization: capture pays the per-op host dispatch once, then a
-    # later prefill of the SAME slot replays each chunk as a single execute_trace. A single one-pass
-    # prefill sees no benefit (each chunk runs once); the pool pays off across repeated prefills.
+    # One trace per chunk index, not one reusable trace: cached_len is a host scalar baked into each
+    # capture (RoPE start row, KV write offset, kv_len, causal chunk_start, and the cached_len==0 no-cache
+    # gate), so each trace serves exactly its chunk index. Amortizes host dispatch across repeated prefills.
 
     def _trace_fwd(self, buf, cached_len: int, slot_id: int, kv_cache):
-        # The trace-clean body: embed (first rank) or a clone of the received activation (non-first —
-        # prefill_forward's first layer frees its input, so feed a clone and keep the persistent buffer),
-        # then the device-only forward. rot_mats_global=self.rope_indexed avoids the SP+trace host reshard.
+        # Non-first rank clones the input because prefill_forward's first layer frees its arg, and the
+        # persistent buffer must survive. rot_mats_global=self.rope_indexed avoids the SP+trace host reshard.
         x = self._embed_tokens(buf) if self.config.is_first_rank else ttnn.clone(buf)
         return self.model.prefill_forward(
             x,
@@ -468,10 +481,8 @@ class TtPrefillRuntime:
         ttnn.synchronize_device(mesh)
         if warm is not None:
             warm.deallocate(True)
-        # The warm forward has set the device slot metadata (read begins + KV-write slot/kv_actual) to
-        # slot_id; freeze them so the captured forward only reads (a host copy inside the trace would be
-        # illegal). A later replay for another user updates the slot via kv_cache.set_read_user, outside
-        # the trace.
+        # The warm forward pre-set the device slot metadata to slot_id; freeze it so the captured forward
+        # only reads it — a host copy inside a trace is illegal (set_read_user re-targets it outside).
         kv_cache._slot_frozen = True
         tid = ttnn.begin_trace_capture(mesh, cq_id=0)
         out = self._trace_fwd(buf, cached_len, slot_id, kv_cache)
@@ -509,6 +520,17 @@ class TtPrefillRuntime:
                 ttnn.release_trace(self.mesh_device, slot["tid"])
             self._trace_pool = None
         self._trace_in = None
+
+    def capture_trace(self, kv_cache) -> None:
+        """Runner hook (`prefill_runner.py`), called ONCE before the request loop when config.use_trace is
+        set: pre-capture the whole per-bucket pool so every later prefill_chunk replays instead of
+        dispatching. One trace per depth bucket up to the configured max (chunk boundaries 0..max_seq_len),
+        captured over slot 0; num_users > 1 makes the slot device-valued so the one pool serves any user via
+        set_read_user at replay. No-op if not use_trace or already captured."""
+        if not self.config.use_trace or self._trace_pool is not None:
+            return
+        n_buckets = self.config.max_seq_len // self.config.chunk_size
+        self.capture_prefill_trace_pool(kv_cache, slot_id=0, n_chunks=n_buckets)
 
     def gather_layer(self, kv_cache, slot_id: int, layer_idx: int, n_tokens: int):
         """Read one layer's device cache back to NATURAL token order (un-rotating the block-cyclic SP

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -109,6 +109,10 @@ class TtPrefillRuntime:
         self._on_layer_complete = None
         # Per-layer completion sink for pipelined prefill, registered via set_layer_completion_sink().
         self._layer_completion_sink = None
+        # Per-chunk metal-trace pool (c -> {tid, in, out, cached_len}) + its persistent input buffers,
+        # populated by capture_chunk_trace / capture_prefill_trace_pool. None until captured.
+        self._trace_pool = None
+        self._trace_in = None
 
         # The Model builds `hf_config.num_hidden_layers` decoder layers, but the KV cache (and gather /
         # PCC) is sized to `config.num_layers`. Pin them equal so a partial-model run (PREFILL_NUM_LAYERS
@@ -398,6 +402,107 @@ class TtPrefillRuntime:
         LayerCompletionQueue and the LayerCompletionRouter re-emits it in seq order to the scheduler channel."""
         assert self.compiled, "Call compile() before set_layer_completion_sink()"
         self._layer_completion_sink = sink
+
+    # --- Per-chunk metal-trace pool -------------------------------------------------------------------
+    # One trace per chunk INDEX, not one reusable trace: cached_len is a host scalar baked into each
+    # capture — it selects the RoPE start row, the KV-cache write offset, kv_len and the causal
+    # chunk_start, and (at cached_len==0) gates the no-cache op path — so a trace serves exactly its
+    # chunk index and slot. The win is amortization: capture pays the per-op host dispatch once, then a
+    # later prefill of the SAME slot replays each chunk as a single execute_trace. A single one-pass
+    # prefill sees no benefit (each chunk runs once); the pool pays off across repeated prefills.
+
+    def _trace_fwd(self, buf, cached_len: int, slot_id: int, kv_cache):
+        # The trace-clean body: embed (first rank) or a clone of the received activation (non-first —
+        # prefill_forward's first layer frees its input, so feed a clone and keep the persistent buffer),
+        # then the device-only forward. rot_mats_global=self.rope_indexed avoids the SP+trace host reshard.
+        x = self._embed_tokens(buf) if self.config.is_first_rank else ttnn.clone(buf)
+        return self.model.prefill_forward(
+            x,
+            rot_mats_global=self.rope_indexed,
+            kv_cache=kv_cache,
+            cached_len=cached_len,
+            user_id=slot_id,
+            get_last_token=-1,
+            skip_lm_head=True,
+            indexed_rope=True,
+            on_layer_complete=None,
+        )
+
+    def _ensure_trace_buffers(self, n_chunks: int) -> None:
+        # Address-stable per-chunk input buffers the traces bind to; replay overwrites them in place.
+        # Never reallocate or free these while the pool is live.
+        if self._trace_in is not None:
+            return
+        self._trace_in = {c: self.make_chunk_input([0] * self.config.chunk_size) for c in range(n_chunks)}
+
+    def update_chunk_input(self, c: int, *, tokens=None, activation=None) -> None:
+        """Overwrite chunk c's persistent input buffer in place before replay — the trace binds the
+        buffer's address, so we update contents, never the handle. First rank: host token ids →
+        copy_host_to_device. Non-first rank: the freshly-received D2D activation → device copy."""
+        buf = self._trace_in[c]
+        if tokens is not None:
+            sp = self.config.sp_factor
+            s_local = self.config.chunk_size // sp
+            host = torch.tensor(tokens, dtype=torch.int32).reshape(sp, 1, s_local)
+            host_tt = ttnn.from_torch(
+                host,
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device, mesh_shape=self.config.mesh_shape, dims=(self.config.sp_axis, None)
+                ),
+            )
+            ttnn.copy_host_to_device_tensor(host_tt, buf)
+        elif activation is not None:
+            ttnn.copy(activation, buf)
+
+    def capture_chunk_trace(self, c: int, kv_cache, *, slot_id: int, cached_len: int) -> None:
+        """Capture chunk c's trace over the input already loaded in its persistent buffer. Runs one warm
+        forward first (writes KV[c] so downstream cache-reads see valid history, and stabilizes
+        allocations), then captures the recorded forward. Call in chunk order after loading each input."""
+        assert self.compiled, "compile() before capturing traces"
+        assert self.rope_indexed is not None, "indexed rope must be built (avoids the SP+trace host reshard)"
+        mesh = self.mesh_device
+        buf = self._trace_in[c]
+        warm = self._trace_fwd(buf, cached_len, slot_id, kv_cache)
+        ttnn.synchronize_device(mesh)
+        if warm is not None:
+            warm.deallocate(True)
+        tid = ttnn.begin_trace_capture(mesh, cq_id=0)
+        out = self._trace_fwd(buf, cached_len, slot_id, kv_cache)
+        ttnn.end_trace_capture(mesh, tid, cq_id=0)
+        ttnn.synchronize_device(mesh)
+        if self._trace_pool is None:
+            self._trace_pool = {}
+        self._trace_pool[c] = {"tid": tid, "in": buf, "out": out, "cached_len": cached_len}
+
+    def capture_prefill_trace_pool(self, kv_cache, *, slot_id: int, n_chunks: int, token_ids=None) -> dict:
+        """Capture the whole pool for a single-rank (first-rank) prefill: allocate the per-chunk buffers,
+        load each chunk's real tokens, and capture in order. token_ids is the full padded prompt; slice
+        [c*chunk : (c+1)*chunk] per chunk. Non-first pipeline ranks capture per chunk via
+        capture_chunk_trace after receiving the real activation (see the runner)."""
+        chunk = self.config.chunk_size
+        self._ensure_trace_buffers(n_chunks)
+        for c in range(n_chunks):
+            if self.config.is_first_rank and token_ids is not None:
+                self.update_chunk_input(c, tokens=token_ids[c * chunk : (c + 1) * chunk])
+            self.capture_chunk_trace(c, kv_cache, slot_id=slot_id, cached_len=c * chunk)
+        return self._trace_pool
+
+    def replay_chunk(self, c: int):
+        """Replay chunk c's captured trace (input must already be updated). Returns the output-hidden
+        handle for a middle rank (the caller MUST clone it before the D2D send, which frees its arg —
+        else the next replay corrupts); None on the last/single rank."""
+        slot = self._trace_pool[c]
+        ttnn.execute_trace(self.mesh_device, slot["tid"], cq_id=0, blocking=True)
+        return slot["out"] if not self.config.is_last_rank else None
+
+    def release_trace_pool(self) -> None:
+        if self._trace_pool is not None:
+            for slot in self._trace_pool.values():
+                ttnn.release_trace(self.mesh_device, slot["tid"])
+            self._trace_pool = None
+        self._trace_in = None
 
     def gather_layer(self, kv_cache, slot_id: int, layer_idx: int, n_tokens: int):
         """Read one layer's device cache back to NATURAL token order (un-rotating the block-cyclic SP


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
Changes to M3's single-galaxy (8,4)/EP32 chunked prefill to enable metal trace:
1. **Per-chunk metal-trace pool** - One captured trace per distinct `cached_len` - KV bucket.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zbaczewski/perf/m3-8x4-e2e-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zbaczewski/perf/m3-8x4-e2e-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zbaczewski/perf/m3-8x4-e2e-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zbaczewski/perf/m3-8x4-e2e-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zbaczewski/perf/m3-8x4-e2e-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zbaczewski/perf/m3-8x4-e2e-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zbaczewski/perf/m3-8x4-e2e-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zbaczewski/perf/m3-8x4-e2e-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zbaczewski/perf/m3-8x4-e2e-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zbaczewski/perf/m3-8x4-e2e-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zbaczewski/perf/m3-8x4-e2e-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zbaczewski/perf/m3-8x4-e2e-trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zbaczewski/perf/m3-8x4-e2e-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zbaczewski/perf/m3-8x4-e2e-trace)