### PR TITLE
[Bug fix] prelu: fuse the tensor weight path into one kernel

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_prelu_tensor_weight.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_prelu_tensor_weight.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""prelu with a per-channel weight tensor.
+
+The weight is broadcast along the channel dimension, so these cover the shapes
+where that broadcast is what the op is doing, plus the sign boundary, which is
+the only branch in the kernel.
+"""
+
+import pytest
+import torch
+import ttnn
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("shape, channels", [((1, 8, 32, 32), 8), ((2, 16, 64, 64), 16), ((1, 4, 32, 32), 4)])
+def test_prelu_tensor_weight(device, dtype, shape, channels):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch.manual_seed(0)
+
+    x = (torch.rand(shape, dtype=torch.float32) * 20 - 10).to(torch_dtype)
+    w = (torch.rand((channels,), dtype=torch.float32) * 2 - 1).to(torch_dtype)
+    want = torch.nn.functional.prelu(x.float(), w.float()).to(torch_dtype)
+
+    ix = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    iw = ttnn.from_torch(w, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.prelu(ix, iw))
+
+    if dtype == ttnn.float32:
+        assert torch.equal(got, want), f"{int((got != want).sum())} of {want.numel()} differ"
+    else:
+        # bfloat16 rounds one ulp differently from the composite this replaced,
+        # on about 1.2 percent of elements; see the PR. Bound it rather than
+        # assert equality, so a larger drift fails here.
+        diff = (got.view(torch.int16).to(torch.int32) - want.view(torch.int16).to(torch.int32)).abs()
+        assert int(diff.max()) <= 1, f"max {int(diff.max())} ulp"
+        assert int((diff != 0).sum()) <= want.numel() // 20, f"{int((diff != 0).sum())} of {want.numel()} differ"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_prelu_sign_boundary_and_specials(device, dtype):
+    """Zero takes the non-negative arm, and the weight must not touch it."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    vals = [-1.0, 0.0, -0.0, 1.0, float("inf"), float("-inf"), float("nan"), -3.0]
+
+    x = torch.tensor(vals * 128, dtype=torch_dtype).reshape(1, 8, 32, 4).repeat(1, 1, 1, 8)
+    w = torch.full((8,), 0.25, dtype=torch_dtype)
+    want = torch.nn.functional.prelu(x.float(), w.float()).to(torch_dtype)
+
+    ix = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    iw = ttnn.from_torch(w, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.prelu(ix, iw))
+
+    finite = torch.isfinite(want)
+    assert torch.equal(got[finite], want[finite])
+
+    # NaN propagation is not asserted. The composite this replaces does not
+    # carry a NaN operand through either, and the two agree element for element
+    # on this case set, so requiring it here would be testing a separate defect.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
@@ -19,6 +19,10 @@ sfpi_inline sfpi::vFloat _sfpu_prelu_binary_(sfpi::vFloat a, sfpi::vFloat w) {
     v_if(a < 0.0f) { a = a * w; }
     v_endif;
 
+    if constexpr (!is_fp32_dest_acc_en) {
+        a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::Nearest);
+    }
+
     return a;
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// prelu(a, w) = a < 0 ? a * w : a, with w per element rather than a scalar.
+// The body is the same as calculate_prelu's; only where the weight comes from
+// differs, so the two stay one line apart on purpose.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_prelu_binary_(sfpi::vFloat a, sfpi::vFloat w) {
+    v_if(a < 0.0f) { a = a * w; }
+    v_endif;
+
+    return a;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_prelu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_prelu_binary_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_prelu_binary_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
@@ -19,6 +19,10 @@ sfpi_inline sfpi::vFloat _sfpu_prelu_binary_(sfpi::vFloat a, sfpi::vFloat w) {
     v_if(a < 0.0f) { a = a * w; }
     v_endif;
 
+    if constexpr (!is_fp32_dest_acc_en) {
+        a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::Nearest);
+    }
+
     return a;
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu_binary.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// prelu(a, w) = a < 0 ? a * w : a, with w per element rather than a scalar.
+// The body is the same as calculate_prelu's; only where the weight comes from
+// differs, so the two stay one line apart on purpose.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_prelu_binary_(sfpi::vFloat a, sfpi::vFloat w) {
+    v_if(a < 0.0f) { a = a * w; }
+    v_endif;
+
+    return a;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_prelu_binary(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_prelu_binary_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_prelu_binary_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/prelu_binary.h
+++ b/tt_metal/hw/inc/api/compute/prelu_binary.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_prelu_binary.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise prelu operation on two inputs: y = idst0 if idst0 is not
+ * negative, otherwise idst0 * idst1.
+ * Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void prelu_binary_tile(std::uint32_t idst0, std::uint32_t idst1, std::uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_sfpu_prelu_binary,
+        (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void prelu_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(unused, sfpu::calculate_sfpu_prelu_binary_init, (APPROX, DST_ACCUM_MODE))));
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -121,6 +121,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/isclose.h
     inc/api/compute/layernorm.h
     inc/api/compute/lcm.h
+    inc/api/compute/prelu_binary.h
     inc/api/compute/logsigmoid.h
     inc/api/compute/mask.h
     inc/api/compute/matmul.h

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_dtype_policy.cpp
@@ -54,6 +54,7 @@ std::span<const DataType> supported_tensor_a_dtypes(BinaryOpType op) {
         case BinaryOpType::POWER:
         case BinaryOpType::XLOGY:
         case BinaryOpType::ATAN2:
+        case BinaryOpType::PRELU:
         case BinaryOpType::HYPOT: return float_only;
         case BinaryOpType::WHERE_TST:
         case BinaryOpType::WHERE_TTS: return where;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -23,6 +23,7 @@ enum class BinaryOpType {
     LOGICAL_OR,
     LOGICAL_XOR,
     LDEXP,
+    PRELU,
     LOGADDEXP2,
     DIV,
     DIV_FLOOR,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -439,8 +439,21 @@ Tensor prelu(const Tensor& input_a, const Tensor& input_b, const std::optional<M
         b = ttnn::reshape(input_b, ttnn::Shape(reshape));
     }
 
-    Tensor result = ttnn::where(ttnn::ltz(input_a, output_mem_config), ttnn::multiply(input_a, b), input_a);
-    return result;
+    // x < 0 ? x * w : x, which is the scalar prelu kernel with the weight read
+    // from a second tile rather than from a compile-time argument. binary_ng
+    // carries the broadcast of the reshaped weight, so the reshape above is the
+    // only shape work left here.
+    return ttnn::detail::invoke_binary_ng(
+        input_a,
+        b,
+        binary::BinaryOpType::PRELU,
+        std::nullopt,
+        output_mem_config,
+        std::nullopt,
+        {},
+        {},
+        {},
+        std::nullopt);
 }
 
 // REMAINDER result = input − (other * floor(input/other))

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -22,6 +22,7 @@
 #include "api/compute/binary_max_min.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/gcd.h"
 #include "api/compute/lcm.h"
 #include "api/compute/binary_comp.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -61,6 +61,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case MINIMUM:
         case XLOGY:
         case ATAN2:
+        case PRELU:
         case POWER:
         case WHERE_TST:
         case WHERE_TTS:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -366,6 +366,13 @@ OpConfig::OpConfig(
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::PRELU:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::PRELU;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         case BinaryOpType::ATAN2:
             if (is_sfpu_op()) {
                 binary_op = SfpuBinaryOp::ATAN2;
@@ -501,6 +508,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
+        case PRELU: return {"prelu_binary_tile_init();", "prelu_binary_tile"};
         case LT:
             if (int_data_format) {
                 return {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -79,6 +79,7 @@ struct OpConfig {
         MINIMUM,
         XLOGY,
         ATAN2,
+        PRELU,
         LT,
         GT,
         GE,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -20,6 +20,7 @@
 #include "api/compute/quantization.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_col_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "api/compute/bcast.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_bcast.cpp
@@ -25,6 +25,7 @@
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/bcast.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_row_col_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_sfpu_scalar_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/prelu_binary.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "api/compute/bcast.h"


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #53782.

`prelu` with a tensor weight becomes one kernel. The body is the scalar overload's, `x < 0 ? x * w : x`, with the weight read from a second tile rather than from a compile-time argument, so the two overloads now differ only in where the weight comes from.

`binary_ng` carries the channel broadcast, so the reshape that lines the weight up against the input is the only shape work left in the op.

### Accuracy

Two random shapes and one sign-boundary set per dtype, on P300 and N300, against what the composite returned. Both machines give the same counts.

| | float32 | bfloat16 |
|---|---|---|
| `[1, 8, 32, 32]`, C=8 | identical | 107 of 8192 differ |
| `[2, 16, 64, 64]`, C=16 | identical | 1536 of 131072 differ |
| sign boundary, inf, nan | identical | identical |

**bfloat16 moves by one ulp on 1643 of 139264 elements, 1.18 percent, and never by more than one.** The composite multiplied through `ttnn::multiply`, which for bfloat16 rounds on the FPU; this rounds the same product on the SFPU. Rounding explicitly to bfloat16 in the kernel brings the disagreement down from 24 percent to 1.18 percent, and the remainder is the two units rounding the same value differently. float32 is unaffected and bit-identical throughout.

### Cost

Device profiler, `[1, 32, 128, 128]` with a 32 element weight, 33 invocations, median cycles per core on the math thread. Zone counts give the kernel count.

| | P300 bf16 | P300 fp32 | N300 bf16 | N300 fp32 |
|---|---|---|---|---|
| kernels per call | 3 → **1** | 3 → **1** | 3 → **1** | 3 → **1** |
| TRISC_1, before | 19362 | 39534 | 36468 | 72042 |
| TRISC_1, after | **6058** | **13520** | **11086** | **22364** |
| | **3.2x** | **2.9x** | **3.3x** | **3.2x** |

### Tests

`test_prelu_tensor_weight.py`, 8 cases: three shapes across both dtypes, and the sign boundary with infinities and NaN. bfloat16 is bounded at one ulp rather than asserted equal, for the reason above, so a larger drift fails there.

88 existing prelu cases in `test_binary_composite.py` pass unchanged.

### Related context

#52153 lists `prelu` for migration to a device op. #48240 item 21 reports the scalar and array overloads ignoring `output_mem_config`; those overloads are already single-dispatch and are untouched here.

### Not covered

- The scalar and array overloads.
- `bfloat8_b` and `bfloat4_b`, and the sharded paths.
- NaN propagation, which the composite does not carry either, so the two agree on it.
