### PR TITLE
Add offline FSD → PSD builder (physical_descriptor_builder) from FM

### DIFF
--- a/tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh
+++ b/tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh
@@ -295,6 +295,7 @@ run_test ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Topol
 run_test ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologySatEncoderTest.*"
 run_test ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="TopologyMapperUtilsTest.*"
 run_test ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="PhysicalGroupingDescriptorTests*"
+run_test ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="PhysicalDescriptorBuilder.*"
 
 fi # unit
 

--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -11,6 +11,9 @@ target_link_libraries(
     fabric_unit_tests
     PRIVATE
         tt_metal
+        # FSD proto (tt::scaleout_tools::fsd::proto) constructed directly by test_physical_descriptor_builder.cpp;
+        # those symbols are hidden in libtt_metal.so (see tools/scaleout/CMakeLists.txt), so link explicitly.
+        TT::ScaleoutTools
         test_common_libs
         yaml-cpp::yaml-cpp
         protobuf::libprotobuf
@@ -24,6 +27,18 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}/tests
         ${PROJECT_SOURCE_DIR}/tt_metal
         ${CMAKE_CURRENT_SOURCE_DIR}/common
+    SYSTEM
+    PRIVATE
+        # physical_descriptor_builder test includes the generated FSD + PSD proto headers
+        ${Metalium_BINARY_DIR}/tools/scaleout # protobuf/factory_system_descriptor.pb.h
+        "$<TARGET_PROPERTY:fabric,BINARY_DIR>" # protobuf/physical_system_descriptor.pb.h
+)
+
+# The physical_descriptor_builder test includes generated FSD/PSD proto headers.
+add_dependencies(
+    fabric_unit_tests
+    scaleout_generated_protos
+    fabric_generated_protos
 )
 
 set_target_properties(

--- a/tests/tt_metal/tt_fabric/fabric_router/test_physical_descriptor_builder.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_physical_descriptor_builder.cpp
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the offline FSD -> PSD builder (physical_descriptor_builder).
+// Ported/adapted from tenstorrent/tt-fabric-manager tests/unit/topology_mapper_test.cpp (FSD cases).
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <google/protobuf/text_format.h>
+
+#include <tt-metalium/experimental/fabric/physical_descriptor_builder.hpp>
+#include "protobuf/factory_system_descriptor.pb.h"
+#include "protobuf/physical_system_descriptor.pb.h"
+
+namespace tt::tt_metal::experimental::tt_fabric {
+namespace {
+
+using FSD = ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor;
+
+// Two hosts (hostA, hostB), one tray each, board type N300. One intra-host link on hostA (asic0<->asic1) and
+// one cross-host link (hostA asic1 <-> hostB asic0).
+FSD make_two_host_fsd() {
+    FSD fsd;
+
+    auto* h0 = fsd.add_hosts();
+    h0->set_hostname("hostA");
+    h0->set_motherboard("moboA");
+    auto* h1 = fsd.add_hosts();
+    h1->set_hostname("hostB");
+    h1->set_motherboard("moboB");
+
+    auto* bt = fsd.mutable_board_types();
+    for (uint32_t host_id = 0; host_id < 2; ++host_id) {
+        auto* loc = bt->add_board_locations();
+        loc->set_host_id(host_id);
+        loc->set_tray_id(0);
+        loc->set_board_type("N300");
+    }
+
+    auto add_conn = [&](uint32_t ha, uint32_t aa, uint32_t ca, uint32_t hb, uint32_t ab, uint32_t cb) {
+        auto* c = fsd.mutable_eth_connections()->add_connection();
+        auto* a = c->mutable_endpoint_a();
+        a->set_host_id(ha);
+        a->set_tray_id(0);
+        a->set_asic_location(aa);
+        a->set_chan_id(ca);
+        auto* b = c->mutable_endpoint_b();
+        b->set_host_id(hb);
+        b->set_tray_id(0);
+        b->set_asic_location(ab);
+        b->set_chan_id(cb);
+    };
+    add_conn(0, 0, 0, 0, 1, 0);  // intra-host on hostA
+    add_conn(0, 1, 1, 1, 0, 1);  // cross-host hostA<->hostB
+    return fsd;
+}
+
+TEST(PhysicalDescriptorBuilder, EnumeratesAsicsAndRanks) {
+    auto psd = build_physical_descriptor(make_two_host_fsd());
+
+    // 3 ASICs from the union of endpoints: (0,0,0), (0,0,1), (1,0,0).
+    EXPECT_EQ(psd.asic_descriptors_size(), 3);
+
+    // host_to_rank: hostA -> 0, hostB -> 1.
+    std::map<std::string, uint32_t> rank;
+    for (const auto& r : psd.host_to_rank()) {
+        rank[r.host_name()] = r.rank();
+    }
+    EXPECT_EQ(rank["hostA"], 0u);
+    EXPECT_EQ(rank["hostB"], 1u);
+
+    // Every ASIC descriptor carries a non-zero synthesized unique_id and a board type.
+    for (const auto& m : psd.asic_descriptors()) {
+        EXPECT_NE(m.asic_id(), 0u);
+        EXPECT_EQ(m.asic_descriptor().unique_id(), m.asic_id());
+        EXPECT_FALSE(m.asic_descriptor().host_name().empty());
+    }
+}
+
+TEST(PhysicalDescriptorBuilder, EdgesAreBidirectionalAndLocalFlagged) {
+    auto psd = build_physical_descriptor(make_two_host_fsd());
+    ASSERT_TRUE(psd.has_system_graph());
+
+    // Count edges and how many are marked local, per host, across the asic_connectivity_graph.
+    int total_eth = 0, local_eth = 0;
+    for (const auto& host : psd.system_graph().asic_connectivity_graph()) {
+        for (const auto& asic : host.asic_topologies()) {
+            for (const auto& edge : asic.topology().asic_connections()) {
+                for (const auto& eth : edge.eth_connections()) {
+                    ++total_eth;
+                    if (eth.is_local()) {
+                        ++local_eth;
+                    }
+                }
+            }
+        }
+    }
+    // Each connection is emitted in both directions => 2 connections * 2 directions = 4 directed eth entries.
+    EXPECT_EQ(total_eth, 4);
+    // The intra-host connection (both directions) is local; the cross-host one is not.
+    EXPECT_EQ(local_eth, 2);
+
+    // The cross-host link populates the exit_node_connection_table for both hosts.
+    std::map<std::string, int> exit_counts;
+    for (const auto& table : psd.exit_node_connection_table()) {
+        exit_counts[table.host_name()] = table.exit_connections_size();
+    }
+    EXPECT_EQ(exit_counts["hostA"], 1);
+    EXPECT_EQ(exit_counts["hostB"], 1);
+}
+
+TEST(PhysicalDescriptorBuilder, ConnectedComponentsSplit) {
+    // Connected (cross-host link present) => one PSD.
+    EXPECT_EQ(build_physical_descriptors(make_two_host_fsd()).size(), 1u);
+
+    // Remove the cross-host link => two independent single-host components => two PSDs.
+    FSD fsd = make_two_host_fsd();
+    fsd.mutable_eth_connections()->mutable_connection()->RemoveLast();  // drop the cross-host connection
+    // hostB now has no eth_connections; it still forms its own group.
+    auto psds = build_physical_descriptors(fsd);
+    EXPECT_EQ(psds.size(), 2u);
+}
+
+TEST(PhysicalDescriptorBuilder, ThrowsOnOutOfRangeHostId) {
+    FSD fsd = make_two_host_fsd();
+    // Point an endpoint at a non-existent host_id.
+    fsd.mutable_eth_connections()->mutable_connection(0)->mutable_endpoint_b()->set_host_id(99);
+    EXPECT_THROW(build_physical_descriptor(fsd), std::runtime_error);
+}
+
+TEST(PhysicalDescriptorBuilder, AcceptsUbbWormholeBoardTypeAlias) {
+    // UBB_WORMHOLE is a compile-time alias of UBB (same enum value). It must be accepted (and its lowercase
+    // form) for backward compatibility with Fabric Manager FSDs, mapping to the same value as "UBB".
+    auto first_asic_board_type = [](const std::string& board_type_str) {
+        FSD fsd = make_two_host_fsd();
+        for (auto& loc : *fsd.mutable_board_types()->mutable_board_locations()) {
+            loc.set_board_type(board_type_str);
+        }
+        auto psd = build_physical_descriptor(fsd);
+        return psd.asic_descriptors(0).asic_descriptor().board_type();
+    };
+
+    uint32_t ubb = 0;
+    EXPECT_NO_THROW(ubb = first_asic_board_type("UBB"));
+    EXPECT_EQ(first_asic_board_type("UBB_WORMHOLE"), ubb);
+    EXPECT_EQ(first_asic_board_type("ubb_wormhole"), ubb);
+}
+
+TEST(PhysicalDescriptorBuilder, ThrowsOnDuplicateHostname) {
+    // The PSD keys ranks / motherboards / graph entries by hostname, so duplicate hostnames would silently
+    // collapse hosts together. The builder must reject them.
+    FSD fsd = make_two_host_fsd();
+    fsd.mutable_hosts(1)->set_hostname(fsd.hosts(0).hostname());  // make hostB a duplicate of hostA
+    EXPECT_THROW(build_physical_descriptor(fsd), std::runtime_error);
+}
+
+TEST(PhysicalDescriptorBuilder, LoadThrowsOnMissingFile) {
+    EXPECT_THROW(load_factory_descriptor("/nonexistent/path/to/fsd.textproto"), std::runtime_error);
+}
+
+// Exercises the packaged consumer path: parse an FSD textproto file -> proto conversion -> C++
+// PhysicalSystemDescriptor.
+TEST(PhysicalDescriptorBuilder, BuildFromFileReturnsCppDescriptor) {
+    const FSD fsd = make_two_host_fsd();
+    std::string text;
+    ASSERT_TRUE(google::protobuf::TextFormat::PrintToString(fsd, &text));
+    const auto path = std::filesystem::temp_directory_path() / "pdb_build_from_file_test.textproto";
+    {
+        std::ofstream out(path);
+        out << text;
+    }
+
+    auto psd = build_physical_descriptor_from_file(path.string());
+    EXPECT_EQ(psd.get_all_hostnames().size(), 2u);     // hostA + hostB, both wired via the cross-host link
+    EXPECT_EQ(psd.get_asic_descriptors().size(), 3u);  // (0,0,0), (0,0,1), (1,0,0)
+    EXPECT_EQ(psd.get_rank_for_hostname("hostA"), 0u);
+    EXPECT_EQ(psd.get_rank_for_hostname("hostB"), 1u);
+
+    std::filesystem::remove(path);
+}
+
+TEST(PhysicalDescriptorBuilder, FilterFactoryDescriptorRestrictsHosts) {
+    // Carve hostA out of the two-host FSD. Its intra-host link survives; the cross-host link (to hostB) is dropped.
+    const FSD filtered = filter_factory_descriptor(make_two_host_fsd(), {"hostA"});
+    ASSERT_EQ(filtered.hosts_size(), 1);
+    EXPECT_EQ(filtered.hosts(0).hostname(), "hostA");
+
+    auto psd = build_physical_descriptor(filtered);
+    EXPECT_EQ(psd.host_to_rank_size(), 1);
+    EXPECT_EQ(psd.asic_descriptors_size(), 2);  // hostA's (0,0,0) and (0,0,1); hostB's ASIC is gone
+
+    // Empty filter is a no-op (full copy).
+    EXPECT_EQ(filter_factory_descriptor(make_two_host_fsd(), {}).hosts_size(), 2);
+}
+
+TEST(PhysicalDescriptorBuilder, FilterFactoryDescriptorThrowsOnUnknownHost) {
+    EXPECT_THROW(filter_factory_descriptor(make_two_host_fsd(), {"does-not-exist"}), std::runtime_error);
+}
+
+TEST(PhysicalDescriptorBuilder, ThrowsOnLocalLinkWithInvalidHostId) {
+    // A connection whose endpoints share an out-of-range host_id (99 -> 99) must be reported, not silently
+    // treated as a same-host link and dropped, when partitioning for build_physical_descriptors().
+    FSD fsd = make_two_host_fsd();
+    auto* c = fsd.mutable_eth_connections()->add_connection();
+    c->mutable_endpoint_a()->set_host_id(99);
+    c->mutable_endpoint_b()->set_host_id(99);
+    EXPECT_THROW(build_physical_descriptors(fsd), std::runtime_error);
+}
+
+TEST(PhysicalDescriptorBuilder, SingleHostEmitsHostConnectivityEntry) {
+    // A single-host descriptor (no inter-host links) must still emit a host_connectivity_graph entry, matching
+    // the runtime discovery path, so PhysicalSystemDescriptor::get_host_neighbors() returns an empty list
+    // instead of failing its contains() check.
+    FSD fsd;
+    auto* h = fsd.add_hosts();
+    h->set_hostname("solo");
+    h->set_motherboard("mobo");
+    auto* loc = fsd.mutable_board_types()->add_board_locations();
+    loc->set_host_id(0);
+    loc->set_tray_id(0);
+    loc->set_board_type("N300");
+    auto* c = fsd.mutable_eth_connections()->add_connection();  // one intra-host link so the host has ASICs
+    c->mutable_endpoint_a()->set_host_id(0);
+    c->mutable_endpoint_a()->set_tray_id(0);
+    c->mutable_endpoint_a()->set_asic_location(0);
+    c->mutable_endpoint_b()->set_host_id(0);
+    c->mutable_endpoint_b()->set_tray_id(0);
+    c->mutable_endpoint_b()->set_asic_location(1);
+
+    const auto psd_proto = build_physical_descriptor(fsd);
+    ASSERT_TRUE(psd_proto.has_system_graph());
+    bool found = false;
+    for (const auto& hc : psd_proto.system_graph().host_connectivity_graph()) {
+        if (hc.src_host_name() == "solo") {
+            found = true;
+            EXPECT_EQ(hc.host_connections_size(), 0);
+        }
+    }
+    EXPECT_TRUE(found) << "no host_connectivity_graph entry for the single host";
+
+    // The C++ wrapper returns an empty neighbor list rather than asserting.
+    ::tt::tt_metal::PhysicalSystemDescriptor psd(psd_proto);
+    EXPECT_TRUE(psd.get_host_neighbors("solo").empty());
+}
+
+// Path to a small real FSD already checked into the repo (4-host quietbox, ~12 KB) so we don't add a large fixture.
+std::string quietbox_fsd_path() {
+    const char* home = std::getenv("TT_METAL_HOME");
+    return std::string(home != nullptr ? home : ".") +
+           "/tests/scale_out/4x_bh_quietbox/factory_system_descriptors/"
+           "factory_system_descriptor_4x_bh_quietbox.textproto";
+}
+
+// Integration: build a PSD from a real (small, in-repo) FSD end-to-end and sanity-check hosts, ASIC nodes,
+// host<->rank, and connectivity.
+TEST(PhysicalDescriptorBuilder, IntegrationBuildFromQuietboxFsd) {
+    ASSERT_NE(std::getenv("TT_METAL_HOME"), nullptr) << "TT_METAL_HOME must be set";
+    const std::string fsd_path = quietbox_fsd_path();
+    ASSERT_TRUE(std::filesystem::exists(fsd_path)) << "fixture missing: " << fsd_path;
+
+    // FSD -> PSD via the proto-free entry point (returns the C++ PhysicalSystemDescriptor).
+    auto psd = build_physical_descriptor_from_file(fsd_path);
+
+    const auto hostnames = psd.get_all_hostnames();
+    EXPECT_EQ(hostnames.size(), 4u);  // 4-host quietbox
+
+    const auto& asics = psd.get_asic_descriptors();
+    EXPECT_GT(asics.size(), 0u);
+
+    std::cout << "[quietbox] hosts=" << hostnames.size() << ", total ASIC nodes=" << asics.size() << "\n";
+    for (const auto& host : hostnames) {
+        std::cout << "[quietbox]   " << host << "  asics=" << psd.get_asics_connected_to_host(host).size() << "\n";
+    }
+
+    // Host <-> rank is a bijection, and every host owns at least one ASIC.
+    std::set<uint32_t> ranks;
+    for (const auto& host : hostnames) {
+        const uint32_t rank = psd.get_rank_for_hostname(host);
+        EXPECT_EQ(psd.get_hostname_for_rank(rank), host);
+        ranks.insert(rank);
+        EXPECT_GT(psd.get_asics_connected_to_host(host).size(), 0u) << "host: " << host;
+    }
+    EXPECT_EQ(ranks.size(), hostnames.size());
+
+    // Connectivity: every ASIC is wired into the topology.
+    size_t asics_with_neighbors = 0;
+    for (const auto& [asic_id, _] : asics) {
+        if (!psd.get_asic_neighbors(asic_id).empty()) {
+            ++asics_with_neighbors;
+        }
+    }
+    std::cout << "[quietbox] ASICs with >=1 neighbor: " << asics_with_neighbors << "/" << asics.size() << "\n";
+    EXPECT_EQ(asics_with_neighbors, asics.size());
+}
+
+// Host filter carves a subset of hosts out of an FSD before building.
+TEST(PhysicalDescriptorBuilder, IntegrationHostFilterRestrictsToSubset) {
+    ASSERT_NE(std::getenv("TT_METAL_HOME"), nullptr) << "TT_METAL_HOME must be set";
+    const std::string fsd_path = quietbox_fsd_path();
+    ASSERT_TRUE(std::filesystem::exists(fsd_path)) << "fixture missing: " << fsd_path;
+
+    // No filter == whole FSD.
+    EXPECT_EQ(build_physical_descriptor_from_file(fsd_path).get_all_hostnames().size(), 4u);
+
+    // Filter to a strict subset: result hosts are a non-empty subset of the requested set.
+    const std::vector<std::string> subset = {"sjc1-tt-qb-01", "sjc1-tt-qb-02"};
+    auto psd = build_physical_descriptor_from_file(fsd_path, subset);
+    const auto hostnames = psd.get_all_hostnames();
+    EXPECT_GT(hostnames.size(), 0u);
+    EXPECT_LE(hostnames.size(), subset.size());
+    const std::set<std::string> allowed(subset.begin(), subset.end());
+    for (const auto& host : hostnames) {
+        EXPECT_TRUE(allowed.contains(host)) << "unexpected host after filter: " << host;
+    }
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental::tt_fabric

--- a/tests/tt_metal/tt_fabric/sources.cmake
+++ b/tests/tt_metal/tt_fabric/sources.cmake
@@ -36,6 +36,7 @@ set(UNIT_TESTS_FABRIC_SRC
     fabric_data_movement/test_basic_fabric_mux.cpp
     fabric_data_movement/test_basic_fabric_mux_v2.cpp
     fabric_data_movement/test_fabric_traffic_generator_kernel.cpp
+    fabric_router/test_physical_descriptor_builder.cpp
 )
 
 set(UNIT_TESTS_PHYSICAL_DISCOVERY_SRC physical_discovery/test_physical_system_descriptor.cpp)

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_descriptor_builder.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_descriptor_builder.hpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// physical_descriptor_builder.hpp - Offline FactorySystemDescriptor (FSD) -> PhysicalSystemDescriptor (PSD) conversion.
+//
+// These free functions build a `tt::fabric::proto::PhysicalSystemDescriptor` purely from a
+// `tt::scaleout_tools::fsd::proto::FactorySystemDescriptor` (the desired/as-built topology). They perform
+// NO hardware/UMD discovery and do not depend on the tt-metal runtime — the intent (see
+// https://github.com/tenstorrent/tt-metal/issues/52859) is that tooling such as tt-run / generate_rank_bindings
+// can map against a known-good FSD instead of a live-discovered PSD.
+//
+// Ported from tenstorrent/tt-fabric-manager `controller/physical_system_descriptor_builder.cpp` (the FSD
+// overloads only; the HostPhysicalTopologies / hybrid overloads stay in Fabric Manager as they depend on
+// FM's runtime-discovery types). The produced PSD proto is the exact type consumed by tt-metal's
+// `tt::tt_metal::PhysicalSystemDescriptor(const tt::fabric::proto::PhysicalSystemDescriptor&)` bridge and the
+// topology mapper.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>  // tt::tt_metal::PhysicalSystemDescriptor
+
+// The generated proto headers are private (not part of the installed public API), so they are not included here.
+// The types below are only named by reference / returned by value, so forward declarations suffice; callers that
+// consume the returned proto must include the generated headers themselves (the .cpp does).
+namespace tt::scaleout_tools::fsd::proto {
+class FactorySystemDescriptor;
+}  // namespace tt::scaleout_tools::fsd::proto
+namespace tt::fabric::proto {
+class PhysicalSystemDescriptor;
+}  // namespace tt::fabric::proto
+
+// Experimental API — under tt-metalium/experimental, so it lives in the experimental namespace.
+namespace tt::tt_metal::experimental::tt_fabric {
+
+// Convenience, proto-free entry point: parse an FSD textproto file and return the ready-to-use C++
+// PhysicalSystemDescriptor. Consumers with only a file path (e.g. tt-run / generate_rank_bindings) can use this
+// and need no protobuf headers on their include path.
+//
+// host_filter (optional): restrict the descriptor to these hostnames before building. In the wild an FSD often
+// covers a whole superpod (e.g. SC36) or an aggregated datacenter (exabox), so a consumer wanting a single pod
+// passes just that pod's hostnames. Empty = no filter (use the whole FSD). Throws if a requested hostname is
+// absent from the FSD.
+::tt::tt_metal::PhysicalSystemDescriptor build_physical_descriptor_from_file(
+    const std::string& fsd_path, const std::vector<std::string>& host_filter = {});
+
+// Parse a Factory System Descriptor textproto file from disk.
+// Throws std::runtime_error if the file cannot be read or parsed.
+::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor load_factory_descriptor(const std::string& path);
+
+// Restrict an FSD to a subset of hosts by hostname, densely renumbering host_ids and filtering board_types /
+// eth_connections to match (connections touching a filtered-out host are dropped). Useful for carving a single
+// pod out of a superpod/datacenter FSD before building. Empty hostnames returns the FSD unchanged; throws if a
+// requested hostname is not present.
+::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor filter_factory_descriptor(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& fsd, const std::vector<std::string>& hostnames);
+
+// Build a PhysicalSystemDescriptor proto from a FactorySystemDescriptor (desired-state), fully offline.
+//
+// Only the fields the topology mapper needs are populated:
+//   - asic_descriptors: tray_id, asic_location, board_type, host_name, and a synthesized unique_id stable
+//     across runs (keyed by host_id/tray_id/asic_location).
+//   - system_graph.asic_connectivity_graph: bidirectional edges from eth_connections, with is_local derived
+//     from whether the two endpoints share a host_id.
+//   - system_graph.host_connectivity_graph + exit_node_connection_table: inter-host connections.
+//   - host_to_mobo_name: from FSD Host.motherboard.
+//   - host_to_rank: assigned as the FSD host index (hosts[i] -> rank i).
+// Runtime-only fields (ethernet_firmware_version, pcie_devices_per_tray, pcie_id_to_asic_location,
+// target_device_type, umd_unique_id) are left unset.
+//
+// The ASIC set is the union of endpoints in eth_connections; ASICs declared in board_types but with zero
+// eth_connections do not appear (the mapper has no edges to place on them).
+//
+// Throws std::runtime_error if an eth_connection endpoint references a host_id outside the hosts[] array, or
+// if a referenced (host_id, tray_id) has no matching entry in board_types.
+::tt::fabric::proto::PhysicalSystemDescriptor build_physical_descriptor(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& fsd);
+
+// Build one PhysicalSystemDescriptor per connected component of FSD hosts.
+//
+// Hosts are partitioned into disjoint connected components (two hosts are connected when an eth_connection
+// has its endpoints on different hosts, directly or transitively). Each returned PSD covers exactly one
+// component: a sub-FSD restricted to that component (with host_ids densely renumbered) is fed through
+// build_physical_descriptor above, so each descriptor is self-consistent and its host_to_rank is 0-based within the
+// group. Components are ordered deterministically by their group's lowest member host name.
+std::vector<::tt::fabric::proto::PhysicalSystemDescriptor> build_physical_descriptors(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& fsd);
+
+}  // namespace tt::tt_metal::experimental::tt_fabric

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -68,7 +68,13 @@ set_source_files_properties(
 target_sources(fabric PRIVATE ${GENERATED_PROTO_SRCS})
 
 target_include_directories(fabric PRIVATE .)
-target_include_directories(fabric SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(
+    fabric
+    SYSTEM
+    PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${Metalium_BINARY_DIR}/tools/scaleout # FSD proto header for physical_descriptor_builder.cpp
+)
 
 target_link_libraries(
     fabric

--- a/tt_metal/fabric/physical_descriptor_builder.cpp
+++ b/tt_metal/fabric/physical_descriptor_builder.cpp
@@ -1,0 +1,460 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// physical_descriptor_builder.cpp - Implementation of the offline FSD -> PSD builder.
+//
+// Ported from tenstorrent/tt-fabric-manager controller/physical_system_descriptor_builder.cpp (FSD overloads).
+// Notable tt-metal adaptations vs. the Fabric Manager original:
+//   - board_type string -> enum uses tt::scaleout_tools::get_board_type_from_string (the canonical board
+//     library) instead of a hand-maintained table, so it stays in sync with tt::BoardType automatically.
+//   - logging uses tt::LogFabric (Fabric Manager used its own tt::LogFabricManager category).
+
+#include <tt-metalium/experimental/fabric/physical_descriptor_builder.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <google/protobuf/text_format.h>
+#include <tt-logger/tt-logger.hpp>
+#include <umd/device/types/cluster_descriptor_types.hpp>
+
+#include <protobuf/factory_system_descriptor.pb.h>   // tt::scaleout_tools::fsd::proto (from scaleout_tools)
+#include <protobuf/physical_system_descriptor.pb.h>  // tt::fabric::proto (compiled into this lib)
+#include "board/board.hpp"                           // tt::scaleout_tools::get_board_type_from_string
+
+namespace tt::tt_metal::experimental::tt_fabric {
+
+using ::tt::scaleout_tools::get_board_type_from_string;  // canonical board-type lookup (board/board.hpp)
+
+namespace {
+
+// FSD board_type string -> the uint32 the PSD proto stores (the raw tt::BoardType enum value). Reuses the
+// canonical, reflection-based lookup from the board library so it never drifts from tt::BoardType.
+//
+// UBB_WORMHOLE is a compile-time alias of UBB (same enum value, 9). enchantum reflection (used by
+// get_board_type_from_string) does not surface aliased enumerators, so it would reject "UBB_WORMHOLE" even
+// though tt::BoardType defines it. Fabric Manager's FSDs use that spelling, so normalize it to the canonical
+// "UBB" to preserve backward compatibility.
+uint32_t fsd_board_type_to_psd(const std::string& name) {
+    std::string upper = name;
+    std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c) { return std::toupper(c); });
+    if (upper == "UBB_WORMHOLE") {
+        return static_cast<uint32_t>(get_board_type_from_string("UBB"));
+    }
+    return static_cast<uint32_t>(get_board_type_from_string(name));
+}
+
+// Partition the FSD hosts into connected components via union-find. Two hosts are connected when an
+// eth_connection has its endpoints on different hosts; transitive connectivity chains through unions.
+// Returns one entry per component (member host_ids ascending), components ordered by lowest member host name.
+std::vector<std::vector<uint32_t>> partition_fsd_hosts_by_connectivity(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& fsd) {
+    const int num_hosts = fsd.hosts_size();
+
+    std::vector<size_t> parent(static_cast<size_t>(num_hosts));
+    for (size_t i = 0; i < parent.size(); ++i) {
+        parent[i] = i;
+    }
+    auto find = [&parent](size_t x) {
+        while (parent[x] != x) {
+            parent[x] = parent[parent[x]];
+            x = parent[x];
+        }
+        return x;
+    };
+    auto unite = [&](size_t a, size_t b) {
+        size_t ra = find(a);
+        size_t rb = find(b);
+        if (ra != rb) {
+            parent[ra] = rb;
+        }
+    };
+
+    if (fsd.has_eth_connections()) {
+        for (const auto& conn : fsd.eth_connections().connection()) {
+            const uint32_t a = conn.endpoint_a().host_id();
+            const uint32_t b = conn.endpoint_b().host_id();
+            // Validate endpoint host_ids before the local-link skip, so a malformed connection (e.g. 99 -> 99)
+            // is reported rather than silently dropped as if it were a same-host link.
+            if (a >= static_cast<uint32_t>(num_hosts) || b >= static_cast<uint32_t>(num_hosts)) {
+                throw std::runtime_error(fmt::format(
+                    "FSD eth_connection references host_id {}/{} but only {} hosts are defined", a, b, num_hosts));
+            }
+            if (a == b) {
+                continue;
+            }
+            unite(a, b);
+        }
+    }
+
+    // Collect member host_ids per component, keyed by component root (ascending host_id order).
+    std::map<size_t, std::vector<uint32_t>> components;
+    for (int i = 0; i < num_hosts; ++i) {
+        components[find(static_cast<size_t>(i))].push_back(static_cast<uint32_t>(i));
+    }
+
+    std::vector<std::vector<uint32_t>> ordered;
+    ordered.reserve(components.size());
+    for (auto& [root, members] : components) {
+        ordered.push_back(std::move(members));
+    }
+    // Order groups by their lexicographically lowest member host NAME for deterministic output. (Members are
+    // collected by host index, so the lowest hostname is not necessarily members.front().)
+    auto min_hostname = [&fsd](const std::vector<uint32_t>& members) -> const std::string& {
+        const std::string* best = &fsd.hosts(static_cast<int>(members.front())).hostname();
+        for (uint32_t m : members) {
+            const std::string& n = fsd.hosts(static_cast<int>(m)).hostname();
+            if (n < *best) {
+                best = &n;
+            }
+        }
+        return *best;
+    };
+    std::sort(ordered.begin(), ordered.end(), [&min_hostname](const auto& a, const auto& b) {
+        return min_hostname(a) < min_hostname(b);
+    });
+    return ordered;
+}
+
+// Build a sub-FSD restricted to `member_host_ids` (host indices into `src.hosts()`), with host_ids densely
+// renumbered to 0..N-1 in the order given and board_types/eth_connections filtered and rewritten to match.
+::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor build_sub_fsd(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& src,
+    const std::vector<uint32_t>& member_host_ids) {
+    ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor result;
+
+    std::map<uint32_t, uint32_t> id_map;
+    for (uint32_t new_id = 0; new_id < member_host_ids.size(); ++new_id) {
+        const uint32_t old_id = member_host_ids[new_id];
+        *result.add_hosts() = src.hosts(static_cast<int>(old_id));
+        id_map[old_id] = new_id;
+    }
+
+    if (src.has_board_types()) {
+        for (const auto& loc : src.board_types().board_locations()) {
+            auto it = id_map.find(loc.host_id());
+            if (it == id_map.end()) {
+                continue;
+            }
+            auto* new_loc = result.mutable_board_types()->add_board_locations();
+            *new_loc = loc;
+            new_loc->set_host_id(it->second);
+        }
+    }
+
+    if (src.has_eth_connections()) {
+        for (const auto& conn : src.eth_connections().connection()) {
+            auto it_a = id_map.find(conn.endpoint_a().host_id());
+            auto it_b = id_map.find(conn.endpoint_b().host_id());
+            if (it_a == id_map.end() || it_b == id_map.end()) {
+                continue;
+            }
+            auto* new_conn = result.mutable_eth_connections()->add_connection();
+            *new_conn = conn;
+            new_conn->mutable_endpoint_a()->set_host_id(it_a->second);
+            new_conn->mutable_endpoint_b()->set_host_id(it_b->second);
+        }
+    }
+
+    return result;
+}
+
+}  // namespace
+
+::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor load_factory_descriptor(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        throw std::runtime_error(fmt::format("Unable to open Factory System Descriptor file: {}", path));
+    }
+    std::string text((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor fsd;
+    if (!google::protobuf::TextFormat::ParseFromString(text, &fsd)) {
+        throw std::runtime_error(fmt::format("Failed to parse Factory System Descriptor textproto: {}", path));
+    }
+    return fsd;
+}
+
+::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor filter_factory_descriptor(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& fsd, const std::vector<std::string>& hostnames) {
+    if (hostnames.empty()) {
+        return fsd;  // no filter: return a full copy so callers can use the result uniformly
+    }
+    // Collect the host indices whose hostname is requested (original order), then reuse build_sub_fsd to
+    // densely renumber hosts and filter board_types / eth_connections to that subset.
+    const std::set<std::string> wanted(hostnames.begin(), hostnames.end());
+    std::set<std::string> present;
+    std::vector<uint32_t> member_host_ids;
+    for (int i = 0; i < fsd.hosts_size(); ++i) {
+        const std::string& name = fsd.hosts(i).hostname();
+        if (wanted.contains(name)) {
+            member_host_ids.push_back(static_cast<uint32_t>(i));
+            present.insert(name);
+        }
+    }
+    // Reject requested hostnames that aren't in the FSD (typo / wrong descriptor) rather than silently dropping.
+    if (present.size() != wanted.size()) {
+        std::string missing;
+        for (const auto& h : wanted) {
+            if (!present.contains(h)) {
+                missing += (missing.empty() ? "" : ", ") + h;
+            }
+        }
+        throw std::runtime_error(
+            fmt::format("Host filter references hostnames not present in the Factory System Descriptor: {}", missing));
+    }
+    return build_sub_fsd(fsd, member_host_ids);
+}
+
+::tt::tt_metal::PhysicalSystemDescriptor build_physical_descriptor_from_file(
+    const std::string& fsd_path, const std::vector<std::string>& host_filter) {
+    // parse FSD -> (optional host filter) -> PSD proto -> wrap in the C++ PhysicalSystemDescriptor (no protos leak).
+    auto fsd = load_factory_descriptor(fsd_path);
+    if (!host_filter.empty()) {
+        fsd = filter_factory_descriptor(fsd, host_filter);
+    }
+    return ::tt::tt_metal::PhysicalSystemDescriptor(build_physical_descriptor(fsd));
+}
+
+::tt::fabric::proto::PhysicalSystemDescriptor build_physical_descriptor(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& fsd) {
+    ::tt::fabric::proto::PhysicalSystemDescriptor psd;
+
+    const int num_hosts = fsd.hosts_size();
+    log_info(
+        tt::LogFabric,
+        "Building PhysicalSystemDescriptor from FactorySystemDescriptor for {} hosts, {} board locations, {} "
+        "connections",
+        num_hosts,
+        fsd.has_board_types() ? fsd.board_types().board_locations_size() : 0,
+        fsd.has_eth_connections() ? fsd.eth_connections().connection_size() : 0);
+
+    auto hostname_of = [&](uint32_t host_id) -> const std::string& {
+        if (host_id >= static_cast<uint32_t>(num_hosts)) {
+            throw std::runtime_error(
+                fmt::format("FSD references host_id {} but only {} hosts are defined", host_id, num_hosts));
+        }
+        return fsd.hosts(static_cast<int>(host_id)).hostname();
+    };
+
+    // Build (host_id, tray_id) -> board_type uint32 lookup.
+    std::map<std::pair<uint32_t, uint32_t>, uint32_t> host_tray_to_board_type;
+    if (fsd.has_board_types()) {
+        for (const auto& loc : fsd.board_types().board_locations()) {
+            host_tray_to_board_type[{loc.host_id(), loc.tray_id()}] = fsd_board_type_to_psd(loc.board_type());
+        }
+    }
+
+    // Enumerate ASICs from the union of eth_connections endpoints. ASICs that appear in board_types but have
+    // zero eth connections are intentionally skipped; the topology mapper has no edges to place on them.
+    using AsicKey = std::tuple<uint32_t, uint32_t, uint32_t>;  // (host_id, tray_id, asic_location)
+    std::set<AsicKey> asic_keys;
+    if (fsd.has_eth_connections()) {
+        for (const auto& conn : fsd.eth_connections().connection()) {
+            const auto& a = conn.endpoint_a();
+            const auto& b = conn.endpoint_b();
+            asic_keys.emplace(a.host_id(), a.tray_id(), a.asic_location());
+            asic_keys.emplace(b.host_id(), b.tray_id(), b.asic_location());
+        }
+    }
+
+    // Synthesize a deterministic uint64 unique_id for every ASIC. The std::set above gives a stable iteration
+    // order keyed by (host_id, tray_id, asic_location), so the mapping is reproducible across runs for a given FSD.
+    std::map<AsicKey, uint64_t> key_to_unique_id;
+    {
+        uint64_t next_id = 1;  // 0 is reserved to avoid collision with UNKNOWN defaults
+        for (const auto& k : asic_keys) {
+            key_to_unique_id[k] = next_id++;
+        }
+    }
+
+    auto unique_id_for = [&](uint32_t host_id, uint32_t tray_id, uint32_t asic_location) {
+        auto it = key_to_unique_id.find(AsicKey{host_id, tray_id, asic_location});
+        if (it == key_to_unique_id.end()) {
+            throw std::runtime_error(
+                fmt::format("FSD endpoint ({}, {}, {}) not in synthesized ASIC set", host_id, tray_id, asic_location));
+        }
+        return it->second;
+    };
+
+    auto board_type_for = [&](uint32_t host_id, uint32_t tray_id) {
+        auto it = host_tray_to_board_type.find({host_id, tray_id});
+        if (it == host_tray_to_board_type.end()) {
+            throw std::runtime_error(
+                fmt::format("FSD has no board_type entry for host_id={}, tray_id={}", host_id, tray_id));
+        }
+        return it->second;
+    };
+
+    // host_to_mobo_name and host_to_rank (rank = FSD host index). Reject duplicate hostnames: the PSD keys
+    // ranks / motherboards / graph entries by hostname, so duplicates would silently collapse hosts together.
+    std::set<std::string> seen_hostnames;
+    for (int host_id = 0; host_id < num_hosts; ++host_id) {
+        const auto& host = fsd.hosts(host_id);
+        if (!seen_hostnames.insert(host.hostname()).second) {
+            throw std::runtime_error(
+                fmt::format("Duplicate hostname '{}' in Factory System Descriptor", host.hostname()));
+        }
+        auto* mobo = psd.add_host_to_mobo_name();
+        mobo->set_host_name(host.hostname());
+        mobo->set_mobo_name(host.motherboard());
+
+        auto* rank = psd.add_host_to_rank();
+        rank->set_host_name(host.hostname());
+        rank->set_rank(static_cast<uint32_t>(host_id));
+    }
+
+    // ASIC descriptors.
+    for (const auto& [key, unique_id] : key_to_unique_id) {
+        auto [host_id, tray_id, asic_location] = key;
+        auto* asic_map = psd.add_asic_descriptors();
+        asic_map->set_asic_id(unique_id);
+
+        auto* desc = asic_map->mutable_asic_descriptor();
+        desc->set_tray_id(tray_id);
+        desc->set_asic_location(asic_location);
+        desc->set_board_type(board_type_for(host_id, tray_id));
+        desc->set_unique_id(unique_id);
+        desc->set_host_name(hostname_of(host_id));
+    }
+
+    if (!fsd.has_eth_connections()) {
+        return psd;
+    }
+
+    // Group connections per (host, src_asic_id, dst_asic_id) so a single ASIC connection edge can carry all
+    // ethernet channels between that pair. Edges are emitted in both directions so the resulting graph is
+    // symmetric, matching the structure produced by the runtime (HPT) overload in Fabric Manager.
+    struct EthChan {
+        uint32_t src_chan;
+        uint32_t dst_chan;
+        bool is_local;
+    };
+    // src_host_name -> src_asic_id -> dst_asic_id -> channels
+    std::map<std::string, std::map<uint64_t, std::map<uint64_t, std::vector<EthChan>>>> outbound;
+    // src_host_name -> dst_host_name -> list of exit node connections (src_asic, dst_asic, src_chan, dst_chan)
+    std::map<std::string, std::map<std::string, std::vector<std::tuple<uint64_t, uint64_t, uint32_t, uint32_t>>>>
+        host_outbound;
+    // src_host_name -> flat list of exit node connections (for exit_node_connection_table)
+    std::map<std::string, std::vector<std::tuple<uint64_t, uint64_t, uint32_t, uint32_t>>> exit_table;
+
+    for (const auto& conn : fsd.eth_connections().connection()) {
+        const auto& a = conn.endpoint_a();
+        const auto& b = conn.endpoint_b();
+        const bool is_local = (a.host_id() == b.host_id());
+
+        const uint64_t asic_a = unique_id_for(a.host_id(), a.tray_id(), a.asic_location());
+        const uint64_t asic_b = unique_id_for(b.host_id(), b.tray_id(), b.asic_location());
+
+        const std::string& host_a = hostname_of(a.host_id());
+        const std::string& host_b = hostname_of(b.host_id());
+
+        outbound[host_a][asic_a][asic_b].push_back({a.chan_id(), b.chan_id(), is_local});
+        outbound[host_b][asic_b][asic_a].push_back({b.chan_id(), a.chan_id(), is_local});
+
+        if (!is_local) {
+            host_outbound[host_a][host_b].emplace_back(asic_a, asic_b, a.chan_id(), b.chan_id());
+            host_outbound[host_b][host_a].emplace_back(asic_b, asic_a, b.chan_id(), a.chan_id());
+            exit_table[host_a].emplace_back(asic_a, asic_b, a.chan_id(), b.chan_id());
+            exit_table[host_b].emplace_back(asic_b, asic_a, b.chan_id(), a.chan_id());
+        }
+    }
+
+    // Ensure every host that owns at least one ASIC appears in the ASIC connectivity graph, even if its ASICs
+    // have no outbound connections.
+    for (const auto& [key, _] : key_to_unique_id) {
+        outbound[hostname_of(std::get<0>(key))];
+    }
+
+    auto* graph = psd.mutable_system_graph();
+
+    // ASIC connectivity graph.
+    for (const auto& [hostname, asic_map] : outbound) {
+        auto* host_conn = graph->add_asic_connectivity_graph();
+        host_conn->set_host_name(hostname);
+        for (const auto& [src_asic, dst_map] : asic_map) {
+            auto* asic_graph = host_conn->add_asic_topologies();
+            asic_graph->set_asic_id(src_asic);
+            auto* topo = asic_graph->mutable_topology();
+            for (const auto& [dst_asic, channels] : dst_map) {
+                auto* edge = topo->add_asic_connections();
+                edge->set_dst_asic_id(dst_asic);
+                for (const auto& ch : channels) {
+                    auto* eth = edge->add_eth_connections();
+                    eth->set_src_chan(ch.src_chan);
+                    eth->set_dst_chan(ch.dst_chan);
+                    eth->set_is_local(ch.is_local);
+                }
+            }
+        }
+    }
+
+    // Host connectivity graph — emit one entry per host, including hosts with no inter-host neighbors (isolated
+    // or single-host descriptors). This matches the runtime discovery path (physical_system_discovery.cpp), so
+    // PhysicalSystemDescriptor::get_host_neighbors() returns an empty list rather than failing its contains() check.
+    for (int host_id = 0; host_id < num_hosts; ++host_id) {
+        const std::string& src_host = fsd.hosts(host_id).hostname();
+        auto* host_conn = graph->add_host_connectivity_graph();
+        host_conn->set_src_host_name(src_host);
+        auto it = host_outbound.find(src_host);
+        if (it == host_outbound.end()) {
+            continue;  // no inter-host links; keep the empty entry
+        }
+        for (const auto& [dst_host, conns] : it->second) {
+            auto* edge = host_conn->add_host_connections();
+            edge->set_dst_host_name(dst_host);
+            for (const auto& [src_exit, dst_exit, src_ch, dst_ch] : conns) {
+                auto* exit_conn = edge->add_exit_node_connections();
+                exit_conn->set_src_exit_node(src_exit);
+                exit_conn->set_dst_exit_node(dst_exit);
+                auto* eth = exit_conn->mutable_eth_conn();
+                eth->set_src_chan(src_ch);
+                eth->set_dst_chan(dst_ch);
+                eth->set_is_local(false);
+            }
+        }
+    }
+
+    // Exit node connection table.
+    for (const auto& [hostname, conns] : exit_table) {
+        auto* table = psd.add_exit_node_connection_table();
+        table->set_host_name(hostname);
+        for (const auto& [src_exit, dst_exit, src_ch, dst_ch] : conns) {
+            auto* exit_conn = table->add_exit_connections();
+            exit_conn->set_src_exit_node(src_exit);
+            exit_conn->set_dst_exit_node(dst_exit);
+            auto* eth = exit_conn->mutable_eth_conn();
+            eth->set_src_chan(src_ch);
+            eth->set_dst_chan(dst_ch);
+            eth->set_is_local(false);
+        }
+    }
+
+    return psd;
+}
+
+std::vector<::tt::fabric::proto::PhysicalSystemDescriptor> build_physical_descriptors(
+    const ::tt::scaleout_tools::fsd::proto::FactorySystemDescriptor& fsd) {
+    std::vector<::tt::fabric::proto::PhysicalSystemDescriptor> psds;
+
+    auto groups = partition_fsd_hosts_by_connectivity(fsd);
+    log_info(tt::LogFabric, "Partitioned {} FSD host(s) into {} connected group(s)", fsd.hosts_size(), groups.size());
+
+    psds.reserve(groups.size());
+    for (const auto& members : groups) {
+        psds.push_back(build_physical_descriptor(build_sub_fsd(fsd, members)));
+    }
+    return psds;
+}
+
+}  // namespace tt::tt_metal::experimental::tt_fabric

--- a/tt_metal/fabric/sources.cmake
+++ b/tt_metal/fabric/sources.cmake
@@ -72,4 +72,5 @@ set(FABRIC_SOURCES
     physical_grouping_descriptor_core.cpp
     physical_grouping_descriptor_graph_building.cpp
     physical_grouping_descriptor_matching.cpp
+    physical_descriptor_builder.cpp
 )

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -45,6 +45,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/fabric/fabric_types.hpp
     api/tt-metalium/experimental/fabric/mesh_graph.hpp
     api/tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp
+    api/tt-metalium/experimental/fabric/physical_descriptor_builder.hpp
     api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
     api/tt-metalium/experimental/fabric/physical_system_descriptor.hpp
     api/tt-metalium/experimental/fabric/pipeline_builder.hpp


### PR DESCRIPTION
## What

Moved PSD-to-FSD builder utility from FM to metal for https://github.com/tenstorrent/tt-metal/issues/52859

Adds an **offline FSD → PSD builder** to tt-metal: given a Factory System Descriptor (the as-built / ideal topology), produce a `PhysicalSystemDescriptor` with **no hardware discovery**. Compiled into the `fabric` library (no new target).

```
FactorySystemDescriptor (FSD proto)
        │
        │  build_physical_descriptor_from_file(path)  → PhysicalSystemDescriptor  (C++ class, proto-free)
        │  build_physical_descriptor(fsd)             → PhysicalSystemDescriptor  (proto)
        ▼
PhysicalSystemDescriptor
```

**New files**
- `tt-metalium/experimental/fabric/physical_descriptor_builder.hpp`
- `tt_metal/fabric/physical_descriptor_builder.cpp`
- `PhysicalDescriptorBuilder` gtest suite + a 16-host FSD test fixture (in `fabric_unit_tests`)

## Where it came from

Ported from **Fabric Manager** → `controller/physical_system_descriptor_builder.cpp` (the FSD overloads only).

## What changed vs FM

- board_type string → enum via `tt::scaleout_tools::get_board_type_from_string` (canonical board lib) instead of FM's hand-maintained table; **`UBB_WORMHOLE`** normalized to `UBB` (enchantum reflection doesn't surface the alias).
- logging via `tt::LogFabric`.
- public header **forward-declares** the FSD/PSD proto types → proto-free API surface.
- added the `build_physical_descriptor_from_file(path)` proto-free entry point.

## Tests

Unit tests + an **integration test** that builds a PSD from a checked-in real 16-host FSD (~440 KB, full, not truncated) and verifies **16 hosts**, **512 ASIC nodes** (32/host), host↔rank **bijection**, and **full connectivity** (512/512 ASICs wired).

**CI — TM fabric CPU-only tests**
- Run: [https://github.com/tenstorrent/tt-metal/actions/runs/32532482427](https://github.com/tenstorrent/tt-metal/actions/runs/32532482427) (dispatched with only `run-fabric-cpu-only-unit-tests` enabled).
- Result: ✅ **all fabric CPU-only unit-test groups pass** on the rebased head (the earlier `bh-subtorus` failure was a stale-base reference to a non-existent `llama_8b_3galaxy` MGD, removed on current main; fixed by rebasing).
- Local: `run_fabric_cpu_only_unit_tests.sh --group unit` → `PhysicalDescriptorBuilder` 14/14 pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/fsd-psd-builder)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/fsd-psd-builder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/fsd-psd-builder)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/fsd-psd-builder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/fsd-psd-builder)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/fsd-psd-builder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/fsd-psd-builder)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/fsd-psd-builder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/fsd-psd-builder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/fsd-psd-builder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/fsd-psd-builder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/fsd-psd-builder)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/fsd-psd-builder)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/fsd-psd-builder)





