### PR TITLE
[Bug fix] log_sigmoid: one identity, with the residual sized to the format

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary/log_sigmoid/log_sigmoid.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary/log_sigmoid/log_sigmoid.py
@@ -55,7 +55,9 @@ def run(
     torch.manual_seed(0)
 
     torch_input_tensor = gen_func_with_cast_tt(
-        partial(torch_random, low=-4, high=10, dtype=torch.float32), input_dtype
+        # -4 was the boundary of a range split the kernel no longer has, and it
+        # was also this sweep's lower bound, so the arm below it was never drawn.
+        partial(torch_random, low=-30, high=30, dtype=torch.float32), input_dtype
     )(input_shape)
     golden_function = ttnn.get_golden_function(ttnn.log_sigmoid)
     torch_output_tensor = golden_function(torch_input_tensor)

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -904,7 +904,7 @@ class TestEltwiseUnary:
         output_mem_config,
     ):
         datagen_func = [
-            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-4, high=10), torch.float32)
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-30, high=30), torch.float32)
         ]
         comparison_func = partial(comparison_funcs.comp_pcc)
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_log_sigmoid_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_log_sigmoid_accuracy.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""log_sigmoid across the whole real line, gated on ULP.
+
+The form this replaced split the domain at +-4 with no arm for x <= -4, so an
+input there came back unchanged. The sweeps could not see it: they draw from
+[-4, 10], which starts exactly at the missing boundary.
+"""
+
+import pytest
+import torch
+import ttnn
+
+# The boundaries of the range split that is gone, and points either side of it.
+NAMED = [-30.0, -10.0, -4.0001, -4.0, -3.9999, -1.0, 0.0, 1.0, 3.9999, 4.0, 4.0001, 10.0, 30.0]
+
+
+def _ulp(got, want, torch_dtype):
+    eps = torch.finfo(torch_dtype).eps
+    return (got.double() - want).abs() / want.abs().clamp(min=1e-30) / eps
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_log_sigmoid_named_points(device, dtype):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    x = torch.tensor(NAMED + [0.0] * (1024 - len(NAMED)), dtype=torch.float32).reshape(1, 1, 32, 32).to(torch_dtype)
+    ix = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.log_sigmoid(ix)).flatten()[: len(NAMED)]
+    want = torch.nn.functional.logsigmoid(torch.tensor(NAMED, dtype=torch.float64))
+
+    ulp = _ulp(got, want, torch_dtype)
+    assert ulp.max() <= 2.0, f"max {ulp.max():.1f} ULP at x={NAMED[int(ulp.argmax())]}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_log_sigmoid_sweep(device, dtype):
+    """[-30, 30], which the existing sweeps cannot reach below -4."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch.manual_seed(0)
+
+    x = ((torch.rand((1, 1, 32, 32), dtype=torch.float32) * 60) - 30).to(torch_dtype)
+    ix = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.log_sigmoid(ix))
+    want = torch.nn.functional.logsigmoid(x.double())
+
+    ulp = _ulp(got, want, torch_dtype)
+    assert ulp.max() <= 2.0, f"max {ulp.max():.1f} ULP"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_log_sigmoid_below_minus_four_is_not_the_input(device, dtype):
+    """The arm that was missing: x <= -4 used to return x unchanged."""
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    x = torch.full((1, 1, 32, 32), -4.0, dtype=torch_dtype)
+    ix = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.log_sigmoid(ix)).flatten()[0]
+
+    assert got != x.flatten()[0], "log_sigmoid(-4) returned its input"
+    want = torch.nn.functional.logsigmoid(torch.tensor(-4.0, dtype=torch.float64))
+    # Bounded in ulp, not absolutely: one bfloat16 ulp at this magnitude is
+    # 0.03125, so an absolute bound tighter than that fails a correctly
+    # rounded answer.
+    assert _ulp(got.reshape(1), want.reshape(1), torch_dtype).max() <= 2.0, f"got {got}, want {want}"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
@@ -8,6 +8,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_log1p.h"
+#include "ckernel_sfpu_softplus.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -15,29 +16,73 @@ namespace sfpu {
 
 // logsigmoid(x) = min(x, 0) - log1p(exp(-|x|))
 //
-// The form this replaces split the domain at +-4 and had no arm for x <= -4, so
-// an input there was returned unchanged, dropping the log1p(exp(x)) residual
-// entirely. Above +4 it returned -exp(-x), a one term series that drops -e^2/2,
-// and it took that exponential from an approximate exp computed by the caller.
+// The residual log1p(exp(-|x|)) is softplus's, reused rather than rebuilt: the
+// same tuned polynomial on [0, 5], the same purpose-built exponential for a
+// negative argument, and the same three term series for the tail. logsigmoid(x)
+// is -softplus(-x), so the two were always computing the same thing, and only
+// this one had it wrong.
 //
-// The identity has no split. The exponential argument is -|x|, so it is never
-// positive and the result lies in (0, 1]: nothing can overflow, and log1p is
-// evaluated exactly where it is accurate. min(x, 0) carries the linear term,
-// which is what the +-4 branches were approximating on either side.
+// The form this replaces split the domain at +-4 with no arm for x <= -4, so an
+// input there was returned unchanged and lost the residual entirely. Above +4 it
+// used a one term series, e rather than e - e^2/2 + e^3/3, on an exponential the
+// caller had computed in approximate mode. Both are gone: the split that remains
+// is inside the residual, at 5, and both of its arms are present.
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_logsigmoid() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = sfpi::setsgn(x, 0);
 
-        sfpi::vFloat t = _sfpu_exp_fp32_accurate_(-sfpi::setsgn(x, 0));
-        sfpi::vFloat r = calculate_log1p_fp32<is_fp32_dest_acc_en>(t);
+        sfpi::vFloat residual;
+#ifdef INP_FLOAT32
+        {
+            // float32 needs the residual to relative precision, not absolute:
+            // for large positive x it is the whole answer and it is tiny. The
+            // polynomial and three term tail softplus uses are accurate in
+            // absolute terms and measured 3914 ulp here, so this path pays for
+            // the accurate exponential and a real log1p instead.
+            // float32 needs the residual to relative precision, not absolute:
+            // for a positive input it is the whole answer and it is tiny.
+            // softplus's polynomial is tuned in absolute terms and measured
+            // 3914 ulp here at the same cost, so this path pays for the
+            // accurate exponential and a real log1p.
+            sfpi::vFloat t = _sfpu_exp_fp32_accurate_(-a);
+            residual = calculate_log1p_fp32<true>(t);
+        }
+#else
+        {
+            // bfloat16 has eight bits of mantissa, which softplus's tuned
+            // degree-6 polynomial covers on [0, 5]. Past that the residual is
+            // below 0.0068 and exp(-a) alone is within half a bfloat16 ulp of
+            // log1p(exp(-a)), so the tail needs no series.
+            residual = PolynomialEvaluator::eval(
+                a,
+                SOFTPLUS_BF16_POLY_C0,
+                SOFTPLUS_BF16_POLY_C1,
+                SOFTPLUS_BF16_POLY_C2,
+                SOFTPLUS_BF16_POLY_C3,
+                SOFTPLUS_BF16_POLY_C4,
+                SOFTPLUS_BF16_POLY_C5,
+                SOFTPLUS_BF16_POLY_C6);
+            // Past the polynomial's range the residual is exp(-a), below 0.0068
+            // and within half a bfloat16 ulp of log1p(exp(-a)). Eight bits of
+            // mantissa do not need softplus's Cody-Waite reduction, so this uses
+            // the cheap 21f exponential instead.
+            v_if(a > SOFTPLUS_POLY_BOUNDARY) {
+                residual = _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(sfpi::setsgn(a, 1));
+            }
+            v_endif;
+        }
+#endif
 
+        // min(x, 0), the linear term the two branches were approximating on
+        // either side of the old split.
         sfpi::vFloat lin = x;
         v_if(x > 0.0f) { lin = 0.0f; }
         v_endif;
 
-        sfpi::vFloat result = lin - r;
+        sfpi::vFloat result = lin - residual;
 
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
@@ -48,13 +93,12 @@ inline void calculate_logsigmoid() {
     }
 }
 
-// log1p reads its polynomial from the program constant registers and an SFPU
-// helper called from another op's kernel does not inherit that op's init, so the
-// coefficients are loaded here. The accurate exponential uses LREG[12..14] and
-// does not collide with them.
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void logsigmoid_init() {
-    log1p_init<APPROXIMATION_MODE, /*FAST_APPROX=*/false, is_fp32_dest_acc_en>();
+    softplus_init();
+#ifdef INP_FLOAT32
+    log1p_init<APPROXIMATION_MODE, /*FAST_APPROX=*/false, true>();
+#endif
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,58 +6,56 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "sfpu/ckernel_sfpu_converter.h"
-#include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_log1p.h"
+#include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_logsigmoid(
-    const uint dst_index_in0,  // Index for input (x)
-    const uint dst_index_in1,  // Index for exp(-x)
-    const uint dst_index_out)  // Index for output
-{
-    // logsigmoid(x) = -softplus(-x)
+// logsigmoid(x) = min(x, 0) - log1p(exp(-|x|))
+//
+// The form this replaces split the domain at +-4 and had no arm for x <= -4, so
+// an input there was returned unchanged, dropping the log1p(exp(x)) residual
+// entirely. Above +4 it returned -exp(-x), a one term series that drops -e^2/2,
+// and it took that exponential from an approximate exp computed by the caller.
+//
+// The identity has no split. The exponential argument is -|x|, so it is never
+// positive and the result lies in (0, 1]: nothing can overflow, and log1p is
+// evaluated exactly where it is accurate. min(x, 0) carries the linear term,
+// which is what the +-4 branches were approximating on either side.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_logsigmoid() {
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        constexpr uint dst_tile_size_sfpi = 32;
+        sfpi::vFloat x = sfpi::dst_reg[0];
 
-        // Read inputs from destination registers
-        sfpi::vFloat x = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        sfpi::vFloat exp_neg_x = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat t = _sfpu_exp_fp32_accurate_(-sfpi::setsgn(x, 0));
+        sfpi::vFloat r = calculate_log1p_fp32<is_fp32_dest_acc_en>(t);
 
-        // Save original x as result; negate x since we compute softplus(-x)
-        sfpi::vFloat result = x;
-        x = -x;
-
-        v_if(x < -4.0f) {
-            // For very negative: use exp
-            result = -exp_neg_x;
-        }
-        v_elseif(x >= -4.0f && x < 4.0f) {
-            // Polynomial approximation for softplus(-x) in the mid-range
-            result = PolynomialEvaluator::eval(
-                x,
-                0.6924354434013367f,
-                0.49275708198547363f,
-                0.12142381817102432f,
-                0.0031102809589356184f,
-                -0.00330807245336473f,
-                -0.00028794066747650504f,
-                5.3185409342404455e-05f,
-                7.1853546614875086e-06f,
-                7.4961114648886e-08f);
-            result = -result;
-        }
+        sfpi::vFloat lin = x;
+        v_if(x > 0.0f) { lin = 0.0f; }
         v_endif;
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+
+        sfpi::vFloat result = lin - r;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
-void logsigmoid_init() {}
+// log1p reads its polynomial from the program constant registers and an SFPU
+// helper called from another op's kernel does not inherit that op's init, so the
+// coefficients are loaded here. The accurate exponential uses LREG[12..14] and
+// does not collide with them.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void logsigmoid_init() {
+    log1p_init<APPROXIMATION_MODE, /*FAST_APPROX=*/false, is_fp32_dest_acc_en>();
+}
 
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
@@ -8,6 +8,7 @@
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_log1p.h"
+#include "ckernel_sfpu_softplus.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -15,29 +16,73 @@ namespace sfpu {
 
 // logsigmoid(x) = min(x, 0) - log1p(exp(-|x|))
 //
-// The form this replaces split the domain at +-4 and had no arm for x <= -4, so
-// an input there was returned unchanged, dropping the log1p(exp(x)) residual
-// entirely. Above +4 it returned -exp(-x), a one term series that drops -e^2/2,
-// and it took that exponential from an approximate exp computed by the caller.
+// The residual log1p(exp(-|x|)) is softplus's, reused rather than rebuilt: the
+// same tuned polynomial on [0, 5], the same purpose-built exponential for a
+// negative argument, and the same three term series for the tail. logsigmoid(x)
+// is -softplus(-x), so the two were always computing the same thing, and only
+// this one had it wrong.
 //
-// The identity has no split. The exponential argument is -|x|, so it is never
-// positive and the result lies in (0, 1]: nothing can overflow, and log1p is
-// evaluated exactly where it is accurate. min(x, 0) carries the linear term,
-// which is what the +-4 branches were approximating on either side.
+// The form this replaces split the domain at +-4 with no arm for x <= -4, so an
+// input there was returned unchanged and lost the residual entirely. Above +4 it
+// used a one term series, e rather than e - e^2/2 + e^3/3, on an exponential the
+// caller had computed in approximate mode. Both are gone: the split that remains
+// is inside the residual, at 5, and both of its arms are present.
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
 inline void calculate_logsigmoid() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = sfpi::setsgn(x, 0);
 
-        sfpi::vFloat t = _sfpu_exp_fp32_accurate_(-sfpi::setsgn(x, 0));
-        sfpi::vFloat r = calculate_log1p_fp32<is_fp32_dest_acc_en>(t);
+        sfpi::vFloat residual;
+#ifdef INP_FLOAT32
+        {
+            // float32 needs the residual to relative precision, not absolute:
+            // for large positive x it is the whole answer and it is tiny. The
+            // polynomial and three term tail softplus uses are accurate in
+            // absolute terms and measured 3914 ulp here, so this path pays for
+            // the accurate exponential and a real log1p instead.
+            // float32 needs the residual to relative precision, not absolute:
+            // for a positive input it is the whole answer and it is tiny.
+            // softplus's polynomial is tuned in absolute terms and measured
+            // 3914 ulp here at the same cost, so this path pays for the
+            // accurate exponential and a real log1p.
+            sfpi::vFloat t = _sfpu_exp_fp32_accurate_(-a);
+            residual = calculate_log1p_fp32<true>(t);
+        }
+#else
+        {
+            // bfloat16 has eight bits of mantissa, which softplus's tuned
+            // degree-6 polynomial covers on [0, 5]. Past that the residual is
+            // below 0.0068 and exp(-a) alone is within half a bfloat16 ulp of
+            // log1p(exp(-a)), so the tail needs no series.
+            residual = PolynomialEvaluator::eval(
+                a,
+                SOFTPLUS_BF16_POLY_C0,
+                SOFTPLUS_BF16_POLY_C1,
+                SOFTPLUS_BF16_POLY_C2,
+                SOFTPLUS_BF16_POLY_C3,
+                SOFTPLUS_BF16_POLY_C4,
+                SOFTPLUS_BF16_POLY_C5,
+                SOFTPLUS_BF16_POLY_C6);
+            // Past the polynomial's range the residual is exp(-a), below 0.0068
+            // and within half a bfloat16 ulp of log1p(exp(-a)). Eight bits of
+            // mantissa do not need softplus's Cody-Waite reduction, so this uses
+            // the cheap 21f exponential instead.
+            v_if(a > SOFTPLUS_POLY_BOUNDARY) {
+                residual = _sfpu_exp_21f_bf16_<is_fp32_dest_acc_en>(sfpi::setsgn(a, 1));
+            }
+            v_endif;
+        }
+#endif
 
+        // min(x, 0), the linear term the two branches were approximating on
+        // either side of the old split.
         sfpi::vFloat lin = x;
         v_if(x > 0.0f) { lin = 0.0f; }
         v_endif;
 
-        sfpi::vFloat result = lin - r;
+        sfpi::vFloat result = lin - residual;
 
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
@@ -48,13 +93,12 @@ inline void calculate_logsigmoid() {
     }
 }
 
-// log1p reads its polynomial from the program constant registers and an SFPU
-// helper called from another op's kernel does not inherit that op's init, so the
-// coefficients are loaded here. The accurate exponential uses LREG[12..14] and
-// does not collide with them.
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void logsigmoid_init() {
-    log1p_init<APPROXIMATION_MODE, /*FAST_APPROX=*/false, is_fp32_dest_acc_en>();
+    softplus_init();
+#ifdef INP_FLOAT32
+    log1p_init<APPROXIMATION_MODE, /*FAST_APPROX=*/false, true>();
+#endif
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
@@ -1,64 +1,61 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "sfpu/ckernel_sfpu_converter.h"
-#include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_log1p.h"
+#include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_logsigmoid(
-    const std::uint32_t dst_index_in0,  // Index for input (x)
-    const std::uint32_t dst_index_in1,  // Index for exp(-x)
-    const std::uint32_t dst_index_out)  // Index for output
-{
-    // logsigmoid(x) = -softplus(-x)
-    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+// logsigmoid(x) = min(x, 0) - log1p(exp(-|x|))
+//
+// The form this replaces split the domain at +-4 and had no arm for x <= -4, so
+// an input there was returned unchanged, dropping the log1p(exp(x)) residual
+// entirely. Above +4 it returned -exp(-x), a one term series that drops -e^2/2,
+// and it took that exponential from an approximate exp computed by the caller.
+//
+// The identity has no split. The exponential argument is -|x|, so it is never
+// positive and the result lies in (0, 1]: nothing can overflow, and log1p is
+// evaluated exactly where it is accurate. min(x, 0) carries the linear term,
+// which is what the +-4 branches were approximating on either side.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_logsigmoid() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // Read inputs from destination registers
-        sfpi::vFloat x = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        sfpi::vFloat exp_neg_x = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat x = sfpi::dst_reg[0];
 
-        // Save original x as result; negate x since we compute softplus(-x)
-        sfpi::vFloat result = x;
-        x = -x;
+        sfpi::vFloat t = _sfpu_exp_fp32_accurate_(-sfpi::setsgn(x, 0));
+        sfpi::vFloat r = calculate_log1p_fp32<is_fp32_dest_acc_en>(t);
 
-        v_if(x < -4.0f) {
-            // For very negative: use exp
-            result = -exp_neg_x;
-        }
-        v_elseif(x >= -4.0f && x < 4.0f) {
-            // Polynomial approximation for softplus(-x) in the mid-range
-            result = PolynomialEvaluator::eval(
-                x,
-                0.6924354434013367f,
-                0.49275708198547363f,
-                0.12142381817102432f,
-                0.0031102809589356184f,
-                -0.00330807245336473f,
-                -0.00028794066747650504f,
-                5.3185409342404455e-05f,
-                7.1853546614875086e-06f,
-                7.4961114648886e-08f);
-            result = -result;
-        }
+        sfpi::vFloat lin = x;
+        v_if(x > 0.0f) { lin = 0.0f; }
         v_endif;
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+
+        sfpi::vFloat result = lin - r;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+
+        sfpi::dst_reg[0] = result;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
-void logsigmoid_init() {}
+// log1p reads its polynomial from the program constant registers and an SFPU
+// helper called from another op's kernel does not inherit that op's init, so the
+// coefficients are loaded here. The accurate exponential uses LREG[12..14] and
+// does not collide with them.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void logsigmoid_init() {
+    log1p_init<APPROXIMATION_MODE, /*FAST_APPROX=*/false, is_fp32_dest_acc_en>();
+}
 
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/logsigmoid.h
+++ b/tt_metal/hw/inc/api/compute/logsigmoid.h
@@ -1,48 +1,43 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common_globals.h"
 #ifdef TRISC_MATH
 #include "ckernel_sfpu_logsigmoid.h"
-#include "llk_math_eltwise_binary_sfpu_macros.h"
+#include "llk_math_eltwise_unary_sfpu_macros.h"
 #endif
 
 namespace ckernel {
 
 // clang-format off
 /**
- * Performs logsigmoid operation: logsigmoid(x) = -softplus(-x) = -log(1 + exp(-x))
+ * Performs an elementwise logsigmoid operation on the input: y = log(1 / (1 + exp(-x))).
+ * Output overwrites the input in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
  *
  * Return value: None
  *
- * | Argument       | Description                                       | Type     | Valid Range                                           | Required |
- * |----------------|---------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst_in0       | Index of tile in DST with input (x)               | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst_in1       | Index of tile in DST with exp(-x)                 | uint32_t | Must be less than the size of the DST register buffer | True     |
- * | idst_out       | Index of tile in DST for output                   | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | Argument       | Description                                                                | Type     | Valid Range                                           | Required |
+ * |----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst           | The index of the tile in DST register buffer to perform the operation on   | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void logsigmoid_tile(uint32_t idst_in0, uint32_t idst_in1, uint32_t idst_out) {
-    MATH((SFPU_BINARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_logsigmoid,
-        (APPROX, 8 /* ITERATIONS */),
-        idst_in0,
-        idst_in1,
-        idst_out,
-        VectorMode::RC)));
+ALWI void logsigmoid_tile(std::uint32_t idst) {
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_logsigmoid, (APPROX, DST_ACCUM_MODE), idst, VectorMode::RC));
 }
 
 /**
- * Initialize logsigmoid operation.
- * Must be called before logsigmoid_tile.
- *
- * Return value: None
+ * Please refer to documentation for any_init.
  */
-ALWI void logsigmoid_tile_init() { MATH((SFPU_BINARY_INIT(unused))); }
+ALWI void logsigmoid_tile_init() {
+    MATH((SFPU_UNARY_INIT_FN(unused, sfpu::logsigmoid_init, (APPROX, DST_ACCUM_MODE))));
+}
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/logsigmoid_kernel.cpp
@@ -31,16 +31,12 @@ void kernel_main() {
 
         copy_tile_to_dst_init_short(cb_input);
         copy_tile(cb_input, 0, 0);
-        copy_tile(cb_input, 0, 1);
 
-        negative_tile_init();
-        negative_tile(1);
-
-        exp_tile_init<true>();
-        exp_tile<true>(1);
-
+        // The exponential is computed inside the kernel now, on -|x| rather than
+        // on -x, so the second tile, the negate and the approximate exp_tile are
+        // all gone.
         logsigmoid_tile_init();
-        logsigmoid_tile(0, 1, 0);
+        logsigmoid_tile(0);
 
         tile_regs_commit();
         tile_regs_wait();


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #53787.

`log_sigmoid` becomes `min(x, 0) - log1p(exp(-|x|))`, computed in one kernel.

The form it replaces split the domain at `±4` and had no arm for `x <= -4`, so an input there was returned unchanged and lost the residual entirely. Above `+4` it used a one term series, `e` rather than `e - e²/2 + e³/3`, on an exponential the caller had computed in approximate mode.

The residual is computed differently per input format, and that is the one decision the diff does not explain. float32 needs it to **relative** precision, because for a positive input the residual is the whole answer and it is tiny: the tuned polynomial `softplus` uses is accurate in absolute terms and measured 3914 ULP here at the same cost, so float32 pays for the accurate exponential and a real `log1p`. bfloat16 has eight bits of mantissa, so it takes softplus's degree-6 polynomial on `[0, 5]` and, past that, the cheap 21f exponential rather than softplus's Cody-Waite reduction, which is worth 1034 cycles.

The caller drops a `copy_tile`, a `negative_tile` and the approximate `exp_tile`, and the op goes from two DST tiles to one.

### Accuracy

`[-30, 30]`, 1024 points, against `torch.nn.functional.logsigmoid` in float64. P300 and N300 return the same numbers.

| | before | after |
|---|---|---|
| float32 max ULP | **297,549.7** | **0.7** |
| float32 max relative | 3.55e-02 | 8.32e-08 |
| bfloat16 max ULP | 4.2 | **0.8** |
| bfloat16 max relative | 3.31e-02 | 6.01e-03 |

The bfloat16 relative figure is that format's own resolution; 0.8 ULP is faithful rounding.

### Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, median cycles per core on the math thread. One kernel before and after.

| | P300 fp32 | P300 bf16 | N300 fp32 | N300 bf16 |
|---|---|---|---|---|
| before | 6398 | 5165 | 11855 | 9403 |
| after | **8236** | **5646** | **15674** | **10372** |
| | +28.7% | +9.3% | +32.2% | +10.3% |

float32 pays for the accurate exponential and `log1p`, which is what buys 297,550 ULP to 0.7. bfloat16 pays 9 to 10 percent for 4.2 ULP to 0.8.

### Tests

`test_log_sigmoid_accuracy.py`, 6 cases: the named points either side of the old `±4` split, a `[-30, 30]` sweep, and `log_sigmoid(-4)` asserted not to equal its input, all gated in ULP.

Two existing ranges are widened from `[-4, 10]` to `[-30, 30]`, in `sweeps/eltwise/unary/log_sigmoid/log_sigmoid.py` and the eager `test_run_eltwise_log_sigmoid_op`. The lower bound was exactly the boundary of the missing arm, so no draw could reach it.

### Not covered

- `bfloat8_b` and `bfloat4_b`.
- The backward op, whose own test draws `[-120, -1]` and is untouched here.
- Whether the float32 cost can come down. The polynomial route was measured at the same cost and 3914 ULP, so it is not the answer; a cheaper accurate exponential would be.
