### PR TITLE
[Feature] #0 - Link node tt-telemetry Grafana dashboard from health check tickets

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -141,6 +141,12 @@ def parse_args() -> argparse.Namespace:
         help="Transition used to close a node's open ticket when it recovers "
         "(falls back to any done-category transition if not found)",
     )
+    jira.add_argument(
+        "--grafana-base-url",
+        default="https://grafana.it.aws.tenstorrent.com",
+        help="Grafana base URL for the node's tt-telemetry dashboard link in failure "
+        "tickets; empty string omits the link",
+    )
 
     p.add_argument(
         "--create-jira",
@@ -454,6 +460,7 @@ def main() -> int:
                         test_output=full_output,
                         attachment_names=attachment_names,
                         restart_count=restart_count,
+                        grafana_base_url=args.grafana_base_url,
                     )
                 )
                 add_comment_to_jira(
@@ -485,6 +492,7 @@ def main() -> int:
                     telemetry_summary=prom_output,
                     attachment_names=attachment_names,
                     restart_count=restart_count,
+                    grafana_base_url=args.grafana_base_url,
                 )
                 if ticket_key:
                     transition_jira_ticket(

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/grafana.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/grafana.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Grafana deep links to the per-device tt-telemetry dashboard."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from urllib.parse import urlencode
+
+DASHBOARD_UID = "tt-telemetry-overview"
+DASHBOARD_SLUG = "tt-telemetry-e28094-device-overview"
+DATASOURCE_UID = "ffkl22q5tp3pcd"
+CLUSTER = "exabox"
+
+WINDOW_BEFORE = timedelta(minutes=60)
+WINDOW_AFTER = timedelta(minutes=15)
+
+
+def telemetry_dashboard_url(*, base_url: str, node: str, fail_time: datetime) -> str:
+    """Per-node tt-telemetry dashboard URL, time-boxed around ``fail_time``.
+
+    Bounds are absolute epoch-ms: tickets get read days later, when a relative
+    range would show a node that has since rebooted.
+    """
+    query = urlencode(
+        [
+            ("orgId", "1"),
+            ("from", str(int((fail_time - WINDOW_BEFORE).timestamp() * 1000))),
+            ("to", str(int((fail_time + WINDOW_AFTER).timestamp() * 1000))),
+            ("timezone", "utc"),
+            ("var-DS_PROMETHEUS", DATASOURCE_UID),
+            ("var-cluster", CLUSTER),
+            ("var-hostname", node),
+        ]
+    )
+    return f"{base_url.rstrip('/')}/d/{DASHBOARD_UID}/{DASHBOARD_SLUG}?{query}"

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import requests
 
+from .grafana import telemetry_dashboard_url
+
 log = logging.getLogger(__name__)
 
 
@@ -30,10 +32,12 @@ def _build_failure_body(
     test_output: str,
     attachment_names: list[str] | None = None,
     restart_count: int = 0,
+    grafana_base_url: str = "",
 ) -> str:
     """Build the shared failure detail block used by both a new ticket's
     description and a recurring-failure comment, so the two never drift."""
-    fail_date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    fail_time = datetime.now(timezone.utc)
+    fail_date = fail_time.strftime("%Y-%m-%d %H:%M:%S UTC")
     log_tail = test_output[-4096:]
 
     reboot_line = ""
@@ -43,6 +47,11 @@ def _build_failure_body(
     telemetry_section = ""
     if telemetry_summary:
         telemetry_section = f"\n*Telemetry Metrics:*\n" f"{{noformat}}\n{telemetry_summary}\n{{noformat}}\n"
+
+    grafana_section = ""
+    if grafana_base_url:
+        url = telemetry_dashboard_url(base_url=grafana_base_url, node=node, fail_time=fail_time)
+        grafana_section = f"\n*Telemetry dashboard:* [Grafana {node}|{url}]\n"
 
     attachment_section = ""
     if attachment_names:
@@ -59,6 +68,7 @@ def _build_failure_body(
         f"*TT-KMD Version:* {versions['tt_kmd']}\n"
         f"*Firmware Version:* {versions['fw_bundle']}\n"
         f"{telemetry_section}"
+        f"{grafana_section}"
         f"{attachment_section}\n"
         f"*Last lines of output:*\n"
         f"{{noformat}}\n{log_tail}\n{{noformat}}"
@@ -211,6 +221,7 @@ def create_jira_ticket(
     telemetry_summary: str = "",
     attachment_names: list[str] | None = None,
     restart_count: int = 0,
+    grafana_base_url: str = "",
 ) -> str | None:
     """Create a JIRA ticket for a failed health check. Returns ticket key or None."""
 
@@ -223,6 +234,7 @@ def create_jira_ticket(
         test_output=test_output,
         attachment_names=attachment_names,
         restart_count=restart_count,
+        grafana_base_url=grafana_base_url,
     )
 
     payload = {


### PR DESCRIPTION
### PR Category
Feature

### Summary
Health-check failure tickets carry raw telemetry counters with no way to see the surrounding trend. This adds a per-node Grafana deep link next to those counters. The link is built in `_build_failure_body`, so it lands in both the initial ticket
description and every recurring-failure comment.
Time bounds are absolute epoch-ms (-60m/+15m around the run) 
On by default; `--grafana-base-url ""` omits the link.

Tested on
https://tenstorrent.atlassian.net/browse/DCAMP-1442, look at the newest comment

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-grafana-telemetry-link)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/hc-grafana-telemetry-link)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-grafana-telemetry-link)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/hc-grafana-telemetry-link)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/hc-grafana-telemetry-link)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/hc-grafana-telemetry-link)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/hc-grafana-telemetry-link)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/hc-grafana-telemetry-link)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/hc-grafana-telemetry-link)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/hc-grafana-telemetry-link)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/hc-grafana-telemetry-link)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/hc-grafana-telemetry-link)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/hc-grafana-telemetry-link)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/hc-grafana-telemetry-link)