### PR TITLE
fix H3 quad read. Revert dit mmrs

### DIFF
--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -499,6 +499,7 @@ class RowParallelLinear(Module):
         # Branch addition kept over main: the H3 / Qwen3-VL layers pass an explicit config for
         # the sites that need more precision than the shared default.
         compute_kernel_config=None,
+        mm_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
     ):
         super().__init__()
 
@@ -508,6 +509,7 @@ class RowParallelLinear(Module):
         self.mesh_axis = mesh_axis
         self.fsdp_mesh_axis = fsdp_mesh_axis
         self.ccl_manager = ccl_manager
+        self.mm_memory_config = mm_memory_config
 
         if self.fsdp_mesh_axis is not None:
             assert self.mesh_axis != self.fsdp_mesh_axis
@@ -666,7 +668,7 @@ class RowParallelLinear(Module):
             multi_device_global_semaphore=self.ccl_manager.get_rs_ping_pong_semaphore(self.mesh_axis),
             **get_fused_mmrs_config(M, K, N, core_grid, self.ccl_manager.num_links),
             bias=self.bias.data if self.bias is not None else None,
-            memory_config_mm=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+            memory_config_mm=self.mm_memory_config,
             rs_intermediate_mem_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
             rs_output_mem_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
             topology=self.ccl_manager.topology,

--- a/models/tt_dit/models/transformers/transformer_flux2.py
+++ b/models/tt_dit/models/transformers/transformer_flux2.py
@@ -110,6 +110,7 @@ class Flux2SingleTransformerBlock(Module):
             mesh_axis=tp_axis,
             ccl_manager=ccl_manager,
             fsdp_mesh_axis=fsdp_mesh_axis,
+            mm_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
         )
 
         self._dim = dim
@@ -293,6 +294,7 @@ class Flux2Transformer(Module):
             mesh_device=device,
             mesh_axis=tp_axis,
             ccl_manager=ccl_manager,
+            mm_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
         )
 
         self.device = device

--- a/models/tt_dit/tests/models/minimax_h3/test_performance_minimax_h3.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_performance_minimax_h3.py
@@ -28,7 +28,7 @@ from ....pipelines.minimax_h3.packing import (
     resolve_canvas_size,
     video_latent_num_frames,
 )
-from ....utils.tensor import bf16_tensor_2dshard, from_torch
+from ....utils.tensor import bf16_tensor_2dshard, from_torch, local_device_to_torch
 from ....utils.test import skip_if_unsupported_num_links
 from .common import (
     GALAXY_RING,
@@ -182,6 +182,6 @@ def test_minimax_h3_transformer_block_perf(
         padded_len // sp_factor,
         HIDDEN_SIZE // tp_factor,
     ), f"unexpected output shape {tuple(tt_out.shape)}"
-    local = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).float()
+    local = local_device_to_torch(tt_out).float()
     assert torch.isfinite(local).all(), "block output contains NaN or Inf"
     logger.info(f"output {tuple(tt_out.shape)}, local shard std={local.std().item():.4f}")


### PR DESCRIPTION
### PR Category
Bug fix

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/rever_dit_mmrs_default)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/rever_dit_mmrs_default)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/rever_dit_mmrs_default)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/rever_dit_mmrs_default)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/rever_dit_mmrs_default)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/rever_dit_mmrs_default)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/rever_dit_mmrs_default)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/rever_dit_mmrs_default)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/rever_dit_mmrs_default)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/rever_dit_mmrs_default)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/rever_dit_mmrs_default)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/rever_dit_mmrs_default)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/rever_dit_mmrs_default)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/rever_dit_mmrs_default)