### PR TITLE
[Cleanup] Consolidating `MeshBuffer` read/write API

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -122,8 +122,7 @@ inline void m2_writeshard_barrier_uint32(
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     std::vector<T> rdback;
-    distributed::EnqueueReadMeshBuffer(
-        unit_mesh.mesh_command_queue(), rdback, in_tensor.mesh_buffer(), /*blocking=*/true);
+    unit_mesh.mesh_command_queue().enqueue_read_mesh_buffer(rdback, in_tensor.mesh_buffer(), /*blocking=*/true);
     tt_driver_atomics::mfence();
     ASSERT_EQ(rdback, input) << "M2: WriteShard did not complete before LaunchProgram (Quasar emu #38042)";
 }
@@ -428,7 +427,7 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, total_words);
     auto& cq = mesh_device.mesh_command_queue();
     if (in_tensor) {
-        distributed::EnqueueWriteMeshBuffer(cq, in_tensor->mesh_buffer(), input, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(in_tensor->mesh_buffer(), input, /*blocking=*/true);
         m2_writeshard_barrier_uint32(mesh_device, *in_tensor, input);
     }
 
@@ -475,7 +474,7 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
     // Verify (DM consumer only — Tensix consumer doesn't write DRAM).
     if (p.consumer_type == M2PorCType::DM) {
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, out_tensor->mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, out_tensor->mesh_buffer(), /*blocking=*/true);
         // For Tensix→DM ring-pressure with STRIDED, each consumer reads ring slot
         // (c % num_entries), so expected output is the corresponding input slice.
         if (p.producer_type == M2PorCType::TENSIX && entries_per_core > p.num_entries &&

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -122,7 +122,8 @@ inline void m2_writeshard_barrier_uint32(
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     std::vector<T> rdback;
-    slow_dispatch::ReadFromBuffer(in_tensor.mesh_buffer(), rdback);
+    distributed::EnqueueReadMeshBuffer(
+        unit_mesh.mesh_command_queue(), rdback, in_tensor.mesh_buffer(), /*blocking=*/true);
     tt_driver_atomics::mfence();
     ASSERT_EQ(rdback, input) << "M2: WriteShard did not complete before LaunchProgram (Quasar emu #38042)";
 }
@@ -425,8 +426,9 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
     // Stimulus
     const uint32_t total_words = p.entry_size * entries_per_core / sizeof(uint32_t);
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, total_words);
+    auto& cq = mesh_device.mesh_command_queue();
     if (in_tensor) {
-        slow_dispatch::WriteToBuffer(in_tensor->mesh_buffer(), input);
+        distributed::EnqueueWriteMeshBuffer(cq, in_tensor->mesh_buffer(), input, /*blocking=*/true);
         m2_writeshard_barrier_uint32(mesh_device, *in_tensor, input);
     }
 
@@ -473,7 +475,7 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
     // Verify (DM consumer only — Tensix consumer doesn't write DRAM).
     if (p.consumer_type == M2PorCType::DM) {
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(out_tensor->mesh_buffer(), output);
+        distributed::EnqueueReadMeshBuffer(cq, output, out_tensor->mesh_buffer(), /*blocking=*/true);
         // For Tensix→DM ring-pressure with STRIDED, each consumer reads ring slot
         // (c % num_entries), so expected output is the corresponding input slice.
         if (p.producer_type == M2PorCType::TENSIX && entries_per_core > p.num_entries &&

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -273,8 +273,8 @@ void run_alias_dfb_program(
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
 
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_a.mesh_buffer(), input_a, /*blocking=*/true);
-    distributed::EnqueueWriteMeshBuffer(cq, in_b.mesh_buffer(), input_b, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_a.mesh_buffer(), input_a, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_b.mesh_buffer(), input_b, /*blocking=*/true);
 
     if (mesh_device.arch() == ARCH::QUASAR) {
         // TODO #38042: barrier for Quasar DRAM write visibility.
@@ -284,8 +284,8 @@ void run_alias_dfb_program(
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
-    distributed::EnqueueReadMeshBuffer(cq, result_a, out_a.mesh_buffer(), /*blocking=*/true);
-    distributed::EnqueueReadMeshBuffer(cq, result_b, out_b.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_a, out_a.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_b, out_b.mesh_buffer(), /*blocking=*/true);
 
     EXPECT_EQ(result_a, input_a)
         << "Phase A output mismatch: DFB_A data did not round-trip correctly";
@@ -608,10 +608,10 @@ TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
     auto input_rb = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
 
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, left.in_a.mesh_buffer(), input_la, /*blocking=*/true);
-    distributed::EnqueueWriteMeshBuffer(cq, left.in_b.mesh_buffer(), input_lb, /*blocking=*/true);
-    distributed::EnqueueWriteMeshBuffer(cq, right.in_a.mesh_buffer(), input_ra, /*blocking=*/true);
-    distributed::EnqueueWriteMeshBuffer(cq, right.in_b.mesh_buffer(), input_rb, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(left.in_a.mesh_buffer(), input_la, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(left.in_b.mesh_buffer(), input_lb, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(right.in_a.mesh_buffer(), input_ra, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(right.in_b.mesh_buffer(), input_rb, /*blocking=*/true);
     if (is_quasar) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
@@ -619,10 +619,10 @@ TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> out_la, out_lb, out_ra, out_rb;
-    distributed::EnqueueReadMeshBuffer(cq, out_la, left.out_a.mesh_buffer(), /*blocking=*/true);
-    distributed::EnqueueReadMeshBuffer(cq, out_lb, left.out_b.mesh_buffer(), /*blocking=*/true);
-    distributed::EnqueueReadMeshBuffer(cq, out_ra, right.out_a.mesh_buffer(), /*blocking=*/true);
-    distributed::EnqueueReadMeshBuffer(cq, out_rb, right.out_b.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(out_la, left.out_a.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(out_lb, left.out_b.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(out_ra, right.out_a.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(out_rb, right.out_b.mesh_buffer(), /*blocking=*/true);
 
     EXPECT_EQ(out_la, input_la) << "left half DFB_A round-trip mismatch";
     EXPECT_EQ(out_lb, input_lb) << "left half DFB_B (alias) round-trip mismatch";
@@ -870,8 +870,8 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words);
 
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_a.mesh_buffer(), input_a, /*blocking=*/true);
-    distributed::EnqueueWriteMeshBuffer(cq, in_b.mesh_buffer(), input_b, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_a.mesh_buffer(), input_a, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_b.mesh_buffer(), input_b, /*blocking=*/true);
 
     if (this->device().arch() == ARCH::QUASAR) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -880,8 +880,8 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
-    distributed::EnqueueReadMeshBuffer(cq, result_a, out_a.mesh_buffer(), /*blocking=*/true);
-    distributed::EnqueueReadMeshBuffer(cq, result_b, out_b.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_a, out_a.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_b, out_b.mesh_buffer(), /*blocking=*/true);
 
     EXPECT_EQ(result_a, input_a)
         << "Phase A (dfb_borrowed) data did not round-trip correctly";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -272,8 +272,9 @@ void run_alias_dfb_program(
     auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_a);
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
 
-    slow_dispatch::WriteToBuffer(in_a.mesh_buffer(), input_a);
-    slow_dispatch::WriteToBuffer(in_b.mesh_buffer(), input_b);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_a.mesh_buffer(), input_a, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, in_b.mesh_buffer(), input_b, /*blocking=*/true);
 
     if (mesh_device.arch() == ARCH::QUASAR) {
         // TODO #38042: barrier for Quasar DRAM write visibility.
@@ -283,8 +284,8 @@ void run_alias_dfb_program(
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
-    slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
-    slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
+    distributed::EnqueueReadMeshBuffer(cq, result_a, out_a.mesh_buffer(), /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, result_b, out_b.mesh_buffer(), /*blocking=*/true);
 
     EXPECT_EQ(result_a, input_a)
         << "Phase A output mismatch: DFB_A data did not round-trip correctly";
@@ -606,10 +607,11 @@ TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
     auto input_ra = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_a);
     auto input_rb = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
 
-    slow_dispatch::WriteToBuffer(left.in_a.mesh_buffer(), input_la);
-    slow_dispatch::WriteToBuffer(left.in_b.mesh_buffer(), input_lb);
-    slow_dispatch::WriteToBuffer(right.in_a.mesh_buffer(), input_ra);
-    slow_dispatch::WriteToBuffer(right.in_b.mesh_buffer(), input_rb);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, left.in_a.mesh_buffer(), input_la, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, left.in_b.mesh_buffer(), input_lb, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, right.in_a.mesh_buffer(), input_ra, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, right.in_b.mesh_buffer(), input_rb, /*blocking=*/true);
     if (is_quasar) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
@@ -617,10 +619,10 @@ TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> out_la, out_lb, out_ra, out_rb;
-    slow_dispatch::ReadFromBuffer(left.out_a.mesh_buffer(), out_la);
-    slow_dispatch::ReadFromBuffer(left.out_b.mesh_buffer(), out_lb);
-    slow_dispatch::ReadFromBuffer(right.out_a.mesh_buffer(), out_ra);
-    slow_dispatch::ReadFromBuffer(right.out_b.mesh_buffer(), out_rb);
+    distributed::EnqueueReadMeshBuffer(cq, out_la, left.out_a.mesh_buffer(), /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, out_lb, left.out_b.mesh_buffer(), /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, out_ra, right.out_a.mesh_buffer(), /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, out_rb, right.out_b.mesh_buffer(), /*blocking=*/true);
 
     EXPECT_EQ(out_la, input_la) << "left half DFB_A round-trip mismatch";
     EXPECT_EQ(out_lb, input_lb) << "left half DFB_B (alias) round-trip mismatch";
@@ -867,8 +869,9 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words);
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words);
 
-    slow_dispatch::WriteToBuffer(in_a.mesh_buffer(), input_a);
-    slow_dispatch::WriteToBuffer(in_b.mesh_buffer(), input_b);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_a.mesh_buffer(), input_a, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, in_b.mesh_buffer(), input_b, /*blocking=*/true);
 
     if (this->device().arch() == ARCH::QUASAR) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -877,8 +880,8 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
-    slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
-    slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
+    distributed::EnqueueReadMeshBuffer(cq, result_a, out_a.mesh_buffer(), /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, result_b, out_b.mesh_buffer(), /*blocking=*/true);
 
     EXPECT_EQ(result_a, input_a)
         << "Phase A (dfb_borrowed) data did not round-trip correctly";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -259,7 +259,7 @@ void run_borrowed_memory_dfb_program(
     std::vector<uint32_t> input(cfg.num_entries * cfg.entry_size / sizeof(uint32_t));
     std::iota(input.begin(), input.end(), 0u);
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, src_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(src_tensor.mesh_buffer(), input, /*blocking=*/true);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
@@ -276,7 +276,7 @@ void run_borrowed_memory_dfb_program(
 
     if (cfg.verify_data && !cfg.tensix_consumer) {
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, dst_tensor->mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, dst_tensor->mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(input, output);
     }
 }
@@ -384,7 +384,7 @@ void run_update_address_test(
     // --- Run 1: ring at ring_tensor_a ---
     std::vector<uint32_t> input_a(total_words);
     std::iota(input_a.begin(), input_a.end(), 0u);
-    distributed::EnqueueWriteMeshBuffer(cq, src_tensor.mesh_buffer(), input_a, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(src_tensor.mesh_buffer(), input_a, /*blocking=*/true);
 
     ProgramRunArgs params1;
     params1.kernel_run_args = {
@@ -410,7 +410,7 @@ void run_update_address_test(
         static_cast<uint32_t>(ring_tensor_a.address()));
     {
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, dst_tensor.mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, dst_tensor.mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(input_a, output);
     }
 
@@ -420,7 +420,7 @@ void run_update_address_test(
     // UpdateTensorArgs fast-path (address only).
     std::vector<uint32_t> input_b(total_words);
     std::iota(input_b.begin(), input_b.end(), total_words);  // distinct from run 1
-    distributed::EnqueueWriteMeshBuffer(cq, src_tensor.mesh_buffer(), input_b, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(src_tensor.mesh_buffer(), input_b, /*blocking=*/true);
 
     if (reentry_num_entries_override.has_value()) {
         // Combined re-bind + resize in ONE SetProgramRunArgs: point the borrowed ring at a different
@@ -461,7 +461,7 @@ void run_update_address_test(
     }
     {
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, dst_tensor.mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, dst_tensor.mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(input_b, output);
     }
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -258,7 +258,8 @@ void run_borrowed_memory_dfb_program(
     // -----------------------------------------------------------------------
     std::vector<uint32_t> input(cfg.num_entries * cfg.entry_size / sizeof(uint32_t));
     std::iota(input.begin(), input.end(), 0u);
-    slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_tensor.mesh_buffer(), input, /*blocking=*/true);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
@@ -275,7 +276,7 @@ void run_borrowed_memory_dfb_program(
 
     if (cfg.verify_data && !cfg.tensix_consumer) {
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(dst_tensor->mesh_buffer(), output);
+        distributed::EnqueueReadMeshBuffer(cq, output, dst_tensor->mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(input, output);
     }
 }
@@ -379,10 +380,11 @@ void run_update_address_test(
     const KernelRunArgs::RuntimeArgValues dm_rtas =
         MakeRuntimeArgsForSingleNode(node, {{"chunk_offset", 0u}, {"entries_per_core", num_entries}});
 
+    auto& cq = mesh_device.mesh_command_queue();
     // --- Run 1: ring at ring_tensor_a ---
     std::vector<uint32_t> input_a(total_words);
     std::iota(input_a.begin(), input_a.end(), 0u);
-    slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input_a);
+    distributed::EnqueueWriteMeshBuffer(cq, src_tensor.mesh_buffer(), input_a, /*blocking=*/true);
 
     ProgramRunArgs params1;
     params1.kernel_run_args = {
@@ -408,7 +410,7 @@ void run_update_address_test(
         static_cast<uint32_t>(ring_tensor_a.address()));
     {
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(dst_tensor.mesh_buffer(), output);
+        distributed::EnqueueReadMeshBuffer(cq, output, dst_tensor.mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(input_a, output);
     }
 
@@ -418,7 +420,7 @@ void run_update_address_test(
     // UpdateTensorArgs fast-path (address only).
     std::vector<uint32_t> input_b(total_words);
     std::iota(input_b.begin(), input_b.end(), total_words);  // distinct from run 1
-    slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input_b);
+    distributed::EnqueueWriteMeshBuffer(cq, src_tensor.mesh_buffer(), input_b, /*blocking=*/true);
 
     if (reentry_num_entries_override.has_value()) {
         // Combined re-bind + resize in ONE SetProgramRunArgs: point the borrowed ring at a different
@@ -459,7 +461,7 @@ void run_update_address_test(
     }
     {
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(dst_tensor.mesh_buffer(), output);
+        distributed::EnqueueReadMeshBuffer(cq, output, dst_tensor.mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(input_b, output);
     }
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -176,8 +176,7 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     input[1] = tile0_val1;
     input[words_per_entry + 0] = tile1_val0;
     input[words_per_entry + 1] = tile1_val1;
-    distributed::EnqueueWriteMeshBuffer(
-        this->device().mesh_command_queue(), in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    this->device().mesh_command_queue().enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
 
     std::vector<DataT> result_init(expected_scalar_reads.size(), 0u);
     slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), result_l1_addr, result_init);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -176,7 +176,8 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     input[1] = tile0_val1;
     input[words_per_entry + 0] = tile1_val0;
     input[words_per_entry + 1] = tile1_val1;
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    distributed::EnqueueWriteMeshBuffer(
+        this->device().mesh_command_queue(), in_tensor.mesh_buffer(), input, /*blocking=*/true);
 
     std::vector<DataT> result_init(expected_scalar_reads.size(), 0u);
     slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), result_l1_addr, result_init);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -297,7 +297,7 @@ TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
     std::vector<std::vector<uint32_t>> expected(per_half * 2);
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         expected[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
-        distributed::EnqueueWriteMeshBuffer(cq, inputs[i].mesh_buffer(), expected[i], /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(inputs[i].mesh_buffer(), expected[i], /*blocking=*/true);
         m2_writeshard_barrier_uint32(this->device(), inputs[i], expected[i]);
         params.tensor_args.insert({m2::TensorParamName{"in_" + std::to_string(i)}, std::cref(inputs[i])});
         params.tensor_args.insert({m2::TensorParamName{"out_" + std::to_string(i)}, std::cref(outputs[i])});
@@ -308,7 +308,7 @@ TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
 
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         std::vector<uint32_t> got;
-        distributed::EnqueueReadMeshBuffer(cq, got, outputs[i].mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(got, outputs[i].mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(got, expected[i]) << "DFB " << i << " round-trip mismatch";
     }
 }
@@ -446,16 +446,16 @@ TEST_F(UnitMeshFixture, HalfGridOnDeviceDataflow1DFBEach) {
     auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_a.mesh_buffer(), input_a, /*blocking=*/true);
-    distributed::EnqueueWriteMeshBuffer(cq, in_b.mesh_buffer(), input_b, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_a.mesh_buffer(), input_a, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_b.mesh_buffer(), input_b, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_a, input_a);
     m2_writeshard_barrier_uint32(this->device(), in_b, input_b);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
-    distributed::EnqueueReadMeshBuffer(cq, result_a, out_a.mesh_buffer(), /*blocking=*/true);
-    distributed::EnqueueReadMeshBuffer(cq, result_b, out_b.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_a, out_a.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_b, out_b.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(result_a, input_a) << "left-half DFB round-trip mismatch";
     EXPECT_EQ(result_b, input_b) << "right-half DFB round-trip mismatch";
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -293,10 +293,11 @@ TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
         {.kernel = m2::KernelSpecName{"cons_b"}, .runtime_arg_values = rtas(node_b)},
     };
     const uint32_t words = num_entries * entry_size / sizeof(uint32_t);
+    auto& cq = this->device().mesh_command_queue();
     std::vector<std::vector<uint32_t>> expected(per_half * 2);
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         expected[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
-        slow_dispatch::WriteToBuffer(inputs[i].mesh_buffer(), expected[i]);
+        distributed::EnqueueWriteMeshBuffer(cq, inputs[i].mesh_buffer(), expected[i], /*blocking=*/true);
         m2_writeshard_barrier_uint32(this->device(), inputs[i], expected[i]);
         params.tensor_args.insert({m2::TensorParamName{"in_" + std::to_string(i)}, std::cref(inputs[i])});
         params.tensor_args.insert({m2::TensorParamName{"out_" + std::to_string(i)}, std::cref(outputs[i])});
@@ -307,7 +308,7 @@ TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
 
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         std::vector<uint32_t> got;
-        slow_dispatch::ReadFromBuffer(outputs[i].mesh_buffer(), got);
+        distributed::EnqueueReadMeshBuffer(cq, got, outputs[i].mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(got, expected[i]) << "DFB " << i << " round-trip mismatch";
     }
 }
@@ -444,16 +445,17 @@ TEST_F(UnitMeshFixture, HalfGridOnDeviceDataflow1DFBEach) {
     const uint32_t words = num_entries * entry_size / sizeof(uint32_t);
     auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
-    slow_dispatch::WriteToBuffer(in_a.mesh_buffer(), input_a);
-    slow_dispatch::WriteToBuffer(in_b.mesh_buffer(), input_b);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_a.mesh_buffer(), input_a, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, in_b.mesh_buffer(), input_b, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_a, input_a);
     m2_writeshard_barrier_uint32(this->device(), in_b, input_b);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
-    slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
-    slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
+    distributed::EnqueueReadMeshBuffer(cq, result_a, out_a.mesh_buffer(), /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, result_b, out_b.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(result_a, input_a) << "left-half DFB round-trip mismatch";
     EXPECT_EQ(result_b, input_b) << "right-half DFB round-trip mismatch";
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -124,13 +124,13 @@ static void run_a1_pipeline(distributed::MeshDevice& mesh_device, A1Transform tr
                      ? create_random_vector_of_bfloat16(total_bytes, 1.0f, 0xA1A1)   // positive only
                      : create_random_vector_of_bfloat16(total_bytes, 2.0f, 0xA1A1);  // [-1,1]
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
 
     if (transform == A1Transform::Relu) {
         // Positive bf16 inputs → relu identity, allow bf16 tolerance.
@@ -224,7 +224,7 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
     const uint32_t total_words = entry_size * total_tiles / sizeof(uint32_t);
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, total_words);
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     for (uint32_t iter = 0; iter < num_iterations; ++iter) {
@@ -232,7 +232,7 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
     }
 
     std::vector<uint32_t> output;
-    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(input, output) << "M2 DM→DFB→DM identity mismatch";
 }
 
@@ -362,13 +362,13 @@ TEST_F(UnitMeshFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
 
     auto input = create_random_vector_of_bfloat16(kPushTiles * kEntrySize, 1.0f, 0xD1D1);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
 
     // Diagnostic: on mismatch, dump first divergent tile + per-tile histogram so
     // we can characterize the failure mode (all-zeros from start, wrap-point only, etc.).
@@ -594,13 +594,13 @@ TEST_F(UnitMeshFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
 
     auto input = create_constant_vector_of_bfloat16(2 * entries_per_core * entry_size, 1.0f);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
     // For the m2 version we just verify the shared DFB ran end-to-end on core B.
     // The "two DfbGroups" assertion from the legacy test depends on inspecting
     // program.impl() before LaunchProgram; we keep that for the legacy test and

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -123,13 +123,14 @@ static void run_a1_pipeline(distributed::MeshDevice& mesh_device, A1Transform tr
     auto input = (transform == A1Transform::Relu)
                      ? create_random_vector_of_bfloat16(total_bytes, 1.0f, 0xA1A1)   // positive only
                      : create_random_vector_of_bfloat16(total_bytes, 2.0f, 0xA1A1);  // [-1,1]
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
 
     if (transform == A1Transform::Relu) {
         // Positive bf16 inputs → relu identity, allow bf16 tolerance.
@@ -222,7 +223,8 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
 
     const uint32_t total_words = entry_size * total_tiles / sizeof(uint32_t);
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, total_words);
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     for (uint32_t iter = 0; iter < num_iterations; ++iter) {
@@ -230,7 +232,7 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
     }
 
     std::vector<uint32_t> output;
-    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(input, output) << "M2 DM→DFB→DM identity mismatch";
 }
 
@@ -359,13 +361,14 @@ TEST_F(UnitMeshFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
     m2::SetProgramRunArgs(program, params);
 
     auto input = create_random_vector_of_bfloat16(kPushTiles * kEntrySize, 1.0f, 0xD1D1);
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
 
     // Diagnostic: on mismatch, dump first divergent tile + per-tile histogram so
     // we can characterize the failure mode (all-zeros from start, wrap-point only, etc.).
@@ -590,13 +593,14 @@ TEST_F(UnitMeshFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
     m2::SetProgramRunArgs(program, params);
 
     auto input = create_constant_vector_of_bfloat16(2 * entries_per_core * entry_size, 1.0f);
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
     // For the m2 version we just verify the shared DFB ran end-to-end on core B.
     // The "two DfbGroups" assertion from the legacy test depends on inspecting
     // program.impl() before LaunchProgram; we keep that for the legacy test and

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -241,7 +241,7 @@ TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     const uint32_t total_bytes = entry_size * num_entries;
     auto input = create_random_vector_of_bfloat16(total_bytes, 1.0f, 0xC2C2);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
     // Finalize early so host can assert INTRA remapper assignment before launch.
@@ -261,7 +261,7 @@ TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_TRUE(packed_uint32_t_vector_comparison(output, input, [](float a, float b) {
         return std::abs(a - b) < 0.01f;
     })) << "M2 C2 double-relu identity mismatch";
@@ -528,8 +528,8 @@ TEST_F(UnitMeshFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     // Fill DRAM input; DM NOC-reads this into the remapper ring's L1.
     auto input_remapper =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, num_entries * entry_size / sizeof(uint32_t));
-    distributed::EnqueueWriteMeshBuffer(
-        this->device().mesh_command_queue(), in_tensor.mesh_buffer(), input_remapper, /*blocking=*/true);
+    this->device().mesh_command_queue().enqueue_write_mesh_buffer(
+        in_tensor.mesh_buffer(), input_remapper, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input_remapper);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -240,7 +240,8 @@ TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     // Positive bf16 inputs → double-relu identity.
     const uint32_t total_bytes = entry_size * num_entries;
     auto input = create_random_vector_of_bfloat16(total_bytes, 1.0f, 0xC2C2);
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
     // Finalize early so host can assert INTRA remapper assignment before launch.
@@ -260,7 +261,7 @@ TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_TRUE(packed_uint32_t_vector_comparison(output, input, [](float a, float b) {
         return std::abs(a - b) < 0.01f;
     })) << "M2 C2 double-relu identity mismatch";
@@ -527,7 +528,8 @@ TEST_F(UnitMeshFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     // Fill DRAM input; DM NOC-reads this into the remapper ring's L1.
     auto input_remapper =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, num_entries * entry_size / sizeof(uint32_t));
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input_remapper);
+    distributed::EnqueueWriteMeshBuffer(
+        this->device().mesh_command_queue(), in_tensor.mesh_buffer(), input_remapper, /*blocking=*/true);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input_remapper);
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -109,13 +109,13 @@ static void run_single_dfb_multicore_2_0(
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
         0, 1000000, 2 * num_entries * entry_size / sizeof(uint32_t));
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(input, output) << "M2 multi-core DFB identity mismatch";
 }
 
@@ -216,13 +216,13 @@ static void run_concurrent_dfbs_program_2_0(
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
         0, 1000000, total_entries * entry_size / sizeof(uint32_t));
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(input, output) << "M2 concurrent DFBs mismatch";
 }
 
@@ -360,7 +360,7 @@ static void run_sequential_4_dfbs_2_0(
     for (uint32_t i = 0; i < 4; ++i) {
         inputs[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(
             0, 100, num_entries * entry_size / sizeof(uint32_t));
-        distributed::EnqueueWriteMeshBuffer(cq, in_tensors[i].mesh_buffer(), inputs[i], /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(in_tensors[i].mesh_buffer(), inputs[i], /*blocking=*/true);
         m2_writeshard_barrier_uint32(mesh_device, in_tensors[i], inputs[i]);
     }
 
@@ -368,7 +368,7 @@ static void run_sequential_4_dfbs_2_0(
 
     for (uint32_t i = 0; i < 4; ++i) {
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, out_tensors[i].mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, out_tensors[i].mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(inputs[i], output) << "M2 sequential 4xDFB[" << i << "] output mismatch";
     }
 }
@@ -562,7 +562,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
     auto& cq = this->device().mesh_command_queue();
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, out_tensors[i].mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, out_tensors[i].mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(inputs[i], output) << "M2 concurrent Tensix→DM 4xDFB[" << i << "] mismatch";
     }
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -108,13 +108,14 @@ static void run_single_dfb_multicore_2_0(
 
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
         0, 1000000, 2 * num_entries * entry_size / sizeof(uint32_t));
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(input, output) << "M2 multi-core DFB identity mismatch";
 }
 
@@ -214,13 +215,14 @@ static void run_concurrent_dfbs_program_2_0(
 
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
         0, 1000000, total_entries * entry_size / sizeof(uint32_t));
-    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
-    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+    distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
     EXPECT_EQ(input, output) << "M2 concurrent DFBs mismatch";
 }
 
@@ -353,11 +355,12 @@ static void run_sequential_4_dfbs_2_0(
     }
     m2::SetProgramRunArgs(program, params);
 
+    auto& cq = mesh_device.mesh_command_queue();
     std::vector<std::vector<uint32_t>> inputs(4);
     for (uint32_t i = 0; i < 4; ++i) {
         inputs[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(
             0, 100, num_entries * entry_size / sizeof(uint32_t));
-        slow_dispatch::WriteToBuffer(in_tensors[i].mesh_buffer(), inputs[i]);
+        distributed::EnqueueWriteMeshBuffer(cq, in_tensors[i].mesh_buffer(), inputs[i], /*blocking=*/true);
         m2_writeshard_barrier_uint32(mesh_device, in_tensors[i], inputs[i]);
     }
 
@@ -365,7 +368,7 @@ static void run_sequential_4_dfbs_2_0(
 
     for (uint32_t i = 0; i < 4; ++i) {
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(out_tensors[i].mesh_buffer(), output);
+        distributed::EnqueueReadMeshBuffer(cq, output, out_tensors[i].mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(inputs[i], output) << "M2 sequential 4xDFB[" << i << "] output mismatch";
     }
 }
@@ -556,9 +559,10 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
+    auto& cq = this->device().mesh_command_queue();
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(out_tensors[i].mesh_buffer(), output);
+        distributed::EnqueueReadMeshBuffer(cq, output, out_tensors[i].mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(inputs[i], output) << "M2 concurrent Tensix→DM 4xDFB[" << i << "] mismatch";
     }
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -160,19 +160,19 @@ static void run_dfb_size_override_test(
         EXPECT_EQ(dfb->config.entry_size, eff_entry_size);
         EXPECT_EQ(dfb->config.num_entries, eff_num_entries);
 
-        distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(in_tensor.mesh_buffer(), input, /*blocking=*/true);
         if (mesh_device.arch() == ARCH::QUASAR) {
             // TODO #38042: barrier not yet uplifted for Quasar; wait for the DRAM write to land.
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
             std::vector<uint32_t> rdback;
-            distributed::EnqueueReadMeshBuffer(cq, rdback, in_tensor.mesh_buffer(), /*blocking=*/true);
+            cq.enqueue_read_mesh_buffer(rdback, in_tensor.mesh_buffer(), /*blocking=*/true);
             tt_driver_atomics::mfence();
             ASSERT_EQ(rdback, input);
         }
         slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, out_tensor.mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(output, input);
     }
 }

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -121,6 +121,7 @@ static void run_dfb_size_override_test(
     const auto input =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, workload * data_entry_size / sizeof(uint32_t));
 
+    auto& cq = mesh_device.mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
     uint32_t eff_entry_size = entry_size_spec;
     uint32_t eff_num_entries = num_entries_spec;
@@ -159,19 +160,19 @@ static void run_dfb_size_override_test(
         EXPECT_EQ(dfb->config.entry_size, eff_entry_size);
         EXPECT_EQ(dfb->config.num_entries, eff_num_entries);
 
-        slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+        distributed::EnqueueWriteMeshBuffer(cq, in_tensor.mesh_buffer(), input, /*blocking=*/true);
         if (mesh_device.arch() == ARCH::QUASAR) {
             // TODO #38042: barrier not yet uplifted for Quasar; wait for the DRAM write to land.
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
             std::vector<uint32_t> rdback;
-            slow_dispatch::ReadFromBuffer(in_tensor.mesh_buffer(), rdback);
+            distributed::EnqueueReadMeshBuffer(cq, rdback, in_tensor.mesh_buffer(), /*blocking=*/true);
             tt_driver_atomics::mfence();
             ASSERT_EQ(rdback, input);
         }
         slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
+        distributed::EnqueueReadMeshBuffer(cq, output, out_tensor.mesh_buffer(), /*blocking=*/true);
         EXPECT_EQ(output, input);
     }
 }

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -41,7 +41,7 @@ TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SanityCheck) {
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     EXPECT_DEATH(
-        distributed::EnqueueWriteMeshBuffer(this->device().mesh_command_queue(), *buffer, data, /*blocking=*/true),
+        this->device().mesh_command_queue().enqueue_write_mesh_buffer(*buffer, data, /*blocking=*/true),
         ".*Use-After-Free.*WriteToBuffer.*");
 }
 
@@ -56,7 +56,7 @@ TEST_F(UnitMeshFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
 
     std::vector<uint32_t> out;
     EXPECT_DEATH(
-        distributed::EnqueueReadMeshBuffer(this->device().mesh_command_queue(), out, *buffer, /*blocking=*/true),
+        this->device().mesh_command_queue().enqueue_read_mesh_buffer(out, *buffer, /*blocking=*/true),
         ".*Use-After-Free.*ReadFromBuffer.*");
 }
 
@@ -108,7 +108,7 @@ TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     EXPECT_DEATH(
-        distributed::EnqueueWriteMeshBuffer(this->device().mesh_command_queue(), *buffer, data, /*blocking=*/true),
+        this->device().mesh_command_queue().enqueue_write_mesh_buffer(*buffer, data, /*blocking=*/true),
         ".*Use-After-Free.*WriteToBuffer.*");
 }
 
@@ -125,10 +125,10 @@ TEST_F(UnitMeshFixture, Host_UAF_Allocated_NoViolation) {
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *buffer, data, /*blocking=*/true);  // must NOT abort
+    cq.enqueue_write_mesh_buffer(*buffer, data, /*blocking=*/true);  // must NOT abort
 
     std::vector<uint32_t> out;
-    distributed::EnqueueReadMeshBuffer(cq, out, *buffer, /*blocking=*/true);  // must NOT abort
+    cq.enqueue_read_mesh_buffer(out, *buffer, /*blocking=*/true);  // must NOT abort
     EXPECT_EQ(out, data);
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -12,11 +12,11 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -40,7 +40,9 @@ TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SanityCheck) {
     DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
-    EXPECT_DEATH(slow_dispatch::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
+    EXPECT_DEATH(
+        distributed::EnqueueWriteMeshBuffer(this->device().mesh_command_queue(), *buffer, data, /*blocking=*/true),
+        ".*Use-After-Free.*WriteToBuffer.*");
 }
 
 TEST_F(UnitMeshFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
@@ -53,7 +55,9 @@ TEST_F(UnitMeshFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
     DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint32_t> out;
-    EXPECT_DEATH(slow_dispatch::ReadFromBuffer(*buffer, out), ".*Use-After-Free.*ReadFromBuffer.*");
+    EXPECT_DEATH(
+        distributed::EnqueueReadMeshBuffer(this->device().mesh_command_queue(), out, *buffer, /*blocking=*/true),
+        ".*Use-After-Free.*ReadFromBuffer.*");
 }
 
 TEST_F(UnitMeshFixture, Host_UAF_ReadShard_SanityCheck) {
@@ -103,7 +107,9 @@ TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
     DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
-    EXPECT_DEATH(slow_dispatch::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
+    EXPECT_DEATH(
+        distributed::EnqueueWriteMeshBuffer(this->device().mesh_command_queue(), *buffer, data, /*blocking=*/true),
+        ".*Use-After-Free.*WriteToBuffer.*");
 }
 
 // Positive control: a write/read round-trip on a LIVE (still-allocated) buffer
@@ -118,10 +124,11 @@ TEST_F(UnitMeshFixture, Host_UAF_Allocated_NoViolation) {
         &this->device());  // left allocated
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
-    slow_dispatch::WriteToBuffer(*buffer, data);  // must NOT abort
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *buffer, data, /*blocking=*/true);  // must NOT abort
 
     std::vector<uint32_t> out;
-    slow_dispatch::ReadFromBuffer(*buffer, out);  // must NOT abort
+    distributed::EnqueueReadMeshBuffer(cq, out, *buffer, /*blocking=*/true);  // must NOT abort
     EXPECT_EQ(out, data);
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -87,7 +87,7 @@ bool reader_only(
     ////////////////////////////////////////////////////////////////////////////
 
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    distributed::EnqueueWriteMeshBuffer(cq, *input_dram_buffer, inputs, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*input_dram_buffer, inputs, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -174,7 +174,7 @@ bool writer_only(
     distributed::Finish(cq);
 
     std::vector<uint32_t> dest_buffer_data;
-    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, *output_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(dest_buffer_data, *output_dram_buffer, /*blocking=*/true);
     pass &= (dest_buffer_data == inputs);
     if (not pass) {
         std::cout << "Mismatch at Core: " << writer_core.str() << std::endl;
@@ -208,7 +208,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     std::vector<uint32_t> inputs = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -1.0f, 1.0f, byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
     auto& cq = mesh_device->mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *input_dram_buffer, inputs, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*input_dram_buffer, inputs, /*blocking=*/true);
 
     // DRAM buffer is configured with page_size = byte_size (whole buffer),
     // so aligned_page_size() returns the whole-buffer stride, not per-tile.
@@ -313,7 +313,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     slow_dispatch::LaunchProgram(*mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dest_buffer_data;
-    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, *output_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(dest_buffer_data, *output_dram_buffer, /*blocking=*/true);
     return inputs == dest_buffer_data;
 }
 struct ReaderDatacopyWriterConfig {
@@ -356,8 +356,7 @@ static ReaderDatacopyWriterContext setup_reader_datacopy_writer_context(
 
     ctx.inputs = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -1.0f, 1.0f, ctx.byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
-    distributed::EnqueueWriteMeshBuffer(
-        mesh_device->mesh_command_queue(), *ctx.input_dram_buffer, ctx.inputs, /*blocking=*/true);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(*ctx.input_dram_buffer, ctx.inputs, /*blocking=*/true);
 
     // DRAM buffer uses page_size = byte_size (whole-buffer), so derive the
     // per-tile DRAM stride directly from byte_size / num_tiles.
@@ -368,11 +367,8 @@ static ReaderDatacopyWriterContext setup_reader_datacopy_writer_context(
 
 static bool verify_reader_datacopy_writer_output(const ReaderDatacopyWriterContext& ctx) {
     std::vector<uint32_t> dest_buffer_data;
-    distributed::EnqueueReadMeshBuffer(
-        ctx.output_dram_buffer->device()->mesh_command_queue(),
-        dest_buffer_data,
-        *ctx.output_dram_buffer,
-        /*blocking=*/true);
+    ctx.output_dram_buffer->device()->mesh_command_queue().enqueue_read_mesh_buffer(
+        dest_buffer_data, *ctx.output_dram_buffer, /*blocking=*/true);
     return ctx.inputs == dest_buffer_data;
 }
 

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -87,7 +87,7 @@ bool reader_only(
     ////////////////////////////////////////////////////////////////////////////
 
     auto inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    slow_dispatch::WriteToBuffer(*input_dram_buffer, inputs);
+    distributed::EnqueueWriteMeshBuffer(cq, *input_dram_buffer, inputs, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -174,7 +174,7 @@ bool writer_only(
     distributed::Finish(cq);
 
     std::vector<uint32_t> dest_buffer_data;
-    slow_dispatch::ReadFromBuffer(*output_dram_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, *output_dram_buffer, /*blocking=*/true);
     pass &= (dest_buffer_data == inputs);
     if (not pass) {
         std::cout << "Mismatch at Core: " << writer_core.str() << std::endl;
@@ -207,7 +207,8 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
 
     std::vector<uint32_t> inputs = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -1.0f, 1.0f, byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*input_dram_buffer, inputs);
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *input_dram_buffer, inputs, /*blocking=*/true);
 
     // DRAM buffer is configured with page_size = byte_size (whole buffer),
     // so aligned_page_size() returns the whole-buffer stride, not per-tile.
@@ -312,7 +313,7 @@ bool reader_writer(const std::shared_ptr<distributed::MeshDevice>& mesh_device, 
     slow_dispatch::LaunchProgram(*mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dest_buffer_data;
-    slow_dispatch::ReadFromBuffer(*output_dram_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, *output_dram_buffer, /*blocking=*/true);
     return inputs == dest_buffer_data;
 }
 struct ReaderDatacopyWriterConfig {
@@ -355,7 +356,8 @@ static ReaderDatacopyWriterContext setup_reader_datacopy_writer_context(
 
     ctx.inputs = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         -1.0f, 1.0f, ctx.byte_size / sizeof(bfloat16), std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*ctx.input_dram_buffer, ctx.inputs);
+    distributed::EnqueueWriteMeshBuffer(
+        mesh_device->mesh_command_queue(), *ctx.input_dram_buffer, ctx.inputs, /*blocking=*/true);
 
     // DRAM buffer uses page_size = byte_size (whole-buffer), so derive the
     // per-tile DRAM stride directly from byte_size / num_tiles.
@@ -366,7 +368,11 @@ static ReaderDatacopyWriterContext setup_reader_datacopy_writer_context(
 
 static bool verify_reader_datacopy_writer_output(const ReaderDatacopyWriterContext& ctx) {
     std::vector<uint32_t> dest_buffer_data;
-    slow_dispatch::ReadFromBuffer(*ctx.output_dram_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(
+        ctx.output_dram_buffer->device()->mesh_command_queue(),
+        dest_buffer_data,
+        *ctx.output_dram_buffer,
+        /*blocking=*/true);
     return ctx.inputs == dest_buffer_data;
 }
 

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -105,7 +105,7 @@ std::pair<std::shared_ptr<distributed::MeshBuffer>, std::vector<uint32_t>> l1_bu
     auto input =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, test_config.size_bytes / sizeof(uint32_t));
 
-    distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), *buffer, input, /*blocking=*/true);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(*buffer, input, /*blocking=*/true);
 
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
     return std::move(std::pair(buffer, input));
@@ -119,7 +119,7 @@ bool l1_buffer_read(
     auto buffer = write_info.first;
     auto input = write_info.second;
     auto output = std::vector<uint32_t>(input.size());
-    distributed::EnqueueReadMeshBuffer(mesh_device->mesh_command_queue(), output, *buffer, /*blocking=*/true);
+    mesh_device->mesh_command_queue().enqueue_read_mesh_buffer(output, *buffer, /*blocking=*/true);
     bool pass = (output == input);
 
     if (!pass) {
@@ -202,7 +202,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_WritesOnlyFilteredCores) 
         std::vector<uint32_t> sentinel(num_u32, k_sentinel);
         std::vector<uint32_t> newest(num_u32, k_new);
         auto& cq = mesh_device->mesh_command_queue();
-        distributed::EnqueueWriteMeshBuffer(cq, *buffer, sentinel, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*buffer, sentinel, /*blocking=*/true);
         CoreRangeSet filter(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
         tt::tt_metal::experimental::core_subset_write::WriteToBuffer(
             *buffer->get_reference_buffer(),
@@ -211,7 +211,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_WritesOnlyFilteredCores) 
             filter);
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, *buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, *buffer, /*blocking=*/true);
         auto expected =
             local_test_functions::expected_host_after_filtered_write(buffer, test_config, k_sentinel, k_new, filter);
         EXPECT_EQ(output, expected);
@@ -227,7 +227,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_EmptyFilterIsNoop) {
         std::vector<uint32_t> sentinel(num_u32, k_sentinel);
         std::vector<uint32_t> newest(num_u32, 0x99999999u);
         auto& cq = mesh_device->mesh_command_queue();
-        distributed::EnqueueWriteMeshBuffer(cq, *buffer, sentinel, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*buffer, sentinel, /*blocking=*/true);
         CoreRangeSet empty_filter;
         tt::tt_metal::experimental::core_subset_write::WriteToBuffer(
             *buffer->get_reference_buffer(),
@@ -236,7 +236,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_EmptyFilterIsNoop) {
             empty_filter);
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, *buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, *buffer, /*blocking=*/true);
         EXPECT_EQ(output, sentinel);
     }
 }
@@ -250,9 +250,9 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_FullFilterMatchesUnfilter
         const uint32_t num_u32 = test_config.size_bytes / sizeof(uint32_t);
         std::vector<uint32_t> data(num_u32, k_pattern);
         auto& cq = mesh_device->mesh_command_queue();
-        distributed::EnqueueWriteMeshBuffer(cq, *buffer_a, data, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*buffer_a, data, /*blocking=*/true);
         std::vector<uint32_t> sentinel(num_u32, 0x01010101u);
-        distributed::EnqueueWriteMeshBuffer(cq, *buffer_b, sentinel, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*buffer_b, sentinel, /*blocking=*/true);
         CoreRangeSet full_filter = test_config.shard_spec().grid();
         tt::tt_metal::experimental::core_subset_write::WriteToBuffer(
             *buffer_b->get_reference_buffer(),
@@ -261,8 +261,8 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_FullFilterMatchesUnfilter
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         std::vector<uint32_t> out_a;
         std::vector<uint32_t> out_b;
-        distributed::EnqueueReadMeshBuffer(cq, out_a, *buffer_a, /*blocking=*/true);
-        distributed::EnqueueReadMeshBuffer(cq, out_b, *buffer_b, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(out_a, *buffer_a, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(out_b, *buffer_b, /*blocking=*/true);
         EXPECT_EQ(out_a, out_b);
     }
 }
@@ -340,7 +340,7 @@ TEST_F(MeshDeviceFixture, TestUnorderedHeightShardReadWrite) {
         auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_size / sizeof(uint32_t));
 
         auto& cq = mesh_device->mesh_command_queue();
-        distributed::EnqueueWriteMeshBuffer(cq, *buffer, input, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*buffer, input, /*blocking=*/true);
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         auto input_it = input.begin();
         for (const auto& physical_core : physical_cores) {
@@ -350,7 +350,7 @@ TEST_F(MeshDeviceFixture, TestUnorderedHeightShardReadWrite) {
             input_it += tt::constants::TILE_HW;
         }
         std::vector<uint32_t> output;
-        distributed::EnqueueReadMeshBuffer(cq, output, *buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(output, *buffer, /*blocking=*/true);
         EXPECT_EQ(input, output);
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -18,7 +18,6 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <tt-metalium/distributed.hpp>
 #include "gtest/gtest.h"
 #include "llrt.hpp"
@@ -106,7 +105,7 @@ std::pair<std::shared_ptr<distributed::MeshBuffer>, std::vector<uint32_t>> l1_bu
     auto input =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, test_config.size_bytes / sizeof(uint32_t));
 
-    slow_dispatch::WriteToBuffer(*buffer, input);
+    distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), *buffer, input, /*blocking=*/true);
 
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
     return std::move(std::pair(buffer, input));
@@ -114,13 +113,13 @@ std::pair<std::shared_ptr<distributed::MeshBuffer>, std::vector<uint32_t>> l1_bu
 
 template <typename T>
 bool l1_buffer_read(
-    const std::shared_ptr<distributed::MeshDevice>& /*mesh_device*/,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const L1Config<T>& test_config,
     const auto& write_info) {
     auto buffer = write_info.first;
     auto input = write_info.second;
     auto output = std::vector<uint32_t>(input.size());
-    slow_dispatch::ReadFromBuffer(*buffer, output);
+    distributed::EnqueueReadMeshBuffer(mesh_device->mesh_command_queue(), output, *buffer, /*blocking=*/true);
     bool pass = (output == input);
 
     if (!pass) {
@@ -202,7 +201,8 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_WritesOnlyFilteredCores) 
         const uint32_t num_u32 = test_config.size_bytes / sizeof(uint32_t);
         std::vector<uint32_t> sentinel(num_u32, k_sentinel);
         std::vector<uint32_t> newest(num_u32, k_new);
-        slow_dispatch::WriteToBuffer(*buffer, sentinel);
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, *buffer, sentinel, /*blocking=*/true);
         CoreRangeSet filter(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
         tt::tt_metal::experimental::core_subset_write::WriteToBuffer(
             *buffer->get_reference_buffer(),
@@ -211,7 +211,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_WritesOnlyFilteredCores) 
             filter);
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(*buffer, output);
+        distributed::EnqueueReadMeshBuffer(cq, output, *buffer, /*blocking=*/true);
         auto expected =
             local_test_functions::expected_host_after_filtered_write(buffer, test_config, k_sentinel, k_new, filter);
         EXPECT_EQ(output, expected);
@@ -226,7 +226,8 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_EmptyFilterIsNoop) {
         const uint32_t num_u32 = test_config.size_bytes / sizeof(uint32_t);
         std::vector<uint32_t> sentinel(num_u32, k_sentinel);
         std::vector<uint32_t> newest(num_u32, 0x99999999u);
-        slow_dispatch::WriteToBuffer(*buffer, sentinel);
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, *buffer, sentinel, /*blocking=*/true);
         CoreRangeSet empty_filter;
         tt::tt_metal::experimental::core_subset_write::WriteToBuffer(
             *buffer->get_reference_buffer(),
@@ -235,7 +236,7 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_EmptyFilterIsNoop) {
             empty_filter);
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(*buffer, output);
+        distributed::EnqueueReadMeshBuffer(cq, output, *buffer, /*blocking=*/true);
         EXPECT_EQ(output, sentinel);
     }
 }
@@ -248,9 +249,10 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_FullFilterMatchesUnfilter
         auto buffer_b = local_test_functions::make_height_sharded_l1_buffer(mesh_device, test_config);
         const uint32_t num_u32 = test_config.size_bytes / sizeof(uint32_t);
         std::vector<uint32_t> data(num_u32, k_pattern);
-        slow_dispatch::WriteToBuffer(*buffer_a, data);
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, *buffer_a, data, /*blocking=*/true);
         std::vector<uint32_t> sentinel(num_u32, 0x01010101u);
-        slow_dispatch::WriteToBuffer(*buffer_b, sentinel);
+        distributed::EnqueueWriteMeshBuffer(cq, *buffer_b, sentinel, /*blocking=*/true);
         CoreRangeSet full_filter = test_config.shard_spec().grid();
         tt::tt_metal::experimental::core_subset_write::WriteToBuffer(
             *buffer_b->get_reference_buffer(),
@@ -259,8 +261,8 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_FullFilterMatchesUnfilter
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         std::vector<uint32_t> out_a;
         std::vector<uint32_t> out_b;
-        slow_dispatch::ReadFromBuffer(*buffer_a, out_a);
-        slow_dispatch::ReadFromBuffer(*buffer_b, out_b);
+        distributed::EnqueueReadMeshBuffer(cq, out_a, *buffer_a, /*blocking=*/true);
+        distributed::EnqueueReadMeshBuffer(cq, out_b, *buffer_b, /*blocking=*/true);
         EXPECT_EQ(out_a, out_b);
     }
 }
@@ -337,7 +339,8 @@ TEST_F(MeshDeviceFixture, TestUnorderedHeightShardReadWrite) {
             distributed::ReplicatedBufferConfig{.size = total_size}, local_config, mesh_device.get());
         auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_size / sizeof(uint32_t));
 
-        slow_dispatch::WriteToBuffer(*buffer, input);
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, *buffer, input, /*blocking=*/true);
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(mesh_device->get_device_ids()[0]);
         auto input_it = input.begin();
         for (const auto& physical_core : physical_cores) {
@@ -347,7 +350,7 @@ TEST_F(MeshDeviceFixture, TestUnorderedHeightShardReadWrite) {
             input_it += tt::constants::TILE_HW;
         }
         std::vector<uint32_t> output;
-        slow_dispatch::ReadFromBuffer(*buffer, output);
+        distributed::EnqueueReadMeshBuffer(cq, output, *buffer, /*blocking=*/true);
         EXPECT_EQ(input, output);
     }
 }

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -103,11 +103,11 @@ TEST_F(UnitMeshFixture, ZeroMemoryApi) {
         MeshTensor::allocate_on_device(this->device(), make_flat_dram_tensor_spec(page_size_bytes, num_pages));
     std::vector<uint32_t> stamped(total_words, 0xFFFFFFFFu);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, tensor.mesh_buffer(), stamped, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(tensor.mesh_buffer(), stamped, /*blocking=*/true);
 
     // Pre-write verify: confirm the DRAM stamp landed so the post-zero check is meaningful.
     std::vector<uint32_t> stamp_check;
-    distributed::EnqueueReadMeshBuffer(cq, stamp_check, tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(stamp_check, tensor.mesh_buffer(), /*blocking=*/true);
     ASSERT_EQ(stamp_check.size(), total_words);
     for (uint32_t i = 0; i < total_words; ++i) {
         ASSERT_EQ(stamp_check[i], 0xFFFFFFFFu) << "Pre-write 0xFF stamp did not land at DRAM word " << i;
@@ -189,7 +189,7 @@ TEST_F(UnitMeshFixture, ZeroMemoryApi) {
 
     // DRAM: every word should be zero after overload (2).
     std::vector<uint32_t> result;
-    distributed::EnqueueReadMeshBuffer(cq, result, tensor.mesh_buffer(), /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result, tensor.mesh_buffer(), /*blocking=*/true);
     ASSERT_EQ(result.size(), total_words);
     for (uint32_t i = 0; i < total_words; ++i) {
         EXPECT_EQ(result[i], 0u) << "DRAM word " << i << " not zeroed; got 0x" << std::hex << result[i];
@@ -217,8 +217,7 @@ TEST_F(UnitMeshFixture, ZeroMemoryApiBatchedL1) {
     auto tensor =
         MeshTensor::allocate_on_device(this->device(), make_flat_dram_tensor_spec(page_size_bytes, num_pages));
     std::vector<uint32_t> stamped(total_words, 0xFFFFFFFFu);
-    distributed::EnqueueWriteMeshBuffer(
-        this->device().mesh_command_queue(), tensor.mesh_buffer(), stamped, /*blocking=*/true);
+    this->device().mesh_command_queue().enqueue_write_mesh_buffer(tensor.mesh_buffer(), stamped, /*blocking=*/true);
 
     experimental::DataflowBufferSpec scratch_spec{
         .unique_id = SCRATCH_DFB,

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -102,11 +102,12 @@ TEST_F(UnitMeshFixture, ZeroMemoryApi) {
     auto tensor =
         MeshTensor::allocate_on_device(this->device(), make_flat_dram_tensor_spec(page_size_bytes, num_pages));
     std::vector<uint32_t> stamped(total_words, 0xFFFFFFFFu);
-    slow_dispatch::WriteToBuffer(tensor.mesh_buffer(), stamped);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, tensor.mesh_buffer(), stamped, /*blocking=*/true);
 
     // Pre-write verify: confirm the DRAM stamp landed so the post-zero check is meaningful.
     std::vector<uint32_t> stamp_check;
-    slow_dispatch::ReadFromBuffer(tensor.mesh_buffer(), stamp_check);
+    distributed::EnqueueReadMeshBuffer(cq, stamp_check, tensor.mesh_buffer(), /*blocking=*/true);
     ASSERT_EQ(stamp_check.size(), total_words);
     for (uint32_t i = 0; i < total_words; ++i) {
         ASSERT_EQ(stamp_check[i], 0xFFFFFFFFu) << "Pre-write 0xFF stamp did not land at DRAM word " << i;
@@ -188,7 +189,7 @@ TEST_F(UnitMeshFixture, ZeroMemoryApi) {
 
     // DRAM: every word should be zero after overload (2).
     std::vector<uint32_t> result;
-    slow_dispatch::ReadFromBuffer(tensor.mesh_buffer(), result);
+    distributed::EnqueueReadMeshBuffer(cq, result, tensor.mesh_buffer(), /*blocking=*/true);
     ASSERT_EQ(result.size(), total_words);
     for (uint32_t i = 0; i < total_words; ++i) {
         EXPECT_EQ(result[i], 0u) << "DRAM word " << i << " not zeroed; got 0x" << std::hex << result[i];
@@ -216,7 +217,8 @@ TEST_F(UnitMeshFixture, ZeroMemoryApiBatchedL1) {
     auto tensor =
         MeshTensor::allocate_on_device(this->device(), make_flat_dram_tensor_spec(page_size_bytes, num_pages));
     std::vector<uint32_t> stamped(total_words, 0xFFFFFFFFu);
-    slow_dispatch::WriteToBuffer(tensor.mesh_buffer(), stamped);
+    distributed::EnqueueWriteMeshBuffer(
+        this->device().mesh_command_queue(), tensor.mesh_buffer(), stamped, /*blocking=*/true);
 
     experimental::DataflowBufferSpec scratch_spec{
         .unique_id = SCRATCH_DFB,

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -193,7 +193,7 @@ void run_bcast_test(distributed::MeshDevice& mesh_device, BcastDim::Enum bcast_d
         &mesh_device);
     uint32_t dram_buffer_src1_addr = src1_dram_buffer->address();
     auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, bcast_tiled_u32, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src1_dram_buffer, bcast_tiled_u32, /*blocking=*/true);
 
     std::vector<uint32_t> reader_compile_time_args;
     TensorAccessorArgs(src0_dram_buffer).append_to(reader_compile_time_args);
@@ -254,12 +254,12 @@ void run_bcast_test(distributed::MeshDevice& mesh_device, BcastDim::Enum bcast_d
 
     // Execute
     vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 10.0f, 0x1234);
-    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, src0_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src0_dram_buffer, src0_vec, /*blocking=*/true);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     auto comparison_function = [](float a, float b) {

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -192,7 +192,8 @@ void run_bcast_test(distributed::MeshDevice& mesh_device, BcastDim::Enum bcast_d
         {.page_size = src1_page_size, .buffer_type = BufferType::DRAM},
         &mesh_device);
     uint32_t dram_buffer_src1_addr = src1_dram_buffer->address();
-    slow_dispatch::WriteToBuffer(*src1_dram_buffer, bcast_tiled_u32);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, bcast_tiled_u32, /*blocking=*/true);
 
     std::vector<uint32_t> reader_compile_time_args;
     TensorAccessorArgs(src0_dram_buffer).append_to(reader_compile_time_args);
@@ -253,12 +254,12 @@ void run_bcast_test(distributed::MeshDevice& mesh_device, BcastDim::Enum bcast_d
 
     // Execute
     vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 10.0f, 0x1234);
-    slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, src0_vec, /*blocking=*/true);
 
     slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     auto comparison_function = [](float a, float b) {

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -167,7 +167,7 @@ TEST_F(UnitMeshFixture, CoreRangeSet) {
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src_dram_buffer, src_vec, /*blocking=*/true);
 
     const std::array reader_rt_args = {(uint32_t)src_dram_buffer->address(), uint(0), num_tiles};
     for (const auto& [core, dst_l1_buffer] : core_to_l1_buffer) {
@@ -192,7 +192,7 @@ TEST_F(UnitMeshFixture, CoreRangeSet) {
 
     for (const auto& [core, dst_l1_buffer] : core_to_l1_buffer) {
         std::vector<uint32_t> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_l1_buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(result_vec, *dst_l1_buffer, /*blocking=*/true);
         EXPECT_EQ(src_vec, result_vec) << "Mismatch on core " << core.x << "," << core.y;
     }
 }

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -166,7 +166,8 @@ TEST_F(UnitMeshFixture, CoreRangeSet) {
 
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
 
     const std::array reader_rt_args = {(uint32_t)src_dram_buffer->address(), uint(0), num_tiles};
     for (const auto& [core, dst_l1_buffer] : core_to_l1_buffer) {
@@ -191,7 +192,7 @@ TEST_F(UnitMeshFixture, CoreRangeSet) {
 
     for (const auto& [core, dst_l1_buffer] : core_to_l1_buffer) {
         std::vector<uint32_t> result_vec;
-        slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);
+        distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_l1_buffer, /*blocking=*/true);
         EXPECT_EQ(src_vec, result_vec) << "Mismatch on core " << core.x << "," << core.y;
     }
 }

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -76,7 +76,7 @@ TEST_F(UnitMeshFixture, Datacopy) {
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
@@ -84,7 +84,7 @@ TEST_F(UnitMeshFixture, Datacopy) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -75,7 +75,8 @@ TEST_F(UnitMeshFixture, Datacopy) {
     // Execute
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
@@ -83,7 +84,7 @@ TEST_F(UnitMeshFixture, Datacopy) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -78,7 +78,7 @@ TEST_F(UnitMeshFixture, DatacopyBfp8b) {
         100,
         std::chrono::system_clock::now().time_since_epoch().count());
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
@@ -86,7 +86,7 @@ TEST_F(UnitMeshFixture, DatacopyBfp8b) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -77,7 +77,8 @@ TEST_F(UnitMeshFixture, DatacopyBfp8b) {
         /*is_exp_a=*/false,
         100,
         std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
@@ -85,7 +86,7 @@ TEST_F(UnitMeshFixture, DatacopyBfp8b) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -77,7 +77,7 @@ TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {(std::uint32_t)src_dram_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(
@@ -92,7 +92,7 @@ TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_l1_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_l1_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -76,7 +76,8 @@ TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
     // Execute
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {(std::uint32_t)src_dram_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(
@@ -91,7 +92,7 @@ TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_l1_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -96,8 +96,7 @@ TEST_F(UnitMeshFixture, DramCopySticksMultiCore) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        distributed::EnqueueWriteMeshBuffer(
-            this->device().mesh_command_queue(), *src_dram_buffer, src_vec, /*blocking=*/true);
+        this->device().mesh_command_queue().enqueue_write_mesh_buffer(*src_dram_buffer, src_vec, /*blocking=*/true);
 
         std::cout << "Num cores " << num_cores_r * num_cores_c << std::endl;
         uint32_t core_index = 0;
@@ -119,7 +118,7 @@ TEST_F(UnitMeshFixture, DramCopySticksMultiCore) {
 
         slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
         // std::vector<uint32_t> result_vec;
-        // distributed::EnqueueReadMeshBuffer(this->device().mesh_command_queue(), result_vec, *dst_dram_buffer,
+        // this->device().mesh_command_queue().enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer,
         // /*blocking=*/true);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -96,7 +96,8 @@ TEST_F(UnitMeshFixture, DramCopySticksMultiCore) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
+        distributed::EnqueueWriteMeshBuffer(
+            this->device().mesh_command_queue(), *src_dram_buffer, src_vec, /*blocking=*/true);
 
         std::cout << "Num cores " << num_cores_r * num_cores_c << std::endl;
         uint32_t core_index = 0;
@@ -118,7 +119,8 @@ TEST_F(UnitMeshFixture, DramCopySticksMultiCore) {
 
         slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
         // std::vector<uint32_t> result_vec;
-        // slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+        // distributed::EnqueueReadMeshBuffer(this->device().mesh_command_queue(), result_vec, *dst_dram_buffer,
+        // /*blocking=*/true);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -50,7 +50,7 @@ TEST_F(UnitMeshFixture, DramLoopbackSingleCore) {
     std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *input_dram_buffer, input_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*input_dram_buffer, input_vec, /*blocking=*/true);
 
     SetRuntimeArgs(
         program,
@@ -61,7 +61,7 @@ TEST_F(UnitMeshFixture, DramLoopbackSingleCore) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *output_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *output_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(input_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -49,7 +49,8 @@ TEST_F(UnitMeshFixture, DramLoopbackSingleCore) {
     // Execute
     std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*input_dram_buffer, input_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *input_dram_buffer, input_vec, /*blocking=*/true);
 
     SetRuntimeArgs(
         program,
@@ -60,7 +61,7 @@ TEST_F(UnitMeshFixture, DramLoopbackSingleCore) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*output_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *output_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(input_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -283,14 +283,14 @@ TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
         auto& cq = this->device().mesh_command_queue();
-        distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, activations_tile_transposed, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*src0_dram_buffer, activations_tile_transposed, /*blocking=*/true);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
         auto weights_tile_layout =
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*src1_dram_buffer, weights, /*blocking=*/true);
         slow_dispatch::WriteToL1(this->device(), core, source_addresses_in_l1_addr, source_addresses);
 
         tt_metal::SetRuntimeArgs(program, generic_binary_reader_kernel, core, generic_binary_reader_args);
@@ -300,7 +300,7 @@ TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
         slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
         std::vector<uint32_t> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -282,14 +282,15 @@ TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
-        slow_dispatch::WriteToBuffer(*src0_dram_buffer, activations_tile_transposed);
+        auto& cq = this->device().mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, activations_tile_transposed, /*blocking=*/true);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
         auto weights_tile_layout =
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        slow_dispatch::WriteToBuffer(*src1_dram_buffer, weights);
+        distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
         slow_dispatch::WriteToL1(this->device(), core, source_addresses_in_l1_addr, source_addresses);
 
         tt_metal::SetRuntimeArgs(program, generic_binary_reader_kernel, core, generic_binary_reader_args);
@@ -299,7 +300,7 @@ TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
         slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
         std::vector<uint32_t> result_vec;
-        slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+        distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -30,10 +30,10 @@ void test_interleaved_l1_buffer_impl(
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
     auto& cq = device.mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *interleaved_buffer, host_buffer, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*interleaved_buffer, host_buffer, /*blocking=*/true);
 
     std::vector<uint32_t> readback_buffer;
-    distributed::EnqueueReadMeshBuffer(cq, readback_buffer, *interleaved_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(readback_buffer, *interleaved_buffer, /*blocking=*/true);
 
     EXPECT_EQ(host_buffer, readback_buffer);
 
@@ -47,10 +47,10 @@ void test_interleaved_l1_buffer_impl(
     std::vector<uint32_t> second_host_buffer = create_random_vector_of_bfloat16(
         second_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    distributed::EnqueueWriteMeshBuffer(cq, *second_interleaved_buffer, second_host_buffer, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*second_interleaved_buffer, second_host_buffer, /*blocking=*/true);
 
     std::vector<uint32_t> second_readback_buffer;
-    distributed::EnqueueReadMeshBuffer(cq, second_readback_buffer, *second_interleaved_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(second_readback_buffer, *second_interleaved_buffer, /*blocking=*/true);
 
     EXPECT_EQ(second_host_buffer, second_readback_buffer);
 }

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -9,9 +9,9 @@
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -29,10 +29,11 @@ void test_interleaved_l1_buffer_impl(
     std::vector<uint32_t> host_buffer =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    slow_dispatch::WriteToBuffer(*interleaved_buffer, host_buffer);
+    auto& cq = device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *interleaved_buffer, host_buffer, /*blocking=*/true);
 
     std::vector<uint32_t> readback_buffer;
-    slow_dispatch::ReadFromBuffer(*interleaved_buffer, readback_buffer);
+    distributed::EnqueueReadMeshBuffer(cq, readback_buffer, *interleaved_buffer, /*blocking=*/true);
 
     EXPECT_EQ(host_buffer, readback_buffer);
 
@@ -46,10 +47,10 @@ void test_interleaved_l1_buffer_impl(
     std::vector<uint32_t> second_host_buffer = create_random_vector_of_bfloat16(
         second_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    slow_dispatch::WriteToBuffer(*second_interleaved_buffer, second_host_buffer);
+    distributed::EnqueueWriteMeshBuffer(cq, *second_interleaved_buffer, second_host_buffer, /*blocking=*/true);
 
     std::vector<uint32_t> second_readback_buffer;
-    slow_dispatch::ReadFromBuffer(*second_interleaved_buffer, second_readback_buffer);
+    distributed::EnqueueReadMeshBuffer(cq, second_readback_buffer, *second_interleaved_buffer, /*blocking=*/true);
 
     EXPECT_EQ(second_host_buffer, second_readback_buffer);
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -83,7 +83,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
         100,
         std::chrono::system_clock::now().time_since_epoch().count());
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, activations, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src0_dram_buffer, activations, /*blocking=*/true);
 
     int num_float_in_tile = 32 * 32;
     std::vector<float> vec(num_float_in_tile, (float)0);
@@ -93,7 +93,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
     std::vector<uint32_t> weights =
         pack_as_bfp8_tiles(ttsl::make_const_span(vec), /*row_major_input=*/true, /*is_exp_a=*/false);
 
-    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src1_dram_buffer, weights, /*blocking=*/true);
 
     SetRuntimeArgs(
         program,
@@ -114,7 +114,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation - matmul with identity should return same result
     EXPECT_EQ(activations, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -82,7 +82,8 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
         /*is_exp_a=*/false,
         100,
         std::chrono::system_clock::now().time_since_epoch().count());
-    slow_dispatch::WriteToBuffer(*src0_dram_buffer, activations);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, activations, /*blocking=*/true);
 
     int num_float_in_tile = 32 * 32;
     std::vector<float> vec(num_float_in_tile, (float)0);
@@ -92,7 +93,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
     std::vector<uint32_t> weights =
         pack_as_bfp8_tiles(ttsl::make_const_span(vec), /*row_major_input=*/true, /*is_exp_a=*/false);
 
-    slow_dispatch::WriteToBuffer(*src1_dram_buffer, weights);
+    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
 
     SetRuntimeArgs(
         program,
@@ -113,7 +114,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation - matmul with identity should return same result
     EXPECT_EQ(activations, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -90,12 +90,12 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(tensor.get_values()));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, activations, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src0_dram_buffer, activations, /*blocking=*/true);
 
     auto identity = create_identity_matrix(32, 32, 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src1_dram_buffer, weights, /*blocking=*/true);
 
     SetRuntimeArgs(
         program,
@@ -120,7 +120,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_l1_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_l1_buffer, /*blocking=*/true);
 
     // Validation
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -89,12 +89,13 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
     auto activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(tensor.get_values()));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-    slow_dispatch::WriteToBuffer(*src0_dram_buffer, activations);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, activations, /*blocking=*/true);
 
     auto identity = create_identity_matrix(32, 32, 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    slow_dispatch::WriteToBuffer(*src1_dram_buffer, weights);
+    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
 
     SetRuntimeArgs(
         program,
@@ -119,7 +120,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_l1_buffer, /*blocking=*/true);
 
     // Validation
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -103,7 +103,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelSameRuntimeArgs) {
         src_dram_buffer->size(), 100, std::chrono::system_clock::now().time_since_epoch().count());
 
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src_dram_buffer, src_vec, /*blocking=*/true);
 
     const std::array unary_reader_args{
         (std::uint32_t)src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
@@ -116,7 +116,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelSameRuntimeArgs) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     EXPECT_EQ(src_vec, result_vec);
 }
@@ -151,7 +151,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelUniqueRuntimeArgs) {
         src_dram_buffer->size(), 100, std::chrono::system_clock::now().time_since_epoch().count());
 
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src_dram_buffer, src_vec, /*blocking=*/true);
 
     const std::array unary_reader_args{
         (std::uint32_t)src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
@@ -172,13 +172,13 @@ TEST_F(UnitMeshFixture, MultiCoreKernelUniqueRuntimeArgs) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec_1;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec_1, *dst_dram_buffer_1, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec_1, *dst_dram_buffer_1, /*blocking=*/true);
 
     std::vector<uint32_t> result_vec_2;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec_2, *dst_dram_buffer_2, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec_2, *dst_dram_buffer_2, /*blocking=*/true);
 
     std::vector<uint32_t> result_vec_3;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec_3, *dst_dram_buffer_3, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec_3, *dst_dram_buffer_3, /*blocking=*/true);
 
     EXPECT_EQ(src_vec, result_vec_1);
     EXPECT_EQ(src_vec, result_vec_2);

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -102,7 +102,8 @@ TEST_F(UnitMeshFixture, MultiCoreKernelSameRuntimeArgs) {
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         src_dram_buffer->size(), 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
 
     const std::array unary_reader_args{
         (std::uint32_t)src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
@@ -115,7 +116,7 @@ TEST_F(UnitMeshFixture, MultiCoreKernelSameRuntimeArgs) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     EXPECT_EQ(src_vec, result_vec);
 }
@@ -149,7 +150,8 @@ TEST_F(UnitMeshFixture, MultiCoreKernelUniqueRuntimeArgs) {
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         src_dram_buffer->size(), 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src_dram_buffer, src_vec, /*blocking=*/true);
 
     const std::array unary_reader_args{
         (std::uint32_t)src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
@@ -170,13 +172,13 @@ TEST_F(UnitMeshFixture, MultiCoreKernelUniqueRuntimeArgs) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec_1;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer_1, result_vec_1);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec_1, *dst_dram_buffer_1, /*blocking=*/true);
 
     std::vector<uint32_t> result_vec_2;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer_2, result_vec_2);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec_2, *dst_dram_buffer_2, /*blocking=*/true);
 
     std::vector<uint32_t> result_vec_3;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer_3, result_vec_3);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec_3, *dst_dram_buffer_3, /*blocking=*/true);
 
     EXPECT_EQ(src_vec, result_vec_1);
     EXPECT_EQ(src_vec, result_vec_2);

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -200,14 +200,14 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(src0_tensor.get_values()));
     auto src0_activations = pack_bfloat16_vec_into_uint32_vec(src0_activations_tile_layout);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, src0_activations, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src0_dram_buffer, src0_activations, /*blocking=*/true);
 
     tt::deprecated::Tensor<bfloat16> src1_tensor = tt::deprecated::initialize_tensor<bfloat16>(
         shape, tt::deprecated::Initialize::ZEROS, 0, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto src1_activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(src1_tensor.get_values()));
     auto src1_activations = pack_bfloat16_vec_into_uint32_vec(src1_activations_tile_layout);
-    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, src1_activations, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src1_dram_buffer, src1_activations, /*blocking=*/true);
 
     write_program_runtime_args_to_device(
         program1,
@@ -222,7 +222,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
     slow_dispatch::LaunchProgram(this->device(), program1, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> intermediate_result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, intermediate_result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(intermediate_result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validate Intermediate Result
     EXPECT_EQ(src0_activations, intermediate_result_vec) << "Eltwise binary did not produce expected result";
@@ -231,7 +231,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
     auto identity = create_identity_matrix(32, 32, 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src1_dram_buffer, weights, /*blocking=*/true);
 
     write_program_runtime_args_to_device(
         program2,
@@ -246,7 +246,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
     slow_dispatch::LaunchProgram(this->device(), program2, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validate - matmul with identity should give same result
     EXPECT_EQ(intermediate_result_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -199,14 +199,15 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
     auto src0_activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(src0_tensor.get_values()));
     auto src0_activations = pack_bfloat16_vec_into_uint32_vec(src0_activations_tile_layout);
-    slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_activations);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, src0_activations, /*blocking=*/true);
 
     tt::deprecated::Tensor<bfloat16> src1_tensor = tt::deprecated::initialize_tensor<bfloat16>(
         shape, tt::deprecated::Initialize::ZEROS, 0, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto src1_activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(src1_tensor.get_values()));
     auto src1_activations = pack_bfloat16_vec_into_uint32_vec(src1_activations_tile_layout);
-    slow_dispatch::WriteToBuffer(*src1_dram_buffer, src1_activations);
+    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, src1_activations, /*blocking=*/true);
 
     write_program_runtime_args_to_device(
         program1,
@@ -221,7 +222,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
     slow_dispatch::LaunchProgram(this->device(), program1, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> intermediate_result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, intermediate_result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, intermediate_result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validate Intermediate Result
     EXPECT_EQ(src0_activations, intermediate_result_vec) << "Eltwise binary did not produce expected result";
@@ -230,7 +231,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
     auto identity = create_identity_matrix(32, 32, 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    slow_dispatch::WriteToBuffer(*src1_dram_buffer, weights);
+    distributed::EnqueueWriteMeshBuffer(cq, *src1_dram_buffer, weights, /*blocking=*/true);
 
     write_program_runtime_args_to_device(
         program2,
@@ -245,7 +246,7 @@ TEST_F(UnitMeshFixture, MultiplePrograms) {
     slow_dispatch::LaunchProgram(this->device(), program2, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validate - matmul with identity should give same result
     EXPECT_EQ(intermediate_result_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -293,18 +293,18 @@ static bool test_sdpa_reduce_c(
     auto qk_im_tilized = tiny ? tilize_16x32(qk_im_tensor.get_values(), q_chunk_size * tile_height, k_chunk_size * 32)
                               : tilize_nfaces(qk_im_tensor.get_values(), q_chunk_size * 32, k_chunk_size * 32);
     qk_im = pack_bfloat16_vec_into_uint32_vec(qk_im_tilized);
-    distributed::EnqueueWriteMeshBuffer(cq, *qk_im_buffer, qk_im, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*qk_im_buffer, qk_im, /*blocking=*/true);
 
     std::vector<bfloat16> prev_max_first_col;
     auto prev_max_rm = make_prev_max_matrix(q_chunk_size, 25.0f, 65.0f, prev_max_first_col, tile_height);
     auto prev_max_tilized = tiny ? tilize_16x32(prev_max_rm, q_chunk_size * tile_height, 32)
                                  : tilize_nfaces(prev_max_rm, q_chunk_size * 32, 32);
     auto prev_max_uint_vec = pack_bfloat16_vec_into_uint32_vec(prev_max_tilized);
-    distributed::EnqueueWriteMeshBuffer(cq, *prev_max_buffer, prev_max_uint_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*prev_max_buffer, prev_max_uint_vec, /*blocking=*/true);
 
     auto identity_scale_tile = make_identity_scale_tile(tile_height);
     auto identity_scale_uint_vec = pack_bfloat16_vec_into_uint32_vec(identity_scale_tile);
-    distributed::EnqueueWriteMeshBuffer(cq, *identity_scale_buffer, identity_scale_uint_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*identity_scale_buffer, identity_scale_uint_vec, /*blocking=*/true);
 
     // Execute program using MeshWorkload
     tt_metal::distributed::MeshWorkload workload;
@@ -318,7 +318,7 @@ static bool test_sdpa_reduce_c(
 
     // Read outputs
     std::vector<uint32_t> out_max_vec;
-    distributed::EnqueueReadMeshBuffer(cq, out_max_vec, *out_max_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(out_max_vec, *out_max_buffer, /*blocking=*/true);
     auto out_max_bfp16 = unpack_uint32_vec_into_bfloat16_vec(out_max_vec);
     auto out_max_rm = tiny ? untilize_16x32(out_max_bfp16, q_chunk_size * tile_height, 32)
                            : untilize_nfaces(out_max_bfp16, q_chunk_size * 32, 32);

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -293,18 +293,18 @@ static bool test_sdpa_reduce_c(
     auto qk_im_tilized = tiny ? tilize_16x32(qk_im_tensor.get_values(), q_chunk_size * tile_height, k_chunk_size * 32)
                               : tilize_nfaces(qk_im_tensor.get_values(), q_chunk_size * 32, k_chunk_size * 32);
     qk_im = pack_bfloat16_vec_into_uint32_vec(qk_im_tilized);
-    slow_dispatch::WriteToBuffer(*qk_im_buffer, qk_im);
+    distributed::EnqueueWriteMeshBuffer(cq, *qk_im_buffer, qk_im, /*blocking=*/true);
 
     std::vector<bfloat16> prev_max_first_col;
     auto prev_max_rm = make_prev_max_matrix(q_chunk_size, 25.0f, 65.0f, prev_max_first_col, tile_height);
     auto prev_max_tilized = tiny ? tilize_16x32(prev_max_rm, q_chunk_size * tile_height, 32)
                                  : tilize_nfaces(prev_max_rm, q_chunk_size * 32, 32);
     auto prev_max_uint_vec = pack_bfloat16_vec_into_uint32_vec(prev_max_tilized);
-    slow_dispatch::WriteToBuffer(*prev_max_buffer, prev_max_uint_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, *prev_max_buffer, prev_max_uint_vec, /*blocking=*/true);
 
     auto identity_scale_tile = make_identity_scale_tile(tile_height);
     auto identity_scale_uint_vec = pack_bfloat16_vec_into_uint32_vec(identity_scale_tile);
-    slow_dispatch::WriteToBuffer(*identity_scale_buffer, identity_scale_uint_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, *identity_scale_buffer, identity_scale_uint_vec, /*blocking=*/true);
 
     // Execute program using MeshWorkload
     tt_metal::distributed::MeshWorkload workload;
@@ -318,7 +318,7 @@ static bool test_sdpa_reduce_c(
 
     // Read outputs
     std::vector<uint32_t> out_max_vec;
-    slow_dispatch::ReadFromBuffer(*out_max_buffer, out_max_vec);
+    distributed::EnqueueReadMeshBuffer(cq, out_max_vec, *out_max_buffer, /*blocking=*/true);
     auto out_max_bfp16 = unpack_uint32_vec_into_bfloat16_vec(out_max_vec);
     auto out_max_rm = tiny ? untilize_16x32(out_max_bfp16, q_chunk_size * tile_height, 32)
                            : untilize_nfaces(out_max_bfp16, q_chunk_size * 32, 32);

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -120,7 +120,7 @@ TEST_F(UnitMeshFixture, TransposeHC) {
     std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 100U, 0x1234);
     auto src_4f_16 = u16_from_u32_vector(src0_vec);
     auto& cq = this->device().mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, src0_vec, /*blocking=*/true);
+    cq.enqueue_write_mesh_buffer(*src0_dram_buffer, src0_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, reader_kernel, core, {dram_buffer_src0_addr, 0U, W, H, C, HW, N, CHW});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0U, num_tensor_tiles});
@@ -128,7 +128,7 @@ TEST_F(UnitMeshFixture, TransposeHC) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
+    cq.enqueue_read_mesh_buffer(result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     auto comparison_function = [](float a, float b) {

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -119,7 +119,8 @@ TEST_F(UnitMeshFixture, TransposeHC) {
     // Execute
     std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 100U, 0x1234);
     auto src_4f_16 = u16_from_u32_vector(src0_vec);
-    slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_vec);
+    auto& cq = this->device().mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, *src0_dram_buffer, src0_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, reader_kernel, core, {dram_buffer_src0_addr, 0U, W, H, C, HW, N, CHW});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0U, num_tensor_tiles});
@@ -127,7 +128,7 @@ TEST_F(UnitMeshFixture, TransposeHC) {
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, *dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     auto comparison_function = [](float a, float b) {

--- a/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
@@ -64,11 +64,10 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
         for (auto& v : src_vec_dram_interleaved_case) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
-        distributed::EnqueueWriteMeshBuffer(
-            cq, *device_dram_interleaved_buffer, src_vec_dram_interleaved_case, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*device_dram_interleaved_buffer, src_vec_dram_interleaved_case, /*blocking=*/true);
         std::vector<uint8_t> result_vec_dram_interleaved_case;
-        distributed::EnqueueReadMeshBuffer(
-            cq, result_vec_dram_interleaved_case, *device_dram_interleaved_buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(
+            result_vec_dram_interleaved_case, *device_dram_interleaved_buffer, /*blocking=*/true);
         pass &= (src_vec_dram_interleaved_case == result_vec_dram_interleaved_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write DRAM Interleaved Buffer Test");
@@ -95,12 +94,10 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        distributed::EnqueueWriteMeshBuffer(
-            cq, *device_dram_sharded_buffer, src_vec_dram_sharded_case, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*device_dram_sharded_buffer, src_vec_dram_sharded_case, /*blocking=*/true);
 
         std::vector<uint8_t> result_vec_dram_sharded_case;
-        distributed::EnqueueReadMeshBuffer(
-            cq, result_vec_dram_sharded_case, *device_dram_sharded_buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(result_vec_dram_sharded_case, *device_dram_sharded_buffer, /*blocking=*/true);
         pass &= (src_vec_dram_sharded_case == result_vec_dram_sharded_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write DRAM Sharded Buffer Test");
@@ -121,12 +118,10 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        distributed::EnqueueWriteMeshBuffer(
-            cq, *device_l1_interleaved_buffer, src_vec_l1_interleaved_case, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*device_l1_interleaved_buffer, src_vec_l1_interleaved_case, /*blocking=*/true);
 
         std::vector<uint8_t> result_vec_l1_interleaved_case;
-        distributed::EnqueueReadMeshBuffer(
-            cq, result_vec_l1_interleaved_case, *device_l1_interleaved_buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(result_vec_l1_interleaved_case, *device_l1_interleaved_buffer, /*blocking=*/true);
         pass &= (src_vec_l1_interleaved_case == result_vec_l1_interleaved_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write L1 Interleaved Buffer Test");
@@ -153,11 +148,10 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        distributed::EnqueueWriteMeshBuffer(cq, *device_l1_sharded_buffer, src_vec_l1_sharded_case, /*blocking=*/true);
+        cq.enqueue_write_mesh_buffer(*device_l1_sharded_buffer, src_vec_l1_sharded_case, /*blocking=*/true);
 
         std::vector<uint8_t> result_vec_l1_sharded_case;
-        distributed::EnqueueReadMeshBuffer(
-            cq, result_vec_l1_sharded_case, *device_l1_sharded_buffer, /*blocking=*/true);
+        cq.enqueue_read_mesh_buffer(result_vec_l1_sharded_case, *device_l1_sharded_buffer, /*blocking=*/true);
         pass &= (src_vec_l1_sharded_case == result_vec_l1_sharded_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write L1 Sharded Buffer Test");

--- a/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
@@ -31,10 +31,10 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>
-#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include <tt-metalium/distributed.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// This test verifies that the slow dispatch path can perform device reads and writes when the page size is not a
+// This test verifies that mesh buffer reads and writes work when the page size is not a
 // multiple of the DMA alignment requirement.
 //////////////////////////////////////////////////////////////////////////////////////////
 using std::vector;
@@ -43,6 +43,7 @@ using namespace tt::tt_metal;
 
 TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
     bool pass = true;
+    auto& cq = this->device().mesh_command_queue();
 
     try {
         ////////////////////////////////////////////////////////////////////////////
@@ -63,9 +64,11 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
         for (auto& v : src_vec_dram_interleaved_case) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
-        slow_dispatch::WriteToBuffer(*device_dram_interleaved_buffer, src_vec_dram_interleaved_case);
+        distributed::EnqueueWriteMeshBuffer(
+            cq, *device_dram_interleaved_buffer, src_vec_dram_interleaved_case, /*blocking=*/true);
         std::vector<uint8_t> result_vec_dram_interleaved_case;
-        slow_dispatch::ReadFromBuffer(*device_dram_interleaved_buffer, result_vec_dram_interleaved_case);
+        distributed::EnqueueReadMeshBuffer(
+            cq, result_vec_dram_interleaved_case, *device_dram_interleaved_buffer, /*blocking=*/true);
         pass &= (src_vec_dram_interleaved_case == result_vec_dram_interleaved_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write DRAM Interleaved Buffer Test");
@@ -92,10 +95,12 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        slow_dispatch::WriteToBuffer(*device_dram_sharded_buffer, src_vec_dram_sharded_case);
+        distributed::EnqueueWriteMeshBuffer(
+            cq, *device_dram_sharded_buffer, src_vec_dram_sharded_case, /*blocking=*/true);
 
         std::vector<uint8_t> result_vec_dram_sharded_case;
-        slow_dispatch::ReadFromBuffer(*device_dram_sharded_buffer, result_vec_dram_sharded_case);
+        distributed::EnqueueReadMeshBuffer(
+            cq, result_vec_dram_sharded_case, *device_dram_sharded_buffer, /*blocking=*/true);
         pass &= (src_vec_dram_sharded_case == result_vec_dram_sharded_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write DRAM Sharded Buffer Test");
@@ -116,10 +121,12 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        slow_dispatch::WriteToBuffer(*device_l1_interleaved_buffer, src_vec_l1_interleaved_case);
+        distributed::EnqueueWriteMeshBuffer(
+            cq, *device_l1_interleaved_buffer, src_vec_l1_interleaved_case, /*blocking=*/true);
 
         std::vector<uint8_t> result_vec_l1_interleaved_case;
-        slow_dispatch::ReadFromBuffer(*device_l1_interleaved_buffer, result_vec_l1_interleaved_case);
+        distributed::EnqueueReadMeshBuffer(
+            cq, result_vec_l1_interleaved_case, *device_l1_interleaved_buffer, /*blocking=*/true);
         pass &= (src_vec_l1_interleaved_case == result_vec_l1_interleaved_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write L1 Interleaved Buffer Test");
@@ -146,10 +153,11 @@ TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        slow_dispatch::WriteToBuffer(*device_l1_sharded_buffer, src_vec_l1_sharded_case);
+        distributed::EnqueueWriteMeshBuffer(cq, *device_l1_sharded_buffer, src_vec_l1_sharded_case, /*blocking=*/true);
 
         std::vector<uint8_t> result_vec_l1_sharded_case;
-        slow_dispatch::ReadFromBuffer(*device_l1_sharded_buffer, result_vec_l1_sharded_case);
+        distributed::EnqueueReadMeshBuffer(
+            cq, result_vec_l1_sharded_case, *device_l1_sharded_buffer, /*blocking=*/true);
         pass &= (src_vec_l1_sharded_case == result_vec_l1_sharded_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write L1 Sharded Buffer Test");

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -70,37 +70,11 @@ void ReadShard(
 
 template <typename DType>
 void EnqueueWriteMeshBuffer(
-    MeshCommandQueue& mesh_cq, const MeshBuffer& mesh_buffer, const std::vector<DType>& src, bool blocking = false) {
-    TT_FATAL(
-        src.size() * sizeof(DType) >= mesh_buffer.size(),
-        "Source vector is too small for mesh buffer: mesh buffer size={} bytes, source size={} * {} bytes",
-        mesh_buffer.size(),
-        src.size(),
-        sizeof(DType));
-
-    mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, src.data(), blocking);
-}
-
-template <typename DType>
-void EnqueueWriteMeshBuffer(
     MeshCommandQueue& mesh_cq,
     std::shared_ptr<MeshBuffer>& mesh_buffer,
     const std::vector<DType>& src,
     bool blocking = false) {
-    EnqueueWriteMeshBuffer(mesh_cq, *mesh_buffer, src, blocking);
-}
-
-template <typename DType>
-void EnqueueReadMeshBuffer(
-    MeshCommandQueue& mesh_cq, std::vector<DType>& dst, const MeshBuffer& mesh_buffer, bool blocking = true) {
-    // This API supports reading MeshBuffers sharded across devices
-    // and a Unit-MeshBuffer with a replicated layout.
-    if (mesh_buffer.global_layout() == MeshBufferLayout::SHARDED) {
-        dst.resize(mesh_buffer.global_shard_spec().global_size / sizeof(DType));
-    } else {
-        dst.resize(mesh_buffer.size() / sizeof(DType));
-    }
-    mesh_cq.enqueue_read_mesh_buffer(dst.data(), mesh_buffer, blocking);
+    mesh_cq.enqueue_write_mesh_buffer(*mesh_buffer, src, blocking);
 }
 
 template <typename DType>
@@ -109,7 +83,7 @@ void EnqueueReadMeshBuffer(
     std::vector<DType>& dst,
     std::shared_ptr<MeshBuffer>& mesh_buffer,
     bool blocking = true) {
-    EnqueueReadMeshBuffer(mesh_cq, dst, *mesh_buffer, blocking);
+    mesh_cq.enqueue_read_mesh_buffer(dst, *mesh_buffer, blocking);
 }
 
 // Make the current thread block until the event is recorded by the associated MeshCommandQueue.

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -70,17 +70,37 @@ void ReadShard(
 
 template <typename DType>
 void EnqueueWriteMeshBuffer(
-    MeshCommandQueue& mesh_cq,
-    std::shared_ptr<MeshBuffer>& mesh_buffer,
-    const std::vector<DType>& src,
-    bool blocking = false) {
-    TT_FATAL(src.size() * sizeof(DType) >= mesh_buffer->size(),
+    MeshCommandQueue& mesh_cq, MeshBuffer& mesh_buffer, const std::vector<DType>& src, bool blocking = false) {
+    TT_FATAL(
+        src.size() * sizeof(DType) >= mesh_buffer.size(),
         "Source vector is too small for mesh buffer: mesh buffer size={} bytes, source size={} * {} bytes",
-        mesh_buffer->size(),
+        mesh_buffer.size(),
         src.size(),
         sizeof(DType));
 
     mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, src.data(), blocking);
+}
+
+template <typename DType>
+void EnqueueWriteMeshBuffer(
+    MeshCommandQueue& mesh_cq,
+    std::shared_ptr<MeshBuffer>& mesh_buffer,
+    const std::vector<DType>& src,
+    bool blocking = false) {
+    EnqueueWriteMeshBuffer(mesh_cq, *mesh_buffer, src, blocking);
+}
+
+template <typename DType>
+void EnqueueReadMeshBuffer(
+    MeshCommandQueue& mesh_cq, std::vector<DType>& dst, const MeshBuffer& mesh_buffer, bool blocking = true) {
+    // This API supports reading MeshBuffers sharded across devices
+    // and a Unit-MeshBuffer with a replicated layout.
+    if (mesh_buffer.global_layout() == MeshBufferLayout::SHARDED) {
+        dst.resize(mesh_buffer.global_shard_spec().global_size / sizeof(DType));
+    } else {
+        dst.resize(mesh_buffer.size() / sizeof(DType));
+    }
+    mesh_cq.enqueue_read_mesh_buffer(dst.data(), mesh_buffer, blocking);
 }
 
 template <typename DType>
@@ -89,14 +109,7 @@ void EnqueueReadMeshBuffer(
     std::vector<DType>& dst,
     std::shared_ptr<MeshBuffer>& mesh_buffer,
     bool blocking = true) {
-    // This API supports reading MeshBuffers sharded across devices
-    // and a Unit-MeshBuffer with a replicated layout.
-    if (mesh_buffer->global_layout() == MeshBufferLayout::SHARDED) {
-        dst.resize(mesh_buffer->global_shard_spec().global_size / sizeof(DType));
-    } else {
-        dst.resize(mesh_buffer->size() / sizeof(DType));
-    }
-    mesh_cq.enqueue_read_mesh_buffer(dst.data(), mesh_buffer, blocking);
+    EnqueueReadMeshBuffer(mesh_cq, dst, *mesh_buffer, blocking);
 }
 
 // Make the current thread block until the event is recorded by the associated MeshCommandQueue.

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -70,7 +70,7 @@ void ReadShard(
 
 template <typename DType>
 void EnqueueWriteMeshBuffer(
-    MeshCommandQueue& mesh_cq, MeshBuffer& mesh_buffer, const std::vector<DType>& src, bool blocking = false) {
+    MeshCommandQueue& mesh_cq, const MeshBuffer& mesh_buffer, const std::vector<DType>& src, bool blocking = false) {
     TT_FATAL(
         src.size() * sizeof(DType) >= mesh_buffer.size(),
         "Source vector is too small for mesh buffer: mesh buffer size={} bytes, source size={} * {} bytes",

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -17,6 +17,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -85,6 +86,17 @@ public:
     void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
         enqueue_write_mesh_buffer(*buffer, host_data, blocking);
     }
+    template <typename DType>
+    void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const std::vector<DType>& src, bool blocking) {
+        TT_FATAL(
+            src.size() * sizeof(DType) >= buffer.size(),
+            "Source vector is too small for mesh buffer: mesh buffer size={} bytes, source size={} * {} bytes",
+            buffer.size(),
+            src.size(),
+            sizeof(DType));
+
+        enqueue_write_mesh_buffer(buffer, src.data(), blocking);
+    }
     virtual void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) = 0;
     // If PinnedMemory is attached to a HostBuffer used within the enqueue_write, the contents of the memory must not be
     // modified until the enqueue_write has completed on the device. This may be checked by any of
@@ -116,6 +128,16 @@ public:
     // MeshBuffer Read APIs
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
         enqueue_read_mesh_buffer(host_data, *buffer, blocking);
+    }
+    // Supports reading MeshBuffers sharded across devices, and a Unit-MeshBuffer with a replicated layout.
+    template <typename DType>
+    void enqueue_read_mesh_buffer(std::vector<DType>& dst, const MeshBuffer& buffer, bool blocking) {
+        if (buffer.global_layout() == MeshBufferLayout::SHARDED) {
+            dst.resize(buffer.global_shard_spec().global_size / sizeof(DType));
+        } else {
+            dst.resize(buffer.size() / sizeof(DType));
+        }
+        enqueue_read_mesh_buffer(dst.data(), buffer, blocking);
     }
     virtual void enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) = 0;
     void enqueue_read_shards(

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -85,7 +85,7 @@ public:
     void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
         enqueue_write_mesh_buffer(*buffer, host_data, blocking);
     }
-    virtual void enqueue_write_mesh_buffer(MeshBuffer& buffer, const void* host_data, bool blocking) = 0;
+    virtual void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) = 0;
     // If PinnedMemory is attached to a HostBuffer used within the enqueue_write, the contents of the memory must not be
     // modified until the enqueue_write has completed on the device. This may be checked by any of
     // * calling lock() on the PinnedMemory
@@ -96,7 +96,8 @@ public:
         const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
         enqueue_write(*mesh_buffer, host_buffer, blocking);
     }
-    virtual void enqueue_write(MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
+    virtual void enqueue_write(
+        const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
     // If PinnedMemory is set on a ShardDataTransfer, the contents of the memory must not be modified until the
     // enqueue_write has completed on the device. This may be checked by any of
     // * calling lock() on the PinnedMemory
@@ -110,7 +111,7 @@ public:
         enqueue_write_shards(*mesh_buffer, shard_data_transfers, blocking);
     }
     virtual void enqueue_write_shards(
-        MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) = 0;
+        const MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) = 0;
 
     // MeshBuffer Read APIs
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -82,37 +82,59 @@ public:
         const MeshCoordinateRange& device_range,
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) = 0;
-    virtual void enqueue_write_mesh_buffer(
-        const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) = 0;
+    void enqueue_write_mesh_buffer(const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
+        enqueue_write_mesh_buffer(*buffer, host_data, blocking);
+    }
+    virtual void enqueue_write_mesh_buffer(MeshBuffer& buffer, const void* host_data, bool blocking) = 0;
     // If PinnedMemory is attached to a HostBuffer used within the enqueue_write, the contents of the memory must not be
     // modified until the enqueue_write has completed on the device. This may be checked by any of
     // * calling lock() on the PinnedMemory
     // * setting the blocking parameter to true
     // * calling finish() on the MeshCommandQueue
     // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
-    virtual void enqueue_write(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
+    void enqueue_write(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
+        enqueue_write(*mesh_buffer, host_buffer, blocking);
+    }
+    virtual void enqueue_write(MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
     // If PinnedMemory is set on a ShardDataTransfer, the contents of the memory must not be modified until the
     // enqueue_write has completed on the device. This may be checked by any of
     // * calling lock() on the PinnedMemory
     // * setting the blocking parameter to true
     // * calling finish() on the MeshCommandQueue
     // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
-    virtual void enqueue_write_shards(
+    void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<ShardDataTransfer>& shard_data_transfers,
-        bool blocking) = 0;
+        bool blocking) {
+        enqueue_write_shards(*mesh_buffer, shard_data_transfers, blocking);
+    }
+    virtual void enqueue_write_shards(
+        MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) = 0;
 
     // MeshBuffer Read APIs
-    virtual void enqueue_read_mesh_buffer(
-        void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) = 0;
-    virtual void enqueue_read_shards(
+    void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
+        enqueue_read_mesh_buffer(host_data, *buffer, blocking);
+    }
+    virtual void enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) = 0;
+    void enqueue_read_shards(
         const std::vector<ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        bool blocking) = 0;
+        bool blocking) {
+        enqueue_read_shards(shard_data_transfers, *mesh_buffer, blocking);
+    }
+    virtual void enqueue_read_shards(
+        ttsl::Span<const ShardDataTransfer> shard_data_transfers, const MeshBuffer& mesh_buffer, bool blocking) = 0;
     // TODO: does "enqueue" make sense anymore? Return the object by value instead.
-    virtual void enqueue_read(
+    void enqueue_read(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        DistributedHostBuffer& host_buffer,
+        const std::optional<std::unordered_set<MeshCoordinate>>& shards,
+        bool blocking) {
+        enqueue_read(*mesh_buffer, host_buffer, shards, blocking);
+    }
+    virtual void enqueue_read(
+        const MeshBuffer& mesh_buffer,
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) = 0;

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -203,7 +203,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     }
 }
 
-void MeshCommandQueueBase::enqueue_write_mesh_buffer(MeshBuffer& buffer, const void* host_data, bool blocking) {
+void MeshCommandQueueBase::enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) {
     MeshCoordinateRange mesh_device_extent(buffer.device()->shape());
     this->enqueue_write_shard_to_sub_grid(buffer, host_data, mesh_device_extent, blocking);
 }
@@ -226,7 +226,7 @@ void MeshCommandQueueBase::enqueue_read_mesh_buffer(void* host_data, const MeshB
 }
 
 void MeshCommandQueueBase::enqueue_write_shards_nolock(
-    MeshBuffer& buffer,
+    const MeshBuffer& buffer,
     ttsl::Span<const ShardDataTransfer> shard_data_transfers,
     bool blocking,
     const tt::tt_metal::CoreRangeSet* logical_core_filter) {
@@ -283,18 +283,18 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
 }
 
 void MeshCommandQueueBase::enqueue_write_shards(
-    MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) {
+    const MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) {
     auto lock = lock_api_function_();
     this->enqueue_write_shards_nolock(mesh_buffer, shard_data_transfers, blocking, nullptr);
 }
 
 void MeshCommandQueueBase::enqueue_write(
-    MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
+    const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
     this->enqueue_write_with_core_filter(mesh_buffer, host_buffer, blocking, nullptr);
 }
 
 void MeshCommandQueueBase::enqueue_write_with_core_filter(
-    MeshBuffer& mesh_buffer,
+    const MeshBuffer& mesh_buffer,
     const DistributedHostBuffer& host_buffer,
     bool blocking,
     const tt::tt_metal::CoreRangeSet* logical_core_filter) {

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -114,7 +114,7 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
     }
 }
 
-void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
+void MeshCommandQueueBase::read_sharded_buffer(const MeshBuffer& buffer, void* dst) {
     const auto& [height_replicated, width_replicated] = buffer.replicated_dims();
     TT_FATAL(
         not(height_replicated or width_replicated), "Cannot read a MeshBuffer that is replicated along any dimension.");
@@ -203,33 +203,31 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     }
 }
 
-void MeshCommandQueueBase::enqueue_write_mesh_buffer(
-    const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
-    MeshCoordinateRange mesh_device_extent(buffer->device()->shape());
-    this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
+void MeshCommandQueueBase::enqueue_write_mesh_buffer(MeshBuffer& buffer, const void* host_data, bool blocking) {
+    MeshCoordinateRange mesh_device_extent(buffer.device()->shape());
+    this->enqueue_write_shard_to_sub_grid(buffer, host_data, mesh_device_extent, blocking);
 }
 
-void MeshCommandQueueBase::enqueue_read_mesh_buffer(
-    void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
+void MeshCommandQueueBase::enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) {
     TT_FATAL(
-        (buffer->global_layout() == MeshBufferLayout::SHARDED) || (buffer->device()->num_devices() == 1),
+        (buffer.global_layout() == MeshBufferLayout::SHARDED) || (buffer.device()->num_devices() == 1),
         "Can only read a Sharded MeshBuffer from a MeshDevice or a Replicated MeshBuffer from a Unit-Mesh.");
     TT_FATAL(
         blocking, "Non-Blocking reads are not supported through {}. Use enqueue_read_shards_instead.", __FUNCTION__);
-    if (buffer->global_layout() == MeshBufferLayout::SHARDED) {
+    if (buffer.global_layout() == MeshBufferLayout::SHARDED) {
         auto lock = lock_api_function_();
-        this->read_sharded_buffer(*buffer, host_data);
+        this->read_sharded_buffer(buffer, host_data);
     } else {
-        std::vector<ShardDataTransfer> shard_data_transfers = {
-            ShardDataTransfer{MeshCoordinate::zero_coordinate(buffer->device()->shape().dims())}.host_data(host_data)};
+        ShardDataTransfer shard_data_transfer(MeshCoordinate::zero_coordinate(buffer.device()->shape().dims()));
+        shard_data_transfer.host_data(host_data);
         // enqueue_read_shards will call lock_api_function_(), no need to call it here
-        this->enqueue_read_shards(shard_data_transfers, buffer, blocking);
+        this->enqueue_read_shards(ttsl::Span<const ShardDataTransfer>{&shard_data_transfer, 1}, buffer, blocking);
     }
 }
 
 void MeshCommandQueueBase::enqueue_write_shards_nolock(
     MeshBuffer& buffer,
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
+    ttsl::Span<const ShardDataTransfer> shard_data_transfers,
     bool blocking,
     const tt::tt_metal::CoreRangeSet* logical_core_filter) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
@@ -285,16 +283,14 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
 }
 
 void MeshCommandQueueBase::enqueue_write_shards(
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
-    bool blocking) {
+    MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) {
     auto lock = lock_api_function_();
-    this->enqueue_write_shards_nolock(*mesh_buffer, shard_data_transfers, blocking, nullptr);
+    this->enqueue_write_shards_nolock(mesh_buffer, shard_data_transfers, blocking, nullptr);
 }
 
 void MeshCommandQueueBase::enqueue_write(
-    const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
-    this->enqueue_write_with_core_filter(*mesh_buffer, host_buffer, blocking, nullptr);
+    MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
+    this->enqueue_write_with_core_filter(mesh_buffer, host_buffer, blocking, nullptr);
 }
 
 void MeshCommandQueueBase::enqueue_write_with_core_filter(
@@ -322,8 +318,8 @@ void MeshCommandQueueBase::enqueue_write_with_core_filter(
 }
 
 void MeshCommandQueueBase::enqueue_read_shards_nolock(
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
-    const std::shared_ptr<MeshBuffer>& buffer,
+    ttsl::Span<const ShardDataTransfer> shard_data_transfers,
+    const MeshBuffer& buffer,
     bool blocking,
     std::vector<MemoryPin> memory_pins) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
@@ -335,7 +331,7 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
             auto pinned_memory = experimental::ShardDataTransferGetPinnedMemory(shard_data_transfer);
             has_pinned_memory = has_pinned_memory || pinned_memory != nullptr;
             this->read_shard_from_device(
-                *buffer,
+                buffer,
                 shard_data_transfer.shard_coord(),
                 shard_data_transfer.host_data(),
                 pinned_memory,
@@ -359,30 +355,28 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
 }
 
 void MeshCommandQueueBase::enqueue_read_shards(
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    bool blocking) {
+    ttsl::Span<const ShardDataTransfer> shard_data_transfers, const MeshBuffer& mesh_buffer, bool blocking) {
     auto lock = lock_api_function_();
     this->enqueue_read_shards_nolock(shard_data_transfers, mesh_buffer, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_read(
-    const std::shared_ptr<MeshBuffer>& buffer,
+    const MeshBuffer& buffer,
     DistributedHostBuffer& host_buffer,
     const std::optional<std::unordered_set<MeshCoordinate>>& shards,
     bool blocking) {
     auto lock = lock_api_function_();
     std::vector<ShardDataTransfer> shard_data_transfers;
-    shard_data_transfers.reserve(buffer->device()->shape().mesh_size());
+    shard_data_transfers.reserve(buffer.device()->shape().mesh_size());
     // For non-blocking reads, capture a MemoryPin for each shard so the host
     // buffer stays alive until the async reader thread finishes the memcpy
     // (fixes use-after-free, issue #43638). For blocking reads finish_nolock()
     // ensures the copy is complete before we return, so no pin is needed.
     std::vector<MemoryPin> memory_pins;
     if (!blocking) {
-        memory_pins.reserve(buffer->device()->shape().mesh_size());
+        memory_pins.reserve(buffer.device()->shape().mesh_size());
     }
-    for (const auto& coord : MeshCoordinateRange(buffer->device()->shape())) {
+    for (const auto& coord : MeshCoordinateRange(buffer.device()->shape())) {
         if (shards.has_value() && !shards->contains(coord)) {
             continue;
         }

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -67,18 +67,18 @@ protected:
 private:
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
-    void read_sharded_buffer(MeshBuffer& buffer, void* dst);
+    void read_sharded_buffer(const MeshBuffer& buffer, void* dst);
 
     // Must be called with lock_api_function_() held.
     void enqueue_read_shards_nolock(
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        ttsl::Span<const ShardDataTransfer> shard_data_transfers,
+        const MeshBuffer& mesh_buffer,
         bool blocking,
         std::vector<MemoryPin> memory_pins = {});
     // Must be called with lock_api_function_() held.
     void enqueue_write_shards_nolock(
         MeshBuffer& mesh_buffer,
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
+        ttsl::Span<const ShardDataTransfer> shard_data_transfers,
         bool blocking,
         const tt::tt_metal::CoreRangeSet* logical_core_filter = nullptr);
 
@@ -111,25 +111,25 @@ public:
         const MeshCoordinateRange& device_range,
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) override;
-    void enqueue_write_mesh_buffer(
-        const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) override;
+    using MeshCommandQueue::enqueue_write_mesh_buffer;
+    void enqueue_write_mesh_buffer(MeshBuffer& buffer, const void* host_data, bool blocking) override;
+    using MeshCommandQueue::enqueue_write_shards;
     void enqueue_write_shards(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
-        bool blocking) override;
-    void enqueue_write(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const DistributedHostBuffer& host_buffer,
-        bool blocking) override;
+        MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) override;
+    using MeshCommandQueue::enqueue_write;
+    void enqueue_write(MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) override;
 
     // MeshBuffer Read APIs
-    void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) override;
+    using MeshCommandQueue::enqueue_read_mesh_buffer;
+    void enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) override;
+    using MeshCommandQueue::enqueue_read_shards;
     void enqueue_read_shards(
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        ttsl::Span<const ShardDataTransfer> shard_data_transfers,
+        const MeshBuffer& mesh_buffer,
         bool blocking) override;
+    using MeshCommandQueue::enqueue_read;
     void enqueue_read(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        const MeshBuffer& mesh_buffer,
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) override;

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -77,13 +77,13 @@ private:
         std::vector<MemoryPin> memory_pins = {});
     // Must be called with lock_api_function_() held.
     void enqueue_write_shards_nolock(
-        MeshBuffer& mesh_buffer,
+        const MeshBuffer& mesh_buffer,
         ttsl::Span<const ShardDataTransfer> shard_data_transfers,
         bool blocking,
         const tt::tt_metal::CoreRangeSet* logical_core_filter = nullptr);
 
     void enqueue_write_with_core_filter(
-        MeshBuffer& mesh_buffer,
+        const MeshBuffer& mesh_buffer,
         const DistributedHostBuffer& host_buffer,
         bool blocking,
         const tt::tt_metal::CoreRangeSet* logical_core_filter);
@@ -112,12 +112,14 @@ public:
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) override;
     using MeshCommandQueue::enqueue_write_mesh_buffer;
-    void enqueue_write_mesh_buffer(MeshBuffer& buffer, const void* host_data, bool blocking) override;
+    void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) override;
     using MeshCommandQueue::enqueue_write_shards;
     void enqueue_write_shards(
-        MeshBuffer& mesh_buffer, ttsl::Span<const ShardDataTransfer> shard_data_transfers, bool blocking) override;
+        const MeshBuffer& mesh_buffer,
+        ttsl::Span<const ShardDataTransfer> shard_data_transfers,
+        bool blocking) override;
     using MeshCommandQueue::enqueue_write;
-    void enqueue_write(MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) override;
+    void enqueue_write(const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) override;
 
     // MeshBuffer Read APIs
     using MeshCommandQueue::enqueue_read_mesh_buffer;

--- a/tt_metal/impl/dispatch/slow_dispatch.hpp
+++ b/tt_metal/impl/dispatch/slow_dispatch.hpp
@@ -9,15 +9,12 @@
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <tt-metalium/mesh_buffer.hpp>
-#include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/tt_metal.hpp>
 
 namespace tt::tt_metal::slow_dispatch {
 
-// MeshDevice-aware L1 / DRAM channel / MeshBuffer access for unit meshes.
+// MeshDevice-aware L1 / DRAM channel access for unit meshes.
 //
 // WriteToDeviceL1/ReadFromDeviceL1 and DRAM channel APIs index the cluster by IDevice::id(),
 // which for MeshDevice is a logical mesh id — not a chip id. These helpers require a unit mesh
@@ -27,20 +24,6 @@ inline IDevice* physical_device_from_unit_mesh(distributed::MeshDevice& unit_mes
     TT_FATAL(
         unit_mesh.num_devices() == 1, "Expected a unit MeshDevice (num_devices == 1), got {}", unit_mesh.num_devices());
     return unit_mesh.get_devices().at(0);
-}
-
-// MeshBuffer host↔device transfer for a unit mesh (coord (0, 0)). Prefer these over
-// detail::WriteToBuffer/ReadFromBuffer on MeshBuffer::get_reference_buffer().
-template <typename DType>
-inline void WriteToBuffer(const distributed::MeshBuffer& unit_mesh_buffer, const std::vector<DType>& host_buffer) {
-    (void)physical_device_from_unit_mesh(*unit_mesh_buffer.device());
-    detail::WriteToBuffer(*unit_mesh_buffer.get_reference_buffer(), host_buffer);
-}
-
-template <typename DType>
-inline void ReadFromBuffer(const distributed::MeshBuffer& unit_mesh_buffer, std::vector<DType>& host_buffer) {
-    (void)physical_device_from_unit_mesh(*unit_mesh_buffer.device());
-    detail::ReadFromBuffer(*unit_mesh_buffer.get_reference_buffer(), host_buffer);
 }
 
 inline bool WriteToL1(


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Advances #38691, #26591, #51835

We have multiple APIs to read/write a `MeshBuffer`, specifically:
- `MeshCommandQueue` APIs like
https://github.com/tenstorrent/tt-metal/blob/f13c1388d0da395b0a639abc751388bcf20aa32e/tt_metal/api/tt-metalium/mesh_command_queue.hpp#L107-L108
- Free standing functions like `EnqueueReadMeshBuffer` that do extra stuff like correctly resizing the target container
https://github.com/tenstorrent/tt-metal/blob/f13c1388d0da395b0a639abc751388bcf20aa32e/tt_metal/api/tt-metalium/distributed.hpp#L86-L100
- Internal functions like `ReadFromBuffer` that mimic the legacy ones in [tt_metal.hpp](https://github.com/tenstorrent/tt-metal/blob/f13c1388d0da395b0a639abc751388bcf20aa32e/tt_metal/api/tt-metalium/tt_metal.hpp#L131-L141)
https://github.com/tenstorrent/tt-metal/blob/f13c1388d0da395b0a639abc751388bcf20aa32e/tt_metal/impl/dispatch/slow_dispatch.hpp#L40-L44

In this PR, I propose to:
- Make `MeshCommandQueue` methods `enqueue_read_mesh_buffer` and `enqueue_write_mesh_buffer` the canonical API to use, and add overloads that are as convenient to use as existing free functions.
  The motivation is that all these overloads perform conceptually the same operation, but for different input types.
- Add overloads for all the related functions that accept `const MeshBuffer&`, not just `std::shared_ptr<MeshBuffer>&`. This is a necessary step to meet FuSa requirements, and makes the functions more generally applicable. Note that we already have a precedent for this
https://github.com/tenstorrent/tt-metal/blob/f13c1388d0da395b0a639abc751388bcf20aa32e/tt_metal/api/tt-metalium/mesh_command_queue.hpp#L79-L80
  We don't deprecate existing APIs right now, and will do that once `MeshBuffer` provides creation APIs that don't return `shared_ptr`. Otherwise, we'd force the inconvenience of extra dereference onto our users.
- Make new overloads accept `ttsl::Span` instead of `std::vector` to avoid allocating a vector when a single element is passed.

### Breaking changes

This change is breaking in a way, but not for typical users:
- Prebuilt consumers will see changed vtable/ABI. But we don't guarantee ABI stability.
- Subclasses of `MeshCommandQueue` will need to implement different virtual methods than now. However, it's unlikely that any external client actually does this.

Unfortunately, it's impossible to avoid introducing new virtual methods, because `std::shared_ptr<MeshBuffer>&` overload can be expressed through `const MeshBuffer&`, but not the other way.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-enqueue-mesh-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-enqueue-mesh-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-enqueue-mesh-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-enqueue-mesh-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-enqueue-mesh-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-enqueue-mesh-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-enqueue-mesh-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-enqueue-mesh-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-enqueue-mesh-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-enqueue-mesh-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-enqueue-mesh-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-enqueue-mesh-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-enqueue-mesh-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-enqueue-mesh-buffer)