### PR TITLE
Test Only: nightly ULP/exactness characterization for sum, std/var, topk values

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_std_var_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_std_var_ulp.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ULP-based accuracy characterization for ttnn.std / ttnn.var (issue #51180 nightly
+recharter; extends the ``test_mean_ulp.py`` pattern to the Welford ops).
+
+Relationship to existing std/var tests (do not duplicate; different goal):
+
+- ``test_reduction_ops.py`` (this directory): functional coverage of std/var over
+  shapes / dims / correction with PCC-style tolerances, plus corner cases.
+- ``tests/ttnn/unit_tests/gtests/test_reduction.cpp`` (merge gate): one exact smoke
+  cell per Welford program factory (W / H / non-HW dim / multi-dim / fp32).
+
+This file is only for **bounded max-ULP** characterization. The device implements
+std/var with Welford's algorithm, whose defining property is robustness to a large
+mean offset: a naive two-pass E[x^2] - E[x]^2 at offset 1e4 with sigma=1 cancels
+~8 significant digits and produces garbage variance, while Welford's incremental
+update stays well-conditioned. The ``offset`` distributions below are exactly that
+probe — the thresholds on them are the Welford guarantee this suite pins down.
+
+Golden policy:
+- BF16: torch.std/var(bf16_input.float(), ...).to(torch.bfloat16) — FP32
+  accumulation on host, result cast to BF16 (matches the fp32_dest_acc_en=True
+  device policy, as in test_mean_ulp.py).
+- FP32: torch.std/var(fp32_input.double(), ...).to(torch.float32) — an FP64,
+  ordering-insensitive reference, because torch's own fp32 std/var carries
+  accumulation-ordering noise of the same magnitude as the device's.
+
+Offsets are dtype-aware: BF16 uses offset 8 (ULP(8) = 0.0625, so sigma=1 data is
+still resolvable in the input dtype); FP32 uses offset 1e4 (the classic
+catastrophic-cancellation regime for two-pass variance).
+
+Metrics are logged with loguru at INFO for every parametrized case (pass or fail).
+"""
+
+import pytest
+
+pytestmark = pytest.mark.use_module_device
+
+import torch
+from loguru import logger
+
+import ttnn
+from tests.ttnn.utils_for_testing import measure_ulp_with_near_zero_atol
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_std, ttnn_var
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TTNN_OPS = {"std": ttnn_std, "var": ttnn_var}
+_TORCH_OPS = {"std": torch.std, "var": torch.var}
+
+
+def _make_compute_kernel_config(device, fp32_dest_acc_en: bool):
+    """Compute kernel config from device arch."""
+    return ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        packer_l1_acc=True,
+    )
+
+
+def _golden(op: str, x: torch.Tensor, dim, correction: bool, out_dtype: torch.dtype) -> torch.Tensor:
+    """High-precision host golden (see module docstring), cast to the output dtype."""
+    acc_dtype = torch.float32 if out_dtype == torch.bfloat16 else torch.float64
+    return _TORCH_OPS[op](x.to(acc_dtype), dim=dim, keepdim=True, correction=1 if correction else 0).to(out_dtype)
+
+
+def _run_ttnn(op: str, x: torch.Tensor, ttnn_dtype, device, dim, correction: bool, ckc) -> torch.Tensor:
+    """Send tensor to device, run ttnn.std/var (twice, via the determinism wrapper), return torch tensor."""
+    tt_input = ttnn.from_torch(x, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.fill_implicit_tile_padding(tt_input, 42)
+    tt_out = _TTNN_OPS[op](tt_input, dim=dim, keepdim=True, correction=correction, compute_kernel_config=ckc)
+    return ttnn.to_torch(tt_out)
+
+
+def _std_var_input(distribution: str, shape, offset: float, seed: int = 42) -> torch.Tensor:
+    """FP32 test input. Distributions stress different Welford regimes (see module docstring)."""
+    torch.manual_seed(seed)
+    if distribution == "centered":  # mean ~0, sigma 1: the benign regime
+        return torch.randn(shape, dtype=torch.float32)
+    if distribution == "offset":  # mean-shift cancellation probe: sigma 1 on a large offset
+        return offset + torch.randn(shape, dtype=torch.float32)
+    if distribution == "tiny_variance":  # sigma ~3e-3 on the offset: variance << mean^2
+        return offset + torch.empty(shape, dtype=torch.float32).uniform_(0.0, 1e-2)
+    raise ValueError(f"unknown distribution {distribution}")
+
+
+# ---------------------------------------------------------------------------
+# Shape/dim grid — one row per reduction geometry, sized for nightly budget
+# ---------------------------------------------------------------------------
+
+_SHAPES_AND_DIMS = [
+    ((1, 1, 32, 512), -1, "W512"),
+    ((2, 4, 32, 2048), -1, "W2048"),
+    ((1, 1, 512, 64), -2, "H512"),
+    ((2, 2, 256, 256), [-2, -1], "HW256"),
+    ((1, 1, 37, 41), -1, "W-odd"),  # non-tile-aligned: padding must not enter the stats
+]
+
+
+# ---------------------------------------------------------------------------
+# BF16 tests
+# ---------------------------------------------------------------------------
+
+# BF16 max-ULP caps vs FP32-accumulated torch golden. Observed peaks on BH p100a are
+# strikingly small — 0 ULP (fp32_acc_on) and 1 ULP (fp32_acc_off) across the whole grid,
+# including the offset distribution — because Welford's running mean keeps every
+# accumulated quantity at O(1) magnitude, so bf16 accumulation barely costs anything
+# (contrast test_sum_ulp.py: 618 ULP peak for raw bf16 sum accumulation on the same
+# depth class). Caps leave margin over the tiny peaks for cross-arch variance while
+# staying far below the naive-two-pass failure class this suite exists to catch.
+_BF16_ULP_THRESHOLD_FP32_DEST = 16  # observed peak 0
+_BF16_ULP_THRESHOLD_BF16_DEST = 32  # observed peak 1
+_BF16_NEAR_ZERO_ATOL_FRACTION_FP32_DEST = 0.002
+_BF16_NEAR_ZERO_ATOL_FRACTION_BF16_DEST = 0.40
+
+
+@pytest.mark.parametrize(
+    "shape, dim, desc",
+    _SHAPES_AND_DIMS,
+    ids=[c[2] for c in _SHAPES_AND_DIMS],
+)
+@pytest.mark.parametrize("distribution", ["centered", "offset"])
+@pytest.mark.parametrize("op", ["std", "var"])
+@pytest.mark.parametrize("correction", [True, False], ids=["bessel", "biased"])
+@pytest.mark.parametrize("fp32_dest_acc_en", [False, True], ids=["fp32_acc_off", "fp32_acc_on"])
+def test_std_var_ulp_bf16(device, shape, dim, desc, distribution, op, correction, fp32_dest_acc_en):
+    """Characterize BF16 std/var ULP vs FP32-accumulated Torch golden (offset 8: bf16-resolvable)."""
+    x = _std_var_input(distribution, shape, offset=8.0).to(torch.bfloat16)
+
+    golden = _golden(op, x, dim, correction, torch.bfloat16)
+    ckc = _make_compute_kernel_config(device, fp32_dest_acc_en)
+    actual = _run_ttnn(op, x, ttnn.bfloat16, device, dim, correction, ckc)
+
+    ulp_threshold = _BF16_ULP_THRESHOLD_FP32_DEST if fp32_dest_acc_en else _BF16_ULP_THRESHOLD_BF16_DEST
+    atol_fraction = (
+        _BF16_NEAR_ZERO_ATOL_FRACTION_FP32_DEST if fp32_dest_acc_en else _BF16_NEAR_ZERO_ATOL_FRACTION_BF16_DEST
+    )
+    passed, max_ulp, max_atol_err, atol_tol, msg, ulp_stats = measure_ulp_with_near_zero_atol(
+        golden, actual, ulp_threshold, atol_fraction
+    )
+    spec = f"{desc} {distribution} {op} correction={correction} shape={shape} dim={dim} fp32_acc={fp32_dest_acc_en}"
+    logger.info(
+        f"ttnn.{op} ULP (BF16) | {spec} | ulp mean={ulp_stats['mean']:.3g} p95={ulp_stats['p95']:.3g} p99={ulp_stats['p99']:.3g} max={max_ulp:.4g}/{ulp_threshold} atol {max_atol_err:.4g}/{atol_tol:.4g} | {'ok' if passed else 'FAIL'}"
+    )
+    if ulp_stats["worst"]:
+        logger.info(f"  worst: {ulp_stats['worst']}")
+    if not passed:
+        logger.info(f"  {msg}")
+    assert passed, f"[BF16 {op} {desc} {distribution} correction={correction} fp32_acc={fp32_dest_acc_en}] {msg}"
+
+
+# ---------------------------------------------------------------------------
+# FP32 tests
+# ---------------------------------------------------------------------------
+
+# FP32 max-ULP caps vs FP64 torch golden, fp32_dest_acc_en=True, per distribution
+# (observed peaks on BH p100a, ~4x headroom):
+# - centered: 29 ULP — Welford in fp32 is tight in the benign regime.
+# - offset (1e4): 1.4e4 ULP ~ one tf32 rounding of relative error. This IS the Welford
+#   guarantee: a two-pass fp32 variance at offset 1e4 cancels ~8 significant digits and
+#   returns garbage; Welford holds tf32-level relative accuracy.
+# - tiny_variance (sigma ~3e-3 on offset 1e4): 5.5e6 ULP — the documented tf32 floor.
+#   The FPU quantizes operands to tf32, whose ULP at 1e4 is 8, so a variation of 1e-2
+#   is simply invisible to it (sigma < mean * 2^-11). The cap pins this floor; an
+#   accurate-mode (full-fp32 SFPU) flag for std/var, as exists for mean, would collapse it.
+_FP32_ULP_THRESHOLDS = {
+    "centered": 128,
+    "offset": 60_000,
+    "tiny_variance": 22_000_000,
+}
+_FP32_NEAR_ZERO_ATOL_FRACTION = 0.00125
+
+
+@pytest.mark.parametrize(
+    "shape, dim, desc",
+    _SHAPES_AND_DIMS,
+    ids=[c[2] for c in _SHAPES_AND_DIMS],
+)
+@pytest.mark.parametrize("distribution", ["centered", "offset", "tiny_variance"])
+@pytest.mark.parametrize("op", ["std", "var"])
+@pytest.mark.parametrize("correction", [True, False], ids=["bessel", "biased"])
+def test_std_var_ulp_fp32(device, shape, dim, desc, distribution, op, correction):
+    """Characterize FP32 std/var ULP vs FP64 Torch golden (offset 1e4: two-pass would cancel)."""
+    x = _std_var_input(distribution, shape, offset=1.0e4)
+
+    golden = _golden(op, x, dim, correction, torch.float32)
+    ckc = _make_compute_kernel_config(device, fp32_dest_acc_en=True)
+    actual = _run_ttnn(op, x, ttnn.float32, device, dim, correction, ckc)
+
+    ulp_threshold = _FP32_ULP_THRESHOLDS[distribution]
+    passed, max_ulp, max_atol_err, atol_tol, msg, ulp_stats = measure_ulp_with_near_zero_atol(
+        golden, actual, ulp_threshold, _FP32_NEAR_ZERO_ATOL_FRACTION
+    )
+    spec = f"{desc} {distribution} {op} correction={correction} shape={shape} dim={dim}"
+    logger.info(
+        f"ttnn.{op} ULP (FP32) | {spec} | ulp mean={ulp_stats['mean']:.3g} p95={ulp_stats['p95']:.3g} p99={ulp_stats['p99']:.3g} max={max_ulp:.4g}/{ulp_threshold} atol {max_atol_err:.4g}/{atol_tol:.4g} | {'ok' if passed else 'FAIL'}"
+    )
+    if ulp_stats["worst"]:
+        logger.info(f"  worst: {ulp_stats['worst']}")
+    if not passed:
+        logger.info(f"  {msg}")
+    assert passed, f"[FP32 {op} {desc} {distribution} correction={correction}] {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Zero-variance exactness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("op", ["std", "var"])
+@pytest.mark.parametrize(
+    "ttnn_dtype, torch_dtype", [(ttnn.bfloat16, torch.bfloat16), (ttnn.float32, torch.float32)], ids=["bf16", "fp32"]
+)
+def test_std_var_constant_input_exact_zero(device, op, ttnn_dtype, torch_dtype):
+    """std/var of a constant tensor must be exactly 0.0: Welford's (x - mean) terms are exactly
+    zero for constant input in either dtype, so any nonzero output is accumulated noise leaking
+    through (or padding entering the stats)."""
+    shape, dim = (1, 2, 64, 512), -1
+    x = torch.full(shape, 3.140625, dtype=torch_dtype)  # exactly representable in bf16
+    ckc = _make_compute_kernel_config(device, fp32_dest_acc_en=True)
+    actual = _run_ttnn(op, x, ttnn_dtype, device, dim, correction=True, ckc=ckc)
+    assert torch.equal(
+        actual, torch.zeros_like(actual)
+    ), f"{op} of a constant tensor returned nonzero values (max |out| = {actual.abs().max().item()})"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum_ulp.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ULP-based accuracy characterization for ttnn.sum (issue #51180 nightly recharter;
+extends the ``test_mean_ulp.py`` pattern to sum).
+
+Relationship to existing sum tests (do not duplicate; different goal):
+
+- unit-tier ``test_reduction.py`` / ``test_sum.py``: equivalence vs torch via
+  PCC / rtol / atol on modest shapes and many ``dim`` / ``keepdim`` combinations.
+- ``test_sum_int.py`` (this directory): int32 exactness, extreme values, RM padding.
+- ``test_reduction_ops.py`` (this directory): functional corner cases (empty tensors,
+  preallocated outputs, dim parity) — not numeric sweeps.
+- ``tests/ttnn/unit_tests/gtests/test_reduction.cpp`` (merge gate): one exact smoke
+  cell per program factory.
+
+This file is only for **bounded max-ULP** characterization (plus near-zero absolute
+tolerance) over accumulation depth; PCC-style tolerances hide sum regressions
+(pcc 0.95–0.999 passes results that are hundreds of ULP off).
+
+BF16 golden: torch.sum(bf16_input.float(), dim=...).to(torch.bfloat16)
+  - FP32 accumulation on host, result cast to BF16 — the best-practice policy the
+    device path should follow with fp32_dest_acc_en=True.
+
+FP32 golden: torch.sum(fp32_input, dim=...)
+  - True IEEE 754 float32 accumulation. Unlike ttnn.mean / ttnn.max, ttnn.sum has
+    NO fast_and_approximate_mode flag: fp32 sum always reduces on the FPU, which
+    accumulates in TF32. The FP32 thresholds below therefore document the tf32
+    accumulation error of the only available path, and a deep-accumulation section
+    tracks its growth against an FP64 golden.
+
+Distribution note: for zero-mean data the row sum itself is near zero, so most
+outputs land in the near-zero absolute-tolerance regime of
+``measure_ulp_with_near_zero_atol`` (ULP is meaningless when |expected| ~ 0).
+``offset_uniform`` (uniform in [1, 2], all-positive) keeps |sum| ~ 1.5*N so the
+ULP metric is meaningful; ``normal`` deliberately exercises the near-zero /
+cancellation regime; ``wide_uniform`` mixes magnitudes.
+
+Metrics are logged with loguru at INFO for every parametrized case (pass or fail).
+"""
+
+import pytest
+
+pytestmark = pytest.mark.use_module_device
+
+import torch
+from loguru import logger
+
+import ttnn
+from tests.ttnn.utils_for_testing import measure_ulp_with_near_zero_atol
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_sum
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sum_compute_kernel_config(device, fp32_dest_acc_en: bool):
+    """Compute kernel config from device arch."""
+    return ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        packer_l1_acc=True,
+    )
+
+
+def _golden_sum_bf16(input_bf16: torch.Tensor, dim, keepdim: bool) -> torch.Tensor:
+    """FP32-accumulated sum, result cast back to BF16."""
+    return torch.sum(input_bf16.float(), dim=dim, keepdim=keepdim).to(torch.bfloat16)
+
+
+def _golden_sum_fp32(input_fp32: torch.Tensor, dim, keepdim: bool) -> torch.Tensor:
+    """PyTorch IEEE 754 float32 sum; the tile engine accumulates in TF32 (no accurate-mode flag on sum)."""
+    return torch.sum(input_fp32, dim=dim, keepdim=keepdim)
+
+
+def _run_ttnn_sum(
+    input_torch: torch.Tensor,
+    ttnn_dtype,
+    device,
+    dim,
+    keepdim: bool,
+    compute_kernel_config=None,
+) -> torch.Tensor:
+    """Send tensor to device, run ttnn.sum (twice, via the determinism wrapper), return host torch tensor."""
+    tt_input = ttnn.from_torch(input_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.fill_implicit_tile_padding(tt_input, 42)
+    tt_out = ttnn_sum(tt_input, dim=dim, keepdim=keepdim, compute_kernel_config=compute_kernel_config)
+    return ttnn.to_torch(tt_out)
+
+
+def _sum_input(distribution: str, shape, seed: int = 42) -> torch.Tensor:
+    """FP32 test input. Distributions stress different sum regimes (see module docstring)."""
+    torch.manual_seed(seed)
+    if distribution == "offset_uniform":  # |sum| ~ 1.5*N: the ULP-meaningful regime
+        return torch.empty(shape, dtype=torch.float32).uniform_(1.0, 2.0)
+    if distribution == "normal":  # zero-mean: cancellation, near-zero sums (atol regime)
+        return torch.randn(shape, dtype=torch.float32)
+    if distribution == "wide_uniform":  # mixed magnitudes
+        return torch.empty(shape, dtype=torch.float32).uniform_(-1e3, 1e3)
+    raise ValueError(f"unknown distribution {distribution}")
+
+
+# ---------------------------------------------------------------------------
+# Test parameters — same shape grid family as test_mean_ulp.py, trimmed:
+# keepdim is fixed to True (keepdim does not change the accumulation; the mean
+# suite already regression-tracks the keepdim plumbing for this op family).
+# ---------------------------------------------------------------------------
+
+
+def _build_sum_shapes_and_dims():
+    """Build (shape, dim, id) cases: N×C grid for W and H reduction, plus HW and odd."""
+    out = []
+
+    _N_SIZES = [1, 8]  # small, large batch
+    _C_SIZES = [1, 4]  # small, large channel
+    _H_SIZES = [32, 512]  # small, large H
+    _W_SIZES = [64, 512, 2048]  # small, medium, large W
+    _H_FIXED = 32
+    _W_FIXED = 64
+
+    for n in _N_SIZES:
+        for c in _C_SIZES:
+            for w in _W_SIZES:
+                out.append(((n, c, _H_FIXED, w), -1, f"W-{n}x{c}x{_H_FIXED}x{w}"))
+
+    for n in _N_SIZES:
+        for c in _C_SIZES:
+            for h in _H_SIZES:
+                out.append(((n, c, h, _W_FIXED), -2, f"H-{n}x{c}x{h}x{_W_FIXED}"))
+
+    # 2D HW-reduction: one small and one large representative shape
+    out.append(((1, 1, 64, 128), [-2, -1], "HW-small"))
+    out.append(((4, 4, 256, 512), [-2, -1], "HW-large"))
+
+    # One non-tile-aligned shape to catch padding edge cases
+    out.append(((1, 1, 37, 41), -1, "W-odd"))
+
+    return out
+
+
+_SHAPES_AND_DIMS = _build_sum_shapes_and_dims()
+
+
+# ---------------------------------------------------------------------------
+# BF16 tests
+# ---------------------------------------------------------------------------
+
+# BF16 max-ULP cap vs FP32-accumulated torch golden (see measure_ulp_with_near_zero_atol).
+# fp32_dest_acc_en=True (BF16 inputs → FP32 accumulation → BF16 out): observed peak 2 ULP
+# on this grid (BH p100a) — the fp32 accumulator reproduces the golden policy up to the
+# final-rounding step order.
+# fp32_dest_acc_en=False (BF16 accumulation throughout): error grows with depth; observed
+# peak 618 ULP (HW-large normal, 128k-element reduction) — the same peak test_mean_ulp.py
+# documents for mean, as expected (same accumulator, no final divide). The gap documents
+# that fp32 accumulation is essential for BF16 sum accuracy.
+_BF16_ULP_THRESHOLD_FP32_DEST = 8  # 4x headroom over observed peak 2
+_BF16_ULP_THRESHOLD_BF16_DEST = 2500  # ~4x headroom over observed peak 618 (matches mean)
+_BF16_NEAR_ZERO_ATOL_FRACTION_FP32_DEST = 0.002  # tight; fp32 rounding error is tiny
+_BF16_NEAR_ZERO_ATOL_FRACTION_BF16_DEST = 0.40  # loose; BF16 accum on near-zero sums
+
+
+@pytest.mark.parametrize(
+    "shape, dim, desc",
+    _SHAPES_AND_DIMS,
+    ids=[c[2] for c in _SHAPES_AND_DIMS],
+)
+@pytest.mark.parametrize("distribution", ["offset_uniform", "normal", "wide_uniform"])
+@pytest.mark.parametrize("fp32_dest_acc_en", [False, True], ids=["fp32_acc_off", "fp32_acc_on"])
+def test_sum_ulp_bf16(device, shape, dim, desc, distribution, fp32_dest_acc_en):
+    """Characterize BF16 sum ULP vs FP32-accumulated Torch golden.
+
+    fp32_dest_acc_en=True reflects the recommended path (BF16 inputs accumulated in FP32).
+    fp32_dest_acc_en=False documents the accuracy cost of BF16-only accumulation.
+    """
+    x = _sum_input(distribution, shape).to(torch.bfloat16)
+
+    golden = _golden_sum_bf16(x, dim=dim, keepdim=True)
+    ckc = _make_sum_compute_kernel_config(device, fp32_dest_acc_en)
+    actual = _run_ttnn_sum(x, ttnn.bfloat16, device, dim=dim, keepdim=True, compute_kernel_config=ckc)
+
+    ulp_threshold = _BF16_ULP_THRESHOLD_FP32_DEST if fp32_dest_acc_en else _BF16_ULP_THRESHOLD_BF16_DEST
+    atol_fraction = (
+        _BF16_NEAR_ZERO_ATOL_FRACTION_FP32_DEST if fp32_dest_acc_en else _BF16_NEAR_ZERO_ATOL_FRACTION_BF16_DEST
+    )
+    passed, max_ulp, max_atol_err, atol_tol, msg, ulp_stats = measure_ulp_with_near_zero_atol(
+        golden, actual, ulp_threshold, atol_fraction
+    )
+    spec = f"{desc} {distribution} shape={shape} dim={dim} fp32_acc={fp32_dest_acc_en}"
+    logger.info(
+        f"ttnn.sum ULP (BF16) | {spec} | ulp mean={ulp_stats['mean']:.3g} p95={ulp_stats['p95']:.3g} p99={ulp_stats['p99']:.3g} max={max_ulp:.4g}/{ulp_threshold} atol {max_atol_err:.4g}/{atol_tol:.4g} | {'ok' if passed else 'FAIL'}"
+    )
+    if ulp_stats["worst"]:
+        logger.info(f"  worst: {ulp_stats['worst']}")
+    if not passed:
+        logger.info(f"  {msg}")
+    assert passed, f"[BF16 {desc} {distribution} fp32_acc={fp32_dest_acc_en}] {msg}"
+
+
+# ---------------------------------------------------------------------------
+# FP32 tests
+# ---------------------------------------------------------------------------
+
+# ttnn.sum has no accurate-SFPU flag (unlike ttnn.mean / ttnn.max): fp32 inputs reduce on
+# the FPU, which quantizes operands to TF32 (11-bit mantissa). One tf32 rounding is
+# ~2^12 fp32 ULP, so thresholds on this path are inherently in the 1e4–1e6 range — the
+# value of this cap is pinning today's error level, not asserting fp32 accuracy.
+# Observed peak on this grid: 3.5e5 ULP (BH p100a; wide_uniform, 128k-element HW case,
+# where sign cancellation amplifies relative error). A future accurate-mode flag for sum
+# (as added to mean) would let this drop to the ~512-ULP class of test_mean_ulp.py.
+_FP32_ULP_THRESHOLD = 1_400_000  # ~4x headroom over observed peak 3.5e5
+_FP32_NEAR_ZERO_ATOL_FRACTION = 0.00125  # observed peak 2.7% of the previous 0.0125 allowance
+
+
+@pytest.mark.parametrize(
+    "shape, dim, desc",
+    _SHAPES_AND_DIMS,
+    ids=[c[2] for c in _SHAPES_AND_DIMS],
+)
+@pytest.mark.parametrize("distribution", ["offset_uniform", "normal", "wide_uniform"])
+def test_sum_ulp_fp32(device, shape, dim, desc, distribution):
+    """Characterize FP32 sum ULP vs Torch FP32 golden (FPU/tf32 path; fp32_dest_acc_en=True)."""
+    x = _sum_input(distribution, shape)
+
+    golden = _golden_sum_fp32(x, dim=dim, keepdim=True)
+    ckc = _make_sum_compute_kernel_config(device, fp32_dest_acc_en=True)
+    actual = _run_ttnn_sum(x, ttnn.float32, device, dim=dim, keepdim=True, compute_kernel_config=ckc)
+
+    passed, max_ulp, max_atol_err, atol_tol, msg, ulp_stats = measure_ulp_with_near_zero_atol(
+        golden, actual, _FP32_ULP_THRESHOLD, _FP32_NEAR_ZERO_ATOL_FRACTION
+    )
+    spec = f"{desc} {distribution} shape={shape} dim={dim}"
+    logger.info(
+        f"ttnn.sum ULP (FP32, tf32 FPU path) | {spec} | ulp mean={ulp_stats['mean']:.3g} p95={ulp_stats['p95']:.3g} p99={ulp_stats['p99']:.3g} max={max_ulp:.4g}/{_FP32_ULP_THRESHOLD} atol {max_atol_err:.4g}/{atol_tol:.4g} | {'ok' if passed else 'FAIL'}"
+    )
+    if ulp_stats["worst"]:
+        logger.info(f"  worst: {ulp_stats['worst']}")
+    if not passed:
+        logger.info(f"  {msg}")
+    assert passed, f"[FP32 {desc} {distribution}] {msg}"
+
+
+# ---------------------------------------------------------------------------
+# FP32 deep accumulation vs FP64 golden
+# ---------------------------------------------------------------------------
+
+# Accumulation-depth tracking against an order-insensitive FP64 golden. There is no
+# accurate-mode escape hatch for sum (unlike mean/max), so these caps pin the tf32 FPU
+# path's error growth; a kernel change that widens accumulation error at depth shows up
+# here first. Per-case caps are ~4x over the worst observed distribution (BH p100a):
+# W512 2.1e4, W8192 4.2e4, H8192 3.1e5 (the single-stage H factory accumulates deepest),
+# HW1M 1.3e4 (the two-stage W-then-H split keeps each stage shallow — note it beats H8192
+# despite 16x more elements).
+_FP32_DEEP_CASES = [
+    # (shape, dim, id, ulp_cap)
+    ((1, 1, 32, 512), -1, "W512", 84_000),
+    ((1, 1, 32, 8192), -1, "W8192", 170_000),
+    ((1, 1, 8192, 64), -2, "H8192", 1_250_000),
+    ((1, 4, 1024, 1024), [-2, -1], "HW1M", 56_000),
+]
+
+
+@pytest.mark.parametrize(
+    "shape, dim, desc, ulp_cap",
+    _FP32_DEEP_CASES,
+    ids=[c[2] for c in _FP32_DEEP_CASES],
+)
+@pytest.mark.parametrize("distribution", ["offset_uniform", "wide_uniform"])
+def test_sum_fp32_deep_accumulation(device, shape, dim, desc, ulp_cap, distribution):
+    """FP32 sum error growth with accumulation depth, vs an FP64 golden (tf32 FPU path)."""
+    x = _sum_input(distribution, shape, seed=1234)
+    golden = torch.sum(x.to(torch.float64), dim=dim, keepdim=True).to(torch.float32)
+    ckc = _make_sum_compute_kernel_config(device, fp32_dest_acc_en=True)
+    actual = _run_ttnn_sum(x, ttnn.float32, device, dim=dim, keepdim=True, compute_kernel_config=ckc)
+
+    passed, max_ulp, max_atol_err, atol_tol, msg, ulp_stats = measure_ulp_with_near_zero_atol(
+        golden, actual, ulp_cap, _FP32_NEAR_ZERO_ATOL_FRACTION
+    )
+    logger.info(
+        f"ttnn.sum fp32 deep accumulation | {desc} {distribution} | ulp mean={ulp_stats['mean']:.3g} p95={ulp_stats['p95']:.3g} max={max_ulp:.4g}/{ulp_cap} atol {max_atol_err:.4g}/{atol_tol:.4g} | {'ok' if passed else 'FAIL'}"
+    )
+    if not passed:
+        logger.info(f"  {msg}")
+    assert passed, f"[FP32-deep {desc} {distribution}] {msg}"
+
+
+# ---------------------------------------------------------------------------
+# scalar= scaling must not add error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("scalar", [0.5, 2.0], ids=["scalar_half", "scalar_two"])
+def test_sum_scalar_scaling_exact(device, scalar):
+    """sum(x, scalar=s) for a power-of-two s must be bit-identical to s * sum(x): the scale
+    multiplies the accumulated result and a power of two is exact in both dtypes."""
+    torch.manual_seed(7)
+    shape, dim = (1, 2, 64, 512), -1
+    x = _sum_input("offset_uniform", shape, seed=7)
+    ckc = _make_sum_compute_kernel_config(device, fp32_dest_acc_en=True)
+
+    tt_input = ttnn.from_torch(x, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.fill_implicit_tile_padding(tt_input, 42)
+    base = ttnn.to_torch(ttnn_sum(tt_input, dim=dim, keepdim=True, compute_kernel_config=ckc))
+    scaled = ttnn.to_torch(ttnn_sum(tt_input, dim=dim, keepdim=True, scalar=scalar, compute_kernel_config=ckc))
+    assert torch.equal(scaled, base * scalar), "power-of-two scalar= scaling changed the accumulated value"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_topk_values.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_topk_values.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Value-fidelity characterization for ttnn.topk (issue #51180 nightly recharter).
+
+Relationship to existing topk tests (do not duplicate; different goal):
+
+- unit-tier ``tests/ttnn/unit_tests/operations/reduce/test_topk.py``: functional
+  coverage of shapes / k / dim / dtypes with PCC-style value checks.
+- ``tests/ttnn/unit_tests/gtests/test_reduction.cpp`` (merge gate): one exact smoke
+  cell per topk program factory / index-dtype selection (incl. the #53453 multi-core
+  case).
+- the ``reduction/topk`` sweep is currently non-functional (100% invalidated vectors,
+  see the CI-grid analysis) — nothing here depends on it.
+
+topk is a **selection**, not an accumulation: its output values are elements of the
+input, so unlike sum/mean there is no rounding budget to characterize — the sorted
+top-k value sequence must match torch's **exactly**, ties included (ties make the
+*indices* ambiguous, but the sorted value multiset is uniquely determined, so
+comparing sorted values is tie-proof). Two invariants are asserted per case:
+
+1. values == torch.topk(...).values, bit-exact in the input dtype;
+2. self-consistency: values == input gathered at the returned indices (tie-proof,
+   catches index corruption independently of golden agreement).
+
+Tile padding is poisoned with a value that would win the selection if the kernel
+ever read it (padding must never enter the top-k window).
+"""
+
+import pytest
+
+pytestmark = pytest.mark.use_module_device
+
+import torch
+from loguru import logger
+
+import ttnn
+from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_topk
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _topk_input(distribution: str, shape, seed: int) -> torch.Tensor:
+    """FP32 test input. Distributions target selection edge regimes."""
+    torch.manual_seed(seed)
+    if distribution == "normal":
+        return torch.randn(shape, dtype=torch.float32)
+    if distribution == "all_negative":  # padding-sentinel probe: any leaked pad value wins largest=True
+        return -1.0 - torch.rand(shape, dtype=torch.float32)
+    if distribution == "wide_uniform":
+        return torch.empty(shape, dtype=torch.float32).uniform_(-1e3, 1e3)
+    raise ValueError(f"unknown distribution {distribution}")
+
+
+def _run_case(device, x, ttnn_dtype, dim, k, largest):
+    """Run ttnn.topk (twice, via the determinism wrapper) with poisoned tile padding."""
+    tt_input = ttnn.from_torch(x, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    # Poison padding with a value that wins largest=True selections (and its negation
+    # loses smallest=False ones): if the kernel window ever covers padding, values
+    # diverge from the golden and the assert below names it.
+    ttnn.fill_implicit_tile_padding(tt_input, 1.0e4 if largest else -1.0e4)
+    tt_values, tt_indices = ttnn_topk(tt_input, k, dim=dim, largest=largest, sorted=True)
+    return ttnn.to_torch(tt_values), ttnn.to_torch(tt_indices)
+
+
+def _assert_values_exact(x_quantized, torch_dtype, dim, k, largest, values, indices, spec):
+    """The two invariants from the module docstring."""
+    golden_values = torch.topk(x_quantized.float(), k, dim=dim, largest=largest, sorted=True).values.to(torch_dtype)
+    values = values.to(torch_dtype)
+    exact = torch.equal(values, golden_values)
+    # Self-consistency: gather the input at the returned indices along `dim`.
+    gathered = torch.gather(x_quantized, dim, indices.to(torch.int64))
+    consistent = torch.equal(values, gathered.to(torch_dtype))
+    logger.info(
+        f"ttnn.topk values | {spec} | exact={'ok' if exact else 'FAIL'} gather={'ok' if consistent else 'FAIL'}"
+    )
+    if not exact:
+        diff = (values.float() - golden_values.float()).abs()
+        logger.info(f"  max |value - golden| = {diff.max().item():.6g} at flat {diff.argmax().item()}")
+    assert consistent, f"[{spec}] returned values do not match the input gathered at the returned indices"
+    assert exact, f"[{spec}] sorted top-k values are not bit-exact vs torch"
+
+
+# ---------------------------------------------------------------------------
+# Last-dim cases: single-core (W=64/256) and multi-core (W=8192) windows,
+# k below / straddling / at the tile boundary (k=50 exercises pad+slice).
+# ---------------------------------------------------------------------------
+
+_LAST_DIM_CASES = [
+    # (shape, k, id)
+    ((1, 1, 32, 64), 32, "W64-k32"),
+    ((1, 1, 32, 64), 50, "W64-k50-padslice"),
+    ((1, 1, 32, 64), 64, "W64-k64"),
+    ((1, 1, 64, 256), 32, "W256-k32"),
+    ((1, 1, 64, 8192), 32, "W8192-k32-multicore"),
+]
+
+
+@pytest.mark.parametrize("shape, k, desc", _LAST_DIM_CASES, ids=[c[2] for c in _LAST_DIM_CASES])
+@pytest.mark.parametrize("distribution", ["normal", "all_negative"])
+@pytest.mark.parametrize("largest", [True, False], ids=["largest", "smallest"])
+@pytest.mark.parametrize(
+    "ttnn_dtype, torch_dtype", [(ttnn.bfloat16, torch.bfloat16), (ttnn.float32, torch.float32)], ids=["bf16", "fp32"]
+)
+def test_topk_values_last_dim(device, shape, k, desc, distribution, largest, ttnn_dtype, torch_dtype):
+    """Sorted top-k values along -1 must be bit-exact vs torch and self-consistent with indices."""
+    x = _topk_input(distribution, shape, seed=42).to(torch_dtype)
+    values, indices = _run_case(device, x, ttnn_dtype, dim=-1, k=k, largest=largest)
+    spec = f"{desc} {distribution} dim=-1 largest={largest} dtype={torch_dtype}"
+    _assert_values_exact(x, torch_dtype, -1, k, largest, values, indices, spec)
+
+
+# ---------------------------------------------------------------------------
+# Non-last-dim (transpose front-end path) and non-tile-aligned rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("largest", [True, False], ids=["largest", "smallest"])
+def test_topk_values_non_last_dim(device, largest):
+    """dim=1 routes through the front-end transpose wrapper; value exactness must survive it."""
+    shape, k = (1, 64, 32, 64), 32
+    x = _topk_input("normal", shape, seed=7).to(torch.bfloat16)
+    values, indices = _run_case(device, x, ttnn.bfloat16, dim=1, k=k, largest=largest)
+    spec = f"C64-k32 normal dim=1 largest={largest} dtype=bf16"
+    _assert_values_exact(x, torch.bfloat16, 1, k, largest, values, indices, spec)
+
+
+@pytest.mark.parametrize("largest", [True, False], ids=["largest", "smallest"])
+def test_topk_values_padded_rows(device, largest):
+    """Non-tile-aligned H (30 rows): the padded rows are sliced away and must not
+    perturb the 30 real rows' selections (padding is poisoned to win if read)."""
+    shape, k = (1, 1, 30, 64), 32
+    x = _topk_input("wide_uniform", shape, seed=11).to(torch.bfloat16)
+    values, indices = _run_case(device, x, ttnn.bfloat16, dim=-1, k=k, largest=largest)
+    spec = f"H30-k32 wide_uniform dim=-1 largest={largest} dtype=bf16"
+    _assert_values_exact(x, torch.bfloat16, -1, k, largest, values, indices, spec)


### PR DESCRIPTION
### Ticket

#51180 (nightly recharter, Phase 3 of the reduction CI-grid redesign). Completes the characterization item alongside #53358 (nightly restructure — independent, purely additive files) and follows the merged #53547 (merge-gate smoke) and the mean precedent #33740.

### Problem description

Only `ttnn.mean` has bounded-error characterization in nightly (`test_mean_ulp.py`). For every other reduction, numeric regressions hide inside PCC 0.95–0.999 tolerances: a sum kernel that silently loses hundreds of ULP still passes every existing test. The nightly tier's charter (per the CI-grid analysis) is exactly this: ULP/exactness characterization that pins today's measured accuracy so kernel changes that degrade it fail loudly.

### What's changed

Three new nightly suites in `tests/ttnn/nightly/unit_tests/operations/reduction/`, all following the `test_mean_ulp.py` template (scoped docstring, named failure-mode distributions, observed-peak×~4 thresholds with rationale comments, `measure_ulp_with_near_zero_atol`, poisoned tile padding, module-scoped device, determinism wrappers):

**`test_sum_ulp.py`** — BF16 sweep over the mean-suite shape grid (both `fp32_dest_acc_en` modes), FP32 sweep, FP64-golden deep-accumulation tracking (up to 1M elements), and a power-of-two `scalar=` bit-exactness check. `keepdim` is fixed (the mean suite already regression-tracks that plumbing); a sum-specific `offset_uniform` distribution keeps |sum| away from zero so ULP stays meaningful, while `normal` deliberately exercises the near-zero cancellation regime.

**`test_std_var_ulp.py`** — BF16 + FP32 sweeps over ops × correction × dtype-aware offset distributions, plus a zero-variance bit-exactness check (std/var of a constant tensor must be exactly 0.0). The `offset` distributions are the Welford acid test: two-pass E[x²]−E[x]² at offset 1e4 cancels ~8 significant digits; the thresholds on them pin the Welford guarantee.

**`test_topk_values.py`** — topk is a selection, not an accumulation, so its sorted value sequence must be **bit-exact** vs torch (tie-proof: ties only make indices ambiguous, never the sorted value multiset). Asserts exact values plus gather self-consistency (`values == input[indices]`, catching index corruption of the #53453 class independently), across single-core/multi-core widths, k below/straddling/at the tile boundary (pad+slice), largest/smallest, bf16/fp32, the transpose front-end (dim=1), non-tile-aligned rows, and an all-negative distribution with padding poisoned to win any leaked selection.

### What the first characterization measured (BH p100a, baked into thresholds)

- **Welford is the story**: std/var BF16 peaks at **0–1 ULP** across the whole grid — Welford's running mean keeps accumulated quantities at O(1) magnitude, so bf16 accumulation costs almost nothing. Contrast raw bf16 sum accumulation: **618 ULP** peak on the same depth class (identical to the mean suite's documented peak, as expected — same accumulator, no divide).
- **Welford's offset guarantee, quantified**: fp32 std/var at offset 1e4 holds ~1.4e4 ULP ≈ one tf32 rounding of relative error, where two-pass would return garbage.
- **The tf32 floor, quantified**: `ttnn.sum` has no accurate-SFPU flag (unlike mean/max), so fp32 sum runs on the FPU with tf32 operand quantization — one tf32 rounding ≈ 2¹² fp32 ULP, observed peak 3.5e5 on a 128k-element reduction. Likewise std/var's `tiny_variance` case (σ ≈ 3e-3 on mean 1e4) collapses to 5.5e6 ULP because σ < mean·2⁻¹¹ is invisible to tf32. Both caps pin the floor explicitly; **a natural follow-up is extending `fast_and_approximate_mode` (mean's accurate-SFPU flag) to sum and std/var**, which would collapse these thresholds by ~3 orders of magnitude.
- **topk values are bit-exact everywhere tested**, including the multi-core W=8192 factory, fp32 inputs, k=50 pad+slice, and poisoned padding.

### Cost

Nightly only (`tt-metal-l2-nightly`, reduction group). 405 new cases, **6 s** wall on BH p100a with a warm JIT cache (**3:22** cold — the cost is almost entirely one-time kernel compilation) — funded several times over by the −2,216 collected-case reduction already in #53358, no `time_budget.yaml` change. Threshold maintenance follows the template convention: named constants + observed-peak rationale, re-baselined only on legitimate kernel changes.

### Checklist

- [x] All 405 cases pass locally on Blackhole p100a (thresholds calibrated from a measured logging-first pass, then re-run green)
- [ ] Nightly (`tt-metal-l2-nightly`) green
- [x] New/Existing tests provide coverage for changes

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/reduction-nightly-ulp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/reduction-nightly-ulp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/reduction-nightly-ulp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/reduction-nightly-ulp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/reduction-nightly-ulp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/reduction-nightly-ulp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/reduction-nightly-ulp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/reduction-nightly-ulp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/reduction-nightly-ulp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/reduction-nightly-ulp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/reduction-nightly-ulp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/reduction-nightly-ulp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/reduction-nightly-ulp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/reduction-nightly-ulp)