### PR TITLE
Revert "Revert "ttnn: remove non-relocatable build-dir path from INSTALL_RPATH""

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -145,7 +145,7 @@ set_target_properties(
     tt_metal
     PROPERTIES
         INSTALL_RPATH
-            "/opt/openmpi-v5.0.7-ulfm/lib;${PROJECT_BINARY_DIR}/lib;$ORIGIN"
+            "/opt/openmpi-v5.0.7-ulfm/lib;$ORIGIN"
         ADDITIONAL_CLEAN_FILES
             "${PROJECT_BINARY_DIR}/lib;${PROJECT_BINARY_DIR}/obj"
 )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -295,7 +295,7 @@ if(WITH_PYTHON_BINDINGS)
             BUILD_RPATH
                 "${PROJECT_BINARY_DIR}/tt_metal;${PROJECT_BINARY_DIR}/ttnn"
             INSTALL_RPATH
-                "$ORIGIN/build/lib;$ORIGIN"
+                "$ORIGIN/build/lib;$ORIGIN/../../build/lib;$ORIGIN" # $ORIGIN/../../build/lib resolves deps for the tt_pybinds copy installed into the source tree at ttnn/ttnn/_ttnn.so
             CXX_VISIBILITY_PRESET
                 "default" # FIXME: Export the symbols we want, and use hidden visibility instead of default
             ADDITIONAL_CLEAN_FILES

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -206,7 +206,7 @@ set_target_properties(
         BUILD_RPATH
             "${PROJECT_BINARY_DIR}/tt_metal;${PROJECT_BINARY_DIR}/ttnn"
         INSTALL_RPATH
-            "${PROJECT_BINARY_DIR}/lib;$ORIGIN/build/lib;$ORIGIN" # FIXME: Install RPATH should not have a build path!
+            "$ORIGIN/build/lib;$ORIGIN"
         CXX_VISIBILITY_PRESET
             "default" # FIXME: Export the symbols we want, and use hidden visibility instead of default
         ADDITIONAL_CLEAN_FILES
@@ -295,7 +295,7 @@ if(WITH_PYTHON_BINDINGS)
             BUILD_RPATH
                 "${PROJECT_BINARY_DIR}/tt_metal;${PROJECT_BINARY_DIR}/ttnn"
             INSTALL_RPATH
-                "${PROJECT_BINARY_DIR}/lib;$ORIGIN/build/lib;$ORIGIN" # FIXME: Install RPATH should not have a build path!
+                "$ORIGIN/build/lib;$ORIGIN"
             CXX_VISIBILITY_PRESET
                 "default" # FIXME: Export the symbols we want, and use hidden visibility instead of default
             ADDITIONAL_CLEAN_FILES


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#53746

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=revert-53746-revert-53605-fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:revert-53746-revert-53605-fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=revert-53746-revert-53605-fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:revert-53746-revert-53605-fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=revert-53746-revert-53605-fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:revert-53746-revert-53605-fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=revert-53746-revert-53605-fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:revert-53746-revert-53605-fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=revert-53746-revert-53605-fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:revert-53746-revert-53605-fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=revert-53746-revert-53605-fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:revert-53746-revert-53605-fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=revert-53746-revert-53605-fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:revert-53746-revert-53605-fix/53604-install-rpath-build-path)