### PR TITLE
Fix fused indexer semaphore rebinding on cache hits

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/test_ring_indexer_score_dsa.py
@@ -370,9 +370,10 @@ def test_indexer_score_ring4_fused_runtime_kv_len():
 @pytest.mark.parametrize("k_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bf16", "bfp8"])
 def test_indexer_score_ring4_fused_program_cache_reuse(k_dtype):
     """Two dispatches, identical shapes but different chunk_start/kv_len on the SAME device (2nd is a cache
-    hit). chunk_start/kv_len are hash-excluded, so override_runtime_arguments must re-apply them; if not, the
-    2nd dispatch reuses the 1st's frozen offset -> wrong logits. Regression guard for the program-cache
-    stale-scalar bug (every other test dispatches cold). Both bf16 and production bfp8_b K."""
+    hit). chunk_start/kv_len and fused-AG semaphore identity are hash-excluded, so
+    override_runtime_arguments must re-apply them; if not, the 2nd dispatch reuses the 1st's frozen offset or
+    semaphore addresses. Regression guard for the program-cache stale-runtime-argument bugs (every other test
+    dispatches cold). Both bf16 and production bfp8_b K."""
     heads = 16  # the scalar re-patch is head-independent, so one head count suffices (both dtypes kept)
     t_alloc = 4 * CHUNK_GLOBAL  # room for both chunks' causal windows (global block == CHUNK_GLOBAL)
     submesh, parent, ccl_semaphores, subdevice_id, stall_group = _open_ring4_ccl()
@@ -381,13 +382,19 @@ def test_indexer_score_ring4_fused_program_cache_reuse(k_dtype):
         k_bc = _to_slab(k_nat, RING, CHUNK_GLOBAL)  # block-cyclic physical layout
         q_dev, w_dev, k_local, k_gathered = _fused_dev_inputs(submesh, q_g, w_g, k_bc, k_dtype=k_dtype)
 
-        def _score(chunk_start, kv_len):  # identical shapes each call -> 2nd is a program-cache hit
+        # A physically distinct pair exercises the semaphore-address cache-hit override. This is the same
+        # A/B rotation used by model TT_CCL; changing only the addresses must not create another program.
+        grid = submesh.compute_with_storage_grid_size()
+        ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+        alternate_semaphores = [ttnn.create_global_semaphore(submesh, ccl_crs, 0) for _ in range(2)]
+
+        def _score(chunk_start, kv_len, semaphores):  # identical shapes each call -> 2nd is a program-cache hit
             out = ttnn.experimental.ring_indexer_score_dsa(
                 q_dev,
                 k_gathered,
                 w_dev,
                 k_local,
-                ccl_semaphores,
+                semaphores,
                 cluster_axis=SP_AXIS,
                 topology=ttnn.Topology.Linear,
                 num_links=1,
@@ -402,13 +409,23 @@ def test_indexer_score_ring4_fused_program_cache_reuse(k_dtype):
             return ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=2))
 
         # chunk@0 (cache miss/build) then chunk@CHUNK_GLOBAL (cache HIT -- must re-apply chunk_start + kv_len).
-        out0 = _score(chunk_start=0, kv_len=CHUNK_GLOBAL)
-        out1 = _score(chunk_start=CHUNK_GLOBAL, kv_len=2 * CHUNK_GLOBAL)
+        out0 = _score(chunk_start=0, kv_len=CHUNK_GLOBAL, semaphores=ccl_semaphores)
+        entries_after_first = submesh.num_program_cache_entries()
+        out1 = _score(
+            chunk_start=CHUNK_GLOBAL,
+            kv_len=2 * CHUNK_GLOBAL,
+            semaphores=alternate_semaphores,
+        )
+        assert (
+            submesh.num_program_cache_entries() == entries_after_first
+        ), "alternating fused-AG semaphore addresses must reuse the cached ring-indexer program"
         ref0 = _per_sp_ref(q_g, k_nat[:, :, :CHUNK_GLOBAL, :], w_g, RING, 0)
         ref1 = _per_sp_ref(q_g, k_nat[:, :, : 2 * CHUNK_GLOBAL, :], w_g, RING, CHUNK_GLOBAL)
         assert_indexer_match(out0[:, :, :, :CHUNK_GLOBAL], ref0, CHUNK_GLOBAL, CHUNK_GLOBAL, check_neg=True)
         assert_indexer_match(out1[:, :, :, : 2 * CHUNK_GLOBAL], ref1, CHUNK_GLOBAL, 2 * CHUNK_GLOBAL, check_neg=True)
-        logger.info(f"ring4 fused program-cache reuse (heads={heads}): 2nd chunk_start re-applied on cache hit")
+        logger.info(
+            f"ring4 fused program-cache reuse (heads={heads}): 2nd chunk_start and semaphore pair re-applied on cache hit"
+        )
     finally:
         _close_ring4_ccl(parent, submesh, stall_group)
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -236,10 +236,10 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
     // apply_relu / num_groups / block_size pick the compile-time kernel path, so they MUST be hashed (else
     // DSA vs MSA, or pooled vs unpooled, would collide). Hash via the SP/TP accessors so the key is identical
     // to the pre-consolidation (cluster_axis, seq_subshard_axis) form.
-    // The fused descriptor embeds the AG semaphore addresses in worker runtime arguments, while num_links,
-    // topology, and sub-device selection shape worker allocation/routing. The fused override only rebuilds
-    // consumer kernels, so all of that state must participate in the cache key to prevent a stale AG program.
-    std::vector<uint32_t> fused_semaphore_addresses;
+    // The fused descriptor embeds the AG semaphore addresses in worker runtime arguments, but the cache-hit
+    // override re-applies them to all four AG worker kernels. Semaphore identity therefore does not shape the
+    // program and is deliberately excluded from the cache key (matching ExpRingJointSDPA). num_links,
+    // topology, and sub-device selection still shape worker allocation/routing and must remain hashed.
     uint32_t fused_num_links = 0;
     ttnn::ccl::Topology fused_topology = ttnn::ccl::Topology::Linear;
     bool fused_has_sub_device = false;
@@ -250,10 +250,6 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         fused_topology = fused.topology;
         fused_has_sub_device = fused.ag_sub_device_id.has_value();
         fused_sub_device = fused_has_sub_device ? static_cast<uint32_t>(**fused.ag_sub_device_id) : 0u;
-        fused_semaphore_addresses.reserve(fused.ag_semaphore.size());
-        for (const auto& semaphore : fused.ag_semaphore) {
-            fused_semaphore_addresses.push_back(static_cast<uint32_t>(semaphore.address()));
-        }
     }
 
     return tt::tt_metal::operation::hash_operation<IndexerScoreDeviceOperation>(
@@ -282,7 +278,6 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         fused_topology,
         fused_has_sub_device,
         fused_sub_device,
-        fused_semaphore_addresses,
         tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -766,6 +766,22 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
                 }
             }
         };
+
+        // Semaphore identity is hash-excluded. Rebind both ring directions on every cache hit so callers
+        // can alternate double-buffered semaphore pairs without compiling a second otherwise-identical
+        // program. Runtime-arg layouts are declared in ring_attention_all_gather_async_detail.
+        const auto& ag_semaphores = args.fused_ring->ag_semaphore;
+        TT_FATAL(
+            ag_semaphores.size() >= 2,
+            "indexer_score fused override: expected at least 2 AG semaphores, got {}",
+            ag_semaphores.size());
+        const uint32_t backward_semaphore = static_cast<uint32_t>(ag_semaphores[0].address());
+        const uint32_t forward_semaphore = static_cast<uint32_t>(ag_semaphores[1].address());
+        patch_ag_field(/*reader forward=*/3, /*out_ready_sem=*/2, forward_semaphore);
+        patch_ag_field(/*writer forward=*/4, /*out_ready_sem=*/4, forward_semaphore);
+        patch_ag_field(/*reader backward=*/5, /*out_ready_sem=*/2, backward_semaphore);
+        patch_ag_field(/*writer backward=*/6, /*out_ready_sem=*/4, backward_semaphore);
+
         constexpr uint32_t ag_reader_input_base =
             ag_rt::kReaderRuntimeArgHeaderCount + ag_rt::kInputBatchBaseFieldOffset;
         constexpr uint32_t ag_reader_valid_pages = ag_rt::kReaderRuntimeArgHeaderCount + ag_rt::kValidPagesFieldOffset;


### PR DESCRIPTION
## Summary

- exclude fused all-gather semaphore addresses from the indexer program hash
- rebind both ring directions in cached reader and writer runtime arguments
- add regression coverage for cache reuse with physically distinct semaphore pairs

## Validation

- built `ttnncpp`
- GLM 5.2 traced Sparse MLA matrix passed on an 8x4 Blackhole Galaxy
- pre-commit hooks passed

## CI requested

- Blackhole-only sanity tests
- Blackhole-only L2 nightly experimental tests

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-indexer-trace-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-indexer-trace-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-indexer-trace-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-indexer-trace-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-indexer-trace-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-indexer-trace-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-indexer-trace-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-indexer-trace-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-indexer-trace-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-indexer-trace-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-indexer-trace-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-indexer-trace-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-indexer-trace-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-indexer-trace-semaphores)