### PR TITLE
Cleanup/bfd drop initialized flag 1678

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -7,6 +7,7 @@
 #include "internal/firmware_common.h"
 #include "risc_common.h"
 #include <tensix.h>
+#include <cstdint>
 #include "hostdev/dev_msgs.h"
 
 #include "tools/profiler/kernel_profiler.hpp"
@@ -22,37 +23,38 @@
 #endif
 #include "tt-metalium/circular_buffer_constants.h"
 #include "api/kernel_thread_globals.h"
+#include "llk_bfd_alloc.h"  // ckernel::trisc::BfdAllocatorState (definition of bfd_state below)
 
 // clang-format on
 
 #if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-thread_local uint32_t wIndex __attribute__((used));
-thread_local uint32_t stackSize __attribute__((used));
-thread_local uint32_t sums[SUM_COUNT] __attribute__((used));
-thread_local uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+thread_local std::uint32_t wIndex __attribute__((used));
+thread_local std::uint32_t stackSize __attribute__((used));
+thread_local std::uint32_t sums[SUM_COUNT] __attribute__((used));
+thread_local std::uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 }  // namespace kernel_profiler
 #endif
 
-thread_local uint32_t hw_thread_idx __attribute__((used));
-thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
-thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
-thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
+thread_local std::uint32_t hw_thread_idx __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
-thread_local uint32_t rta_count __attribute__((used));
-thread_local uint32_t crta_count __attribute__((used));
+thread_local std::uint32_t rta_count __attribute__((used));
+thread_local std::uint32_t crta_count __attribute__((used));
 #endif
 
-uint8_t my_logical_x_ __attribute__((used));
-uint8_t my_logical_y_ __attribute__((used));
-uint8_t my_relative_x_ __attribute__((used));
-uint8_t my_relative_y_ __attribute__((used));
+std::uint8_t my_logical_x_ __attribute__((used));
+std::uint8_t my_logical_y_ __attribute__((used));
+std::uint8_t my_relative_x_ __attribute__((used));
+std::uint8_t my_relative_y_ __attribute__((used));
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
 #if defined(UCK_CHLKC_PACK)
 thread_local LocalDFBInterface g_dfb_interface[dfb::MAX_ACTIVE_DFBS_PACK] __attribute__((used));
-thread_local uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used));
+thread_local std::uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used));
 #else
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
 #endif
@@ -76,11 +78,16 @@ namespace ckernel {
 #undef PTR_CONST
 
 // Flip between 0 and 1 to keep state between kernel calls
-thread_local uint32_t cfg_state_id __attribute__((used)) = 0;
-thread_local uint32_t op_info_offset __attribute__((used)) = 0;
+thread_local std::uint32_t cfg_state_id __attribute__((used)) = 0;
+thread_local std::uint32_t op_info_offset __attribute__((used)) = 0;
 namespace trisc {
 // Flip between 0 and 1 to keep dest pointer between kernel calls
-thread_local uint32_t dest_register_offset __attribute__((used)) = 0;
+thread_local std::uint32_t dest_register_offset __attribute__((used)) = 0;
+// BFD id allocator state (Quasar). Defined for all TRISC images alongside dest_register_offset;
+// thread_local so the host-threaded emulation gives each TRISC its own allocator (tt-llk#1678).
+// initialized=false is set explicitly (not left to .tbss zeroing) so the first bfd_alloc runs
+// lazy-init, which sets next to the partition base and current[] to BFD_ID_INVALID.
+thread_local BfdAllocatorState bfd_state __attribute__((used)) = {.next = 0, .current = {}, .initialized = false};
 }  // namespace trisc
 
 tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE);
@@ -103,29 +110,30 @@ void init_sync_registers() {
 
 inline void enable_cc_stack() {
 #if defined(UCK_CHLKC_MATH)
-    constexpr uint32_t SFPENCC_IMM12_BOTH = 3;
-    constexpr uint32_t SFPENCC_MOD1_EI_RI = 10;
+    constexpr std::uint32_t SFPENCC_IMM12_BOTH = 3;
+    constexpr std::uint32_t SFPENCC_MOD1_EI_RI = 10;
     TTI_SFPENCC(SFPENCC_IMM12_BOTH, SFPENCC_MOD1_EI_RI);  // Enable all the SFPU lanes
 #endif
 }
 
-extern "C" uint32_t _start1() {
+extern "C" std::uint32_t _start1() {
     configure_csr();
     // Raw read: hw_thread_idx has not been filled yet, and do_thread_crt1() below zeroes the .tbss
     // it lives in, so caching it any earlier would just be discarded.
-    uint32_t hartid = internal_::read_hw_thread_idx();
-    uint32_t neo_id = internal_::get_neo_id();
-    uint32_t trisc_id = internal_::get_trisc_id();
-    volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
-                                                       ->subordinate_sync.map[hartid];  // first entry is for NCRISC
+    std::uint32_t hartid = internal_::read_hw_thread_idx();
+    std::uint32_t neo_id = internal_::get_neo_id();
+    std::uint32_t trisc_id = internal_::get_trisc_id();
+    volatile tt_l1_ptr std::uint8_t* const trisc_run =
+        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
+             ->subordinate_sync.map[hartid];  // first entry is for NCRISC
 
     if (neo_id == 0) {
-        extern uint32_t __ldm_data_start[];
+        extern std::uint32_t __ldm_data_start[];
         do_crt1(__ldm_data_start);
         (*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[MaxDMProcessorsPerCoreType + trisc_id] =
             SHARED_GLOBALS_READY_GO;
     }
-    extern uint32_t __ldm_tdata_init[];
+    extern std::uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
     // .tbss has been zeroed: cache this thread's hw index.
     internal_::init_hw_thread_idx();
@@ -163,15 +171,15 @@ extern "C" uint32_t _start1() {
         // RUN_SYNC_MSG_DONE is signaled.
         {
             DeviceZoneScopedMainN("TRISC-FW");
-            uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
+            std::uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
             launch_msg_t* launch_msg = &(mailboxes->launch[launch_msg_rd_ptr]);
 
             uintptr_t kernel_config_base = launch_msg->kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-            uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base +
-                                                                    launch_msg->kernel_config.local_cb_offset);
-            uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
+            std::uint32_t tt_l1_ptr* dfb_l1_base =
+                (std::uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
+            std::uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
 #if defined(UCK_CHLKC_PACK)
             const DfbPackerRemapperRange packer_rmp = setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
 #else
@@ -180,15 +188,15 @@ extern "C" uint32_t _start1() {
 #endif
 
             // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when PR #38124 is merged
-            rta_l1_base =
-                (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset +
-                                      MEM_L1_UNCACHED_BASE);
-            crta_l1_base =
-                (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].crta_offset +
-                                      MEM_L1_UNCACHED_BASE);
+            rta_l1_base = (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                                     launch_msg->kernel_config.rta_offset[hartid].rta_offset +
+                                                     MEM_L1_UNCACHED_BASE);
+            crta_l1_base = (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                                      launch_msg->kernel_config.rta_offset[hartid].crta_offset +
+                                                      MEM_L1_UNCACHED_BASE);
             sem_l1_base[ProgrammableCoreType::TENSIX] =
-                (uint32_t tt_l1_ptr*)(kernel_config_base +
-                                      launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
+                (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                           launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
             // Initialize RTA count from L1 memory
             // Set to 0 if: 1. offset is sentinel (no args set)
@@ -220,7 +228,7 @@ extern "C" uint32_t _start1() {
             uintptr_t kernel_lma =
                 (kernel_config_base +
                  launch_msg->kernel_config.kernel_text_offset[hartid]);  // TODO verify if depends on kernel
-            auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
+            auto stack_free = reinterpret_cast<std::uint32_t (*)()>(kernel_lma)();
             record_stack_usage(stack_free);
             WAYPOINT("D");
             DEVICE_PRINT_KERNEL_FINISHED();
@@ -231,10 +239,10 @@ extern "C" uint32_t _start1() {
 #endif
 
             // Signal completion
-            DPRINT("SIGNALING COMPLETION {:x}\n", (uint32_t)*trisc_run);
+            DPRINT("SIGNALING COMPLETION {:x}\n", (std::uint32_t)*trisc_run);
             tensix_sync();
         }
         *trisc_run = RUN_SYNC_MSG_DONE;
-        DPRINT("COMPLETION SIGNED OFF {:x}\n", (uint32_t)*trisc_run);
+        DPRINT("COMPLETION SIGNED OFF {:x}\n", (std::uint32_t)*trisc_run);
     }
 }

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -85,9 +85,9 @@ namespace trisc {
 thread_local std::uint32_t dest_register_offset __attribute__((used)) = 0;
 // BFD id allocator state (Quasar). Defined for all TRISC images alongside dest_register_offset;
 // thread_local so the host-threaded emulation gives each TRISC its own allocator (tt-llk#1678).
-// initialized=false is set explicitly (not left to .tbss zeroing) so the first bfd_alloc runs
-// lazy-init, which sets next to the partition base and current[] to BFD_ID_INVALID.
-thread_local BfdAllocatorState bfd_state __attribute__((used)) = {.next = 0, .current = {}, .initialized = false};
+// Constant-initialized by BfdAllocatorState's constexpr ctor (next=partition base, current[]=
+// BFD_ID_INVALID), materialized per-thread from .tdata by do_thread_crt1 (trisck.cc).
+thread_local BfdAllocatorState bfd_state __attribute__((used));
 }  // namespace trisc
 
 tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE);

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
@@ -55,8 +55,8 @@ enum class BfdResource : std::uint8_t
 };
 
 // Sentinel for "no id allocated yet" in current[]. Real ids are 0..31, so 128 is safely out of
-// range and fits uint8_t. current[] is bss zero-init on device (0 is a valid id), so it must be
-// set to this sentinel inside the lazy-init block, not via a static initializer.
+// range and fits uint8_t. BfdAllocatorState's constexpr ctor seeds current[] to this sentinel
+// (materialized per-thread from .tdata), so it starts distinct from the valid id 0.
 constexpr std::uint8_t BFD_ID_INVALID = 128;
 
 constexpr bool bfd_engine_owned_by_trisc(const BfdResource engine, const std::uint32_t trisc)
@@ -108,20 +108,31 @@ constexpr std::uint8_t bfd_partition_size(const std::uint32_t trisc)
 
 struct BfdAllocatorState
 {
-    std::uint8_t next;                                                   // next id to hand out; valid only when initialized
+    std::uint8_t next;                                                   // next id to hand out
     std::uint8_t current[static_cast<std::uint8_t>(BfdResource::Count)]; // most recent id per engine; BFD_ID_INVALID until first alloc
-    bool initialized;                                                    // lazy init: globals are bss zero-init only, no dynamic init on device
+
+    // Constant-initialized per-thread from .tdata by do_thread_crt1 (trisck.cc): seeds next to this
+    // TRISC's partition base and every engine slot to the no-id sentinel. thread_local static init
+    // makes this valid (verified by QuasarComputeKernelTLS), so no runtime lazy-init is needed.
+    constexpr BfdAllocatorState() : next(bfd_partition_base(ckernel::TRISC_ID)), current {}
+    {
+        for (std::uint8_t i = 0; i < static_cast<std::uint8_t>(BfdResource::Count); ++i)
+        {
+            current[i] = BFD_ID_INVALID;
+        }
+    }
 };
 
-// One instance per TRISC image. thread_local so the host-threaded emulation gives each Neo's
-// TRISC its own allocator, matching the per-TRISC physical partitioning of the BFD table. A
-// single shared instance races the id allocator two ways when num_threads > 1 (see tt-llk#1678):
-// an unfenced read-modify-write on next hands the same id to two threads, and the unfenced lazy
-// init lets one role hand out ids from another role's partition. Mirrors trisc::dest_register_offset:
-// ENV_LLK_INFRA (standalone LLK infra, no firmware TU) uses a plain static; the metal build
-// declares it extern thread_local and defines it in firmware (tt_metal/hw/firmware/src/tt-2xx/trisc.cc).
+// One instance per TRISC image. thread_local so the host-threaded emulation gives each Neo's TRISC
+// its own allocator, each constexpr-seeded to that TRISC's own partition base (see the ctor above),
+// matching the per-TRISC physical partitioning of the BFD table. A single shared instance would race
+// the id allocator when num_threads > 1 (see tt-llk#1678): an unfenced read-modify-write on next
+// hands the same id to two threads, and a shared next mixes one role's ids into another's partition.
+// Mirrors trisc::dest_register_offset: ENV_LLK_INFRA (standalone LLK infra, no firmware TU) uses a
+// plain static; the metal build declares it extern thread_local and defines it in firmware
+// (tt_metal/hw/firmware/src/tt-2xx/trisc.cc).
 #ifdef ENV_LLK_INFRA
-static BfdAllocatorState bfd_state; // zero-init; next initialized lazily to the partition base
+static BfdAllocatorState bfd_state; // constexpr ctor seeds next=partition base, current[]=BFD_ID_INVALID
 #else
 extern thread_local BfdAllocatorState bfd_state; // defined in tt_metal/hw/firmware/src/tt-2xx/trisc.cc
 #endif
@@ -141,16 +152,6 @@ inline std::uint8_t bfd_alloc()
     constexpr std::uint8_t base = bfd_partition_base(ckernel::TRISC_ID);
     constexpr std::uint8_t end  = base + bfd_partition_size(ckernel::TRISC_ID);
 
-    if (!bfd_state.initialized)
-    {
-        bfd_state.next = base;
-        for (std::uint8_t i = 0; i < static_cast<std::uint8_t>(BfdResource::Count); ++i)
-        {
-            bfd_state.current[i] = BFD_ID_INVALID;
-        }
-        bfd_state.initialized = true;
-    }
-
     const std::uint8_t id                           = bfd_state.next;
     bfd_state.current[static_cast<std::uint8_t>(E)] = id;
     const std::uint8_t next                         = id + 1;
@@ -168,10 +169,9 @@ inline std::uint8_t bfd_current()
     static_assert(ckernel::TRISC_ID != 1, "math TRISC owns no buffer descriptors");
     static_assert(E < BfdResource::Count, "invalid BFD engine");
     static_assert(bfd_engine_owned_by_trisc(E, ckernel::TRISC_ID), "BFD engine not owned by compiling TRISC");
-    // current[] is bss zero before the first bfd_alloc (0 is a valid id), and the BFD_ID_INVALID
-    // sentinel is only written inside bfd_alloc's lazy-init; gate on initialized so a bfd_current
-    // that races ahead of any allocation trips the assert instead of returning a bogus id 0.
-    LLK_ASSERT(bfd_state.initialized && bfd_state.current[static_cast<std::uint8_t>(E)] != BFD_ID_INVALID, "bfd_current before first bfd_alloc");
+    // current[] is seeded to BFD_ID_INVALID by the constexpr ctor, so a bfd_current that races ahead
+    // of any bfd_alloc trips this assert instead of returning a bogus id 0.
+    LLK_ASSERT(bfd_state.current[static_cast<std::uint8_t>(E)] != BFD_ID_INVALID, "bfd_current before first bfd_alloc");
     return bfd_state.current[static_cast<std::uint8_t>(E)];
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_bfd_alloc.h
@@ -113,8 +113,18 @@ struct BfdAllocatorState
     bool initialized;                                                    // lazy init: globals are bss zero-init only, no dynamic init on device
 };
 
-// One instance per TRISC binary (each TRISC compiles its own image with COMPILE_FOR_TRISC).
-inline BfdAllocatorState bfd_state; // zero-init; next initialized lazily to the partition base
+// One instance per TRISC image. thread_local so the host-threaded emulation gives each Neo's
+// TRISC its own allocator, matching the per-TRISC physical partitioning of the BFD table. A
+// single shared instance races the id allocator two ways when num_threads > 1 (see tt-llk#1678):
+// an unfenced read-modify-write on next hands the same id to two threads, and the unfenced lazy
+// init lets one role hand out ids from another role's partition. Mirrors trisc::dest_register_offset:
+// ENV_LLK_INFRA (standalone LLK infra, no firmware TU) uses a plain static; the metal build
+// declares it extern thread_local and defines it in firmware (tt_metal/hw/firmware/src/tt-2xx/trisc.cc).
+#ifdef ENV_LLK_INFRA
+static BfdAllocatorState bfd_state; // zero-init; next initialized lazily to the partition base
+#else
+extern thread_local BfdAllocatorState bfd_state; // defined in tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+#endif
 
 /**
  * @brief Allocate the next buffer descriptor id for this thread's partition and record it as the


### PR DESCRIPTION
## Summary

Follow-up cleanup to the BFD id-allocator race fix (#53744). Now that `bfd_state`
is `thread_local`, its initial state can be set by a `constexpr` constructor instead
of a runtime lazy-init guarded by an `initialized` flag — removing a per-`bfd_alloc`
branch and a struct field.

Stacked on #53744 — review/merge that first. (I'll rebase onto `main` once it lands
so this shows only the cleanup commit.)

## Background

The lazy `initialized` flag existed for the old *plain-global* world: on-device
globals get only `.bss` zero-init, and `0` is a valid BFD id, so `current[]`'s
`BFD_ID_INVALID` sentinel and the `next = partition base` seed had to be written at
runtime on first `bfd_alloc`.

With `bfd_state` now `thread_local` (#53744), the C-runtime materializes each thread's
TLS from the `.tdata` load image at startup (`do_thread_crt1` in `trisck.cc`), so a
non-zero static initializer is honored on device.

## Change

- `BfdAllocatorState` gains a `constexpr` constructor seeding `next = bfd_partition_base(TRISC_ID)`
  and `current[] = BFD_ID_INVALID`; the `initialized` field is removed.
- `bfd_alloc()` loses its lazy-init block (down to allocate / record / bump).
- `bfd_current()` assert drops the `initialized &&` gate.
- `trisc.cc` definition simplifies to `thread_local BfdAllocatorState bfd_state;`
  (constant-initialized by the ctor).
- Comments updated to reflect the new init path.

Net: −1 field, −1 branch per allocation, same behavior.

## Why it's safe

Non-zero `thread_local` init on compute TRISCs is proven by the existing
`QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS`
(`tests/tt_metal/tt_metal/test_globals_tls.cpp`), which reads back a
`thread_local uint32_t = 10` as `10` on device — confirming the `.tdata` path works
(the "does not work yet" TODO there is stale). Verified passing on Quasar emulation.

## Test

- `QuasarComputeKernelTLS` — PASS on Quasar emulation (proves the non-zero TLS init).
- Per-test ×50 regression over the compute/BFD-relevant Quasar tests in `unit_tests_legacy`
  (`Bmm`, `QuasarComputeKernel*`, `PackRelu*`, `MultiDmAddTwoInts`) on Quasar emulation —
  results to be attached.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cleanup/bfd-drop-initialized-flag-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cleanup/bfd-drop-initialized-flag-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cleanup/bfd-drop-initialized-flag-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cleanup/bfd-drop-initialized-flag-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cleanup/bfd-drop-initialized-flag-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cleanup/bfd-drop-initialized-flag-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cleanup/bfd-drop-initialized-flag-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cleanup/bfd-drop-initialized-flag-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cleanup/bfd-drop-initialized-flag-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cleanup/bfd-drop-initialized-flag-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cleanup/bfd-drop-initialized-flag-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cleanup/bfd-drop-initialized-flag-1678)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cleanup/bfd-drop-initialized-flag-1678)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cleanup/bfd-drop-initialized-flag-1678)