### PR TITLE
[emule] asan: add teardown script + buffer fix

### DIFF
--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -238,6 +238,59 @@ TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     ::unsetenv("TT_METAL_EMULE_ASAN");
 }
 
+// Positive control for live-range lifetime identity. Same-address wrappers are
+// routine (Buffer::view subviews, the mesh workload's kernel-binary view buffers):
+// a temporary non-owning buffer created at a live owner's address — usually with a
+// SMALLER size — registers a second range with the same start. Its destruction must
+// remove ITS range, not the owner's: a start-keyed removal would erase the owner's
+// full extent, leave the temporary's short one behind, and every later valid access
+// past the temporary's end would abort as a false-positive OOB.
+TEST_F(UnitMeshFixture, OOB_Tensor_SameAddressTempBuffer_NoViolation) {
+    ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
+
+    CoreCoord logical_core = {0, 0};
+    Program program = CreateProgram();
+
+    constexpr uint32_t buffer_size = 1024;
+    auto owner = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::DRAM},
+        &this->device());
+    {
+        // Temporary explicit-address wrapper at the owner's address, quarter size
+        // (the mesh_workload kernel-bin view shape). Dies before the launch. Created
+        // on the PHYSICAL device: that id's registry is the one the launch snapshot
+        // consumes, where the owner's per-device buffer is registered.
+        constexpr uint32_t temp_size = buffer_size / 4;
+        auto temp =
+            Buffer::create(this->device().get_devices()[0], owner->address(), temp_size, temp_size, BufferType::DRAM);
+    }
+    // Access the owner PAST the temporary's extent — valid, must stay registered.
+    uint32_t in_addr = static_cast<uint32_t>(owner->address()) + buffer_size / 2;
+
+    std::string kernel_src = R"(
+        #include "api/dataflow/dataflow_api.h"
+        extern "C" uint8_t* __emule_dram_ptr(uint64_t offset);
+        void kernel_main() {
+            uint32_t addr = get_arg_val<uint32_t>(0);
+            volatile uint32_t* ptr = (volatile uint32_t*)__emule_dram_ptr(addr);
+            *ptr = 0x9abc;
+        }
+    )";
+    auto kernel = CreateKernelFromString(
+        program,
+        kernel_src,
+        logical_core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    SetRuntimeArgs(program, kernel, logical_core, {in_addr});
+
+    // Must NOT abort — the owner's full range is still live.
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
+    SUCCEED();
+
+    ::unsetenv("TT_METAL_EMULE_ASAN");
+}
+
 // Positive control for the host-poke fallback. Raw L1 that the host designated
 // via WriteToDeviceL1 (no Buffer allocated) is valid data outside the tensor
 // allocator; a kernel access into that exact [addr, addr+size) region must NOT

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -419,14 +419,19 @@ std::shared_ptr<Buffer> Buffer::create(
     buffer->address_ = address;
     buffer->allocation_status_ = AllocationStatus::ALLOCATED;
 
-    // Explicit-address (non-owning) L1 buffers skip allocate_impl(), so register their
-    // per-core extent here (removed in deallocate()). Rationale: SANITIZER_CHECKS.md §4.
-    if (is_emule_device(device) && buffer->size_ != 0 &&
-        (buffer_type == BufferType::L1 || buffer_type == BufferType::L1_SMALL)) {
-        tt::tt_metal::emule::LiveL1Ranges::add(
-            device->id(),
-            static_cast<uint32_t>(address),
-            static_cast<uint32_t>(address + buffer->aligned_size_per_bank()));
+    // Explicit-address (non-owning) buffers skip allocate_impl(), so register their
+    // extent here (removed in deallocate()): per-core for L1 (SANITIZER_CHECKS.md §4),
+    // full size for DRAM — mirroring the allocate_impl() registration.
+    if (is_emule_device(device) && buffer->size_ != 0) {
+        if (buffer_type == BufferType::L1 || buffer_type == BufferType::L1_SMALL) {
+            tt::tt_metal::emule::LiveL1Ranges::add(
+                device->id(),
+                static_cast<uint32_t>(address),
+                static_cast<uint32_t>(address + buffer->aligned_size_per_bank()));
+        } else if (buffer_type == BufferType::DRAM) {
+            tt::tt_metal::emule::LiveDramRanges::add(
+                device->id(), static_cast<uint32_t>(address), static_cast<uint32_t>(address + size));
+        }
     }
 
     LIGHT_METAL_TRACE_FUNCTION_CALL(
@@ -528,9 +533,12 @@ void Buffer::deallocate() {
         if (emule_device_seen.load(std::memory_order_relaxed)) {
             // Mirror the Buffer::create registration; non-owning buffers skip deallocate_impl().
             // Guard on status: the explicit-call + destructor double-deallocate must remove once.
-            if (allocation_status_ == AllocationStatus::ALLOCATED && size_ != 0 &&
-                (buffer_type_ == BufferType::L1 || buffer_type_ == BufferType::L1_SMALL)) {
-                tt::tt_metal::emule::LiveL1Ranges::remove(device_->id(), static_cast<uint32_t>(address_));
+            if (allocation_status_ == AllocationStatus::ALLOCATED && size_ != 0) {
+                if (buffer_type_ == BufferType::L1 || buffer_type_ == BufferType::L1_SMALL) {
+                    tt::tt_metal::emule::LiveL1Ranges::remove(device_->id(), static_cast<uint32_t>(address_));
+                } else if (buffer_type_ == BufferType::DRAM) {
+                    tt::tt_metal::emule::LiveDramRanges::remove(device_->id(), static_cast<uint32_t>(address_));
+                }
             }
             allocation_status_ = AllocationStatus::DEALLOCATED;
         }

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -427,10 +427,14 @@ std::shared_ptr<Buffer> Buffer::create(
             tt::tt_metal::emule::LiveL1Ranges::add(
                 device->id(),
                 static_cast<uint32_t>(address),
-                static_cast<uint32_t>(address + buffer->aligned_size_per_bank()));
+                static_cast<uint32_t>(address + buffer->aligned_size_per_bank()),
+                buffer->unique_id_);
         } else if (buffer_type == BufferType::DRAM) {
             tt::tt_metal::emule::LiveDramRanges::add(
-                device->id(), static_cast<uint32_t>(address), static_cast<uint32_t>(address + size));
+                device->id(),
+                static_cast<uint32_t>(address),
+                static_cast<uint32_t>(address + size),
+                buffer->unique_id_);
         }
     }
 
@@ -504,10 +508,14 @@ void Buffer::allocate_impl() {
                 tt::tt_metal::emule::LiveL1Ranges::add(
                     device_->id(),
                     static_cast<uint32_t>(address_),
-                    static_cast<uint32_t>(address_ + aligned_size_per_bank()));
+                    static_cast<uint32_t>(address_ + aligned_size_per_bank()),
+                    unique_id_);
             } else if (buffer_type_ == BufferType::DRAM) {
                 tt::tt_metal::emule::LiveDramRanges::add(
-                    device_->id(), static_cast<uint32_t>(address_), static_cast<uint32_t>(address_ + size_));
+                    device_->id(),
+                    static_cast<uint32_t>(address_),
+                    static_cast<uint32_t>(address_ + size_),
+                    unique_id_);
             }
         }
 
@@ -535,9 +543,9 @@ void Buffer::deallocate() {
             // Guard on status: the explicit-call + destructor double-deallocate must remove once.
             if (allocation_status_ == AllocationStatus::ALLOCATED && size_ != 0) {
                 if (buffer_type_ == BufferType::L1 || buffer_type_ == BufferType::L1_SMALL) {
-                    tt::tt_metal::emule::LiveL1Ranges::remove(device_->id(), static_cast<uint32_t>(address_));
+                    tt::tt_metal::emule::LiveL1Ranges::remove(device_->id(), unique_id_);
                 } else if (buffer_type_ == BufferType::DRAM) {
-                    tt::tt_metal::emule::LiveDramRanges::remove(device_->id(), static_cast<uint32_t>(address_));
+                    tt::tt_metal::emule::LiveDramRanges::remove(device_->id(), unique_id_);
                 }
             }
             allocation_status_ = AllocationStatus::DEALLOCATED;
@@ -569,10 +577,10 @@ void Buffer::deallocate_impl() {
             validate_sub_device_manager_id(sub_device_manager_id_, device_);
             if (is_emule_device(device_)) {
                 if (buffer_type_ == BufferType::L1 || buffer_type_ == BufferType::L1_SMALL) {
-                    tt::tt_metal::emule::LiveL1Ranges::remove(device_->id(), static_cast<uint32_t>(address_));
+                    tt::tt_metal::emule::LiveL1Ranges::remove(device_->id(), unique_id_);
                     tt::tt_metal::emule::LiveL1PaddingRanges::clear(device_->id(), static_cast<uint32_t>(address_));
                 } else if (buffer_type_ == BufferType::DRAM) {
-                    tt::tt_metal::emule::LiveDramRanges::remove(device_->id(), static_cast<uint32_t>(address_));
+                    tt::tt_metal::emule::LiveDramRanges::remove(device_->id(), unique_id_);
                 }
             }
             allocator_->deallocate_buffer(this);

--- a/tt_metal/impl/emulation/SANITIZER_CHECKS.md
+++ b/tt_metal/impl/emulation/SANITIZER_CHECKS.md
@@ -203,6 +203,14 @@ access false-positives (for DRAM, every `__emule_dram_ptr` resolve above
 `allocation_status_` guard so the explicit-call + destructor double-deallocate drops it
 exactly once.
 
+Registrations are keyed by the buffer's `unique_id()`, and removal erases exactly
+that registration — never an address match. Several live buffers routinely share a
+start with different ends (`Buffer::view` subviews, the mesh workload's same-address
+kernel-binary view wrappers), so an address-keyed removal could delete another
+wrapper's still-live extent: the owner's full range vanishes, the dead temporary's
+shorter one lingers, and every later valid access past it aborts as a false-positive
+OOB (guarded by `OOB_Tensor_SameAddressTempBuffer_NoViolation`).
+
 On each access the kernel first **normalizes the address
 to a buffer-relative offset** via `__emule_addr_to_offset`. Under the L1 offset
 model, sharded / CB / `l1_alloc` accesses already arrive as **0-based offsets**

--- a/tt_metal/impl/emulation/SANITIZER_CHECKS.md
+++ b/tt_metal/impl/emulation/SANITIZER_CHECKS.md
@@ -194,11 +194,12 @@ adjacent memory, false-positiving unrelated cores' writes.
 
 Both buffer-creation paths must register the extent: owning buffers in
 `allocate_impl()`/`deallocate_impl()`, and **explicit-address (non-owning)** buffers —
-e.g. the per-physical-device L1 buffers `MeshBuffer::initialize_device_buffers` builds,
+e.g. the per-physical-device buffers `MeshBuffer::initialize_device_buffers` builds,
 which never run `allocate_impl()` — in the `Buffer::create(address, …)` overload and
-`Buffer::deallocate()`. Without the latter, the runner's physical-`device->id()`
-snapshot is empty for every mesh sharded-L1 buffer and each legitimate access
-false-positives. The non-owning `deallocate()` removes the range under an
+`Buffer::deallocate()`. This covers DRAM as well as L1: without it, the runner's
+physical-`device->id()` snapshot is empty for every mesh buffer and each legitimate
+access false-positives (for DRAM, every `__emule_dram_ptr` resolve above
+`dram_unreserved_base` aborts). The non-owning `deallocate()` removes the range under an
 `allocation_status_` guard so the explicit-call + destructor double-deallocate drops it
 exactly once.
 

--- a/tt_metal/impl/emulation/emule_asan_setup.sh
+++ b/tt_metal/impl/emulation/emule_asan_setup.sh
@@ -1,12 +1,16 @@
 # =============================================================================
-# emule_setup.sh — tt-emule + ASAN environment for emulated test runs
+# emule_asan_setup.sh — tt-emule + ASAN environment for emulated test runs
 #
-#   USAGE:  source tt_metal/impl/emulation/emule_setup.sh   (from the tt-metal repo
-#           root; source it — do NOT execute — so the exports persist)
+#   USAGE:  source tt_metal/impl/emulation/emule_asan_setup.sh   (from the
+#           tt-metal repo root; source it — do NOT execute — so the exports
+#           persist)
 #
 # Routes tt-metal at the tt-emule software emulator (instead of a physical WH
 # card) and arms the host-side ASAN sanitizers. After sourcing, emule_preflight
 # runs automatically to confirm the build + environment are emule-ready.
+#
+# To undo everything this script does and return to your previous environment:
+#   source tt_metal/impl/emulation/emule_asan_teardown.sh
 #
 # This file only configures emule. Activate your Python venv and set up the
 # normal tt-metal environment (e.g. via create_venv.sh) before sourcing it.
@@ -14,9 +18,27 @@
 
 # Refuse to be executed instead of sourced (exports would be lost).
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
-    echo "ERROR: source this file, do not execute it:  source tt_metal/impl/emulation/emule_setup.sh"
+    echo "ERROR: source this file, do not execute it:  source tt_metal/impl/emulation/emule_asan_setup.sh"
     exit 1
 fi
+
+# Snapshot the pre-existing values of every variable this script exports, so
+# emule_asan_teardown.sh can restore them exactly. Guarded so re-sourcing this
+# file does not overwrite the snapshot with emule values.
+_EMULE_ASAN_ENV_VARS="TT_METAL_HOME ARCH_NAME TT_METAL_EMULE_MODE TT_METAL_SLOW_DISPATCH_MODE TT_METAL_MOCK_CLUSTER_DESC_PATH TT_METAL_EMULE_ASAN"
+if [ -z "${_EMULE_ASAN_ENV_SAVED:-}" ]; then
+    for _v in $_EMULE_ASAN_ENV_VARS; do
+        if [ -n "${!_v+x}" ]; then
+            export "_EMULE_ASAN_HAD_$_v=1"
+            export "_EMULE_ASAN_SAVED_$_v=${!_v}"
+        else
+            unset "_EMULE_ASAN_HAD_$_v" "_EMULE_ASAN_SAVED_$_v"
+        fi
+    done
+    unset _v
+    export _EMULE_ASAN_ENV_SAVED=1
+fi
+unset _EMULE_ASAN_ENV_VARS
 
 # Anchors the mock cluster descriptor path below.
 export TT_METAL_HOME="$(pwd)"
@@ -50,7 +72,7 @@ emule_preflight() {
     if [ "${sym_count:-0}" -eq 0 ]; then
         echo "[preflight] FATAL: libtt_metal.so is not an EMULE build (missing emule::execute_program_emulated)"; ok=0
     fi
-    [ "$ok" = "1" ] || { echo "[preflight] environment NOT ready — fix the above and re-source emule_setup.sh"; return 1; }
+    [ "$ok" = "1" ] || { echo "[preflight] environment NOT ready — fix the above and re-source emule_asan_setup.sh"; return 1; }
     echo "[preflight] OK: emule build + emule mode + slow dispatch + ASAN all set."
     return 0
 }

--- a/tt_metal/impl/emulation/emule_asan_teardown.sh
+++ b/tt_metal/impl/emulation/emule_asan_teardown.sh
@@ -1,0 +1,44 @@
+# =============================================================================
+# emule_asan_teardown.sh — undo everything emule_asan_setup.sh did
+#
+#   USAGE:  source tt_metal/impl/emulation/emule_asan_teardown.sh
+#           (source it — do NOT execute — so the environment changes persist)
+#
+# Restores every variable emule_asan_setup.sh exported to its pre-setup value
+# (or unsets it if it was not set before), and removes the emule_preflight /
+# emule_postflight helper functions — as if the setup script was never sourced.
+# =============================================================================
+
+# Refuse to be executed instead of sourced (env changes would be lost).
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    echo "ERROR: source this file, do not execute it:  source tt_metal/impl/emulation/emule_asan_teardown.sh"
+    exit 1
+fi
+
+_EMULE_ASAN_ENV_VARS="TT_METAL_HOME ARCH_NAME TT_METAL_EMULE_MODE TT_METAL_SLOW_DISPATCH_MODE TT_METAL_MOCK_CLUSTER_DESC_PATH TT_METAL_EMULE_ASAN"
+
+if [ -n "${_EMULE_ASAN_ENV_SAVED:-}" ]; then
+    # Setup was sourced in this shell: restore each variable to its snapshot.
+    for _v in $_EMULE_ASAN_ENV_VARS; do
+        _had="_EMULE_ASAN_HAD_$_v"
+        _saved="_EMULE_ASAN_SAVED_$_v"
+        if [ "${!_had:-}" = "1" ]; then
+            export "$_v=${!_saved}"
+        else
+            unset "$_v"
+        fi
+        unset "$_had" "$_saved"
+    done
+    unset _v _had _saved _EMULE_ASAN_ENV_SAVED
+else
+    # No snapshot (setup not sourced in this shell). Unset only the emule-
+    # specific variables; leave TT_METAL_HOME / ARCH_NAME alone since they are
+    # part of the normal tt-metal environment and their prior values are unknown.
+    echo "[teardown] note: no setup snapshot found in this shell; unsetting emule vars only (TT_METAL_HOME / ARCH_NAME left untouched)"
+    unset TT_METAL_EMULE_MODE TT_METAL_SLOW_DISPATCH_MODE TT_METAL_MOCK_CLUSTER_DESC_PATH TT_METAL_EMULE_ASAN
+fi
+unset _EMULE_ASAN_ENV_VARS
+
+unset -f emule_preflight emule_postflight 2>/dev/null
+
+echo "[teardown] emule + ASAN environment removed."

--- a/tt_metal/impl/emulation/emule_live_ranges.cpp
+++ b/tt_metal/impl/emulation/emule_live_ranges.cpp
@@ -13,51 +13,66 @@ namespace tt::tt_metal::emule {
 
 namespace {
 
-struct RangeRegistry {
-    std::mutex mu;
-    std::unordered_map<int, std::vector<uint64_t>> per_device;
-};
-
 uint64_t pack(uint32_t start, uint32_t end) {
     return (static_cast<uint64_t>(start) << 32) | static_cast<uint64_t>(end);
 }
 
-uint32_t unpack_start(uint64_t r) { return static_cast<uint32_t>(r >> 32); }
+// Each entry keeps the registering buffer's unique_id so removal erases exactly
+// that registration — never an address match (see the header comment).
+struct OwnedRange {
+    uint64_t packed;
+    uint64_t owner;
+};
+
+struct OwnedRangeRegistry {
+    std::mutex mu;
+    std::unordered_map<int, std::vector<OwnedRange>> per_device;
+};
 
 // add never de-dups and remove is a linear find/erase, so each op is O(n).
 // Intentional: a device's live-range set stays small (a handful of buffers) and
 // this is a debug-only build, so the simplicity beats an index.
-void add_to(RangeRegistry& reg, int device_id, uint32_t start, uint32_t end) {
+void add_to(OwnedRangeRegistry& reg, int device_id, uint32_t start, uint32_t end, uint64_t owner) {
     std::lock_guard<std::mutex> g(reg.mu);
-    reg.per_device[device_id].push_back(pack(start, end));
+    reg.per_device[device_id].push_back(OwnedRange{pack(start, end), owner});
 }
 
-void remove_from(RangeRegistry& reg, int device_id, uint32_t start) {
+void remove_from(OwnedRangeRegistry& reg, int device_id, uint64_t owner) {
     std::lock_guard<std::mutex> g(reg.mu);
     auto it = reg.per_device.find(device_id);
     if (it == reg.per_device.end()) {
         return;
     }
     auto& v = it->second;
-    auto match = std::find_if(
-        v.begin(), v.end(), [start](uint64_t r) { return unpack_start(r) == start; });
+    auto match = std::find_if(v.begin(), v.end(), [owner](const OwnedRange& r) { return r.owner == owner; });
     if (match != v.end()) {
         v.erase(match);
     }
 }
 
-std::vector<uint64_t> snapshot_of(RangeRegistry& reg, int device_id) {
+std::vector<uint64_t> snapshot_of(OwnedRangeRegistry& reg, int device_id) {
     std::lock_guard<std::mutex> g(reg.mu);
     auto it = reg.per_device.find(device_id);
     if (it == reg.per_device.end()) {
         return {};
     }
-    return it->second;
+    std::vector<uint64_t> out;
+    out.reserve(it->second.size());
+    for (const auto& r : it->second) {
+        out.push_back(r.packed);
+    }
+    return out;
 }
 
-// Host-poke add path: dedup, since the same scratch address is re-poked every
-// iteration of a benchmark loop and these ranges are never removed.
-void add_dedup_to(RangeRegistry& reg, int device_id, uint32_t start, uint32_t end) {
+// Host-poke ranges have no owning Buffer: add-only with dedup, since the same
+// scratch address is re-poked every iteration of a benchmark loop and these
+// ranges are never removed.
+struct PlainRangeRegistry {
+    std::mutex mu;
+    std::unordered_map<int, std::vector<uint64_t>> per_device;
+};
+
+void add_dedup_to(PlainRangeRegistry& reg, int device_id, uint32_t start, uint32_t end) {
     std::lock_guard<std::mutex> g(reg.mu);
     auto& v = reg.per_device[device_id];
     uint64_t packed = pack(start, end);
@@ -66,42 +81,47 @@ void add_dedup_to(RangeRegistry& reg, int device_id, uint32_t start, uint32_t en
     }
 }
 
-RangeRegistry& l1_registry() {
-    static RangeRegistry r;
+std::vector<uint64_t> snapshot_of(PlainRangeRegistry& reg, int device_id) {
+    std::lock_guard<std::mutex> g(reg.mu);
+    auto it = reg.per_device.find(device_id);
+    if (it == reg.per_device.end()) {
+        return {};
+    }
+    return it->second;
+}
+
+OwnedRangeRegistry& l1_registry() {
+    static OwnedRangeRegistry r;
     return r;
 }
 
-RangeRegistry& dram_registry() {
-    static RangeRegistry r;
+OwnedRangeRegistry& dram_registry() {
+    static OwnedRangeRegistry r;
     return r;
 }
 
-RangeRegistry& l1_host_poke_registry() {
-    static RangeRegistry r;
+PlainRangeRegistry& l1_host_poke_registry() {
+    static PlainRangeRegistry r;
     return r;
 }
 
 }  // namespace
 
-void LiveL1Ranges::add(int device_id, uint32_t start, uint32_t end) {
-    add_to(l1_registry(), device_id, start, end);
+void LiveL1Ranges::add(int device_id, uint32_t start, uint32_t end, uint64_t owner) {
+    add_to(l1_registry(), device_id, start, end, owner);
 }
 
-void LiveL1Ranges::remove(int device_id, uint32_t start) {
-    remove_from(l1_registry(), device_id, start);
-}
+void LiveL1Ranges::remove(int device_id, uint64_t owner) { remove_from(l1_registry(), device_id, owner); }
 
 std::vector<uint64_t> LiveL1Ranges::snapshot(int device_id) {
     return snapshot_of(l1_registry(), device_id);
 }
 
-void LiveDramRanges::add(int device_id, uint32_t start, uint32_t end) {
-    add_to(dram_registry(), device_id, start, end);
+void LiveDramRanges::add(int device_id, uint32_t start, uint32_t end, uint64_t owner) {
+    add_to(dram_registry(), device_id, start, end, owner);
 }
 
-void LiveDramRanges::remove(int device_id, uint32_t start) {
-    remove_from(dram_registry(), device_id, start);
-}
+void LiveDramRanges::remove(int device_id, uint64_t owner) { remove_from(dram_registry(), device_id, owner); }
 
 std::vector<uint64_t> LiveDramRanges::snapshot(int device_id) {
     return snapshot_of(dram_registry(), device_id);

--- a/tt_metal/impl/emulation/emule_live_ranges.hpp
+++ b/tt_metal/impl/emulation/emule_live_ranges.hpp
@@ -13,17 +13,22 @@
 
 namespace tt::tt_metal::emule {
 
+// `owner` is the registering Buffer's unique_id(); remove() erases exactly that
+// registration. Removal keyed by address alone would be wrong: several live
+// buffers can share a start with different ends (Buffer::view subviews, the mesh
+// kernel-bin view wrappers), and erasing a start-match could delete another
+// wrapper's still-live extent.
 class LiveL1Ranges {
 public:
-    static void add(int device_id, uint32_t start, uint32_t end);
-    static void remove(int device_id, uint32_t start);
+    static void add(int device_id, uint32_t start, uint32_t end, uint64_t owner);
+    static void remove(int device_id, uint64_t owner);
     static std::vector<uint64_t> snapshot(int device_id);
 };
 
 class LiveDramRanges {
 public:
-    static void add(int device_id, uint32_t start, uint32_t end);
-    static void remove(int device_id, uint32_t start);
+    static void add(int device_id, uint32_t start, uint32_t end, uint64_t owner);
+    static void remove(int device_id, uint64_t owner);
     static std::vector<uint64_t> snapshot(int device_id);
 };
 


### PR DESCRIPTION
### PR Category
[Issue](https://github.com/tenstorrent/tt-metal/issues/52964)

### Summary
- Creates a teardown script to return dev environment to normal
- fixes a small bug in the oob check inside of the buffer impl

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/asan-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smeydanshahiTT/asan-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/asan-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smeydanshahiTT/asan-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smeydanshahiTT/asan-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smeydanshahiTT/asan-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smeydanshahiTT/asan-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smeydanshahiTT/asan-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smeydanshahiTT/asan-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smeydanshahiTT/asan-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smeydanshahiTT/asan-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smeydanshahiTT/asan-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smeydanshahiTT/asan-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smeydanshahiTT/asan-script)