### PR TITLE
[Perf] is_odd: fold the halving and the floor onto the operands of the ne

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -4,6 +4,7 @@
 
 #include "unary_composite_op.hpp"
 
+#include <array>
 #include <functional>
 #include <optional>
 #include <variant>
@@ -357,9 +358,14 @@ Tensor logical_not_(const Tensor& x, const std::optional<MemoryConfig>& output_m
 namespace ttnn::operations::unary {
 
 Tensor is_odd(const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor result = ttnn::multiply(input, (1.0f / 2.0f), std::nullopt, output_mem_config);
-    Tensor floor_res = ttnn::floor(result, output_mem_config);
-    return ttnn::ne(result, floor_res, std::nullopt, output_mem_config);
+    // The same comparison, with the halving and the floor moved onto the two
+    // operands of the ne that was already reading them. ne applies a unary
+    // chain to each operand before comparing, so the three dispatches become
+    // one and the expression is unchanged, infinities included.
+    const std::array halve = {EltwiseUnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, 0.5f}};
+    const std::array halve_then_floor = {
+        EltwiseUnaryWithParam{UnaryOpType::MUL_UNARY_SFPU, 0.5f}, EltwiseUnaryWithParam{UnaryOpType::FLOOR}};
+    return ttnn::ne(input, input, std::nullopt, output_mem_config, std::nullopt, {}, halve, halve_then_floor);
 }
 
 }  // namespace ttnn::operations::unary


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Closes #53862.

`is_odd` ran `multiply(x, 0.5)`, `floor` and `ne` as three dispatches to ask whether `x/2` is an integer. `ne` applies a unary chain to each of its operands before comparing, so the halving is the left operand's chain and the halving and the floor are the right operand's: three dispatches become one and the expression is unchanged.

Asking the same question of `frac(x/2)` is one dispatch too, and shorter, but it is not the same expression at the infinities and the two machines disagree about it: `frac(±inf)` is NaN on P300 and inf on N300 in bfloat16, so `abs(frac) > 0` answers 0 on one and 1 on the other. `ne(±inf, floor(±inf))` is 0 on both, so the `ne` stays.

## Accuracy

Three case sets per dtype on each machine, against what the composite returned.

| case | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| integers, [-512, 512) | identical | identical | identical | identical |
| fractionals, [-100, 100] | identical | identical | identical | identical |
| ±inf, ±0, ±1, ±2 | identical | identical | identical | identical |

**Exhaustive.** Every one of the 65536 bfloat16 bit patterns, and 4194304 float32 bit patterns drawn uniformly from the 2^32 space, through both builds on the same device, output bits compared as integers:

| | P300 | N300 |
|---|---|---|
| bfloat16, all 65536 patterns | **65536 identical** | **65536 identical** |
| float32, 4194304 patterns | **4194304 identical** | **4194304 identical** |

Not one pattern moves, infinities and NaNs included. The temporary binding described under Tests is what the sweep went through.

## Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, median cycles per core on the math thread, summed over the kernels in a call. Zone counts give the kernel count.

| | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| kernels per call | 3 → **1** | 3 → **1** | 3 → **1** | 3 → **1** |
| TRISC_1, before | 19608 | 37950 | 10281 | 14253 |
| TRISC_1, after | **12522** | **22723** | **6233** | **9220** |
| | **1.57x** | **1.67x** | **1.65x** | **1.55x** |

## Tests

None added: `is_odd` has no Python binding and no caller, so there is no test path to extend. The accuracy table was taken through a temporary local binding, which is not part of this change.

## Not covered

- Exposing or deleting `is_odd`. It is declared, defined, and reachable from nowhere — see the issue. This change leaves that decision open.
- `bfloat8_b` and the sharded paths.

