### PR TITLE
[skip ci] Gate pr-gate's ASan compile on run-clang-tidy (plus Python), not any workflow change

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -26,6 +26,8 @@ outputs:
     value: ${{ steps.find-changed-files.outputs.any-code-changed }}
   run-clang-tidy:
     value: ${{ steps.find-changed-files.outputs.run-clang-tidy }}
+  run-compile:
+    value: ${{ steps.find-changed-files.outputs.run-compile }}
   docs-changed:
     value: ${{ steps.find-changed-files.outputs.docs-changed }}
   model-charts-changed:

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -160,7 +160,7 @@ while IFS= read -r FILE; do
     esac
 done <<< "$CHANGED_FILES"
 
-# --- run-clang-tidy inputs: raw snapshot + dedicated re-scans ---------------
+# --- run-clang-tidy / run-compile inputs: raw snapshot + dedicated re-scans ---
 # Snapshot the language-agnostic per-file flags NOW, before the blanket
 # submodule/workflow "treat as everything changed" fallback below mutates
 # them. run-clang-tidy must reflect only changes that can plausibly alter
@@ -173,6 +173,11 @@ RAW_LLK_WORMHOLE_CHANGED=$LLK_WORMHOLE_CHANGED
 RAW_LLK_BLACKHOLE_CHANGED=$LLK_BLACKHOLE_CHANGED
 RAW_LLK_COMMON_CHANGED=$LLK_COMMON_CHANGED
 RAW_LLK_SFPI_CHANGED=$LLK_SFPI_CHANGED
+# Pre-fallback any-code-changed, used only by run-compile below. This is the
+# language-inclusive counterpart to the C/C++-only scan: it is what
+# any-code-changed would be if the blanket fallback didn't exist, so it still
+# covers the .py changes clang-tidy deliberately ignores.
+RAW_ANY_CODE_CHANGED=$ANY_CODE_CHANGED
 
 # clang-tidy is a C/C++-only linter, so the "did relevant source change?"
 # half of run-clang-tidy gets its own dedicated scan for C/C++ extensions
@@ -265,6 +270,28 @@ if [[ "$CPP_SOURCE_FOR_CLANG_TIDY_CHANGED" = true || \
     RUN_CLANG_TIDY=true
 fi
 
+# run-compile: should the compile job (pr-gate.yaml's asan-build) run? The
+# clang-tidy scan and the compile both consume the same C/C++ sources, the same
+# CMake/LLK/submodule inputs, and the same docker plumbing, so a change that
+# warrants one warrants the other — hence run-clang-tidy is reused wholesale
+# rather than duplicating its inputs or maintaining a second key-workflow list.
+#
+# RAW_ANY_CODE_CHANGED is OR'd in for the one case where the two genuinely
+# differ: clang-tidy is a C/C++-only linter and deliberately ignores .py, but
+# the compile job publishes the package/ttnn-import artifact that pr-gate's
+# smoke tests and examples run against, and those DO exercise Python under
+# tt_metal/, ttnn/ and tests/. Gating on run-clang-tidy alone would silently
+# stop compiling and smoke-testing Python-only PRs.
+#
+# Net effect vs. the old any-code-changed gate: identical, except a workflow
+# file on neither the key-workflow list nor the build-workflow list (i.e. one
+# that cannot affect what gets built) no longer forces a full ASan compile.
+# See tenstorrent/tt-metal#53738.
+RUN_COMPILE=false
+if [[ "$RUN_CLANG_TIDY" = true || "$RAW_ANY_CODE_CHANGED" = true ]]; then
+    RUN_COMPILE=true
+fi
+
 if [[ "$SUBMODULE_CHANGED" = true || "$WORKFLOWS_CHANGED" = true ]]; then
     # Treat any submodule or workflow change as a change to everything; not going to manage dependency trees for this.
     # For workflows this guarantees a workflow-only PR runs the full standard gate (build + smoke + examples + code-analysis)
@@ -308,6 +335,7 @@ declare -A changes=(
     [submodule-changed]=$SUBMODULE_CHANGED
     [any-code-changed]=$ANY_CODE_CHANGED
     [run-clang-tidy]=$RUN_CLANG_TIDY
+    [run-compile]=$RUN_COMPILE
     [docs-changed]=$DOCS_CHANGED
     [model-charts-changed]=$MODEL_CHARTS_CHANGED
     [models-changed]=$MODELS_CHANGED

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -119,12 +119,17 @@ jobs:
       manylinux-docker-image: ${{ needs.build-docker-images.outputs.manylinux-tag }}
       llk-ci-docker-image: ${{ needs.build-docker-images.outputs.llk-ci-tag }}
 
+  # Gated on run-compile rather than any-code-changed so that workflow-only PRs
+  # which cannot affect what gets built (see find-changed-files.sh) don't pay for
+  # a full ASan compile. run-compile is run-clang-tidy OR'd with the pre-fallback
+  # any-code-changed, so Python-only PRs still build and still reach the smoke
+  # tests and examples that consume this job's artifacts.
   asan-build:
     if: >-
       ${{
         github.event.action != 'destroyed' &&
         (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
-        ((github.event_name != 'pull_request' && github.event_name != 'merge_group') || needs.find-changed-files.outputs.any-code-changed == 'true')
+        ((github.event_name != 'pull_request' && github.event_name != 'merge_group') || needs.find-changed-files.outputs.run-compile == 'true')
       }}
     needs: [resolve-docker-pull-refs, build-docker-images, find-changed-files]
     uses: ./.github/workflows/build-artifact.yaml
@@ -165,6 +170,7 @@ jobs:
     outputs:
       any-code-changed: ${{ steps.find-changes.outputs.any-code-changed }}
       run-clang-tidy: ${{ steps.find-changes.outputs.run-clang-tidy }}
+      run-compile: ${{ steps.find-changes.outputs.run-compile }}
       docs-changed: ${{ steps.find-changes.outputs.docs-changed }}
       cmake-changed: ${{ steps.find-changes.outputs.cmake-changed }}
       tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}


### PR DESCRIPTION
### Problem

An unrelated new workflow — a Slack-notification workflow, #53738 — forced a full ASan compile in `pr-gate.yaml`. `find-changed-files.sh` treats **any** `.github/workflows/*.yaml` change as "everything changed" via a generic catch-all (`WORKFLOWS_CHANGED`), which fans out to `any-code-changed`, and `asan-build` gates on `any-code-changed`.

This is the same class of bug #53401 fixed for clang-tidy.

### Fix

#53401 introduced `run-clang-tidy`: an independent output computed from the **RAW pre-fallback** per-file-type flags plus an explicit, human-audited list of workflows that actually affect the scan. Rather than inventing a second parallel key-workflow list for the compile job, this reuses that output wholesale:

```
run-compile = run-clang-tidy || RAW_ANY_CODE_CHANGED
```

The clang-tidy scan and the ASan compile consume the same C/C++ sources, the same CMake/LLK/submodule inputs and the same docker plumbing — a change that warrants one warrants the other. `pr-gate.yaml`'s `asan-build` now gates on `run-compile` instead of `any-code-changed`.

Total diff: **+38/-2 across 3 files.** No new key-workflow list, no restructuring of the shared fallback.

### The Python nuance

`run-clang-tidy`'s source scan **deliberately excludes `.py`** — clang-tidy is a C/C++-only linter and cannot be affected by Python-only changes.

But `asan-build` publishes the package / ttnn-import artifact consumed by `runtime-smoke-tests`, `ttnn-smoke-tests`, `runtime-examples`, `ttnn-examples` and `build-docs`, and those **do** exercise Python under `tt_metal/`, `ttnn/` and `tests/`. Gating `asan-build` on `run-clang-tidy` alone would silently stop compiling and smoke-testing Python-only PRs — a real regression versus `main`.

So `RAW_ANY_CODE_CHANGED` is OR'd in: a snapshot of `any-code-changed` taken at the same point as the existing `RAW_*` flags, i.e. what `any-code-changed` would be without the blanket fallback. It is the language-inclusive counterpart to the C/C++-only scan, and it reuses the existing snapshot mechanism rather than adding a new one.

Net effect versus the old gate is **identical**, except that a workflow file on neither the key-workflow list nor the build-workflow list no longer forces a full ASan compile.

### Blast radius

`any-code-changed`, the blanket fallback and every other output are **untouched**. `find-changed-files.sh` is shared by `merge-gate.yaml` (its own `build`/`build-tsan`/`build-asan`/`build-sweeps`), `code-analysis.yaml` and `all-static-checks.yaml` — all are unaffected. Only `pr-gate.yaml`'s `asan-build` moves to the new gate; `run-compile` is purely additive.

### Test plan

Verified against isolated single-file changesets on `origin/main` — one synthetic file per throwaway branch, running both the `origin/main` script and this branch's script over the same changeset:

| Change | `main`: `any-code-changed` | this PR: `run-compile` | |
|---|---|---|---|
| Unrelated new workflow (`slack-notify-oncall.yaml`) | `true` | **`false`** | the fix |
| `merge-gate.yaml`, `smoke.yaml` | `true` | **`false`** | see open question |
| `check-harbor.yaml` | `true` | **`false`** | registry health check only |
| `tt_metal/impl/buffers/buffer.cpp` | `true` | `true` | |
| `ttnn/core/tensor/tensor.cpp` | `true` | `true` | |
| **Python-only** `tt_metal/**/*.py` | `true` | `true` | no regression |
| **Python-only** `ttnn/**/*.py` | `true` | `true` | no regression |
| **Python-only** `tests/ttnn/**/*.py` | `true` | `true` | no regression |
| `pr-gate.yaml` (key workflow) | `true` | `true` | unchanged |
| `build-artifact.yaml` | `true` | `true` | unchanged |
| `tt_metal/CMakeLists.txt` | `true` | `true` | |
| LLK (`tt_metal/hw/ckernels/wormhole_b0/`) | `true` | `true` | |
| `.clang-tidy` | `false` | `true` | slightly wider, see below |
| `docs/**.rst`, `README.md` | `false` | `false` | unchanged |

`.clang-tidy` is the one row that gets *more* conservative: a config-only PR now also compiles. That falls directly out of "run-clang-tidy implies run-compile" and is rare enough to be worth the consistency.

Plumbing verified structurally: script output -> composite action output -> `find-changed-files` job output -> `asan-build`'s `if:` all reference the same `run-compile` name. `bash -O extglob -n` and YAML parse both clean.

### Open question for review

`smoke.yaml`, `sdk-examples.yaml`, `docs-latest-public.yaml` and `merge-gate.yaml` now yield `run-compile=false`, so editing one no longer triggers a pr-gate compile + smoke run to validate it. That is a deliberate consequence of not adding a second workflow list — but if we want those validated, the cheap fix is adding them to the **existing** `BUILD_WORKFLOWS_CHANGED` case (which already covers `build-artifact.yaml` / `build-docker-artifact.yaml` and already feeds `ANY_CODE_CHANGED`), not a new mechanism. Happy to do that in this PR if wanted.
