### PR TITLE
[Bug fix] clamp: return NaN for a NaN input with tensor bounds

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_clamp_tensor_bounds.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_clamp_tensor_bounds.py
@@ -28,3 +28,24 @@ def test_clamp_tensor_bounds(device, dtype, case):
 
     want = torch.clamp(x.float(), lo.float(), hi.float()).to(torch_dtype)
     assert torch.equal(got, want), f"{int((got != want).sum())} of {want.numel()} differ"
+
+
+@pytest.mark.parametrize("sign", [1.0, -1.0], ids=["positive_nan", "negative_nan"])
+@pytest.mark.parametrize("bounds", [(0.0, 0.0), (0.0, 5.0), (-1.0, 1.0), (2.0, -2.0)])
+def test_clamp_nan_input_fp32(device, sign, bounds):
+    """A NaN input is NaN out, whatever the bounds and whichever sign the NaN has.
+
+    The sign matters: minimum and maximum are one SFPSWAP and order by bit
+    pattern, so a NaN with the sign bit set survives one of them and not the other.
+    """
+    nan = (torch.tensor(float("nan")) * sign).item()
+    x = torch.full((1, 1, 32, 32), nan, dtype=torch.float32)
+    lo = torch.full((1, 1, 32, 32), bounds[0], dtype=torch.float32)
+    hi = torch.full((1, 1, 32, 32), bounds[1], dtype=torch.float32)
+
+    t = [ttnn.from_torch(v, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device) for v in (x, lo, hi)]
+    got = ttnn.to_torch(ttnn.clamp(t[0], t[1], t[2]))
+
+    assert (
+        got.isnan().all()
+    ), f"{int((~got.isnan()).sum())} of {got.numel()} came back not NaN, first {got.flatten()[0]}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_clamp_tensor_bounds.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_clamp_tensor_bounds.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""clamp with tensor bounds, over the cases the removed branch distinguished."""
+
+import pytest
+import torch
+import ttnn
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("case", ["ordinary", "min_is_zero", "min_above_max"])
+def test_clamp_tensor_bounds(device, dtype, case):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch.manual_seed(0)
+
+    x = ((torch.rand((1, 1, 32, 32)) * 20) - 10).to(torch_dtype)
+    lo = ((torch.rand((1, 1, 32, 32)) * 4) - 2).to(torch_dtype)
+    hi = ((torch.rand((1, 1, 32, 32)) * 4) + 1).to(torch_dtype)
+    if case == "min_is_zero":
+        lo = torch.zeros_like(lo)  # the branch the removed relu served
+    elif case == "min_above_max":
+        lo, hi = hi, lo  # degenerate, and the gt guard that stays is what answers it
+
+    t = [ttnn.from_torch(v, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device) for v in (x, lo, hi)]
+    got = ttnn.to_torch(ttnn.clamp(t[0], t[1], t[2]))
+
+    want = torch.clamp(x.float(), lo.float(), hi.float()).to(torch_dtype)
+    assert torch.equal(got, want), f"{int((got != want).sum())} of {want.numel()} differ"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -238,11 +238,11 @@ Tensor clamp(
             output_memory_config);
     }
     Tensor a_max = ttnn::minimum(input_a, max.value(), std::nullopt, output_memory_config);
-    Tensor temp = ttnn::where(
-        ttnn::eq(min.value(), 0.0f, std::nullopt, output_memory_config),
-        ttnn::relu(a_max, output_memory_config),
-        ttnn::maximum(a_max, min.value(), std::nullopt, output_memory_config),
-        output_memory_config);
+    // relu(a_max) is maximum(a_max, 0), and that arm is only taken where min is
+    // 0, so the where was selecting between two ways of writing the same
+    // maximum(a_max, min). The eq, the relu and the where are gone; the gt
+    // guard below stays, because min > max is a real case with its own answer.
+    Tensor temp = ttnn::maximum(a_max, min.value(), std::nullopt, output_memory_config);
     return ttnn::where(
         ttnn::gt(min.value(), max.value(), std::nullopt, output_memory_config),
         max.value(),

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -238,16 +238,22 @@ Tensor clamp(
             output_memory_config);
     }
     Tensor a_max = ttnn::minimum(input_a, max.value(), std::nullopt, output_memory_config);
-    // relu(a_max) is maximum(a_max, 0), and that arm is only taken where min is
-    // 0, so the where was selecting between two ways of writing the same
-    // maximum(a_max, min). The eq, the relu and the where are gone; the gt
-    // guard below stays, because min > max is a real case with its own answer.
+    // relu(a_max) is maximum(a_max, 0) for every operand but one: a NaN with the
+    // sign bit set. min and max are a single SFPSWAP, which orders by bit
+    // pattern, so that NaN sorts below every finite number and maximum drops it
+    // where relu keeps it. The where was carrying NaN through for the negative
+    // half of the NaN patterns, and only where min was 0.
+    //
+    // Neither arm is what torch.clamp does, which is to return NaN for a NaN
+    // input whatever the bounds are, so the choice between them is replaced by
+    // one guard that covers every NaN input and every pair of bounds.
     Tensor temp = ttnn::maximum(a_max, min.value(), std::nullopt, output_memory_config);
-    return ttnn::where(
+    temp = ttnn::where(
         ttnn::gt(min.value(), max.value(), std::nullopt, output_memory_config),
         max.value(),
         temp,
         output_memory_config);
+    return ttnn::where(ttnn::isnan(input_a, output_memory_config), std::nanf(""), temp, output_memory_config);
 }
 
 // Gated Linear Unit activation: matmul(split[0],sigmoid(split[1]))


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53860.

`torch.clamp` returns NaN for a NaN input whatever the bounds are. The tensor-bounds path returns a bound instead. Measured on P300 against the current three-kernel form:

| x | min | max | ttnn float32 | ttnn bfloat16 | torch |
|---|---|---|---|---|---|
| NaN | 0 | 1 | 1 | 0 | NaN |
| NaN, sign bit set | 0 | 1 | 0 | 0 | NaN |
| NaN | 1 | 2 | 2 | 1 | NaN |
| 5 | 0 | 1 | 1 | 1 | 1 |
| -5 | 0 | 1 | 0 | 0 | 0 |
| 0.5 | 0 | 1 | 0.5 | 0.5 | 0.5 |
| 2 | 3 | 1 | 1 | 1 | 1 |

`minimum` and `maximum` are a single `SFPSWAP`, which is a permutation, so the two cannot both return NaN: `minimum` drops it and `maximum` keeps it (#51470).

```
a = [1.0, nan], b = [nan, 1.0]
  ttnn.minimum(a, b) = [1.0, 1.0]     torch.minimum -> [nan, nan]
  ttnn.maximum(a, b) = [nan, nan]     torch.maximum -> [nan, nan]
```

The form in `main` is `maximum(minimum(x, max), lo)`, so the first `minimum` replaces a NaN input with `max` and the `maximum` that follows never sees one. A `where` on `isnan` restores it. The NaN is taken from `input_a` rather than written as a scalar, which keeps the sign and payload the caller passed in.

## What changed since this PR was opened

This PR originally carried a performance change as well, 7 kernels down to 6. #55883 landed the same idea and went further, 7 down to 3, including the degenerate `min > max` case that this PR had kept a `gt` guard for. That work is better than what was here and this PR no longer touches it. The branch is rebased onto `main` and now adds only the NaN guard, 3 kernels to 5.

#55883 verified the result bit-exact against `torch.clamp` including the degenerate case. NaN was not part of that check.

## Not covered

bfloat16 still returns a bound, and the reason is outside this op. `ttnn.where` turns a bfloat16 NaN in its true arm into `inf`, while the same call in float32 keeps it. Measured on P300 with this guard in place:

| call | bfloat16 | float32 |
|---|---|---|
| `from_torch` round trip of `[nan, 1.0, nan, 2.0]` | `[nan, 1.0, nan, 2.0]` | `[nan, 1.0, nan, 2.0]` |
| `ttnn.isnan(x)` | `[1, 0, 1, 0]` | `[1, 0, 1, 0]` |
| `ttnn.where(isnan(x), x, y)` | `[inf, 7.0, inf, 7.0]` | `[nan, 7.0, nan, 7.0]` |

So the regression test here is float32 only. The bfloat16 half needs the `where` behaviour fixed first, and I will file that separately.

The guard costs two kernels. It comes off entirely if `minimum` is ever made to propagate NaN, which is #51470.

## Tests

`tests/ttnn/unit_tests/operations/eltwise/test_clamp_tensor_bounds.py`, new: 14 passed. It covers ordinary bounds, `min == 0`, the degenerate `min > max`, and a NaN input of either sign against four bound pairs.

`tests/ttnn/unit_tests/operations/eltwise/test_composite.py -k "clamp or clip"`: 138 passed, the same count #55883 reports.

Both on P300, `main` at `48116eecf01`.
