### PR TITLE
Isolate Tracy profiling zone stacks per thread

### DIFF
--- a/ttnn/api/tools/profiler/op_profiler_serialize.hpp
+++ b/ttnn/api/tools/profiler/op_profiler_serialize.hpp
@@ -112,32 +112,11 @@ private:
     DEVICE_OP_MAP map;
 };
 
-class thread_safe_call_stack {
-public:
-    void push(const TracyCZoneCtx& ctx) {
-        std::scoped_lock<std::mutex> lock(stack_mutex);
-        call_stack.push(ctx);
-    }
-    bool empty() {
-        std::scoped_lock<std::mutex> lock(stack_mutex);
-        return call_stack.empty();
-    }
-    void pop() {
-        std::scoped_lock<std::mutex> lock(stack_mutex);
-        call_stack.pop();
-    }
-    TracyCZoneCtx& top() {
-        std::scoped_lock<std::mutex> lock(stack_mutex);
-        return call_stack.top();
-    }
-
-private:
-    std::mutex stack_mutex;
-    std::stack<TracyCZoneCtx> call_stack;
-};
-
+// Zone nesting is inherently per-thread (Tracy's own ZoneScopedN uses a per-thread stack
+// internally); a single shared stack here would let two threads pop each other's context and
+// silently corrupt zone durations, so this stack must stay thread_local rather than mutex-shared.
 inline thread_safe_cached_ops_map cached_ops{};
-inline thread_safe_call_stack call_stack;
+inline thread_local std::stack<TracyCZoneCtx> call_stack;
 inline bool op_profiler_is_enabled = false;
 
 #endif  // TRACY_ENABLE


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Shared mutex-protected stack fails even if every push/pop is locked:

Thread A starts -> push ctxA
Thread B starts -> push ctxB
Thread A stops -> pop ctxB, TracyCZoneEnd on A’s queue
A’s timeline closes B’s zone (wrong duration / parent). B’s later stop pops ctxA and ends it on B. Locking only serializes the container; it does not keep each thread’s LIFO. thread_local does.

### Notes for reviewers
I didn't see the problem in the wild.
Verified locally happy path - generated tracy output from galaxy looks valid.

### Manual CI status

[![(T3K) Profiler tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-profiler-tests.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-profiler-tests.yaml?query=branch:vlad/thread_local-call_stack)
[![(Profiler) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml?query=branch:vlad/thread_local-call_stack)
[![(Runtime) Unit Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:vlad/thread_local-call_stack) - important jobs [wn_n150_civ2 RealtimeProfilerSanity](https://github.com/tenstorrent/tt-metal/actions/runs/32391016037/job/96584926204) and [bh_p150b_civ2 RealtimeProfilerSanity](https://github.com/tenstorrent/tt-metal/actions/runs/32391016037/job/96584926682) are green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/thread_local-call_stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vlad/thread_local-call_stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/thread_local-call_stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vlad/thread_local-call_stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/thread_local-call_stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/thread_local-call_stack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/thread_local-call_stack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/thread_local-call_stack)