### PR TITLE
Relocate 2x flag in metal.

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2547,12 +2547,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigDefaultsMapToInternalDefaults) {
     EXPECT_FALSE(built.fp32_dest_acc_en);
     EXPECT_FALSE(built.dst_full_sync_en);      // double_buffer_dest defaults true -> !true
     EXPECT_FALSE(built.math_approx_mode);      // sfpu_precision_mode defaults Precise
-<<<<<<< HEAD
-    EXPECT_FALSE(built.enable_2x_src_format);  // enable_2x_src_register defaults false
-=======
     EXPECT_FALSE(built.enable_2x_src_format);  // no ENABLE_2X_SRC_FORMAT define -> false
-    EXPECT_FALSE(built.unpack_to_dest_en);
->>>>>>> 9f93388c0f8 (First inital set of changes for removing 2x flag from HW configure.)
 }
 
 TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigInversionAndEnumMapToInternal) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2547,7 +2547,6 @@ TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigDefaultsMapToInternalDefaults) {
     EXPECT_FALSE(built.fp32_dest_acc_en);
     EXPECT_FALSE(built.dst_full_sync_en);      // double_buffer_dest defaults true -> !true
     EXPECT_FALSE(built.math_approx_mode);      // sfpu_precision_mode defaults Precise
-    EXPECT_FALSE(built.enable_2x_src_format);  // no ENABLE_2X_SRC_FORMAT define -> false
 }
 
 TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigInversionAndEnumMapToInternal) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2547,7 +2547,12 @@ TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigDefaultsMapToInternalDefaults) {
     EXPECT_FALSE(built.fp32_dest_acc_en);
     EXPECT_FALSE(built.dst_full_sync_en);      // double_buffer_dest defaults true -> !true
     EXPECT_FALSE(built.math_approx_mode);      // sfpu_precision_mode defaults Precise
+<<<<<<< HEAD
     EXPECT_FALSE(built.enable_2x_src_format);  // enable_2x_src_register defaults false
+=======
+    EXPECT_FALSE(built.enable_2x_src_format);  // no ENABLE_2X_SRC_FORMAT define -> false
+    EXPECT_FALSE(built.unpack_to_dest_en);
+>>>>>>> 9f93388c0f8 (First inital set of changes for removing 2x flag from HW configure.)
 }
 
 TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigInversionAndEnumMapToInternal) {

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -282,6 +282,11 @@ static experimental::KernelSpec::CompilerOptions::Defines build_reduce_defines(c
     }
     reduce_defines.emplace("MATH_ONLY", test_config.math_only_reduce ? "1" : "0");
     reduce_defines.emplace("DST_ACCUM_MODE", test_config.fp32_dest_acc_en ? "1" : "0");
+    // Opt into the 2x-packed src-register format via a compile-time define (presence-only);
+    // jit_build detects experimental::k2xSrcFormatDefine and flips the unpack format-table remap.
+    if (test_config.enable_2x_src_format) {
+        reduce_defines.emplace(experimental::k2xSrcFormatDefine, "1");
+    }
     return reduce_defines;
 }
 
@@ -430,7 +435,6 @@ void run_single_core_reduce_program(
             .fpu_math_fidelity = test_config.math_fidelity,
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
-            .enable_2x_src_register = test_config.enable_2x_src_format,
         };
     } else {
         compute_hw_config = experimental::ComputeGen1Config{

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -86,9 +86,6 @@ struct ReduceConfig {
     // Set to MxFp4 to drive the MxFp4 stimulus path: random floats are packed to MxFp4 for the
     // device and decoded back to bf16 to feed the golden. Output stays Float16_b.
     tt::DataFormat input_format = tt::DataFormat::Float16_b;
-    // Opt into the 2x-packed src-register format (Quasar). Only valid with an MxFp4 input on a
-    // column (H) reduce, where GAPOOL reads the 2x-packed SrcA correctly.
-    bool enable_2x_src_format = false;
 };
 
 float get_scaler(const ReduceConfig& test_config) {
@@ -282,11 +279,6 @@ static experimental::KernelSpec::CompilerOptions::Defines build_reduce_defines(c
     }
     reduce_defines.emplace("MATH_ONLY", test_config.math_only_reduce ? "1" : "0");
     reduce_defines.emplace("DST_ACCUM_MODE", test_config.fp32_dest_acc_en ? "1" : "0");
-    // Opt into the 2x-packed src-register format via a compile-time define (presence-only);
-    // jit_build detects experimental::k2xSrcFormatDefine and flips the unpack format-table remap.
-    if (test_config.enable_2x_src_format) {
-        reduce_defines.emplace(experimental::k2xSrcFormatDefine, "1");
-    }
     return reduce_defines;
 }
 
@@ -887,8 +879,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixComputeReduceColumnMxFp4X2) {
         .golden_function = ::unit_tests::compute::gold_reduce_h,
         .result_shape = {1, 1, TILE_HEIGHT, TILE_WIDTH},
         .math_fidelity = MathFidelity::HiFi4,
+        // MxFp4 + column (H) reduce auto-selects the 2x-packed src-register format on Quasar.
         .input_format = tt::DataFormat::MxFp4,
-        .enable_2x_src_format = true,
     };
     run_single_core_reduce_program(this->devices_.at(0), test_config);
 }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -748,9 +748,22 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                     .enable_consumer_implicit_sync = false,
                     .data_format = fmt});
         };
-        in0_id = make_dfb(in0_tile_size, M * K, 0x1, 0x100, in0_fmt);
-        in1_id = make_dfb(in1_tile_size, K * N, 0x1, 0x100, in1_fmt);
-        out_id = make_dfb(out_tile_size, M * N, 0x100, 0x2, out_fmt);
+
+        const std::set<DataMovementProcessor> dm_processors =
+            tt_metal::experimental::quasar::GetAvailableDataMovementProcessors(
+                program_, CoreRangeSet(CoreRange(core, core)), 2, HalProgrammableCoreType::TENSIX);
+        TT_FATAL(
+            dm_processors.size() == 2,
+            "blocked_matmul needs 2 free data movement processors for the reader and writer, got {}",
+            dm_processors.size());
+        auto dm_it = dm_processors.begin();
+        const uint16_t kReaderRiscMask = 1 << static_cast<uint32_t>(*dm_it++);  // reader is created first
+        const uint16_t kWriterRiscMask = 1 << static_cast<uint32_t>(*dm_it);    // writer is created second
+        constexpr uint16_t kComputeRiscMask = 0x100;                            // Tensix risc 0
+
+        in0_id = make_dfb(in0_tile_size, M * K, kReaderRiscMask, kComputeRiscMask, in0_fmt);
+        in1_id = make_dfb(in1_tile_size, K * N, kReaderRiscMask, kComputeRiscMask, in1_fmt);
+        out_id = make_dfb(out_tile_size, M * N, kComputeRiscMask, kWriterRiscMask, out_fmt);
         partials_id = tt_metal::experimental::dfb::CreateDataflowBuffer(
             program_,
             core,

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -74,7 +74,6 @@ struct BlockedMatmulConfig {
     tt::DataFormat in1_fmt = tt::DataFormat::Float16_b;
     tt::DataFormat out_fmt = tt::DataFormat::Float16_b;
     bool fp32_dest_acc_en = false;
-    bool enable_2x_src_format = false;
 };
 
 void create_CBs_for_fused_matmul(
@@ -831,7 +830,6 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
             core,
             tt_metal::experimental::quasar::QuasarComputeConfig{
                 .num_threads_per_cluster = 1,
-                .enable_2x_src_format = cfg.enable_2x_src_format,
                 .compile_args = compute_compile_args,
                 .defines = compute_defines});
 
@@ -1030,10 +1028,10 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixTestSingleCoreSingleBlockComp
         .N = 2,
         .num_blocks = 1,
         .packer_l1_acc = false,
+        // MxFp4 in0/in1 auto-selects the 2x-packed src-register format for matmul on Quasar.
         .in0_fmt = tt::DataFormat::MxFp4,
         .in1_fmt = tt::DataFormat::MxFp4,
-        .out_fmt = tt::DataFormat::Float16_b,
-        .enable_2x_src_format = true};
+        .out_fmt = tt::DataFormat::Float16_b};
     ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(0), config));
 }
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -14,6 +14,12 @@
 
 namespace tt::tt_metal::experimental {
 
+// Compile-time define a compute kernel adds to KernelSpec::compiler_options.defines to opt into
+// the 2x-packed source-register format (Mxfp4 only). See the note in ComputeGen2Config below.
+// This is the single source of truth for the define name, shared by the host-side jit_build path
+// that detects it. Kept as a macro name (no value required); presence is what matters.
+inline constexpr const char* k2xSrcFormatDefine = "ENABLE_2X_SRC_FORMAT";
+
 // ============================================================================
 //  ComputeHardwareConfig
 // ============================================================================

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -166,23 +166,16 @@ struct ComputeGen2Config {
     // Temporary configs (these will change!)
     ///////////////////////////////////////////
 
-    // When true, the unpacker packs two values into each source-register slot instead of one.
-    // The math engine reads twice as many elements per pass, effectively doubling throughput.
+    // NOTE: The former `enable_2x_src_register` bool has been removed from this hardware config.
+    // The 2x-packed source-register format is now opted into per kernel via the compile-time
+    // define `ENABLE_2X_SRC_FORMAT` (see k2xSrcFormatDefine above): add it to the kernel's
+    // KernelSpec::compiler_options.defines. When present, jit_build emits the 2x-packed
+    // src-register format as the unpack_dst_format for 2x-capable (Mxfp4) inputs, so the math
+    // engine reads two elements per source-register slot, effectively doubling throughput.
     //
-    // This is currently ONLY supported for Mxfp4 data format. The setting is ignored for all
-    // other formats.
-    //
-    // WARNING: Only the matmul family of instructions work with this format:
-    //  - matmul (MVMUL/MVMULDI)
-    //  - the GAPOOL instruction that column reduce ops are built on
-    //
-    // Invoking other instructions on Mxfp4 data with the setting enabled will produce garbage
-    // math results! Enable this setting ONLY for kernels whose inputs are consumed solely by
-    // a matmul or a column reduce.
-    //
-    // This API is not final and subject to change!
-    // It should most likely become a per-DFB setting, similar to unpack_modes.
-    bool enable_2x_src_register = false;
+    // WARNING: Mxfp4 only, and matmul-family instructions only (MVMUL/MVMULDI and the GAPOOL
+    // that column reduce is built on). Enabling it for any other op or format produces garbage
+    // math results.
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -160,14 +160,6 @@ struct ComputeGen2Config {
     // Temporary configs (these will change!)
     ///////////////////////////////////////////
 
-    // NOTE: There is no 2x-source-register knob here (the former `enable_2x_src_register` bool was
-    // removed). On Quasar the 2x-packed source-register format is now automatic and has no external
-    // flag: an MxFp4 operand fed to matmul (MVMUL/MVMULDI) or a column reduce (GAPOOL) is ALWAYS
-    // unpacked as the 2x-packed MxFp4_2x_B format, so the math engine reads two elements per
-    // source-register slot (double throughput). This is decided kernel-side in the Quasar matmul /
-    // reduce LLK op init (op-scoped, since only those ops support 2x); plain MxFp4 consumed by any
-    // other op still unpack-expands to Float16_b. Nothing to configure.
-
     ///////////////////////////////////////////////////////////////////////////////////////////////
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp
@@ -14,12 +14,6 @@
 
 namespace tt::tt_metal::experimental {
 
-// Compile-time define a compute kernel adds to KernelSpec::compiler_options.defines to opt into
-// the 2x-packed source-register format (Mxfp4 only). See the note in ComputeGen2Config below.
-// This is the single source of truth for the define name, shared by the host-side jit_build path
-// that detects it. Kept as a macro name (no value required); presence is what matters.
-inline constexpr const char* k2xSrcFormatDefine = "ENABLE_2X_SRC_FORMAT";
-
 // ============================================================================
 //  ComputeHardwareConfig
 // ============================================================================
@@ -166,16 +160,13 @@ struct ComputeGen2Config {
     // Temporary configs (these will change!)
     ///////////////////////////////////////////
 
-    // NOTE: The former `enable_2x_src_register` bool has been removed from this hardware config.
-    // The 2x-packed source-register format is now opted into per kernel via the compile-time
-    // define `ENABLE_2X_SRC_FORMAT` (see k2xSrcFormatDefine above): add it to the kernel's
-    // KernelSpec::compiler_options.defines. When present, jit_build emits the 2x-packed
-    // src-register format as the unpack_dst_format for 2x-capable (Mxfp4) inputs, so the math
-    // engine reads two elements per source-register slot, effectively doubling throughput.
-    //
-    // WARNING: Mxfp4 only, and matmul-family instructions only (MVMUL/MVMULDI and the GAPOOL
-    // that column reduce is built on). Enabling it for any other op or format produces garbage
-    // math results.
+    // NOTE: There is no 2x-source-register knob here (the former `enable_2x_src_register` bool was
+    // removed). On Quasar the 2x-packed source-register format is now automatic and has no external
+    // flag: an MxFp4 operand fed to matmul (MVMUL/MVMULDI) or a column reduce (GAPOOL) is ALWAYS
+    // unpacked as the 2x-packed MxFp4_2x_B format, so the math engine reads two elements per
+    // source-register slot (double throughput). This is decided kernel-side in the Quasar matmul /
+    // reduce LLK op init (op-scoped, since only those ops support 2x); plain MxFp4 consumed by any
+    // other op still unpack-expands to Float16_b. Nothing to configure.
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
 };

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
@@ -50,8 +50,24 @@ inline void llk_math_matmul_init(
         is_2x_format(srcA_format) == is_2x_format(srcB_format),
         "SrcA and SrcB must both be 2x formats or both non-2x formats");
 
-    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
-        srcA_format, srcB_format);
+    // srcA/srcB above are the per-op effective src-register formats, which for MxFp4 differ from the
+    // op-agnostic unpack_dst_format[] table that kernel startup (llk_math_hw_configure) already
+    // programmed the ALU from and latched as DataFormatConfigSet::DEFAULT. That latch keys on which
+    // config set is active, not on the formats, so _configure_default_alu_data_format_state_ would
+    // early-return and leave the ALU decoding 2x-packed src registers as Float16_b while the EN_X2
+    // MOP below ran over them. When the formats deviate, program the ALU directly instead; this is
+    // still the DEFAULT config shape (implied math format off, no dest-format override), so the
+    // latched DataFormatConfigSet::DEFAULT stays truthful and transpose-dest's restore contract holds.
+    if ((srcA_format != static_cast<DataFormat>(get_operand_dst_format(operandB_id))) ||
+        (srcB_format != static_cast<DataFormat>(get_operand_dst_format(operandA_id)))) {
+        const bool en_int32_dest_format = _is_src_fmt_int32_dest_compatible_(srcA_format) &&
+                                          _is_src_fmt_int32_dest_compatible_(srcB_format) && DST_ACCUM_MODE;
+        _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
+            srcA_format, srcB_format, en_int32_dest_format, DataFormat::Invalid /* no dest-format override */);
+    } else {
+        _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
+            srcA_format, srcB_format);
+    }
     const bool src_2x = is_2x_format(srcA_format) && is_2x_format(srcB_format);
     if (src_2x) {
         _llk_math_matmul_init_<math_fidelity, false /*EN_DI*/, true /*EN_X2*/>(ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
@@ -77,6 +77,40 @@ inline void llk_math_matmul_init(
 }
 
 /**
+ * @brief Restore the ALU SrcA/SrcB formats after a matmul that consumed MxFp4 (2x) operands.
+ *
+ * @param operandA: The input0 operand circular buffer (matches the matmul init call)
+ * @param operandB: The input1 operand circular buffer
+ *
+ * Undoes the MxFp4 -> MxFp4_2x_B deviation that @ref llk_math_matmul_init programmed into the ALU
+ * format registers, restoring the op-agnostic unpack_dst_format[] values so a following non-matmul
+ * op decodes its src registers correctly. Only acts when init deviated (an operand was MxFp4). Uses
+ * _configure_alu_formats_ directly for the same reason init does: the DataFormatConfigSet::DEFAULT
+ * latch (still truthful) makes _configure_default_alu_data_format_state_ early-return.
+ *
+ * @note Pair with @ref llk_unpack_AB_matmul_uninit (via mm_uninit); call before the next op when an
+ * MxFp4 matmul operand is reused by a non-matmul op in the same kernel.
+ */
+inline void llk_math_matmul_uninit(const std::uint32_t operandA, const std::uint32_t operandB) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
+    const bool deviated =
+        (static_cast<DataFormat>(get_operand_src_format(operandA_id)) == DataFormat::MxFp4) ||
+        (static_cast<DataFormat>(get_operand_src_format(operandB_id)) == DataFormat::MxFp4);
+    if (!deviated) {
+        return;
+    }
+    // Same operand->src mapping as init: In0(operandA)->SrcB, In1(operandB)->SrcA. The table values
+    // (unpack_dst_format[]) are the op-agnostic formats (Float16_b for MxFp4).
+    const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operandA_id));
+    const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operandB_id));
+    const bool en_int32_dest_format = _is_src_fmt_int32_dest_compatible_(srcA_format) &&
+                                      _is_src_fmt_int32_dest_compatible_(srcB_format) && DST_ACCUM_MODE;
+    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
+        srcA_format, srcB_format, en_int32_dest_format, DataFormat::Invalid /* no dest-format override */);
+}
+
+/**
  * @brief Performs matrix multiply operation, where Input 0, Input 1 and Output are each 1 tile
  *
  * @param dst_index: Tile index into the destination register

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
@@ -34,8 +34,18 @@ inline void llk_math_matmul_init(
     const std::uint32_t rt_dim = 1) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
-    const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operandA_id));
-    const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operandB_id));
+    // MxFp4 fed to matmul is ALWAYS unpacked as the 2x-packed src-register format (MxFp4_2x_B) on
+    // Quasar — there is no non-2x MxFp4 matmul. The generated unpack_dst_format[] table keeps the
+    // op-agnostic MX default (Float16_b), so derive the effective src-register format from the L1
+    // (src) format here; the matching unpacker OUT_DATA_FORMAT override lives in
+    // llk_unpack_AB_matmul_init. This reaches the same HW state the old host-side remap produced.
+    const auto matmul_src_reg_format = [](const std::uint32_t op_id) -> DataFormat {
+        return (static_cast<DataFormat>(get_operand_src_format(op_id)) == DataFormat::MxFp4)
+                   ? DataFormat::MxFp4_2x_B
+                   : static_cast<DataFormat>(get_operand_dst_format(op_id));
+    };
+    const DataFormat srcB_format = matmul_src_reg_format(operandA_id);
+    const DataFormat srcA_format = matmul_src_reg_format(operandB_id);
     LLK_ASSERT(
         is_2x_format(srcA_format) == is_2x_format(srcB_format),
         "SrcA and SrcB must both be 2x formats or both non-2x formats");

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -44,7 +44,22 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
         srcA_2x ? DataFormat::MxFp4_2x_B : static_cast<DataFormat>(unpack_dst_format[operandA_id]);
     const DataFormat srcB_format = static_cast<DataFormat>(unpack_dst_format[operandB_id]);
 
-    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
+    // When srcA_2x, srcA_format deviates from the op-agnostic unpack_dst_format[] table that kernel
+    // startup (llk_math_hw_configure) already programmed the ALU from and latched as
+    // DataFormatConfigSet::DEFAULT. That latch keys on which config set is active, not on the
+    // formats, so _configure_default_alu_data_format_state_ would early-return and leave the ALU
+    // decoding 2x-packed SrcA as Float16_b. Program the ALU directly in that case; this is still the
+    // DEFAULT config shape (implied math format off, no dest-format override), so the latched
+    // DataFormatConfigSet::DEFAULT stays truthful and transpose-dest's restore contract holds.
+    if (srcA_2x) {
+        const bool en_int32_dest_format = _is_src_fmt_int32_dest_compatible_(srcA_format) &&
+                                          _is_src_fmt_int32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
+        _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
+            srcA_format, srcB_format, en_int32_dest_format, DataFormat::Invalid /* no dest-format override */);
+    } else {
+        _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
+            srcA_format, srcB_format);
+    }
     _llk_math_reduce_init_<pool_type, reduce_dim, math_fidelity, is_int_fpu_en>(tensor_shape);
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -64,6 +64,30 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
 }
 
 /**
+ * @brief Restore the ALU SrcA/SrcB formats after a column reduce that consumed an MxFp4 (2x) operand.
+ *
+ * @param operandA: The srcA (data) operand circular buffer (same as reduce init)
+ *
+ * Undoes the MxFp4 -> MxFp4_2x_B deviation that @ref llk_math_reduce_init programmed into the ALU
+ * format registers (column reduce only), restoring the op-agnostic unpack_dst_format[] values so a
+ * following op decodes its src registers correctly. Gates on MxFp4 (only column reduce deviated;
+ * others are a no-op). Uses _configure_alu_formats_ directly because the still-DEFAULT latch makes
+ * _configure_default_alu_data_format_state_ early-return. Pair with @ref llk_unpack_AB_reduce_uninit.
+ */
+inline void llk_math_reduce_uninit(const std::uint32_t operandA) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    if (static_cast<DataFormat>(get_operand_src_format(operandA_id)) != DataFormat::MxFp4) {
+        return;
+    }
+    // All reduce operands (MxFp4 data + scaler) map to Float16_b in unpack_dst_format[], so
+    // reprogramming both ALU srcs to operandA's table value is the correct restore.
+    const DataFormat table_fmt = static_cast<DataFormat>(unpack_dst_format[operandA_id]);
+    const bool en_int32_dest_format = _is_src_fmt_int32_dest_compatible_(table_fmt) && DST_ACCUM_MODE;
+    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
+        table_fmt, table_fmt, en_int32_dest_format, DataFormat::Invalid /* no dest-format override */);
+}
+
+/**
  * @brief Perform a reduce operation
  *
  * @tparam type: Type of reduce pool op, values = [MAX, SUM, AVG]

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -34,7 +34,14 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
-    const DataFormat srcA_format = static_cast<DataFormat>(unpack_dst_format[operandA_id]);
+    // Column reduce is a GAPOOL (op-mmul family) and consumes MxFp4 SrcA as the 2x-packed
+    // src-register format, exactly like matmul. Derive the effective SrcA format from the L1/src
+    // format; the matching unpacker OUT_DATA_FORMAT override lives in llk_unpack_AB_reduce_init.
+    // Only REDUCE_COL supports 2x (row/scalar reduce post-pool ELWADDDI does not).
+    const bool srcA_2x = (reduce_dim == ReduceDim::REDUCE_COL) &&
+                         (static_cast<DataFormat>(get_operand_src_format(operandA_id)) == DataFormat::MxFp4);
+    const DataFormat srcA_format =
+        srcA_2x ? DataFormat::MxFp4_2x_B : static_cast<DataFormat>(unpack_dst_format[operandA_id]);
     const DataFormat srcB_format = static_cast<DataFormat>(unpack_dst_format[operandB_id]);
 
     _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -78,6 +78,35 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
 }
 
 /**
+ * @brief Undo the MxFp4 -> MxFp4_2x_B unpacker OUT_DATA_FORMAT override from @ref llk_unpack_AB_matmul_init.
+ *
+ * @param operandA: The input0 operand circular buffer (matches the matmul init call)
+ * @param operandB: The input1 operand circular buffer
+ *
+ * Restores each MxFp4 operand's unpacker OUT_DATA_FORMAT to the op-agnostic unpack_dst_format[]
+ * value (Float16_b), so a following NON-matmul op on the same MxFp4 buffer unpacks correctly. This
+ * explicit restore is required because the non-matmul unpack inits never reprogram OUT_DATA_FORMAT,
+ * and llk_unpack_reconfig_data_format is silently skipped for a same-format operand
+ * (should_reconfig_src_reg_df keys on the generated table, which never saw the 2x override).
+ *
+ * @note Call after all matmuls, before initializing the next op, whenever an MxFp4 matmul operand is
+ * reused by a non-matmul op in the same kernel. Pair with @ref llk_math_matmul_uninit (via mm_uninit).
+ * Same UNP mapping as init: In0(operandA)->SrcB->UNP_B, In1(operandB)->SrcA->UNP_A.
+ */
+inline void llk_unpack_AB_matmul_uninit(const std::uint32_t operandA, const std::uint32_t operandB) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
+    if (static_cast<DataFormat>(get_operand_src_format(operandB_id)) == DataFormat::MxFp4) {
+        _llk_unpack_reconfig_data_format_src_<p_unpacr::UNP_A, false>(
+            get_operand_src_format(operandB_id), unpack_dst_format[operandB_id]);
+    }
+    if (static_cast<DataFormat>(get_operand_src_format(operandA_id)) == DataFormat::MxFp4) {
+        _llk_unpack_reconfig_data_format_src_<p_unpacr::UNP_B, false>(
+            get_operand_src_format(operandA_id), unpack_dst_format[operandA_id]);
+    }
+}
+
+/**
  *
  * @brief Performs unpack operation for matrix multiply such that:
  *

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -59,6 +59,22 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         ct_dim,
         rt_dim,
         kt_dim);
+
+    // MxFp4 operands feeding matmul are ALWAYS unpacked as the 2x-packed src-register format
+    // (MxFp4_2x_B) on Quasar. The generated unpack_dst_format[] table keeps the op-agnostic MX
+    // default (Float16_b, needed by non-matmul MxFp4 ops), so override only the unpacker gasket
+    // OUT_DATA_FORMAT here. Safe: this runs at init with the unpacker idle (before the first
+    // UNPACR), OUT_DATA_FORMAT is a shadow register, and the buffer descriptor (keyed on the MxFp4
+    // L1 format + tile geometry) is unchanged. In0(operandA)->SrcB->UNP_B, In1(operandB)->SrcA->UNP_A.
+    // EN_32BIT_DEST does not affect the MxFp4->MxFp4_2x_B reconfig validity, so pass false.
+    if (static_cast<DataFormat>(get_operand_src_format(operandB_id)) == DataFormat::MxFp4) {
+        _llk_unpack_reconfig_data_format_src_<p_unpacr::UNP_A, false>(
+            get_operand_src_format(operandB_id), static_cast<std::uint32_t>(DataFormat::MxFp4_2x_B));
+    }
+    if (static_cast<DataFormat>(get_operand_src_format(operandA_id)) == DataFormat::MxFp4) {
+        _llk_unpack_reconfig_data_format_src_<p_unpacr::UNP_B, false>(
+            get_operand_src_format(operandA_id), static_cast<std::uint32_t>(DataFormat::MxFp4_2x_B));
+    }
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -65,8 +65,8 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     // default (Float16_b, needed by non-matmul MxFp4 ops), so override only the unpacker gasket
     // OUT_DATA_FORMAT here. Safe: this runs at init with the unpacker idle (before the first
     // UNPACR), OUT_DATA_FORMAT is a shadow register, and the buffer descriptor (keyed on the MxFp4
-    // L1 format + tile geometry) is unchanged. In0(operandA)->SrcB->UNP_B, In1(operandB)->SrcA->UNP_A.
-    // EN_32BIT_DEST does not affect the MxFp4->MxFp4_2x_B reconfig validity, so pass false.
+    // L1 format + tile geometry) is unchanged. EN_32BIT_DEST does not affect the MxFp4->MxFp4_2x_B reconfig validity,
+    // so pass false.
     if (static_cast<DataFormat>(get_operand_src_format(operandB_id)) == DataFormat::MxFp4) {
         _llk_unpack_reconfig_data_format_src_<p_unpacr::UNP_A, false>(
             get_operand_src_format(operandB_id), static_cast<std::uint32_t>(DataFormat::MxFp4_2x_B));

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -58,6 +58,26 @@ inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::u
 }
 
 /**
+ * @brief Undo the MxFp4 -> MxFp4_2x_B unpacker OUT_DATA_FORMAT override from @ref llk_unpack_AB_reduce_init.
+ *
+ * @param operandA: The srcA (data) operand circular buffer (same as reduce init)
+ *
+ * Restores SrcA's unpacker OUT_DATA_FORMAT to the op-agnostic unpack_dst_format[] value (Float16_b),
+ * so a following NON-reduce op on the same MxFp4 buffer unpacks correctly. Needed because non-reduce
+ * unpack inits never reprogram OUT_DATA_FORMAT and reconfig_data_format is silently skipped for a
+ * same-format operand. Only column reduce overrode it (SrcA -> UNP_A); restoring an operand that was
+ * never overridden just reprograms it to the same table value (harmless), so this gates on MxFp4 only
+ * and needs no reduce_dim template. Pair with the ALU restore in @ref llk_math_reduce_uninit.
+ */
+inline void llk_unpack_AB_reduce_uninit(const std::uint32_t operandA) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    if (static_cast<DataFormat>(get_operand_src_format(operandA_id)) == DataFormat::MxFp4) {
+        _llk_unpack_reconfig_data_format_src_<p_unpacr::UNP_A, false>(
+            get_operand_src_format(operandA_id), unpack_dst_format[operandA_id]);
+    }
+}
+
+/**
  *
  * @brief Unpacks binary operands to SrcA & SrcB for reduce kernels
  *

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -43,6 +43,18 @@ inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::u
         ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
         ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
         tensor_shape);
+
+    // Column reduce (GAPOOL) consumes MxFp4 SrcA as the 2x-packed src-register format, like matmul.
+    // Override only the unpacker gasket OUT_DATA_FORMAT to MxFp4_2x_B (shadow register; unpacker idle
+    // at init before the first UNPACR; buffer descriptor keyed on the MxFp4 L1 format is unchanged).
+    // operandA -> SrcA -> UNP_A. Only REDUCE_COL supports 2x. EN_32BIT_DEST does not affect the
+    // MxFp4->MxFp4_2x_B reconfig validity, so pass false.
+    if constexpr (reduce_dim == ReduceDim::REDUCE_COL) {
+        if (static_cast<DataFormat>(get_operand_src_format(operandA_id)) == DataFormat::MxFp4) {
+            _llk_unpack_reconfig_data_format_src_<p_unpacr::UNP_A, false>(
+                get_operand_src_format(operandA_id), static_cast<std::uint32_t>(DataFormat::MxFp4_2x_B));
+        }
+    }
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -113,6 +113,31 @@ ALWI void matmul_init(
 
 // clang-format off
 /**
+ * (Quasar) Undo the automatic MxFp4 -> MxFp4_2x_B src-format selection applied by matmul_init.
+ *
+ * matmul_init overrides an MxFp4 operand's unpacker OUT_DATA_FORMAT and ALU format to the 2x-packed
+ * MxFp4_2x_B, diverging from the op-agnostic unpack_dst_format[] table. That override PERSISTS: the
+ * non-matmul unpack inits never reprogram OUT_DATA_FORMAT, and reconfig_data_format is silently
+ * skipped for a same-format operand. So a kernel that feeds the SAME MxFp4 buffer to matmul and then
+ * to a non-matmul op (datacopy/SFPU/eltwise) MUST call mm_uninit(in0, in1) after the matmuls and
+ * before the next op, or that op will keep unpacking the buffer as MxFp4_2x_B and produce garbage.
+ * A no-op on non-MxFp4 operands and on non-Quasar architectures.
+ *
+ * | Argument  | Description                                            | Type     | Valid Range | Required |
+ * |-----------|--------------------------------------------------------|----------|-------------|----------|
+ * | in0_cb_id | First input CB used in the matmul (same as matmul_init)| uint32_t | 0 to 31     | True     |
+ * | in1_cb_id | Second input CB used in the matmul                     | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void mm_uninit(uint32_t in0_cb_id, uint32_t in1_cb_id) {
+#ifdef ARCH_QUASAR
+    UNPACK((llk_unpack_AB_matmul_uninit(in0_cb_id, in1_cb_id)));
+    MATH((llk_math_matmul_uninit(in0_cb_id, in1_cb_id)));
+#endif
+}
+
+// clang-format off
+/**
  * Performs tile-sized matrix multiplication *C=A\*B* between the tiles in two
  * specified input CBs and accumulates the result to DST (DST += C). The DST register buffer
  * must be in acquired state via *acquire_dst* call. This call is blocking and

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -98,15 +98,21 @@ ALWI void reduce_init(
  */
 // clang-format on
 ALWI void reduce_uninit(std::uint32_t icb = 0) {
-#ifndef ARCH_QUASAR
-#ifdef ARCH_BLACKHOLE
+#ifdef ARCH_QUASAR
+    // (Quasar) A column reduce over an MxFp4 operand overrides that operand's unpacker OUT_DATA_FORMAT
+    // and ALU src format to MxFp4_2x_B in reduce_init, diverging from the op-agnostic
+    // unpack_dst_format[] table. That override persists (non-reduce inits never restore OUT_DATA_FORMAT,
+    // and reconfig_data_format is skipped for a same-format operand), so restore it here before the
+    // next op. No-op unless icb is an MxFp4 operand.
+    UNPACK((llk_unpack_AB_reduce_uninit(icb)));
+    MATH((llk_math_reduce_uninit(icb)));
+#elif defined(ARCH_BLACKHOLE)
     MATH((llk_math_reduce_uninit()));
 #else
     // Required because MOVB2D/D2B depends on SrcA ALU Format - Hi/Lo16 does not work with Tf32 (only on WH)
     // This is needed because FP32 data from L1 that is unpacked to Src registers is reduced to Tf32
     // See _llk_math_reduce_init_ for more details
     MATH((llk_math_reduce_uninit(icb)));
-#endif
 #endif
     PACK((llk_pack_reduce_mask_clear()));
 }

--- a/tt_metal/impl/host_api/temp_quasar_api.hpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.hpp
@@ -80,7 +80,6 @@ struct QuasarComputeConfig {
     std::vector<UnpackToDestMode> unpack_to_dest_mode;
     bool bfp8_pack_precise = false;
     bool math_approx_mode = false;
-    bool enable_2x_src_format = false;
 
     std::vector<uint32_t> compile_args;
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -1520,9 +1520,6 @@ std::string QuasarComputeKernel::config_hash() const {
         unpack_mode_descriptor = fmt::format("{}", fmt::join(unpack_modes, "."));
     }
 
-    // Note: the 2x-packed src-register format is not hashed here. It is decided kernel-side from the
-    // operand's MxFp4 L1 data format (Quasar matmul/column-reduce), so it is already implied by the
-    // CB data formats that are part of the kernel's build identity.
     return fmt::format(
         "{}_{}_{}_{}_{}_{}_{}",
         fmt::join(compute_processors_, "_"),

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -1520,15 +1520,17 @@ std::string QuasarComputeKernel::config_hash() const {
         unpack_mode_descriptor = fmt::format("{}", fmt::join(unpack_modes, "."));
     }
 
+    // Note: the 2x-packed src-register format is not hashed here. It is decided kernel-side from the
+    // operand's MxFp4 L1 data format (Quasar matmul/column-reduce), so it is already implied by the
+    // CB data formats that are part of the kernel's build identity.
     return fmt::format(
-        "{}_{}_{}_{}_{}_{}_{}_{}",
+        "{}_{}_{}_{}_{}_{}_{}",
         fmt::join(compute_processors_, "_"),
         enchantum::to_string(config_.math_fidelity),
         config_.fp32_dest_acc_en,
         config_.math_approx_mode,
         config_.dst_full_sync_en,
         config_.bfp8_pack_precise,
-        config_.enable_2x_src_format,
         unpack_mode_descriptor);
 }
 
@@ -1543,7 +1545,6 @@ void QuasarComputeKernel::set_build_options(JitBuildOptions& build_options) cons
     build_options.dst_full_sync_en = this->config_.dst_full_sync_en;
     build_options.unpack_to_dest_mode = this->config_.unpack_to_dest_mode;
     build_options.bfp8_pack_precise = this->config_.bfp8_pack_precise;
-    build_options.enable_2x_src_format = this->config_.enable_2x_src_format;
 }
 
 }  // namespace experimental::quasar

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2793,7 +2793,7 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
         .dst_full_sync_en = !gen2.double_buffer_dest,
         .unpack_to_dest_mode = unpack_dst_modes,
         .math_approx_mode = (gen2.sfpu_precision_mode == Precision::Approximate),
-        .enable_2x_src_format = gen2.enable_2x_src_register,
+        .enable_2x_src_format = enable_2x_src_format,
         .compile_args = {},  // Compile args are passed via named_compile_args
         .defines = std::move(defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2781,6 +2781,11 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
 
     std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen2.unpack_modes, dfb_name_to_slot);
 
+    auto defines = to_defines_map(kernel_spec.compiler_options.defines);
+    // The 2x-packed src-register format is opted into via a kernel compile-time define rather than a
+    // ComputeHardwareConfig field. Its presence (any value) flips the jit_build format-table remap.
+    const bool enable_2x_src_format = defines.count(experimental::k2xSrcFormatDefine) > 0;
+
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
         .math_fidelity = gen2.fpu_math_fidelity,
@@ -2790,7 +2795,7 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
         .math_approx_mode = (gen2.sfpu_precision_mode == Precision::Approximate),
         .enable_2x_src_format = gen2.enable_2x_src_register,
         .compile_args = {},  // Compile args are passed via named_compile_args
-        .defines = to_defines_map(kernel_spec.compiler_options.defines),
+        .defines = std::move(defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),
         .opt_level = kernel_spec.compiler_options.opt_level,
         .compiler_include_paths = kernel_spec.compiler_options.include_paths,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2781,11 +2781,6 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
 
     std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen2.unpack_modes, dfb_name_to_slot);
 
-    auto defines = to_defines_map(kernel_spec.compiler_options.defines);
-    // The 2x-packed src-register format is opted into via a kernel compile-time define rather than a
-    // ComputeHardwareConfig field. Its presence (any value) flips the jit_build format-table remap.
-    const bool enable_2x_src_format = defines.count(experimental::k2xSrcFormatDefine) > 0;
-
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
         .math_fidelity = gen2.fpu_math_fidelity,
@@ -2793,9 +2788,8 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
         .dst_full_sync_en = !gen2.double_buffer_dest,
         .unpack_to_dest_mode = unpack_dst_modes,
         .math_approx_mode = (gen2.sfpu_precision_mode == Precision::Approximate),
-        .enable_2x_src_format = enable_2x_src_format,
         .compile_args = {},  // Compile args are passed via named_compile_args
-        .defines = std::move(defines),
+        .defines = to_defines_map(kernel_spec.compiler_options.defines),
         .named_compile_args = to_named_compile_args_map(kernel_spec.compile_time_args),
         .opt_level = kernel_spec.compiler_options.opt_level,
         .compiler_include_paths = kernel_spec.compiler_options.include_paths,

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -159,11 +159,12 @@ DataFormat get_single_unpack_dst_format(
     }
 
     if (is_mx_format(src_format)) {
-        // MX formats unpack-expand to Float16_b in src regs. The 2x-packed MxFp4_2x_B src-register
-        // format for matmul / column-reduce is NOT decided here: it is applied kernel-side in the
-        // Quasar matmul/reduce LLK op init (op-scoped, since only those ops support 2x), by
-        // overriding the unpacker OUT_DATA_FORMAT. Keeping the op-agnostic default here means plain
-        // MxFp4 (datacopy/SFPU/eltwise/pack) still gets the correct bf16 expansion.
+        // MX formats unpack-expand to Float16_b in src regs — the op-agnostic default. The 2x-packed
+        // MxFp4_2x_B src-register format is NOT decided here (this table can't see which op consumes
+        // the operand): matmul and column-reduce select it kernel-side in their LLK op init by
+        // overriding the unpacker OUT_DATA_FORMAT and the ALU src-format, then restore this default
+        // on exit via mm_uninit / reduce_uninit. Keeping Float16_b here means plain MxFp4 consumed by
+        // any other op (datacopy/SFPU/eltwise/pack) still gets the correct bf16 expansion.
         dst_format = DataFormat::Float16_b;
     }
 

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -142,8 +142,7 @@ std::vector<DataFormat> get_unpack_src_formats(std::span<const DataFormat> data_
 DataFormat get_single_unpack_dst_format(
     const DataFormat src_format,
     const DataFormat /*pack_format*/,
-    const DataFormat unpack_conditional_dst_format,
-    const bool enable_2x_src_format) {
+    const DataFormat unpack_conditional_dst_format) {
     // NOTE: DataFormat::UInt8 is intentionally not remapped to Int8 here. The unpacker's 4-bit
     // OutDataFormat register field has no UInt8 encoding; the LLK applies masked_data_format()
     // at the register-write site so UInt8 (=30) lands as INT8 (=14) in the bitfield. We preserve
@@ -160,11 +159,12 @@ DataFormat get_single_unpack_dst_format(
     }
 
     if (is_mx_format(src_format)) {
-        if (enable_2x_src_format && src_format == DataFormat::MxFp4) {
-            dst_format = DataFormat::MxFp4_2x_B;
-        } else {
-            dst_format = DataFormat::Float16_b;  // Default: MX formats unpack-expand to Float16_b in src regs.
-        }
+        // MX formats unpack-expand to Float16_b in src regs. The 2x-packed MxFp4_2x_B src-register
+        // format for matmul / column-reduce is NOT decided here: it is applied kernel-side in the
+        // Quasar matmul/reduce LLK op init (op-scoped, since only those ops support 2x), by
+        // overriding the unpacker OUT_DATA_FORMAT. Keeping the op-agnostic default here means plain
+        // MxFp4 (datacopy/SFPU/eltwise/pack) still gets the correct bf16 expansion.
+        dst_format = DataFormat::Float16_b;
     }
 
     return dst_format;
@@ -184,8 +184,7 @@ std::vector<DataFormat> get_unpack_dst_formats(
     DataFormat unpack_conditional_dst_format,
     bool /*fp32_dest_acc_en*/,
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode,
-    bool int_fpu_en,
-    bool enable_2x_src_format) {
+    bool int_fpu_en) {
     if (!unpack_to_dest_mode.empty()) {
         TT_FATAL(
             // Allow size >= buf_formats.size() to support host-side allocations sized for
@@ -215,10 +214,10 @@ std::vector<DataFormat> get_unpack_dst_formats(
             if (src_format == DataFormat::Float32 && !unpack_to_dest_mode.empty() &&
                 unpack_to_dest_mode[i] != tt::tt_metal::UnpackToDestMode::Default) {
                 unpack_dst_format.push_back(get_single_unpack_dst_format(
-                    src_format, DataFormat::Invalid, DataFormat::Float32, enable_2x_src_format));
+                    src_format, DataFormat::Invalid, DataFormat::Float32));
             } else {
                 unpack_dst_format.push_back(get_single_unpack_dst_format(
-                    src_format, DataFormat::Invalid, unpack_conditional_dst_format, enable_2x_src_format));
+                    src_format, DataFormat::Invalid, unpack_conditional_dst_format));
             }
         }
     }

--- a/tt_metal/jit_build/data_format.hpp
+++ b/tt_metal/jit_build/data_format.hpp
@@ -35,8 +35,7 @@ std::vector<DataFormat> get_unpack_dst_formats(
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode,
-    bool int_fpu_en = false,
-    bool enable_2x_src_format = false);
+    bool int_fpu_en = false);
 
 // True if any data-flow buffer is configured to unpack directly to Dest (i.e. any entry is not
 // UnpackToDestMode::Default). Used to derive the (Quasar-only) kernel-wide UnpackToDestEn sync

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -668,7 +668,6 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_unpack_data
     DataFormat unpack_conditional_dst_format,
     bool fp32_dest_acc_en,
     std::vector<UnpackToDestMode> unpack_to_dest_mode,
-    bool enable_2x_src_format,
     uint32_t max_cbs) {
     vector<DataFormat> src_formats = tt::get_unpack_src_formats(desc.buf_dataformat_arr);
 
@@ -677,8 +676,7 @@ std::pair<std::vector<DataFormat>, std::vector<DataFormat>> generate_unpack_data
         unpack_conditional_dst_format,
         fp32_dest_acc_en,
         std::move(unpack_to_dest_mode),
-        /*int_fpu_en=*/false,
-        enable_2x_src_format);
+        /*int_fpu_en=*/false);
 
     TT_ASSERT(src_formats.size() == max_cbs);
     TT_ASSERT(dst_formats.size() == max_cbs);
@@ -812,7 +810,6 @@ ComputedDataFormats compute_data_formats(const JitBuildOptions& options, tt::ARC
         unpack_conditional_dst_format,
         options.fp32_dest_acc_en,
         options.unpack_to_dest_mode,
-        options.enable_2x_src_format,
         max_cbs);
 
     auto [pack_src_formats_all_cbs, pack_dst_formats_all_cbs] = generate_pack_data_formats(

--- a/tt_metal/jit_build/jit_build_options.hpp
+++ b/tt_metal/jit_build/jit_build_options.hpp
@@ -44,10 +44,6 @@ public:
 
     bool dst_full_sync_en{};
 
-    // When set, jit_build emits the 2x-packed src-register format as the
-    // unpack_dst_format for 2x-capable inputs.
-    bool enable_2x_src_format{};
-
     JitBuildOptions(const JitBuildEnv& env);
     void set_name(const std::string& name);
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -122,7 +122,7 @@ tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
             .enable_32_bit_dest = config.fp32_dest_acc_en,
             .double_buffer_dest = !config.dst_full_sync_en,
             // Per-DFB unpack_modes is left default for the program factory to set.
-            // 2x-packed src format is opted into per kernel via the ENABLE_2X_SRC_FORMAT define.
+            // 2x-packed src format is automatic for MxFp4 matmul/column-reduce (LLK op init).
         };
     }
     return tt::tt_metal::experimental::ComputeGen1Config{

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -122,7 +122,7 @@ tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
             .enable_32_bit_dest = config.fp32_dest_acc_en,
             .double_buffer_dest = !config.dst_full_sync_en,
             // Per-DFB unpack_modes is left default for the program factory to set.
-            // The temporary Gen2 field enable_2x_src_register is left default.
+            // 2x-packed src format is opted into per kernel via the ENABLE_2X_SRC_FORMAT define.
         };
     }
     return tt::tt_metal::experimental::ComputeGen1Config{

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.cpp
@@ -122,7 +122,6 @@ tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
             .enable_32_bit_dest = config.fp32_dest_acc_en,
             .double_buffer_dest = !config.dst_full_sync_en,
             // Per-DFB unpack_modes is left default for the program factory to set.
-            // 2x-packed src format is automatic for MxFp4 matmul/column-reduce (LLK op init).
         };
     }
     return tt::tt_metal::experimental::ComputeGen1Config{

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -70,9 +70,8 @@ std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kerne
 // The result's per-DFB unpack_modes table is left default for the program factory to set.
 // bfp_pack_precision_mode is likewise left default (rarely set non-default).
 //
-// The following Gen2-only TEMPORARY field is also not set here; a use site that needs
-// it should set it on the returned config instead:
-//   enable_2x_src_register
+// The 2x-packed src-register format is not a field here; a kernel that needs it opts in via the
+// ENABLE_2X_SRC_FORMAT compile-time define (KernelSpec::compiler_options.defines).
 tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
     tt::ARCH arch, const ComputeKernelConfig& config);
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -70,8 +70,6 @@ std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kerne
 // The result's per-DFB unpack_modes table is left default for the program factory to set.
 // bfp_pack_precision_mode is likewise left default (rarely set non-default).
 //
-// The 2x-packed src-register format has no knob here: on Quasar it is automatic for MxFp4 fed to
-// matmul / column-reduce (decided in the LLK op init).
 tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
     tt::ARCH arch, const ComputeKernelConfig& config);
 

--- a/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp
@@ -70,8 +70,8 @@ std::tuple<tt::tt_metal::MathFidelity, bool, bool, bool, bool> get_compute_kerne
 // The result's per-DFB unpack_modes table is left default for the program factory to set.
 // bfp_pack_precision_mode is likewise left default (rarely set non-default).
 //
-// The 2x-packed src-register format is not a field here; a kernel that needs it opts in via the
-// ENABLE_2X_SRC_FORMAT compile-time define (KernelSpec::compiler_options.defines).
+// The 2x-packed src-register format has no knob here: on Quasar it is automatic for MxFp4 fed to
+// matmul / column-reduce (decided in the LLK op init).
 tt::tt_metal::experimental::ComputeHardwareConfig to_compute_hardware_config(
     tt::ARCH arch, const ComputeKernelConfig& config);
 


### PR DESCRIPTION
### Summary

Removes the `enable_2x_src_format` / `enable_2x_src_register` opt-in flag and makes MxFp4 →
`MxFp4_2x_B` src-register packing **automatic** for the two Quasar ops that support it: matmul
(`MVMUL`/`MVMULDI`) and column reduce (`GAPOOL`).

**Why the decision cannot live on the host.** The `jit_build` format tables are op-agnostic — they
see only the CB `buf_dataformat_arr`, never "this is a matmul" — and MxFp4 is also consumed by ops
that must *not* get the 2x format (typecast / SFPU / eltwise / pack / tilize all need the
`Float16_b` expansion). A host flag can therefore only ever be a hint the op writer has to remember
to set, and setting it wrongly fails silently. So `unpack_dst_format[]` now always keeps the safe MX
default (`Float16_b`), and the two ops that need 2x derive it themselves from the L1 format.

**Kernel-side auto-detect** (Quasar LLK API layer only — no `tt-llk` lib changes):

- `llk_unpack_AB_matmul_api.h`, `llk_unpack_AB_reduce_api.h` — when the operand's L1 format is
  MxFp4, override *only* the unpacker gasket `OUT_DATA_FORMAT` to `MxFp4_2x_B` through the existing
  `_llk_unpack_reconfig_data_format_src_`. The buffer descriptor is untouched — it carries the L1
  format and geometry, not the src-register format — so this lands in the same HW state the old
  host-side remap produced. Runs at init with the unpacker idle, before the first `UNPACR`.
- `llk_math_matmul_api.h`, `llk_math_reduce_api.h` — derive the effective src-register format the
  same way; it drives both the ALU format registers and `EN_X2` MOP selection. Reduce is gated to
  `REDUCE_COL`, since row/scalar reduce goes through post-pool `ELWADDDI`, which does not support 2x.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uvelimirovic/relocate_2x_flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uvelimirovic/relocate_2x_flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uvelimirovic/relocate_2x_flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uvelimirovic/relocate_2x_flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uvelimirovic/relocate_2x_flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uvelimirovic/relocate_2x_flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uvelimirovic/relocate_2x_flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uvelimirovic/relocate_2x_flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uvelimirovic/relocate_2x_flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uvelimirovic/relocate_2x_flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uvelimirovic/relocate_2x_flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uvelimirovic/relocate_2x_flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uvelimirovic/relocate_2x_flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uvelimirovic/relocate_2x_flag)