### PR TITLE
ttnn.topk: route the pow2 [8192, 65535) k<=64 band to topk_large_indices on BH (up to 3.9x)

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -707,6 +707,16 @@ def test_topk_large_k_routed(k, W, device):
     run_topk_large_k_routed_test(1, 1, 32, W, k, device)
 
 
+@pytest.mark.skipif(not is_blackhole(), reason="large-k routing is Blackhole-only")
+@pytest.mark.parametrize("k, W", [(32, 8192), (50, 8192), (64, 32768)])
+def test_topk_small_k_routed_bitonic_band(k, W, device):
+    # Bitonic-band arm of the small-k route: pow2 widths in [8192, 65535) with
+    # k <= 64 are eligible for the stock multi-core bitonic but route to the
+    # topk_large_indices composite (measured faster; see topk.cpp). k=50
+    # exercises the k % 16 != 0 rounding tail inside the band.
+    run_topk_large_k_routed_test(1, 1, 32, W, k, device)
+
+
 @pytest.mark.skipif(
     not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
 )
@@ -875,8 +885,17 @@ def test_topk_large_k_routing_engages(device):
     ttnn.topk(ttnn_input, 96, dim=-1, largest=True, sorted=True)
     assert ran_large_indices(ttnn.graph.end_graph_capture())
 
-    # Stock shape (k=32, pow2 width >= 8192 -> multi-core bitonic eligible):
-    # the routed op must NOT appear.
+    # Bitonic-band shape (k=32, pow2 width in [8192, 65535)): eligible for the
+    # stock multi-core bitonic, but the bitonic-band arm routes it too.
     ttnn.graph.begin_graph_capture()
     ttnn.topk(ttnn_input, 32, dim=-1, largest=True, sorted=True)
+    assert ran_large_indices(ttnn.graph.end_graph_capture())
+
+    # Stock probe: an explicit sub_core_grids request declines routing (the
+    # routed pipeline ignores custom core grids), so the same shape must run
+    # the stock device op.
+    grid = device.compute_with_storage_grid_size()
+    full_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))])
+    ttnn.graph.begin_graph_capture()
+    ttnn.topk(ttnn_input, 32, dim=-1, largest=True, sorted=True, sub_core_grids=full_grid)
     assert not ran_large_indices(ttnn.graph.end_graph_capture())

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -640,16 +640,22 @@ def test_topk_multicore_values_beyond_first_tile_row(num_rows, largest, device):
 
 
 # ---------------------------------------------------------------------------
-# Large-k Blackhole routing: ttnn.topk with bf16, dim=-1, largest=True,
-# stable=False and 64 < k <= 2048 is routed at the composite level through
-# ttnn.experimental.topk_large_indices (fused untilize+clamp to lowest-finite
-# bf16 — the private topk_route_prep device op, exercised by EVERY routed
-# call below -> op -> fused gather of the ORIGINAL values straight from the
-# TILE source + TILE assembly of both outputs + index dtype emit — the
-# private topk_route_finish device op, also exercised by EVERY routed call;
-# a slice pair only when k is not a multiple of 16), bypassing the
-# single-core cliff (the device op's own multi-core path is gated at
-# k <= 64 + pow2 width + width < 65536).
+# Blackhole routing suite: ttnn.topk with bf16, dim=-1, largest=True,
+# stable=False is routed at the composite level through
+# ttnn.experimental.topk_large_indices for two k regions:
+#   * large-k: 64 < k <= 2048, bypassing the single-core cliff (the device
+#     op's own multi-core path is gated at k <= 64 + pow2 width +
+#     width < 65536);
+#   * small-k (k <= 64): widths structurally ineligible for the multi-core
+#     bitonic (>= 65535, non-pow2, or pow2 below 8192, at padded width
+#     >= 4096) PLUS the bitonic-eligible pow2 [8192, 65535) band, where the
+#     routed composite measured faster than the bitonic (see topk.cpp).
+# The routed chain is the same in both regions: fused untilize+clamp to
+# lowest-finite bf16 — the private topk_route_prep device op, exercised by
+# EVERY routed call below -> op -> fused gather of the ORIGINAL values
+# straight from the TILE source + TILE assembly of both outputs + index
+# dtype emit — the private topk_route_finish device op, also exercised by
+# EVERY routed call; a slice pair only when k is not a multiple of 16.
 #
 # Tie semantics on the routed path: the returned index SET is a correct top-k
 # set with deterministic-but-unspecified tie order, so these tests assert

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -315,6 +315,11 @@ bool should_route_to_topk_large_indices(
         //    composite still wins it — measured on p150a (bf16 largest W=4096, 3 Tracy
         //    trials, <0.2% spread): 70.3 -> 46.8 us (k=32, 1 tile row) up to
         //    165.5 -> 48.0 us (k=64, 2 tile rows).
+        //  * the pow2 [multi_core_min_width, 65535) bitonic band: stock is
+        //    structurally eligible, but its serial final gather-merge scales
+        //    with num_cores * k. The routed chain stays column-parallel end to
+        //    end and measured 155.7 -> 67.4 us at 32x8192 k=50 and 302.2 ->
+        //    178.6 us at 32x32768 k=64 on the #53793 stock model.
         // Both collapse to evaluating the SHARED
         // ttnn::prim::topk_multicore_structurally_eligible helper with the
         // low-Ht relaxation disabled (num_tile_rows pinned above
@@ -332,7 +337,17 @@ bool should_route_to_topk_large_indices(
             padded_width, ttnn::prim::constants::multi_core_low_ht_max_tile_rows + 1, k);
         const bool wide_arm =
             multicore_ineligible_ignoring_low_ht_arm && padded_width >= small_k_route_min_padded_width;
-        if (!wide_arm) {
+        const bool is_pow2 = padded_width != 0 && (padded_width & (padded_width - 1)) == 0;
+        // Bitonic-band arm: pow2 widths in [8192, 65535) with k <= 64 ARE
+        // eligible for the stock multi-core bitonic, but the routed composite
+        // measures faster there as well (p150a, Tracy device kernel duration,
+        // 3 trials, full prep+op+finish+slice chain): 32x8192 k=50 263.5 ->
+        // 67.4 us, 32x32768 k=64 333.8 -> 178.6 us. The bitonic's serial
+        // final gather-merge stage scales with num_cores * k while the routed
+        // chain stays column-parallel end to end.
+        const bool bitonic_band_arm = is_pow2 && padded_width >= ttnn::prim::constants::multi_core_min_width &&
+                                      padded_width < std::numeric_limits<uint16_t>::max();
+        if (!wide_arm && !bitonic_band_arm) {
             return false;
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -234,18 +234,17 @@ std::vector<Tensor> post_topk_transform_tensor(
 // input width; every other stage works on [rows, k_rounded <= 2048] tensors
 // (topk_route_finish reads 64 B per selected element, not whole rows).
 
-// k <= 64 keeps the device op's fast multi-core bitonic path for pow2 widths
-// at or above multi_core_min_width (plus the grid/L1 cost check). Below that
-// floor the stock op either falls to the single-core factory — linear in
-// width (~137 ns/elem measured on p150a: 695 us at W=5000, 1.38 ms at 10000,
-// 6.87 ms at 50000, 9.49 ms at 65536) while the routed composite is tens of
-// microseconds — or, for pow2 low-tile-row cells eligible via the Ht-aware
-// gate, runs a multi-core bitonic that the composite still beats (measured
-// at W=4096: 70–166 us stock multi-core vs 47–48 us composite; numbers at
-// the wide-arm predicate below). The small-k arm therefore routes every
-// >= small_k_route_min_padded_width cell below the plain
-// multi_core_min_width floor, pow2 or not; eligible pow2 cells at or above
-// the floor keep the stock bitonic path.
+// k <= 64 is the device op's multi-core bitonic regime when that path is
+// eligible: normally for power-of-two padded widths in [8192, 65535), plus
+// the #53793 low-tile-row relaxation below that floor. The small-k router
+// covers two measured-win regions: (a) padded widths >= 4096 that fail the
+// plain structural gate (non-pow2, >= 65535, or below the 8192 floor), with
+// low-tile-row cells below the floor deliberately included, and (b) the
+// standard bitonic-eligible pow2 [8192, 65535) band. Outside bitonic
+// eligibility the stock op falls to a single-core factory linear in width
+// (~137 ns/elem on p150a); inside it, the routed composite avoids the
+// bitonic's serial final gather-merge bottleneck. See the predicate comments
+// for measurements.
 constexpr uint32_t large_k_route_min_k_exclusive = 64;
 // Small-k arm floor (on the tile-padded width): below this the single-core
 // fallback is already sub-ms and the routed composite's fixed envelope is
@@ -574,15 +573,13 @@ std::vector<Tensor> topk(
     Tensor transformed_tensor = ::reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
 
     // Blackhole routing onto ttnn::experimental::topk_large_indices covers
-    // two regions where the composite measures faster than the device op:
-    // k in (64, 2048] (above the device op's multi-core k <= 64 gate), and
-    // k <= 64 calls whose padded width is >= small_k_route_min_padded_width
-    // but fails the plain multi_core_min_width bitonic gate (>= 65535,
-    // non-pow2, or pow2 below multi_core_min_width). The router evaluates
-    // that gate without the device op's Ht-aware low-tile-row relaxation:
-    // the composite also beats the stock multi-core bitonic on those
-    // low-tile-row cells. See the comment block on
-    // should_route_to_topk_large_indices for the full predicate and contract.
+    // three regions: k in (64, 2048] (off the multi-core k <= 64 gate, would
+    // land on the linear single-core factory), k <= 64 rows whose padded
+    // width is >= 4096 but fails the plain structural gate (non-pow2,
+    // >= 65535, or below the 8192 floor, including #53793's low-tile-row
+    // bitonic cells), and k <= 64 rows in the standard bitonic-eligible pow2
+    // [8192, 65535) band. See the predicate comments for the full routing
+    // contract.
     if (operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::should_route_to_topk_large_indices(
             transformed_tensor,
             k,


### PR DESCRIPTION
### What

Extends the Blackhole small-k routing arm in `should_route_to_topk_large_indices` (`topk.cpp`) to also route **pow2 widths in [8192, 65535) with k <= 64** — the one small-k class deliberately left to the stock multi-core bitonic when the route was introduced.

### Why the band was originally excluded, and what changed

The small-k arm only claimed cells the stock multi-core bitonic *cannot* take (non-pow2, >= 65535, or below its 8192 width floor), on the assumption that an eligible bitonic is the right engine. Fitting a makespan model to that bitonic for #53793 showed why it isn't: its final gather-merge stage is **serial** and scales with `num_cores * k`, so even the best split leaves 2x+ on the table against a chain that stays column-parallel end to end. The routed composite (`topk_route_prep` → `topk_large_indices` → `topk_route_finish`) measured faster at both band anchor cells — including against #53793's improved stock numbers.

### Measured (Tracy device kernel duration, 3 trials, zero cross-trial variance, p150a; routed side = full prep+op+finish+slice chain)

| shape | k | main stock (mc bitonic) | routed (this PR) | delta | vs #53793 stock |
|---|---|---|---|---|---|
| 32x8192 | 50 | 263.5 us | 67.4 us | **3.9x** | 155.7 us → **-57%** |
| 32x32768 | 64 | 333.8 us | 178.6 us | **1.9x** | 302.2 us → **-41%** |

Stock arm forced via a full-grid `sub_core_grids` on the same build (identical device-op behavior to a default main call).

### Guards / contract

Every other routing guard is unchanged: bf16, TILE, not sharded, `largest`, `!stable`, no `sub_core_grids` / user index tensor / preallocated outputs, last-dim reductions, existing width envelope. Explicit `sub_core_grids`, preallocated-output, 32-bit-index, and `stable=True` callers keep the stock bitonic exactly as today.

KEEP-IN-SYNC note: the `models/common/sampling` Python mirror of this predicate (`topk_would_route_to_large_indices`) is not on main (it ships with the sampling-integration PR), so there is no mirror to update in this change; the branch that carries it must fold the band in when it lands.

### Validation

- `tests/ttnn/unit_tests/operations/reduce/test_reduction.py` + `test_topk.py`: **660 passed, 32 skipped, 80 xfailed** (one unrelated `test_std` flake from a shared-JIT-cache rename race passed 160/160 on rerun).
- New `test_topk_small_k_routed_bitonic_band` covers (k=32, W=8192), (k=50, W=8192 — the k % 16 != 0 rounding tail), (k=64, W=32768).
- `test_topk_large_k_routing_engages` updated: asserts the band **routes** by graph capture, and uses a full-grid `sub_core_grids` call as the guaranteed-stock probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/topk-route-mc-band)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/topk-route-mc-band)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/topk-route-mc-band)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/topk-route-mc-band)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/topk-route-mc-band)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/topk-route-mc-band)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/topk-route-mc-band)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/topk-route-mc-band)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/topk-route-mc-band)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/topk-route-mc-band)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/topk-route-mc-band)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/topk-route-mc-band)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/topk-route-mc-band)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/topk-route-mc-band)