### PR TITLE
[Performance] GDN scan: prefetch (nbuf=2) per-chunk inputs at deep mcast fan-out

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_chunk_gated_delta_rule_mcast.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_chunk_gated_delta_rule_mcast.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Bit-exactness gate for the GDN scan shared-input multicast.
+
+The scan phase of ttnn.transformer.chunk_gated_delta_rule multicasts its six shared V-independent
+inputs (kd, q_decay, intra, k_dec_t, dl, t_inv) from one sender core per head into the sibling
+V-block cores' CBs instead of every sibling re-reading identical DRAM pages. The multicast forwards
+the exact bytes the sender read into the same CB indices, so the op's outputs must be BIT-IDENTICAL
+with the multicast on and off — any difference is a bug, not numerical noise.
+
+QWEN_GDN_SCAN_MCAST is read where ChunkGdnScanParams is built and stored as a hashed attribute
+(`use_mcast`), so toggling it between calls in one process compiles two distinct cached scan
+programs — the test asserts this via the program-cache entry count, which also makes the A/B
+non-vacuous (on a build that stops reading or hashing the env, both runs would use one program
+and the cache assertion fails).
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+CHUNK = 32  # the fused op's supported chunk size (Ct=1)
+
+
+def _scan_nv(device, bh, vt):
+    """Replicates distribute_scan's row-aligned NV selection (largest divisor of vt whose 1xNV
+    head rectangles fit the padded grid)."""
+    grid = device.compute_with_storage_grid_size()
+    for cand in range(vt, 0, -1):
+        if vt % cand != 0 or cand > grid.x:
+            continue
+        if bh <= (grid.x // cand) * grid.y:
+            return cand
+    return 1
+
+
+def _const_tiles(device, chunk_size=CHUNK):
+    """The fused op's constant tiles (mirrors qwen36 fused_chunk.build_fused_const_tiles)."""
+    c = chunk_size
+    eye = torch.eye(c, dtype=torch.float32)
+    tril = torch.tril(torch.ones(c, c, dtype=torch.float32))
+    ones = torch.ones(c, c, dtype=torch.float32)
+    ii = torch.arange(32).unsqueeze(1)
+    jj = torch.arange(32).unsqueeze(0)
+    lo_i, lo_j = ii < 16, jj < 16
+    qtl = (lo_i & lo_j).float()
+    qbr = (~lo_i & ~lo_j).float()
+    qbl = (~lo_i & lo_j).float()
+    masks = torch.cat([qtl, qbr, qbl], dim=1)  # [32, 96]
+
+    def _up(t):
+        return ttnn.from_torch(t.reshape(1, 1, *t.shape), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    return (_up(eye), _up(tril), _up(ones), _up(masks))
+
+
+def _run_op(device, tensors, const_tiles, initial_state):
+    q, k, v, g, beta = tensors
+    eye, tril, ones, masks = const_tiles
+    o, fs = ttnn.transformer.chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        chunk_size=CHUNK,
+        eye=eye,
+        tril=tril,
+        ones=ones,
+        masks=masks,
+    )
+    o_t = ttnn.to_torch(o)
+    fs_t = ttnn.to_torch(fs)
+    ttnn.deallocate(o)
+    ttnn.deallocate(fs)
+    return o_t, fs_t
+
+
+@pytest.mark.parametrize(
+    "batch, num_k_heads, num_v_heads, want_mcast",
+    [
+        (1, 4, 12, True),  # TP-4-like per-device shape: BH=12 -> NV=4 on a 13x10 grid, fan-out 3
+        (1, 16, 48, True),  # single-device Qwen3.6 shape: BH=48 -> NV=2, fan-out 1
+        (2, 16, 48, False),  # batched prefill: BH=96 -> NV=1, multicast degenerates to plain reader
+    ],
+)
+@pytest.mark.parametrize("with_initial_state", [False, True])
+def test_scan_mcast_bit_exact(device, monkeypatch, batch, num_k_heads, num_v_heads, want_mcast, with_initial_state):
+    torch.manual_seed(20260819)
+    B, T, Dk, Dv = batch, 256, 128, 128
+    BH = B * num_v_heads
+
+    grid = device.compute_with_storage_grid_size()
+    if BH > grid.x * grid.y:
+        pytest.skip(f"BH={BH} exceeds the {grid.x}x{grid.y} compute grid (scan needs a core per head)")
+    nv = _scan_nv(device, BH, Dv // 32)
+    if want_mcast and nv == 1:
+        pytest.skip(f"grid {grid.x}x{grid.y} gives NV=1 for BH={BH}: multicast path not exercised")
+
+    # Neutralize ambient GDN debug/profiling knobs that would bypass or fork the scan path.
+    monkeypatch.setenv("QWEN_GDN_PHASED", "1")
+    monkeypatch.delenv("QWEN_GDN_SCAN_SERIAL", raising=False)
+    # QWEN_GDN_DUMP is read once via a function-local static; delenv helps only if the op has not
+    # run yet in this process — kept for hygiene.
+    monkeypatch.delenv("QWEN_GDN_DUMP", raising=False)
+
+    # Realistic-shaped inputs; bit-exactness holds for any values, but keep them in the op's
+    # numeric regime (L2-normalized keys upstream, beta in (0,1), g <= 0).
+    q = torch.randn(B, T, num_k_heads, Dk, dtype=torch.bfloat16)
+    k = torch.randn(B, T, num_k_heads, Dk, dtype=torch.bfloat16)
+    v = torch.randn(B, T, num_v_heads, Dv, dtype=torch.bfloat16)
+    beta = torch.sigmoid(torch.randn(B, T, num_v_heads, dtype=torch.float32))
+    g = -torch.nn.functional.softplus(torch.randn(B, T, num_v_heads, dtype=torch.float32)) * 0.5
+
+    def dev(t, dtype):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tensors = (
+        dev(q, ttnn.bfloat16),
+        dev(k, ttnn.bfloat16),
+        dev(v, ttnn.bfloat16),
+        dev(g, ttnn.float32),
+        dev(beta, ttnn.float32),
+    )
+    s0 = None
+    if with_initial_state:
+        s0_t = 0.1 * torch.randn(B, num_v_heads, Dk, Dv, dtype=torch.float32)
+        s0 = dev(s0_t, ttnn.float32)
+    const_tiles = _const_tiles(device)
+
+    monkeypatch.setenv("QWEN_GDN_SCAN_MCAST", "1")
+    o_on, fs_on = _run_op(device, tensors, const_tiles, s0)
+    n_on = device.num_program_cache_entries()
+
+    monkeypatch.setenv("QWEN_GDN_SCAN_MCAST", "0")
+    o_off, fs_off = _run_op(device, tensors, const_tiles, s0)
+    n_off = device.num_program_cache_entries()
+
+    # The toggle must recompile exactly the scan prim (use_mcast is a hashed attribute); everything
+    # else is a cache hit. A delta of 0 means the env was not read per-call or not hashed — and the
+    # bit-exact comparison below would be vacuously comparing the op against itself.
+    assert n_off - n_on == 1, (
+        f"QWEN_GDN_SCAN_MCAST toggle compiled {n_off - n_on} new programs (expected exactly the "
+        "scan prim): env not read per-call or use_mcast not in the program-cache key"
+    )
+
+    # Bit-exact: the multicast delivers the same bytes to the same CB slots the plain reader fills.
+    assert torch.equal(o_on, o_off), "scan multicast changed o (must be bit-identical)"
+    assert torch.equal(fs_on, fs_off), "scan multicast changed final_state (must be bit-identical)"

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased.cpp
@@ -210,6 +210,8 @@ std::vector<Tensor> chunk_gdn_scan(
     const DeviceComputeKernelConfig& compute_kernel_config) {
     const auto& vb_shape = v_beta.logical_shape();  // [BH, NC, C, V]
     const auto& kd_shape = kd.logical_shape();      // [BH, NC, C, K]
+    const char* mcast_env = std::getenv("QWEN_GDN_SCAN_MCAST");
+    const char* serial_env = std::getenv("QWEN_GDN_SCAN_SERIAL");
     auto attrs = ChunkGdnScanOperation::operation_attributes_t{
         .BH = vb_shape[0],
         .num_chunks = vb_shape[1],
@@ -218,6 +220,8 @@ std::vector<Tensor> chunk_gdn_scan(
         .val_dim = vb_shape[3],
         .has_initial_state = initial_state.has_value(),
         .output_final_state = output_final_state,
+        .use_mcast = !(mcast_env && mcast_env[0] == '0'),
+        .force_serial = serial_env && serial_env[0] == '1',
         .output_mem_config = output_mem_config,
         .compute_kernel_config = compute_kernel_config,
     };

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased.hpp
@@ -114,6 +114,18 @@ struct ChunkGdnScanParams {
     uint32_t val_dim;
     bool has_initial_state;
     bool output_final_state;
+    // Per-head NoC multicast of the shared V-independent scan inputs (kd, q_decay, intra, k_dec_t,
+    // dl, t_inv): the head's v-block-0 core reads them from DRAM once and multicasts into the
+    // sibling V-block cores' CBs, instead of every sibling re-reading identical DRAM pages
+    // (NV-fold read amplification). Bit-exact: identical bytes land in identical CB slots.
+    // Kill switch QWEN_GDN_SCAN_MCAST=0 (read where params are built, NOT in the factory, so the
+    // flag participates in the program-cache key and in-process A/B toggling is safe).
+    // The factory still falls back to the plain reader when NV==1 (nothing to share).
+    bool use_mcast = true;
+    // QWEN_GDN_SCAN_SERIAL=1 pins NV=1 (perf A/B only). Hashed here for the same reason as
+    // use_mcast: it changes the placement AND the kernel topology (mcast on/off), so a
+    // factory-local env read would silently serve a stale cached program on in-process toggles.
+    bool force_serial = false;
     tt::tt_metal::MemoryConfig output_mem_config;
     DeviceComputeKernelConfig compute_kernel_config;
 };

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
@@ -7,8 +7,10 @@
 //         out across the ENTIRE compute grid — mirroring FLA's WY-prep Triton kernels, whose
 //         launch grid spans (chunk-tile index, batch*head). This is the perf payoff of the
 //         phase split: prep runs chunk-parallel across dozens of cores instead of 1 core/head.
-//   SCAN: one Tensix core per head walks chunks sequentially carrying state S [K,V]
-//         (inherently sequential — the recurrence forbids chunk-parallelism here).
+//   SCAN: one Tensix core per (head, v-block) walks chunks sequentially carrying its slice of the
+//         state S [K,Vtl] (inherently sequential in time — the recurrence forbids chunk-
+//         parallelism). Each head's v-block cores form a 1xNV row rectangle; the v-block-0 core
+//         multicasts the head's shared V-independent inputs to its siblings (see distribute_scan).
 
 #include "chunk_gdn_phased.hpp"
 
@@ -121,8 +123,11 @@ PrepWorkDist distribute_prep(CoreCoord grid, uint32_t total, uint32_t core_cap) 
 // scan op — kd@S, T_inv@diff, q_decay@S, intra@v_new, k_dec_t@v_new, S*dl — is column-wise in V,
 // needing only the full-K shared per-chunk tensors + that block's own V-slice). This mirrors FLA's
 // fwd_h/fwd_o launch grid over (i_v, i_bh) with a sequential loop over time. K is NOT split (v_new
-// and o reduce over all K). We pick the finest V-blocking that fits the grid: the largest NV | Vt
-// with BH*NV <= cores. Each core runs one (head, v-block) => BH*NV independent scans vs BH today.
+// and o reduce over all K). We pick the finest V-blocking whose ROW-ALIGNED placement fits the
+// grid: the largest NV | Vt with NV <= grid.x and BH <= (grid.x/NV)*grid.y — each head's NV cores
+// must form a 1xNV row rectangle (the shared-input multicast targets it), so row-alignment can
+// pick a smaller NV than the old flat BH*NV <= cores rule for some non-shipping BH values (same
+// math, coarser V split). Each core runs one (head, v-block) => BH*NV independent scans.
 struct ScanWorkDist {
     std::vector<CoreCoord> cores;
     std::vector<uint32_t> head;  // head index per core
@@ -132,15 +137,23 @@ struct ScanWorkDist {
     CoreRangeSet core_set;
 };
 
-ScanWorkDist distribute_scan(CoreCoord grid, uint32_t BH, uint32_t Vt) {
+ScanWorkDist distribute_scan(CoreCoord grid, uint32_t BH, uint32_t Vt, bool force_serial) {
     const uint32_t ncores = grid.x * grid.y;
     TT_FATAL(BH <= ncores, "num_heads {} exceeds compute cores {}", BH, ncores);
-    // QWEN_GDN_SCAN_SERIAL=1 forces NV=1 (full V on 1 core/head, the old layout) for perf A/B only.
-    const char* serial_env = std::getenv("QWEN_GDN_SCAN_SERIAL");
-    const bool force_serial = serial_env && serial_env[0] == '1';
+    // force_serial (QWEN_GDN_SCAN_SERIAL=1, hashed into ChunkGdnScanParams) pins NV=1 — full V on
+    // 1 core/head, the old layout — for perf A/B only.
+    // Row-aligned placement: each head's NV v-block cores must form a 1xNV NoC RECTANGLE (the
+    // shared-input multicast targets it), so the effective row width is padded down to a multiple
+    // of NV — HPR = grid.x/NV heads per row, grid.x mod NV columns idle per used row. Feasibility
+    // is therefore BH <= HPR*grid.y (not BH*NV <= ncores). NV==1 always satisfies (HPR = grid.x,
+    // BH <= ncores asserted above). Per-core work is unchanged: one (head, v-block) each.
     uint32_t NV = 1;
-    for (uint32_t cand = force_serial ? 1u : Vt; cand >= 1; cand--) {  // cand==1 always satisfies
-        if (Vt % cand == 0 && BH * cand <= ncores) {
+    for (uint32_t cand = force_serial ? 1u : Vt; cand >= 1; cand--) {
+        if (Vt % cand != 0 || cand > grid.x) {
+            continue;  // cand > grid.x would give 0 heads per row
+        }
+        const uint32_t hpr = grid.x / cand;
+        if (BH <= hpr * grid.y) {
             NV = cand;
             break;
         }
@@ -148,16 +161,19 @@ ScanWorkDist distribute_scan(CoreCoord grid, uint32_t BH, uint32_t Vt) {
     ScanWorkDist d;
     d.NV = NV;
     d.Vtl = Vt / NV;
+    const uint32_t HPR = grid.x / NV;  // heads per row
     const uint32_t total = BH * NV;
     d.cores.reserve(total);
     d.head.reserve(total);
     d.vblk.reserve(total);
     std::set<CoreRange> crs;
     for (uint32_t i = 0; i < total; i++) {
-        const CoreCoord core{i % grid.x, i / grid.x};  // row-major over the grid
+        const uint32_t h = i / NV;  // heads' v-blocks grouped contiguously (index i = h*NV + v)
+        const uint32_t v = i % NV;
+        const CoreCoord core{(h % HPR) * NV + v, h / HPR};  // never crosses a grid row
         d.cores.push_back(core);
-        d.head.push_back(i / NV);  // heads' v-blocks grouped contiguously
-        d.vblk.push_back(i % NV);
+        d.head.push_back(h);
+        d.vblk.push_back(v);
         crs.insert(CoreRange{core, core});
     }
     d.core_set = CoreRangeSet{crs};
@@ -363,7 +379,7 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
 
     auto* device = in.v_beta.device();
     // Value-parallel fan-out: each core runs one (head, v-block) sequential scan.
-    auto sdist = distribute_scan(device->compute_with_storage_grid_size(), BH, Vt_full);
+    auto sdist = distribute_scan(device->compute_with_storage_grid_size(), BH, Vt_full, attrs.force_serial);
     const CoreRangeSet& cores = sdist.core_set;
     const uint32_t Vt = sdist.Vtl;  // per-core V-block width; CBs/compute use this
     const uint32_t n_used = static_cast<uint32_t>(sdist.cores.size());
@@ -405,6 +421,37 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
     add_cb(pcb::stmp, kv);
     add_cb(pcb::scr1, scr);
 
+    // Per-head multicast of the shared V-independent inputs (kd, q_decay, intra, k_dec_t, dl,
+    // t_inv): the head's v-block-0 core (leftmost of its 1xNV row rectangle) reads them from DRAM
+    // once and multicasts into the sibling cores' CBs — the siblings would otherwise re-read
+    // identical DRAM pages (NV-fold read amplification). Needs NV >= 2 to have anyone to share
+    // with; NV == 1 keeps the plain reader on every core (today's behavior, bit-exact either way).
+    const bool do_mcast = attrs.use_mcast && sdist.NV > 1;
+
+    CoreRangeSet sender_set, receiver_set;
+    if (do_mcast) {
+        std::set<CoreRange> s_crs, r_crs;
+        for (uint32_t i = 0; i < n_used; i++) {
+            (sdist.vblk[i] == 0 ? s_crs : r_crs).insert(CoreRange{sdist.cores[i], sdist.cores[i]});
+        }
+        sender_set = CoreRangeSet{s_crs};
+        receiver_set = CoreRangeSet{r_crs};
+        // Handshake semaphores, declared on ALL scan cores so each id resolves to the same L1
+        // address on sender and receivers (the sender multicasts the VALID flag into the
+        // receivers' copies). id 0 = ready (receivers inc the sender's copy once per chunk after
+        // reserving CB space; returns to 0 every chunk), id 1 = valid (sender mcasts VALID after
+        // the data mcasts; each kernel resets its local copy to 0 at teardown — the sender only
+        // AFTER its write barrier, since its copy is the async mcast payload source). Replay
+        // safety does not hinge on the end state: receivers reset valid before every ready inc,
+        // and dispatch re-initializes semaphore values on every enqueue.
+        // Ids are mirrored as SEM_READY/SEM_VALID constants in reader_chunk_gdn_scan.cpp — keep
+        // in sync (move to trailing compile-time args before fusing this op with anything).
+        desc.semaphores.push_back(
+            SemaphoreDescriptor{.id = 0, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
+        desc.semaphores.push_back(
+            SemaphoreDescriptor{.id = 1, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
+    }
+
     const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/";
     // ct arg 2 = per-core Vt(=Vtl); arg 4 = Vt_full (full V in tiles) for the readers'/writer's
     // V-slice row stride. Compute reads only args 0..2 (Ct, Kt, Vt) so the extra arg is harmless.
@@ -420,17 +467,41 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
     TensorAccessorArgs(*in.t_inv.buffer()).append_to(reader_ct);
     TensorAccessorArgs(in.initial_state.has_value() ? in.initial_state->buffer() : nullptr).append_to(reader_ct);
 
+    // Mcast receivers read only their private V-sliced tensors (v_beta, s0) from DRAM; the shared
+    // block arrives over the NoC. Their accessor chain therefore has just those two blocks.
+    std::vector<uint32_t> receiver_ct;
+    if (do_mcast) {
+        receiver_ct = ct_args;
+        TensorAccessorArgs(*in.v_beta.buffer()).append_to(receiver_ct);
+        TensorAccessorArgs(in.initial_state.has_value() ? in.initial_state->buffer() : nullptr).append_to(receiver_ct);
+    }
+
     std::vector<uint32_t> writer_ct = ct_args;
     TensorAccessorArgs(*outputs[0].buffer()).append_to(writer_ct);
     TensorAccessorArgs(*outputs[1].buffer()).append_to(writer_ct);
 
+    // Plain reader (no mcast) or mcast sender — the full accessor set either way.
     KernelDescriptor reader;
     reader.kernel_source = kdir + "dataflow/reader_chunk_gdn_scan.cpp";
     reader.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader.core_ranges = cores;
+    reader.core_ranges = do_mcast ? sender_set : cores;
     reader.compile_time_args = reader_ct;
+    if (do_mcast) {
+        reader.defines = {{"GDN_MCAST_SENDER", "1"}};
+    }
     reader.config = ReaderConfigDescriptor{};
-    reader.runtime_args.reserve(n_used);
+    reader.runtime_args.reserve(do_mcast ? BH : n_used);
+
+    KernelDescriptor receiver;  // used only when do_mcast
+    if (do_mcast) {
+        receiver.kernel_source = kdir + "dataflow/reader_chunk_gdn_scan.cpp";
+        receiver.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        receiver.core_ranges = receiver_set;
+        receiver.compile_time_args = receiver_ct;
+        receiver.defines = {{"GDN_MCAST_RECEIVER", "1"}};
+        receiver.config = ReaderConfigDescriptor{};
+        receiver.runtime_args.reserve(n_used - BH);
+    }
 
     KernelDescriptor writer;
     writer.kernel_source = kdir + "dataflow/writer_chunk_gdn_scan.cpp";
@@ -463,13 +534,49 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
         const auto& core = sdist.cores[i];
         const uint32_t h = sdist.head[i];
         const uint32_t vb = sdist.vblk[i];
-        reader.emplace_runtime_args(
-            core, {h, vb, NC, vb_buf, kd_buf, qd_buf, it_buf, kdec_buf, dl_buf, ti_buf, s0_buf});
+        if (!do_mcast) {
+            reader.emplace_runtime_args(
+                core, {h, vb, NC, vb_buf, kd_buf, qd_buf, it_buf, kdec_buf, dl_buf, ti_buf, s0_buf});
+        } else if (vb == 0) {
+            // Sender. Its receivers are the 1x(NV-1) rectangle immediately to its right (the
+            // row-aligned placement guarantees cores[i+1 .. i+NV-1] are this head's remaining
+            // v-blocks on the same row). Rectangle in VIRTUAL worker coords; the reader kernel
+            // runs on NOC_0 (ReaderConfigDescriptor -> preferred_noc_for_dram_read), whose mcast
+            // orientation is top-left -> bottom-right, so the coords go UNSWAPPED.
+            const CoreCoord rcv_start = device->worker_core_from_logical_core(sdist.cores[i + 1]);
+            const CoreCoord rcv_end = device->worker_core_from_logical_core(sdist.cores[i + sdist.NV - 1]);
+            reader.emplace_runtime_args(
+                core,
+                {h,
+                 vb,
+                 NC,
+                 vb_buf,
+                 kd_buf,
+                 qd_buf,
+                 it_buf,
+                 kdec_buf,
+                 dl_buf,
+                 ti_buf,
+                 s0_buf,
+                 static_cast<uint32_t>(rcv_start.x),
+                 static_cast<uint32_t>(rcv_start.y),
+                 static_cast<uint32_t>(rcv_end.x),
+                 static_cast<uint32_t>(rcv_end.y),
+                 sdist.NV - 1});
+        } else {
+            // Receiver: needs only its private tensors + the sender's coords for the ready inc.
+            const CoreCoord snd = device->worker_core_from_logical_core(sdist.cores[i - vb]);
+            receiver.emplace_runtime_args(
+                core, {h, vb, NC, vb_buf, s0_buf, static_cast<uint32_t>(snd.x), static_cast<uint32_t>(snd.y)});
+        }
         writer.emplace_runtime_args(core, {h, vb, NC, o_buf, fs_buf});
         compute.emplace_runtime_args(core, {NC});
     }
 
     desc.kernels.push_back(std::move(reader));
+    if (do_mcast) {
+        desc.kernels.push_back(std::move(receiver));
+    }
     desc.kernels.push_back(std::move(writer));
     desc.kernels.push_back(std::move(compute));
     return desc;

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
@@ -399,14 +399,32 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
                 {CBFormatDescriptor{.buffer_index = static_cast<uint8_t>(idx), .data_format = fmt, .page_size = ts}}}});
     };
 
-    // Per-chunk inputs (streamed from DRAM). u-slot holds v_beta, w-slot holds kd. nbuf=1.
-    add_cb(pcb::u, cv, 1);  // v_beta
-    add_cb(pcb::w, ck, 1);  // kd
-    add_cb(pcb::qdecay, ck, 1);
-    add_cb(pcb::intra, cc, 1);
-    add_cb(pcb::kdec_t, kc, 1);
-    add_cb(pcb::dl, 1, 1);
-    add_cb(pcb::Tinv, cc, 1);  // t_inv (WY inverse)
+    // Per-chunk inputs (streamed from DRAM). Double-buffered ONLY in the deep-fan-out multicast
+    // regime (NV >= 4): there the reader's chunk-c+1 prefetch (receivers reserve+ready early,
+    // the sender stages ahead) overlaps the multicast convoy and measures +17% on the scan op
+    // (BH=12/NV=4, T=4096: 708 -> 604 us). At NV=2 with twice the active cores (BH=48: 96 cores)
+    // the same prefetch ADDS 6% — DRAM is already saturated and the extra outstanding reads only
+    // queue — and on the plain (no-mcast) path it measures dead neutral at every shape, so both
+    // keep nbuf=1. Costs (cv + 2ck + 2cc + kc + 1) extra fp32 tiles (~64KB at Ct=1/Kt=4/Vtl=1)
+    // when enabled. The multicast lockstep argument survives nbuf=2: both roles reserve+push
+    // exactly one slot per chunk per CB, so write pointers ping-pong in unison and the sender's
+    // reserve-time address still names the receivers' reserved slot; the alternating ready/valid
+    // handshake keeps at most one multicast outstanding, which nbuf=2 fully absorbs.
+    // Per-head multicast of the shared V-independent inputs (kd, q_decay, intra, k_dec_t, dl,
+    // t_inv): the head's v-block-0 core (leftmost of its 1xNV row rectangle) reads them from DRAM
+    // once and multicasts into the sibling cores' CBs — the siblings would otherwise re-read
+    // identical DRAM pages (NV-fold read amplification). Needs NV >= 2 to have anyone to share
+    // with; NV == 1 keeps the plain reader on every core (today's behavior, bit-exact either way).
+    const bool do_mcast = attrs.use_mcast && sdist.NV > 1;
+
+    const uint32_t nbuf_in = (do_mcast && sdist.NV >= 4) ? 2u : 1u;
+    add_cb(pcb::u, cv, nbuf_in);  // v_beta
+    add_cb(pcb::w, ck, nbuf_in);  // kd
+    add_cb(pcb::qdecay, ck, nbuf_in);
+    add_cb(pcb::intra, cc, nbuf_in);
+    add_cb(pcb::kdec_t, kc, nbuf_in);
+    add_cb(pcb::dl, 1, nbuf_in);
+    add_cb(pcb::Tinv, cc, nbuf_in);  // t_inv (WY inverse)
     // State: cb_S is reader-produced (chunk 0 only); s2/s3 are compute-only ping-pong.
     add_cb(pcb::S, kv);
     add_cb(pcb::s2, kv);
@@ -420,13 +438,6 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
     add_cb(pcb::supd, kv);
     add_cb(pcb::stmp, kv);
     add_cb(pcb::scr1, scr);
-
-    // Per-head multicast of the shared V-independent inputs (kd, q_decay, intra, k_dec_t, dl,
-    // t_inv): the head's v-block-0 core (leftmost of its 1xNV row rectangle) reads them from DRAM
-    // once and multicasts into the sibling cores' CBs — the siblings would otherwise re-read
-    // identical DRAM pages (NV-fold read amplification). Needs NV >= 2 to have anyone to share
-    // with; NV == 1 keeps the plain reader on every core (today's behavior, bit-exact either way).
-    const bool do_mcast = attrs.use_mcast && sdist.NV > 1;
 
     CoreRangeSet sender_set, receiver_set;
     if (do_mcast) {

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
@@ -3,11 +3,42 @@
 //
 // Phase B (scan) reader: the initial state S [K,V] once, then per chunk the seven prep
 // intermediates v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv from DRAM. All fp32.
+//
+// Three compile variants (host selects via defines; no define = the plain reader):
+//   GDN_MCAST_SENDER   — this core is its head's v-block-0. It reads the six SHARED V-independent
+//                        tensors (kd, q_decay, intra, k_dec_t, dl, t_inv) from DRAM once per chunk
+//                        and multicasts them into the sibling v-block cores' CBs (identical CB
+//                        base addresses on every scan core — CBs are declared on one CoreRangeSet).
+//   GDN_MCAST_RECEIVER — a sibling v-block core. Reads only its private V-sliced tensors (v_beta,
+//                        s0) from DRAM; the shared block arrives over the NoC. Handshake:
+//                        reserve CB space -> ready.up(sender) -> wait(valid) -> push.
+// The handshake follows the production matmul in0 mcast idiom (reader_bmm_tile_layout_in0_
+// sender_padding.cpp / _receiver.cpp): ready counts receivers that RESERVED space (so the sender
+// can never overwrite unconsumed data), the data mcasts and the valid-flag mcast share one NOC /
+// static VC with linked=true chaining (data-before-flag), and an async_writes_flushed() sits
+// between data and flag ON EVERY ARCH: on Blackhole it orders flag-after-data (NoC latency >
+// L1<->RISCV latency); everywhere it also proves the data mcasts have read their L1 source slots
+// before the pushes let compute pop them and the next chunk's DRAM reads reuse them (the CBs are
+// single-buffered — without the flush that reuse is a silent data race; the flag mcast runs on a
+// different cmd buf and orders nothing). Everything runs on the reader's NOC_0, so the multicast
+// rectangle coords arrive UNSWAPPED (top-left -> bottom-right).
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+
+#if defined(GDN_MCAST_SENDER) || defined(GDN_MCAST_RECEIVER)
+#include "api/core_local_mem.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "hostdevcommon/common_values.hpp"
+// Semaphore ids fixed by the scan program factory (SemaphoreDescriptors, init 0). Must stay in
+// sync with the ids in chunk_gdn_phased_program_factory.cpp — drift compiles clean and deadlocks
+// at runtime; move to trailing compile-time args before this op is ever fused with another.
+constexpr uint32_t SEM_READY = 0;  // receivers -> sender: "my CB space for this chunk is reserved"
+constexpr uint32_t SEM_VALID = 1;  // sender -> receivers: "this chunk's shared data is in your CBs"
+#endif
 
 constexpr uint32_t cb_dl = 11, cb_S = 8, cb_Tinv = 13;
 constexpr uint32_t cb_vbeta = 17, cb_kd = 18, cb_qdecay = 19, cb_intra = 20, cb_kdec_t = 24;
@@ -20,6 +51,11 @@ void kernel_main() {
     constexpr uint32_t Vt_full = get_compile_time_arg_val(4);  // full V (tiles) for row stride
     (void)has_s0;
 
+#if defined(GDN_MCAST_RECEIVER)
+    // Receivers only access their private V-sliced tensors; the accessor chain has two blocks.
+    constexpr auto vb_a = TensorAccessorArgs<5>();
+    constexpr auto s0_a = TensorAccessorArgs<vb_a.next_compile_time_args_offset()>();
+#else
     constexpr auto vb_a = TensorAccessorArgs<5>();
     constexpr auto kd_a = TensorAccessorArgs<vb_a.next_compile_time_args_offset()>();
     constexpr auto qd_a = TensorAccessorArgs<kd_a.next_compile_time_args_offset()>();
@@ -28,11 +64,18 @@ void kernel_main() {
     constexpr auto dl_a = TensorAccessorArgs<kc_a.next_compile_time_args_offset()>();
     constexpr auto ti_a = TensorAccessorArgs<dl_a.next_compile_time_args_offset()>();
     constexpr auto s0_a = TensorAccessorArgs<ti_a.next_compile_time_args_offset()>();
+#endif
 
     // This core handles head h, V-block vb (columns [vb*Vt, vb*Vt+Vt) of the full V dimension).
     const uint32_t h = get_arg_val<uint32_t>(0);
     const uint32_t vb = get_arg_val<uint32_t>(1);
     const uint32_t NC = get_arg_val<uint32_t>(2);
+#if defined(GDN_MCAST_RECEIVER)
+    const uint32_t vb_addr = get_arg_val<uint32_t>(3);
+    const uint32_t s0_addr = get_arg_val<uint32_t>(4);
+    const uint32_t sender_x = get_arg_val<uint32_t>(5);  // virtual worker coords of the sender
+    const uint32_t sender_y = get_arg_val<uint32_t>(6);
+#else
     const uint32_t vb_addr = get_arg_val<uint32_t>(3);
     const uint32_t kd_addr = get_arg_val<uint32_t>(4);
     const uint32_t qd_addr = get_arg_val<uint32_t>(5);
@@ -41,16 +84,27 @@ void kernel_main() {
     const uint32_t dl_addr = get_arg_val<uint32_t>(8);
     const uint32_t ti_addr = get_arg_val<uint32_t>(9);
     const uint32_t s0_addr = get_arg_val<uint32_t>(10);
+#endif
+#if defined(GDN_MCAST_SENDER)
+    // Receiver rectangle (virtual worker coords, NOC_0 orientation: top-left -> bottom-right).
+    const uint32_t rcv_x0 = get_arg_val<uint32_t>(11);
+    const uint32_t rcv_y0 = get_arg_val<uint32_t>(12);
+    const uint32_t rcv_x1 = get_arg_val<uint32_t>(13);
+    const uint32_t rcv_y1 = get_arg_val<uint32_t>(14);
+    const uint32_t num_dests = get_arg_val<uint32_t>(15);  // NV-1; excludes the sender
+#endif
 
     const uint32_t tb = get_tile_size(cb_vbeta);  // all inputs fp32 -> same tile size
     const auto vb_acc = TensorAccessor(vb_a, vb_addr, tb);
+    const auto s0_acc = TensorAccessor(s0_a, s0_addr, tb);
+#if !defined(GDN_MCAST_RECEIVER)
     const auto kd_acc = TensorAccessor(kd_a, kd_addr, tb);
     const auto qd_acc = TensorAccessor(qd_a, qd_addr, tb);
     const auto it_acc = TensorAccessor(it_a, it_addr, tb);
     const auto kc_acc = TensorAccessor(kc_a, kc_addr, tb);
     const auto dl_acc = TensorAccessor(dl_a, dl_addr, tb);
     const auto ti_acc = TensorAccessor(ti_a, ti_addr, tb);
-    const auto s0_acc = TensorAccessor(s0_a, s0_addr, tb);
+#endif
 
     // V-independent tile counts (full reads). cv/kv are per-row Vt and handled by read_vslice.
     constexpr uint32_t cc = Ct * Ct;
@@ -59,6 +113,7 @@ void kernel_main() {
 
     Noc noc;
 
+#if !defined(GDN_MCAST_RECEIVER) && !defined(GDN_MCAST_SENDER)
     // Full (V-independent) read: n contiguous tiles from `base` into the CB.
     auto read_into = [&](const auto& acc, uint32_t cb_id, uint32_t base, uint32_t n) {
         CircularBuffer cb(cb_id);
@@ -69,6 +124,7 @@ void kernel_main() {
         noc.async_read_barrier();
         cb.push_back(n);
     };
+#endif
 
     // V-slice read: R row-groups of Vt tiles each, laid out in DRAM with row stride Vt_full and
     // this core's column offset vb*Vt. Packs contiguously ([R, Vt]) into the CB. `row_base` is the
@@ -90,6 +146,126 @@ void kernel_main() {
     // initial state S [K, V] (once) — host always provides it (zeros if none). V-sliced.
     read_vslice(s0_acc, cb_S, h * Kt * Vt_full, Kt);
 
+#if defined(GDN_MCAST_SENDER)
+    Semaphore<> ready(SEM_READY);
+    Semaphore<> valid(SEM_VALID);
+    // set_multicast sources its 4-byte value from the sender's LOCAL copy of `valid` — and it
+    // reads that L1 word asynchronously, when the NIU processes the command. Preset it to VALID
+    // once; any future write to this word must be preceded by noc.async_writes_flushed() or
+    // async_write_barrier(), or an in-flight set_multicast can pick up the new value (see the
+    // teardown, where the barrier deliberately comes BEFORE the reset).
+    valid.set(VALID);
+
+    // Stage a shared group: reserve + issue DRAM reads into this core's own CB slot, WITHOUT
+    // pushing (the write pointer must still address the slot when the mcast reads it). Returns
+    // the slot's L1 address — identical on every sibling core (same CB config, same push/pop
+    // history: exactly n tiles per chunk on both sides).
+    auto stage_group = [&](const auto& acc, uint32_t cb_id, uint32_t base, uint32_t n) -> uint32_t {
+        CircularBuffer cb(cb_id);
+        cb.reserve_back(n);
+        for (uint32_t t = 0; t < n; t++) {
+            noc.async_read(acc, cb, tb, {.page_id = base + t}, {.offset_bytes = t * tb});
+        }
+        return cb.get_write_ptr();
+    };
+
+    for (uint32_t c = 0; c < NC; c++) {
+        const uint32_t hc = h * NC + c;
+        read_vslice(vb_acc, cb_vbeta, hc * Ct * Vt_full, Ct);  // private v_beta slice (unchanged)
+
+        // Stage all six shared groups, then one barrier for the lot.
+        const uint32_t p_kd = stage_group(kd_acc, cb_kd, hc * ck, ck);
+        const uint32_t p_qd = stage_group(qd_acc, cb_qdecay, hc * ck, ck);
+        const uint32_t p_it = stage_group(it_acc, cb_intra, hc * cc, cc);
+        const uint32_t p_kc = stage_group(kc_acc, cb_kdec_t, hc * kc, kc);
+        const uint32_t p_dl = stage_group(dl_acc, cb_dl, hc * 1, 1);
+        const uint32_t p_ti = stage_group(ti_acc, cb_Tinv, hc * cc, cc);
+        noc.async_read_barrier();
+
+        // All receivers have reserved this chunk's CB space (their slots are writable).
+        ready.wait(num_dests);
+        ready.set(0);
+
+        // Data mcasts, linked so they chain with the flag mcast on one static VC (data-before-
+        // flag ordering). num_dests excludes the sender — no local copy is performed.
+        MulticastEndpoint mcast_dst;
+        auto mcast_group = [&](uint32_t addr, uint32_t n) {
+            noc.async_write_multicast(
+                CoreLocalMem<uint32_t>(addr),
+                mcast_dst,
+                n * tb,
+                num_dests,
+                {},
+                {.noc_x_start = rcv_x0, .noc_y_start = rcv_y0, .noc_x_end = rcv_x1, .noc_y_end = rcv_y1, .addr = addr},
+                /*linked=*/true);
+        };
+        mcast_group(p_kd, ck);
+        mcast_group(p_qd, ck);
+        mcast_group(p_it, cc);
+        mcast_group(p_kc, kc);
+        mcast_group(p_dl, 1);
+        mcast_group(p_ti, cc);
+        // Flush on EVERY arch, for two reasons. Blackhole: NoC latency exceeds L1<->RISCV latency,
+        // so without it a receiver could see VALID with the data still in flight. All arches: the
+        // flush proves every data mcast has read its L1 source slot; only then may the pushes
+        // below let compute pop the slots and the next chunk's stage_group reuse them (nbuf=1 —
+        // the flag mcast runs on a different cmd buf and provides no such ordering).
+        noc.async_writes_flushed();
+        valid.set_multicast(noc, rcv_x0, rcv_y0, rcv_x1, rcv_y1, num_dests);  // unlinked: ends chain
+
+        // Advance the sender's own CBs only now (the mcasts addressed the pre-push slots).
+        CircularBuffer(cb_kd).push_back(ck);
+        CircularBuffer(cb_qdecay).push_back(ck);
+        CircularBuffer(cb_intra).push_back(cc);
+        CircularBuffer(cb_kdec_t).push_back(kc);
+        CircularBuffer(cb_dl).push_back(1);
+        CircularBuffer(cb_Tinv).push_back(cc);
+    }
+
+    // Barrier BEFORE resetting the local valid word: set_multicast reads its 4-byte payload from
+    // that word asynchronously, so resetting first could multicast INVALID for the final chunk
+    // and deadlock every receiver at valid.wait(VALID). The barrier waits until all nonposted
+    // writes (data + flag mcasts) are acked; only then is the local reset safe.
+    noc.async_write_barrier();
+    valid.set(INVALID);  // restore the semaphore's initial value
+
+#elif defined(GDN_MCAST_RECEIVER)
+    Semaphore<> ready(SEM_READY);
+    Semaphore<> valid(SEM_VALID);
+
+    for (uint32_t c = 0; c < NC; c++) {
+        const uint32_t hc = h * NC + c;
+        read_vslice(vb_acc, cb_vbeta, hc * Ct * Vt_full, Ct);  // private v_beta slice (unchanged)
+
+        // Reserve this chunk's space in every shared CB FIRST — the ready inc is the sender's
+        // proof that these slots are writable (compute has popped the previous chunk).
+        CircularBuffer(cb_kd).reserve_back(ck);
+        CircularBuffer(cb_qdecay).reserve_back(ck);
+        CircularBuffer(cb_intra).reserve_back(cc);
+        CircularBuffer(cb_kdec_t).reserve_back(kc);
+        CircularBuffer(cb_dl).reserve_back(1);
+        CircularBuffer(cb_Tinv).reserve_back(cc);
+
+        // Reset our valid flag BEFORE signalling ready: a fast sender may mcast VALID immediately
+        // after the inc, and a late reset would overwrite it (lost wakeup -> deadlock).
+        valid.set(INVALID);
+        ready.up(noc, sender_x, sender_y, 1);
+        valid.wait(VALID);
+
+        // The shared bytes are in our CBs; make them visible to compute.
+        CircularBuffer(cb_kd).push_back(ck);
+        CircularBuffer(cb_qdecay).push_back(ck);
+        CircularBuffer(cb_intra).push_back(cc);
+        CircularBuffer(cb_kdec_t).push_back(kc);
+        CircularBuffer(cb_dl).push_back(1);
+        CircularBuffer(cb_Tinv).push_back(cc);
+    }
+
+    valid.set(INVALID);  // local store: restore the initial value (the last wait left it VALID)
+    // Drain the ready atomics: no non-posted inc may be in flight at kernel exit.
+    noc.async_atomic_barrier();
+
+#else
     for (uint32_t c = 0; c < NC; c++) {
         const uint32_t hc = h * NC + c;
         read_vslice(vb_acc, cb_vbeta, hc * Ct * Vt_full, Ct);  // v_beta [C, V] slice
@@ -100,4 +276,5 @@ void kernel_main() {
         read_into(dl_acc, cb_dl, hc * 1, 1);
         read_into(ti_acc, cb_Tinv, hc * cc, cc);
     }
+#endif
 }


### PR DESCRIPTION
## What

Stage-2 follow-up to #53790 (per-head multicast of shared GDN scan inputs), **reduced by measurement to its single winning ingredient**: double-buffer (`nbuf=2`) the seven per-chunk scan input CBs so the reader prefetches chunk c+1 while compute consumes chunk c — **gated to `do_mcast && NV >= 4`**, the deep-fan-out multicast regime where it actually wins. One file, +26/−15; the kernel is byte-identical to #53790.

Stacked on `iwrosz/gdn-scan-mcast` — review after/with #53790.

## Measurements (1× p150b, fw 19.11, Tracy device durations, `ChunkGdnScanOperation`, 10 iters)

| shape | stage-1 (#53790) | this PR | vs stage-1 | **total vs pre-mcast main** |
|---|---|---|---|---|
| BH=12/NV=4, T=4096 (TP-4 per-device) | 708 µs | 605–617 µs | **+1.15–1.17×** | **1.87–1.91×** (from 1155 µs) |
| BH=48/NV=2, T=4096 (single-device) | 1505 µs | identical program (gate off) | 1.00× | 1.52× |
| BH=48, T=512 / BH=96 NV=1 guards | — | identical programs | 1.00× | — |

## Why the gate (negative results, measured deliberately)

- **Ungated nbuf=2 at NV=2 (96 active cores) regressed 6%** (1505 → 1594 µs): DRAM is already saturated there; extra outstanding reads only add queueing. At NV=4 (48 cores) the prefetch overlaps the multicast convoy and wins 17%.
- **On the plain (no-mcast) path nbuf=2 is dead neutral at every shape** — that path is aggregate-bandwidth-bound, not latency-bound. Left at nbuf=1.
- **Sender early-push + fused staging barrier: measured neutral at NV=4** (605 vs 604 µs) **and part of a 4% regression at NV=2** — implemented, decomposed, and dropped; the kernel stays exactly as in #53790.
- The t_inv/dl fetch reorder only matters at nbuf=2 on the plain path, which the gate never enables — also dropped.

## Correctness

Bit-exact by construction (same bytes, same CB slots — only buffering depth changes). The multicast lockstep argument survives nbuf=2: both roles reserve+push exactly one slot per chunk per CB, so write pointers ping-pong in unison and the sender's reserve-time address still names the receivers' reserved slot; the alternating ready/valid handshake keeps at most one multicast outstanding, which nbuf=2 fully absorbs. Validated: the #53790 unit test (bit-exact on/off A/B + program-cache assertion) **6/6 passed on hardware** with this change.

## Remaining headroom

The gated scan sits at ~605 µs vs a ~250–310 µs DRAM floor at the TP-4 shape. The next levers are the per-head *multicast of reads themselves* being the sender's serial tail (deeper prefetch needs a second outstanding handshake — a protocol change, not a buffering change) and the NV-duplicated `v_beta`/`s0` slices. Not in scope here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-scan-mcast-stage2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-scan-mcast-stage2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-scan-mcast-stage2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-scan-mcast-stage2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-scan-mcast-stage2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-scan-mcast-stage2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-scan-mcast-stage2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-scan-mcast-stage2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-scan-mcast-stage2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-scan-mcast-stage2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-scan-mcast-stage2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-scan-mcast-stage2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-scan-mcast-stage2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-scan-mcast-stage2)