### PR TITLE
🚧 tools: scaleout: Add cabling matcher functionality and associated tests

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -176,6 +176,28 @@ target_link_libraries(
         cxxopts::cxxopts
 )
 
+add_executable(run_cabling_matcher)
+target_sources(run_cabling_matcher PRIVATE ${RUN_CABLING_MATCHER_SRCS})
+
+set_target_properties(
+    run_cabling_matcher
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${Metalium_BINARY_DIR}/tools/scaleout
+)
+
+add_dependencies(run_cabling_matcher scaleout_generated_protos)
+
+target_include_directories(run_cabling_matcher SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(
+    run_cabling_matcher
+    PRIVATE
+        scaleout_tools
+        protobuf::libprotobuf
+        cxxopts::cxxopts
+)
+
 add_executable(run_regen_descriptors)
 target_sources(run_regen_descriptors PRIVATE ${RUN_REGEN_DESCRIPTORS_SRCS})
 

--- a/tools/scaleout/board/board.cpp
+++ b/tools/scaleout/board/board.cpp
@@ -495,10 +495,18 @@ Board create_board(BoardType board_type) {
 
 BoardType get_board_type_from_string(const std::string& board_name) {
     auto board_type = enchantum::cast<BoardType>(board_name, ttsl::ascii_caseless_comp);
-    if (!board_type.has_value()) {
-        throw std::runtime_error("Invalid board type: " + std::string(board_name));
+    if (board_type.has_value()) {
+        return *board_type;
     }
-    return *board_type;
+    // Reflection surfaces one name per enumerator, so a board the enum spells twice -- UBB_WORMHOLE
+    // aliases UBB -- is reachable by only one of them, and descriptors written elsewhere use the
+    // other. UMD's own table carries those spellings, along with the board revisions that map onto a
+    // single type.
+    BoardType aliased_type = tt::board_type_from_string(board_name);
+    if (aliased_type != BoardType::UNKNOWN) {
+        return aliased_type;
+    }
+    throw std::runtime_error("Invalid board type: " + std::string(board_name));
 }
 
 std::ostream& operator<<(std::ostream& os, const AsicChannel& asic_channel) {

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -489,8 +489,10 @@ Node build_node(
             Node::BoardEndpoint endpoint_b = std::make_pair(board_b_id, port_b_id);
 
             // Check for conflicts: same endpoint connected to different destinations (within this port type)
-            validate_endpoint_conflict(endpoint_a, endpoint_b, endpoint_to_dest, "node descriptor '" + node_descriptor_name + "'");
-            validate_endpoint_conflict(endpoint_b, endpoint_a, endpoint_to_dest, "node descriptor '" + node_descriptor_name + "'");
+            validate_endpoint_conflict(
+                endpoint_a, endpoint_b, endpoint_to_dest, "node descriptor '" + node_descriptor_name + "'");
+            validate_endpoint_conflict(
+                endpoint_b, endpoint_a, endpoint_to_dest, "node descriptor '" + node_descriptor_name + "'");
 
             endpoint_to_dest[endpoint_a] = endpoint_b;
             endpoint_to_dest[endpoint_b] = endpoint_a;
@@ -736,13 +738,11 @@ void collect_host_id_to_hostname(
         }
         const auto& mapping = mapping_it->second;
         if (child_def.has_node_ref()) {
-            if (mapping.mapping_case() ==
-                tt::scaleout_tools::cabling_generator::proto::ChildMapping::kHostId) {
+            if (mapping.mapping_case() == tt::scaleout_tools::cabling_generator::proto::ChildMapping::kHostId) {
                 out[HostId(mapping.host_id())] = child_name;
             }
         } else if (child_def.has_graph_ref()) {
-            if (mapping.mapping_case() ==
-                tt::scaleout_tools::cabling_generator::proto::ChildMapping::kSubInstance) {
+            if (mapping.mapping_case() == tt::scaleout_tools::cabling_generator::proto::ChildMapping::kSubInstance) {
                 collect_host_id_to_hostname(mapping.sub_instance(), cluster_descriptor, out);
             }
         }
@@ -1080,8 +1080,7 @@ CablingGenerator::CablingGenerator(
         chip_connections_ = std::move(merged.chip_connections_);
         deployment_hosts_ = std::move(merged.deployment_hosts_);
     } else {
-        initialize_from_single_file(
-            cluster_descriptor_path, load_deployment_descriptor(deployment_descriptor_path));
+        initialize_from_single_file(cluster_descriptor_path, load_deployment_descriptor(deployment_descriptor_path));
     }
 }
 
@@ -1249,8 +1248,7 @@ static void merge_resolved_graph_instances(
                 // Same instance name, different node type across files (e.g. host declared as
                 // WH_GALAXY in one and BH_GALAXY in another) - real conflict; fail with a clear
                 // message instead of a downstream inter_board_connections mismatch.
-                if (target_template_key && source_template_key &&
-                    *target_template_key != *source_template_key &&
+                if (target_template_key && source_template_key && *target_template_key != *source_template_key &&
                     !are_torus_compatible_for_merge(*target_template_key, *source_template_key)) {
                     throw std::runtime_error(fmt::format(
                         "Node '{}' has conflicting node types across cabling descriptors: "
@@ -1404,8 +1402,8 @@ void CablingGenerator::merge_other(
     std::unordered_map<HostId, HostId> temp_remap;
     {
         HostId next_id = HostId(host_id_to_node_.size());
-        auto remap_level = [&](auto& self, const ResolvedGraphInstance& target_graph,
-                               ResolvedGraphInstance& source_graph) -> void {
+        auto remap_level =
+            [&](auto& self, const ResolvedGraphInstance& target_graph, ResolvedGraphInstance& source_graph) -> void {
             // At this level, build name->host_id map only for THIS level's target nodes
             for (auto& [name, node] : source_graph.nodes) {
                 HostId mapped;
@@ -1448,8 +1446,12 @@ void CablingGenerator::merge_other(
                 for (auto& conn : connections) {
                     auto& [host_a, tray_a, port_a] = conn.first;
                     auto& [host_b, tray_b, port_b] = conn.second;
-                    if (temp_remap.contains(host_a)) { host_a = temp_remap[host_a]; }
-                    if (temp_remap.contains(host_b)) { host_b = temp_remap[host_b]; }
+                    if (temp_remap.contains(host_a)) {
+                        host_a = temp_remap[host_a];
+                    }
+                    if (temp_remap.contains(host_b)) {
+                        host_b = temp_remap[host_b];
+                    }
                 }
             }
             // Rebuild derived lookups after remapping.
@@ -1793,6 +1795,66 @@ const std::vector<Host>& CablingGenerator::get_deployment_hosts() const { return
 const std::vector<LogicalChannelConnection>& CablingGenerator::get_chip_connections() const {
     return chip_connections_;
 }
+
+std::vector<ResolvedCable> CablingGenerator::get_cables() const {
+    std::vector<ResolvedCable> cables;
+    if (!root_instance_) {
+        return cables;
+    }
+
+    auto add = [&cables](
+                   const CableEndpoint& a, const CableEndpoint& b, uint32_t depth, const std::string& declared_at) {
+        cables.push_back(ResolvedCable{
+            .endpoint_a = std::min(a, b), .endpoint_b = std::max(a, b), .depth = depth, .declared_at = declared_at});
+    };
+
+    auto join = [](const std::string& prefix, const std::string& name) {
+        return prefix.empty() ? name : prefix + "/" + name;
+    };
+
+    auto walk = [&](auto& self, const ResolvedGraphInstance& graph, const std::string& path, uint32_t depth) -> void {
+        for (const auto& [port_type, connections] : graph.internal_connections) {
+            for (const auto& conn : connections) {
+                const auto& [host_a, tray_a, port_a] = conn.first;
+                const auto& [host_b, tray_b, port_b] = conn.second;
+                add(CableEndpoint{host_a, tray_a, port_type, port_a},
+                    CableEndpoint{host_b, tray_b, port_type, port_b},
+                    depth,
+                    path);
+            }
+        }
+        for (const auto& [node_name, node] : graph.nodes) {
+            for (const auto& [port_type, connections] : node.inter_board_connections) {
+                for (const auto& [board_a, board_b] : connections) {
+                    add(CableEndpoint{node.host_id, board_a.first, port_type, board_a.second},
+                        CableEndpoint{node.host_id, board_b.first, port_type, board_b.second},
+                        depth + 1,
+                        join(path, node_name));
+                }
+            }
+        }
+        for (const auto& [subgraph_name, subgraph] : graph.subgraphs) {
+            self(self, *subgraph, join(path, subgraph_name), depth + 1);
+        }
+    };
+    walk(walk, *root_instance_, "", 0);
+
+    std::sort(cables.begin(), cables.end(), [](const ResolvedCable& lhs, const ResolvedCable& rhs) {
+        return std::tie(lhs.endpoint_a, lhs.endpoint_b, lhs.depth, lhs.declared_at) <
+               std::tie(rhs.endpoint_a, rhs.endpoint_b, rhs.depth, rhs.declared_at);
+    });
+    return cables;
+}
+
+const Node& CablingGenerator::get_node(HostId host_id) const {
+    auto it = host_id_to_node_.find(host_id);
+    if (it == host_id_to_node_.end()) {
+        throw std::runtime_error(fmt::format("Host ID {} is not part of this cluster", *host_id));
+    }
+    return *it->second;
+}
+
+size_t CablingGenerator::get_num_hosts() const { return host_id_to_node_.size(); }
 
 // Collect host_id -> instance path segments (root..host) by walking the resolved graph.
 static void collect_instance_paths(
@@ -3312,8 +3374,12 @@ void CablingGenerator::reassign_host_ids_dfs() {
             for (auto& conn : connections) {
                 auto& [host_a, tray_a, port_a] = conn.first;
                 auto& [host_b, tray_b, port_b] = conn.second;
-                if (id_remap.contains(host_a)) { host_a = id_remap[host_a]; }
-                if (id_remap.contains(host_b)) { host_b = id_remap[host_b]; }
+                if (id_remap.contains(host_a)) {
+                    host_a = id_remap[host_a];
+                }
+                if (id_remap.contains(host_b)) {
+                    host_b = id_remap[host_b];
+                }
             }
         }
 
@@ -3340,8 +3406,7 @@ void CablingGenerator::reassign_host_ids_dfs() {
     populate_host_id_to_node();
 }
 
-void CablingGenerator::rebuild_deployment_hosts_in_dfs_order(
-    const std::unordered_map<std::string, Host>& all_hosts) {
+void CablingGenerator::rebuild_deployment_hosts_in_dfs_order(const std::unordered_map<std::string, Host>& all_hosts) {
     if (!root_instance_) {
         return;
     }
@@ -3460,6 +3525,12 @@ CableLength calc_cable_length(
 std::ostream& operator<<(std::ostream& os, const PhysicalChannelEndpoint& conn) {
     os << "PhysicalChannelEndpoint{hostname='" << conn.hostname << "', tray_id=" << *conn.tray_id
        << ", asic_channel=" << conn.asic_channel << "}";
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CableEndpoint& endpoint) {
+    os << "host " << *endpoint.host_id << " tray " << *endpoint.tray_id << " "
+       << enchantum::to_string(endpoint.port_type) << " port " << *endpoint.port_id;
     return os;
 }
 

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -18,7 +18,7 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::scaleout_tools::fsd::proto {
-    class FactorySystemDescriptor;
+class FactorySystemDescriptor;
 }
 
 namespace tt::scaleout_tools::cabling_generator::proto {
@@ -89,6 +89,30 @@ using PhysicalPortConnection = std::pair<PhysicalPortEndpoint, PhysicalPortEndpo
 // Port connection types (graph-level connections between nodes)
 using PortEndpoint = std::tuple<HostId, TrayId, PortId>;  // host_id, tray_id, port_id
 using PortConnection = std::pair<PortEndpoint, PortEndpoint>;
+
+struct CableEndpoint {
+    HostId host_id{0};
+    TrayId tray_id{0};
+    PortType port_type = PortType::UNKNOWN;
+    PortId port_id{0};
+
+    auto operator<=>(const CableEndpoint& other) const = default;
+};
+
+// One physical cable of a resolved cluster. get_chip_connections() reports the channel expansion of
+// these; board-internal traces are not cables and never appear here.
+struct ResolvedCable {
+    CableEndpoint endpoint_a;
+    CableEndpoint endpoint_b;
+    // The graph instance whose internal_connections declared this cable, as a depth (0 = root) and a
+    // slash-delimited instance path. A node's own board-to-board wiring comes from its node
+    // descriptor rather than from a graph level, so it is attributed to the node itself: one level
+    // below the graph instance holding it.
+    uint32_t depth = 0;
+    std::string declared_at;
+};
+
+std::ostream& operator<<(std::ostream& os, const CableEndpoint& endpoint);
 
 struct Node {
     std::string motherboard;
@@ -174,6 +198,18 @@ public:
     // Getters for all data
     const std::vector<Host>& get_deployment_hosts() const;
     const std::vector<LogicalChannelConnection>& get_chip_connections() const;
+
+    // Port-level (cable) view of the resolved cluster. Each cable is normalized so endpoint_a <
+    // endpoint_b, and the result is sorted, so the order does not depend on the descriptor's
+    // declaration order or on hash iteration order.
+    std::vector<ResolvedCable> get_cables() const;
+
+    // Resolved node for a host_id. Throws if the host_id is not part of this cluster.
+    const Node& get_node(HostId host_id) const;
+
+    // Number of hosts (leaf nodes) in the resolved cluster. Unlike get_deployment_hosts().size(),
+    // this does not depend on a deployment having been supplied.
+    size_t get_num_hosts() const;
 
     // In-place opt-in sub-cluster filter. Each include/exclude entry is an instance path matched as a
     // suffix (relative): {"bh_galaxy_node_0"} matches under every parent, and matching an instance
@@ -278,8 +314,7 @@ private:
         const std::string& existing_sources);
 
     // Post-construction merge logic shared by both merge() entry points.
-    void merge_other(
-        CablingGenerator& other, const std::string& new_file_path, const std::string& existing_sources);
+    void merge_other(CablingGenerator& other, const std::string& new_file_path, const std::string& existing_sources);
 
     // Utility function for finding descriptor files in a directory
     static std::vector<std::string> find_descriptor_files(const std::string& directory_path);

--- a/tools/scaleout/cabling_matcher/cabling_matcher.cpp
+++ b/tools/scaleout/cabling_matcher/cabling_matcher.cpp
@@ -18,7 +18,10 @@
 #include <fmt/ranges.h>
 #include <google/protobuf/text_format.h>
 
+#include <connector/connector.hpp>
+
 #include "protobuf/cluster_config.pb.h"
+#include "protobuf/factory_system_descriptor.pb.h"
 
 namespace tt::scaleout_tools::matcher {
 
@@ -36,17 +39,49 @@ constexpr uint64_t kMinSeedSteps = 250'000;
 // No level of the search is being abandoned.
 constexpr int kNoPrune = std::numeric_limits<int>::max();
 
-cabling_generator::proto::ClusterDescriptor load_cluster_descriptor(const std::string& path) {
+template <typename Descriptor>
+Descriptor load_textproto(const std::string& path) {
     std::ifstream file(path);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open file: " + path);
     }
     std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-    cabling_generator::proto::ClusterDescriptor descriptor;
+    Descriptor descriptor;
     if (!google::protobuf::TextFormat::ParseFromString(contents, &descriptor)) {
         throw std::runtime_error("Failed to parse textproto file: " + path);
     }
     return descriptor;
+}
+
+cabling_generator::proto::ClusterDescriptor load_cluster_descriptor(const std::string& path) {
+    return load_textproto<cabling_generator::proto::ClusterDescriptor>(path);
+}
+
+fsd::proto::FactorySystemDescriptor load_factory_system_descriptor(const std::string& path) {
+    return load_textproto<fsd::proto::FactorySystemDescriptor>(path);
+}
+
+// Boards are immutable here and building one is not free, so each type is built once.
+const Board& board_for(BoardType board_type) {
+    static std::map<BoardType, Board> cache;
+    auto it = cache.find(board_type);
+    if (it == cache.end()) {
+        it = cache.emplace(board_type, create_board(board_type)).first;
+    }
+    return it->second;
+}
+
+// Channels a cable between these two ports carries, which is a property of the boards rather than of
+// any descriptor.
+size_t expected_channel_count(
+    const std::vector<MatchGraph::HostInfo>& hosts, const CableEndpoint& endpoint_a, const CableEndpoint& endpoint_b) {
+    const Board& board_a = board_for(hosts[*endpoint_a.host_id].trays.at(endpoint_a.tray_id));
+    const Board& board_b = board_for(hosts[*endpoint_b.host_id].trays.at(endpoint_b.tray_id));
+    return get_asic_channel_connections(
+               endpoint_a.port_type,
+               board_a.get_port_channels(endpoint_a.port_type, endpoint_a.port_id),
+               board_b.get_port_channels(endpoint_b.port_type, endpoint_b.port_id))
+        .size();
 }
 
 std::string port_to_string(const CableEndpoint& endpoint) {
@@ -843,21 +878,26 @@ MatchGraph MatchGraph::from_generator(const CablingGenerator& generator, TierSco
         graph.cables_.push_back(std::move(cable));
     }
 
-    graph.cables_by_host_.resize(num_hosts);
-    for (size_t index = 0; index < graph.cables_.size(); ++index) {
-        const auto& cable = graph.cables_[index];
+    graph.index_cables();
+    return graph;
+}
+
+void MatchGraph::index_cables() {
+    cables_by_host_.assign(hosts_.size(), {});
+    cables_by_host_tray_.clear();
+    for (size_t index = 0; index < cables_.size(); ++index) {
+        const auto& cable = cables_[index];
         for (const auto& endpoint : {cable.endpoint_a, cable.endpoint_b}) {
-            auto& by_host = graph.cables_by_host_[*endpoint.host_id];
+            auto& by_host = cables_by_host_[*endpoint.host_id];
             if (by_host.empty() || by_host.back() != index) {
                 by_host.push_back(index);
             }
-            auto& by_tray = graph.cables_by_host_tray_[{*endpoint.host_id, endpoint.tray_id}];
+            auto& by_tray = cables_by_host_tray_[{*endpoint.host_id, endpoint.tray_id}];
             if (by_tray.empty() || by_tray.back() != index) {
                 by_tray.push_back(index);
             }
         }
     }
-    return graph;
 }
 
 MatchGraph MatchGraph::load(
@@ -895,6 +935,147 @@ MatchGraph MatchGraph::load(
         hostnames.push_back(fmt::format("host_{}", host_id));
     }
     return from_generator(CablingGenerator(descriptor, hostnames), tier, std::move(label));
+}
+
+MatchGraph MatchGraph::from_fsd(const std::string& fsd_path, std::string label) {
+    fsd::proto::FactorySystemDescriptor fsd = load_factory_system_descriptor(fsd_path);
+
+    MatchGraph graph;
+    graph.label_ = std::move(label);
+
+    // Hosts are positional: the i-th entry of hosts is host_id i, which is what connection endpoints
+    // and board locations refer to. A board location for a host beyond that list has no host to
+    // belong to, so it decides the count when hosts is absent altogether.
+    size_t num_hosts = fsd.hosts_size();
+    for (const auto& location : fsd.board_types().board_locations()) {
+        num_hosts = std::max<size_t>(num_hosts, location.host_id() + 1);
+    }
+    if (num_hosts == 0) {
+        throw std::runtime_error("Factory system descriptor has no hosts: " + fsd_path);
+    }
+
+    graph.hosts_.resize(num_hosts);
+    for (uint32_t host_id = 0; host_id < num_hosts; ++host_id) {
+        graph.hosts_[host_id].name =
+            host_id < static_cast<uint32_t>(fsd.hosts_size()) && !fsd.hosts(host_id).hostname().empty()
+                ? fsd.hosts(host_id).hostname()
+                : fmt::format("host_{}", host_id);
+    }
+    for (const auto& location : fsd.board_types().board_locations()) {
+        BoardType board_type = get_board_type_from_string(location.board_type());
+        graph.hosts_[location.host_id()].trays.emplace(TrayId(location.tray_id()), board_type);
+    }
+    for (auto& host : graph.hosts_) {
+        std::vector<std::string> parts;
+        for (const auto& [tray_id, board_type] : host.trays) {
+            parts.push_back(fmt::format("{}:{}", *tray_id, enchantum::to_string(board_type)));
+        }
+        host.signature = fmt::format("{}", fmt::join(parts, ","));
+    }
+
+    // Fold the channels back into their ports. Each port connection collects the channel connections
+    // that belong to it, so that the graph is in the same terms as a cabling descriptor's cables.
+    std::map<std::pair<CableEndpoint, CableEndpoint>, size_t> channels_seen;
+    size_t split_traces = 0;
+    for (const auto& connection : fsd.eth_connections().connection()) {
+        auto resolve = [&](const fsd::proto::FactorySystemDescriptor::EndPoint& endpoint) {
+            if (endpoint.host_id() >= num_hosts) {
+                throw std::runtime_error(fmt::format(
+                    "{}: a connection refers to host {}, but the descriptor only has {} hosts",
+                    fsd_path,
+                    endpoint.host_id(),
+                    num_hosts));
+            }
+            const auto& trays = graph.hosts_[endpoint.host_id()].trays;
+            auto tray = trays.find(TrayId(endpoint.tray_id()));
+            if (tray == trays.end()) {
+                throw std::runtime_error(fmt::format(
+                    "{}: a connection uses tray {} of host {}, which has no board type declared",
+                    fsd_path,
+                    endpoint.tray_id(),
+                    endpoint.host_id()));
+            }
+            const Board& board = board_for(tray->second);
+            AsicChannel channel{.asic_location = endpoint.asic_location(), .channel_id = ChanId(endpoint.chan_id())};
+            const Port* port = nullptr;
+            try {
+                port = &board.get_port_for_asic_channel(channel);
+            } catch (const std::exception&) {
+                throw std::runtime_error(fmt::format(
+                    "{}: host {} tray {} is a {}, which has no port carrying ASIC {} channel {}",
+                    fsd_path,
+                    endpoint.host_id(),
+                    endpoint.tray_id(),
+                    enchantum::to_string(tray->second),
+                    endpoint.asic_location(),
+                    endpoint.chan_id()));
+            }
+            return CableEndpoint{
+                .host_id = HostId(endpoint.host_id()),
+                .tray_id = TrayId(endpoint.tray_id()),
+                .port_type = port->port_type,
+                .port_id = port->port_id};
+        };
+
+        CableEndpoint endpoint_a = resolve(connection.endpoint_a());
+        CableEndpoint endpoint_b = resolve(connection.endpoint_b());
+
+        // A trace is wiring inside a board rather than a cable, and the descriptor side does not
+        // report those either.
+        if (endpoint_a.port_type == PortType::TRACE || endpoint_b.port_type == PortType::TRACE) {
+            split_traces += endpoint_a.port_type == endpoint_b.port_type ? 0 : 1;
+            continue;
+        }
+        channels_seen[std::minmax(endpoint_a, endpoint_b)]++;
+    }
+
+    // A cable's channel count is decided by the two ports it joins, so it is known independently of
+    // what the descriptor happens to contain, and a disagreement either way is worth reporting.
+    // channels_seen is keyed by the port pair, so the cables come out sorted.
+    std::vector<std::string> short_of_channels;
+    std::vector<std::string> over_channels;
+    for (const auto& [ports, channels] : channels_seen) {
+        const auto& [endpoint_a, endpoint_b] = ports;
+        size_t expected = expected_channel_count(graph.hosts_, endpoint_a, endpoint_b);
+        if (channels != expected) {
+            (channels < expected ? short_of_channels : over_channels)
+                .push_back(fmt::format(
+                    "{} <-> {} ({} of {} channels)",
+                    port_to_string(endpoint_a),
+                    port_to_string(endpoint_b),
+                    channels,
+                    expected));
+        }
+        graph.cables_.push_back(
+            ResolvedCable{.endpoint_a = endpoint_a, .endpoint_b = endpoint_b, .depth = 0, .declared_at = ""});
+    }
+
+    auto note = [&graph](const std::string& text, const std::vector<std::string>& cables) {
+        constexpr size_t kMaxListed = 4;
+        std::vector<std::string> listed(cables.begin(), cables.begin() + std::min(cables.size(), kMaxListed));
+        graph.notes_.push_back(fmt::format(
+            "{} of {} cables {}: {}{}",
+            cables.size(),
+            graph.cables_.size(),
+            text,
+            fmt::join(listed, "; "),
+            cables.size() > kMaxListed ? fmt::format("; and {} more", cables.size() - kMaxListed) : ""));
+    };
+    if (!short_of_channels.empty()) {
+        note("are missing channels and were taken to be present all the same", short_of_channels);
+    }
+    if (!over_channels.empty()) {
+        note("have more channels than their ports can carry, so the descriptor lists some twice", over_channels);
+    }
+    if (split_traces != 0) {
+        graph.notes_.push_back(fmt::format(
+            "{} connections join a board-internal trace to a cabled port, which no cabling can produce; they were "
+            "dropped",
+            split_traces));
+    }
+
+    graph.index_cables();
+    return graph;
 }
 
 const std::vector<size_t>& MatchGraph::cables_at(uint32_t host_id) const {
@@ -1036,6 +1217,15 @@ std::string format_result(
         to_string(options.mode),
         to_string(options.port_identity),
         to_string(options.tray_symmetry));
+
+    for (const auto& [graph, side] : {std::pair{&pattern, "Pattern"}, std::pair{&target, "Target"}}) {
+        for (const auto& note : graph->notes()) {
+            out << fmt::format("Note ({}): {}\n", side, note);
+        }
+    }
+    if (!pattern.notes().empty() || !target.notes().empty()) {
+        out << "\n";
+    }
 
     if (!result.isolated_pattern_hosts.empty()) {
         std::vector<std::string> names;

--- a/tools/scaleout/cabling_matcher/cabling_matcher.cpp
+++ b/tools/scaleout/cabling_matcher/cabling_matcher.cpp
@@ -1179,6 +1179,157 @@ MatchResult match(const MatchGraph& pattern, const MatchGraph& target, const Mat
     return result;
 }
 
+namespace {
+
+// Descriptor files a library path stands for. A directory holds a scheme per file rather than one
+// scheme spread across it, so unlike --cabling the files are read separately and not merged.
+std::vector<std::string> expand_library_path(const std::string& path) {
+    if (!std::filesystem::is_directory(path)) {
+        return {path};
+    }
+    std::vector<std::string> files;
+    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+        if (entry.is_regular_file() && entry.path().extension() == ".textproto") {
+            files.push_back(entry.path().string());
+        }
+    }
+    std::sort(files.begin(), files.end());
+    if (files.empty()) {
+        throw std::runtime_error("No .textproto descriptors in library directory: " + path);
+    }
+    return files;
+}
+
+// The target hosts a match lands on, sorted. Isolated pattern hosts take no part in the search, so
+// this can be smaller than the scheme's host count.
+std::vector<uint32_t> match_host_set(const ComponentResult& component, const Match& match) {
+    std::vector<uint32_t> hosts;
+    hosts.reserve(component.pattern_hosts.size());
+    for (uint32_t pattern_host : component.pattern_hosts) {
+        hosts.push_back(match.host_map[pattern_host]);
+    }
+    std::sort(hosts.begin(), hosts.end());
+    return hosts;
+}
+
+bool is_subset(const std::vector<uint32_t>& inner, const std::vector<uint32_t>& outer) {
+    return std::includes(outer.begin(), outer.end(), inner.begin(), inner.end());
+}
+
+}  // namespace
+
+LibraryResult score_library(
+    const std::vector<std::string>& paths, const MatchGraph& target, const MatchOptions& options, TierScope tier) {
+    LibraryResult result;
+
+    struct Loaded {
+        LibraryEntry entry;
+        MatchGraph graph;
+    };
+    std::vector<Loaded> loaded;
+    for (const auto& path : paths) {
+        for (const auto& file : expand_library_path(path)) {
+            std::string stem = std::filesystem::path(file).stem().string();
+            for (const auto& template_name : list_graph_templates(file)) {
+                std::string name = fmt::format("{} :: {}", stem, template_name);
+                try {
+                    MatchGraph graph = MatchGraph::load(file, "", template_name, tier, name);
+                    // A scheme in pieces has no single answer to where it sits: the placements would be
+                    // the cross product of the pieces', and which piece went where would be arbitrary.
+                    if (graph.components().size() > 1) {
+                        throw std::runtime_error(fmt::format(
+                            "its cables leave it in {} disconnected pieces, so where it sits is not one answer",
+                            graph.components().size()));
+                    }
+                    if (graph.cables().empty()) {
+                        throw std::runtime_error(
+                            tier == TierScope::OwnLevel ? "it declares no cables of its own"
+                                                        : "it has no cables, so any hosts would do");
+                    }
+                    LibraryEntry entry{
+                        .source = file,
+                        .template_name = template_name,
+                        .name = name,
+                        .num_hosts = graph.hosts().size(),
+                        .num_cables = graph.cables().size()};
+                    loaded.push_back(Loaded{.entry = std::move(entry), .graph = std::move(graph)});
+                } catch (const std::exception& e) {
+                    result.skipped.emplace_back(name, e.what());
+                }
+            }
+        }
+    }
+
+    // Largest first, so that the schemes worth reporting come before the ones they subsume.
+    std::sort(loaded.begin(), loaded.end(), [](const Loaded& lhs, const Loaded& rhs) {
+        if (lhs.entry.num_hosts != rhs.entry.num_hosts) {
+            return lhs.entry.num_hosts > rhs.entry.num_hosts;
+        }
+        if (lhs.entry.num_cables != rhs.entry.num_cables) {
+            return lhs.entry.num_cables > rhs.entry.num_cables;
+        }
+        return lhs.entry.name < rhs.entry.name;
+    });
+
+    MatchOptions entry_options = options;
+    entry_options.allow_disconnected = false;  // the disconnected ones were skipped above
+    for (const auto& [entry, graph] : loaded) {
+        LibraryFinding finding;
+        try {
+            MatchResult matched = match(graph, target, entry_options);
+            finding.inconclusive = matched.inconclusive();
+            for (const auto& component : matched.components) {
+                finding.stopped_at_limit = finding.stopped_at_limit || component.stopped_at_limit;
+                for (const auto& one : component.matches) {
+                    finding.host_sets.push_back(match_host_set(component, one));
+                }
+                if (component.matches.empty() && component.diagnosis) {
+                    finding.stuck_at = fmt::format(
+                        "placed {} of {} cables, then had nowhere for {}",
+                        component.diagnosis->cables_placed,
+                        graph.cables().size(),
+                        cable_to_string(graph.cables()[component.diagnosis->pattern_cable]));
+                }
+            }
+            std::sort(finding.host_sets.begin(), finding.host_sets.end());
+        } catch (const std::exception& e) {
+            result.skipped.emplace_back(entry.name, e.what());
+            continue;
+        }
+        result.entries.push_back(entry);
+        result.findings.push_back(std::move(finding));
+    }
+
+    for (size_t inner = 0; inner < result.entries.size(); ++inner) {
+        if (result.findings[inner].host_sets.empty()) {
+            continue;
+        }
+        for (size_t outer = 0; outer < inner; ++outer) {
+            const auto& outer_sets = result.findings[outer].host_sets;
+            // Two schemes of the same size are alternatives rather than one containing the other,
+            // however their host sets happen to fall.
+            bool larger = std::tie(result.entries[outer].num_hosts, result.entries[outer].num_cables) >
+                          std::tie(result.entries[inner].num_hosts, result.entries[inner].num_cables);
+            if (outer_sets.empty() || !larger) {
+                continue;
+            }
+            bool covers = std::all_of(
+                result.findings[inner].host_sets.begin(),
+                result.findings[inner].host_sets.end(),
+                [&outer_sets](const std::vector<uint32_t>& set) {
+                    return std::any_of(
+                        outer_sets.begin(), outer_sets.end(), [&set](const std::vector<uint32_t>& outer) {
+                            return is_subset(set, outer);
+                        });
+                });
+            if (covers) {
+                result.findings[inner].covered_by.push_back(outer);
+            }
+        }
+    }
+    return result;
+}
+
 std::string to_string(PortIdentity identity) {
     switch (identity) {
         case PortIdentity::Strict: return "strict";
@@ -1329,6 +1480,133 @@ std::string format_result(
                         "      trays on {}: {}\n", pattern.hosts()[pattern_host].name, fmt::join(trays, " "));
                 }
             }
+        }
+    }
+    return out.str();
+}
+
+std::string format_library_result(const MatchGraph& target, const LibraryResult& result, const MatchOptions& options) {
+    // Hostnames are the point of the report, but a scheme spanning tens of hosts should not push the
+    // rest of it off the screen.
+    constexpr size_t kMaxNamesShown = 6;
+    auto host_names = [&target](const std::vector<uint32_t>& hosts) {
+        std::vector<std::string> names;
+        for (size_t index = 0; index < hosts.size() && index < kMaxNamesShown; ++index) {
+            names.push_back(target.hosts()[hosts[index]].name);
+        }
+        std::string listed = fmt::format("{}", fmt::join(names, ", "));
+        return hosts.size() > kMaxNamesShown ? fmt::format("{}, and {} more", listed, hosts.size() - kMaxNamesShown)
+                                             : listed;
+    };
+
+    std::ostringstream out;
+    out << fmt::format(
+        "Target:  {} ({} hosts, {} cables)\n", target.label(), target.hosts().size(), target.cables().size());
+    out << fmt::format("Library: {} scheme(s)\n", result.entries.size());
+    out << fmt::format(
+        "Mode:    {}, port identity {}, {}\n",
+        to_string(options.mode),
+        to_string(options.port_identity),
+        to_string(options.tray_symmetry));
+    for (const auto& note : target.notes()) {
+        out << fmt::format("Note (Target): {}\n", note);
+    }
+    out << "\n";
+
+    size_t matched_count = 0;
+    for (const auto& finding : result.findings) {
+        matched_count += finding.host_sets.empty() ? 0 : 1;
+    }
+    if (matched_count == 0) {
+        out << "NOTHING IN THE LIBRARY FITS\n";
+    }
+
+    for (size_t index = 0; index < result.entries.size(); ++index) {
+        const auto& entry = result.entries[index];
+        const auto& finding = result.findings[index];
+        if (finding.host_sets.empty()) {
+            continue;
+        }
+        out << fmt::format("{} ({} host(s), {} cable(s))\n", entry.name, entry.num_hosts, entry.num_cables);
+        std::string qualifier = finding.stopped_at_limit ? " (stopped at --max-matches; there may be more)" : "";
+        out << fmt::format("  fits {} place(s){}\n", finding.host_sets.size(), qualifier);
+        // Coverage is transitive and the entries are largest first, so naming the largest scheme this
+        // one sits inside says everything the rest of them would.
+        if (!finding.covered_by.empty()) {
+            out << fmt::format("  every one of them inside {}\n", result.entries[finding.covered_by.front()].name);
+        }
+        for (const auto& hosts : finding.host_sets) {
+            out << fmt::format("    {}\n", host_names(hosts));
+            if (hosts.size() != entry.num_hosts) {
+                out << fmt::format(
+                    "      ({} of its {} hosts have no cables to place them, so any host would serve)\n",
+                    entry.num_hosts - hosts.size(),
+                    entry.num_hosts);
+            }
+        }
+    }
+
+    std::vector<size_t> unmatched;
+    for (size_t index = 0; index < result.entries.size(); ++index) {
+        if (result.findings[index].host_sets.empty()) {
+            unmatched.push_back(index);
+        }
+    }
+    if (!unmatched.empty()) {
+        out << "\nDoes not fit\n";
+        for (size_t index : unmatched) {
+            const auto& finding = result.findings[index];
+            out << fmt::format(
+                "  {} ({} host(s), {} cable(s)){}\n",
+                result.entries[index].name,
+                result.entries[index].num_hosts,
+                result.entries[index].num_cables,
+                finding.inconclusive ? " -- undecided, the search budget ran out" : "");
+            if (!finding.stuck_at.empty()) {
+                out << fmt::format("    {}\n", finding.stuck_at);
+            }
+        }
+    }
+
+    if (!result.skipped.empty()) {
+        out << "\nNot asked about\n";
+        for (const auto& [name, reason] : result.skipped) {
+            out << fmt::format("  {}: {}\n", name, reason);
+        }
+    }
+
+    // What each target host is part of, largest scheme first. This is the question the library scan
+    // exists to answer, so it is worth stating directly rather than leaving to be read off the above.
+    if (matched_count != 0) {
+        out << "\nLargest scheme each host belongs to\n";
+        std::vector<bool> claimed(target.hosts().size(), false);
+        for (size_t index = 0; index < result.entries.size(); ++index) {
+            std::vector<uint32_t> newly_claimed;
+            for (const auto& hosts : result.findings[index].host_sets) {
+                for (uint32_t host : hosts) {
+                    if (!claimed[host]) {
+                        claimed[host] = true;
+                        newly_claimed.push_back(host);
+                    }
+                }
+            }
+            if (!newly_claimed.empty()) {
+                std::sort(newly_claimed.begin(), newly_claimed.end());
+                out << fmt::format(
+                    "  {}: {} host(s) -- {}\n",
+                    result.entries[index].name,
+                    newly_claimed.size(),
+                    host_names(newly_claimed));
+            }
+        }
+        std::vector<uint32_t> unclaimed;
+        for (uint32_t host = 0; host < target.hosts().size(); ++host) {
+            if (!claimed[host]) {
+                unclaimed.push_back(host);
+            }
+        }
+        if (!unclaimed.empty()) {
+            out << fmt::format("  nothing in the library: {} host(s) -- {}\n", unclaimed.size(), host_names(unclaimed));
         }
     }
     return out.str();

--- a/tools/scaleout/cabling_matcher/cabling_matcher.cpp
+++ b/tools/scaleout/cabling_matcher/cabling_matcher.cpp
@@ -1,0 +1,1147 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "cabling_matcher.hpp"
+
+#include <algorithm>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <tuple>
+#include <utility>
+
+#include <enchantum/enchantum.hpp>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <google/protobuf/text_format.h>
+
+#include "protobuf/cluster_config.pb.h"
+
+namespace tt::scaleout_tools::matcher {
+
+namespace {
+
+constexpr uint32_t kUnmapped = Diagnosis::kUnmapped;
+
+// Guard against the search space blowing up in the port-agnostic modes, where a cable can be placed
+// many ways. Running out cuts the search short and says so rather than producing a wrong answer. The
+// budget is shared between the candidate seed hosts, with a floor so that a cluster with very many
+// hosts still gives each of them a workable share.
+constexpr uint64_t kMaxSearchSteps = 8'000'000;
+constexpr uint64_t kMinSeedSteps = 250'000;
+
+// No level of the search is being abandoned.
+constexpr int kNoPrune = std::numeric_limits<int>::max();
+
+cabling_generator::proto::ClusterDescriptor load_cluster_descriptor(const std::string& path) {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file: " + path);
+    }
+    std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    cabling_generator::proto::ClusterDescriptor descriptor;
+    if (!google::protobuf::TextFormat::ParseFromString(contents, &descriptor)) {
+        throw std::runtime_error("Failed to parse textproto file: " + path);
+    }
+    return descriptor;
+}
+
+std::string port_to_string(const CableEndpoint& endpoint) {
+    return fmt::format(
+        "host {} tray {} {} port {}",
+        *endpoint.host_id,
+        *endpoint.tray_id,
+        enchantum::to_string(endpoint.port_type),
+        *endpoint.port_id);
+}
+
+std::string cable_to_string(const ResolvedCable& cable) {
+    return fmt::format("{} <-> {}", port_to_string(cable.endpoint_a), port_to_string(cable.endpoint_b));
+}
+
+void count_hosts_in_instance(const cabling_generator::proto::GraphInstance& instance, size_t& count) {
+    for (const auto& [name, mapping] : instance.child_mappings()) {
+        if (mapping.has_sub_instance()) {
+            count_hosts_in_instance(mapping.sub_instance(), count);
+        } else {
+            ++count;
+        }
+    }
+}
+
+void build_instance(
+    const cabling_generator::proto::ClusterDescriptor& source,
+    const std::string& template_name,
+    cabling_generator::proto::GraphInstance* out,
+    uint32_t& next_host_id,
+    std::vector<std::string>& stack) {
+    if (std::find(stack.begin(), stack.end(), template_name) != stack.end()) {
+        throw std::runtime_error(
+            fmt::format("Graph template '{}' contains itself (via {})", template_name, fmt::join(stack, " -> ")));
+    }
+    auto it = source.graph_templates().find(template_name);
+    if (it == source.graph_templates().end()) {
+        std::vector<std::string> available;
+        for (const auto& [name, unused] : source.graph_templates()) {
+            available.push_back(name);
+        }
+        std::sort(available.begin(), available.end());
+        throw std::runtime_error(fmt::format(
+            "Graph template '{}' not found in descriptor. Available templates: {}",
+            template_name,
+            available.empty() ? "(none)" : fmt::format("{}", fmt::join(available, ", "))));
+    }
+    stack.push_back(template_name);
+    out->set_template_name(template_name);
+    for (const auto& child : it->second.children()) {
+        auto& mapping = (*out->mutable_child_mappings())[child.name()];
+        if (child.has_node_ref()) {
+            mapping.set_host_id(next_host_id++);
+        } else if (child.has_graph_ref()) {
+            build_instance(
+                source, child.graph_ref().graph_template(), mapping.mutable_sub_instance(), next_host_id, stack);
+        } else {
+            throw std::runtime_error(fmt::format(
+                "Child '{}' of graph template '{}' is neither a node_ref nor a graph_ref",
+                child.name(),
+                template_name));
+        }
+    }
+    stack.pop_back();
+}
+
+bool hosts_compatible(
+    const MatchGraph::HostInfo& pattern_host, const MatchGraph::HostInfo& target_host, TraySymmetry symmetry) {
+    if (pattern_host.trays.size() != target_host.trays.size()) {
+        return false;
+    }
+    if (symmetry == TraySymmetry::None) {
+        return pattern_host.trays == target_host.trays;
+    }
+    std::vector<BoardType> pattern_boards;
+    std::vector<BoardType> target_boards;
+    for (const auto& [tray, board] : pattern_host.trays) {
+        pattern_boards.push_back(board);
+    }
+    for (const auto& [tray, board] : target_host.trays) {
+        target_boards.push_back(board);
+    }
+    std::sort(pattern_boards.begin(), pattern_boards.end());
+    std::sort(target_boards.begin(), target_boards.end());
+    return pattern_boards == target_boards;
+}
+
+// Searches for placements of one connected component of the pattern.
+//
+// Cables are visited in BFS order from a seed host, so every cable has at least one end on a host
+// that is already mapped by the time it is placed. That end anchors the cable: it fixes which target
+// host and tray the cable must leave from, which narrows the target cables that could serve it to
+// the handful on that tray -- exactly one under strict port identity, which is why the strict search
+// is a linear propagation rather than a search. Placing a cable then forces the host and tray at its
+// far end, so the mapping grows outward from the seed with no guessing beyond the candidate cable
+// itself.
+class Search {
+public:
+    Search(
+        const MatchGraph& pattern,
+        const MatchGraph& target,
+        const MatchOptions& options,
+        std::vector<uint32_t> component_hosts) :
+        pattern_(pattern), target_(target), options_(options), component_hosts_(std::move(component_hosts)) {}
+
+    ComponentResult run() {
+        ComponentResult result;
+        result.pattern_hosts = component_hosts_;
+        if (component_hosts_.empty()) {
+            return result;
+        }
+
+        pick_seed();
+        build_order();
+
+        host_map_.assign(pattern_.hosts().size(), kUnmapped);
+        host_rmap_.assign(target_.hosts().size(), kUnmapped);
+        tray_map_.assign(pattern_.hosts().size(), {});
+        tray_rmap_.assign(pattern_.hosts().size(), {});
+        cable_map_.assign(pattern_.cables().size(), 0);
+        target_cable_used_.assign(target_.cables().size(), false);
+
+        std::set<std::pair<uint32_t, TrayId>> slots;
+        for (uint32_t pattern_host : component_hosts_) {
+            for (size_t cable_idx : pattern_.cables_at(pattern_host)) {
+                const auto& cable = pattern_.cables()[cable_idx];
+                slots.insert({*cable.endpoint_a.host_id, cable.endpoint_a.tray_id});
+                slots.insert({*cable.endpoint_b.host_id, cable.endpoint_b.tray_id});
+            }
+        }
+        needed_slots_ = slots.size();
+
+        // Every target host the seed could stand for is tried in turn, and each gets its own share of
+        // the step budget. A single share is plenty to find the placements around one seed host, and
+        // sharing keeps a seed that has fallen into an expensive corner of the search from spending
+        // the whole budget and leaving the rest of the cluster unexamined.
+        size_t candidate_seeds = 0;
+        for (const auto& target_host : target_.hosts()) {
+            candidate_seeds += hosts_compatible(pattern_.hosts()[seed_], target_host, options_.tray_symmetry) ? 1 : 0;
+        }
+        budget_ = std::max(kMinSeedSteps, kMaxSearchSteps / std::max<size_t>(candidate_seeds, 1));
+
+        for (uint32_t target_host = 0; target_host < target_.hosts().size() && !stopped_at_limit_; ++target_host) {
+            if (!hosts_compatible(pattern_.hosts()[seed_], target_.hosts()[target_host], options_.tray_symmetry)) {
+                continue;
+            }
+            host_map_[seed_] = target_host;
+            host_rmap_[target_host] = seed_;
+            mapped_hosts_ = 1;
+            steps_ = 0;
+            stop_ = false;
+            recurse(0);
+            mapped_hosts_ = 0;
+            prune_to_ = kNoPrune;
+            host_rmap_[target_host] = kUnmapped;
+            host_map_[seed_] = kUnmapped;
+        }
+
+        for (auto& [host_set, accumulated] : found_) {
+            Match match = accumulated.canonical;
+            match.role_assignments = accumulated.role_assignments.size();
+            result.matches.push_back(std::move(match));
+        }
+        result.num_host_sets = found_.size();
+        result.stopped_at_limit = stopped_at_limit_;
+        result.exhausted_budget = exhausted_budget_;
+        if (result.matches.empty()) {
+            result.diagnosis = diagnosis_;
+        }
+        return result;
+    }
+
+private:
+    struct Accumulated {
+        Match canonical;
+        std::set<std::vector<uint32_t>> role_assignments;
+    };
+
+    void pick_seed() {
+        seed_ = component_hosts_.front();
+        size_t best_degree = 0;
+        for (uint32_t host : component_hosts_) {
+            size_t degree = pattern_.cables_at(host).size();
+            if (degree > best_degree) {
+                best_degree = degree;
+                seed_ = host;
+            }
+        }
+    }
+
+    // Cables that decide something -- reaching a new host, or using a tray of a host for the first
+    // time -- go before cables that only need to be accounted for. Everything after the last
+    // deciding cable is a pure assignment problem, which is much cheaper to solve than to search.
+    void build_order() {
+        std::vector<bool> host_seen(pattern_.hosts().size(), false);
+        std::vector<bool> cable_seen(pattern_.cables().size(), false);
+        std::set<std::pair<uint32_t, TrayId>> slot_seen;
+        std::deque<uint32_t> queue{seed_};
+        host_seen[seed_] = true;
+
+        auto decides = [&](const ResolvedCable& cable) {
+            for (const auto& endpoint : {cable.endpoint_a, cable.endpoint_b}) {
+                if (!host_seen[*endpoint.host_id] || !slot_seen.contains({*endpoint.host_id, endpoint.tray_id})) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        auto take = [&](size_t cable_idx) {
+            cable_seen[cable_idx] = true;
+            order_.push_back(cable_idx);
+            const auto& cable = pattern_.cables()[cable_idx];
+            for (const auto& endpoint : {cable.endpoint_a, cable.endpoint_b}) {
+                slot_seen.insert({*endpoint.host_id, endpoint.tray_id});
+                if (!host_seen[*endpoint.host_id]) {
+                    host_seen[*endpoint.host_id] = true;
+                    queue.push_back(*endpoint.host_id);
+                }
+            }
+        };
+
+        while (!queue.empty()) {
+            uint32_t host = queue.front();
+            queue.pop_front();
+            for (int pass = 0; pass < 2; ++pass) {
+                for (size_t cable_idx : pattern_.cables_at(host)) {
+                    if (cable_seen[cable_idx]) {
+                        continue;
+                    }
+                    bool wanted = decides(pattern_.cables()[cable_idx]);
+                    if ((pass == 0) == wanted) {
+                        take(cable_idx);
+                    }
+                }
+            }
+        }
+    }
+
+    // Every pattern host mapped and every tray it uses pinned to a target tray, so no cable left to
+    // place can decide anything new.
+    bool bindings_complete() const { return mapped_hosts_ == component_hosts_.size() && bound_slots_ == needed_slots_; }
+
+    // Injectively assign the remaining pattern cables to distinct unused target cables. With hosts
+    // and trays already pinned, each pattern cable's candidates are just the free target cables
+    // between the two mapped trays whose ports correspond, so this is bipartite matching (Kuhn's
+    // augmenting paths) rather than a search. On failure, first_unmatched names a pattern cable that
+    // no assignment can serve.
+    bool assign_remaining(size_t index, size_t& first_unmatched) {
+        std::vector<std::vector<size_t>> candidates(order_.size() - index);
+        for (size_t position = index; position < order_.size(); ++position) {
+            const auto& cable = pattern_.cables()[order_[position]];
+            const CableEndpoint& a = cable.endpoint_a;
+            const CableEndpoint& b = cable.endpoint_b;
+            uint32_t target_host_a = host_map_[*a.host_id];
+            TrayId target_tray_a = tray_map_[*a.host_id].at(a.tray_id);
+            uint32_t target_host_b = host_map_[*b.host_id];
+            TrayId target_tray_b = tray_map_[*b.host_id].at(b.tray_id);
+            for (size_t target_cable_idx : target_.cables_at(target_host_a, target_tray_a)) {
+                if (target_cable_used_[target_cable_idx]) {
+                    continue;
+                }
+                const auto& target_cable = target_.cables()[target_cable_idx];
+                for (int side = 0; side < 2; ++side) {
+                    const CableEndpoint& target_a = side == 0 ? target_cable.endpoint_a : target_cable.endpoint_b;
+                    const CableEndpoint& target_b = side == 0 ? target_cable.endpoint_b : target_cable.endpoint_a;
+                    if (*target_a.host_id != target_host_a || target_a.tray_id != target_tray_a) {
+                        continue;
+                    }
+                    if (*target_b.host_id != target_host_b || target_b.tray_id != target_tray_b) {
+                        continue;
+                    }
+                    if (ports_match(a, target_a) && ports_match(b, target_b)) {
+                        candidates[position - index].push_back(target_cable_idx);
+                        break;
+                    }
+                }
+            }
+            if (candidates[position - index].empty()) {
+                first_unmatched = position;
+                return false;
+            }
+        }
+
+        std::map<size_t, size_t> target_to_pattern;
+        std::set<size_t> visited;
+        auto augment = [&](auto& self, size_t pattern_slot) -> bool {
+            for (size_t target_cable_idx : candidates[pattern_slot]) {
+                if (!visited.insert(target_cable_idx).second) {
+                    continue;
+                }
+                auto it = target_to_pattern.find(target_cable_idx);
+                if (it == target_to_pattern.end() || self(self, it->second)) {
+                    target_to_pattern[target_cable_idx] = pattern_slot;
+                    return true;
+                }
+            }
+            return false;
+        };
+        for (size_t slot = 0; slot < candidates.size(); ++slot) {
+            visited.clear();
+            if (!augment(augment, slot)) {
+                first_unmatched = index + slot;
+                return false;
+            }
+        }
+        for (const auto& [target_cable_idx, pattern_slot] : target_to_pattern) {
+            cable_map_[order_[index + pattern_slot]] = target_cable_idx;
+        }
+        return true;
+    }
+
+    // Does a target port stand in for a pattern port? Both endpoints are known to be on hosts with
+    // the same board layout, so ASIC locations are directly comparable.
+    bool ports_match(const CableEndpoint& pattern_end, const CableEndpoint& target_end) const {
+        if (pattern_end.port_type != target_end.port_type) {
+            return false;
+        }
+        switch (options_.port_identity) {
+            case PortIdentity::Strict: return pattern_end.port_id == target_end.port_id;
+            case PortIdentity::Relaxed: return true;
+            case PortIdentity::Chip: {
+                if (pattern_end.port_id == target_end.port_id) {
+                    return true;
+                }
+                const auto& pattern_asics = asics_for_port(
+                    pattern_.hosts()[*pattern_end.host_id].trays.at(pattern_end.tray_id),
+                    pattern_end.port_type,
+                    pattern_end.port_id);
+                const auto& target_asics = asics_for_port(
+                    target_.hosts()[*target_end.host_id].trays.at(target_end.tray_id),
+                    target_end.port_type,
+                    target_end.port_id);
+                return std::any_of(pattern_asics.begin(), pattern_asics.end(), [&](uint32_t asic) {
+                    return target_asics.contains(asic);
+                });
+            }
+        }
+        return false;
+    }
+
+    // Target trays the pattern tray of an already-mapped host could be using.
+    std::vector<TrayId> candidate_trays(uint32_t pattern_host, TrayId pattern_tray) const {
+        const auto& bound = tray_map_[pattern_host];
+        if (auto it = bound.find(pattern_tray); it != bound.end()) {
+            return {it->second};
+        }
+        const auto& pattern_trays = pattern_.hosts()[pattern_host].trays;
+        const auto& target_trays = target_.hosts()[host_map_[pattern_host]].trays;
+        BoardType board = pattern_trays.at(pattern_tray);
+        if (options_.tray_symmetry == TraySymmetry::None) {
+            auto it = target_trays.find(pattern_tray);
+            if (it == target_trays.end() || it->second != board) {
+                return {};
+            }
+            return {pattern_tray};
+        }
+        std::vector<TrayId> candidates;
+        for (const auto& [tray, target_board] : target_trays) {
+            if (target_board == board && !tray_rmap_[pattern_host].contains(tray)) {
+                candidates.push_back(tray);
+            }
+        }
+        return candidates;
+    }
+
+    void bind_tray(uint32_t pattern_host, TrayId pattern_tray, TrayId target_tray) {
+        tray_map_[pattern_host][pattern_tray] = target_tray;
+        tray_rmap_[pattern_host][target_tray] = pattern_tray;
+        ++bound_slots_;
+    }
+
+    void unbind_tray(uint32_t pattern_host, TrayId pattern_tray, TrayId target_tray) {
+        tray_map_[pattern_host].erase(pattern_tray);
+        tray_rmap_[pattern_host].erase(target_tray);
+        --bound_slots_;
+    }
+
+    // True when this level and everything under it should be abandoned because a completed match has
+    // already been recorded for every decision made at or below the level that is being retried.
+    bool abandon(size_t index) {
+        if (prune_to_ == kNoPrune) {
+            return false;
+        }
+        if (static_cast<int>(index) > prune_to_) {
+            return true;
+        }
+        prune_to_ = kNoPrune;
+        return false;
+    }
+
+    void recurse(size_t index) {
+        if (stop_) {
+            return;
+        }
+        if (index == order_.size()) {
+            record_match();
+            return;
+        }
+        if (!have_diagnosis_ || index > deepest_) {
+            have_diagnosis_ = true;
+            deepest_ = index;
+            diagnosis_ = diagnose(index);
+        }
+        if (bindings_complete()) {
+            size_t unmatched = index;
+            if (assign_remaining(index, unmatched)) {
+                record_match();
+            } else if (!have_diagnosis_ || unmatched > deepest_) {
+                have_diagnosis_ = true;
+                deepest_ = unmatched;
+                diagnosis_ = diagnose(unmatched);
+                diagnosis_->reason +=
+                    " (no way of dealing out the remaining cables avoids this, having pinned every host and tray)";
+            }
+            return;
+        }
+
+        size_t pattern_cable_idx = order_[index];
+        const auto& pattern_cable = pattern_.cables()[pattern_cable_idx];
+        bool anchor_is_a = host_map_[*pattern_cable.endpoint_a.host_id] != kUnmapped;
+        const CableEndpoint& anchor = anchor_is_a ? pattern_cable.endpoint_a : pattern_cable.endpoint_b;
+        const CableEndpoint& far = anchor_is_a ? pattern_cable.endpoint_b : pattern_cable.endpoint_a;
+        uint32_t anchor_pattern_host = *anchor.host_id;
+        uint32_t anchor_target_host = host_map_[anchor_pattern_host];
+
+        for (TrayId anchor_target_tray : candidate_trays(anchor_pattern_host, anchor.tray_id)) {
+            bool anchor_tray_was_bound = tray_map_[anchor_pattern_host].contains(anchor.tray_id);
+            if (!anchor_tray_was_bound) {
+                bind_tray(anchor_pattern_host, anchor.tray_id, anchor_target_tray);
+            }
+
+            for (size_t target_cable_idx : target_.cables_at(anchor_target_host, anchor_target_tray)) {
+                if (target_cable_used_[target_cable_idx]) {
+                    continue;
+                }
+                if (++steps_ > budget_) {
+                    exhausted_budget_ = true;
+                    stop_ = true;
+                    break;
+                }
+                const auto& target_cable = target_.cables()[target_cable_idx];
+                for (int side = 0; side < 2; ++side) {
+                    const CableEndpoint& target_anchor = side == 0 ? target_cable.endpoint_a : target_cable.endpoint_b;
+                    const CableEndpoint& target_far = side == 0 ? target_cable.endpoint_b : target_cable.endpoint_a;
+                    if (*target_anchor.host_id != anchor_target_host || target_anchor.tray_id != anchor_target_tray) {
+                        continue;
+                    }
+                    if (!ports_match(anchor, target_anchor)) {
+                        continue;
+                    }
+                    try_place(index, pattern_cable_idx, far, target_far, target_cable_idx);
+                    if (stop_ || abandon(index)) {
+                        break;
+                    }
+                }
+                if (stop_ || abandon(index)) {
+                    break;
+                }
+            }
+
+            if (!anchor_tray_was_bound) {
+                unbind_tray(anchor_pattern_host, anchor.tray_id, anchor_target_tray);
+            }
+            if (stop_ || abandon(index)) {
+                return;
+            }
+        }
+    }
+
+    // Commit the far end of a candidate cable if it is consistent with the mapping so far, recurse,
+    // then roll back.
+    void try_place(
+        size_t index,
+        size_t pattern_cable_idx,
+        const CableEndpoint& far,
+        const CableEndpoint& target_far,
+        size_t target_cable_idx) {
+        uint32_t far_pattern_host = *far.host_id;
+        uint32_t far_target_host = *target_far.host_id;
+        bool bound_host = false;
+        if (host_map_[far_pattern_host] == kUnmapped) {
+            if (host_rmap_[far_target_host] != kUnmapped) {
+                return;
+            }
+            if (!hosts_compatible(
+                    pattern_.hosts()[far_pattern_host], target_.hosts()[far_target_host], options_.tray_symmetry)) {
+                return;
+            }
+            host_map_[far_pattern_host] = far_target_host;
+            host_rmap_[far_target_host] = far_pattern_host;
+            host_binding_levels_.push_back(static_cast<int>(index));
+            ++mapped_hosts_;
+            bound_host = true;
+        } else if (host_map_[far_pattern_host] != far_target_host) {
+            return;
+        }
+
+        bool bound_tray = false;
+        auto rollback = [&]() {
+            if (bound_tray) {
+                unbind_tray(far_pattern_host, far.tray_id, target_far.tray_id);
+            }
+            if (bound_host) {
+                host_binding_levels_.pop_back();
+                --mapped_hosts_;
+                host_rmap_[far_target_host] = kUnmapped;
+                host_map_[far_pattern_host] = kUnmapped;
+            }
+        };
+
+        auto bound = tray_map_[far_pattern_host].find(far.tray_id);
+        if (bound != tray_map_[far_pattern_host].end()) {
+            if (bound->second != target_far.tray_id) {
+                rollback();
+                return;
+            }
+        } else {
+            const auto& target_trays = target_.hosts()[far_target_host].trays;
+            auto target_tray = target_trays.find(target_far.tray_id);
+            if (target_tray == target_trays.end() ||
+                target_tray->second != pattern_.hosts()[far_pattern_host].trays.at(far.tray_id) ||
+                tray_rmap_[far_pattern_host].contains(target_far.tray_id) ||
+                (options_.tray_symmetry == TraySymmetry::None && far.tray_id != target_far.tray_id)) {
+                rollback();
+                return;
+            }
+            bind_tray(far_pattern_host, far.tray_id, target_far.tray_id);
+            bound_tray = true;
+        }
+
+        if (!ports_match(far, target_far)) {
+            rollback();
+            return;
+        }
+
+        target_cable_used_[target_cable_idx] = true;
+        cable_map_[pattern_cable_idx] = target_cable_idx;
+        recurse(index + 1);
+        target_cable_used_[target_cable_idx] = false;
+        rollback();
+    }
+
+    // Role assignment of the current state: the target host each pattern host of this component
+    // plays, in pattern host order. Two placements onto the same set of target hosts differ only in
+    // this, which is what makes it the right key for counting a pattern's automorphisms.
+    std::vector<uint32_t> role_assignment_of(const std::vector<uint32_t>& host_map) const {
+        std::vector<uint32_t> roles;
+        roles.reserve(component_hosts_.size());
+        for (uint32_t pattern_host : component_hosts_) {
+            roles.push_back(host_map[pattern_host]);
+        }
+        return roles;
+    }
+
+    void record_match() {
+        // The answer is which target hosts play which pattern roles. Which target cable serves which
+        // pattern cable, and which target tray stands in for which pattern tray, are not part of it,
+        // so once a placement is complete there is nothing to learn from the other ways of dealing
+        // out the same cables and trays. Abandon everything back to the last host decision, which is
+        // where a different answer could still come from -- and cannot come from anywhere deeper,
+        // since every host is already mapped by this point. Without this, the modes that let a cable
+        // land on several ports spend their whole budget enumerating equivalent placements.
+        if (!options_.search_every_placement) {
+            prune_to_ = host_binding_levels_.empty() ? -1 : host_binding_levels_.back();
+        }
+
+        std::vector<uint32_t> role_assignment = role_assignment_of(host_map_);
+        std::vector<uint32_t> host_set = role_assignment;
+        std::sort(host_set.begin(), host_set.end());
+
+        auto it = found_.find(host_set);
+        if (it == found_.end()) {
+            it = found_.emplace(host_set, Accumulated{}).first;
+        }
+        if (it->second.role_assignments.empty() ||
+            role_assignment < role_assignment_of(it->second.canonical.host_map)) {
+            it->second.canonical.host_map = host_map_;
+            it->second.canonical.tray_map = tray_map_;
+            it->second.canonical.cable_map = cable_map_;
+        }
+        it->second.role_assignments.insert(std::move(role_assignment));
+
+        // Stop as soon as the caller has as many host sets as it asked for, rather than going on to
+        // prove there are no others. Under the port-agnostic identity modes that proof is the
+        // expensive part, so --max-matches 1 is how to ask a cheap "does it fit anywhere" question.
+        if (options_.max_matches != 0 && found_.size() >= options_.max_matches) {
+            stopped_at_limit_ = true;
+            stop_ = true;
+        }
+    }
+
+    // Explain the state the search is in at the given step: which pattern cable is next, where its
+    // anchored end lands in the target, and what the target has there.
+    Diagnosis diagnose(size_t index) const {
+        Diagnosis diagnosis;
+        diagnosis.cables_placed = index;
+        diagnosis.partial_host_map = host_map_;
+        size_t pattern_cable_idx = order_[index];
+        diagnosis.pattern_cable = pattern_cable_idx;
+        const auto& pattern_cable = pattern_.cables()[pattern_cable_idx];
+        bool anchor_is_a = host_map_[*pattern_cable.endpoint_a.host_id] != kUnmapped;
+        const CableEndpoint& anchor = anchor_is_a ? pattern_cable.endpoint_a : pattern_cable.endpoint_b;
+        const CableEndpoint& far = anchor_is_a ? pattern_cable.endpoint_b : pattern_cable.endpoint_a;
+        uint32_t anchor_target_host = host_map_[*anchor.host_id];
+        diagnosis.anchor_host = anchor_target_host;
+
+        // With trays held fixed the anchor tray is known even before anything binds it.
+        const auto& bound = tray_map_[*anchor.host_id];
+        auto tray = bound.find(anchor.tray_id);
+        TrayId anchor_target_tray = anchor.tray_id;
+        if (tray != bound.end()) {
+            anchor_target_tray = tray->second;
+        } else if (options_.tray_symmetry != TraySymmetry::None) {
+            diagnosis.reason = fmt::format(
+                "no cable on target host {} could serve it, on any tray still free to stand in for tray {}",
+                anchor_target_host,
+                *anchor.tray_id);
+            return diagnosis;
+        }
+        diagnosis.anchor_tray = anchor_target_tray;
+
+        for (size_t target_cable_idx : target_.cables_at(anchor_target_host, anchor_target_tray)) {
+            const auto& target_cable = target_.cables()[target_cable_idx];
+            for (int side = 0; side < 2; ++side) {
+                const CableEndpoint& target_anchor = side == 0 ? target_cable.endpoint_a : target_cable.endpoint_b;
+                const CableEndpoint& target_far = side == 0 ? target_cable.endpoint_b : target_cable.endpoint_a;
+                if (*target_anchor.host_id != anchor_target_host || target_anchor.tray_id != anchor_target_tray ||
+                    !ports_match(anchor, target_anchor)) {
+                    continue;
+                }
+                diagnosis.rejections.push_back(Diagnosis::Rejection{
+                    .candidate = target_anchor,
+                    .cable = target_cable,
+                    .reason = why_not(target_cable_idx, far, target_far)});
+            }
+        }
+        if (diagnosis.rejections.empty()) {
+            switch (options_.port_identity) {
+                case PortIdentity::Strict: diagnosis.reason = "the target has no cable on that port"; break;
+                case PortIdentity::Chip:
+                    diagnosis.reason = "the target has no cable on any port of that tray reaching the same ASIC";
+                    break;
+                case PortIdentity::Relaxed: diagnosis.reason = "the target has no cable on that tray"; break;
+            }
+        }
+        return diagnosis;
+    }
+
+    // Why one particular target cable could not serve the pattern cable being placed.
+    std::string why_not(size_t target_cable_idx, const CableEndpoint& far, const CableEndpoint& target_far) const {
+        if (target_cable_used_[target_cable_idx]) {
+            return "already carrying another pattern cable";
+        }
+        uint32_t far_mapped = host_map_[*far.host_id];
+        if (far_mapped != kUnmapped && far_mapped != *target_far.host_id) {
+            return fmt::format(
+                "far end is target host {}, but pattern host {} is already mapped to target host {}",
+                *target_far.host_id,
+                *far.host_id,
+                far_mapped);
+        }
+        if (far_mapped == kUnmapped && host_rmap_[*target_far.host_id] != kUnmapped) {
+            return fmt::format(
+                "far end is target host {}, already taken by pattern host {}",
+                *target_far.host_id,
+                host_rmap_[*target_far.host_id]);
+        }
+        if (!ports_match(far, target_far)) {
+            return fmt::format(
+                "far end is {}, but the pattern needs {}", port_to_string(target_far), port_to_string(far));
+        }
+        auto far_bound = tray_map_[*far.host_id].find(far.tray_id);
+        if (far_bound != tray_map_[*far.host_id].end() && far_bound->second != target_far.tray_id) {
+            return fmt::format(
+                "far end is tray {} of target host {}, but pattern tray {} there is already taken to be tray {}",
+                *target_far.tray_id,
+                *target_far.host_id,
+                *far.tray_id,
+                *far_bound->second);
+        }
+        if (far_mapped == kUnmapped &&
+            !hosts_compatible(
+                pattern_.hosts()[*far.host_id], target_.hosts()[*target_far.host_id], options_.tray_symmetry)) {
+            return fmt::format(
+                "far end is target host {}, whose boards do not match pattern host {}",
+                *target_far.host_id,
+                *far.host_id);
+        }
+        return "no reason found at this port; the placement failed further on";
+    }
+
+    const MatchGraph& pattern_;
+    const MatchGraph& target_;
+    const MatchOptions& options_;
+    std::vector<uint32_t> component_hosts_;
+
+    uint32_t seed_ = 0;
+    std::vector<size_t> order_;
+
+    std::vector<uint32_t> host_map_;
+    std::vector<uint32_t> host_rmap_;
+    std::vector<std::map<TrayId, TrayId>> tray_map_;
+    std::vector<std::map<TrayId, TrayId>> tray_rmap_;
+    std::vector<size_t> cable_map_;
+    std::vector<bool> target_cable_used_;
+
+    std::map<std::vector<uint32_t>, Accumulated> found_;
+    // Search levels at which a pattern host was bound to a target host, innermost last.
+    std::vector<int> host_binding_levels_;
+    size_t needed_slots_ = 0;
+    size_t bound_slots_ = 0;
+    size_t mapped_hosts_ = 0;
+    int prune_to_ = kNoPrune;
+    size_t deepest_ = 0;
+    bool have_diagnosis_ = false;
+    std::optional<Diagnosis> diagnosis_;
+    uint64_t steps_ = 0;
+    uint64_t budget_ = kMaxSearchSteps;
+    bool stopped_at_limit_ = false;
+    bool exhausted_budget_ = false;
+    bool stop_ = false;
+};
+
+}  // namespace
+
+const std::set<uint32_t>& asics_for_port(BoardType board_type, PortType port_type, PortId port_id) {
+    static std::map<std::tuple<BoardType, PortType, PortId>, std::set<uint32_t>> cache;
+    auto key = std::make_tuple(board_type, port_type, port_id);
+    auto it = cache.find(key);
+    if (it == cache.end()) {
+        Board board = create_board(board_type);
+        std::set<uint32_t> asics;
+        for (const auto& channel : board.get_port_channels(port_type, port_id)) {
+            asics.insert(channel.asic_location);
+        }
+        it = cache.emplace(std::move(key), std::move(asics)).first;
+    }
+    return it->second;
+}
+
+std::vector<std::string> list_graph_templates(const std::string& cabling_path) {
+    auto descriptor = load_cluster_descriptor(cabling_path);
+    std::vector<std::string> names;
+    for (const auto& [name, unused] : descriptor.graph_templates()) {
+        names.push_back(name);
+    }
+    std::sort(names.begin(), names.end());
+    return names;
+}
+
+size_t count_hosts(const cabling_generator::proto::ClusterDescriptor& descriptor) {
+    size_t count = 0;
+    count_hosts_in_instance(descriptor.root_instance(), count);
+    return count;
+}
+
+cabling_generator::proto::ClusterDescriptor synthesize_pattern_descriptor(
+    const cabling_generator::proto::ClusterDescriptor& source, const std::string& template_name) {
+    cabling_generator::proto::ClusterDescriptor pattern = source;
+    pattern.clear_root_instance();
+    uint32_t next_host_id = 0;
+    std::vector<std::string> stack;
+    build_instance(source, template_name, pattern.mutable_root_instance(), next_host_id, stack);
+    if (next_host_id == 0) {
+        throw std::runtime_error(fmt::format("Graph template '{}' contains no nodes", template_name));
+    }
+    return pattern;
+}
+
+MatchGraph MatchGraph::from_generator(const CablingGenerator& generator, TierScope tier, std::string label) {
+    MatchGraph graph;
+    graph.label_ = std::move(label);
+
+    size_t num_hosts = generator.get_num_hosts();
+    const auto& deployment_hosts = generator.get_deployment_hosts();
+    graph.hosts_.reserve(num_hosts);
+    for (uint32_t host_id = 0; host_id < num_hosts; ++host_id) {
+        HostInfo info;
+        info.name =
+            host_id < deployment_hosts.size() ? deployment_hosts[host_id].hostname : fmt::format("host_{}", host_id);
+        std::vector<std::string> parts;
+        for (const auto& [tray_id, board] : generator.get_node(HostId(host_id)).boards) {
+            info.trays.emplace(tray_id, board.get_board_type());
+            parts.push_back(fmt::format("{}:{}", *tray_id, enchantum::to_string(board.get_board_type())));
+        }
+        info.signature = fmt::format("{}", fmt::join(parts, ","));
+        graph.hosts_.push_back(std::move(info));
+    }
+
+    for (auto& cable : generator.get_cables()) {
+        if (tier == TierScope::OwnLevel && cable.depth != 0) {
+            continue;
+        }
+        graph.cables_.push_back(std::move(cable));
+    }
+
+    graph.cables_by_host_.resize(num_hosts);
+    for (size_t index = 0; index < graph.cables_.size(); ++index) {
+        const auto& cable = graph.cables_[index];
+        for (const auto& endpoint : {cable.endpoint_a, cable.endpoint_b}) {
+            auto& by_host = graph.cables_by_host_[*endpoint.host_id];
+            if (by_host.empty() || by_host.back() != index) {
+                by_host.push_back(index);
+            }
+            auto& by_tray = graph.cables_by_host_tray_[{*endpoint.host_id, endpoint.tray_id}];
+            if (by_tray.empty() || by_tray.back() != index) {
+                by_tray.push_back(index);
+            }
+        }
+    }
+    return graph;
+}
+
+MatchGraph MatchGraph::load(
+    const std::string& cabling_path,
+    const std::string& deployment_path,
+    const std::string& template_name,
+    TierScope tier,
+    std::string label) {
+    if (!deployment_path.empty()) {
+        if (!template_name.empty()) {
+            throw std::runtime_error(
+                "A graph template is instantiated with synthetic hosts, so it cannot be combined with a "
+                "deployment descriptor");
+        }
+        return from_generator(CablingGenerator(cabling_path, deployment_path), tier, std::move(label));
+    }
+
+    if (std::filesystem::is_directory(cabling_path)) {
+        throw std::runtime_error(
+            "A directory of cabling descriptors is only merged against a deployment descriptor; pass "
+            "--deployment (or --pattern-deployment) alongside it: " +
+            cabling_path);
+    }
+    auto descriptor = load_cluster_descriptor(cabling_path);
+    if (!template_name.empty()) {
+        descriptor = synthesize_pattern_descriptor(descriptor, template_name);
+    }
+    size_t num_hosts = count_hosts(descriptor);
+    if (num_hosts == 0) {
+        throw std::runtime_error("Descriptor has no hosts: " + cabling_path);
+    }
+    std::vector<std::string> hostnames;
+    hostnames.reserve(num_hosts);
+    for (size_t host_id = 0; host_id < num_hosts; ++host_id) {
+        hostnames.push_back(fmt::format("host_{}", host_id));
+    }
+    return from_generator(CablingGenerator(descriptor, hostnames), tier, std::move(label));
+}
+
+const std::vector<size_t>& MatchGraph::cables_at(uint32_t host_id) const {
+    static const std::vector<size_t> empty;
+    return host_id < cables_by_host_.size() ? cables_by_host_[host_id] : empty;
+}
+
+const std::vector<size_t>& MatchGraph::cables_at(uint32_t host_id, TrayId tray_id) const {
+    static const std::vector<size_t> empty;
+    auto it = cables_by_host_tray_.find({host_id, tray_id});
+    return it == cables_by_host_tray_.end() ? empty : it->second;
+}
+
+std::vector<uint32_t> MatchGraph::isolated_hosts() const {
+    std::vector<uint32_t> isolated;
+    for (uint32_t host_id = 0; host_id < hosts_.size(); ++host_id) {
+        if (cables_at(host_id).empty()) {
+            isolated.push_back(host_id);
+        }
+    }
+    return isolated;
+}
+
+std::vector<std::vector<uint32_t>> MatchGraph::components() const {
+    std::vector<std::vector<uint32_t>> components;
+    std::vector<bool> seen(hosts_.size(), false);
+    for (uint32_t start = 0; start < hosts_.size(); ++start) {
+        if (seen[start] || cables_at(start).empty()) {
+            continue;
+        }
+        std::vector<uint32_t> component;
+        std::deque<uint32_t> queue{start};
+        seen[start] = true;
+        while (!queue.empty()) {
+            uint32_t host = queue.front();
+            queue.pop_front();
+            component.push_back(host);
+            for (size_t cable_idx : cables_at(host)) {
+                const auto& cable = cables_[cable_idx];
+                for (uint32_t end : {*cable.endpoint_a.host_id, *cable.endpoint_b.host_id}) {
+                    if (!seen[end]) {
+                        seen[end] = true;
+                        queue.push_back(end);
+                    }
+                }
+            }
+        }
+        std::sort(component.begin(), component.end());
+        components.push_back(std::move(component));
+    }
+    return components;
+}
+
+MatchResult match(const MatchGraph& pattern, const MatchGraph& target, const MatchOptions& options) {
+    MatchResult result;
+    result.isolated_pattern_hosts = pattern.isolated_hosts();
+
+    if (pattern.cables().empty()) {
+        throw std::runtime_error(
+            "The pattern has no cables, so every set of hosts of the right size would match. Pick a template "
+            "that declares connections, or widen --tier.");
+    }
+
+    auto components = pattern.components();
+    if (components.size() > 1 && !options.allow_disconnected) {
+        std::vector<std::string> sizes;
+        for (const auto& component : components) {
+            sizes.push_back(fmt::format("{} hosts", component.size()));
+        }
+        throw std::runtime_error(fmt::format(
+            "The pattern's cables split it into {} disconnected components ({}). Nothing ties the components to "
+            "each other, so the matches would be the cross product of their independent placements. Pass "
+            "--allow-disconnected to match each component on its own.",
+            components.size(),
+            fmt::join(sizes, ", ")));
+    }
+
+    if (options.mode == MatchMode::Exact) {
+        if (pattern.hosts().size() != target.hosts().size()) {
+            result.exact_mismatch = fmt::format(
+                "exact match needs equal host counts: pattern has {}, target has {}",
+                pattern.hosts().size(),
+                target.hosts().size());
+        } else if (pattern.cables().size() != target.cables().size()) {
+            result.exact_mismatch = fmt::format(
+                "exact match needs equal cable counts: pattern has {}, target has {}",
+                pattern.cables().size(),
+                target.cables().size());
+        }
+    }
+
+    result.matched = result.exact_mismatch.empty();
+    for (auto& component : components) {
+        Search search(pattern, target, options, component);
+        auto component_result = search.run();
+        if (component_result.matches.empty()) {
+            result.matched = false;
+        }
+        result.components.push_back(std::move(component_result));
+    }
+    return result;
+}
+
+std::string to_string(PortIdentity identity) {
+    switch (identity) {
+        case PortIdentity::Strict: return "strict";
+        case PortIdentity::Chip: return "chip";
+        case PortIdentity::Relaxed: return "relaxed";
+    }
+    return "unknown";
+}
+
+std::string to_string(TraySymmetry symmetry) {
+    return symmetry == TraySymmetry::None ? "trays fixed" : "trays interchangeable";
+}
+
+std::string to_string(MatchMode mode) { return mode == MatchMode::Contains ? "contains" : "exact"; }
+
+std::string to_string(TierScope tier) { return tier == TierScope::Full ? "full" : "own-level"; }
+
+bool MatchResult::inconclusive() const {
+    if (matched) {
+        return false;
+    }
+    return std::any_of(components.begin(), components.end(), [](const ComponentResult& component) {
+        return component.matches.empty() && component.exhausted_budget;
+    });
+}
+
+std::string format_result(
+    const MatchGraph& pattern, const MatchGraph& target, const MatchResult& result, const MatchOptions& options) {
+    std::ostringstream out;
+    out << fmt::format(
+        "Pattern: {} ({} hosts, {} cables)\n", pattern.label(), pattern.hosts().size(), pattern.cables().size());
+    out << fmt::format(
+        "Target:  {} ({} hosts, {} cables)\n", target.label(), target.hosts().size(), target.cables().size());
+    out << fmt::format(
+        "Mode:    {}, port identity {}, {}\n\n",
+        to_string(options.mode),
+        to_string(options.port_identity),
+        to_string(options.tray_symmetry));
+
+    if (!result.isolated_pattern_hosts.empty()) {
+        std::vector<std::string> names;
+        for (uint32_t host_id : result.isolated_pattern_hosts) {
+            names.push_back(pattern.hosts()[host_id].name);
+        }
+        out << fmt::format(
+            "Note: {} pattern host(s) have no cables and were left out of the search ({}). Any compatible target "
+            "host would serve for them.\n\n",
+            names.size(),
+            fmt::join(names, ", "));
+    }
+
+    if (!result.exact_mismatch.empty()) {
+        out << "NO MATCH\n  " << result.exact_mismatch << "\n";
+        return out.str();
+    }
+
+    if (result.matched) {
+        out << "MATCH\n";
+    } else if (result.inconclusive()) {
+        out << "INCONCLUSIVE\n  The search budget ran out before every placement had been tried, so this is not a "
+               "proof that the pattern does not fit.\n";
+    } else {
+        out << "NO MATCH\n";
+    }
+
+    for (size_t index = 0; index < result.components.size(); ++index) {
+        const auto& component = result.components[index];
+        if (result.components.size() > 1) {
+            out << fmt::format("\nComponent {} ({} pattern hosts)\n", index + 1, component.pattern_hosts.size());
+        }
+        if (component.matches.empty()) {
+            if (component.diagnosis) {
+                const auto& diagnosis = *component.diagnosis;
+                out << fmt::format(
+                    "  Furthest attempt placed {} of {} pattern cables.\n",
+                    diagnosis.cables_placed,
+                    pattern.cables().size());
+                out << fmt::format(
+                    "  Stuck on pattern cable {}\n", cable_to_string(pattern.cables()[diagnosis.pattern_cable]));
+                out << fmt::format(
+                    "    anchored on target host {}{}\n",
+                    target.hosts()[diagnosis.anchor_host].name,
+                    diagnosis.anchor_tray ? fmt::format(" tray {}", **diagnosis.anchor_tray) : "");
+                if (diagnosis.rejections.empty()) {
+                    out << fmt::format("    {}\n", diagnosis.reason);
+                } else {
+                    out << fmt::format(
+                        "    {} target cable(s) could have served that end, and none worked:\n",
+                        diagnosis.rejections.size());
+                    constexpr size_t kMaxShown = 8;
+                    for (size_t shown = 0; shown < diagnosis.rejections.size() && shown < kMaxShown; ++shown) {
+                        const auto& rejection = diagnosis.rejections[shown];
+                        out << fmt::format(
+                            "      port {} -> {}: {}\n",
+                            *rejection.candidate.port_id,
+                            cable_to_string(rejection.cable),
+                            rejection.reason);
+                    }
+                    if (diagnosis.rejections.size() > kMaxShown) {
+                        out << fmt::format("      ... and {} more\n", diagnosis.rejections.size() - kMaxShown);
+                    }
+                }
+            }
+            continue;
+        }
+
+        std::string qualifier;
+        if (component.stopped_at_limit) {
+            qualifier = " (stopped at --max-matches; there may be more)";
+        } else if (component.exhausted_budget) {
+            qualifier = " (search budget exhausted; there may be more)";
+        }
+        out << fmt::format("  {} distinct target host set(s){}\n", component.num_host_sets, qualifier);
+        for (size_t match_index = 0; match_index < component.matches.size(); ++match_index) {
+            const auto& match = component.matches[match_index];
+            std::vector<std::string> roles;
+            bool trays_moved = false;
+            for (uint32_t pattern_host : component.pattern_hosts) {
+                roles.push_back(fmt::format(
+                    "{} -> {}", pattern.hosts()[pattern_host].name, target.hosts()[match.host_map[pattern_host]].name));
+                for (const auto& [from, to] : match.tray_map[pattern_host]) {
+                    trays_moved = trays_moved || from != to;
+                }
+            }
+            out << fmt::format("  #{}: {}\n", match_index + 1, fmt::join(roles, ", "));
+            if (match.role_assignments > 1) {
+                out << fmt::format(
+                    "      {}{} role assignments onto this host set\n",
+                    (component.stopped_at_limit || component.exhausted_budget) ? "at least " : "",
+                    match.role_assignments);
+            }
+            if (trays_moved) {
+                for (uint32_t pattern_host : component.pattern_hosts) {
+                    std::vector<std::string> trays;
+                    for (const auto& [from, to] : match.tray_map[pattern_host]) {
+                        trays.push_back(fmt::format("{}->{}", *from, *to));
+                    }
+                    out << fmt::format(
+                        "      trays on {}: {}\n", pattern.hosts()[pattern_host].name, fmt::join(trays, " "));
+                }
+            }
+        }
+    }
+    return out.str();
+}
+
+}  // namespace tt::scaleout_tools::matcher

--- a/tools/scaleout/cabling_matcher/cabling_matcher.hpp
+++ b/tools/scaleout/cabling_matcher/cabling_matcher.hpp
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <board/board.hpp>
+#include <cabling_generator/cabling_generator.hpp>
+
+namespace tt::scaleout_tools::cabling_generator::proto {
+class ClusterDescriptor;
+}
+
+namespace tt::scaleout_tools::matcher {
+
+// How much freedom the matcher has when calling a pattern cable and a target cable the same
+// connection. Every mode requires the port type to agree; they differ in what they do with port ids.
+enum class PortIdentity {
+    // Port ids must agree. A factory descriptor's cable is matched only by the same cable.
+    Strict,
+    // Ports are compared by the ASIC they reach, read from the board's port-to-channel map. A port
+    // whose channels span two ASICs counts as reaching either one (fixed or configured to one of
+    // two), so two ports match when there is at least one ASIC they can both reach.
+    Chip,
+    // Port ids are ignored; only the host and tray of each endpoint matter.
+    Relaxed,
+};
+
+// Whether trays within a host may be relabelled. Factory descriptors number trays by physical slot,
+// so the default holds them fixed; Full searches every tray bijection that preserves board types,
+// which is what finds a scheme cabled onto a different set of trays.
+enum class TraySymmetry { None, Full };
+
+// Contains: the pattern must appear somewhere in the target. Exact: it must additionally account for
+// every host and every cable of the target.
+enum class MatchMode { Contains, Exact };
+
+// Full: the pattern is every cable in the root template's subtree. OwnLevel: only the cables that
+// template declares itself, which is how to ask whether the outer tiers agree while ignoring a
+// mismatch further in.
+enum class TierScope { Full, OwnLevel };
+
+struct MatchOptions {
+    PortIdentity port_identity = PortIdentity::Strict;
+    TraySymmetry tray_symmetry = TraySymmetry::None;
+    MatchMode mode = MatchMode::Contains;
+    // Number of distinct target host sets to report; the search stops once this many are found, so 1
+    // asks only whether the pattern fits anywhere. 0 searches for all of them, which under the
+    // port-agnostic identity modes is far and away the most expensive thing to ask for.
+    size_t max_matches = 16;
+    // Match each connected component of the pattern separately instead of rejecting a pattern whose
+    // cables do not tie all of its hosts together.
+    bool allow_disconnected = false;
+    // Visit every placement instead of abandoning the ways of dealing out the same cables and trays
+    // that are equivalent to one already recorded. Costs a great deal and changes nothing, so this is
+    // here for tests that check the pruning against the unpruned search.
+    bool search_every_placement = false;
+};
+
+// A cluster reduced to what matching needs: hosts with their board layout, and cables. Host ids
+// index hosts() directly, matching the dense 0..N-1 space CablingGenerator assigns.
+class MatchGraph {
+public:
+    struct HostInfo {
+        std::string name;
+        std::map<TrayId, BoardType> trays;
+        // Board types in tray order, for candidate pre-filtering. Two hosts can only stand in for
+        // each other if these agree, so a pattern leaf declaring a UBB galaxy never matches a P150.
+        std::string signature;
+    };
+
+    // Load a cabling descriptor into a graph. deployment_path may be empty, in which case hosts are
+    // named host_0..host_N-1 and cabling_path must be a single file. template_name, when non-empty,
+    // names a graph_template to instantiate as the root instead of the descriptor's own
+    // root_instance; see synthesize_pattern_descriptor.
+    static MatchGraph load(
+        const std::string& cabling_path,
+        const std::string& deployment_path,
+        const std::string& template_name,
+        TierScope tier,
+        std::string label);
+
+    static MatchGraph from_generator(const CablingGenerator& generator, TierScope tier, std::string label);
+
+    const std::string& label() const { return label_; }
+    const std::vector<HostInfo>& hosts() const { return hosts_; }
+    const std::vector<ResolvedCable>& cables() const { return cables_; }
+
+    // Cable indices touching a host, and touching a specific tray of a host.
+    const std::vector<size_t>& cables_at(uint32_t host_id) const;
+    const std::vector<size_t>& cables_at(uint32_t host_id, TrayId tray_id) const;
+
+    // Hosts with no cables, which every host of a compatible target would match.
+    std::vector<uint32_t> isolated_hosts() const;
+
+    // Connected components over the cables, as pattern host id sets. Isolated hosts are excluded.
+    std::vector<std::vector<uint32_t>> components() const;
+
+private:
+    std::string label_;
+    std::vector<HostInfo> hosts_;
+    std::vector<ResolvedCable> cables_;
+    std::vector<std::vector<size_t>> cables_by_host_;
+    std::map<std::pair<uint32_t, TrayId>, std::vector<size_t>> cables_by_host_tray_;
+};
+
+// One placement of the pattern into the target.
+struct Match {
+    std::vector<uint32_t> host_map;                  // pattern host id -> target host id
+    std::vector<std::map<TrayId, TrayId>> tray_map;  // per pattern host; identity unless trays move
+    std::vector<size_t> cable_map;                   // pattern cable index -> target cable index
+    // Distinct role assignments found onto this same set of target hosts, this one included.
+    uint64_t role_assignments = 1;
+};
+
+// Where the search got stuck, taken from the attempt that placed the most cables. Reported when
+// nothing matched: the matcher always knows which pattern cable it could not place, which target
+// cables it weighed for that cable, and what was wrong with each of them.
+struct Diagnosis {
+    size_t cables_placed = 0;
+    size_t pattern_cable = 0;
+    // Target host the anchored end of that cable landed on, and the tray when one is determined.
+    uint32_t anchor_host = 0;
+    std::optional<TrayId> anchor_tray;
+
+    // A target cable that could have served the anchored end, and why it did not work out. Under the
+    // port-agnostic identity modes there is usually more than one, and reporting a single one of them
+    // reads as if it were the only option.
+    struct Rejection {
+        CableEndpoint candidate;  // the target port the anchored end would have used
+        ResolvedCable cable;      // the cable the target has there
+        std::string reason;
+    };
+    std::vector<Rejection> rejections;
+    // Why there was nothing to try at all. Set only when rejections is empty.
+    std::string reason;
+    // Pattern host -> target host at the point of failure; kUnmapped where undecided.
+    std::vector<uint32_t> partial_host_map;
+    static constexpr uint32_t kUnmapped = ~0u;
+};
+
+struct ComponentResult {
+    std::vector<uint32_t> pattern_hosts;
+    std::vector<Match> matches;
+    size_t num_host_sets = 0;
+    bool stopped_at_limit = false;
+    bool exhausted_budget = false;
+    std::optional<Diagnosis> diagnosis;
+};
+
+struct MatchResult {
+    bool matched = false;
+    // One entry per connected component of the pattern. A connected pattern has exactly one.
+    std::vector<ComponentResult> components;
+    // Pattern hosts dropped for having no cables to constrain them.
+    std::vector<uint32_t> isolated_pattern_hosts;
+    // Set when Exact was asked for and the counts rule it out, independent of any placement.
+    std::string exact_mismatch;
+
+    // A failure is only a proof that the pattern does not fit if the search ran to completion.
+    // Otherwise all that is known is that nothing turned up in the steps available.
+    bool inconclusive() const;
+};
+
+MatchResult match(const MatchGraph& pattern, const MatchGraph& target, const MatchOptions& options);
+
+// Turn a graph_template into a loadable ClusterDescriptor by instantiating it as the root and
+// assigning host ids 0..k-1 to its leaf nodes in template child order. A graph_template is not
+// loadable on its own: it has no root_instance, so nothing binds its leaves to hosts.
+cabling_generator::proto::ClusterDescriptor synthesize_pattern_descriptor(
+    const cabling_generator::proto::ClusterDescriptor& source, const std::string& template_name);
+
+// Leaf nodes under a descriptor's root_instance, i.e. how many hostnames a CablingGenerator needs.
+size_t count_hosts(const cabling_generator::proto::ClusterDescriptor& descriptor);
+
+// Names of the graph templates a cabling descriptor defines, sorted. These are the candidates for
+// MatchGraph::load's template_name.
+std::vector<std::string> list_graph_templates(const std::string& cabling_path);
+
+// ASIC locations a port can reach. More than one means the port is read as reaching either of them;
+// see PortIdentity::Chip.
+const std::set<uint32_t>& asics_for_port(BoardType board_type, PortType port_type, PortId port_id);
+
+std::string to_string(PortIdentity identity);
+std::string to_string(TraySymmetry symmetry);
+std::string to_string(MatchMode mode);
+std::string to_string(TierScope tier);
+
+// Human-readable report of a match run, as printed by run_cabling_matcher.
+std::string format_result(
+    const MatchGraph& pattern, const MatchGraph& target, const MatchResult& result, const MatchOptions& options);
+
+}  // namespace tt::scaleout_tools::matcher

--- a/tools/scaleout/cabling_matcher/cabling_matcher.hpp
+++ b/tools/scaleout/cabling_matcher/cabling_matcher.hpp
@@ -89,9 +89,21 @@ public:
 
     static MatchGraph from_generator(const CablingGenerator& generator, TierScope tier, std::string label);
 
+    // Load a factory system descriptor. An FSD records ethernet channels rather than cables, so the
+    // channels are folded back into the ports they belong to, using the board's own channel-to-port
+    // map; a port connection missing some of its channels still counts as a cable, and is reported in
+    // notes(). Board-internal traces are not cables and are dropped, matching the cabling descriptor
+    // side. An FSD does not record which tier of a hierarchy declared a cable, so it has no tier
+    // scoping: see TierScope.
+    static MatchGraph from_fsd(const std::string& fsd_path, std::string label);
+
     const std::string& label() const { return label_; }
     const std::vector<HostInfo>& hosts() const { return hosts_; }
     const std::vector<ResolvedCable>& cables() const { return cables_; }
+
+    // Anything about the input worth telling the user, e.g. cables that are missing channels. Not
+    // errors: the graph is usable, but the answer was reached having read the input this way.
+    const std::vector<std::string>& notes() const { return notes_; }
 
     // Cable indices touching a host, and touching a specific tray of a host.
     const std::vector<size_t>& cables_at(uint32_t host_id) const;
@@ -104,9 +116,13 @@ public:
     std::vector<std::vector<uint32_t>> components() const;
 
 private:
+    // Build the by-host and by-tray cable indices from cables_. Called once the cables are in place.
+    void index_cables();
+
     std::string label_;
     std::vector<HostInfo> hosts_;
     std::vector<ResolvedCable> cables_;
+    std::vector<std::string> notes_;
     std::vector<std::vector<size_t>> cables_by_host_;
     std::map<std::pair<uint32_t, TrayId>, std::vector<size_t>> cables_by_host_tray_;
 };

--- a/tools/scaleout/cabling_matcher/cabling_matcher.hpp
+++ b/tools/scaleout/cabling_matcher/cabling_matcher.hpp
@@ -200,6 +200,48 @@ size_t count_hosts(const cabling_generator::proto::ClusterDescriptor& descriptor
 // MatchGraph::load's template_name.
 std::vector<std::string> list_graph_templates(const std::string& cabling_path);
 
+// ---- Scoring a library of schemes against one target ----
+
+// One scheme available to be looked for: a graph template, named by the descriptor defining it.
+struct LibraryEntry {
+    std::string source;
+    std::string template_name;
+    std::string name;  // what the report calls it, e.g. "sc36 :: bh_glx_pod"
+    size_t num_hosts = 0;
+    size_t num_cables = 0;
+};
+
+struct LibraryFinding {
+    // Target host sets the entry fits, each sorted. Empty when it does not fit.
+    std::vector<std::vector<uint32_t>> host_sets;
+    bool stopped_at_limit = false;
+    bool inconclusive = false;
+    // Larger entries that fit over every host set this one does. Wherever a pod is found inside a
+    // superpod that was also found, the pod is not a separate answer, so it is reported as covered
+    // rather than listed again.
+    std::vector<size_t> covered_by;
+    // One line saying where the search got stuck, when it did not fit.
+    std::string stuck_at;
+};
+
+struct LibraryResult {
+    // Largest scheme first, which is the order everything else refers to by index.
+    std::vector<LibraryEntry> entries;
+    std::vector<LibraryFinding> findings;  // parallel to entries
+    // Schemes that could not be asked about at all, with the reason: a template declaring no cables
+    // of its own, or one whose cables leave it in pieces.
+    std::vector<std::pair<std::string, std::string>> skipped;
+};
+
+// Search the target for every scheme in a library. paths are descriptor files, or directories whose
+// .textproto files are each read on their own; every graph template of every one of them is a
+// scheme to look for. Note that under --max-matches the host sets are the ones found rather than all
+// there are, which makes the coverage between entries provisional in the same way.
+LibraryResult score_library(
+    const std::vector<std::string>& paths, const MatchGraph& target, const MatchOptions& options, TierScope tier);
+
+std::string format_library_result(const MatchGraph& target, const LibraryResult& result, const MatchOptions& options);
+
 // ASIC locations a port can reach. More than one means the port is read as reaching either of them;
 // see PortIdentity::Chip.
 const std::set<uint32_t>& asics_for_port(BoardType board_type, PortType port_type, PortId port_id);

--- a/tools/scaleout/sources.cmake
+++ b/tools/scaleout/sources.cmake
@@ -13,6 +13,7 @@ set(SCALEOUT_TOOLS_API_HEADERS
     board/board.hpp
     cabling_generator/cabling_generator.hpp
     cabling_generator/regen_descriptors.hpp
+    cabling_matcher/cabling_matcher.hpp
     connector/connector.hpp
     factory_system_descriptor/query.hpp
     factory_system_descriptor/utils.hpp
@@ -25,6 +26,7 @@ set(SCALEOUT_TOOLS_SRCS
     board/board.cpp
     cabling_generator/cabling_generator.cpp
     cabling_generator/regen_descriptors.cpp
+    cabling_matcher/cabling_matcher.cpp
     connector/connector.cpp
     factory_system_descriptor/query.cpp
     factory_system_descriptor/utils.cpp
@@ -45,6 +47,8 @@ set(RUN_FABRIC_MANAGER_SRCS
 set(SCALEOUT_2D_BIG_MESH_CABLING_GEN_SRCS src/2d_big_mesh_cabling_gen.cpp)
 
 set(RUN_CABLING_GENERATOR_SRCS src/run_cabling_generator.cpp)
+
+set(RUN_CABLING_MATCHER_SRCS src/run_cabling_matcher.cpp)
 
 set(RUN_REGEN_DESCRIPTORS_SRCS src/run_regen_descriptors.cpp)
 

--- a/tools/scaleout/src/run_cabling_matcher.cpp
+++ b/tools/scaleout/src/run_cabling_matcher.cpp
@@ -23,9 +23,11 @@ namespace {
 struct Config {
     std::string cabling_path;
     std::string deployment_path;
+    std::string fsd_path;
     std::string pattern_cabling_path;
     std::string pattern_deployment_path;
     std::string pattern_template;
+    std::string pattern_fsd_path;
     TierScope tier = TierScope::Full;
     MatchOptions options;
 };
@@ -50,7 +52,8 @@ Config parse_arguments(int argc, char** argv) {
         "Find a cabling scheme inside another cabling scheme.\n\n"
         "The pattern is a cabling descriptor, or one graph_template out of one, and the target is the\n"
         "descriptor to search. A match is an assignment of pattern hosts to target hosts under which\n"
-        "every pattern cable is a cable the target actually has.");
+        "every pattern cable is a cable the target actually has. Either side can instead be a factory\n"
+        "system descriptor, which asks whether a built system implements the scheme, or more than it.");
 
     options.add_options()(
         "c,cabling",
@@ -59,6 +62,10 @@ Config parse_arguments(int argc, char** argv) {
         "d,deployment",
         "Target deployment descriptor (.textproto). Without it, target hosts are named host_0..host_N-1 and "
         "--cabling must be a single file",
+        cxxopts::value<std::string>()->default_value(""))(
+        "f,fsd",
+        "Target factory system descriptor (.textproto), in place of --cabling. Its ethernet channels are folded "
+        "back into the ports they belong to, so the comparison is in the same terms either way",
         cxxopts::value<std::string>()->default_value(""))(
         "p,pattern-cabling",
         "Pattern cabling descriptor (.textproto). Defaults to --cabling, which asks whether a template of a "
@@ -71,6 +78,10 @@ Config parse_arguments(int argc, char** argv) {
         "pattern-deployment",
         "Deployment descriptor for the pattern; only valid without --pattern-template, since a template is "
         "instantiated with synthetic hosts",
+        cxxopts::value<std::string>()->default_value(""))(
+        "pattern-fsd",
+        "Factory system descriptor to use as the pattern, in place of --pattern-cabling. Asks whether one built "
+        "system's wiring is reproduced in another",
         cxxopts::value<std::string>()->default_value(""))(
         "i,identity",
         "How strictly ports must correspond: strict (same port id), chip (same ASIC reached, treating a port "
@@ -110,16 +121,20 @@ Config parse_arguments(int argc, char** argv) {
         std::cout << "  " << argv[0] << " -c system.textproto -t bh_galaxy_sp\n";
         std::cout << "  # Does the superpod template recur elsewhere in the system it came from?\n\n";
         std::cout << "  " << argv[0] << " -c st_sc36.textproto -p sc36.textproto -t bh_glx_pod --identity chip\n";
-        std::cout << "  # Does an SC36 pod sit inside an ST-SC36 system, comparing chips rather than port ids?\n";
+        std::cout << "  # Does an SC36 pod sit inside an ST-SC36 system, comparing chips rather than port ids?\n\n";
+        std::cout << "  " << argv[0] << " -f built_system.textproto -p sc36.textproto -t bh_glx_pod\n";
+        std::cout << "  # Does a built system, as recorded in its FSD, implement the SC36 pod scheme?\n";
         exit(0);
     }
 
     Config config;
     config.cabling_path = result["cabling"].as<std::string>();
     config.deployment_path = result["deployment"].as<std::string>();
+    config.fsd_path = result["fsd"].as<std::string>();
     config.pattern_cabling_path = result["pattern-cabling"].as<std::string>();
     config.pattern_deployment_path = result["pattern-deployment"].as<std::string>();
     config.pattern_template = result["pattern-template"].as<std::string>();
+    config.pattern_fsd_path = result["pattern-fsd"].as<std::string>();
 
     // Listing what a descriptor offers is a question about one file, so it needs neither a target to
     // search nor a template to look for.
@@ -136,10 +151,29 @@ Config parse_arguments(int argc, char** argv) {
         exit(0);
     }
 
-    if (config.cabling_path.empty()) {
-        throw std::invalid_argument("--cabling is required");
+    // Each side comes from one kind of descriptor, and a factory system descriptor already says which
+    // hosts it is about, so it takes neither a deployment nor a template.
+    if (!config.fsd_path.empty()) {
+        if (!config.cabling_path.empty() || !config.deployment_path.empty()) {
+            throw std::invalid_argument(
+                "--fsd is the target on its own; it cannot be combined with --cabling or --deployment");
+        }
+    } else if (config.cabling_path.empty()) {
+        throw std::invalid_argument("A target is required, given with --cabling or --fsd");
     }
-    if (config.pattern_cabling_path.empty()) {
+
+    if (!config.pattern_fsd_path.empty()) {
+        if (!config.pattern_cabling_path.empty() || !config.pattern_deployment_path.empty() ||
+            !config.pattern_template.empty()) {
+            throw std::invalid_argument(
+                "--pattern-fsd is the pattern on its own; it cannot be combined with --pattern-cabling, "
+                "--pattern-deployment or --pattern-template");
+        }
+    } else if (config.pattern_cabling_path.empty()) {
+        if (config.cabling_path.empty()) {
+            throw std::invalid_argument(
+                "With an --fsd target the pattern must be given explicitly, using --pattern-cabling or --pattern-fsd");
+        }
         config.pattern_cabling_path = config.cabling_path;
         if (config.pattern_template.empty()) {
             throw std::invalid_argument(
@@ -147,9 +181,11 @@ Config parse_arguments(int argc, char** argv) {
                 "--pattern-template to say which part of it to look for");
         }
     }
-    for (const auto& path : {config.cabling_path, config.pattern_cabling_path}) {
-        if (!std::filesystem::exists(path)) {
-            throw std::invalid_argument("Cabling descriptor path not found: '" + path + "'");
+
+    for (const auto& path :
+         {config.cabling_path, config.fsd_path, config.pattern_cabling_path, config.pattern_fsd_path}) {
+        if (!path.empty() && !std::filesystem::exists(path)) {
+            throw std::invalid_argument("Descriptor path not found: '" + path + "'");
         }
     }
 
@@ -167,6 +203,14 @@ Config parse_arguments(int argc, char** argv) {
         "tier", result["tier"].as<std::string>(), {{"full", TierScope::Full}, {"own-level", TierScope::OwnLevel}});
     config.options.max_matches = result["max-matches"].as<size_t>();
     config.options.allow_disconnected = result["allow-disconnected"].as<bool>();
+
+    // A factory system descriptor records the cables a system has, not which tier of a hierarchy
+    // called for them, so there is no level to scope a pattern to.
+    if (config.tier == TierScope::OwnLevel && !config.pattern_fsd_path.empty()) {
+        throw std::invalid_argument(
+            "--tier own-level needs a pattern that declares cables at levels, which a factory system descriptor "
+            "does not; use --pattern-cabling with --pattern-template instead");
+    }
     return config;
 }
 
@@ -176,22 +220,30 @@ int main(int argc, char** argv) {
     try {
         Config config = parse_arguments(argc, argv);
 
-        std::string pattern_label = config.pattern_cabling_path;
-        if (!config.pattern_template.empty()) {
-            pattern_label += " :: " + config.pattern_template;
-        }
-        if (config.tier == TierScope::OwnLevel) {
-            pattern_label += " (own level only)";
-        }
+        MatchGraph pattern = [&] {
+            if (!config.pattern_fsd_path.empty()) {
+                return MatchGraph::from_fsd(config.pattern_fsd_path, config.pattern_fsd_path + " (fsd)");
+            }
+            std::string label = config.pattern_cabling_path;
+            if (!config.pattern_template.empty()) {
+                label += " :: " + config.pattern_template;
+            }
+            if (config.tier == TierScope::OwnLevel) {
+                label += " (own level only)";
+            }
+            return MatchGraph::load(
+                config.pattern_cabling_path,
+                config.pattern_deployment_path,
+                config.pattern_template,
+                config.tier,
+                label);
+        }();
 
-        MatchGraph pattern = MatchGraph::load(
-            config.pattern_cabling_path,
-            config.pattern_deployment_path,
-            config.pattern_template,
-            config.tier,
-            pattern_label);
         MatchGraph target =
-            MatchGraph::load(config.cabling_path, config.deployment_path, "", TierScope::Full, config.cabling_path);
+            config.fsd_path.empty()
+                ? MatchGraph::load(
+                      config.cabling_path, config.deployment_path, "", TierScope::Full, config.cabling_path)
+                : MatchGraph::from_fsd(config.fsd_path, config.fsd_path + " (fsd)");
 
         MatchResult result = match(pattern, target, config.options);
         std::cout << format_result(pattern, target, result, config.options);

--- a/tools/scaleout/src/run_cabling_matcher.cpp
+++ b/tools/scaleout/src/run_cabling_matcher.cpp
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <cxxopts.hpp>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <cabling_matcher/cabling_matcher.hpp>
+
+using namespace tt::scaleout_tools;
+using namespace tt::scaleout_tools::matcher;
+
+namespace {
+
+struct Config {
+    std::string cabling_path;
+    std::string deployment_path;
+    std::string pattern_cabling_path;
+    std::string pattern_deployment_path;
+    std::string pattern_template;
+    TierScope tier = TierScope::Full;
+    MatchOptions options;
+};
+
+template <typename T>
+T parse_choice(const std::string& flag, const std::string& value, const std::map<std::string, T>& choices) {
+    auto it = choices.find(value);
+    if (it == choices.end()) {
+        std::vector<std::string> names;
+        for (const auto& [name, unused] : choices) {
+            names.push_back(name);
+        }
+        throw std::invalid_argument(
+            "Invalid --" + flag + " '" + value + "'; expected one of: " + fmt::format("{}", fmt::join(names, ", ")));
+    }
+    return it->second;
+}
+
+Config parse_arguments(int argc, char** argv) {
+    cxxopts::Options options(
+        "run_cabling_matcher",
+        "Find a cabling scheme inside another cabling scheme.\n\n"
+        "The pattern is a cabling descriptor, or one graph_template out of one, and the target is the\n"
+        "descriptor to search. A match is an assignment of pattern hosts to target hosts under which\n"
+        "every pattern cable is a cable the target actually has.");
+
+    options.add_options()(
+        "c,cabling",
+        "Target cabling descriptor (.textproto file, or directory to merge)",
+        cxxopts::value<std::string>()->default_value(""))(
+        "d,deployment",
+        "Target deployment descriptor (.textproto). Without it, target hosts are named host_0..host_N-1 and "
+        "--cabling must be a single file",
+        cxxopts::value<std::string>()->default_value(""))(
+        "p,pattern-cabling",
+        "Pattern cabling descriptor (.textproto). Defaults to --cabling, which asks whether a template of a "
+        "descriptor recurs elsewhere in it",
+        cxxopts::value<std::string>()->default_value(""))(
+        "t,pattern-template",
+        "graph_template within the pattern descriptor to use as the pattern. Without it, the descriptor's own "
+        "root_instance is the pattern",
+        cxxopts::value<std::string>()->default_value(""))(
+        "pattern-deployment",
+        "Deployment descriptor for the pattern; only valid without --pattern-template, since a template is "
+        "instantiated with synthetic hosts",
+        cxxopts::value<std::string>()->default_value(""))(
+        "i,identity",
+        "How strictly ports must correspond: strict (same port id), chip (same ASIC reached, treating a port "
+        "that spans two ASICs as reaching either), relaxed (port ids ignored)",
+        cxxopts::value<std::string>()->default_value("strict"))(
+        "tray-symmetry",
+        "fixed (a pattern tray must map to the same tray number) or any (search tray relabellings that "
+        "preserve board types)",
+        cxxopts::value<std::string>()->default_value("fixed"))(
+        "m,mode",
+        "contains (the pattern appears somewhere in the target) or exact (it also accounts for every target "
+        "host and cable)",
+        cxxopts::value<std::string>()->default_value("contains"))(
+        "tier",
+        "full (the pattern is every cable in the template's subtree) or own-level (only the cables the template "
+        "declares itself)",
+        cxxopts::value<std::string>()->default_value("full"))(
+        "max-matches",
+        "Distinct target host sets to report before stopping; 0 for no limit. Proving there are no further "
+        "placements is the expensive part under --identity chip/relaxed, so pass 1 to ask a cheap does-it-fit "
+        "question",
+        cxxopts::value<size_t>()->default_value("16"))(
+        "allow-disconnected",
+        "Match each connected component of the pattern separately instead of refusing a pattern whose cables do "
+        "not tie all its hosts together",
+        cxxopts::value<bool>()->default_value("false")->implicit_value("true"))(
+        "list-templates",
+        "List the graph templates in the pattern descriptor and exit",
+        cxxopts::value<bool>()->default_value("false")->implicit_value("true"))("h,help", "Print usage information");
+
+    auto result = options.parse(argc, argv);
+    if (result.contains("help") || argc == 1) {
+        std::cout << options.help() << std::endl;
+        std::cout << "\nExit status: 0 if the pattern matched, 1 if it did not, 2 on error, 3 if the search ran out "
+                     "of budget without deciding.\n";
+        std::cout << "\nExamples:\n";
+        std::cout << "  " << argv[0] << " -c system.textproto -t bh_galaxy_sp\n";
+        std::cout << "  # Does the superpod template recur elsewhere in the system it came from?\n\n";
+        std::cout << "  " << argv[0] << " -c st_sc36.textproto -p sc36.textproto -t bh_glx_pod --identity chip\n";
+        std::cout << "  # Does an SC36 pod sit inside an ST-SC36 system, comparing chips rather than port ids?\n";
+        exit(0);
+    }
+
+    Config config;
+    config.cabling_path = result["cabling"].as<std::string>();
+    config.deployment_path = result["deployment"].as<std::string>();
+    config.pattern_cabling_path = result["pattern-cabling"].as<std::string>();
+    config.pattern_deployment_path = result["pattern-deployment"].as<std::string>();
+    config.pattern_template = result["pattern-template"].as<std::string>();
+
+    // Listing what a descriptor offers is a question about one file, so it needs neither a target to
+    // search nor a template to look for.
+    if (result["list-templates"].as<bool>()) {
+        const std::string& path =
+            config.pattern_cabling_path.empty() ? config.cabling_path : config.pattern_cabling_path;
+        if (path.empty()) {
+            throw std::invalid_argument(
+                "--list-templates needs a descriptor, given with --cabling or --pattern-cabling");
+        }
+        for (const auto& name : list_graph_templates(path)) {
+            std::cout << name << std::endl;
+        }
+        exit(0);
+    }
+
+    if (config.cabling_path.empty()) {
+        throw std::invalid_argument("--cabling is required");
+    }
+    if (config.pattern_cabling_path.empty()) {
+        config.pattern_cabling_path = config.cabling_path;
+        if (config.pattern_template.empty()) {
+            throw std::invalid_argument(
+                "Without --pattern-cabling the pattern comes from --cabling, which then needs "
+                "--pattern-template to say which part of it to look for");
+        }
+    }
+    for (const auto& path : {config.cabling_path, config.pattern_cabling_path}) {
+        if (!std::filesystem::exists(path)) {
+            throw std::invalid_argument("Cabling descriptor path not found: '" + path + "'");
+        }
+    }
+
+    config.options.port_identity = parse_choice<PortIdentity>(
+        "identity",
+        result["identity"].as<std::string>(),
+        {{"strict", PortIdentity::Strict}, {"chip", PortIdentity::Chip}, {"relaxed", PortIdentity::Relaxed}});
+    config.options.tray_symmetry = parse_choice<TraySymmetry>(
+        "tray-symmetry",
+        result["tray-symmetry"].as<std::string>(),
+        {{"fixed", TraySymmetry::None}, {"any", TraySymmetry::Full}});
+    config.options.mode = parse_choice<MatchMode>(
+        "mode", result["mode"].as<std::string>(), {{"contains", MatchMode::Contains}, {"exact", MatchMode::Exact}});
+    config.tier = parse_choice<TierScope>(
+        "tier", result["tier"].as<std::string>(), {{"full", TierScope::Full}, {"own-level", TierScope::OwnLevel}});
+    config.options.max_matches = result["max-matches"].as<size_t>();
+    config.options.allow_disconnected = result["allow-disconnected"].as<bool>();
+    return config;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        Config config = parse_arguments(argc, argv);
+
+        std::string pattern_label = config.pattern_cabling_path;
+        if (!config.pattern_template.empty()) {
+            pattern_label += " :: " + config.pattern_template;
+        }
+        if (config.tier == TierScope::OwnLevel) {
+            pattern_label += " (own level only)";
+        }
+
+        MatchGraph pattern = MatchGraph::load(
+            config.pattern_cabling_path,
+            config.pattern_deployment_path,
+            config.pattern_template,
+            config.tier,
+            pattern_label);
+        MatchGraph target =
+            MatchGraph::load(config.cabling_path, config.deployment_path, "", TierScope::Full, config.cabling_path);
+
+        MatchResult result = match(pattern, target, config.options);
+        std::cout << format_result(pattern, target, result, config.options);
+        if (result.matched) {
+            return 0;
+        }
+        return result.inconclusive() ? 3 : 1;
+    } catch (const cxxopts::exceptions::exception& e) {
+        std::cerr << "Error parsing arguments: " << e.what() << std::endl;
+        return 2;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 2;
+    }
+}

--- a/tools/scaleout/src/run_cabling_matcher.cpp
+++ b/tools/scaleout/src/run_cabling_matcher.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
 #include <map>
@@ -28,6 +29,7 @@ struct Config {
     std::string pattern_deployment_path;
     std::string pattern_template;
     std::string pattern_fsd_path;
+    std::vector<std::string> library_paths;
     TierScope tier = TierScope::Full;
     MatchOptions options;
 };
@@ -53,7 +55,10 @@ Config parse_arguments(int argc, char** argv) {
         "The pattern is a cabling descriptor, or one graph_template out of one, and the target is the\n"
         "descriptor to search. A match is an assignment of pattern hosts to target hosts under which\n"
         "every pattern cable is a cable the target actually has. Either side can instead be a factory\n"
-        "system descriptor, which asks whether a built system implements the scheme, or more than it.");
+        "system descriptor, which asks whether a built system implements the scheme, or more than it.\n\n"
+        "With --library the question is turned around: every scheme in a set of descriptors is looked\n"
+        "for in one target, which reports what the target is built out of rather than whether one\n"
+        "guess about it holds.");
 
     options.add_options()(
         "c,cabling",
@@ -83,6 +88,11 @@ Config parse_arguments(int argc, char** argv) {
         "Factory system descriptor to use as the pattern, in place of --pattern-cabling. Asks whether one built "
         "system's wiring is reproduced in another",
         cxxopts::value<std::string>()->default_value(""))(
+        "l,library",
+        "Search the target for every graph_template of these descriptors (files, or directories whose "
+        ".textproto files are each read on their own) instead of for one pattern, and report the largest "
+        "scheme each host belongs to. Repeatable",
+        cxxopts::value<std::vector<std::string>>())(
         "i,identity",
         "How strictly ports must correspond: strict (same port id), chip (same ASIC reached, treating a port "
         "that spans two ASICs as reaching either), relaxed (port ids ignored)",
@@ -123,7 +133,9 @@ Config parse_arguments(int argc, char** argv) {
         std::cout << "  " << argv[0] << " -c st_sc36.textproto -p sc36.textproto -t bh_glx_pod --identity chip\n";
         std::cout << "  # Does an SC36 pod sit inside an ST-SC36 system, comparing chips rather than port ids?\n\n";
         std::cout << "  " << argv[0] << " -f built_system.textproto -p sc36.textproto -t bh_glx_pod\n";
-        std::cout << "  # Does a built system, as recorded in its FSD, implement the SC36 pod scheme?\n";
+        std::cout << "  # Does a built system, as recorded in its FSD, implement the SC36 pod scheme?\n\n";
+        std::cout << "  " << argv[0] << " -f built_system.textproto -l descriptors/ --identity chip\n";
+        std::cout << "  # Which of the known schemes is this system built out of, and where?\n";
         exit(0);
     }
 
@@ -135,6 +147,9 @@ Config parse_arguments(int argc, char** argv) {
     config.pattern_deployment_path = result["pattern-deployment"].as<std::string>();
     config.pattern_template = result["pattern-template"].as<std::string>();
     config.pattern_fsd_path = result["pattern-fsd"].as<std::string>();
+    if (result.contains("library")) {
+        config.library_paths = result["library"].as<std::vector<std::string>>();
+    }
 
     // Listing what a descriptor offers is a question about one file, so it needs neither a target to
     // search nor a template to look for.
@@ -162,7 +177,19 @@ Config parse_arguments(int argc, char** argv) {
         throw std::invalid_argument("A target is required, given with --cabling or --fsd");
     }
 
-    if (!config.pattern_fsd_path.empty()) {
+    // A library is searched for in place of a pattern, not alongside one.
+    if (!config.library_paths.empty()) {
+        if (!config.pattern_cabling_path.empty() || !config.pattern_deployment_path.empty() ||
+            !config.pattern_template.empty() || !config.pattern_fsd_path.empty()) {
+            throw std::invalid_argument(
+                "--library says what to look for, so it cannot be combined with the --pattern-* options");
+        }
+        for (const auto& path : config.library_paths) {
+            if (!std::filesystem::exists(path)) {
+                throw std::invalid_argument("Library path not found: '" + path + "'");
+            }
+        }
+    } else if (!config.pattern_fsd_path.empty()) {
         if (!config.pattern_cabling_path.empty() || !config.pattern_deployment_path.empty() ||
             !config.pattern_template.empty()) {
             throw std::invalid_argument(
@@ -220,6 +247,21 @@ int main(int argc, char** argv) {
     try {
         Config config = parse_arguments(argc, argv);
 
+        MatchGraph target =
+            config.fsd_path.empty()
+                ? MatchGraph::load(
+                      config.cabling_path, config.deployment_path, "", TierScope::Full, config.cabling_path)
+                : MatchGraph::from_fsd(config.fsd_path, config.fsd_path + " (fsd)");
+
+        if (!config.library_paths.empty()) {
+            LibraryResult result = score_library(config.library_paths, target, config.options, config.tier);
+            std::cout << format_library_result(target, result, config.options);
+            bool anything_fits = std::any_of(result.findings.begin(), result.findings.end(), [](const auto& finding) {
+                return !finding.host_sets.empty();
+            });
+            return anything_fits ? 0 : 1;
+        }
+
         MatchGraph pattern = [&] {
             if (!config.pattern_fsd_path.empty()) {
                 return MatchGraph::from_fsd(config.pattern_fsd_path, config.pattern_fsd_path + " (fsd)");
@@ -238,12 +280,6 @@ int main(int argc, char** argv) {
                 config.tier,
                 label);
         }();
-
-        MatchGraph target =
-            config.fsd_path.empty()
-                ? MatchGraph::load(
-                      config.cabling_path, config.deployment_path, "", TierScope::Full, config.cabling_path)
-                : MatchGraph::from_fsd(config.fsd_path, config.fsd_path + " (fsd)");
 
         MatchResult result = match(pattern, target, config.options);
         std::cout << format_result(pattern, target, result, config.options);

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -144,6 +144,24 @@ target_link_libraries(
 # Make sure protobuf files are generated before compiling instance filter tests
 add_dependencies(test_instance_filter scaleout_generated_protos)
 
+# Test for finding one cabling scheme inside another
+add_executable(test_cabling_matcher)
+target_sources(test_cabling_matcher PRIVATE ${TEST_CABLING_MATCHER_SRCS})
+
+target_include_directories(test_cabling_matcher SYSTEM PRIVATE ${Metalium_BINARY_DIR}/tools/scaleout)
+
+target_link_libraries(
+    test_cabling_matcher
+    PRIVATE
+        TT::ScaleoutTools
+        gmock_main
+        enchantum::enchantum
+        protobuf::libprotobuf
+)
+
+# Make sure protobuf files are generated before compiling cabling matcher tests
+add_dependencies(test_cabling_matcher scaleout_generated_protos)
+
 add_executable(test_generate_rank_bindings)
 target_sources(test_generate_rank_bindings PRIVATE ${TEST_GENERATE_RANK_BINDINGS_SRCS})
 

--- a/tools/tests/scaleout/sources.cmake
+++ b/tools/tests/scaleout/sources.cmake
@@ -21,3 +21,5 @@ set(TEST_HOST_ID_ASSIGNMENT_SRCS test_host_id_assignment.cpp)
 set(TEST_INSTANCE_FILTER_SRCS test_instance_filter.cpp)
 
 set(TEST_GENERATE_RANK_BINDINGS_SRCS test_generate_rank_bindings.cpp)
+
+set(TEST_CABLING_MATCHER_SRCS test_cabling_matcher.cpp)

--- a/tools/tests/scaleout/test_cabling_matcher.cpp
+++ b/tools/tests/scaleout/test_cabling_matcher.cpp
@@ -12,7 +12,12 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
+#include <google/protobuf/text_format.h>
+
 #include <cabling_matcher/cabling_matcher.hpp>
+
+#include "protobuf/factory_system_descriptor.pb.h"
 
 namespace tt::scaleout_tools::matcher {
 namespace {
@@ -114,6 +119,27 @@ std::vector<std::pair<CableEndpoint, CableEndpoint>> endpoints(const MatchGraph&
     }
     std::sort(result.begin(), result.end());
     return result;
+}
+
+// The factory system descriptor a cabling descriptor would be built into, with the given hostnames.
+fsd::proto::FactorySystemDescriptor generate_fsd(std::string_view name, const std::vector<std::string>& hostnames) {
+    return CablingGenerator(fixture(name), hostnames).generate_factory_system_descriptor();
+}
+
+std::vector<std::string> synthetic_hostnames(size_t count) {
+    std::vector<std::string> hostnames;
+    for (size_t index = 0; index < count; ++index) {
+        hostnames.push_back(fmt::format("host_{}", index));
+    }
+    return hostnames;
+}
+
+std::string write_fsd(const fsd::proto::FactorySystemDescriptor& fsd) {
+    std::string contents;
+    if (!google::protobuf::TextFormat::PrintToString(fsd, &contents)) {
+        throw std::runtime_error("failed to serialise the factory system descriptor");
+    }
+    return write_descriptor("fsd", contents);
 }
 
 std::vector<std::vector<uint32_t>> host_sets(const MatchResult& result) {
@@ -347,6 +373,141 @@ TEST(CablingMatcher, APatternInTwoPiecesIsRefusedUnlessAskedFor) {
     for (const auto& component : result.components) {
         EXPECT_EQ(component.num_host_sets, 2u);
     }
+}
+
+// ---- Factory system descriptors as input ----
+
+TEST(CablingMatcherFsd, BuiltSystemHasTheSameCablesAsTheDescriptorItWasBuiltFrom) {
+    // An FSD records ethernet channels, a cabling descriptor records cables, and the FSD also carries
+    // the traces inside each board. Reading one back has to recover the cables exactly: same count,
+    // same ports, no traces among them.
+    for (std::string_view name : {kT3k, kDualT3k, k5Lb, kBhGalaxyMesh}) {
+        MatchGraph from_descriptor = load(name);
+        fsd::proto::FactorySystemDescriptor fsd =
+            generate_fsd(name, synthetic_hostnames(from_descriptor.hosts().size()));
+
+        // A connection with both ends on one board is wiring inside that board rather than a cable.
+        // Asserting these are present is what makes the comparison below evidence that they are
+        // dropped, rather than evidence that there were none to drop.
+        size_t within_a_board = 0;
+        for (const auto& connection : fsd.eth_connections().connection()) {
+            within_a_board += connection.endpoint_a().host_id() == connection.endpoint_b().host_id() &&
+                                      connection.endpoint_a().tray_id() == connection.endpoint_b().tray_id()
+                                  ? 1
+                                  : 0;
+        }
+        EXPECT_GT(within_a_board, 0u) << name;
+
+        MatchGraph from_fsd = MatchGraph::from_fsd(write_fsd(fsd), "fsd");
+
+        EXPECT_EQ(from_fsd.hosts().size(), from_descriptor.hosts().size()) << name;
+        EXPECT_EQ(endpoints(from_fsd), endpoints(from_descriptor)) << name;
+        EXPECT_TRUE(from_fsd.notes().empty()) << name << ": " << fmt::format("{}", from_fsd.notes().front());
+        for (const auto& cable : from_fsd.cables()) {
+            EXPECT_NE(cable.endpoint_a.port_type, PortType::TRACE) << name;
+            EXPECT_NE(cable.endpoint_b.port_type, PortType::TRACE) << name;
+        }
+    }
+}
+
+TEST(CablingMatcherFsd, ADescriptorMatchesTheSystemBuiltFromItExactly) {
+    // The capability this is for: given what was built, does it implement the scheme it was meant to?
+    for (std::string_view name : {kT3k, kDualT3k, k5Lb}) {
+        MatchGraph pattern = load(name);
+        MatchGraph target =
+            MatchGraph::from_fsd(write_fsd(generate_fsd(name, synthetic_hostnames(pattern.hosts().size()))), "fsd");
+
+        MatchOptions options = strict();
+        options.mode = MatchMode::Exact;
+        MatchResult result = match(pattern, target, options);
+        ASSERT_TRUE(result.matched) << name;
+        ASSERT_EQ(result.components[0].matches.size(), 1u) << name;
+        const auto& host_map = result.components[0].matches[0].host_map;
+        for (uint32_t host = 0; host < pattern.hosts().size(); ++host) {
+            EXPECT_EQ(host_map[host], host) << name << " host " << host;
+        }
+    }
+}
+
+TEST(CablingMatcherFsd, ASchemeIsFoundInABuiltSystemLargerThanIt) {
+    // Containment rather than equality: one T3K node is wired inside a dual-T3K system, twice over.
+    MatchGraph target = MatchGraph::from_fsd(write_fsd(generate_fsd(kDualT3k, synthetic_hostnames(2))), "dual_t3k fsd");
+    MatchResult result = match(load(kT3k), target, strict());
+    ASSERT_TRUE(result.matched);
+    EXPECT_EQ(host_sets(result), (std::vector<std::vector<uint32_t>>{{0}, {1}}));
+}
+
+TEST(CablingMatcherFsd, HostnamesComeFromTheDescriptor) {
+    // An FSD names its hosts, unlike a bare cabling descriptor, and those names are what make the
+    // report worth reading on a real system.
+    std::vector<std::string> hostnames{"rack1-shelf3", "rack1-shelf5"};
+    MatchGraph graph = MatchGraph::from_fsd(write_fsd(generate_fsd(kDualT3k, hostnames)), "fsd");
+    ASSERT_EQ(graph.hosts().size(), 2u);
+    EXPECT_EQ(graph.hosts()[0].name, hostnames[0]);
+    EXPECT_EQ(graph.hosts()[1].name, hostnames[1]);
+}
+
+TEST(CablingMatcherFsd, ACableMissingAChannelIsStillACableAndIsReported) {
+    // A dead lane leaves a cable with fewer channels than the boards call for. Whether that link is
+    // usable is not this tool's question, so the cable stands, but the report says what was read.
+    fsd::proto::FactorySystemDescriptor fsd = generate_fsd(kDualT3k, synthetic_hostnames(2));
+    auto* connections = fsd.mutable_eth_connections()->mutable_connection();
+    auto crossing = std::find_if(connections->begin(), connections->end(), [](const auto& connection) {
+        return connection.endpoint_a().host_id() != connection.endpoint_b().host_id();
+    });
+    ASSERT_NE(crossing, connections->end()) << "dual_t3k joins its two hosts, so some channel must cross";
+    connections->erase(crossing);
+
+    MatchGraph graph = MatchGraph::from_fsd(write_fsd(fsd), "fsd");
+    MatchGraph whole = load(kDualT3k);
+    EXPECT_EQ(graph.cables().size(), whole.cables().size()) << "the cable is short a channel, not absent";
+    ASSERT_EQ(graph.notes().size(), 1u);
+    EXPECT_NE(graph.notes()[0].find("missing channels"), std::string::npos) << graph.notes()[0];
+    EXPECT_NE(graph.notes()[0].find("1 of 2 channels"), std::string::npos) << graph.notes()[0];
+
+    // And the scheme is still recognised in it, which is the point of not dropping the cable.
+    MatchOptions options = strict();
+    options.mode = MatchMode::Exact;
+    MatchResult result = match(whole, graph, options);
+    EXPECT_TRUE(result.matched);
+    EXPECT_NE(format_result(whole, graph, result, options).find("Note (Target)"), std::string::npos)
+        << "a match reached by reading the input this way has to say so";
+}
+
+TEST(CablingMatcherFsd, AChannelListedTwiceIsReported) {
+    // Nothing about matching goes wrong, but a descriptor that counts a channel twice is not one to
+    // trust silently.
+    fsd::proto::FactorySystemDescriptor fsd = generate_fsd(kDualT3k, synthetic_hostnames(2));
+    const auto& connections = fsd.eth_connections().connection();
+    auto crossing = std::find_if(connections.begin(), connections.end(), [](const auto& connection) {
+        return connection.endpoint_a().host_id() != connection.endpoint_b().host_id();
+    });
+    ASSERT_NE(crossing, connections.end());
+    *fsd.mutable_eth_connections()->add_connection() = *crossing;
+
+    MatchGraph graph = MatchGraph::from_fsd(write_fsd(fsd), "fsd");
+    EXPECT_EQ(graph.cables().size(), load(kDualT3k).cables().size());
+    ASSERT_EQ(graph.notes().size(), 1u);
+    EXPECT_NE(graph.notes()[0].find("lists some twice"), std::string::npos) << graph.notes()[0];
+}
+
+TEST(CablingMatcherFsd, AConnectionOnATrayWithNoBoardIsRefused) {
+    // Without a board type there is no channel-to-port map, so the connection cannot be read at all
+    // and guessing would be worse than stopping.
+    fsd::proto::FactorySystemDescriptor fsd = generate_fsd(kT3k, synthetic_hostnames(1));
+    ASSERT_GT(fsd.eth_connections().connection_size(), 0);
+    fsd.mutable_eth_connections()->mutable_connection(0)->mutable_endpoint_a()->set_tray_id(99);
+
+    EXPECT_THROW(MatchGraph::from_fsd(write_fsd(fsd), "fsd"), std::exception);
+}
+
+TEST(CablingMatcherFsd, OneBuiltSystemIsComparedAgainstAnother) {
+    // Both sides read from FSDs, which asks whether one system's wiring is reproduced in another.
+    MatchGraph pattern = MatchGraph::from_fsd(write_fsd(generate_fsd(kT3k, {"node-a"})), "one node");
+    MatchGraph target = MatchGraph::from_fsd(write_fsd(generate_fsd(kDualT3k, {"node-b", "node-c"})), "two nodes");
+    MatchResult result = match(pattern, target, strict());
+    ASSERT_TRUE(result.matched);
+    EXPECT_EQ(host_sets(result), (std::vector<std::vector<uint32_t>>{{0}, {1}}));
 }
 
 // ---- Search shortcuts ----

--- a/tools/tests/scaleout/test_cabling_matcher.cpp
+++ b/tools/tests/scaleout/test_cabling_matcher.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <filesystem>
 #include <fstream>
@@ -27,6 +28,8 @@ constexpr std::string_view kT3k = "t3k.textproto";
 constexpr std::string_view kDualT3k = "dual_t3k.textproto";
 constexpr std::string_view k5Lb = "5_n300_lb_superpod.textproto";
 constexpr std::string_view kBhGalaxyMesh = "bh_galaxy_mesh.textproto";
+constexpr std::string_view kWhGalaxyMesh = "wh_galaxy_mesh.textproto";
+constexpr std::string_view k16Cluster = "16_n300_lb_cluster.textproto";
 
 std::string fixture(std::string_view name) { return std::string(kDescriptorDir) + std::string(name); }
 
@@ -43,6 +46,50 @@ std::string write_descriptor(const std::string& name, const std::string& content
     auto path = dir / (name + ".textproto");
     std::ofstream(path) << contents;
     return path.string();
+}
+
+// One graph template of BH galaxy nodes cabled as given on tray 1. Nodes are numbered from 1, and a
+// cable is (node, port, node, port).
+using Cable = std::array<uint32_t, 4>;
+std::string node_template(const std::string& name, size_t num_nodes, const std::vector<Cable>& cables) {
+    std::string out = fmt::format("graph_templates {{\n  key: \"{}\"\n  value {{\n", name);
+    for (size_t node = 1; node <= num_nodes; ++node) {
+        out += fmt::format(
+            "    children {{ name: \"node{}\" node_ref {{ node_descriptor: \"BH_GALAXY_REV_C\" }} }}\n", node);
+    }
+    out += "    internal_connections {\n      key: \"QSFP_DD\"\n      value {\n";
+    for (const auto& [node_a, port_a, node_b, port_b] : cables) {
+        out += fmt::format(
+            "        connections {{ port_a {{ path: [\"node{}\"] tray_id: 1 port_id: {} }} "
+            "port_b {{ path: [\"node{}\"] tray_id: 1 port_id: {} }} }}\n",
+            node_a,
+            port_a,
+            node_b,
+            port_b);
+    }
+    out += "      }\n    }\n  }\n}\n";
+    return out;
+}
+
+// Instantiates a template's nodes onto hosts 0..n-1, which is what makes a descriptor loadable.
+std::string root_instance_for(const std::string& name, size_t num_nodes) {
+    std::string out = fmt::format("root_instance {{\n  template_name: \"{}\"\n", name);
+    for (size_t node = 1; node <= num_nodes; ++node) {
+        out += fmt::format("  child_mappings {{ key: \"node{}\" value {{ host_id: {} }} }}\n", node, node - 1);
+    }
+    return out + "}\n";
+}
+
+// Several descriptors in one directory, which is what a library path stands for.
+std::string write_library(const std::vector<std::pair<std::string, std::string>>& descriptors) {
+    static std::atomic<int> sequence{0};
+    auto dir = std::filesystem::temp_directory_path() / ("cabling_library_" + std::to_string(sequence++));
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    for (const auto& [name, contents] : descriptors) {
+        std::ofstream(dir / (name + ".textproto")) << contents;
+    }
+    return dir.string();
 }
 
 // Two BH galaxy nodes with a single cable between them, on the given ports of tray 1.
@@ -501,6 +548,25 @@ TEST(CablingMatcherFsd, AConnectionOnATrayWithNoBoardIsRefused) {
     EXPECT_THROW(MatchGraph::from_fsd(write_fsd(fsd), "fsd"), std::exception);
 }
 
+TEST(CablingMatcherFsd, ABoardTypeSpelledByItsOtherEnumNameIsAccepted) {
+    // The board type enum spells a wormhole galaxy tray both UBB and UBB_WORMHOLE. Reflection
+    // surfaces only the first, and descriptors written elsewhere use the second, so reading one
+    // through reflection alone rejects a system it otherwise understands completely.
+    ASSERT_EQ(get_board_type_from_string("UBB_WORMHOLE"), get_board_type_from_string("UBB"));
+
+    fsd::proto::FactorySystemDescriptor fsd = generate_fsd(kWhGalaxyMesh, synthetic_hostnames(1));
+    size_t respelled = 0;
+    for (auto& location : *fsd.mutable_board_types()->mutable_board_locations()) {
+        if (get_board_type_from_string(location.board_type()) == BoardType::UBB_WORMHOLE) {
+            location.set_board_type("UBB_WORMHOLE");
+            ++respelled;
+        }
+    }
+    ASSERT_GT(respelled, 0u) << "a wormhole galaxy is built from UBB trays, so there is something to respell";
+
+    EXPECT_EQ(endpoints(MatchGraph::from_fsd(write_fsd(fsd), "fsd")), endpoints(load(kWhGalaxyMesh)));
+}
+
 TEST(CablingMatcherFsd, OneBuiltSystemIsComparedAgainstAnother) {
     // Both sides read from FSDs, which asks whether one system's wiring is reproduced in another.
     MatchGraph pattern = MatchGraph::from_fsd(write_fsd(generate_fsd(kT3k, {"node-a"})), "one node");
@@ -508,6 +574,145 @@ TEST(CablingMatcherFsd, OneBuiltSystemIsComparedAgainstAnother) {
     MatchResult result = match(pattern, target, strict());
     ASSERT_TRUE(result.matched);
     EXPECT_EQ(host_sets(result), (std::vector<std::vector<uint32_t>>{{0}, {1}}));
+}
+
+// ---- Scoring a library of schemes ----
+
+TEST(CablingMatcherLibrary, TheSchemesInsideAMatchedOneAreReportedAsCoveredByIt) {
+    // The cluster fixture is built from four superpods, so both fit, and saying the superpod fits in
+    // four places is only worth reading if it also says all four are inside the cluster.
+    std::string path = fixture(k16Cluster);
+    LibraryResult result = score_library({path}, load(k16Cluster), strict(), TierScope::Full);
+
+    ASSERT_EQ(result.entries.size(), 2u);
+    ASSERT_TRUE(result.skipped.empty()) << result.skipped.front().second;
+
+    EXPECT_EQ(result.entries[0].template_name, "n300_lb_cluster") << "the larger scheme is reported first";
+    EXPECT_EQ(result.findings[0].host_sets.size(), 1u);
+    EXPECT_TRUE(result.findings[0].covered_by.empty()) << "nothing in the library is bigger than the cluster";
+
+    EXPECT_EQ(result.entries[1].template_name, "n300_lb_superpod");
+    EXPECT_EQ(result.findings[1].host_sets.size(), 4u);
+    EXPECT_EQ(result.findings[1].covered_by, std::vector<size_t>{0});
+}
+
+TEST(CablingMatcherLibrary, ASchemeAlsoFoundOutsideTheLargerOneIsNotCoveredByIt) {
+    // The discriminating case for coverage. A three node chain, and a pair that sits inside it but
+    // also once more on hosts the chain does not reach. That second placement is exactly what a
+    // reader wants to know about, so the pair must be reported in its own right.
+    std::string library = write_library(
+        {{"schemes",
+          node_template("chain", 3, {{1, 1, 2, 1}, {2, 2, 3, 2}}) + node_template("pair", 2, {{1, 1, 2, 1}})}});
+    MatchGraph target = MatchGraph::load(
+        write_descriptor(
+            "target",
+            node_template("target", 5, {{1, 1, 2, 1}, {2, 2, 3, 2}, {4, 1, 5, 1}}) + root_instance_for("target", 5)),
+        "",
+        "",
+        TierScope::Full,
+        "chain and a spare pair");
+
+    LibraryResult result = score_library({library}, target, strict(), TierScope::Full);
+    ASSERT_EQ(result.entries.size(), 2u);
+    ASSERT_TRUE(result.skipped.empty()) << result.skipped.front().second;
+
+    EXPECT_EQ(result.entries[0].template_name, "chain");
+    EXPECT_EQ(result.findings[0].host_sets, (std::vector<std::vector<uint32_t>>{{0, 1, 2}}));
+
+    EXPECT_EQ(result.entries[1].template_name, "pair");
+    EXPECT_EQ(result.findings[1].host_sets, (std::vector<std::vector<uint32_t>>{{0, 1}, {3, 4}}));
+    EXPECT_TRUE(result.findings[1].covered_by.empty()) << "one of its two placements is outside the chain";
+}
+
+TEST(CablingMatcherLibrary, ASchemeOnlyFoundInsideTheLargerOneIsCoveredByIt) {
+    // The same library, with the spare pair taken away: now every placement of the pair is inside
+    // the chain, and repeating it as a finding of its own would add nothing.
+    std::string library = write_library(
+        {{"schemes",
+          node_template("chain", 3, {{1, 1, 2, 1}, {2, 2, 3, 2}}) + node_template("pair", 2, {{1, 1, 2, 1}})}});
+    MatchGraph target = MatchGraph::load(
+        write_descriptor(
+            "target", node_template("target", 3, {{1, 1, 2, 1}, {2, 2, 3, 2}}) + root_instance_for("target", 3)),
+        "",
+        "",
+        TierScope::Full,
+        "chain alone");
+
+    LibraryResult result = score_library({library}, target, strict(), TierScope::Full);
+    ASSERT_EQ(result.entries.size(), 2u);
+    EXPECT_EQ(result.findings[1].host_sets, (std::vector<std::vector<uint32_t>>{{0, 1}}));
+    EXPECT_EQ(result.findings[1].covered_by, std::vector<size_t>{0});
+}
+
+TEST(CablingMatcherLibrary, SameNamedTemplatesInDifferentFilesStayDistinct) {
+    // A library is a set of files, each free to name its templates as it likes, and both of these
+    // call theirs "pair". They are different schemes and the report has to tell them apart.
+    std::string library =
+        write_library({{"on_port_1", two_node_descriptor(1, 1)}, {"on_port_4", two_node_descriptor(4, 4)}});
+    MatchGraph target =
+        MatchGraph::load(write_descriptor("target", two_node_descriptor(1, 1)), "", "", TierScope::Full, "target");
+
+    LibraryResult result = score_library({library}, target, strict(), TierScope::Full);
+    ASSERT_EQ(result.entries.size(), 2u);
+    EXPECT_NE(result.entries[0].name, result.entries[1].name);
+
+    // Same size, so the order between them is by name, and only the one cabled like the target fits.
+    size_t on_port_1 = result.entries[0].name.find("on_port_1") != std::string::npos ? 0 : 1;
+    EXPECT_FALSE(result.findings[on_port_1].host_sets.empty());
+    EXPECT_TRUE(result.findings[1 - on_port_1].host_sets.empty());
+}
+
+TEST(CablingMatcherLibrary, EqualSizedSchemesDoNotCoverEachOther) {
+    // Both fit the same two hosts under relaxed ports, but neither contains the other: they are
+    // alternative descriptions of that wiring, and calling one covered would hide it.
+    std::string library =
+        write_library({{"on_port_1", two_node_descriptor(1, 1)}, {"on_port_4", two_node_descriptor(4, 4)}});
+    MatchOptions options = strict();
+    options.port_identity = PortIdentity::Relaxed;
+
+    LibraryResult result = score_library(
+        {library},
+        MatchGraph::load(write_descriptor("target", two_node_descriptor(1, 1)), "", "", TierScope::Full, "target"),
+        options,
+        TierScope::Full);
+    ASSERT_EQ(result.entries.size(), 2u);
+    ASSERT_FALSE(result.findings[0].host_sets.empty());
+    ASSERT_FALSE(result.findings[1].host_sets.empty());
+    EXPECT_EQ(result.findings[0].host_sets, result.findings[1].host_sets);
+    EXPECT_TRUE(result.findings[1].covered_by.empty());
+}
+
+TEST(CablingMatcherLibrary, ASchemeThatDoesNotFitSaysWhereItGotStuck) {
+    LibraryResult result = score_library({fixture(kDualT3k)}, load(kT3k), strict(), TierScope::Full);
+    ASSERT_EQ(result.entries.size(), 1u);
+    EXPECT_TRUE(result.findings[0].host_sets.empty());
+    EXPECT_FALSE(result.findings[0].stuck_at.empty());
+    EXPECT_FALSE(result.findings[0].inconclusive);
+
+    std::string report = format_library_result(load(kT3k), result, strict());
+    EXPECT_NE(report.find("NOTHING IN THE LIBRARY FITS"), std::string::npos);
+    EXPECT_NE(report.find("Does not fit"), std::string::npos);
+}
+
+TEST(CablingMatcherLibrary, ASchemeWithNoCablesOfItsOwnIsSkippedRatherThanMatched) {
+    // A single-node template declares no cables itself, so at own-level scope there is nothing to
+    // look for and any host would satisfy it. That is not an answer worth reporting as a match.
+    LibraryResult result = score_library({fixture(kWhGalaxyMesh)}, load(kWhGalaxyMesh), strict(), TierScope::OwnLevel);
+    EXPECT_TRUE(result.entries.empty());
+    ASSERT_FALSE(result.skipped.empty());
+    EXPECT_NE(result.skipped.front().second.find("no cables"), std::string::npos) << result.skipped.front().second;
+}
+
+TEST(CablingMatcherLibrary, HostsBelongingToNoKnownSchemeAreCalledOut) {
+    // Half of a two-superpod target is wired as a known superpod and half is not. A report that only
+    // listed what matched would leave the other half unaccounted for.
+    LibraryResult result = score_library({fixture(k5Lb)}, load(k16Cluster), strict(), TierScope::Full);
+    ASSERT_EQ(result.entries.size(), 1u);
+    EXPECT_TRUE(result.findings[0].host_sets.empty()) << "the 5lb star is not how the cluster wires its superpods";
+
+    std::string report = format_library_result(load(k16Cluster), result, strict());
+    EXPECT_EQ(report.find("Largest scheme each host belongs to"), std::string::npos)
+        << "with nothing matched there is no coverage to summarise";
 }
 
 // ---- Search shortcuts ----

--- a/tools/tests/scaleout/test_cabling_matcher.cpp
+++ b/tools/tests/scaleout/test_cabling_matcher.cpp
@@ -1,0 +1,397 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <cabling_matcher/cabling_matcher.hpp>
+
+namespace tt::scaleout_tools::matcher {
+namespace {
+
+constexpr std::string_view kDescriptorDir = "tools/tests/scaleout/cabling_descriptors/";
+constexpr std::string_view kT3k = "t3k.textproto";
+constexpr std::string_view kDualT3k = "dual_t3k.textproto";
+constexpr std::string_view k5Lb = "5_n300_lb_superpod.textproto";
+constexpr std::string_view kBhGalaxyMesh = "bh_galaxy_mesh.textproto";
+
+std::string fixture(std::string_view name) { return std::string(kDescriptorDir) + std::string(name); }
+
+MatchGraph load(std::string_view name, std::string template_name = "", TierScope tier = TierScope::Full) {
+    return MatchGraph::load(fixture(name), "", template_name, tier, std::string(name));
+}
+
+// Writes a descriptor to a scratch file so a test can state exactly the cabling it is about.
+std::string write_descriptor(const std::string& name, const std::string& contents) {
+    static std::atomic<int> sequence{0};
+    auto dir = std::filesystem::temp_directory_path() / ("cabling_matcher_" + std::to_string(sequence++));
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    auto path = dir / (name + ".textproto");
+    std::ofstream(path) << contents;
+    return path.string();
+}
+
+// Two BH galaxy nodes with a single cable between them, on the given ports of tray 1.
+std::string two_node_descriptor(uint32_t port_a, uint32_t port_b) {
+    return R"(
+graph_templates {
+  key: "pair"
+  value {
+    children { name: "node1" node_ref { node_descriptor: "BH_GALAXY_REV_C" } }
+    children { name: "node2" node_ref { node_descriptor: "BH_GALAXY_REV_C" } }
+    internal_connections {
+      key: "QSFP_DD"
+      value {
+        connections {
+          port_a { path: ["node1"] tray_id: 1 port_id: )" +
+           std::to_string(port_a) + R"( }
+          port_b { path: ["node2"] tray_id: 1 port_id: )" +
+           std::to_string(port_b) + R"( }
+        }
+      }
+    }
+  }
+}
+root_instance {
+  template_name: "pair"
+  child_mappings { key: "node1" value { host_id: 0 } }
+  child_mappings { key: "node2" value { host_id: 1 } }
+}
+)";
+}
+
+// Four BH galaxy nodes cabled as two separate pairs, so nothing ties the halves together.
+std::string two_pairs_descriptor() {
+    return R"(
+graph_templates {
+  key: "two_pairs"
+  value {
+    children { name: "node1" node_ref { node_descriptor: "BH_GALAXY_REV_C" } }
+    children { name: "node2" node_ref { node_descriptor: "BH_GALAXY_REV_C" } }
+    children { name: "node3" node_ref { node_descriptor: "BH_GALAXY_REV_C" } }
+    children { name: "node4" node_ref { node_descriptor: "BH_GALAXY_REV_C" } }
+    internal_connections {
+      key: "QSFP_DD"
+      value {
+        connections {
+          port_a { path: ["node1"] tray_id: 1 port_id: 1 }
+          port_b { path: ["node2"] tray_id: 1 port_id: 1 }
+        }
+        connections {
+          port_a { path: ["node3"] tray_id: 1 port_id: 1 }
+          port_b { path: ["node4"] tray_id: 1 port_id: 1 }
+        }
+      }
+    }
+  }
+}
+root_instance {
+  template_name: "two_pairs"
+  child_mappings { key: "node1" value { host_id: 0 } }
+  child_mappings { key: "node2" value { host_id: 1 } }
+  child_mappings { key: "node3" value { host_id: 2 } }
+  child_mappings { key: "node4" value { host_id: 3 } }
+}
+)";
+}
+
+// Cables reduced to the ports they join, which is all that matching looks at. Where a cable was
+// declared is deliberately left out: the same cabling reached through a synthesised root is
+// declared at a different path.
+std::vector<std::pair<CableEndpoint, CableEndpoint>> endpoints(const MatchGraph& graph) {
+    std::vector<std::pair<CableEndpoint, CableEndpoint>> result;
+    for (const auto& cable : graph.cables()) {
+        result.emplace_back(cable.endpoint_a, cable.endpoint_b);
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+std::vector<std::vector<uint32_t>> host_sets(const MatchResult& result) {
+    std::vector<std::vector<uint32_t>> sets;
+    for (const auto& component : result.components) {
+        for (const auto& match : component.matches) {
+            std::vector<uint32_t> hosts;
+            for (uint32_t pattern_host : component.pattern_hosts) {
+                hosts.push_back(match.host_map[pattern_host]);
+            }
+            std::sort(hosts.begin(), hosts.end());
+            sets.push_back(std::move(hosts));
+        }
+    }
+    std::sort(sets.begin(), sets.end());
+    return sets;
+}
+
+MatchOptions strict() { return MatchOptions{.max_matches = 0}; }
+
+// ---- Loading and pattern synthesis ----
+
+TEST(CablingMatcher, ListsGraphTemplates) {
+    EXPECT_EQ(list_graph_templates(fixture(kDualT3k)), std::vector<std::string>{"dual_t3k"});
+}
+
+TEST(CablingMatcher, TemplateAsPatternMatchesTheRootInstanceItDefines) {
+    // dual_t3k's root instance is an instantiation of the dual_t3k template, so synthesising a root
+    // for that template has to reproduce the same graph.
+    MatchGraph from_root = load(kDualT3k);
+    MatchGraph from_template = load(kDualT3k, "dual_t3k");
+    EXPECT_EQ(from_template.hosts().size(), from_root.hosts().size());
+    EXPECT_EQ(endpoints(from_template), endpoints(from_root));
+}
+
+TEST(CablingMatcher, UnknownTemplateNameIsRejectedWithTheAvailableOnes) {
+    EXPECT_THROW(load(kDualT3k, "no_such_template"), std::exception);
+}
+
+TEST(CablingMatcher, OwnLevelTierKeepsOnlyTheCablesTheTemplateDeclares) {
+    // dual_t3k declares 4 cables of its own and inherits the rest from the two nodes it contains.
+    MatchGraph own_level = load(kDualT3k, "dual_t3k", TierScope::OwnLevel);
+    MatchGraph full = load(kDualT3k, "dual_t3k", TierScope::Full);
+    EXPECT_EQ(own_level.cables().size(), 4u);
+    EXPECT_GT(full.cables().size(), own_level.cables().size());
+    for (const auto& cable : own_level.cables()) {
+        EXPECT_NE(cable.endpoint_a.host_id, cable.endpoint_b.host_id)
+            << "a cable declared by dual_t3k itself has to cross between its two nodes";
+    }
+}
+
+// ---- Matching ----
+
+TEST(CablingMatcher, EveryDescriptorMatchesItselfExactlyAsTheIdentity) {
+    for (std::string_view name : {kT3k, kDualT3k, k5Lb, kBhGalaxyMesh}) {
+        MatchGraph graph = load(name);
+        MatchOptions options = strict();
+        options.mode = MatchMode::Exact;
+        MatchResult result = match(graph, graph, options);
+        ASSERT_TRUE(result.matched) << name;
+        ASSERT_EQ(result.components.size(), 1u) << name;
+        ASSERT_EQ(result.components[0].matches.size(), 1u) << name;
+        const auto& host_map = result.components[0].matches[0].host_map;
+        for (uint32_t host = 0; host < graph.hosts().size(); ++host) {
+            EXPECT_EQ(host_map[host], host) << name << " host " << host;
+        }
+    }
+}
+
+TEST(CablingMatcher, RoleAssignmentsCountTheSymmetriesOfThePattern) {
+    MatchOptions options = strict();
+    options.mode = MatchMode::Exact;
+
+    // dual_t3k joins its two nodes on the same tray and port at both ends, so exchanging the nodes
+    // maps every cable onto a cable and the pattern fits its own cluster two ways.
+    MatchGraph dual_t3k = load(kDualT3k);
+    MatchResult symmetric = match(dual_t3k, dual_t3k, options);
+    ASSERT_TRUE(symmetric.matched);
+    ASSERT_EQ(symmetric.components[0].matches.size(), 1u) << "both ways use the same pair of hosts";
+    EXPECT_EQ(symmetric.components[0].matches[0].role_assignments, 2u);
+
+    // The 5lb star reaches each of its four outer nodes from a different port of the centre, so no
+    // exchange of nodes preserves the cabling and the only way it fits is the one.
+    MatchGraph star = load(k5Lb);
+    MatchResult rigid = match(star, star, options);
+    ASSERT_TRUE(rigid.matched);
+    ASSERT_EQ(rigid.components[0].matches.size(), 1u);
+    EXPECT_EQ(rigid.components[0].matches[0].role_assignments, 1u);
+}
+
+TEST(CablingMatcher, OneNodeSitsInEitherHalfOfATwoNodeCluster) {
+    MatchResult result = match(load(kT3k), load(kDualT3k), strict());
+    ASSERT_TRUE(result.matched);
+    // A single node has no cable to any other, so it is placed by its boards alone and fits either
+    // half. Both placements are reported, and neither is preferred.
+    EXPECT_EQ(host_sets(result), (std::vector<std::vector<uint32_t>>{{0}, {1}}));
+}
+
+TEST(CablingMatcher, TwoNodesDoNotFitInOne) {
+    MatchResult result = match(load(kDualT3k), load(kT3k), strict());
+    EXPECT_FALSE(result.matched);
+    EXPECT_FALSE(result.inconclusive());
+}
+
+TEST(CablingMatcher, HostsWithDifferentBoardsNeverStandInForEachOther) {
+    // An N300 loopback node and a Blackhole galaxy have nothing in common to match on.
+    EXPECT_FALSE(match(load(kT3k), load(kBhGalaxyMesh), strict()).matched);
+    EXPECT_FALSE(match(load(kBhGalaxyMesh), load(kT3k), strict()).matched);
+}
+
+TEST(CablingMatcher, ExactMatchRejectsAPatternSmallerThanTheTarget) {
+    MatchOptions options = strict();
+    options.mode = MatchMode::Exact;
+    MatchResult result = match(load(kT3k), load(kDualT3k), options);
+    EXPECT_FALSE(result.matched);
+    EXPECT_FALSE(result.exact_mismatch.empty()) << "the host counts alone rule this out, before any search";
+}
+
+// ---- Port identity modes ----
+
+TEST(CablingMatcher, PortsOfABlackholeGalaxyReachTheAsicsTheBoardSays) {
+    // The premise of the chip identity mode: some ports reach one ASIC, others either of two, and
+    // that is what makes a cable on one port able to stand in for a cable on another.
+    const auto& port_1 = asics_for_port(BoardType::UBB_BLACKHOLE, PortType::QSFP_DD, PortId(1));
+    const auto& port_8 = asics_for_port(BoardType::UBB_BLACKHOLE, PortType::QSFP_DD, PortId(8));
+    EXPECT_EQ(port_1.size(), 1u);
+    EXPECT_EQ(port_8.size(), 2u);
+    EXPECT_TRUE(std::includes(port_8.begin(), port_8.end(), port_1.begin(), port_1.end()))
+        << "port 8 spans the ASIC port 1 reaches, so a port 1 cable can be carried by port 8";
+}
+
+TEST(CablingMatcher, ChipIdentityAcceptsADifferentPortReachingTheSameAsic) {
+    // Port 1 reaches a single ASIC; port 8 reaches that one or its neighbour. A cable the pattern
+    // puts on port 1 is therefore satisfied by a target cable on port 8, but only once port ids stop
+    // being identities.
+    MatchGraph pattern =
+        MatchGraph::load(write_descriptor("pattern", two_node_descriptor(1, 1)), "", "", TierScope::Full, "pattern");
+    MatchGraph target =
+        MatchGraph::load(write_descriptor("target", two_node_descriptor(8, 8)), "", "", TierScope::Full, "target");
+
+    EXPECT_FALSE(match(pattern, target, strict()).matched);
+
+    MatchOptions chip = strict();
+    chip.port_identity = PortIdentity::Chip;
+    EXPECT_TRUE(match(pattern, target, chip).matched);
+}
+
+TEST(CablingMatcher, ChipIdentityStillRefusesPortsOnDifferentAsics) {
+    // Port 1 and port 4 reach different ASICs, so no relaxation short of ignoring ports entirely
+    // lets one carry the other.
+    MatchGraph pattern =
+        MatchGraph::load(write_descriptor("pattern", two_node_descriptor(1, 1)), "", "", TierScope::Full, "pattern");
+    MatchGraph target =
+        MatchGraph::load(write_descriptor("target", two_node_descriptor(4, 4)), "", "", TierScope::Full, "target");
+
+    ASSERT_TRUE(
+        asics_for_port(BoardType::UBB_BLACKHOLE, PortType::QSFP_DD, PortId(1)) !=
+        asics_for_port(BoardType::UBB_BLACKHOLE, PortType::QSFP_DD, PortId(4)));
+
+    MatchOptions chip = strict();
+    chip.port_identity = PortIdentity::Chip;
+    EXPECT_FALSE(match(pattern, target, chip).matched);
+
+    MatchOptions relaxed = strict();
+    relaxed.port_identity = PortIdentity::Relaxed;
+    EXPECT_TRUE(match(pattern, target, relaxed).matched);
+}
+
+TEST(CablingMatcher, RelaxingPortIdentityNeverLosesAMatch) {
+    // Each mode is a relaxation of the one before it, so a pattern that fits under a stricter reading
+    // of ports has to keep fitting under a looser one.
+    for (std::string_view pattern_name : {kT3k, kDualT3k, k5Lb}) {
+        for (std::string_view target_name : {kT3k, kDualT3k, k5Lb}) {
+            MatchGraph pattern = load(pattern_name);
+            MatchGraph target = load(target_name);
+            MatchOptions options = strict();
+            options.max_matches = 1;
+            bool strict_match = match(pattern, target, options).matched;
+            options.port_identity = PortIdentity::Chip;
+            bool chip_match = match(pattern, target, options).matched;
+            options.port_identity = PortIdentity::Relaxed;
+            bool relaxed_match = match(pattern, target, options).matched;
+            EXPECT_TRUE(!strict_match || chip_match) << pattern_name << " in " << target_name;
+            EXPECT_TRUE(!chip_match || relaxed_match) << pattern_name << " in " << target_name;
+        }
+    }
+}
+
+// ---- Diagnostics ----
+
+TEST(CablingMatcher, AFailureNamesThePatternCableThatCouldNotBePlaced) {
+    // Both clusters wire one cable between their two nodes, but on ports that reach different ASICs,
+    // so the very first cable fails and the report has to say so in those terms.
+    MatchGraph pattern =
+        MatchGraph::load(write_descriptor("pattern", two_node_descriptor(1, 1)), "", "", TierScope::Full, "pattern");
+    MatchGraph target =
+        MatchGraph::load(write_descriptor("target", two_node_descriptor(4, 4)), "", "", TierScope::Full, "target");
+
+    MatchResult result = match(pattern, target, strict());
+    ASSERT_FALSE(result.matched);
+    ASSERT_EQ(result.components.size(), 1u);
+    const auto& diagnosis = result.components[0].diagnosis;
+    ASSERT_TRUE(diagnosis.has_value());
+
+    const auto& stuck = pattern.cables()[diagnosis->pattern_cable];
+    EXPECT_NE(stuck.endpoint_a.host_id, stuck.endpoint_b.host_id);
+    EXPECT_EQ(*stuck.endpoint_a.port_id, 1u);
+
+    std::string report = format_result(pattern, target, result, strict());
+    EXPECT_NE(report.find("NO MATCH"), std::string::npos);
+    EXPECT_NE(report.find("Stuck on pattern cable"), std::string::npos);
+}
+
+// ---- Disconnected patterns ----
+
+TEST(CablingMatcher, APatternInTwoPiecesIsRefusedUnlessAskedFor) {
+    // Nothing ties the pieces to each other, so the matches would be the cross product of their
+    // independent placements. The default is to say so rather than produce that.
+    std::string path = write_descriptor("two_pairs", two_pairs_descriptor());
+    MatchGraph pattern = MatchGraph::load(path, "", "", TierScope::Full, "two_pairs");
+    ASSERT_EQ(pattern.components().size(), 2u);
+
+    EXPECT_THROW(match(pattern, pattern, strict()), std::exception);
+
+    MatchOptions options = strict();
+    options.allow_disconnected = true;
+    MatchResult result = match(pattern, pattern, options);
+    ASSERT_TRUE(result.matched);
+    ASSERT_EQ(result.components.size(), 2u);
+    // Either pair can play either role, so each piece has both pairs as candidates.
+    for (const auto& component : result.components) {
+        EXPECT_EQ(component.num_host_sets, 2u);
+    }
+}
+
+// ---- Search shortcuts ----
+
+TEST(CablingMatcher, AbandoningEquivalentPlacementsDoesNotChangeTheAnswer) {
+    // The search stops exploring the other ways of dealing out the same cables and trays once one
+    // has been recorded. That is only sound if the host sets and the count of role assignments come
+    // out the same as they do when every placement is visited.
+    for (std::string_view name : {kT3k, kDualT3k, k5Lb}) {
+        for (auto identity : {PortIdentity::Strict, PortIdentity::Chip}) {
+            MatchGraph graph = load(name);
+            MatchOptions pruned = strict();
+            pruned.port_identity = identity;
+            MatchOptions exhaustive = pruned;
+            exhaustive.search_every_placement = true;
+
+            MatchResult from_pruned = match(graph, graph, pruned);
+            MatchResult from_exhaustive = match(graph, graph, exhaustive);
+            ASSERT_FALSE(from_pruned.inconclusive()) << name;
+            ASSERT_FALSE(from_exhaustive.inconclusive()) << name;
+            EXPECT_EQ(host_sets(from_pruned), host_sets(from_exhaustive)) << name;
+            ASSERT_EQ(from_pruned.components.size(), from_exhaustive.components.size()) << name;
+            for (size_t index = 0; index < from_pruned.components.size(); ++index) {
+                const auto& pruned_matches = from_pruned.components[index].matches;
+                const auto& exhaustive_matches = from_exhaustive.components[index].matches;
+                ASSERT_EQ(pruned_matches.size(), exhaustive_matches.size()) << name;
+                for (size_t match_index = 0; match_index < pruned_matches.size(); ++match_index) {
+                    EXPECT_EQ(
+                        pruned_matches[match_index].role_assignments, exhaustive_matches[match_index].role_assignments)
+                        << name << " match " << match_index;
+                }
+            }
+        }
+    }
+}
+
+TEST(CablingMatcher, StoppingAtTheReportingLimitIsReportedAsSuch) {
+    MatchOptions options = strict();
+    options.max_matches = 1;
+    MatchResult result = match(load(kT3k), load(kDualT3k), options);
+    ASSERT_TRUE(result.matched);
+    ASSERT_EQ(result.components.size(), 1u);
+    EXPECT_EQ(result.components[0].num_host_sets, 1u);
+    EXPECT_TRUE(result.components[0].stopped_at_limit) << "the second placement exists and was not looked for";
+}
+
+}  // namespace
+}  // namespace tt::scaleout_tools::matcher


### PR DESCRIPTION
### PR Category
Feature

### Summary
This commit introduces a new executable `run_cabling_matcher` to facilitate the matching of cabling schemes within descriptors. It includes the implementation of the cabling matcher in `cabling_matcher.cpp` and its header in `cabling_matcher.hpp`. Additionally, new source files for running the matcher and corresponding test cases have been added to ensure functionality.

Key changes:
- Added `run_cabling_matcher` executable in `CMakeLists.txt`.
- Implemented cabling matcher logic in `cabling_matcher.cpp` and defined necessary structures in `cabling_matcher.hpp`.
- Created test cases for the cabling matcher in `test_cabling_matcher.cpp` to validate its functionality.

This enhancement aims to improve the ability to find and validate cabling schemes, contributing to the overall robustness of the system.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=p1-0tr/cabling-matcher-tool)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:p1-0tr/cabling-matcher-tool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=p1-0tr/cabling-matcher-tool)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:p1-0tr/cabling-matcher-tool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=p1-0tr/cabling-matcher-tool)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:p1-0tr/cabling-matcher-tool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=p1-0tr/cabling-matcher-tool)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:p1-0tr/cabling-matcher-tool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=p1-0tr/cabling-matcher-tool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:p1-0tr/cabling-matcher-tool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=p1-0tr/cabling-matcher-tool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:p1-0tr/cabling-matcher-tool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=p1-0tr/cabling-matcher-tool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:p1-0tr/cabling-matcher-tool)