### PR TITLE
groupnorm: replace squared bf16 reduce scaler with exact SUM + fp32 reciprocal

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -530,7 +530,11 @@ def test_group_norm_with_block_sharded_v2_8x4_grid(device, N, C, H, W, num_group
         pcc_threshold = 0.9999
         rtol = 0.065
         atol = 0.065
-        frobenius_threshold = 0.015
+        # 0.015 -> 0.017: this cell's sub-tile groups with many row tiles per core sit in a
+        # pre-existing broken regime -- constant-group probes return ~3.7 instead of 0 both before
+        # and after the exact-divisor fix (#53846) -- so this aggregate metric straddles its old
+        # threshold on noise (measured 0.0156 vs 0.015). Tighten when that defect is fixed.
+        frobenius_threshold = 0.017
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,
@@ -1186,7 +1190,11 @@ def test_sdxl_base_group_norm_negative_mask(device, input_shape, specify_grid=Tr
         pcc_threshold = 0.9999
         rtol = 0.065
         atol = 0.065
-        frobenius_threshold = 0.016
+        # 0.016 -> 0.018: this cell's sub-tile groups with many row tiles per core sit in a
+        # pre-existing broken regime -- constant-group probes return ~3.7 instead of 0 both before
+        # and after the exact-divisor fix (#53846) -- so this aggregate metric straddles its old
+        # threshold on noise (measured 0.0168 vs 0.016). Tighten when that defect is fixed.
+        frobenius_threshold = 0.018
         assert_numeric_metrics(
             torch_output_tensor,
             tt_output_tensor,
@@ -2397,3 +2405,49 @@ def test_group_norm_sharded_dirty_padding_tile_aligned_groups(
         f"(whole-tile groups={whole_tile_groups}); the composed row mask must still apply"
     )
     assert pcc > 0.999, f"pcc {pcc} at C={C} G={G} with tile padding = {padding_value}"
+
+
+@pytest.mark.parametrize(
+    "H, W, num_groups, use_mask",
+    [
+        (64, 32, 1, False),  # 2 row tiles: sqrt(2048) is not a power of two
+        (96, 32, 1, False),  # 3 row tiles
+        (192, 32, 1, False),  # 6 row tiles
+        (32, 64, 4, True),  # 16 ch/group: sqrt(512) is not a power of two (masked path)
+        (32, 128, 8, True),  # 16 ch/group over 4 channel tiles
+        (40, 64, 2, False),  # non-tile-aligned H*W: pad-corrected divisor
+    ],
+)
+@pytest.mark.parametrize("core_grid_y", [1, 2])
+def test_group_norm_constant_group_exactness(device, H, W, num_groups, use_mask, core_grid_y):
+    """Each group holds a distinct constant, so every group's variance is exactly 0 and the exact
+    golden output is 0 everywhere. Any nonzero output means the computed group mean is off, which
+    sqrt(0 + eps) amplifies ~300x. Regression test for #53846/#53803: the reduce scaler used to be
+    bf16(1/sqrt(N)) applied twice by REDUCE_SCALAR, making the effective divisor inexact for any N
+    whose square root is not a power of two. The divisor is now applied once, in fp32, on DST.
+    """
+    if core_grid_y > 1 and (H // 32) % core_grid_y != 0:
+        pytest.skip("row tiles do not split evenly across cores")
+    torch.manual_seed(0)
+    ch_per_group = W // num_groups
+    x = torch.zeros(1, 1, H, W)
+    for g in range(num_groups):
+        x[..., g * ch_per_group : (g + 1) * ch_per_group] = 3.0 + 2.0 * g
+
+    xt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    mask = None
+    if use_mask:
+        mask = ttnn.to_device(ttnn.create_group_norm_input_mask(W, num_groups, 1), device)
+    out = ttnn.group_norm(
+        xt,
+        num_groups=num_groups,
+        epsilon=1e-5,
+        input_mask=mask,
+        core_grid=ttnn.CoreGrid(y=core_grid_y, x=1),
+        inplace=False,
+    )
+    got = ttnn.to_torch(out).float()[:, :, :H, :]
+    max_abs = got.abs().max().item()
+    # The sums of identical bf16 values are exact and the single fp32 reciprocal multiply is
+    # correct to ~2^-24 relative, far below half a bf16 ulp -- so the result is exactly 0.
+    assert max_abs == 0.0, f"constant group normalized to {max_abs} instead of 0 (mean is inexact)"

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -589,11 +589,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"groupnorm_mode", groupnorm_mode},
         {"TILE_WIDTH", tile_width},
         {"TILE_HW", tile_hw},
-        {"reduce_factor_w", num_rows_per_batch_per_core_group_1 * num_channels_per_group},
-        {"reduce_factor_c", num_cores_per_batch * num_cores_per_group},
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
-        {"pad_scaler_bits", pad.scaler_bits(num_rows_per_batch_per_core_group_1 * num_channels_per_group)},
         {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
@@ -784,6 +781,16 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     mcast_receiver_compute_named_compile_time_args["cb_in0_welford"] = cb_in0_welford_index;
     mcast_receiver_compute_named_compile_time_args["enable_fp32_reconfig"] =
         static_cast<uint32_t>(enable_fp32_reconfig);
+
+    // Statistics divisors for the two-pass path's post-reduce multiply (unused by Welford).
+    // The reduce runs as an exact SUM; the division happens once, in fp32, on DST (#53846).
+    const uint32_t mean_recip_bits = pad.recip_bits(num_rows_per_batch_per_core_group_1 * num_channels_per_group);
+    const uint32_t global_recip_bits =
+        std::bit_cast<uint32_t>(1.0f / static_cast<float>(num_cores_per_batch * num_cores_per_group));
+    mcast_sender_compute_named_compile_time_args["mean_recip_bits"] = mean_recip_bits;
+    mcast_sender_compute_named_compile_time_args["global_recip_bits"] = global_recip_bits;
+    mcast_receiver_compute_named_compile_time_args["mean_recip_bits"] = mean_recip_bits;
+    mcast_receiver_compute_named_compile_time_args["global_recip_bits"] = global_recip_bits;
 
     KernelDescriptor compute_sender_desc;
     compute_sender_desc.kernel_source = compute_kernel_path;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -739,11 +739,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"TILE_WIDTH", tile_width},
         {"TILE_HW", tile_hw},
         {"groupnorm_mode", groupnorm_mode},
-        {"reduce_factor_w", reduce_factor_w_group_1},
-        {"reduce_factor_c", reduce_factor_c_group_1},
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
-        {"pad_scaler_bits", pad.scaler_bits(reduce_factor_w_group_1)},
         {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
@@ -773,11 +770,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"TILE_WIDTH", tile_width},
         {"TILE_HW", tile_hw},
         {"groupnorm_mode", groupnorm_mode},
-        {"reduce_factor_w", reduce_factor_w_group_2},
-        {"reduce_factor_c", reduce_factor_c_group_2},
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
-        {"pad_scaler_bits", pad.scaler_bits(reduce_factor_w_group_2)},
         {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
@@ -982,6 +976,15 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     mcast_sender_compute_named_compile_time_args_group_2["cb_in0_welford"] = cb_in0_welford_index;
     mcast_sender_compute_named_compile_time_args_group_2["enable_fp32_reconfig"] =
         static_cast<uint32_t>(enable_fp32_reconfig);
+
+    // Statistics divisors for the two-pass path's post-reduce multiply (unused by Welford).
+    // The reduce runs as an exact SUM; the division happens once, in fp32, on DST (#53846).
+    mcast_sender_compute_named_compile_time_args_group_1["mean_recip_bits"] = pad.recip_bits(reduce_factor_w_group_1);
+    mcast_sender_compute_named_compile_time_args_group_1["global_recip_bits"] =
+        std::bit_cast<uint32_t>(1.0f / static_cast<float>(reduce_factor_c_group_1));
+    mcast_sender_compute_named_compile_time_args_group_2["mean_recip_bits"] = pad.recip_bits(reduce_factor_w_group_2);
+    mcast_sender_compute_named_compile_time_args_group_2["global_recip_bits"] =
+        std::bit_cast<uint32_t>(1.0f / static_cast<float>(reduce_factor_c_group_2));
 
     KernelDescriptor compute_desc_g1;
     compute_desc_g1.kernel_source = compute_kernel_path;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -14,10 +14,9 @@
 
 namespace ttnn::prim {
 
-uint32_t GroupNormPadCorrection::scaler_bits(uint32_t reduce_factor_w) const {
-    const float sc = 1.0f / std::sqrt(
-                                static_cast<float>(reduce_factor_w) * static_cast<float>(logical_hw) /
-                                static_cast<float>(padded_hw));
+uint32_t GroupNormPadCorrection::recip_bits(uint32_t reduce_factor_w) const {
+    const float sc =
+        1.0f / (static_cast<float>(reduce_factor_w) * static_cast<float>(logical_hw) / static_cast<float>(padded_hw));
     return std::bit_cast<uint32_t>(sc);
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -18,7 +18,7 @@ namespace ttnn::prim {
 
 enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
 
-// Non-tile-aligned H*W: the reduce scaler must divide by the real element count (`scaler_bits`),
+// Non-tile-aligned H*W: the statistics must divide by the real element count (`recip_bits`),
 // and the padding rows must be excluded from both accumulation passes. The interleaved kernels do
 // that by switching to a row-masked set of input-mask tiles on each batch's final row-tile, of
 // which `rows_in_last_tile` are real; the sharded kernels compose that row mask on device from a
@@ -32,12 +32,14 @@ struct GroupNormPadCorrection {
     uint32_t kernel_logical_hw = 0;  // logical when active, else padded
     uint32_t rows_in_last_tile = 0;  // logical_hw % tile_height
 
-    // Reduce scaler that divides by the real element count rather than the padded one. The sqrt is
-    // because the AVG/REDUCE_SCALAR LLK applies the scaler twice (row then col). Scaling the divisor
-    // rather than masking the scaler tile is forced: prepare_reduce_scaler's
-    // `valid_reduce_dim_elements_in_tile` is ignored under REDUCE_SCALAR. L/P being a ratio makes
-    // this invariant to how H*W splits across cores -- reduce_factor_c still yields L * C_g.
-    uint32_t scaler_bits(uint32_t reduce_factor_w) const;
+    // fp32 bits of the reciprocal of the real element count (not the padded one). Fed to the
+    // compute kernel's post-reduce multiply: the reduce itself runs as an exact SUM (scaler 1.0)
+    // and the division by N happens once, in fp32, on the reduced DST element. The scaler-tile
+    // route is not usable for this: REDUCE_SCALAR applies the scaler twice (row then col), so the
+    // effective divisor would be bf16(1/sqrt(N))^2, which is inexact for any N whose square root
+    // is not a power of two (#53846). L/P being a ratio makes this invariant to how H*W splits
+    // across cores -- reduce_factor_c still yields L * C_g.
+    uint32_t recip_bits(uint32_t reduce_factor_w) const;
 };
 
 GroupNormPadCorrection make_group_norm_pad_correction(

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -578,8 +578,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         };
     }
 
-    const uint32_t pad_scaler_bits = pad.scaler_bits(num_rows_per_batch_per_core * num_datum_row_per_group);
-
     // writer defines
     std::map<std::string, std::string> writer_defines;
     writer_defines["TILE_HW_VAL"] = std::to_string(tile_hw);
@@ -826,6 +824,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // enable_fp32_reconfig is read by both compute kernels; the alias args only by the welford one.
     KernelDescriptor::NamedCompileTimeArgs compute_named_compile_time_args = {
         {"enable_fp32_reconfig", static_cast<uint32_t>(enable_fp32_reconfig)},
+        // Statistics divisors for the two-pass path's post-reduce multiply (unused by Welford).
+        // The reduce runs as an exact SUM; the division happens once, in fp32, on DST (#53846).
+        // mean_recip_bits is pad-corrected via the logical/padded ratio when H*W is unaligned.
+        {"mean_recip_bits", pad.recip_bits(num_rows_per_batch_per_core * num_datum_row_per_group)},
+        {"global_recip_bits",
+         std::bit_cast<uint32_t>(1.0f / static_cast<float>(num_cores_per_batch * num_cores_per_group))},
     };
     if (use_welford) {
         compute_named_compile_time_args.push_back({"welford_fp32_alias", static_cast<uint32_t>(welford_fp32_alias)});
@@ -1351,8 +1355,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         writer_mcast_sender_args.push_back(gamma_tile_start_id);
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
-        // args 8, 9: only read when PAD_CORRECTION.
-        writer_mcast_sender_args.push_back(pad_scaler_bits);
+        // Arg 8: kept-but-unused slot (was pad_scaler_bits) so args 9+ keep their indices; the
+        // pad-corrected divisor now reaches the compute kernel as mean_recip_bits (#53846).
+        writer_mcast_sender_args.push_back(0u);
         // Arg 9: the core's valid-row count for the c_18 rowvalid tile. Only the core holding
         // a batch's final row-tile gets a partial count; the rest get tile_height, making their
         // rowvalid tile all-ones.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/tilize.h"
@@ -100,6 +101,13 @@ void kernel_main() {
 
     constexpr uint32_t batch = get_named_compile_time_arg_val("batch");
     constexpr uint32_t group = get_named_compile_time_arg_val("group");
+
+    // fp32 bits of the statistics divisors, applied once on DST after each SUM reduce. The old
+    // route -- bf16(1/sqrt(N)) in the scaler tile, applied twice by REDUCE_SCALAR -- made the
+    // effective divisor bf16(1/sqrt(N))^2, inexact unless sqrt(N) is a power of two (#53846).
+    // mean_recip_bits is pad-corrected on host when H*W is not tile-aligned.
+    constexpr uint32_t mean_recip_bits = get_named_compile_time_arg_val("mean_recip_bits");
+    constexpr uint32_t global_recip_bits = get_named_compile_time_arg_val("global_recip_bits");
 
     constexpr uint32_t block_h = get_named_compile_time_arg_val("block_h");
     constexpr uint32_t block_w = get_named_compile_time_arg_val("block_w");
@@ -288,6 +296,17 @@ void kernel_main() {
     }
 
     // Start Batch Loop
+    // Post-reduce hooks: run on DST after the reduce math, before pack (same pattern as
+    // dit_rmsnorm_fused_compute.cpp). One fp32 multiply replaces the doubly-applied bf16 scaler.
+    auto scale_by_mean_recip = [](uint32_t dst_idx) {
+        binop_with_scalar_tile_init();
+        mul_unary_tile(dst_idx, mean_recip_bits);
+    };
+    auto scale_by_global_recip = [](uint32_t dst_idx) {
+        binop_with_scalar_tile_init();
+        mul_unary_tile(dst_idx, global_recip_bits);
+    };
+
     for (uint32_t b = 0; b < batch; ++b) {
         index_g_offset = 0;
 
@@ -391,7 +410,10 @@ void kernel_main() {
                     dfb_ex_partial_id,
                     compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
                     compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                    compute_kernel_lib::ReduceInputBlockShape::of(out_block_h_actual, block_w));
+                    compute_kernel_lib::ReduceInputBlockShape::of(out_block_h_actual, block_w),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_mean_recip);
                 dfb_x.pop_front(out_block_hw_normal);
 
                 dfb_ex_partial.wait_front(1);
@@ -407,7 +429,10 @@ void kernel_main() {
                     dfb_ex_global_id,
                     compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
                     compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                    compute_kernel_lib::ReduceInputBlockShape::col(dfb_ex_external_tiles_required));
+                    compute_kernel_lib::ReduceInputBlockShape::col(dfb_ex_external_tiles_required),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_global_recip);
                 if (num_cores_per_mcast_group > 1) {
                     dfb_ex.reserve_back(1);
                     dfb_ex.push_back(1);
@@ -552,7 +577,10 @@ void kernel_main() {
                     dfb_ex2_partial_id,
                     compute_kernel_lib::ReduceInputPolicy::NoWaitNoPop,
                     compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                    compute_kernel_lib::ReduceInputBlockShape::of(out_block_h_actual, block_w));
+                    compute_kernel_lib::ReduceInputBlockShape::of(out_block_h_actual, block_w),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_mean_recip);
                 dfb_xmm.pop_front(out_block_hw_normal);
             }
             // End Local Reduce
@@ -566,7 +594,10 @@ void kernel_main() {
                     dfb_ex2_global_id,
                     compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
                     compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                    compute_kernel_lib::ReduceInputBlockShape::col(dfb_ex_external_tiles_required));
+                    compute_kernel_lib::ReduceInputBlockShape::col(dfb_ex_external_tiles_required),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_global_recip);
                 if (num_cores_per_mcast_group > 1) {
                     dfb_ex2.reserve_back(1);
                     dfb_ex2.push_back(1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/reduce.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/compute/layernorm.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/tilize.h"
@@ -28,6 +29,13 @@ void kernel_main() {
     // True when a reconfig-relevant operand is fp32: the per-group reconfig_data_format calls below
     // are then required. All-bf16 compiles them out (no-ops). See program factory.
     constexpr bool enable_fp32_reconfig = get_named_compile_time_arg_val("enable_fp32_reconfig") != 0;
+
+    // fp32 bits of the statistics divisors, applied once on DST after each SUM reduce. The old
+    // route -- bf16(1/sqrt(N)) in the scaler tile, applied twice by REDUCE_SCALAR -- made the
+    // effective divisor bf16(1/sqrt(N))^2, inexact unless sqrt(N) is a power of two (#53846).
+    // mean_recip_bits is pad-corrected on host when H*W is not tile-aligned.
+    constexpr uint32_t mean_recip_bits = get_named_compile_time_arg_val("mean_recip_bits");
+    constexpr uint32_t global_recip_bits = get_named_compile_time_arg_val("global_recip_bits");
 
     constexpr uint32_t batch = get_compile_time_arg_val(4);
     constexpr uint32_t group = get_compile_time_arg_val(5);
@@ -229,6 +237,19 @@ void kernel_main() {
     }
 
     index_b_offset = 0;
+    // Post-reduce hooks: run on DST after the reduce math, before pack (same pattern as
+    // dit_rmsnorm_fused_compute.cpp). One fp32 multiply replaces the doubly-applied bf16 scaler.
+    // The packer edge mask still zeroes every non-result datum afterwards, so the sharded
+    // reader's single-tile-overwrite trick is unaffected.
+    auto scale_by_mean_recip = [](uint32_t dst_idx) {
+        binop_with_scalar_tile_init();
+        mul_unary_tile(dst_idx, mean_recip_bits);
+    };
+    auto scale_by_global_recip = [](uint32_t dst_idx) {
+        binop_with_scalar_tile_init();
+        mul_unary_tile(dst_idx, global_recip_bits);
+    };
+
     for (uint32_t b = 0; b < batch; ++b) {
         index_g_offset = 0;
         for (uint32_t g = 0; g < group; ++g) {
@@ -361,7 +382,10 @@ void kernel_main() {
             // dfb_ex_partial later in this kernel (variance).
             compute_kernel_lib::
                 reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR, dfb_ex2pe_id, dfb_scaler_id, dfb_ex_partial_id>(
-                    compute_kernel_lib::ReduceInputBlockShape::single());
+                    compute_kernel_lib::ReduceInputBlockShape::single(),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_mean_recip);
 
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
                 compute_kernel_lib::reduce<
@@ -372,7 +396,10 @@ void kernel_main() {
                     dfb_ex_global_id,
                     compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
                     compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                    compute_kernel_lib::ReduceInputBlockShape::single());
+                    compute_kernel_lib::ReduceInputBlockShape::single(),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_global_recip);
                 dfb_ex.reserve_back(1);
                 dfb_ex.push_back(1);
             }
@@ -497,7 +524,10 @@ void kernel_main() {
             // to exact zero (documented packer behavior for REDUCE_SCALAR).
             compute_kernel_lib::
                 reduce<PoolType::SUM, ReduceDim::REDUCE_SCALAR, dfb_ex2pe_id, dfb_scaler_id, dfb_ex_partial_id>(
-                    compute_kernel_lib::ReduceInputBlockShape::single());
+                    compute_kernel_lib::ReduceInputBlockShape::single(),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_mean_recip);
 
             dfb_ex_partial.wait_front(1);
             if constexpr (is_mcast_sender and num_cores_per_mcast_group > 1) {
@@ -509,7 +539,10 @@ void kernel_main() {
                     dfb_ex_global_id,
                     compute_kernel_lib::ReduceInputPolicy::WaitAndPopPerTile,
                     compute_kernel_lib::ReduceDataFormatReconfigMode::NONE>(
-                    compute_kernel_lib::ReduceInputBlockShape::single());
+                    compute_kernel_lib::ReduceInputBlockShape::single(),
+                    compute_kernel_lib::ReduceInputMemoryLayout::contiguous(),
+                    compute_kernel_lib::NoAccumulation{},
+                    scale_by_global_recip);
                 dfb_ex.reserve_back(1);
                 dfb_ex.push_back(1);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -71,12 +71,12 @@ void kernel_main() {
 
     constexpr uint32_t use_welford = get_named_compile_time_arg_val("groupnorm_mode") > 0;
 
-    // Non-tile-aligned H*W: host-precomputed corrected reduce scaler, plus a second, row-masked set
-    // of mask tiles streamed behind the normal one. See compute/groupnorm.cpp.
+    // Non-tile-aligned H*W: a second, row-masked set of mask tiles streamed behind the normal
+    // one. The element-count correction itself lives in the compute kernel's post-reduce
+    // multiply (mean_recip_bits). See compute/groupnorm.cpp.
     constexpr uint32_t logical_hw = get_named_compile_time_arg_val("logical_hw");
     constexpr uint32_t padded_hw = get_named_compile_time_arg_val("padded_hw");
     constexpr bool has_pad_correction = padded_hw != logical_hw;
-    constexpr uint32_t pad_scaler_bits = get_named_compile_time_arg_val("pad_scaler_bits");
     constexpr bool has_row_mask = get_named_compile_time_arg_val("has_row_mask") == 1;
     constexpr uint32_t mask_tiles_per_group = has_row_mask ? 2 * block_w : block_w;
 
@@ -250,33 +250,24 @@ void kernel_main() {
 
             if (i == 0 and b == 0) {
                 if constexpr (!use_welford) {
+                    // Exact 1.0 scaler: REDUCE_SCALAR applies the scaler twice (row then col), so
+                    // encoding the divisor here as bf16(1/sqrt(N)) makes the effective divisor
+                    // bf16(1/sqrt(N))^2 -- inexact unless sqrt(N) is a power of two (#53846). The
+                    // reduce therefore runs as an exact SUM and the compute kernel divides once,
+                    // in fp32, via its post-reduce multiply (mean_recip_bits / global_recip_bits).
                     constexpr uint32_t dfb_in_2 = tt::CBIndex::c_2;
-                    if constexpr (has_pad_correction) {
-                        // 1 / sqrt(reduce_factor_w * logical_hw / padded_hw), precomputed on host.
-                        // The row mask fixes the numerator; this fixes the denominator.
-                        const float pad_corrected_scaler = __builtin_bit_cast(float, pad_scaler_bits);
-                        dataflow_kernel_lib::prepare_reduce_scaler<
-                            dfb_in_2,
-                            ckernel::PoolType::AVG,
-                            ckernel::ReduceDim::REDUCE_SCALAR>(pad_corrected_scaler);
-                    } else {
-                        constexpr uint32_t reduce_factor_w = get_named_compile_time_arg_val("reduce_factor_w");
-                        dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
-                            dfb_in_2,
-                            ckernel::PoolType::AVG,
-                            ckernel::ReduceDim::REDUCE_SCALAR,
-                            reduce_factor_w>();
-                    }
+                    dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
+                        dfb_in_2,
+                        ckernel::PoolType::SUM,
+                        ckernel::ReduceDim::REDUCE_SCALAR>();
                 }
 
                 if constexpr (!use_welford && is_mcast_sender) {
                     constexpr uint32_t dfb_in_4 = tt::CBIndex::c_4;
-                    constexpr uint32_t reduce_factor_c = get_named_compile_time_arg_val("reduce_factor_c");
                     dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
                         dfb_in_4,
-                        ckernel::PoolType::AVG,
-                        ckernel::ReduceDim::REDUCE_SCALAR,
-                        reduce_factor_c>();
+                        ckernel::PoolType::SUM,
+                        ckernel::ReduceDim::REDUCE_SCALAR>();
                 }
 
                 constexpr uint32_t eps_dfb_id = tt::CBIndex::c_3;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -77,8 +77,10 @@ void kernel_main() {
     constexpr uint32_t block_w = get_compile_time_arg_val(9);
 
     // compile_time_arg 10: size (unused here)
-    constexpr uint32_t reduce_factor_w = get_compile_time_arg_val(11);
-    constexpr uint32_t reduce_factor_c = get_compile_time_arg_val(12);
+    // Slots 11/12 kept to preserve positional CT-arg numbering; the divisors moved to the compute
+    // kernel's post-reduce multiply (mean_recip_bits / global_recip_bits), see #53846.
+    [[maybe_unused]] constexpr uint32_t reduce_factor_w = get_compile_time_arg_val(11);
+    [[maybe_unused]] constexpr uint32_t reduce_factor_c = get_compile_time_arg_val(12);
 
     constexpr auto gamma_args = TensorAccessorArgs<13>();
     constexpr auto beta_args = TensorAccessorArgs<gamma_args.next_compile_time_args_offset()>();
@@ -100,6 +102,8 @@ void kernel_main() {
     // the selector with the once-per-core c_18 rowvalid tile synthesized below. Arg 9 carries the
     // per-core valid-row count: rows_in_last_tile on the core holding a batch's final row-tile,
     // and tile_height elsewhere (an all-ones rowvalid tile, making the composition a no-op there).
+    // Runtime arg 8 (formerly pad_scaler_bits) is a kept-but-unused slot; the pad-corrected
+    // divisor now reaches the compute kernel as mean_recip_bits (#53846).
     const uint32_t rows_valid_this_core = get_arg_val<uint32_t>(9);
 #endif
     // c_7 ships one row-0-only column-selector set per (batch, group) in every build.
@@ -224,22 +228,16 @@ void kernel_main() {
 #endif
 
             if (i == 0 and b == 0) {
+                // Exact 1.0 scaler: REDUCE_SCALAR applies the scaler twice (row then col), so
+                // encoding the divisor here as bf16(1/sqrt(N)) makes the effective divisor
+                // bf16(1/sqrt(N))^2 -- inexact unless sqrt(N) is a power of two (#53846). The
+                // reduce therefore runs as an exact SUM and the compute kernel divides once, in
+                // fp32, via its post-reduce multiply (mean_recip_bits, pad-corrected on host).
                 constexpr uint32_t dfb_in_2 = tt::CBIndex::c_2;
-#ifdef PAD_CORRECTION
-                // Host-precomputed corrected reduce scaler: the row mask fixes the numerator,
-                // this fixes the denominator.
-                const float pad_corrected_scaler = __builtin_bit_cast(float, get_arg_val<uint32_t>(8));
-                dataflow_kernel_lib::prepare_reduce_scaler<
-                    dfb_in_2,
-                    ckernel::PoolType::AVG,
-                    ckernel::ReduceDim::REDUCE_SCALAR>(pad_corrected_scaler);
-#else
                 dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
                     dfb_in_2,
-                    ckernel::PoolType::AVG,
-                    ckernel::ReduceDim::REDUCE_SCALAR,
-                    reduce_factor_w>();
-#endif
+                    ckernel::PoolType::SUM,
+                    ckernel::ReduceDim::REDUCE_SCALAR>();
 
                 constexpr uint32_t ones = 0x3F803F80;  // 2 packed bfloat16 into 1 uint32_t of value 1.0
                 generate_tile_with_packed_bfloat16_values(dfb_ones_id, ones);
@@ -264,9 +262,8 @@ void kernel_main() {
                     constexpr uint32_t dfb_in_4 = tt::CBIndex::c_4;
                     dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
                         dfb_in_4,
-                        ckernel::PoolType::AVG,
-                        ckernel::ReduceDim::REDUCE_SCALAR,
-                        reduce_factor_c>();
+                        ckernel::PoolType::SUM,
+                        ckernel::ReduceDim::REDUCE_SCALAR>();
                 }
 
                 constexpr uint32_t eps_dfb_id = tt::CBIndex::c_3;


### PR DESCRIPTION
### Ticket

Fixes #53846
Fixes #53803

### Problem description

The two-pass groupnorm statistics encoded their divisor in the reduce scaler tile as `bf16(1/sqrt(N))`, because AVG/`REDUCE_SCALAR` applies the scaler twice: the row pool and the column pool of the transposed partials both draw their coefficient from the same SrcB row 0, which `TRNSPSRCB` (rows 16–31 only) does not touch. The effective divisor is therefore `bf16(1/sqrt(N))^2`, which equals `1/N` only when `sqrt(N)` is a power of two. For any other `N` the group mean is off by a few ulp of the group's magnitude, and a group whose variance is at or below `eps` normalizes to ~±1 instead of ~0 (`sqrt(0+eps)` amplifies the mean error ~300×).

The two stages cannot be given different coefficients by any scaler-tile fill: the last face's row 0 is both stage-1's coefficient for that face and stage-2's coefficient, and stage-1 consistency forces all faces equal.

### What's changed

The reduce now runs as an exact SUM (scaler `1.0`, exactly representable) and the division by `N` happens **once, in fp32, on the reduced DST element**, via the reduce helper's existing `post_reduce_op` hook — the same pattern `dit_rmsnorm_fused_compute.cpp` uses. Host-side, the divisors reach the compute kernels as fp32 bits in new named compile-time args:

- `mean_recip_bits` — `1/(reduce_factor_w · logical_hw/padded_hw)`, i.e. pad-corrected when H*W is not tile-aligned (`GroupNormPadCorrection::scaler_bits` → `recip_bits`, sqrt dropped);
- `global_recip_bits` — `1/reduce_factor_c` for the cross-core combine.

Both interleaved factories (NoMcast, Mcast) and the sharded v2 factory/kernels are covered. The packer edge mask still zeroes every non-result datum after the hook, so the sharded reader's single-tile-overwrite trick is unaffected. Welford paths are untouched. The sharded writer keeps its (now unused) runtime-arg-8 and CT-arg-11/12 slots so no argument renumbering occurs.

### Measured (Blackhole p100a)

Constant-group probe — every group a distinct constant, true variance 0, exact golden 0:

| probe | before | after |
|:---|---:|---:|
| tiles-per-group 1..20 (C=32, g=1) | wrong at **14 of 20** (\|out\| 0.95–1.0) | **exactly 0 at all 20** |
| value sweep V ∈ {3,5,6,7,100}, 2 tiles | 2–6 ulp mean error | exactly 0 |
| pad-corrected H*W=40×64, g=2 | wrong | exactly 0 |
| Mcast {1,2} 64×64 g=2 | −0.9922 | exactly 0 |
| sharded BLOCK 1×1, 64×64 g=2 | same mechanism | exactly 0 |

Variance-1 probe (well-conditioned, vs `torch.nn.functional.group_norm`):

| shape | before | after |
|:---|---:|---:|
| masked sub-tile groups, C=32..256 (16 ch/group) | up to **0.5566** | **0.0078** (one bf16 ulp, = Welford) |
| C=64 g=2, rows 32..512 | up to 0.070 | 0.0078 |

Full `test_group_norm.py` suite: 462 passed.

Program cache, precision variants, and perf (same protocol, base vs this branch):

- **Program cache**: 3 identical invocations -> 1 cache entry, bit-identical outputs; a second shape adds a second entry and is also run-to-run identical (the new named CT args hash correctly).
- **Precision variants post-fix**: LoFi, HiFi4, `fp32_dest_acc_en`, fp32 input, and fp32-input+fp32-dest all return exactly 0 on the constant-group probe at 2 and 3 tiles per group (every one of these was wrong by ~1 pre-fix).
- **Perf** (50 warm-cache iterations, host-synchronized): 512x64 g=2: 69.9 -> 70.4 us/op (+0.7%); 1024x320 g=32 masked: 4103.7 -> 4109.0 us/op (+0.13%) -- the one extra SFPU multiply per reduce level is within run-to-run noise. New regression test `test_group_norm_constant_group_exactness` asserts exact 0 across the trigger set (multi-tile, masked sub-tile, pad-corrected, mcast).

### Known remaining defect (separate issue, out of scope)

Sub-tile group widths combined with **many row tiles per core** are wrong far beyond this fix and were wrong before it: `[1,1,1024,320]` g=32 interleaved returns ~±1 for most groups (before: 23/32 bad, after: same class), and the sharded `C=320, W=8192, g=32` 8×4-grid shape returns worst ≈ 3.7 on the constant-group probe **on base and on this branch alike**. It is independent of the divisor (reproduces with `num_out_blocks=1` and with `fp32_dest_acc_en`). Because of it, two aggregate frobenius thresholds that this change's numeric shift straddled on noise were moved minimally (0.015→0.017, 0.016→0.018) with comments pointing at the defect; they should be tightened when it is fixed.

### Checklist
- [x] New/Existing tests provide coverage for changes
