### PR TITLE
[LLK] Stop updating pack zero flags in L1 accumulation reconfig

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -332,12 +332,8 @@ inline void set_packer_strides(const std::uint32_t pack_src_format, const std::u
 
 inline void reconfigure_packer_l1_acc(const std::uint32_t pack_l1_acc)
 {
-    // Stall to avoid clobbering current packer configuration
+    // Stall to avoid clobbering current packer configuration, then enable/disable L1 accumulation
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-
-    // While packing, if all datums of a face are 0s, the packer will automatically set the zflags. For L1 accumulation mode, even if we pack out an entire face
-    // of 0s, because the data we are accumulating with is unknown, we don't want to set the zflags.
-    cfg_reg_rmw_tensix<THCON_SEC0_REG1_Disable_pack_zero_flags_RMW>(pack_l1_acc);
     cfg_reg_rmw_tensix<THCON_SEC0_REG1_Pack_L1_Acc_RMW>(pack_l1_acc);
 }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -959,29 +959,12 @@ inline void program_packer_dest_offset_registers(std::uint32_t dest_tile_offset)
 
 inline void reconfigure_packer_l1_acc(const std::uint32_t pack_l1_acc)
 {
-    // Stall to avoid clobbering current packer configuration
+    // Stall to avoid clobbering current packer configuration, then enable/disable L1 accumulation
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-
-    // While packing, if all datums of a face are 0s, the packer will automatically set the zflags. For L1 accumulation mode, even if we pack out an entire face
-    // of 0s, because the data we are accumulating with is unknown, we don't want to set the zflags.
-    const std::uint32_t pack_l1_acc_disable_pack_zero_flag = pack_l1_acc ? (0b11) : (0b00);
-
-    cfg_reg_rmw_tensix<
-        THCON_SEC0_REG1_Pack_L1_Acc_ADDR32,
-        THCON_SEC0_REG1_Pack_L1_Acc_SHAMT,
-        THCON_SEC0_REG1_Disable_pack_zero_flags_MASK | THCON_SEC0_REG1_Pack_L1_Acc_MASK>(pack_l1_acc_disable_pack_zero_flag);
-    cfg_reg_rmw_tensix<
-        THCON_SEC0_REG8_Pack_L1_Acc_ADDR32,
-        THCON_SEC0_REG8_Pack_L1_Acc_SHAMT,
-        THCON_SEC0_REG8_Disable_pack_zero_flags_MASK | THCON_SEC0_REG8_Pack_L1_Acc_MASK>(pack_l1_acc_disable_pack_zero_flag);
-    cfg_reg_rmw_tensix<
-        THCON_SEC1_REG1_Pack_L1_Acc_ADDR32,
-        THCON_SEC1_REG1_Pack_L1_Acc_SHAMT,
-        THCON_SEC1_REG1_Disable_pack_zero_flags_MASK | THCON_SEC1_REG1_Pack_L1_Acc_MASK>(pack_l1_acc_disable_pack_zero_flag);
-    cfg_reg_rmw_tensix<
-        THCON_SEC1_REG8_Pack_L1_Acc_ADDR32,
-        THCON_SEC1_REG8_Pack_L1_Acc_SHAMT,
-        THCON_SEC1_REG8_Disable_pack_zero_flags_MASK | THCON_SEC1_REG8_Pack_L1_Acc_MASK>(pack_l1_acc_disable_pack_zero_flag);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG1_Pack_L1_Acc_RMW>(pack_l1_acc);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG8_Pack_L1_Acc_RMW>(pack_l1_acc);
+    cfg_reg_rmw_tensix<THCON_SEC1_REG1_Pack_L1_Acc_RMW>(pack_l1_acc);
+    cfg_reg_rmw_tensix<THCON_SEC1_REG8_Pack_L1_Acc_RMW>(pack_l1_acc);
 }
 
 // READERS FOR CONFIG STRUCTS


### PR DESCRIPTION
### PR Category
Performance

### Summary
This removes unnecessary `Disable_pack_zero_flags` updates from the Wormhole and Blackhole packer L1 accumulation reconfiguration paths. That bit controls tracking of whether packed data was all zero, which is not used by the relevant software path, and the previous comment made the behavior sound more broadly meaningful than it is. Leaving the bit cleared avoids extra config writes, keeps the L1 accumulation reconfiguration focused on `Pack_L1_Acc`, and removes misleading dead code without changing the pack data path.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/pack-disable-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/pack-disable-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/pack-disable-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/pack-disable-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/pack-disable-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/pack-disable-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/pack-disable-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/pack-disable-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/pack-disable-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/pack-disable-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/pack-disable-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/pack-disable-zero-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/pack-disable-zero-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/pack-disable-zero-flag)