### PR TITLE
Fix stale  sweep test that still passes the removed  kwarg

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_eltwise_unary.py
@@ -954,12 +954,10 @@ class TestEltwiseUnary:
             device,
         )
 
-    @pytest.mark.parametrize("fn_kind", ["erf", "erfc"])
     @pytest.mark.parametrize("fast_and_approx", [True, False])
     def test_run_eltwise_erf_ops(
         self,
         input_shapes,
-        fn_kind,
         fast_and_approx,
         device,
         function_level_defaults,
@@ -979,7 +977,35 @@ class TestEltwiseUnary:
         )
         comparison_func = comparison_funcs.comp_pcc
         run_single_pytorch_test(
-            f"eltwise-{fn_kind}",
+            "eltwise-erf",
+            input_shapes,
+            datagen_func,
+            comparison_func,
+            device,
+            test_args,
+        )
+
+    def test_run_eltwise_erfc_op(
+        self,
+        input_shapes,
+        device,
+        function_level_defaults,
+        input_mem_config,
+        output_mem_config,
+    ):
+        datagen_func = [
+            generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=-100, high=100), torch.bfloat16)
+        ]
+        test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
+        test_args.update(
+            {
+                "input_mem_config": [input_mem_config],
+                "output_mem_config": output_mem_config,
+            }
+        )
+        comparison_func = comparison_funcs.comp_pcc
+        run_single_pytorch_test(
+            "eltwise-erfc",
             input_shapes,
             datagen_func,
             comparison_func,

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -207,7 +207,6 @@ def eltwise_erf(
 def eltwise_erfc(
     x,
     *args,
-    fast_and_approx,
     device,
     dtype,
     layout,
@@ -2025,7 +2024,6 @@ eltwise_isneginf = make_unary_op_optional_output(ttnn.isneginf)
 eltwise_isnan = make_unary_op_optional_output(ttnn.isnan)
 eltwise_erfinv = make_unary_op_optional_output(ttnn.erfinv)
 eltwise_erf = make_unary_op_optional_output_with_fast_approx(ttnn.erf)
-eltwise_erfc = make_unary_op_optional_output_with_fast_approx(ttnn.erfc)
 eltwise_gelu = make_unary_op_optional_output_with_fast_approx(ttnn.gelu)
 eltwise_exp = make_unary_op_optional_output_with_fast_approx(ttnn.exp)
 eltwise_softplus = make_unary_op_optional_output(ttnn.softplus)


### PR DESCRIPTION
## Summary

`test_run_eltwise_erf_ops` fails on `main` with 8 errors, all for `erfc`:

```
TypeError: ttnn.erfc(): incompatible function arguments.
Called with: erfc(ttnn.Tensor, fast_and_approximate_mode=True)
```

`ttnn.erfc` no longer has an approximate mode. #41850 moved it to `bind_unary_operation_subcoregrids`, so the binding does not accept `fast_and_approximate_mode`. `ttnn.erf` still does, which is why only the `erfc` cases fail (2 approx values x 4 memory-config combos = 8).

The test helper was already updated for this. `tt_lib_ops.py` has a hand-written `eltwise_erfc` that correctly calls `ttnn.erfc(t0, memory_config=...)` with no approx kwarg — but a later blanket assignment overwrote it:

```python
eltwise_erfc = make_unary_op_optional_output_with_fast_approx(ttnn.erfc)
```

That wrapper always passes `fast_and_approximate_mode`, so every `erfc` call was rejected by Python before the op ever ran.

## Changes

- Removed the stale `eltwise_erfc` re-assignment so the correct hand-written wrapper is used. It also honors `output_mem_config`, which the overwriting wrapper ignored.
- Dropped the now-unused `fast_and_approx` parameter from `eltwise_erfc`.
- Split `erfc` into its own test. Approximate mode is a real `erf` option, so only `erf` is parametrized over it; `erfc` no longer runs duplicate cases.

`erf` is untouched — its kwarg is still valid.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/erfc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/erfc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/erfc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/erfc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/erfc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/erfc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/erfc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/erfc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/erfc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/erfc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/erfc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/erfc_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/erfc_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/erfc_test)