### PR TITLE
[bug fix] Fix CTA vararg not available in constexpr when assert is on

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -47,6 +47,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>  // for CompileProgram (JIT trigger)
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgsConfig / ArgConfig::RuntimePageSize
+#include "impl/context/metal_context.hpp"                // for rtoptions (kernel-assert flavor overrides)
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -4403,6 +4404,110 @@ TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKern
 
     kernel_b->set_compile_time_vararg_count(1u);
     EXPECT_NE(kernel_a->compute_hash(), kernel_b->compute_hash());
+}
+
+// ============================================================================
+// Compile-time varargs with kernel asserts enabled
+// ============================================================================
+//
+// get_compile_time_vararg(idx) is constexpr AND bounds-checked, and those two properties collide
+// with how ASSERT is defined. The lightweight-assert flavor expands to inline asm ("ebreak");
+// C++20 permits inline asm inside a constexpr function but C++17 rejects it
+// (-Werror=c++20-extensions), and kernels build with -std=c++17. So an ASSERT sitting directly in
+// the constexpr body fails EVERY Metal 2.0 kernel build whenever lightweight asserts are on --
+// the accessor is emitted unconditionally, even for kernels with no varargs at all.
+//
+// These two tests pin both halves of the contract with asserts turned on:
+//   1. an in-range index still folds in a constant expression (the accessor stays constexpr), and
+//   2. an out-of-range index in a constant expression is still rejected at build time.
+//
+// Fixture note: the flag must be flipped BEFORE the device opens. JitBuildState assembles its -D
+// defines in its constructor (jit_build/build.cpp) and those states are built at device open, so
+// setting the option from a test body -- after mesh_device_ exists -- would never reach the
+// compiler and the test would pass while exercising nothing.
+//
+// Watcher note: assert.h is `#if WATCHER_ENABLED ... #elif LIGHTWEIGHT_KERNEL_ASSERTS`, and the
+// watcher flavor expands to a plain function call that compiles fine under C++17. Watcher is
+// forced off so that running this suite under TT_METAL_WATCHER does not silently exercise the
+// wrong branch and go green.
+class ProgramSpecTestGen1LightweightAsserts : public ProgramSpecTestGen1 {
+protected:
+    void SetUp() override {
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        prev_lightweight_kernel_asserts_ = rtoptions.get_lightweight_kernel_asserts();
+        prev_watcher_enabled_ = rtoptions.get_watcher_enabled();
+        rtoptions.set_lightweight_kernel_asserts(true);
+        rtoptions.set_watcher_enabled(false);
+        // Device opens here; the JIT build state picks up -DLIGHTWEIGHT_KERNEL_ASSERTS.
+        ProgramSpecTestGen1::SetUp();
+    }
+    void TearDown() override {
+        ProgramSpecTestGen1::TearDown();
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        rtoptions.set_lightweight_kernel_asserts(prev_lightweight_kernel_asserts_);
+        rtoptions.set_watcher_enabled(prev_watcher_enabled_);
+    }
+
+private:
+    bool prev_lightweight_kernel_asserts_ = false;
+    bool prev_watcher_enabled_ = false;
+};
+
+// In-range index, asserts on: the bounds check must not cost the accessor its constexpr-ness.
+// Before the fix this failed to build with
+//   error: 'asm' in 'constexpr' function only available with '-std=c++20'
+// for every Metal 2.0 kernel, regardless of the index used.
+TEST_F(ProgramSpecTestGen1LightweightAsserts, InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
+    NodeCoord node{0, 0};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    // Constant-evaluated: proves the accessor is still usable in a constant expression while the
+    // out-of-range path carries a (non-constexpr) assert.
+    static_assert(get_compile_time_vararg(0) == 0xCAFEBABEu);
+    static_assert(get_compile_time_vararg(2) == 0x11112222u);
+    // Runtime-evaluated: the index is not a constant expression, so this is the path that actually
+    // emits the bounds check and the ebreak.
+    volatile uint32_t idx = 1;
+    volatile uint32_t sink = get_compile_time_vararg(idx);
+    (void)sink;
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_in_range_asserts_on";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+// Out-of-range index in a constant expression, asserts on: must still fail the build. Constant
+// evaluation reaches the non-constexpr out-of-range report, which is not a constant expression --
+// so this is a clean build failure rather than a read past kernel_compile_time_args.
+TEST_F(ProgramSpecTestGen1LightweightAsserts, OutOfRangeCompileTimeVarargFailsToCompileWithAssertsEnabled) {
+    NodeCoord node{0, 0};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    // Only 1 vararg is baked, so index 1 is out of range. Should not compile.
+    static_assert(get_compile_time_vararg(1) == 0u);
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu};
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_oob_asserts_on";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    // MakeProgramFromSpec compiles; the OOB constant evaluation must fail that build.
+    EXPECT_ANY_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -47,7 +47,6 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>  // for CompileProgram (JIT trigger)
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgsConfig / ArgConfig::RuntimePageSize
-#include "impl/context/metal_context.hpp"                // for rtoptions (kernel-assert flavor overrides)
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -4421,46 +4420,13 @@ TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKern
 //   1. an in-range index still folds in a constant expression (the accessor stays constexpr), and
 //   2. an out-of-range index in a constant expression is still rejected at build time.
 //
-// Fixture note: the flag must be flipped BEFORE the device opens. JitBuildState assembles its -D
-// defines in its constructor (jit_build/build.cpp) and those states are built at device open, so
-// setting the option from a test body -- after mesh_device_ exists -- would never reach the
-// compiler and the test would pass while exercising nothing.
-//
-// Watcher note: assert.h is `#if WATCHER_ENABLED ... #elif LIGHTWEIGHT_KERNEL_ASSERTS`, and the
-// watcher flavor expands to a plain function call that compiles fine under C++17. Watcher is
-// forced off so that running this suite under TT_METAL_WATCHER does not silently exercise the
-// wrong branch and go green.
-class ProgramSpecTestGen1LightweightAsserts : public ProgramSpecTestGen1 {
-protected:
-    void SetUp() override {
-        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-        prev_lightweight_kernel_asserts_ = rtoptions.get_lightweight_kernel_asserts();
-        prev_watcher_enabled_ = rtoptions.get_watcher_enabled();
-        rtoptions.set_lightweight_kernel_asserts(true);
-        rtoptions.set_watcher_enabled(false);
-        // Device opens here; the JIT build state picks up -DLIGHTWEIGHT_KERNEL_ASSERTS.
-        ProgramSpecTestGen1::SetUp();
-    }
-    void TearDown() override {
-        ProgramSpecTestGen1::TearDown();
-        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-        rtoptions.set_lightweight_kernel_asserts(prev_lightweight_kernel_asserts_);
-        rtoptions.set_watcher_enabled(prev_watcher_enabled_);
-    }
+// Lightweight (hacky) simulation of assertion-on environment to verify vararg CTA work with assertion.
 
-private:
-    bool prev_lightweight_kernel_asserts_ = false;
-    bool prev_watcher_enabled_ = false;
-};
-
-// In-range index, asserts on: the bounds check must not cost the accessor its constexpr-ness.
-// Before the fix this failed to build with
-//   error: 'asm' in 'constexpr' function only available with '-std=c++20'
-// for every Metal 2.0 kernel, regardless of the index used.
-TEST_F(ProgramSpecTestGen1LightweightAsserts, InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
+TEST_F(ProgramSpecTestGen1, InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
     NodeCoord node{0, 0};
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.compiler_options.defines = {{"LIGHTWEIGHT_KERNEL_ASSERTS", "1"}, {"FORCE_WATCHER_OFF", "1"}};
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
     // Constant-evaluated: proves the accessor is still usable in a constant expression while the
@@ -4489,10 +4455,11 @@ void kernel_main() {
 // Out-of-range index in a constant expression, asserts on: must still fail the build. Constant
 // evaluation reaches the non-constexpr out-of-range report, which is not a constant expression --
 // so this is a clean build failure rather than a read past kernel_compile_time_args.
-TEST_F(ProgramSpecTestGen1LightweightAsserts, OutOfRangeCompileTimeVarargFailsToCompileWithAssertsEnabled) {
+TEST_F(ProgramSpecTestGen1, OutOfRangeCompileTimeVarargFailsToCompileWithAssertsEnabled) {
     NodeCoord node{0, 0};
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.compiler_options.defines = {{"LIGHTWEIGHT_KERNEL_ASSERTS", "1"}, {"FORCE_WATCHER_OFF", "1"}};
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
     // Only 1 vararg is baked, so index 1 is out of range. Should not compile.

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4411,16 +4411,9 @@ TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKern
 //
 // get_compile_time_vararg(idx) is constexpr AND bounds-checked, and those two properties collide
 // with how ASSERT is defined. The lightweight-assert flavor expands to inline asm ("ebreak");
-// C++20 permits inline asm inside a constexpr function but C++17 rejects it
-// (-Werror=c++20-extensions), and kernels build with -std=c++17. So an ASSERT sitting directly in
-// the constexpr body fails EVERY Metal 2.0 kernel build whenever lightweight asserts are on --
-// the accessor is emitted unconditionally, even for kernels with no varargs at all.
-//
-// These two tests pin both halves of the contract with asserts turned on:
-//   1. an in-range index still folds in a constant expression (the accessor stays constexpr), and
-//   2. an out-of-range index in a constant expression is still rejected at build time.
-//
-// Lightweight (hacky) simulation of assertion-on environment to verify vararg CTA work with assertion.
+// inline assembly is unconditionally not allowed in a constexpr function in C++17.
+// These tests ensure that this caveat is properly handled. The assertion-on environment is
+// simulated in a lightweight (and hacky) way by defining the assertion-enable macro manually.
 
 TEST_F(ProgramSpecTestGen1, InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
     NodeCoord node{0, 0};

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -361,6 +361,16 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     //   1. get_num_compile_time_varargs() — baked prefix length
     //   2. get_compile_time_vararg<idx>() — template index (with bounds check)
     //   3. get_compile_time_vararg(idx) — function-parameter index
+    //
+    // The out-of-range report for (3) sits behind a non-constexpr call rather than being an
+    // ASSERT in the constexpr body: the lightweight-assert flavor of ASSERT expands to inline
+    // asm ("ebreak"), which C++20 allows inside a constexpr function but C++17 rejects
+    // (-Werror=c++20-extensions), and kernels are built with -std=c++17. Calling a
+    // non-constexpr function from a constexpr one is fine in C++17 as long as constant
+    // evaluation never reaches the call, which an in-range index never does — so (3) stays
+    // usable in constant expressions under every assert flavor. Out-of-range indices keep the
+    // runtime assert, and in a constant expression they now fail the build outright instead of
+    // reading past the array.
     content << fmt::format(
         R"(
 FORCE_INLINE constexpr uint32_t get_num_compile_time_varargs() {{
@@ -371,8 +381,13 @@ FORCE_INLINE constexpr uint32_t get_compile_time_vararg() {{
     static_assert(idx < get_num_compile_time_varargs(), "Compile-time vararg index out of range");
     return kernel_compile_time_args[idx];
 }}
+inline void assert_compile_time_vararg_index_out_of_range() {{
+    ASSERT(false);  // Attempt to access out of bound vararg CTA.
+}}
 FORCE_INLINE constexpr uint32_t get_compile_time_vararg(uint32_t idx) {{
-    ASSERT(idx < get_num_compile_time_varargs());  // Attempt to access out of bound vararg CTA.
+    if (idx >= get_num_compile_time_varargs()) {{
+        assert_compile_time_vararg_index_out_of_range();
+    }}
     return kernel_compile_time_args[idx];
 }}
 )",

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -361,16 +361,6 @@ void write_kernel_args_generated_header(const std::filesystem::path& out_dir, co
     //   1. get_num_compile_time_varargs() — baked prefix length
     //   2. get_compile_time_vararg<idx>() — template index (with bounds check)
     //   3. get_compile_time_vararg(idx) — function-parameter index
-    //
-    // The out-of-range report for (3) sits behind a non-constexpr call rather than being an
-    // ASSERT in the constexpr body: the lightweight-assert flavor of ASSERT expands to inline
-    // asm ("ebreak"), which C++20 allows inside a constexpr function but C++17 rejects
-    // (-Werror=c++20-extensions), and kernels are built with -std=c++17. Calling a
-    // non-constexpr function from a constexpr one is fine in C++17 as long as constant
-    // evaluation never reaches the call, which an in-range index never does — so (3) stays
-    // usable in constant expressions under every assert flavor. Out-of-range indices keep the
-    // runtime assert, and in a constant expression they now fail the build outright instead of
-    // reading past the array.
     content << fmt::format(
         R"(
 FORCE_INLINE constexpr uint32_t get_num_compile_time_varargs() {{
@@ -381,6 +371,10 @@ FORCE_INLINE constexpr uint32_t get_compile_time_vararg() {{
     static_assert(idx < get_num_compile_time_varargs(), "Compile-time vararg index out of range");
     return kernel_compile_time_args[idx];
 }}
+// Called when an OOB access to vararg CTA is attempted. Meant to trigger the assertion
+// failure as an indirection: the ASSERT macro may expand to inline asm, which cannot be
+// present in a C++17 constexpr function. This is a workaround and can be inlined once we
+// migrate to C++20.
 inline void assert_compile_time_vararg_index_out_of_range() {{
     ASSERT(false);  // Attempt to access out of bound vararg CTA.
 }}


### PR DESCRIPTION
### Summary

Metal 2.0 exposes compile-time varargs to kernels via the generated `constexpr` accessor `get_compile_time_vararg(uint32_t)`, which bounds-checks with `ASSERT`.

Under lightweight kernel asserts, `ASSERT` expands to inline `asm ("ebreak")`. Inline assembly is not allowed in a C++17 `constexpr` function, and kernels build with `-std=c++17`, so the accessor fails to compile whenever asserts are on.

This PR moves the out-of-range `ASSERT` behind a non-`constexpr` helper and calls it only on the failing path. C++17 allows a `constexpr` function to call a non-`constexpr` function as long as constant evaluation never reaches that call, so in-range indices stay usable in constant expressions.

### Note to reviewers

Tests cover both sides with asserts enabled: an in-range index still folds in a constant expression, and an out-of-range index still fails the build. The assertion-on environment is simulated by defining the assertion-enable macro on the kernel.

Verified locally.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/m2-constexpr-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/m2-constexpr-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/m2-constexpr-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/m2-constexpr-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/m2-constexpr-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/m2-constexpr-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/m2-constexpr-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/m2-constexpr-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/m2-constexpr-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/m2-constexpr-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/m2-constexpr-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/m2-constexpr-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/m2-constexpr-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/m2-constexpr-fix)
