### PR TITLE
[skip ci] [Test Only] #51180: reduce scalar and dim parameters of a nightly reduction test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_memory_configs.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_memory_configs.py
@@ -267,7 +267,8 @@ def test_generic_ops_wh_block_shard(
     assert passing, f"op={op} {output_pcc}, torch: {torch_output_tensor}, ttnn: {output_tensor}"
 
 
-# Test that generic reduction ops work correctly with a scalar applied to the input.
+# Test that generic reduction ops produce correct results, preserve dtype, and emit the
+# layout documented in nanobind across all supported dtype/layout combinations.
 @pytest.mark.parametrize("op", ["sum", "mean", "max", "min", "std", "var"])
 # bfloat8_b only exists in TILE layout, so dtype and layout are paired.
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.use_module_device
 
 
 SHAPES = [(3, 4), (1, 1, 3, 4, 5), (3, 4, 8, 56, 33)]
-DIMS = [-1, -2, 0, (-2, -1), (0, -2, -1), None]
+DIMS = [-1, 0, (0, -2, -1), None]
 
 # Pair (shape, dim) to drop combos with more reduction dims than rank, and
 # (op, correction) since correction is live only for std/var.
@@ -39,7 +39,7 @@ OP_CORRECTION = [
 
 
 @pytest.mark.parametrize("op, correction", OP_CORRECTION)
-@pytest.mark.parametrize("scalar", [1.0, -2.0, 2.0, -2.43, 2.43, 4.0])
+@pytest.mark.parametrize("scalar", [1.0, -2.43, 4.0])
 @pytest.mark.parametrize("shape, dim", VALID_SHAPE_DIMS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype):

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
@@ -53,7 +53,7 @@ OP_CORRECTION = [
 ]
 
 
-def run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype):
+def _run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype):
     if op in ("var", "std") and correction:
         # Bessel's correction divides by (N - 1) where N is the number of elements
         # reduced. With N == 1 this is a divide-by-zero, producing all-NaN output;
@@ -230,20 +230,22 @@ def run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype):
 
 # Test that generic reduction ops work correctly with a scalar applied to the input.
 # Split into two parts to avoid large test count from full cross product.
+# Simple powers of two run with reduced set of dim parameters.
 @pytest.mark.parametrize("op, correction", OP_CORRECTION)
 @pytest.mark.parametrize("scalar", [1.0, -2.0, 2.0])
 @pytest.mark.parametrize("shape, dim", VALID_SHAPE_DIMS_PART1)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_generic_ops_w_scalar_part1(device, op, scalar, correction, dim, shape, dtype):
-    run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
+    _run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
 
 
+# Non-powers of two and a slightly larger power of two run with full set of dim parameters.
 @pytest.mark.parametrize("op, correction", OP_CORRECTION)
 @pytest.mark.parametrize("scalar", [-2.43, 2.43, 4.0])
 @pytest.mark.parametrize("shape, dim", VALID_SHAPE_DIMS_PART2)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_generic_ops_w_scalar_part2(device, op, scalar, correction, dim, shape, dtype):
-    run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
+    _run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
 
 
 # Test that generic reduction ops produce correct results, preserve dtype, and emit the

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
@@ -246,7 +246,3 @@ def test_generic_ops_w_scalar_part1(device, op, scalar, correction, dim, shape, 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_generic_ops_w_scalar_part2(device, op, scalar, correction, dim, shape, dtype):
     _run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
-
-
-# Test that generic reduction ops produce correct results, preserve dtype, and emit the
-# layout documented in nanobind across all supported dtype/layout combinations.

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops_w_scalar.py
@@ -21,11 +21,26 @@ pytestmark = pytest.mark.use_module_device
 
 
 SHAPES = [(3, 4), (1, 1, 3, 4, 5), (3, 4, 8, 56, 33)]
-DIMS = [-1, 0, (0, -2, -1), None]
+DIMS_PART1 = [(-2, -1), None]
+DIMS_PART2 = [-1, -2, 0, (-2, -1), (0, -2, -1), None]
 
-# Pair (shape, dim) to drop combos with more reduction dims than rank, and
-# (op, correction) since correction is live only for std/var.
-VALID_SHAPE_DIMS = [(s, d) for s in SHAPES for d in DIMS if not (isinstance(d, tuple) and len(d) > len(s))]
+
+# Pair (shape, dim) to drop combos with more reduction dims than rank, and dims that
+# duplicate another dim of the same list at rank 2.
+def _valid_shape_dims(dims, rank2_duplicates):
+    return [
+        (s, d)
+        for s in SHAPES
+        for d in dims
+        if not (isinstance(d, tuple) and len(d) > len(s)) and not (len(s) == 2 and d in rank2_duplicates)
+    ]
+
+
+# At rank 2, dim=(-2, -1) is the same reduction as dim=None, and dim=0 the same as dim=-2.
+VALID_SHAPE_DIMS_PART1 = _valid_shape_dims(DIMS_PART1, rank2_duplicates=[None])
+VALID_SHAPE_DIMS_PART2 = _valid_shape_dims(DIMS_PART2, rank2_duplicates=[0, (-2, -1)])
+
+# Pair (op, correction) since correction is live only for std/var.
 OP_CORRECTION = [
     ("sum", False),
     ("mean", False),
@@ -38,11 +53,7 @@ OP_CORRECTION = [
 ]
 
 
-@pytest.mark.parametrize("op, correction", OP_CORRECTION)
-@pytest.mark.parametrize("scalar", [1.0, -2.43, 4.0])
-@pytest.mark.parametrize("shape, dim", VALID_SHAPE_DIMS)
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype):
+def run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype):
     if op in ("var", "std") and correction:
         # Bessel's correction divides by (N - 1) where N is the number of elements
         # reduced. With N == 1 this is a divide-by-zero, producing all-NaN output;
@@ -215,6 +226,24 @@ def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
     )
 
     assert passing, f"{output_msg}, torch: {torch_result}, ttnn: {ttnn_result}"
+
+
+# Test that generic reduction ops work correctly with a scalar applied to the input.
+# Split into two parts to avoid large test count from full cross product.
+@pytest.mark.parametrize("op, correction", OP_CORRECTION)
+@pytest.mark.parametrize("scalar", [1.0, -2.0, 2.0])
+@pytest.mark.parametrize("shape, dim", VALID_SHAPE_DIMS_PART1)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_generic_ops_w_scalar_part1(device, op, scalar, correction, dim, shape, dtype):
+    run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
+
+
+@pytest.mark.parametrize("op, correction", OP_CORRECTION)
+@pytest.mark.parametrize("scalar", [-2.43, 2.43, 4.0])
+@pytest.mark.parametrize("shape, dim", VALID_SHAPE_DIMS_PART2)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_generic_ops_w_scalar_part2(device, op, scalar, correction, dim, shape, dtype):
+    run_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
 
 
 # Test that generic reduction ops produce correct results, preserve dtype, and emit the


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Relates to #51180 

Cross product of test cases for test_generic_ops_w_scalar was very large. Scalar values are redundant and all dims are tested in other tests and can be safely cut down. Therefore reduced test cases to help with test runtime in CI.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-51180_night_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-51180_night_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-51180_night_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-51180_night_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-51180_night_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-51180_night_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-51180_night_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-51180_night_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-51180_night_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-51180_night_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-51180_night_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-51180_night_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-51180_night_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-51180_night_reduce)