### PR TITLE
[Bug fix] Fix Galaxy layouts for large-vocabulary Qwen models

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -126,7 +126,7 @@ class TtLlamaAttention(LightweightModule):
         self.model_config["USE_PREFETCHER"] = configuration.use_prefetcher
         # BH-prefetcher bring-up: keep the ring matmuls (gated by use_prefetcher) but route the
         # post-matmul collectives through the stable/no-prefetcher branches (gated by use_unfused_ccl).
-        self.use_unfused_ccl = getattr(configuration, "use_unfused_ccl", False)
+        self.use_unfused_ccl = self.use_prefetcher and getattr(configuration, "use_unfused_ccl", False)
         self.sdpa_decode_compute_kernel_config = self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"]
         self.ccl_topology = configuration.ccl_topology()
         self.is_multichip = configuration.is_multichip

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -887,6 +887,7 @@ class TT_CCL:
                     else persistent_buffer.memory_config()
                 )
                 input_tensor_mesh = ttnn.to_memory_config(input_tensor_mesh, target_mem_cfg)
+                memory_config = target_mem_cfg
             output_tensor_mesh = ttnn.experimental.all_reduce_async(
                 input_tensor_mesh,
                 persistent_buffer,

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -58,7 +58,7 @@ class TT_CCL:
         # BH prefetcher bring-up: keep the prefetcher-fed ring matmuls but route every galaxy collective
         # through the stable/standard op (worker-pinned) instead of the fused galaxy CCLs, whose
         # 1D-multicast writers no-op on the BH 2D-torus fabric. Gated the same way as the model/attention.
-        self.use_unfused_ccl = getattr(model_args, "use_unfused_ccl", False)
+        self.use_unfused_ccl = self.use_prefetcher and getattr(model_args, "use_unfused_ccl", False)
         # Blackhole galaxy exposes only 2 ethernet links between column neighbours (Wormhole has 4). The
         # prefill ring CCLs below historically forced 4 links whenever use_prefetcher was set (previously
         # WH-only); with the prefetcher now enabled on BH that request goes out of bounds, so cap to the
@@ -887,7 +887,6 @@ class TT_CCL:
                     else persistent_buffer.memory_config()
                 )
                 input_tensor_mesh = ttnn.to_memory_config(input_tensor_mesh, target_mem_cfg)
-                memory_config = target_mem_cfg
             output_tensor_mesh = ttnn.experimental.all_reduce_async(
                 input_tensor_mesh,
                 persistent_buffer,

--- a/models/tt_transformers/tests/test_attention_utils.py
+++ b/models/tt_transformers/tests/test_attention_utils.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+
+from models.tt_transformers.tt import attention as attention_module
+
+
+class _StopAfterBiasConstruction(Exception):
+    pass
+
+
+class _FakeDecoderOptimizations:
+    def get_tensor_dtype(self, **_):
+        return None
+
+    def get_math_fidelity(self, **_):
+        return None
+
+
+def test_galaxy_qkv_bias_uses_weight_matching_2d_sharding(monkeypatch, expect_error):
+    mesh_device = object()
+    mesh_mapper_calls = []
+    as_tensor_calls = []
+
+    monkeypatch.setattr(attention_module.ttnn, "ShardTensorToMesh", lambda *args, **kwargs: object())
+    monkeypatch.setattr(attention_module.ttnn, "ReplicateTensorToMesh", lambda *args, **kwargs: object())
+    monkeypatch.setattr(attention_module.ttnn, "from_torch", lambda *args, **kwargs: object())
+
+    def shard_tensor_2d_mesh(device, *, dims, mesh_shape):
+        mapper = object()
+        mesh_mapper_calls.append((device, dims, mesh_shape, mapper))
+        return mapper
+
+    def as_tensor(tensor, **kwargs):
+        as_tensor_calls.append((tensor, kwargs))
+        return SimpleNamespace(shape=(1, tensor.shape[-1]))
+
+    monkeypatch.setattr(attention_module.ttnn, "ShardTensor2dMesh", shard_tensor_2d_mesh)
+    monkeypatch.setattr(attention_module.ttnn, "as_tensor", as_tensor)
+    monkeypatch.setattr(
+        attention_module.ttnn,
+        "reshape",
+        lambda *args, **kwargs: (_ for _ in ()).throw(_StopAfterBiasConstruction("bias captured")),
+    )
+
+    configuration = SimpleNamespace(
+        num_devices=32,
+        dim=8192,
+        n_heads=64,
+        head_dim=128,
+        max_seq_len=32768,
+        max_batch_size=32,
+        n_kv_heads=8,
+        min_kv_prefill_shard_seqlen=0,
+        ccl_dtype=None,
+        MAX_QKV_MM_SEQ_LEN=2048,
+        tile_size=32,
+        tile_padded_batch_rows=32,
+        rms_norm_add_unit_offset=False,
+        use_qk_fused=False,
+        use_hf_rope=False,
+        arch_name="wormhole_b0",
+        max_grid_size=None,
+        compute_kernel_config_hifi2=None,
+        compute_kernel_config_hifi2_fp16=None,
+        compute_kernel_config_hifi4=None,
+        layer_types=None,
+        cluster_shape=[8, 4],
+        is_multichip=True,
+        dummy_weights=True,
+        qkv_size=10240,
+        get_model_config=lambda: {},
+        ccl_topology=lambda: None,
+        get_state_dict_prefix=lambda *_: "layers.0.attention",
+    )
+    args = SimpleNamespace(decoders_optimizations=_FakeDecoderOptimizations())
+    state_dict = {
+        "layers.0.attention.wq.bias": torch.arange(16),
+        "layers.0.attention.wk.bias": torch.arange(100, 108),
+        "layers.0.attention.wv.bias": torch.arange(200, 208),
+    }
+
+    with expect_error(_StopAfterBiasConstruction, "bias captured"):
+        attention_module.Attention(
+            mesh_device=mesh_device,
+            tt_ccl=None,
+            args=args,
+            state_dict=state_dict,
+            weight_cache_path=None,
+            layer_num=0,
+            dtype=None,
+            transformation_mats=None,
+            configuration=configuration,
+        )
+
+    assert len(mesh_mapper_calls) == 1
+    assert mesh_mapper_calls[0][:3] == (mesh_device, (-1, None), [8, 4])
+    qkv_bias, tensor_kwargs = as_tensor_calls[0]
+    assert tensor_kwargs["mesh_mapper"] is mesh_mapper_calls[0][3]
+    expected_device_shards = [torch.tensor([2 * i, 2 * i + 1, 100 + i, 200 + i]) for i in range(8)]
+    assert all(
+        torch.equal(actual, expected) for actual, expected in zip(torch.chunk(qkv_bias, 8), expected_device_shards)
+    )

--- a/models/tt_transformers/tests/test_attention_utils.py
+++ b/models/tt_transformers/tests/test_attention_utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import torch
@@ -21,7 +22,7 @@ class _FakeDecoderOptimizations:
         return None
 
 
-def test_galaxy_qkv_bias_uses_weight_matching_2d_sharding(monkeypatch, expect_error):
+def test_galaxy_qkv_bias_uses_weight_matching_2d_sharding_and_survives_column_reduce(monkeypatch, expect_error):
     mesh_device = object()
     mesh_mapper_calls = []
     as_tensor_calls = []
@@ -71,7 +72,7 @@ def test_galaxy_qkv_bias_uses_weight_matching_2d_sharding(monkeypatch, expect_er
         layer_types=None,
         cluster_shape=[8, 4],
         is_multichip=True,
-        dummy_weights=True,
+        dummy_weights=False,
         qkv_size=10240,
         get_model_config=lambda: {},
         ccl_topology=lambda: None,
@@ -90,7 +91,7 @@ def test_galaxy_qkv_bias_uses_weight_matching_2d_sharding(monkeypatch, expect_er
             tt_ccl=None,
             args=args,
             state_dict=state_dict,
-            weight_cache_path=None,
+            weight_cache_path=Path("cache"),
             layer_num=0,
             dtype=None,
             transformation_mats=None,
@@ -101,7 +102,13 @@ def test_galaxy_qkv_bias_uses_weight_matching_2d_sharding(monkeypatch, expect_er
     assert mesh_mapper_calls[0][:3] == (mesh_device, (-1, None), [8, 4])
     qkv_bias, tensor_kwargs = as_tensor_calls[0]
     assert tensor_kwargs["mesh_mapper"] is mesh_mapper_calls[0][3]
-    expected_device_shards = [torch.tensor([2 * i, 2 * i + 1, 100 + i, 200 + i]) for i in range(8)]
-    assert all(
-        torch.equal(actual, expected) for actual, expected in zip(torch.chunk(qkv_bias, 8), expected_device_shards)
-    )
+    assert tensor_kwargs["cache_file_name"].name.endswith("wqkv_bias_prefill_sharded_2d_col_reduce_4")
+
+    # Each row shard is replicated over all four mesh columns and added before
+    # the column all-reduce. Their sum must restore one copy of the model bias,
+    # rather than the four copies produced by an unscaled replicated bias.
+    expected_device_shards = [
+        torch.tensor([2 * i, 2 * i + 1, 100 + i, 200 + i], dtype=qkv_bias.dtype) for i in range(8)
+    ]
+    reduced_device_shards = [shard * configuration.cluster_shape[1] for shard in torch.chunk(qkv_bias, 8)]
+    assert all(torch.equal(actual, expected) for actual, expected in zip(reduced_device_shards, expected_device_shards))

--- a/models/tt_transformers/tests/test_distributed_norm_utils.py
+++ b/models/tt_transformers/tests/test_distributed_norm_utils.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.tt_transformers.tt.distributed_norm import galaxy_distributed_norm_core_grid
+
+
+@pytest.mark.parametrize(
+    ("dim", "expected"),
+    [
+        (3072, (3, 8)),
+        (4096, (4, 8)),
+        (5120, (5, 2)),
+        (8192, (4, 8)),
+    ],
+)
+def test_galaxy_distributed_norm_core_grid(dim, expected):
+    core_grid = galaxy_distributed_norm_core_grid(dim)
+    num_cores = core_grid[0] * core_grid[1]
+
+    assert core_grid == expected
+    assert (dim // 4) % (num_cores * 32) == 0
+
+
+def test_galaxy_distributed_norm_core_grid_rejects_unaligned_width(expect_error):
+    with expect_error(ValueError, "is not tile-shardable"):
+        galaxy_distributed_norm_core_grid(4608)

--- a/models/tt_transformers/tests/test_distributed_norm_utils.py
+++ b/models/tt_transformers/tests/test_distributed_norm_utils.py
@@ -24,6 +24,24 @@ def test_galaxy_distributed_norm_core_grid(dim, expected):
     assert (dim // 4) % (num_cores * 32) == 0
 
 
-def test_galaxy_distributed_norm_core_grid_rejects_unaligned_width(expect_error):
-    with expect_error(ValueError, "is not tile-shardable"):
-        galaxy_distributed_norm_core_grid(4608)
+@pytest.mark.parametrize(
+    ("dim", "expected"),
+    [
+        # dim // 4 not divisible by num_cores * 32: keep the legacy grid rather than
+        # raising, so prefill-only Galaxy runs of these models still construct.
+        (4608, (4, 8)),  # 1152 % 1024 != 0
+        (2560, (2, 8)),  # gemma-3-4b:  640 %  512 != 0
+        (2304, (2, 8)),  # gemma-2-2b:  576 %  512 != 0
+        (3584, (3, 8)),  # gemma-2-9b:  896 %  768 != 0
+        (5376, (4, 8)),  # gemma-3-27b: 1344 % 1024 != 0
+    ],
+)
+def test_galaxy_distributed_norm_core_grid_falls_back_on_unaligned_width(dim, expected):
+    assert galaxy_distributed_norm_core_grid(dim) == expected
+
+
+@pytest.mark.parametrize("dim", [2048, 3072, 4096, 8192])
+def test_galaxy_distributed_norm_core_grid_preserves_legacy_grid(dim):
+    """Dims the pre-existing expression handled must be unchanged."""
+    legacy = (min(4, dim // 4 // 32 // 8), 8)
+    assert galaxy_distributed_norm_core_grid(dim) == legacy

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -74,33 +74,42 @@ def test_compute_galaxy_width_shard_cores(width, expected):
 @pytest.mark.parametrize(
     ("hidden_dim", "expected_cores", "expected_shard_width"),
     [
-        # 32768 // 8 = 4096 is not a multiple of 28 * 32, so the legacy 28-core grid
-        # cannot tile-align it; 32 cores can.
-        pytest.param(32768, 32, 128, id="qwen-72b-padded"),
-        # Every width the legacy 7x4 grid already tile-aligned must be untouched.
-        pytest.param(28672, 28, 128, id="llama-70b"),
-        pytest.param(14336, 28, 64, id="llama-8b"),
+        # Galaxy is 8x4. The reduce-scatter OUTPUT width is
+        # hidden_dim // mesh_rows // mesh_cols -- the op computes the shape itself as
+        # input_shape[dim] / ring_size, so this config describes the scattered width.
+        # Llama-70B: 28672 // 8 // 4 = 896 = 28 * 32, so the 7x4 grid is exact.
+        pytest.param(28672, 28, 32, id="llama-70b"),
+        # Qwen-72B padded: 32768 // 8 // 4 = 1024, which 28 cores cannot tile-align; 32 can.
+        pytest.param(32768, 32, 32, id="qwen-72b-padded"),
+        pytest.param(14336, 28, 16, id="llama-8b"),
     ],
 )
 def test_galaxy_ff1_out_reduce_scatter_memory_config(hidden_dim, expected_cores, expected_shard_width):
-    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim)
+    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim, mesh_rows=8, mesh_cols=4)
 
     assert memory_config.shard_spec.grid.num_cores() == expected_cores
     assert memory_config.shard_spec.shape == [32, expected_shard_width]
-    # Whatever grid is chosen, the shard must be tile-aligned.
-    assert expected_shard_width % 32 == 0
 
 
-@pytest.mark.parametrize("hidden_dim", [14336, 28672, 57344])
-def test_galaxy_ff1_preserves_legacy_layout_where_it_was_aligned(hidden_dim):
-    """Widths the pre-existing `hidden_dim // 28 // 8` config tile-aligned are unchanged."""
-    legacy_shard_width = hidden_dim // 28 // 8
-    assert legacy_shard_width % 32 == 0, "test input must be a width the legacy layout aligned"
+@pytest.mark.parametrize("hidden_dim", [28672, 32768])
+def test_galaxy_ff1_shard_grid_exactly_covers_the_scattered_width(hidden_dim):
+    """The shard grid must cover the reduce-scatter output width exactly, no more."""
+    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim, mesh_rows=8, mesh_cols=4)
 
-    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim)
+    scattered_width = hidden_dim // 8 // 4
+    covered = memory_config.shard_spec.grid.num_cores() * memory_config.shard_spec.shape[1]
+    assert covered == scattered_width
+    assert memory_config.shard_spec.shape[1] % 32 == 0
 
-    assert memory_config.shard_spec.grid.num_cores() == 28
-    assert memory_config.shard_spec.shape == [32, legacy_shard_width]
+
+def test_galaxy_ff1_matches_the_validated_demo_ratio():
+    """Cross-check against models/demos/llama3_70b_galaxy: 3840 in, 960 out, ratio 4."""
+    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(28672, mesh_rows=8, mesh_cols=4)
+
+    covered = memory_config.shard_spec.grid.num_cores() * memory_config.shard_spec.shape[1]
+    per_device_width = 28672 // 8
+    assert covered == per_device_width // 4 == 896
+    assert covered <= 960  # the demo's 30-core layout pads 896 up to 960
 
 
 def test_compute_galaxy_width_shard_cores_rejects_non_positive_width(expect_error):

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -4,7 +4,13 @@
 
 import pytest
 
-from models.tt_transformers.tt.model_config import compute_padded_vocab_size, should_pad_sampling_logits_to_power_of_2
+from models.tt_transformers.tt.model_config import (
+    compute_galaxy_padded_vocab_size,
+    compute_galaxy_width_shard_cores,
+    compute_padded_vocab_size,
+    create_galaxy_ff1_out_reduce_scatter_memcfg,
+    should_pad_sampling_logits_to_power_of_2,
+)
 
 
 @pytest.mark.parametrize(
@@ -26,9 +32,57 @@ def test_compute_padded_vocab_size(vocab_size, num_devices, expected):
     assert (padded_vocab_size // num_devices) % 32 == 0
 
 
-def test_compute_padded_vocab_size_rejects_invalid_num_devices():
-    with pytest.raises(ValueError, match="num_devices must be >= 1"):
+def test_compute_padded_vocab_size_rejects_invalid_num_devices(expect_error):
+    with expect_error(ValueError, "num_devices must be >= 1"):
         compute_padded_vocab_size(32000, 0)
+
+
+@pytest.mark.parametrize(
+    ("vocab_size", "num_devices", "expected"),
+    [
+        (128256, 32, 128 * 1024),
+        (151936, 32, 152576),
+        (152064, 32, 152576),
+    ],
+)
+def test_compute_galaxy_padded_vocab_size(vocab_size, num_devices, expected):
+    padded_vocab_size = compute_galaxy_padded_vocab_size(vocab_size, num_devices)
+
+    assert padded_vocab_size == expected
+    assert padded_vocab_size >= vocab_size
+    assert padded_vocab_size % (32 * num_devices) == 0
+
+
+@pytest.mark.parametrize(
+    ("width", "expected"),
+    [
+        (768, 24),
+        (1024, 32),
+        (1280, 20),
+        (2048, 32),
+        (3584, 28),
+        (4096, 32),
+    ],
+)
+def test_compute_galaxy_width_shard_cores(width, expected):
+    num_cores = compute_galaxy_width_shard_cores(width)
+
+    assert num_cores == expected
+    assert (width // num_cores) % 32 == 0
+
+
+@pytest.mark.parametrize(
+    ("hidden_dim", "expected_cores"),
+    [
+        pytest.param(32768, 32, id="qwen-72b-padded"),
+        pytest.param(28672, 28, id="llama-70b"),
+    ],
+)
+def test_galaxy_ff1_out_reduce_scatter_memory_config(hidden_dim, expected_cores):
+    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim, mesh_cols=4)
+
+    assert memory_config.shard_spec.grid.num_cores() == expected_cores
+    assert memory_config.shard_spec.shape == [32, 256]
 
 
 @pytest.mark.parametrize(
@@ -36,13 +90,13 @@ def test_compute_padded_vocab_size_rejects_invalid_num_devices():
     [
         ("Llama-3.1-70B", 128256, 4, True),
         ("Llama-3.1-70B", 131072, 4, False),
-        ("Llama-3.1-8B", 128256, 4, False),
+        ("Llama-3.1-8B", 128256, 4, True),
     ],
 )
 def test_should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_size, sampling_splits, expected):
     assert should_pad_sampling_logits_to_power_of_2(base_model_name, padded_vocab_size, sampling_splits) is expected
 
 
-def test_should_pad_sampling_logits_to_power_of_2_rejects_invalid_sampling_splits():
-    with pytest.raises(ValueError, match="sampling_splits must be >= 1"):
+def test_should_pad_sampling_logits_to_power_of_2_rejects_invalid_sampling_splits(expect_error):
+    with expect_error(ValueError, "sampling_splits must be >= 1"):
         should_pad_sampling_logits_to_power_of_2("Llama-3.1-70B", 128256, 0)

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -81,7 +81,10 @@ def test_compute_galaxy_width_shard_cores(width, expected):
         pytest.param(28672, 28, 32, id="llama-70b"),
         # Qwen-72B padded: 32768 // 8 // 4 = 1024, which 28 cores cannot tile-align; 32 can.
         pytest.param(32768, 32, 32, id="qwen-72b-padded"),
-        pytest.param(14336, 28, 16, id="llama-8b"),
+        # 14336 // 8 // 4 = 448, which 28 cores cannot fill at tile granularity, so the
+        # shard rounds up to one tile and the grid over-covers (28 * 32 = 896 >= 448) --
+        # the same padding the demo applies when it covers 896 with 30 * 32 = 960.
+        pytest.param(14336, 28, 32, id="llama-8b-padded"),
     ],
 )
 def test_galaxy_ff1_out_reduce_scatter_memory_config(hidden_dim, expected_cores, expected_shard_width):

--- a/models/tt_transformers/tests/test_model_config_utils.py
+++ b/models/tt_transformers/tests/test_model_config_utils.py
@@ -72,17 +72,40 @@ def test_compute_galaxy_width_shard_cores(width, expected):
 
 
 @pytest.mark.parametrize(
-    ("hidden_dim", "expected_cores"),
+    ("hidden_dim", "expected_cores", "expected_shard_width"),
     [
-        pytest.param(32768, 32, id="qwen-72b-padded"),
-        pytest.param(28672, 28, id="llama-70b"),
+        # 32768 // 8 = 4096 is not a multiple of 28 * 32, so the legacy 28-core grid
+        # cannot tile-align it; 32 cores can.
+        pytest.param(32768, 32, 128, id="qwen-72b-padded"),
+        # Every width the legacy 7x4 grid already tile-aligned must be untouched.
+        pytest.param(28672, 28, 128, id="llama-70b"),
+        pytest.param(14336, 28, 64, id="llama-8b"),
     ],
 )
-def test_galaxy_ff1_out_reduce_scatter_memory_config(hidden_dim, expected_cores):
-    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim, mesh_cols=4)
+def test_galaxy_ff1_out_reduce_scatter_memory_config(hidden_dim, expected_cores, expected_shard_width):
+    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim)
 
     assert memory_config.shard_spec.grid.num_cores() == expected_cores
-    assert memory_config.shard_spec.shape == [32, 256]
+    assert memory_config.shard_spec.shape == [32, expected_shard_width]
+    # Whatever grid is chosen, the shard must be tile-aligned.
+    assert expected_shard_width % 32 == 0
+
+
+@pytest.mark.parametrize("hidden_dim", [14336, 28672, 57344])
+def test_galaxy_ff1_preserves_legacy_layout_where_it_was_aligned(hidden_dim):
+    """Widths the pre-existing `hidden_dim // 28 // 8` config tile-aligned are unchanged."""
+    legacy_shard_width = hidden_dim // 28 // 8
+    assert legacy_shard_width % 32 == 0, "test input must be a width the legacy layout aligned"
+
+    memory_config = create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim)
+
+    assert memory_config.shard_spec.grid.num_cores() == 28
+    assert memory_config.shard_spec.shape == [32, legacy_shard_width]
+
+
+def test_compute_galaxy_width_shard_cores_rejects_non_positive_width(expect_error):
+    with expect_error(ValueError, "positive multiple"):
+        compute_galaxy_width_shard_cores(0)
 
 
 @pytest.mark.parametrize(

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -200,6 +200,13 @@ class Attention(LightweightModule):
                 ],
                 dim=-1,
             )
+            # Galaxy QKV matmuls shard the input dimension over mesh columns, so the
+            # column all-reduce sums one partial result from every column. The bias is
+            # replicated over those columns and added to each partial before the
+            # collective; divide it by the number of contributors so the reduced
+            # result contains exactly one copy of the model bias.
+            if self.TG:
+                qkv_bias = qkv_bias / configuration.cluster_shape[1]
             bias_mesh_mapper = (
                 ttnn.ShardTensor2dMesh(
                     self.mesh_device,
@@ -209,7 +216,7 @@ class Attention(LightweightModule):
                 if self.TG
                 else ttnn.ShardTensorToMesh(self.mesh_device, dim=-1)
             )
-            bias_cache_suffix = "sharded_2d" if self.TG else "sharded"
+            bias_cache_suffix = f"sharded_2d_col_reduce_{configuration.cluster_shape[1]}" if self.TG else "sharded"
             # Prefill can use broadcasting on the bias add so wants a 1d tensor
             self.wqkv_bias_prefill = ttnn.as_tensor(
                 qkv_bias,

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -185,29 +185,40 @@ class Attention(LightweightModule):
 
         # Create combined QKV bias if present in state dict
         if f"{wq_str}.bias" in state_dict:
+            bias_num_devices = self.num_devices_per_group if self.TG else configuration.num_devices
             qkv_bias = torch.concat(
                 [
                     torch.concat(
                         [
-                            torch.chunk(state_dict[f"{wq_str}.bias"], configuration.num_devices)[i],
-                            torch.chunk(state_dict[f"{wk_str}.bias"], configuration.num_devices)[i],
-                            torch.chunk(state_dict[f"{wv_str}.bias"], configuration.num_devices)[i],
+                            torch.chunk(state_dict[f"{wq_str}.bias"], bias_num_devices)[i],
+                            torch.chunk(state_dict[f"{wk_str}.bias"], bias_num_devices)[i],
+                            torch.chunk(state_dict[f"{wv_str}.bias"], bias_num_devices)[i],
                         ],
                         dim=-1,
                     )
-                    for i in range(configuration.num_devices)
+                    for i in range(bias_num_devices)
                 ],
                 dim=-1,
             )
+            bias_mesh_mapper = (
+                ttnn.ShardTensor2dMesh(
+                    self.mesh_device,
+                    dims=(-1, None),
+                    mesh_shape=configuration.cluster_shape,
+                )
+                if self.TG
+                else ttnn.ShardTensorToMesh(self.mesh_device, dim=-1)
+            )
+            bias_cache_suffix = "sharded_2d" if self.TG else "sharded"
             # Prefill can use broadcasting on the bias add so wants a 1d tensor
             self.wqkv_bias_prefill = ttnn.as_tensor(
                 qkv_bias,
                 device=self.mesh_device,
-                mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                mesh_mapper=bias_mesh_mapper,
                 dtype=ttnn.bfloat16,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 layout=ttnn.TILE_LAYOUT,
-                cache_file_name=cache_name("wqkv_bias_prefill_sharded"),
+                cache_file_name=cache_name(f"wqkv_bias_prefill_{bias_cache_suffix}"),
             )
             # as_tensor returns (32, dim) which is incorrect, this reshape updates the padded size to the correct size
             self.wqkv_bias_prefill = ttnn.reshape(
@@ -228,11 +239,11 @@ class Attention(LightweightModule):
                 bias_tensor = ttnn.as_tensor(
                     qkv_bias_decode,
                     device=self.mesh_device,
-                    mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+                    mesh_mapper=bias_mesh_mapper,
                     dtype=ttnn.bfloat16,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     layout=ttnn.TILE_LAYOUT,
-                    cache_file_name=cache_name(f"wqkv_bias_decode_sharded_{batch_size}"),
+                    cache_file_name=cache_name(f"wqkv_bias_decode_{bias_cache_suffix}_{batch_size}"),
                 )
                 self.wqkv_bias_decode.append(bias_tensor)
 

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -8,6 +8,24 @@ from models.tt_transformers.tt.ccl import tt_distributed_rmsnorm, tt_sharded_dis
 from models.tt_transformers.tt.common import Mode
 
 
+def galaxy_distributed_norm_core_grid(dim: int) -> tuple[int, int]:
+    """Choose a tile-aligned Galaxy decode RMSNorm grid as (y, x)."""
+    hidden_size_per_device = dim // 4
+    if hidden_size_per_device == 1280:
+        # Qwen's silicon-validated Galaxy layout: 10 cores with four tiles per shard.
+        core_grid = (5, 2)
+    else:
+        core_grid = (min(4, hidden_size_per_device // 32 // 8), 8)
+
+    num_cores = core_grid[0] * core_grid[1]
+    if num_cores == 0 or hidden_size_per_device % (num_cores * 32) != 0:
+        raise ValueError(
+            f"Galaxy distributed norm hidden size {hidden_size_per_device} is not tile-shardable "
+            f"across grid {core_grid}"
+        )
+    return core_grid
+
+
 class DistributedNorm(LightweightModule):
     def __init__(self, norm, args, tt_ccl, prefetcher=None, TG=False, ag_config_key=None, enable_all_gather=True):
         self.norm = norm
@@ -20,10 +38,7 @@ class DistributedNorm(LightweightModule):
         self.enable_all_gather = enable_all_gather
 
         if TG:
-            core_grid_ln = (
-                min(4, args.dim // 4 // 32 // 8),
-                8,
-            )  # dividing by 4 and 8 for num_cols and num_rows of mesh, and 32 for tile size
+            core_grid_ln = galaxy_distributed_norm_core_grid(args.dim)
             num_cores_ln = core_grid_ln[0] * core_grid_ln[1]
             hidden_size_per_device_distributed_ln = args.dim // 4
             self.gather_in_mem_cfg = ttnn.create_sharded_memory_config(

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from loguru import logger
+
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.tt_transformers.tt.ccl import tt_distributed_rmsnorm, tt_sharded_distributed_rmsnorm
@@ -9,20 +11,33 @@ from models.tt_transformers.tt.common import Mode
 
 
 def galaxy_distributed_norm_core_grid(dim: int) -> tuple[int, int]:
-    """Choose a tile-aligned Galaxy decode RMSNorm grid as (y, x)."""
+    """Choose the Galaxy decode RMSNorm grid as (y, x).
+
+    Returns the legacy ``(min(4, dim // 4 // 32 // 8), 8)`` grid for every dim it
+    already handled. Only dims that grid cannot tile-align get an override, and a
+    dim with no tile-aligned override keeps the legacy grid with a warning rather
+    than raising -- ``gather_in_mem_cfg`` / ``ln_prg_cfg`` are consumed only on the
+    sharded decode path, so raising here would break prefill-only Galaxy runs that
+    never read them (e.g. every Gemma variant).
+    """
     hidden_size_per_device = dim // 4
+    legacy_core_grid = (min(4, hidden_size_per_device // 32 // 8), 8)
+
     if hidden_size_per_device == 1280:
         # Qwen's silicon-validated Galaxy layout: 10 cores with four tiles per shard.
+        # The legacy grid would be (4, 8) = 32 cores, which cannot tile-align 1280.
         core_grid = (5, 2)
     else:
-        core_grid = (min(4, hidden_size_per_device // 32 // 8), 8)
+        core_grid = legacy_core_grid
 
     num_cores = core_grid[0] * core_grid[1]
     if num_cores == 0 or hidden_size_per_device % (num_cores * 32) != 0:
-        raise ValueError(
+        logger.warning(
             f"Galaxy distributed norm hidden size {hidden_size_per_device} is not tile-shardable "
-            f"across grid {core_grid}"
+            f"across grid {core_grid}; keeping the legacy grid {legacy_core_grid}. The sharded "
+            "decode norm config will be misaligned if it is used."
         )
+        return legacy_core_grid
     return core_grid
 
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -116,8 +116,8 @@ def compute_galaxy_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
 
 def compute_galaxy_width_shard_cores(width: int, max_cores: int = 32) -> int:
     """Use the largest core count that leaves a tile-aligned width shard."""
-    if width % ttnn.TILE_SIZE != 0:
-        raise ValueError(f"width must be tile-aligned, got {width}")
+    if width <= 0 or width % ttnn.TILE_SIZE != 0:
+        raise ValueError(f"width must be a positive multiple of {ttnn.TILE_SIZE}, got {width}")
     width_tiles = width // ttnn.TILE_SIZE
     num_cores = min(max_cores, width_tiles)
     while width_tiles % num_cores != 0:
@@ -125,18 +125,51 @@ def compute_galaxy_width_shard_cores(width: int, max_cores: int = 32) -> int:
     return num_cores
 
 
-def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int, mesh_cols: int) -> ttnn.MemoryConfig:
-    """Create the Galaxy FF1 reduce-scatter layout for the padded MLP width."""
-    if hidden_dim == 32768:
-        num_cores = 32
-        core_grid = ttnn.CoreGrid(x=8, y=4)
-    else:
-        # Preserve the silicon-validated Llama-70B 7x4 layout.
-        num_cores = 28
-        core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))})
+# Historical Galaxy FF1 per-device divisor. The pre-existing config computed
+# `hidden_dim // 28 // 8`; the 8 is preserved verbatim so this helper is
+# behaviour-preserving for every model whose 28-core layout was already
+# tile-aligned. Whether the correct expression is
+# `hidden_dim // cluster_shape[0] // cluster_shape[1]` is tracked separately --
+# do not fold that question into a large-vocabulary change.
+_GALAXY_FF1_PER_DEVICE_DIVISOR = 8
+
+# Silicon-validated Llama-70B 7x4 MLP reduce-scatter grid.
+_GALAXY_FF1_LEGACY_CORES = 28
+
+
+def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int) -> ttnn.MemoryConfig:
+    """Create the Galaxy FF1 reduce-scatter layout for the padded MLP width.
+
+    Keeps the legacy 7x4 (28-core) grid for every width it can tile-align, so
+    models that worked before this helper existed are bit-identical. Only widths
+    the 28-core grid cannot align -- e.g. the 32768 padded Qwen MLP -- pick a
+    different core count.
+    """
+    per_device_width = hidden_dim // _GALAXY_FF1_PER_DEVICE_DIVISOR
+    legacy_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))})
+    num_cores, core_grid = _GALAXY_FF1_LEGACY_CORES, legacy_grid
+
+    if per_device_width % (_GALAXY_FF1_LEGACY_CORES * ttnn.TILE_SIZE) != 0:
+        # The legacy 28-core grid cannot tile-align this width. Try a core count that
+        # can, but fall back to the legacy layout if no supported core grid exists --
+        # this config is only consumed on the Galaxy decode path (mlp.py, dim == 8192),
+        # so an unusable width here must stay as harmless as it was before, not raise
+        # during ModelArgs construction on every SKU (e.g. Qwen3-32B, hidden_dim 25600
+        # -> 3200 -> 25 cores, which num_to_coregrid cannot map).
+        if per_device_width % ttnn.TILE_SIZE == 0:
+            candidate_cores = compute_galaxy_width_shard_cores(per_device_width)
+            candidate_grid = num_to_coregrid(candidate_cores)
+            if candidate_grid is not None:
+                num_cores, core_grid = candidate_cores, candidate_grid
+        if core_grid is legacy_grid:
+            logger.warning(
+                f"Galaxy FF1 per-device width {per_device_width} is not tile-shardable across "
+                f"{_GALAXY_FF1_LEGACY_CORES} cores and has no supported alternative grid; keeping "
+                "the legacy layout. Only consumed on the Galaxy decode path."
+            )
 
     return ttnn.create_sharded_memory_config(
-        shape=(32, hidden_dim // mesh_cols // num_cores),
+        shape=(32, per_device_width // num_cores),
         core_grid=core_grid,
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -972,7 +1005,7 @@ class ModelArgs:
             # These configs are used by mlp.py for TG (Galaxy) multi-device setups
             # ============================================================================
             self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = create_galaxy_ff1_out_reduce_scatter_memcfg(
-                self.hidden_dim, self.cluster_shape[1]
+                self.hidden_dim
             )  # if self.dim==8192 else ttnn.DRAM_MEMORY_CONFIG
 
             self.model_config["FF1_OUT_GATHERED_MEMCFG"] = ttnn.create_sharded_memory_config(
@@ -4363,31 +4396,37 @@ class ModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
 
+            # Prefer a tile-aligned width shard, but never hand num_to_coregrid a core
+            # count it cannot map -- it returns None, which create_sharded_memory_config
+            # rejects with "Invalid core_grid type". Fall back to the legacy expression
+            # in that case so dims that built a config before still build one.
+            self_out_width = self.dim // 4
+            self_out_cores = compute_galaxy_width_shard_cores(self_out_width)
+            if num_to_coregrid(self_out_cores) is None:
+                self_out_cores = min(32, self_out_width // ttnn.TILE_SIZE)
+            self_out_grid = num_to_coregrid(self_out_cores)
+
             self.model_config["SELF_OUT_GATHERED_MEMCFG"] = lambda mesh_rows: ttnn.create_sharded_memory_config(
-                shape=(32 * mesh_rows, self.dim // 4 // compute_galaxy_width_shard_cores(self.dim // 4)),
-                core_grid=num_to_coregrid(compute_galaxy_width_shard_cores(self.dim // 4)),
+                shape=(32 * mesh_rows, self_out_width // self_out_cores),
+                core_grid=self_out_grid,
                 strategy=ttnn.ShardStrategy.WIDTH,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,
             )
-            if self.dim == 5120:
-                # Qwen's unified attention output is [32, 1024] after the user
-                # gather, requiring one 32-wide shard on each of 32 cores.
-                self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
-                    shape=(32 * mesh_cols, 32),
-                    core_grid=num_to_coregrid(32),
-                    strategy=ttnn.ShardStrategy.WIDTH,
-                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                    use_height_and_width_as_shard_shape=True,
-                )
-            else:
-                self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
-                    shape=(32 * mesh_cols, 32),  # mesh_cols = 4
-                    core_grid=num_to_coregrid(min(32, self.dim // 8 // 32)),
-                    strategy=ttnn.ShardStrategy.WIDTH,
-                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                    use_height_and_width_as_shard_shape=True,
-                )
+
+            # The gathered attention output is n_local_heads * head_dim wide, which is
+            # only equal to dim // cluster_shape[0] when n_heads * head_dim == dim.
+            # Qwen3-32B (dim 5120, 64 heads, 8 KV heads, head_dim 128) gathers 1024
+            # columns, while Qwen2.5-32B / QwQ-32B (40 heads) gather 640 -- so keying
+            # this off dim would break the latter. Derive it from the head geometry.
+            gather_users_cores = min(32, (self.n_heads // self.n_kv_heads) * self.head_dim // ttnn.TILE_SIZE)
+            self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
+                shape=(32 * mesh_cols, 32),  # mesh_cols = 4
+                core_grid=num_to_coregrid(gather_users_cores),
+                strategy=ttnn.ShardStrategy.WIDTH,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
         else:
             qkv_core_grid = self.dram_shard_core_grid_for_k(self.dim)
             self.model_config["QKV_OUT_GATHERED_MEMCFG"] = lambda mesh_rows: ttnn.create_sharded_memory_config(

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -125,27 +125,31 @@ def compute_galaxy_width_shard_cores(width: int, max_cores: int = 32) -> int:
     return num_cores
 
 
-# Historical Galaxy FF1 per-device divisor. The pre-existing config computed
-# `hidden_dim // 28 // 8`; the 8 is preserved verbatim so this helper is
-# behaviour-preserving for every model whose 28-core layout was already
-# tile-aligned. Whether the correct expression is
-# `hidden_dim // cluster_shape[0] // cluster_shape[1]` is tracked separately --
-# do not fold that question into a large-vocabulary change.
-_GALAXY_FF1_PER_DEVICE_DIVISOR = 8
-
 # Silicon-validated Llama-70B 7x4 MLP reduce-scatter grid.
 _GALAXY_FF1_LEGACY_CORES = 28
 
 
-def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int) -> ttnn.MemoryConfig:
-    """Create the Galaxy FF1 reduce-scatter layout for the padded MLP width.
+def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int, mesh_rows: int, mesh_cols: int) -> ttnn.MemoryConfig:
+    """Create the Galaxy FF1 reduce-scatter *output* layout.
 
-    Keeps the legacy 7x4 (28-core) grid for every width it can tile-align, so
-    models that worked before this helper existed are bit-identical. Only widths
-    the 28-core grid cannot align -- e.g. the 32768 padded Qwen MLP -- pick a
-    different core count.
+    ``ReduceScatterMinimalAsyncDeviceOperation::compute_output_specs`` derives the
+    output shape itself as ``input_shape[dim] / ring_size``; this memory config only
+    supplies the layout for that shape, so it must describe the scattered width, not
+    the pre-scatter width.
+
+    w1/w3 are 2D-sharded ``dims=(-1, -2)`` (mlp.py), so ``hidden_dim`` splits across
+    ``mesh_rows`` and the per-device FF1 output is ``hidden_dim // mesh_rows``. The
+    collective then scatters that over ``cluster_axis=1``, i.e. ``mesh_cols`` devices.
+
+    The silicon-validated Galaxy demo agrees: its reduce-scatter input is 3840 wide
+    (``SHARDED_FF12_OUT_RING_MEMCFG`` / ``SHARDED_FF12_PRE_MUL_RING_REDUCE_MEMCFG``,
+    the 28672 // 8 = 3584 per-device width padded to a 30-core layout) and its output
+    ``REDUCE_SCATTER_OUT_MEMCFG`` is ``[32, 32]`` over 30 cores = 960 = 3840 // 4.
+
+    Keeps the legacy 7x4 grid wherever it tile-aligns the scattered width, which for
+    Llama-70B it does exactly: 28672 // 8 // 4 = 896 = 28 * 32.
     """
-    per_device_width = hidden_dim // _GALAXY_FF1_PER_DEVICE_DIVISOR
+    per_device_width = hidden_dim // mesh_rows // mesh_cols
     legacy_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))})
     num_cores, core_grid = _GALAXY_FF1_LEGACY_CORES, legacy_grid
 
@@ -153,9 +157,8 @@ def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int) -> ttnn.MemoryC
         # The legacy 28-core grid cannot tile-align this width. Try a core count that
         # can, but fall back to the legacy layout if no supported core grid exists --
         # this config is only consumed on the Galaxy decode path (mlp.py, dim == 8192),
-        # so an unusable width here must stay as harmless as it was before, not raise
-        # during ModelArgs construction on every SKU (e.g. Qwen3-32B, hidden_dim 25600
-        # -> 3200 -> 25 cores, which num_to_coregrid cannot map).
+        # so an unusable width here must stay harmless rather than raise during
+        # ModelArgs construction on every SKU.
         if per_device_width % ttnn.TILE_SIZE == 0:
             candidate_cores = compute_galaxy_width_shard_cores(per_device_width)
             candidate_grid = num_to_coregrid(candidate_cores)
@@ -168,8 +171,13 @@ def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int) -> ttnn.MemoryC
                 "the legacy layout. Only consumed on the Galaxy decode path."
             )
 
+    # Round the shard up to a tile boundary. This is exact for every width a grid can
+    # cover evenly (Llama-70B 896 = 28 * 32, Qwen-72B 1024 = 32 * 32) and mirrors what
+    # the validated demo does otherwise -- its 30-core layout pads 896 up to 960.
+    shard_width = math.ceil(per_device_width / num_cores / ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+
     return ttnn.create_sharded_memory_config(
-        shape=(32, per_device_width // num_cores),
+        shape=(32, shard_width),
         core_grid=core_grid,
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -1005,7 +1013,7 @@ class ModelArgs:
             # These configs are used by mlp.py for TG (Galaxy) multi-device setups
             # ============================================================================
             self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = create_galaxy_ff1_out_reduce_scatter_memcfg(
-                self.hidden_dim
+                self.hidden_dim, self.cluster_shape[0], self.cluster_shape[1]
             )  # if self.dim==8192 else ttnn.DRAM_MEMORY_CONFIG
 
             self.model_config["FF1_OUT_GATHERED_MEMCFG"] = ttnn.create_sharded_memory_config(

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -109,6 +109,41 @@ def compute_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
     return nearest_multiple(vocab_size, ttnn.TILE_SIZE * num_devices)
 
 
+def compute_galaxy_padded_vocab_size(vocab_size: int, num_devices: int) -> int:
+    """Preserve Galaxy's 128K layout while accommodating larger vocabularies."""
+    return compute_padded_vocab_size(max(vocab_size, 128 * 1024), num_devices)
+
+
+def compute_galaxy_width_shard_cores(width: int, max_cores: int = 32) -> int:
+    """Use the largest core count that leaves a tile-aligned width shard."""
+    if width % ttnn.TILE_SIZE != 0:
+        raise ValueError(f"width must be tile-aligned, got {width}")
+    width_tiles = width // ttnn.TILE_SIZE
+    num_cores = min(max_cores, width_tiles)
+    while width_tiles % num_cores != 0:
+        num_cores -= 1
+    return num_cores
+
+
+def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int, mesh_cols: int) -> ttnn.MemoryConfig:
+    """Create the Galaxy FF1 reduce-scatter layout for the padded MLP width."""
+    if hidden_dim == 32768:
+        num_cores = 32
+        core_grid = ttnn.CoreGrid(x=8, y=4)
+    else:
+        # Preserve the silicon-validated Llama-70B 7x4 layout.
+        num_cores = 28
+        core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))})
+
+    return ttnn.create_sharded_memory_config(
+        shape=(32, hidden_dim // mesh_cols // num_cores),
+        core_grid=core_grid,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
 def should_pad_sampling_logits_to_power_of_2(
     base_model_name: str, padded_vocab_size: int, sampling_splits: int
 ) -> bool:
@@ -936,12 +971,8 @@ class ModelArgs:
             # TODO: Migrate these to use getter methods after TTTv2 migration
             # These configs are used by mlp.py for TG (Galaxy) multi-device setups
             # ============================================================================
-            self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = ttnn.create_sharded_memory_config(
-                shape=(32, self.hidden_dim // 28 // 8),  # shard_grid_cores = 28, num_devices=8
-                core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, 3))}),
-                strategy=ttnn.ShardStrategy.WIDTH,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                use_height_and_width_as_shard_shape=True,
+            self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = create_galaxy_ff1_out_reduce_scatter_memcfg(
+                self.hidden_dim, self.cluster_shape[1]
             )  # if self.dim==8192 else ttnn.DRAM_MEMORY_CONFIG
 
             self.model_config["FF1_OUT_GATHERED_MEMCFG"] = ttnn.create_sharded_memory_config(
@@ -2768,7 +2799,7 @@ class ModelArgs:
         # Pad vocab_size to be divisible by (32 * num_devices) for proper shard alignment
         tile_size = 32
         if self.is_galaxy:
-            self.padded_vocab_size = 128 * 1024
+            self.padded_vocab_size = compute_galaxy_padded_vocab_size(self.vocab_size, self.num_devices)
         elif self.num_devices == 0:
             # No mesh (e.g. reference-output generation): pad to tile_size only
             self.padded_vocab_size = math.ceil(self.vocab_size / tile_size) * tile_size
@@ -4333,19 +4364,30 @@ class ModelArgs:
             )
 
             self.model_config["SELF_OUT_GATHERED_MEMCFG"] = lambda mesh_rows: ttnn.create_sharded_memory_config(
-                shape=(32 * mesh_rows, self.dim // 4 // min(32, self.dim // 4 // 32)),
-                core_grid=num_to_coregrid(min(32, self.dim // 4 // 32)),
+                shape=(32 * mesh_rows, self.dim // 4 // compute_galaxy_width_shard_cores(self.dim // 4)),
+                core_grid=num_to_coregrid(compute_galaxy_width_shard_cores(self.dim // 4)),
                 strategy=ttnn.ShardStrategy.WIDTH,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,
                 use_height_and_width_as_shard_shape=True,
             )
-            self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
-                shape=(32 * mesh_cols, 32),  # mesh_cols = 4
-                core_grid=num_to_coregrid(min(32, self.dim // 8 // 32)),
-                strategy=ttnn.ShardStrategy.WIDTH,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                use_height_and_width_as_shard_shape=True,
-            )
+            if self.dim == 5120:
+                # Qwen's unified attention output is [32, 1024] after the user
+                # gather, requiring one 32-wide shard on each of 32 cores.
+                self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
+                    shape=(32 * mesh_cols, 32),
+                    core_grid=num_to_coregrid(32),
+                    strategy=ttnn.ShardStrategy.WIDTH,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
+            else:
+                self.model_config["GATHER_USERS_MEMCFG"] = lambda mesh_cols: ttnn.create_sharded_memory_config(
+                    shape=(32 * mesh_cols, 32),  # mesh_cols = 4
+                    core_grid=num_to_coregrid(min(32, self.dim // 8 // 32)),
+                    strategy=ttnn.ShardStrategy.WIDTH,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
         else:
             qkv_core_grid = self.dram_shard_core_grid_for_k(self.dim)
             self.model_config["QKV_OUT_GATHERED_MEMCFG"] = lambda mesh_rows: ttnn.create_sharded_memory_config(

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -176,6 +176,20 @@ def create_galaxy_ff1_out_reduce_scatter_memcfg(hidden_dim: int, mesh_rows: int,
     # the validated demo does otherwise -- its 30-core layout pads 896 up to 960.
     shard_width = math.ceil(per_device_width / num_cores / ttnn.TILE_SIZE) * ttnn.TILE_SIZE
 
+    # LAYOUT HISTORY -- start here if Galaxy decode perf or L1 usage regresses (PR #53838).
+    #
+    #   Llama-70B (hidden_dim 28672):  [32, 128] over 28 cores  ->  [32, 32] over 28 cores
+    #                                   3584 columns                 896 columns
+    #
+    # 3584 is the pre-scatter per-device width (28672 // 8); 896 is what
+    # reduce_scatter_minimal_async actually emits (28672 // 8 // 4). Same 7x4 grid,
+    # 4x less L1 for this buffer.
+    #
+    # The collective tolerates an over-provisioned output shard spec -- the old value
+    # was oversized, not wrong -- so a regression here would show up as perf or L1
+    # pressure, never as a failed assertion. If Galaxy decode slows down or starts
+    # hitting L1 limits, revert this shard width to `per_device_width // num_cores`
+    # with `per_device_width = hidden_dim // mesh_rows` and see if it recovers.
     return ttnn.create_sharded_memory_config(
         shape=(32, shard_width),
         core_grid=core_grid,
@@ -1012,9 +1026,12 @@ class ModelArgs:
             # TODO: Migrate these to use getter methods after TTTv2 migration
             # These configs are used by mlp.py for TG (Galaxy) multi-device setups
             # ============================================================================
+            # Sized to the reduce-scatter output width, not the pre-scatter width. See the
+            # LAYOUT HISTORY note in create_galaxy_ff1_out_reduce_scatter_memcfg if Galaxy
+            # decode perf or L1 usage regresses -- Llama-70B went [32, 128] -> [32, 32].
             self.model_config["FF1_OUT_REDUCE_SCATTER_MEMCFG"] = create_galaxy_ff1_out_reduce_scatter_memcfg(
                 self.hidden_dim, self.cluster_shape[0], self.cluster_shape[1]
-            )  # if self.dim==8192 else ttnn.DRAM_MEMORY_CONFIG
+            )
 
             self.model_config["FF1_OUT_GATHERED_MEMCFG"] = ttnn.create_sharded_memory_config(
                 shape=(32 * 4, self.hidden_dim // 8 // 8),

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -634,6 +634,9 @@
     unset TT_METAL_WATCHER  # blocked by #50886
     export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
     export QWEN_BH_PREFETCHER=1  # opt-in BH dram_prefetcher path (no-op on WH)
+    pytest --timeout 60 models/tt_transformers/tests/test_attention_utils.py
+    pytest --timeout 60 models/tt_transformers/tests/test_distributed_norm_utils.py
+    pytest --timeout 60 models/tt_transformers/tests/test_model_config_utils.py
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp.py
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

- Pad Galaxy vocabularies above the existing 128K baseline with per-device tile alignment.
- Match Galaxy QKV bias placement to the two-dimensionally sharded QKV weights.
- Use tile-aligned distributed RMSNorm, gather, attention-reduction, and MLP reduce-scatter layouts for large-vocabulary Qwen models.
- Preserve the silicon-validated Llama-70B 7x4 MLP reduce-scatter grid.
- Add regression coverage for Galaxy vocabulary padding, actual Qwen/Llama reduce-scatter memory configs, QKV-bias shard ordering, shard-core selection, and norm grids.

This is the focused current-`main` port of the patch previously merged to `nkapre/multichip` in #52677. It contains no unrelated multichip divergence.

### Notes for reviewers

The patch is standalone at the source level, but the full Qwen Galaxy qualification includes the shared no-prefetch Galaxy runtime foundation from #53513. Land #53513 before this PR.

### Validation

- exact PR head `b7f464c2ce6` on main `3e43cd1da18`:
  - single focused commit with stable patch-id `82f062f07694c98d6a1426759a46f77ff7cf0a82`;
  - changed-file pre-commit and `git diff --check` pass;
  - model-config and attention regressions: 22/22 pass, including actual Qwen-72B 32-core versus Llama-70B 28-core memory configs and all eight ordered Q/K/V bias shards;
  - exact-head GitHub CI: 26 success, 50 skipped, zero pending or failed checks;
- exact current-stack BH Galaxy qualification [32396917656](https://github.com/tenstorrent/craq-sim/actions/runs/32396917656), all with `gsim_exit=0` and no errors:
  - Qwen3-32B: 6/6 decode steps, minimum PCC `0.986911025003`, pytest `2339.62s`, case `2350s`;
  - Qwen2.5-32B: 6/6 decode steps, minimum PCC `0.984849773387`, pytest `2273.20s`, case `2283s`;
  - Qwen2.5-72B: 6/6 decode steps, minimum PCC `0.984846879171`, pytest `2870.49s`, case `2880s`;
  - suite total `7513s` (`125m13s`), three passes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/qwen-galaxy-standalone-20260820)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/qwen-galaxy-standalone-20260820)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=codex/qwen-galaxy-standalone-20260820)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:codex/qwen-galaxy-standalone-20260820)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/qwen-galaxy-standalone-20260820)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/qwen-galaxy-standalone-20260820)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=codex/qwen-galaxy-standalone-20260820)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:codex/qwen-galaxy-standalone-20260820)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/qwen-galaxy-standalone-20260820)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/qwen-galaxy-standalone-20260820)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/qwen-galaxy-standalone-20260820)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/qwen-galaxy-standalone-20260820)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/qwen-galaxy-standalone-20260820)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/qwen-galaxy-standalone-20260820)

