### PR TITLE
[skip ci] Update descriptor migration recipe to current framework doctrine

### DIFF
--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -661,6 +661,8 @@ Surgical `override_runtime_arguments` (the target cache-hit mechanism, §1.4):
 - `ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp`
 - Hash-excluded scalar re-applied per dispatch:
   `ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp`
+- Complete override for a shape-agnostic key + CB refresh by `CBIndex`:
+  `ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp`
 - Override done *wrong* (rebuild — do not copy): `eltwise/unary` and the other entries in
   `scripts/detect_override_rebuild_baseline.txt`
 
@@ -676,4 +678,5 @@ Declarative `WorkloadDescriptor` examples:
 Per-coordinate program (4-arg `create_descriptor`):
 - `ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp`
 
-Full doctrine, reviewer checklist, and source map: `tech_reports/ttnn/descriptors_and_specs.md`.
+Full doctrine, reviewer checklist, and source map:
+<https://gist.github.com/dgomezTT/7584e4eb0dc6ddc5214f9a7e90e77181>.

--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -23,7 +23,6 @@ This recipe was validated on the Bernoulli, Matmul, Conv2d, and FullLike operati
 > **Background reading:** "Descriptors and Specs: how a TTNN op describes its program" is the
 > full "what good looks like and why" document (cache mechanics, keying, refresh, bad
 > practices); this recipe is the mechanical procedure. It lives at
-> `tech_reports/ttnn/descriptors_and_specs.md` and at
 > <https://gist.github.com/dgomezTT/7584e4eb0dc6ddc5214f9a7e90e77181>. For a brand-new op (not
 > a migration), also consider a **Spec** factory (`create_program_artifacts`) — Specs are the
 > Metal 2.0 direction; see §3 and §6 of that document for whether your op's shape fits yet.
@@ -311,10 +310,11 @@ supersedes binding patching (branch (a) of §1.2). Rules for writing it:
    named constants or a comment; multi-factory ops mirror `select_program_factory` through a
    shared helper too.
 
-See `sparse_sdpa_program_factory.cpp` and
-`interleaved_to_sharded_partial_program_factory.cpp` for the model: a few addresses and one
-hash-excluded scalar written in place, everything else deliberately untouched because a hit
-guarantees it is already right.
+See `sparse_sdpa_program_factory.cpp` for the model: a few addresses and one hash-excluded
+scalar written in place, everything else deliberately untouched because a hit guarantees it is
+already right. (`interleaved_to_sharded_partial_program_factory.cpp` does the same job but
+builds a positional placeholder list and indexes `desc.cbs[i]`; do not copy that part — rule 6
+above requires matching CBs by `CBIndex`.)
 
 > **`get_dynamic_runtime_args` is FORBIDDEN in new code.** The older per-slot
 > `{kernel_idx, core, arg_idx, value}` dynamic-args hook is legacy and being removed
@@ -349,9 +349,11 @@ kernel ELF. They must stay in the hash.
 >
 > Some ops deliberately do the opposite: they **exclude shape from the hash** so one program is
 > reused across shapes, with the per-core args (num_tiles, offsets, num_cores) carrying the shape and
-> the **slow-path rebuild** recomputing them every dispatch (e.g. `binary_ng` hashes `shard_volumes`,
-> not shape). Such shape-agnostic ops **cannot** use bindings-only fast patching — it would leave
-> the shape-dependent args stale and miscompute; adding a binding *removes* the rebuild that was
+> the **slow-path rebuild** recomputing them every dispatch (`binary_ng` hashes `shard_volumes`, not
+> shape; it now re-derives those args in
+> `BinaryNgDeviceOperation::ProgramFactory::override_runtime_arguments`, not via a rebuild).
+> Such shape-agnostic ops **cannot** use bindings-only fast patching — it would leave the
+> shape-dependent args stale and miscompute; adding a binding *removes* the rebuild that was
 > silently saving them. Pick deliberately between: re-key the hash so a work-split change is a
 > miss (losing the cross-shape reuse), keep the slow-path rebuild, or re-derive every per-core arg
 > in the override (which is just the rebuild wearing a different name).

--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -20,6 +20,14 @@ The migration has three phases:
 
 This recipe was validated on the Bernoulli, Matmul, Conv2d, and FullLike operations.
 
+> **Background reading:** "Descriptors and Specs: how a TTNN op describes its program" is the
+> full "what good looks like and why" document (cache mechanics, keying, refresh, bad
+> practices); this recipe is the mechanical procedure. It lives at
+> `tech_reports/ttnn/descriptors_and_specs.md` and at
+> <https://gist.github.com/dgomezTT/7584e4eb0dc6ddc5214f9a7e90e77181>. For a brand-new op (not
+> a migration), also consider a **Spec** factory (`create_program_artifacts`) — Specs are the
+> Metal 2.0 direction; see §3 and §6 of that document for whether your op's shape fits yet.
+
 ---
 
 ## Phase 1 — Create the `_new` descriptor operation
@@ -71,11 +79,30 @@ struct MyDeviceOperation {
 - No `shared_variables_t`. No `cached_program_t`. No `ProgramFactory` wrapper struct.
 - `create_descriptor()` is a static method directly on the operation struct.
 - The framework synthesizes the variant dispatch wrapper internally.
-- No `program_factory_t` alias or `select_program_factory` needed for single-descriptor ops.
-- The framework handles buffer address patching on cache hits automatically.
-- The framework handles dynamic circular buffer address patching automatically
+- Single-descriptor ops with **no override**: `create_descriptor` can sit directly on the op
+  struct — no `program_factory_t`, no `select_program_factory`. Ops **with** an
+  `override_runtime_arguments` need a factory struct holding both hooks plus a
+  single-alternative `program_factory_t = std::variant<ProgramFactory>` (still no
+  `select_program_factory`); the override is rejected on the op struct itself.
+- Buffer addresses are patched on cache hits via the bindings you declare with
+  `emplace_runtime_args` (§1.3) — declare a binding for every address; never bake one.
+- Tensor-backed circular buffer addresses are patched the same way
   (set `.buffer` on `CBDescriptor` for sharded ops).
 - Include `<tt-metalium/program_descriptors.hpp>`.
+
+**Know which cache-hit branch your op lands in.** On a cache hit the framework picks one of
+three branches, in priority order:
+
+- **(a)** The program factory defines `override_runtime_arguments()` → the framework calls it
+  and does **nothing else** — no binding patching. The op owns the whole refresh. This is the
+  target mechanism; write it surgically (§1.4). The hook MUST live on the factory struct: a
+  static_assert rejects it on the DeviceOperation itself (only the factory is probed there,
+  so an operation-scope hook would be silently dead code).
+- **(b)** Else, if the factory declared runtime-arg buffer bindings → fast patch: only the
+  bound address slots are rewritten. Correct only when addresses are the *only* thing that
+  varies between two calls sharing a key.
+- **(c)** Else → slow path: `create_descriptor()` re-runs on **every dispatch**. Correct but
+  expensive — this is the host cost that blew the perf budget. Don't land a new op here.
 
 **Multi-variant programs (advanced):**
 
@@ -99,59 +126,54 @@ static program_factory_t select_program_factory(
 **Mesh-workload ops with workload-scoped state — `WorkloadDescriptor` pattern:**
 
 Most ops only need `create_descriptor`. But mesh-workload ops that allocate
-`GlobalSemaphore`s or call `Synchronize` need to do that **once per workload**
-(not once per coord, not once per dispatch). For those ops, define a
-declarative `WorkloadDescriptor` that owns both the workload-scoped resources
-**and** the per-coord program descriptors:
+`GlobalSemaphore`s / call `Synchronize`, own device scratch (halo lookup tables),
+or emit different programs per coordinate (CCL rings) need to do that **once per
+workload** (cache miss), not once per dispatch. For those ops, return the
+framework's `tt::tt_metal::WorkloadDescriptor`
+(`<tt-metalium/workload_descriptor.hpp>`):
 
 ```cpp
-struct MyMeshFactory {
-    // Op-defined struct holding the entire workload:
-    //   - workload-scoped resources (GlobalSemaphores, Synchronize tokens,
-    //     anything that must outlive the per-coord programs)
-    //   - a `programs` vector with one ProgramDescriptor per coord (or per
-    //     coord-range, if multiple coords share the same program).
-    //
-    // GlobalSemaphore has no default constructor; wrap each in
-    // std::optional<> so WorkloadDescriptor is value-initialisable.
-    struct WorkloadDescriptor {
-        std::optional<ttnn::GlobalSemaphore> semaphore;
-        // ... any other workload-wide resources
-        std::vector<std::pair<ttnn::MeshCoordinateRange, tt::tt_metal::ProgramDescriptor>> programs;
-    };
-
-    // Builds the entire workload in one call. Invoked ONCE per workload
-    // (cache miss). The right place to:
-    //   1. Allocate GlobalSemaphores / run Synchronize.
-    //   2. Loop over `tensor_coords` and push a ProgramDescriptor per coord
-    //      into `programs`.
-    // The framework iterates `programs` verbatim to build the MeshWorkload.
-    static WorkloadDescriptor create_workload_descriptor(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+struct WorkloadDescriptor {
+    std::vector<GlobalSemaphore> semaphores;   // workload-scoped resources, kept alive
+    std::vector<WorkloadBuffer> buffers;       //   for the cached workload's lifetime
+    struct PerCoordProgram { distributed::MeshCoordinateRange range; ProgramDescriptor descriptor; };
+    std::vector<PerCoordProgram> programs;     // which program goes where
 };
+
+static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+    const operation_attributes_t&,
+    const tensor_args_t&,
+    tensor_return_value_t&,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords);
 ```
 
-When the framework adapter sees `T::WorkloadDescriptor` + `T::create_workload_descriptor`
-+ a `programs` field on the descriptor, it dispatches through this contract:
+The contract:
 
-1. **Cache miss**: calls `create_workload_descriptor` ONCE. The factory allocates
-   resources and populates `programs`. The adapter then turns each
-   `(MeshCoordinateRange, ProgramDescriptor)` pair into a `Program` and adds
-   it to the cached `MeshWorkload`.
-2. **Cache hit**: the factory is **not** invoked. The framework's
-   `BufferBinding` fast path patches buffer addresses directly into the
-   cached programs. Declarative factories MUST use `emplace_runtime_args()`
-   with `Buffer*` args for every position that can change between dispatches
-   — there is no rebuild fallback for declarative ops (a rebuild would
-   reallocate GlobalSemaphores).
+1. **Cache miss**: `create_workload_descriptor` is called ONCE. Allocate
+   `GlobalSemaphore`s / run `Synchronize`, park them (and any op-owned scratch, via
+   `WorkloadBuffer{owner, buffer}` — `owner` is typically a `shared_ptr<Tensor>` deferring
+   deallocation) on the descriptor so they outlive the call, and push one `PerCoordProgram`
+   per coordinate — or per range, since `programs` is range-keyed: one program replicated
+   across the mesh is a single entry. The framework materialises `programs` verbatim into
+   the cached `MeshWorkload`.
+2. **Cache hit**: the factory is **not** invoked and there is **no rebuild fallback** (a
+   rebuild would reallocate the semaphores and re-run the barrier). Only declared
+   `BufferBinding`s are patched, so use `emplace_runtime_args()` with `Buffer*` for every
+   position that can change between dispatches.
+3. **The per-`Program` `override_runtime_arguments` hook is NEVER called on this path**
+   (#52554) — it compiles, looks right, and everything it was meant to re-apply freezes at
+   the first miss. If the op also has a hash-excluded scalar, wrap the descriptor adapter in
+   a hand-written `<Op>MeshWorkloadFactory` whose override takes the whole cached workload:
+   delegate to `descriptor_adapter_t::apply_descriptor(...)` first (binding behavior stays
+   bit-identical), then patch the extra slots per coordinate. See
+   `ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp`.
 
-> Single-device ops without workload-scoped state continue to use just
-> `create_descriptor` (no workload concept). Only ops that need to allocate
-> something once per workload (`GlobalSemaphore`s, halo lookup tables uploaded
-> to device, etc.) need the declarative `WorkloadDescriptor` pattern above.
+> Single-device ops without workload-scoped state continue to use just `create_descriptor`
+> (no workload concept). An op whose program merely *differs per mesh coordinate* (no shared
+> resources) instead takes the 4-arg `create_descriptor` with a
+> `const std::optional<ttnn::MeshCoordinate>&` — the framework then calls it once per
+> coordinate instead of once per range; returning an empty descriptor means "no work here".
+> Only take the coordinate if the program genuinely differs (cost: one program per device).
 
 ### 1.3 Program factory implementation (`create_descriptor`)
 
@@ -179,9 +201,9 @@ reader_desc.core_ranges = all_cores;
 reader_desc.compile_time_args = {...};
 reader_desc.config = ReaderConfigDescriptor{};
 
-// Runtime args per core
-reader_desc.runtime_args.emplace_back(
-    core, KernelDescriptor::CoreRuntimeArgs{addr, offset, count});
+// Runtime args per core — pass Buffer* (NOT ->address()) so the framework
+// records a BufferBinding and can patch the address on cache hits
+reader_desc.emplace_runtime_args(core, {src_buffer, offset, count});
 
 desc.kernels.push_back(std::move(reader_desc));
 return desc;
@@ -190,82 +212,148 @@ return desc;
 **Reuse existing kernels** — point `kernel_source` to the old operation's kernels directory.
 No need to duplicate kernel files.
 
-### 1.4 Hashing
+**Never smuggle an address.** The two ways to push runtime args are not equivalent:
 
-No custom `compute_program_hash` is needed. The framework automatically hashes
-`type_hash<YourDeviceOperation>` + all of `operation_attributes_t` + all of
-`tensor_args_t`.
+```cpp
+kernel.runtime_args.emplace_back(core, CoreRuntimeArgs{num_tiles});   // raw values only
+kernel.emplace_runtime_args(core, {src_buffer, num_tiles, start_id}); // Buffer* => binding
+```
+
+Passing a `Buffer*` (or `const MeshTensor&`) records a `BufferBinding`; on cache hit the
+framework writes the current address into that slot. Pushing `buffer->address()` as a raw
+`uint32_t` hides the pointer: the op then needs a hand-written override or falls to the
+rebuild-every-hit slow path. Same for common runtime args (`emplace_common_runtime_args`) and
+for tensor-backed CBs (set `.buffer` / `.tensor`, never the address). The
+`detect-smuggled-rta` pre-commit hook flags violations; a deliberate exception needs
+`// smuggled-rta-ok: <real reason>` (e.g. a workload-scoped `GlobalSemaphore` address).
+
+Compile notes for the binding overload: a bare `0` literal is ambiguous against `Buffer*` →
+write `0u`; `page_size()` is `uint64` → `static_cast<uint32_t>`; dynamically built or mixed
+lists need `RTArgList` or the `vector<variant<uint32_t, Buffer*>>` overload; an absent
+optional tensor passes a null `Buffer*` (the framework emits 0 and registers no binding).
+
+### 1.4 Hashing and keying
+
+No custom `compute_program_hash` is needed by default. The framework automatically hashes
+`type_hash<YourDeviceOperation>` + all of `operation_attributes_t` + all of `tensor_args_t`.
+The tensor part of the key is the tensor **specs** (shape, dtype, layout, memory config,
+shard spec) — **no buffer addresses**. That single fact generates every rule here: anything
+derivable from a `TensorSpec` may be baked into the cached program; anything derived from an
+address must be re-applied on every dispatch.
 
 While both the old and `_new` operations exist side by side (Phase 1), their program
 caches won't collide because the default hash includes `type_hash<YourDeviceOperation>`,
 which differs between the two distinct operation types.
 
-**Never write a custom `compute_program_hash` to exclude a per-call value.** A legacy op
-often hand-wrote a hash that dropped a value which varies per call but doesn't change the
-program structure (RNG `seed`, a fused `scalar`, a `from`/`to` range, a semaphore address).
-Under the descriptor framework that is a trap: on a cache **hit** only `Buffer*` address
-slots are re-patched, so a non-`Buffer` value baked into the runtime args is **frozen** at
-the first miss (silent wrong result), unless the op happens to fall to the slow-path rebuild.
+**If the default key is wrong, write `compute_program_hash`.** That is the one supported
+mechanism for changing the key, and there are exactly two reasons to reach for it:
 
-The correct pattern (static/dynamic split):
+- **Hashing a derived quantity** the reflection hash can't express (unary hashes shard
+  volumes, and padded shape for row-major, because page size depends on width).
+- **Excluding a per-call value** that doesn't change the program structure (RNG `seed`, a
+  fused `scalar`, a cache slot index, a token range): hashing it would recompile per call,
+  so leave it out of the hash and re-apply it per dispatch (below). Put a comment next to
+  the hash naming the mechanism that re-applies the excluded value, so both halves of the
+  decision are findable from either end.
 
-- **Static** (program identity → hashed): exclude the per-call value from the default hash by
-  giving `operation_attributes_t` an `attribute_names` / `attribute_values()` pair that lists
-  only the structural fields and omits the dynamic one. Do **not** add a `compute_program_hash`.
+**Do not narrow `attribute_names` / `attribute_values()` to drop a field from the hash.**
+Existing code does this (dropout omits `seed` that way) and it works today, but the loophole
+is being removed: `attribute_names` is a reflection/printing contract that happens to feed
+the hash, so keying through it makes the key invisible at the place a reader looks for it,
+and silently changes what graph capture and op logging report. Express keying in
+`compute_program_hash`, where it is one function a reviewer can read.
 
-  ```cpp
-  struct operation_attributes_t {
-      Shape shape; DataType dtype; MemoryConfig memory_config;
-      uint32_t seed;  // dynamic — omitted below
-      static constexpr auto attribute_names = std::forward_as_tuple("shape", "dtype", "memory_config");
-      auto attribute_values() const { return std::forward_as_tuple(shape, dtype, memory_config); }
-  };
-  ```
+The cost of a custom hash is real: the op is **opted out of canonical-key collision
+resolution**, so a 64-bit hash collision between two configurations of *your* op resolves to
+a wrong hit instead of a rebuild. Hash everything structural, exhaustively.
 
-- **Dynamic** (re-patched every dispatch): declare a `get_dynamic_runtime_args` hook returning the
-  current value at the (kernel, core, arg) slot `create_descriptor()` wrote it to. The framework
-  re-applies these on every cache hit (the non-`Buffer` analog of a `BufferBinding`):
+**Every excluded value must be re-applied on every cache hit.** There is no third category:
+every attribute is either structural (in the key, baked into the program) or dynamic (out of
+the key **and** re-applied per dispatch). A field that is neither is a stale-value bug. The
+mechanism is a **surgical `override_runtime_arguments` on the program factory struct**
+(never on the DeviceOperation — the adapter static-asserts against that, because only the
+factory is probed and an operation-scope hook would be silently dead code):
 
-  ```cpp
-  static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-      const operation_attributes_t& attrs, const tensor_args_t&, tensor_return_value_t& output,
-      const std::optional<ttnn::MeshCoordinate>& coord = std::nullopt);
-  ```
+```cpp
+static void override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&,
+    const std::optional<ttnn::MeshCoordinate>& coord = std::nullopt);
+```
 
-  Each `DynamicRuntimeArg` is `{kernel_idx, core, arg_idx, value}`. Ops without the hook compile
-  to nothing — only declare it when you excluded a value from the hash.
+When present, the framework calls it on every cache hit and does **nothing else** — it
+supersedes binding patching (branch (a) of §1.2). Rules for writing it:
 
-  > **Gotcha:** `attribute_values()` is also how the framework **discovers the mesh device** (via
-  > `get_first_object_of_type<MeshDevice*>`). For ops with no input tensor (e.g. `rand`) the device
-  > lives in the attrs, so it must appear in `attribute_values()` — and as the **first** element,
-  > because that helper's tuple path only inspects element 0. Put `device` first; otherwise dispatch
-  > throws "No mesh device found". Ops with an input tensor source the device from `tensor_args`, so
-  > this only bites device-in-attrs ops.
+1. **Single-source the work split.** Put the core split / per-core layout in one helper
+   called by *both* `create_descriptor` and the override, so arg indices can't drift.
+   **But keep the override lean**: the descriptor path has no `shared_variables_t`, so
+   whatever the helper computes is recomputed on EVERY hit. A full
+   `split_work_to_cores`/`grid_to_cores`/`CoreRangeSet` re-derivation costs ~2-3µs/dispatch
+   (measured on the randn trial: +7-9% vs the legacy op, which stashed `cores`) — that alone
+   can breach the §2.3 perf threshold. Re-derive only what the patch loop actually needs
+   (often just the core coords), and benchmark the hit path, not only correctness.
+2. **Must re-apply:** every buffer-address slot (anything emplaced as `Buffer*`), every
+   scalar derived from a hash-excluded attribute, and every globally-allocated CB base
+   address.
+3. **May skip:** anything derived purely from hashed inputs — a hit means it's identical.
+   Trace each value to its inputs; never skip on "looks static".
+4. **Cover every core** the descriptor emplaced args for, including zero-work / no-op cores.
+5. **Never gate the address patching behind an early return.** An override that returns
+   early when it has no scalar to write also skips the addresses, and nothing else refreshes
+   them (this bit rotary_embedding's prefill path). Gate only the scalars.
+6. **Match CBs by `CBIndex`, not by `desc.cbs` position** — positions shift between
+   descriptor variants.
+7. **Never call `create_descriptor()` from inside the override.** That pays the cache-miss
+   host cost on every hit (the ResNet50 20x cliff). The `detect-override-rebuild` pre-commit
+   hook rejects it; don't hide a rebuild inside a shared helper either.
+8. Pin the `kernel_idx` / `arg_idx` coupling to `create_descriptor`'s `push_back` order with
+   named constants or a comment; multi-factory ops mirror `select_program_factory` through a
+   shared helper too.
 
-- **Do not copy-paste** the work-split / core enumeration between `create_descriptor` and
-  `get_dynamic_runtime_args`. Extract a shared helper both call, so the miss-build and the
-  hit-patch derive the identical core list and value by construction.
+See `sparse_sdpa_program_factory.cpp` and
+`interleaved_to_sharded_partial_program_factory.cpp` for the model: a few addresses and one
+hash-excluded scalar written in place, everything else deliberately untouched because a hit
+guarantees it is already right.
+
+> **`get_dynamic_runtime_args` is FORBIDDEN in new code.** The older per-slot
+> `{kernel_idx, core, arg_idx, value}` dynamic-args hook is legacy and being removed
+> (elimination campaign in progress; remaining users are backlog, not examples). The adapter
+> static-asserts that an op does not declare both it and `override_runtime_arguments`. A
+> migration must never introduce it; when the op being ported has it, replace it with the
+> surgical override.
 
 - **In-place ops** (output aliases an input) take the fast path fine — register both as `Buffer*`
-  bindings via `emplace_runtime_args`; the framework allows the output==input alias. (A duplicate
-  among two *distinct* inputs, e.g. `matmul(X, X)`, still bails to the slow path.)
+  bindings via `emplace_runtime_args`; the framework allows the output==input alias. A duplicate
+  among two *distinct* inputs (e.g. `matmul(X, X)`) still bails to the slow path. An optional
+  `output_tensor` carried inside `tensor_args` lands in the *input* region and looks ambiguous —
+  read the `allow_inplace_output_tensor_alias` comment in
+  `tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp` before touching it.
 
 Compile-time values (CB sizes, `#define`s, compile args) can **never** be dynamic — they bake the
-kernel ELF. They must stay hashed (keep them in `attribute_values()`).
+kernel ELF. They must stay in the hash.
+
+> **Gotcha for ops with no input tensor** (e.g. `rand`): the framework discovers the mesh device
+> via `get_first_object_of_type<MeshDevice*>` over the attrs. A plain struct (no
+> `attribute_names`) is searched member-by-member, so `device` is found at any position. But if
+> the struct defines `attribute_names` / `attribute_values()`, discovery recurses into that
+> tuple and only inspects **element 0** — `device` must be first or dispatch throws "No mesh
+> device found". One more reason not to define the pair for keying. Ops with an input tensor
+> source the device from `tensor_args`.
 
 > **Precondition for the fast path: the program hash must include everything the per-core runtime
-> args depend on — in particular the shape.** The fast cache-hit path (buffer bindings +
-> `get_dynamic_runtime_args`) only re-patches buffer addresses and your declared dynamic scalars; it
-> does **not** recompute the rest of the runtime args. So it's only correct when "same hash" implies
+> args depend on — in particular the shape.** The fast cache-hit path (buffer bindings, or a
+> surgical override that patches only addresses and hash-excluded scalars) does **not** recompute
+> the rest of the runtime args. So it's only correct when "same hash" implies
 > "same program structure" — same shape, same work-split, same per-core tile counts/offsets.
 >
 > Some ops deliberately do the opposite: they **exclude shape from the hash** so one program is
 > reused across shapes, with the per-core args (num_tiles, offsets, num_cores) carrying the shape and
 > the **slow-path rebuild** recomputing them every dispatch (e.g. `binary_ng` hashes `shard_volumes`,
-> not shape). Such shape-agnostic ops **cannot** use buffer bindings — the fast path would leave the
-> shape-dependent args stale and miscompute. Leave them on the slow path (raw addresses, no
-> bindings). Forcing the fast path would require either putting shape back in the hash (losing the
-> cross-shape reuse) or re-deriving every per-core arg (which is just the slow-path rebuild).
+> not shape). Such shape-agnostic ops **cannot** use bindings-only fast patching — it would leave
+> the shape-dependent args stale and miscompute; adding a binding *removes* the rebuild that was
+> silently saving them. Pick deliberately between: re-key the hash so a work-split change is a
+> miss (losing the cross-shape reuse), keep the slow-path rebuild, or re-derive every per-core arg
+> in the override (which is just the rebuild wearing a different name).
 
 ### 1.5 CMakeLists.txt
 
@@ -322,6 +410,24 @@ TEST_F(MyBenchmark, DispatchPerformance) {
 
 Register the test in `tests/ttnn/unit_tests/gtests/sources.cmake`.
 
+**The cached test is the one that matters.** A single call per configuration exercises only
+`create_descriptor` and proves nothing about the refresh path, which is where the bugs are.
+Make the second call use **different tensors of the same spec** (so buffer addresses actually
+change between miss and hit), add an in-place call if the op supports it, and if the op has a
+hash-excluded value, assert that a differing value does NOT add a cache entry AND does change
+the output (re-applied, not frozen).
+
+**Parity check (descriptor ops):** configure the build with
+`-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON`. Every cache hit is then byte-compared against
+a full rebuild (the rebuild is the oracle) and fails with op/kernel/core/arg detail instead
+of PCC garbage. Caveats: `ninja` alone leaves the Python-imported `.so` stale (run the
+install step and verify the loaded library carries the define); it only covers factories your
+suite dispatches *twice* with reallocated tensors; it is wired into the
+`ProgramDescriptor` hit branches only — `create_workload_descriptor` ops get no parity
+coverage; and for ops whose per-dispatch values are *intentionally* nondeterministic (an
+unseeded RNG drawing fresh seeds per call), the rebuild oracle legitimately differs — run
+the parity suite with a fixed seed so miss and hit derive identical values.
+
 ### 2.2 Run tests (multiple times)
 
 ```bash
@@ -351,6 +457,8 @@ Run the performance test **3-5 times** and compute the average overhead.
 | Performance  | < 3% overhead (release), < 5% for complex ops |
 
 If performance exceeds the threshold, check:
+- Which §1.2 cache-hit branch the op lands in. Branch (c) — the slow-path rebuild — is the
+  usual culprit: add bindings, or a surgical `override_runtime_arguments`.
 - In `mesh_device_operation_adapter.hpp`, verify the hash path is efficient.
 
 ---
@@ -362,9 +470,12 @@ If performance exceeds the threshold, check:
 In `<op_name>_device_operation.hpp`:
 
 1. Add `#include <tt-metalium/program_descriptors.hpp>`
-2. For single-descriptor operations: remove the `ProgramFactory` wrapper struct,
-   `program_factory_t` alias, and `select_program_factory`. Place `create_descriptor`
-   directly on the operation struct.
+2. For single-descriptor operations **without** an override: remove the `ProgramFactory`
+   wrapper struct, `program_factory_t` alias, and `select_program_factory`; place
+   `create_descriptor` directly on the operation struct. **With** a surgical override, keep a
+   slim factory struct holding `create_descriptor` + `override_runtime_arguments` and a
+   single-alternative `program_factory_t` (drop `shared_variables_t`, `cached_program_t`,
+   and `select_program_factory`).
 3. For multi-variant operations: replace each factory struct's `shared_variables_t`,
    `cached_program_t`, `create()`, and `override_runtime_arguments(cached_program_t&, ...)`
    with `create_descriptor()`. Keep `program_factory_t` and `select_program_factory`.
@@ -378,16 +489,23 @@ directory. Update:
 - Include paths (from `<op_name>_new_device_operation.hpp` to `<op_name>_device_operation.hpp`)
 - Class names (from `<Op>NewDeviceOperation` to `<Op>DeviceOperation`)
 
-### 3.3 Delete `compute_program_hash`
+### 3.3 Reconcile `compute_program_hash`
 
-If the old operation had a custom `compute_program_hash`, delete it. The framework
-handles hashing automatically.
+If the old operation had a custom `compute_program_hash`, classify it before deleting:
 
-If that custom hash existed to **exclude a per-call value** (seed, scalar, range, semaphore
-address), deleting it would put the value back in the key (recompile per value). Instead apply
-the static/dynamic split from §1.4: omit the value from `attribute_values()` and re-apply it via
-`get_dynamic_runtime_args`. Verify with a regression test: a differing value must NOT add a cache
-entry (it's not in the key) AND must change the output (it's re-patched, not frozen).
+- **It re-hashed exactly what the default hash covers** → delete it. The default hash is
+  strictly better: it keeps canonical-key collision resolution.
+- **It hashed a buffer address** → delete that part; the value it actually wanted is a
+  per-dispatch refresh (§1.4). An address in the key means a new cache entry per allocation.
+- **It excluded a per-call value** (seed, scalar, range, semaphore address) → deleting it
+  would put the value back in the key (recompile per value). Keep a custom hash that omits
+  the value — and hashes *everything* structural, exhaustively — and re-apply the value in a
+  surgical `override_runtime_arguments` (§1.4). Do **not** re-express the exclusion by
+  narrowing `attribute_names`.
+- **It hashed a derived quantity** (shard volumes, padded shape for row-major) → keep it.
+
+Verify exclusions with a regression test: a differing value must NOT add a cache entry (it's
+not in the key) AND must change the output (it's re-applied, not frozen).
 
 ### 3.4 Update CMakeLists.txt
 
@@ -420,7 +538,55 @@ factory's types or `shared_variables_t`, you must either:
 - Keep the old factory files alongside the new ones (add them back to CMakeLists.txt)
 - Migrate the external consumer as well
 
-### 3.8 Build and verify
+### 3.8 Legacy MeshWorkload factories (`create_mesh_workload` / `create_at`)
+
+CCL-family ops sit on `MeshWorkloadFactoryConcept` instead of `ProgramFactoryConcept`. Two
+legacy shapes exist, and both migrate to the same target — a factory struct whose only hook is
+`create_workload_descriptor` (§1.2):
+
+- **`create_mesh_workload(attrs, tensor_coords, tensor_args, out)`** returning
+  `cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>`, usually
+  allocating `GlobalSemaphore`s then delegating per coord to a `create_at(attrs, coord,
+  tensor_args, out, <resource params...>)` (e.g. `reduce_scatter`).
+- **`create_at`-only** — the framework builds the workload by calling `create_at` per coord
+  (e.g. `ccl/mesh_partition`).
+
+Teardown mapping:
+
+| Legacy | Becomes |
+|---|---|
+| `create_mesh_workload` body | `create_workload_descriptor(attrs, tensor_args, out, tensor_coords)` — same skeleton: allocate resources + `Synchronize` once, then loop `tensor_coords` |
+| `create_at` body (builds a `Program`) | a per-coord helper that builds a `ProgramDescriptor` (§1.3) → `programs.push_back({MeshCoordinateRange(coord), std::move(desc)})`; extra resource params stay as plain helper params |
+| `shared_variables_t`: `GlobalSemaphore`s | `WorkloadDescriptor::semaphores` (framework keeps them alive for the cache entry) |
+| `shared_variables_t`: op-owned tensors/buffers | `WorkloadDescriptor::buffers` as `WorkloadBuffer{owner, buffer}` (`owner` = `shared_ptr<Tensor>` deferring dealloc) |
+| `shared_variables_t`: kernel handles, core lists, per-coord metadata for the override | deleted — their only consumer was the override |
+| `cached_mesh_workload_t` / `AdaptedCachedMeshWorkload` | deleted |
+| `override_runtime_arguments(cached_mesh_workload_t&, ...)` | deleted — replaced by `BufferBinding`s: `emplace_runtime_args` with `Buffer*` for **every** address that varies per dispatch |
+| `program_factory_t` variant alternative | the new factory struct (keep the variant) |
+
+Rules specific to this path (they differ from the per-`Program` flow, see §1.2/§4):
+
+1. **There is no rebuild fallback and no per-`Program` override.** On a cache hit only the
+   declared bindings are patched. Anything varying that isn't a binding is frozen at first
+   miss. If a hash-excluded scalar survives the port, you need the hand-written
+   `<Op>MeshWorkloadFactory` wrapper (delegate to `descriptor_adapter_t::apply_descriptor`,
+   then patch) — `ring_joint_sdpa_program_factory.hpp`.
+2. **Workload-scoped `GlobalSemaphore` addresses are stable** for the cache entry's lifetime,
+   so they may be baked as raw args — suppress the guard with
+   `// smuggled-rta-ok: persistent GlobalSemaphore (parked on the WorkloadDescriptor)`.
+3. **Reconcile the custom hash per §3.3.** Legacy CCL hashes sometimes key on semaphore or
+   buffer addresses — that's the §4.4 antipattern (unbounded cache growth); the semaphore is
+   workload-scoped now, so drop it from the key entirely.
+4. **The parity check does not cover this path** (§2 caveats), so the cache-hit regression
+   test — second call with different tensors of the same spec — is the *only* net. Non-trivial
+   CCL ops should also run twice under a shifted allocation to prove every binding is declared.
+5. Coordinates that should do nothing: emit no `PerCoordProgram` for them (don't push empty
+   descriptors).
+
+Reference conversion: `all_gather_via_broadcast_factory.cpp` (semaphores + `Synchronize` on
+miss, per-coord descriptors, bindings-only hits).
+
+### 3.9 Build and verify
 
 ```bash
 ./build_metal.sh --debug --build-all    # Debug
@@ -437,7 +603,7 @@ Both must succeed with zero errors.
 |------|--------------|
 | Header | `device/<op>_device_operation.hpp` — ProgramFactory struct |
 | Factory impl | `device/<op>_program_factory.cpp` (or `device/factory/*.cpp`) |
-| Hash | Delete `compute_program_hash` if present (framework handles it) |
+| Hash | Reconcile `compute_program_hash` per §3.3 (delete redundant ones; keep exclusions/derived quantities) |
 | CMake (op) | `<op>/CMakeLists.txt` — source entries |
 | CMake (ttnn) | `ttnn/CMakeLists.txt` — remove `_new` subdirectory and link target |
 | Tests | `tests/.../sources.cmake` — remove benchmark entries |
@@ -462,6 +628,22 @@ Both must succeed with zero errors.
    algorithmic comments from the original code. These explain non-obvious hardware
    behavior, NOC bandwidth constraints, padding rules, etc.
 
+5. **By-value runtime-args grid copies.** `GetRuntimeArgs(program, kernel_id)` (the grid
+   form) returns `std::vector<std::vector<RuntimeArgsData>>&`; binding it to a by-value local
+   (or plain `auto`) deep-copies the whole per-core arg grid. Invisible in testing —
+   `RuntimeArgsData` is a view, so writes through the copy still land — but pure wasted work
+   on every cache hit. Hoist above the loops and take `auto&`.
+
+6. **A per-`Program` override on a `create_workload_descriptor` op is never called.** It
+   compiles and silently freezes everything it was meant to re-apply. Use the
+   mesh-workload-scoped `<Op>MeshWorkloadFactory` shape (§1.2), and prove reachability with
+   `clang++ -fsyntax-only` static_asserts rather than assuming (#52554).
+
+7. **Pre-commit guards.** `detect-smuggled-rta` (raw `.address()` into a descriptor sink) and
+   `detect-override-rebuild` (`create_descriptor` called from an override) both run on
+   `ttnn/**/device/**`. A migration should *remove* lines from
+   `scripts/detect_override_rebuild_baseline.txt`, never add them.
+
 ## Example Reference
 
 See the FullLike operation for the simplest complete example:
@@ -472,8 +654,23 @@ See the Bernoulli operation for another complete example:
 - Factory: `ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp`
 - Header: `ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp`
 
-See `pool/generic` for a complete declarative `WorkloadDescriptor` example
-whose descriptor carries device-uploaded helper tensors (halo lookup
-table, avg-pool scalar config) alongside the per-coord programs:
-- Header: `ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp`
-- Factory: `ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp`
+Surgical `override_runtime_arguments` (the target cache-hit mechanism, §1.4):
+- `ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp`
+- Hash-excluded scalar re-applied per dispatch:
+  `ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp`
+- Override done *wrong* (rebuild — do not copy): `eltwise/unary` and the other entries in
+  `scripts/detect_override_rebuild_baseline.txt`
+
+Declarative `WorkloadDescriptor` examples:
+- Workload-scoped semaphores:
+  `ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_via_broadcast_factory.cpp`
+- Op-owned device buffers (halo lookup table, avg-pool scalar config):
+  `ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp` +
+  `pool_multi_core_program_factory.cpp`
+- Workload-scoped override for a hash-excluded scalar:
+  `ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp`
+
+Per-coordinate program (4-arg `create_descriptor`):
+- `ttnn/cpp/ttnn/operations/debug/device/apply_device_delay_device_operation.cpp`
+
+Full doctrine, reviewer checklist, and source map: `tech_reports/ttnn/descriptors_and_specs.md`.

--- a/.cursor/commands/ttnn/descriptor-migration-recipe.md
+++ b/.cursor/commands/ttnn/descriptor-migration-recipe.md
@@ -287,11 +287,12 @@ supersedes binding patching (branch (a) of §1.2). Rules for writing it:
 1. **Single-source the work split.** Put the core split / per-core layout in one helper
    called by *both* `create_descriptor` and the override, so arg indices can't drift.
    **But keep the override lean**: the descriptor path has no `shared_variables_t`, so
-   whatever the helper computes is recomputed on EVERY hit. A full
-   `split_work_to_cores`/`grid_to_cores`/`CoreRangeSet` re-derivation costs ~2-3µs/dispatch
-   (measured on the randn trial: +7-9% vs the legacy op, which stashed `cores`) — that alone
-   can breach the §2.3 perf threshold. Re-derive only what the patch loop actually needs
-   (often just the core coords), and benchmark the hit path, not only correctness.
+   whatever the helper computes is recomputed on EVERY hit, and the cost scales with core
+   count. A full `split_work_to_cores`/`grid_to_cores`/`CoreRangeSet` re-derivation measured
+   ~+3µs/dispatch (+8-9%) on a 64-core grid vs the legacy op that stashed `cores` (randn
+   trial, interleaved A/B; single-core shapes were within noise) — that alone can breach the
+   §2.3 perf threshold. Re-derive only what the patch loop actually needs (often just the
+   core coords), and benchmark the hit path, not only correctness.
 2. **Must re-apply:** every buffer-address slot (anything emplaced as `Buffer*`), every
    scalar derived from a hash-excluded attribute, and every globally-allocated CB base
    address.


### PR DESCRIPTION
## [NO CI] Docs-only change

Single-file update to `.cursor/commands/ttnn/descriptor-migration-recipe.md` (the AI/cursor migration recipe). No code, no tests, no pipelines needed — commit is tagged `[skip ci]`.

### What changed

Brings the recipe in line with the "Descriptors and Specs" doc (`tech_reports/ttnn/descriptors_and_specs.md`) and the current framework:

- **Keying**: express keying in `compute_program_hash` (hash derived quantities, exclude per-call values); narrowing `attribute_names`/`attribute_values()` is banned. Custom hash = opting out of canonical-key collision resolution, so hash everything structural.
- **Refresh**: `get_dynamic_runtime_args` is forbidden in new code (legacy hook being removed; the adapter static-asserts it can't coexist with an override). The mechanism is a surgical `override_runtime_arguments` on the **program factory struct** (the adapter rejects it on the DeviceOperation), with the 8 rules for writing it (single-sourced work split, no early return past address patching, CBIndex matching, no rebuild-in-override, keep the hit-path work lean).
- **Cache-hit branches**: documents the override / binding-fast-patch / slow-rebuild priority order and which one an op should land in.
- **Mesh workloads**: replaces the outdated op-defined struct with the framework `tt::tt_metal::WorkloadDescriptor` (semaphores / `WorkloadBuffer` / `PerCoordProgram`), the no-rebuild-on-hit contract, the never-called per-Program-override trap (#52554) and the `<Op>MeshWorkloadFactory` mesh-scope override shape.
- **New §3.8**: teardown walkthrough for legacy `create_mesh_workload`/`create_at` ops (mapping table + path-specific rules).
- **Testing**: cache-hit regression discipline (different tensors of the same spec) and the `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON` oracle with its caveats.
- Binding discipline (`emplace_runtime_args` with `Buffer*`, `smuggled-rta-ok` etiquette), pre-commit guards, refreshed reference-op list, link to the full doc.

### Validation

The updated recipe was exercised end-to-end on a trial `randn` port (legacy `CachedProgram` factory → `create_descriptor` + surgical override): builds clean, 61/61 relevant tests pass on ttsim, cache-hit refresh verified (seed re-applied per dispatch, cache-entry-neutral, addresses survive reallocation), and the patching parity check passes on seeded cache hits. The trial is not part of this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=descriptor-recipe-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:descriptor-recipe-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=descriptor-recipe-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:descriptor-recipe-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=descriptor-recipe-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:descriptor-recipe-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=descriptor-recipe-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:descriptor-recipe-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=descriptor-recipe-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:descriptor-recipe-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=descriptor-recipe-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:descriptor-recipe-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=descriptor-recipe-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:descriptor-recipe-update)