### PR TITLE
Add set/restore_fp32_dest_acc to switch dest-acc around a kernel section

### DIFF
--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -145,4 +145,69 @@ ALWI void disable_fp32_dest_acc() {
 }
 #endif
 
+// clang-format off
+/**
+ * Sets FP32 destination accumulation to `enable` for a subsequent section
+ * of the kernel.
+ *
+ * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
+ * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data).
+ * This is a lightweight, standalone reconfiguration that is safe to call
+ * mid-kernel without re-running compute_kernel_hw_startup.
+ *
+ * No-op when `enable` already matches the kernel's DST_ACCUM_MODE
+ * (compute_kernel_hw_startup already programmed the requested mode).
+ * Must be paired with restore_fp32_dest_acc<enable>() using the same flag.
+ *
+ * Only available on Wormhole and Blackhole. Not supported on Quasar (compile error)
+ *
+ * Return value: None
+ *
+ * | Param Type | Name   | Description                                         | Type | Valid Range | Required |
+ * |------------|--------|-----------------------------------------------------|------|-------------|----------|
+ * | Template   | enable | Dest-acc mode the enclosed section needs            | bool | true, false | True     |
+ */
+// clang-format on
+#ifndef ARCH_QUASAR
+template <bool enable>
+ALWI void set_fp32_dest_acc() {
+    if constexpr (enable != static_cast<bool>(DST_ACCUM_MODE)) {
+        MATH((llk_math_set_fp32_dest_acc(enable)));
+        PACK((llk_pack_set_fp32_dest_acc(enable)));
+    }
+}
+#endif
+
+// clang-format off
+/**
+ * Restores destination accumulation to the kernel's DST_ACCUM_MODE after a
+ * matching set_fp32_dest_acc<enable>().
+ *
+ * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
+ * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data).
+ * This is a lightweight, standalone reconfiguration that is safe to call
+ * mid-kernel without re-running compute_kernel_hw_startup.
+ *
+ * No-op when `enable` already matches DST_ACCUM_MODE (the matching set
+ * was also a no-op). Pass the same `enable` used at the set.
+ *
+ * Only available on Wormhole and Blackhole. Not supported on Quasar (compile error)
+ *
+ * Return value: None
+ *
+ * | Param Type | Name   | Description                                         | Type | Valid Range | Required |
+ * |------------|--------|-----------------------------------------------------|------|-------------|----------|
+ * | Template   | enable | Same flag passed to the matching set_fp32_dest_acc  | bool | true, false | True     |
+ */
+// clang-format on
+#ifndef ARCH_QUASAR
+template <bool enable>
+ALWI void restore_fp32_dest_acc() {
+    if constexpr (enable != static_cast<bool>(DST_ACCUM_MODE)) {
+        MATH((llk_math_set_fp32_dest_acc(static_cast<bool>(DST_ACCUM_MODE))));
+        PACK((llk_pack_set_fp32_dest_acc(static_cast<bool>(DST_ACCUM_MODE))));
+    }
+}
+#endif
+
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -148,7 +148,7 @@ ALWI void disable_fp32_dest_acc() {
 // clang-format off
 /**
  * Sets FP32 destination accumulation to `enable` for a subsequent section
- * of the kernel.
+ * of the kernel by calling enable_fp32_dest_acc() or disable_fp32_dest_acc().
  *
  * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
  * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data).
@@ -172,8 +172,11 @@ ALWI void disable_fp32_dest_acc() {
 template <bool enable>
 ALWI void set_fp32_dest_acc() {
     if constexpr (enable != static_cast<bool>(DST_ACCUM_MODE)) {
-        MATH((llk_math_set_fp32_dest_acc(enable)));
-        PACK((llk_pack_set_fp32_dest_acc(enable)));
+        if constexpr (enable) {
+            enable_fp32_dest_acc();
+        } else {
+            disable_fp32_dest_acc();
+        }
     }
 }
 #endif
@@ -181,7 +184,8 @@ ALWI void set_fp32_dest_acc() {
 // clang-format off
 /**
  * Restores destination accumulation to the kernel's DST_ACCUM_MODE after a
- * matching set_fp32_dest_acc<enable>().
+ * matching set_fp32_dest_acc<enable>(), via enable_fp32_dest_acc() or
+ * disable_fp32_dest_acc().
  *
  * Configures both the math pipeline (ALU_ACC_CTRL Fp32_enabled and
  * SFPU_Fp32_enabled) and the packer (PCK_DEST_RD_CTRL Read_32b_data).
@@ -204,8 +208,11 @@ ALWI void set_fp32_dest_acc() {
 template <bool enable>
 ALWI void restore_fp32_dest_acc() {
     if constexpr (enable != static_cast<bool>(DST_ACCUM_MODE)) {
-        MATH((llk_math_set_fp32_dest_acc(static_cast<bool>(DST_ACCUM_MODE))));
-        PACK((llk_pack_set_fp32_dest_acc(static_cast<bool>(DST_ACCUM_MODE))));
+        if constexpr (DST_ACCUM_MODE) {
+            enable_fp32_dest_acc();
+        } else {
+            disable_fp32_dest_acc();
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Add `set_fp32_dest_acc<enable>()` / `restore_fp32_dest_acc<enable>()` to switch dest-acc for a kernel section and restore the compile-time `DST_ACCUM_MODE` afterward.
- Both compile out when `enable` already matches `DST_ACCUM_MODE`, so turning FP32 on or off is a no-op when the kernel is already in that mode.
- Leave `enable_fp32_dest_acc()` / `disable_fp32_dest_acc()` unchanged.
- The idea is that if a piece of code needs a specific fp32 dest acc, then we can use this if we don't know what mode the code has been compiled with.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=halgh/fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:halgh/fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=halgh/fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:halgh/fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=halgh/fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:halgh/fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=halgh/fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:halgh/fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=halgh/fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:halgh/fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=halgh/fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:halgh/fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=halgh/fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:halgh/fp32)