### PR TITLE
Remove /codeowners bypass command

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -84,14 +84,15 @@ jobs:
       - name: Approve PR
         if: steps.verify.outputs.safe == 'true'
         env:
-          # Must be a token for an account in tenstorrent/codeowner-bypass.
-          # Reuses the existing codeowners bypass PAT — already a member of
-          # tenstorrent/codeowner-bypass. See codeowners-group-analysis.yaml.
+          # Must be a token for an account listed as a CODEOWNERS owner on the
+          # file paths this workflow covers (sfpi-info.sh, sfpi-version,
+          # ttsim-version, pipeline_reorg/, third_party/umd, third_party/tracy —
+          # see #53814). Reuses the existing codeowners-group-analysis PAT.
           GH_TOKEN: ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Use REST API instead of `gh pr review` to avoid GraphQL rate limits.
-          # Same PAT, same approving account, same CODEOWNERS bypass — just different transport.
+          # Same PAT, same approving account, same narrow CODEOWNERS ownership — just different transport.
           curl -s -X POST \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
@@ -163,7 +164,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Use REST API instead of `gh pr review` to avoid GraphQL rate limits.
-          # Same PAT, same approving account, same CODEOWNERS bypass — just different transport.
+          # Same PAT, same approving account, same narrow CODEOWNERS ownership — just different transport.
           curl -s -X POST \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -51,7 +51,6 @@ jobs:
       is-direct-ping: ${{ steps.parse.outputs.is-direct-ping }}
       comment-author: ${{ steps.parse.outputs.comment-author }}
       is-bypass-command: ${{ steps.parse.outputs.is-bypass-command }}
-      bypass-authorized: ${{ steps.parse.outputs.bypass-authorized }}
     steps:
       - name: Parse comment and get PR info
         id: parse
@@ -106,36 +105,26 @@ jobs:
                 echo "send-slack-notification=false" >> $GITHUB_OUTPUT
                 echo "is-direct-ping=false" >> $GITHUB_OUTPUT
                 echo "is-bypass-command=true" >> $GITHUB_OUTPUT
-                echo "Command: bypass approval"
+                echo "Command: bypass (retired)"
 
-                # Check if user is member of metalium-developers-infra team
-                INFRA_TEAM_API="https://api.github.com/orgs/tenstorrent/teams/metalium-developers-infra/members"
-                INFRA_MEMBERS_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                         -H "Accept: application/vnd.github.v3+json" \
-                                         "$INFRA_TEAM_API" 2>/dev/null)
+                RETIRED_MSG='❌ The `/codeowners bypass` command has been retired. To bypass code-owner review, merge as a member of the `@tenstorrent/codeowner-bypass` team via the normal "Merge when ready" button — the `main-codeowner-bypass` ruleset now grants that directly, no bot approval needed.'
+                TEMP_JSON_FILE=$(mktemp)
+                jq -n --arg body "$RETIRED_MSG" '{"body": $body}' > "$TEMP_JSON_FILE"
 
-                # Verify the API call was successful and returned valid JSON
-                if ! echo "$INFRA_MEMBERS_DATA" | jq -e '.[0]' > /dev/null 2>&1; then
-                  echo "❌ Failed to fetch team members, denying access"
-                  echo "bypass-authorized=false" >> $GITHUB_OUTPUT
-                else
-                  # Use jq to perform exact username matching
-                  IS_MEMBER=$(echo "$INFRA_MEMBERS_DATA" | jq -r --arg user "$COMMENT_AUTHOR" '[.[].login] | contains([$user])')
-                  if [ "$IS_MEMBER" = "true" ]; then
-                    echo "✅ User $COMMENT_AUTHOR is authorized (metalium-developers-infra member)"
-                    echo "bypass-authorized=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "❌ User $COMMENT_AUTHOR is NOT authorized (not in metalium-developers-infra)"
-                    echo "bypass-authorized=false" >> $GITHUB_OUTPUT
-                  fi
-                fi
+                curl -s -X POST \
+                  -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -H "Content-Type: application/json" \
+                  --data-binary @"$TEMP_JSON_FILE" \
+                  "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
+
+                rm -f "$TEMP_JSON_FILE"
               elif echo "$COMMENT_BODY" | grep -E "^/codeowners?\s+new(\s|$)" > /dev/null; then
                 echo "create-new-comment=true" >> $GITHUB_OUTPUT
                 echo "ping-pending-owners=false" >> $GITHUB_OUTPUT
                 echo "send-slack-notification=false" >> $GITHUB_OUTPUT
                 echo "is-direct-ping=false" >> $GITHUB_OUTPUT
                 echo "is-bypass-command=false" >> $GITHUB_OUTPUT
-                echo "bypass-authorized=false" >> $GITHUB_OUTPUT
                 echo "Command: new comment"
               elif echo "$COMMENT_BODY" | grep -E "^/codeowners?\s+ping(\s|$)|^/ping\s+codeowners?(\s|$)" > /dev/null; then
                 echo "create-new-comment=false" >> $GITHUB_OUTPUT
@@ -143,7 +132,6 @@ jobs:
                 echo "send-slack-notification=true" >> $GITHUB_OUTPUT
                 echo "is-direct-ping=false" >> $GITHUB_OUTPUT
                 echo "is-bypass-command=false" >> $GITHUB_OUTPUT
-                echo "bypass-authorized=false" >> $GITHUB_OUTPUT
                 echo "Command: ping owners"
               elif echo "$COMMENT_BODY" | grep -E "^/ping\s+" > /dev/null; then
                 echo "create-new-comment=false" >> $GITHUB_OUTPUT
@@ -151,7 +139,6 @@ jobs:
                 echo "send-slack-notification=true" >> $GITHUB_OUTPUT
                 echo "is-direct-ping=true" >> $GITHUB_OUTPUT
                 echo "is-bypass-command=false" >> $GITHUB_OUTPUT
-                echo "bypass-authorized=false" >> $GITHUB_OUTPUT
                 echo "Command: direct ping"
 
                 # Extract GitHub usernames and optional author notes from /ping command
@@ -181,7 +168,6 @@ jobs:
                 echo "send-slack-notification=false" >> $GITHUB_OUTPUT
                 echo "is-direct-ping=false" >> $GITHUB_OUTPUT
                 echo "is-bypass-command=false" >> $GITHUB_OUTPUT
-                echo "bypass-authorized=false" >> $GITHUB_OUTPUT
                 echo "Command: update existing comment"
               fi
 
@@ -292,187 +278,6 @@ jobs:
             echo "pr-exists=true" >> $GITHUB_OUTPUT
           fi
 
-
-  bypass-approval:
-    needs: [parse-comment, find-pr]
-    if: needs.parse-comment.outputs.is-bypass-command == 'true' && needs.parse-comment.outputs.bypass-authorized == 'true' && needs.find-pr.outputs.pr-exists == 'true'
-    runs-on: ubuntu-slim
-    steps:
-      - name: Approve PR
-        run: |
-          PR_NUMBER="${{ needs.find-pr.outputs.pr-number }}"
-          COMMENT_AUTHOR="${{ needs.parse-comment.outputs.comment-author }}"
-
-          echo "Approving PR #$PR_NUMBER as requested by authorized user: $COMMENT_AUTHOR"
-
-          # Pre-flight: detect self-approval (GitHub rejects reviews where the
-          # authenticated user is also the PR author).
-          # PR author is available from the event payload (issue_comment trigger),
-          # avoiding an extra API call.
-          PR_AUTHOR="${{ github.event.issue.user.login }}"
-
-          PAT_USER=$(curl -s \
-            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/user" \
-            | jq -r '.login // empty')
-
-          if [ -n "$PAT_USER" ] && [ "$PAT_USER" = "$PR_AUTHOR" ]; then
-            echo "❌ Self-approval detected: PAT belongs to '$PAT_USER' who is also the PR author."
-            echo "GitHub does not allow a user to approve their own pull request."
-
-            SELF_APPROVE_MSG=$(cat <<'EOFMSG'
-          ❌ **Bypass Approval Failed — Self-Approval Not Allowed**
-
-          The bypass PAT (`CODEOWNERS_GROUP_ANALYSIS_PAT`) is authenticated as **@PATUSER**, who is also the author of this PR. GitHub does not permit a user to approve their own pull request.
-
-          **To fix:** A different team member with bypass authority must run `/codeowners bypass`, or the infra team must configure a second PAT belonging to a different account for bypass approvals.
-          EOFMSG
-          )
-            SELF_APPROVE_MSG="${SELF_APPROVE_MSG//PATUSER/$PAT_USER}"
-
-            TEMP_FILE=$(mktemp)
-            jq -n --arg body "$SELF_APPROVE_MSG" '{"body": $body}' > "$TEMP_FILE"
-
-            curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Content-Type: application/json" \
-              -d @"$TEMP_FILE" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
-
-            rm -f "$TEMP_FILE"
-
-            curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Content-Type: application/json" \
-              -d '{"content": "-1"}' \
-              "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions"
-
-            exit 1
-          fi
-
-          # Create approval
-          REVIEW_API="https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews"
-
-          REVIEW_PAYLOAD=$(jq -n \
-            --arg event "APPROVE" \
-            --arg body "✅ CodeOwners bypass approval granted by @$COMMENT_AUTHOR (metalium-developers-infra team)" \
-            '{
-              event: $event,
-              body: $body
-            }')
-
-          REVIEW_RESPONSE=$(curl -s -X POST \
-            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Content-Type: application/json" \
-            -d "$REVIEW_PAYLOAD" \
-            "$REVIEW_API")
-
-          REVIEW_ID=$(echo "$REVIEW_RESPONSE" | jq -r '.id // empty')
-          ERROR_MSG=$(echo "$REVIEW_RESPONSE" | jq -r '.message // empty')
-
-          if [ -n "$REVIEW_ID" ] && [ "$REVIEW_ID" != "null" ]; then
-            echo "✅ Successfully approved PR #$PR_NUMBER (Review ID: $REVIEW_ID)"
-
-            # Add success reaction to the command comment
-            curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Content-Type: application/json" \
-              -d '{"content": "+1"}' \
-              "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions"
-          else
-            echo "❌ Failed to approve PR #$PR_NUMBER"
-            echo "Response: $REVIEW_RESPONSE"
-
-            # Build a diagnostic error message
-            if echo "$ERROR_MSG" | grep -qi "can not approve your own"; then
-              FAIL_DETAIL="The PAT user ($PAT_USER) is the PR author — GitHub blocks self-approval. Use a different account's PAT or have another team member run the bypass."
-            elif echo "$ERROR_MSG" | grep -qi "validation failed"; then
-              FAIL_DETAIL="GitHub rejected the review: $ERROR_MSG"
-            else
-              FAIL_DETAIL="GitHub API error: $ERROR_MSG. This might be a temporary issue — try again or contact the infra team."
-            fi
-
-            FAIL_BODY=$(printf '❌ **Bypass Approval Failed**\n\n%s' "$FAIL_DETAIL")
-            TEMP_FILE=$(mktemp)
-            jq -n --arg body "$FAIL_BODY" '{"body": $body}' > "$TEMP_FILE"
-
-            curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Content-Type: application/json" \
-              -d @"$TEMP_FILE" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
-
-            rm -f "$TEMP_FILE"
-
-            # Add failure reaction
-            curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Content-Type: application/json" \
-              -d '{"content": "-1"}' \
-              "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions"
-
-            exit 1
-          fi
-
-      - name: Post confirmation comment
-        if: success()
-        run: |
-          PR_NUMBER="${{ needs.find-pr.outputs.pr-number }}"
-          COMMENT_AUTHOR="${{ needs.parse-comment.outputs.comment-author }}"
-
-          CONFIRMATION=$'✅ **CodeOwners Bypass Approval Granted**\n\nThis PR has been approved by @'"$COMMENT_AUTHOR"$' (metalium-developers-infra team) using the bypass mechanism.\n\n⚠️ **Note:** This bypass should only be used for emergency fixes or when standard approval process is blocked.'
-
-          TEMP_JSON_FILE=$(mktemp)
-          jq -n --arg body "$CONFIRMATION" '{"body": $body}' > "$TEMP_JSON_FILE"
-
-          curl -s -X POST \
-            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Content-Type: application/json" \
-            --data-binary @"$TEMP_JSON_FILE" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
-
-          rm -f "$TEMP_JSON_FILE"
-          echo "Confirmation comment posted for PR #$PR_NUMBER"
-
-  bypass-unauthorized:
-    needs: [parse-comment, find-pr]
-    if: needs.parse-comment.outputs.is-bypass-command == 'true' && needs.parse-comment.outputs.bypass-authorized == 'false' && needs.find-pr.outputs.pr-exists == 'true'
-    runs-on: ubuntu-slim
-    steps:
-      - name: Post unauthorized message
-        run: |
-          PR_NUMBER="${{ needs.find-pr.outputs.pr-number }}"
-          COMMENT_AUTHOR="${{ needs.parse-comment.outputs.comment-author }}"
-
-          UNAUTHORIZED_MSG=$'❌ **Access Denied**: The `/codeowners bypass` command can only be used by members of the `@tenstorrent/metalium-developers-infra` team.\n\nUser @'"$COMMENT_AUTHOR"$' is not authorized to use this command.\n\nIf you need bypass approval, please contact a member of the infra team.'
-
-          TEMP_JSON_FILE=$(mktemp)
-          jq -n --arg body "$UNAUTHORIZED_MSG" '{"body": $body}' > "$TEMP_JSON_FILE"
-
-          curl -s -X POST \
-            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Content-Type: application/json" \
-            --data-binary @"$TEMP_JSON_FILE" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
-
-          rm -f "$TEMP_JSON_FILE"
-
-          # Add thumbs down reaction to the command comment
-          curl -s -X POST \
-            -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Content-Type: application/json" \
-            -d '{"content": "-1"}' \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions"
 
   get-reviews:
     needs: [find-pr]
@@ -1005,7 +810,6 @@ jobs:
               [ -z "$team_entry" ] && continue
               team=$(echo "$team_entry" | cut -d':' -f1)
               [ -z "$team" ] && continue
-              [ "$team" = "@tenstorrent/codeowner-bypass" ] && continue
               team_files=$(echo "$team_entry" | cut -d':' -f2-)
               clean_team=$(echo "$team" | sed 's/^@//')
               sorted_files=$(echo "$team_files" | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -111,14 +111,19 @@ jobs:
                 TEMP_JSON_FILE=$(mktemp)
                 jq -n --arg body "$RETIRED_MSG" '{"body": $body}' > "$TEMP_JSON_FILE"
 
-                curl -s -X POST \
+                RETIRED_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
                   -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                   -H "Accept: application/vnd.github.v3+json" \
                   -H "Content-Type: application/json" \
                   --data-binary @"$TEMP_JSON_FILE" \
-                  "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
+                  "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments")
 
                 rm -f "$TEMP_JSON_FILE"
+
+                if [ "$RETIRED_HTTP_CODE" != "201" ]; then
+                  echo "❌ Failed to post retirement notice (HTTP $RETIRED_HTTP_CODE)"
+                  exit 1
+                fi
               elif echo "$COMMENT_BODY" | grep -E "^/codeowners?\s+new(\s|$)" > /dev/null; then
                 echo "create-new-comment=true" >> $GITHUB_OUTPUT
                 echo "ping-pending-owners=false" >> $GITHUB_OUTPUT
@@ -233,7 +238,7 @@ jobs:
 
   find-pr:
     needs: [parse-comment]
-    if: always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && needs.parse-comment.outputs.should-run == 'true'))
+    if: always() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && needs.parse-comment.outputs.should-run == 'true' && needs.parse-comment.outputs.is-bypass-command != 'true'))
     runs-on: ubuntu-slim
     outputs:
       pr-number: ${{ steps.find-pr.outputs.pr-number }}


### PR DESCRIPTION
## Summary
- The `main-branch-protection` ruleset was replaced with a two-ruleset split (`main-branch-protection` + `main-codeowner-bypass`) so members of the `@tenstorrent/codeowner-bypass` team can merge directly via "Merge when ready" without code-owner review, while still going through required status checks and the merge queue like everyone else. Confirmed working end-to-end on a live test PR (#53603).
- With that in place, the `/codeowners bypass` PR-comment command in `codeowners-group-analysis.yaml` (a bot PAT submitting an "APPROVE" review on behalf of a `metalium-developers-infra` team member) is fully redundant, and has the same self-approval deadlock problem discussed for the ruleset approach: if the invoking user happens to be the PR author, GitHub blocks the bot's approval outright.

## Changes
- `codeowners-group-analysis.yaml`: removed the `bypass-approval` and `bypass-unauthorized` jobs, the infra-team-membership authorization check, and the `bypass-authorized` output entirely. The `/codeowners bypass` comment pattern is still recognized, but now only posts a retirement notice pointing at the ruleset-based bypass instead of approving anything. Also removed a now-dead skip-case for `@tenstorrent/codeowner-bypass` in the pending-owner analysis (that team can no longer appear in CODEOWNERS-derived team lists since #53712 stripped it).
- `auto-approve.yaml`: updated three stale comments that described the bot's approval authority as coming from team membership in `tenstorrent/codeowner-bypass` — inaccurate since #53814 switched this workflow to being a directly-listed CODEOWNERS owner on 6 specific file paths instead.

## Test plan
- [x] Validated YAML syntax of both files after edits
- [x] Grepped for `is-bypass-command`, `bypass-authorized`, `bypass-approval`, `bypass-unauthorized`, `codeowner-bypass` to confirm nothing was missed beyond the intended retirement-notice text
- [ ] Comment `/codeowners bypass` on a scratch PR post-merge to confirm the retirement notice posts correctly
- [ ] Confirm `/codeowners ping` and a plain re-trigger comment still work untouched

Co-authored-by: BrAIn <brain@tenstorrent.com>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=remove-codeowners-bypass-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:remove-codeowners-bypass-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=remove-codeowners-bypass-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:remove-codeowners-bypass-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=remove-codeowners-bypass-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:remove-codeowners-bypass-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=remove-codeowners-bypass-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:remove-codeowners-bypass-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=remove-codeowners-bypass-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:remove-codeowners-bypass-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=remove-codeowners-bypass-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:remove-codeowners-bypass-command)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=remove-codeowners-bypass-command)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:remove-codeowners-bypass-command)