### PR TITLE
[skip ci] Restore auto-approve.yaml codeowner review for bump PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,7 @@ conftest.py @tenstorrent/metalium-developers-infra
 
 # test scripts
 tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
-tests/pipeline_reorg/ @roseli-TT @tdowdallTT
+tests/pipeline_reorg/ @roseli-TT @tdowdallTT @tenstorrent-github-bot
 tests/pipeline_reorg/blaze_models_prefill_tests.yaml @mbezuljTT @mtairum @roseli-TT
 tests/pipeline_reorg/models_device_perf_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_e2e_tests.yaml @mtairum @uaydonat @roseli-TT
@@ -210,9 +210,9 @@ tt_metal/tools/profiler/tracy_debug_categories.txt @mo-tenstorrent @akerteszTT @
 tt_metal/tools/profiler/tracy_debug_zones.hpp @mo-tenstorrent @akerteszTT @yusufbashiTT
 
 # metal misc
-tt_metal/sfpi-info.sh @nathan-TT @tenstorrent/metalium-developers-infra
-tt_metal/sfpi-version @nathan-TT @tenstorrent/metalium-developers-infra
-tt_metal/ttsim-version @mcraigheadTT
+tt_metal/sfpi-info.sh @nathan-TT @tenstorrent/metalium-developers-infra @tenstorrent-github-bot
+tt_metal/sfpi-version @nathan-TT @tenstorrent/metalium-developers-infra @tenstorrent-github-bot
+tt_metal/ttsim-version @mcraigheadTT @tenstorrent-github-bot
 tt_metal/**/profiler/**/CMakeLists.txt @mo-tenstorrent @akerteszTT @tenstorrent/metalium-developers-infra
 tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra
 
@@ -224,7 +224,7 @@ tt_metal/**/dprint* @tenstorrent/metalium-developers-triage
 tt_metal/**/inspector* @tenstorrent/metalium-developers-triage
 
 # LLK in-tree (tt_metal/tt-llk/) — mirrors tenstorrent/tt-llk CODEOWNERS
-tt_metal/third_party/umd @broskoTT @pjanevskiTT @tenstorrent/umd-admins
+tt_metal/third_party/umd @broskoTT @pjanevskiTT @tenstorrent/umd-admins @tenstorrent-github-bot
 tt_metal/tt-llk/ @rtawfik01 @rdjogoTT @nvelickovicTT @amahmudTT @lpremovicTT @ncvetkovicTT @ndivnicTT @fvranicTT
 tt_metal/tt-llk/.claude/ @nstamatovicTT @njokovicTT
 tt_metal/tt-llk/.cursor/ @nstamatovicTT @njokovicTT
@@ -610,7 +610,7 @@ models/vllm_test_utils/ @viktorpusTT @tchedaTT @uaydonat
 
 # tracy
 tools/tracy/ @mo-tenstorrent @akerteszTT
-tt_metal/third_party/tracy @mo-tenstorrent @akerteszTT
+tt_metal/third_party/tracy @mo-tenstorrent @akerteszTT @tenstorrent-github-bot
 
 tools/scripts/ @mtairum
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,7 +75,6 @@ tests/pipeline_reorg/models_e2e_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_sweep_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_unit_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/vllm_model_tests.yaml @viktorpusTT @tchedaTT @ppetrovicTT @tenstorrent/metalium-developers-infra
-tests/pipeline_reorg/ @roseli-TT @tdowdallTT
 tests/pipeline_reorg/ttsim-skip-list.yaml @roseli-TT @tdowdallTT @mcraigheadTT @tenstorrent-github-bot
 tests/scripts/ @tenstorrent/metalium-developers-infra
 tests/scripts/quasar @kstevensTT @fvranicTT @tenstorrent/metalium-developers-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,7 +75,8 @@ tests/pipeline_reorg/models_e2e_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_sweep_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_unit_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/vllm_model_tests.yaml @viktorpusTT @tchedaTT @ppetrovicTT @tenstorrent/metalium-developers-infra
-tests/pipeline_reorg/ttsim-skip-list.yaml @roseli-TT @tdowdallTT @tenstorrent-github-bot
+tests/pipeline_reorg/ @roseli-TT @tdowdallTT
+tests/pipeline_reorg/ttsim-skip-list.yaml @roseli-TT @tdowdallTT @mcraigheadTT @tenstorrent-github-bot
 tests/scripts/ @tenstorrent/metalium-developers-infra
 tests/scripts/quasar @kstevensTT @fvranicTT @tenstorrent/metalium-developers-infra
 tests/scripts/single_card/run_single_card_profiler_tests.sh @mo-tenstorrent @akerteszTT @tenstorrent/metalium-developers-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,13 +68,14 @@ conftest.py @tenstorrent/metalium-developers-infra
 
 # test scripts
 tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
-tests/pipeline_reorg/ @roseli-TT @tdowdallTT @tenstorrent-github-bot
+tests/pipeline_reorg/ @roseli-TT @tdowdallTT
 tests/pipeline_reorg/blaze_models_prefill_tests.yaml @mbezuljTT @mtairum @roseli-TT
 tests/pipeline_reorg/models_device_perf_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_e2e_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_sweep_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/models_unit_tests.yaml @mtairum @uaydonat @roseli-TT
 tests/pipeline_reorg/vllm_model_tests.yaml @viktorpusTT @tchedaTT @ppetrovicTT @tenstorrent/metalium-developers-infra
+tests/pipeline_reorg/ttsim-skip-list.yaml @roseli-TT @tdowdallTT @tenstorrent-github-bot
 tests/scripts/ @tenstorrent/metalium-developers-infra
 tests/scripts/quasar @kstevensTT @fvranicTT @tenstorrent/metalium-developers-infra
 tests/scripts/single_card/run_single_card_profiler_tests.sh @mo-tenstorrent @akerteszTT @tenstorrent/metalium-developers-infra


### PR DESCRIPTION
## Summary
- #53712 removed `@tenstorrent/codeowner-bypass` from every line of CODEOWNERS, replacing it with a ruleset-based bypass (the `main-branch-protection` ruleset now has a `Team`/`exempt` bypass actor) so members of that group can merge directly into the merge queue.
- Those two mechanisms aren't equivalent: a **CODEOWNERS entry** lets an approving review from that account satisfy "code owner review" for arbitrary PRs. A **ruleset bypass actor** only lets that actor skip the ruleset on their *own* actions (push/merge) — it doesn't help a bot's approval satisfy someone else's PR requirements.
- `.github/workflows/auto-approve.yaml` relies on the former: `tenstorrent-github-bot` (via `CODEOWNERS_GROUP_ANALYSIS_PAT`) approves narrow, file-scoped SFPI/ttsim/UMD/Tracy version-bump PRs after verifying via the GitHub API that only the allowlisted file(s) changed. Since the bot is no longer a code owner of anything, its approvals became cosmetic — `reviewDecision` stays `REVIEW_REQUIRED` and the PR never reaches the merge queue.
- Confirmed live: #53718 ("SFPI 7.70.0 847") was auto-approved by `tenstorrent-github-bot` right after #53712 merged, but `reviewDecision` stayed `REVIEW_REQUIRED` — it had to be merged manually.

## Fix
Re-add `tenstorrent-github-bot` as an owner on exactly the 6 CODEOWNERS lines `auto-approve.yaml`'s file-allowlists cover (`tt_metal/sfpi-info.sh`, `tt_metal/sfpi-version`, `tt_metal/ttsim-version`, `tests/pipeline_reorg/` — the only pattern matching `ttsim-skip-list.yaml`, `tt_metal/third_party/umd`, `tt_metal/third_party/tracy`), instead of restoring the blanket bypass on every path. This is strictly narrower than what was removed and doesn't touch the new ruleset mechanism — required status checks and the merge queue stay fully enforced; only the code-owner-review requirement gets satisfied again for these specific bump PRs.

## Also flagged, not fixed here
`.github/workflows/codeowners-group-analysis.yaml`'s `/codeowners bypass` comment command has the same failure mode (same PAT/bot, same expectation of blanket code-owner status), but can't be fixed the same way since it's meant to work on arbitrary files/PRs. That one likely needs to be re-pointed at the ruleset bypass mechanism directly (e.g. merge via a member of the exempt team) rather than approve — happy to take that on separately if wanted.

## Test plan
- [ ] Confirm `tenstorrent-github-bot`'s approval flips `reviewDecision` to `APPROVED` on the next SFPI/ttsim/UMD/Tracy bump PR
- [ ] Confirm that PR proceeds into the merge queue without manual intervention

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-auto-approve-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-auto-approve-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-auto-approve-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-auto-approve-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-auto-approve-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-auto-approve-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-auto-approve-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-auto-approve-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-auto-approve-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-auto-approve-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-auto-approve-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-auto-approve-codeowners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-auto-approve-codeowners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-auto-approve-codeowners)