### PR TITLE
[Perf] normalize_hw: let the multiply take the rsqrt as an operand activation

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_normalize_hw.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_normalize_hw.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def torch_normalize_hw(x):
+    xd = x.double()
+    mean = xd.mean(dim=(2, 3), keepdim=True)
+    std = xd.std(dim=(2, 3), keepdim=True, unbiased=False)
+    return ((xd - mean) / std).float()
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("scale", [1.0, 100.0, 1e-3])
+@pytest.mark.parametrize("shape", [[1, 1, 32, 32], [1, 2, 64, 64]])
+def test_normalize_hw(device, dtype, scale, shape):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch.manual_seed(0)
+    x = (torch.randn(shape) * scale).to(torch_dtype)
+
+    got = ttnn.to_torch(ttnn.normalize_hw(ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)))
+
+    assert_with_pcc(torch_normalize_hw(x.float()), got.float(), 0.999)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_normalize_hw_zero_variance(device, dtype):
+    # Every element equal, so the divisor is zero. rsqrt(0) is inf where
+    # reciprocal(sqrt(0)) was, and 0 * inf resolves the same way.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    x = torch.full([1, 1, 32, 32], 3.0, dtype=torch_dtype)
+
+    got = ttnn.to_torch(ttnn.normalize_hw(ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)))
+
+    assert torch.isfinite(got.float()).all() or torch.isnan(got.float()).all()

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -4,6 +4,7 @@
 
 #include "unary_composite_op.hpp"
 
+#include <array>
 #include <functional>
 #include <optional>
 #include <variant>
@@ -150,10 +151,12 @@ Tensor normalize_hw(const Tensor& y, const std::optional<MemoryConfig>& output_m
     ttsl::SmallVector<int> dims = {2, 3};
     Tensor mean_y = ttnn::mean(y, dims, true);
     Tensor y_minus_mean_y = ttnn::bcast(y, mean_y, ttnn::BcastOpMath::SUB, ttnn::BcastOpDim::HW);
-    Tensor std_y = detail::_std(y, mean_y, y_minus_mean_y, output_mem_config);
-    Tensor recip_std_y = ttnn::reciprocal(std_y, output_mem_config);
-    Tensor z = ttnn::multiply(y_minus_mean_y, recip_std_y, std::nullopt, output_mem_config);
-    return z;
+    // The divisor was built as reciprocal(sqrt(variance)), two dispatches for
+    // what rsqrt is, and multiply applies a unary chain to its operands anyway,
+    // so the rsqrt rides on the multiply that was going to read it.
+    Tensor var_y = detail::_variance_impl(y, mean_y, y_minus_mean_y, output_mem_config);
+    const std::array rsqrt_of_var = {operations::unary::EltwiseUnaryWithParam{operations::unary::UnaryOpType::RSQRT}};
+    return ttnn::multiply(y_minus_mean_y, var_y, std::nullopt, output_mem_config, std::nullopt, {}, {}, rsqrt_of_var);
 }
 
 // Function Clip


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Closes #53868.

The divisor was `reciprocal(sqrt(variance))` — two dispatches for what `rsqrt` is in one — and the `multiply` that reads it applies a unary chain to its operands anyway. The rsqrt now rides on that multiply, so both dispatches go and nothing else moves.

`_std` is no longer called from here; `_variance_impl` is, since the square root was only ever there to be undone.

## Accuracy

Four case sets per dtype on each machine, against `(x - mean) / std` in float64.

| case | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| randn | identical | identical | identical | max &#124;base-fused&#124; 2.4e-07 |
| randn x 100 | one step, fused closer (2.23e-2 vs 2.62e-2) | identical | one step, fused closer | identical |
| randn x 1e-3 | one step, base closer (1.53e-2 vs 1.76e-2) | identical | one step, base closer | identical |
| constant input, zero variance | identical | identical | identical | identical |

The bfloat16 differences are `rsqrt(v)` against `1/sqrt(v)`, one step either way, and the same two sets move on both machines.

**One tile holding every bfloat16 bit pattern**, and one holding 4194304 float32 bit patterns drawn uniformly from the 2^32 space, through both builds on the same device:

| | P300 | N300 |
|---|---|---|
| bfloat16, all 65536 patterns in one tile | **identical** | **identical** |
| float32, 4194304 patterns | **identical** | **identical** |

This is input coverage rather than an exhaustive check of the op: `normalize_hw` reduces over H and W, so a tile of every pattern is one case, not 65536. The case sets above are where the op is exercised at different scales, and they are where the two bfloat16 steps show up.

## Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, TRISC_1 cycles summed over the cores in a call.

| | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| dispatches per call | 9 → **7** | 9 → **7** | 9 → **7** | 9 → **7** |
| TRISC_1, before | 4,716,010 | 7,374,688 | 3,891,650 | 8,664,706 |
| TRISC_1, after | **4,114,590** | 7,565,665 | **3,840,570** | **8,277,959** |
| | **1.15x** | 0.97x | 1.01x | **1.05x** |

The dispatch count is the result. The two dropped dispatches run on a reduced tensor, so the cycle total moves by a few percent either way depending on machine and dtype, and on N300 float32 it moves the wrong way by 2.6%.

## Measured against #52615

#52615 is open against #52614, the range failure of the same composite, and touches the same function, so the two cannot both land unchanged. Applied to `04cf22f7ee` and measured on P300, `[1, 1, 64, 64]`, float32.

It does not compile, at its own base `565641307c7` either: the 3-arg `_std` calls the 4-arg one defined below it, and the 4-arg one leaves `mean_y` unused under `-Werror`. Everything below is with those two fixed.

**The boundary it repairs is not reached by any workload.** The bounds are `|x - mean| < 1.084e-19` and `> 1.304e19`: below the first a tensor is already zero to everything downstream, above the second the run has diverged. Neither inference nor training passes through either. The cost is paid on every call, at every magnitude — `normalize_hw` goes from 9 dispatches to **17** and float32 device cycles rise **47%**, to move a number at 1e-20 and 1e20.

| first element of | torch | today | #52615 |
|---|---|---|---|
| `normalize_hw`, spread 1e-20 | -1.1238 | -inf | **-1.1273** |
| `normalize_hw`, spread 1e20 | -1.1238 | -48.25 | **-1.1232** |
| `std_hw`, spread 1e-20 | 9.93e-21 | 0 | **0** |
| `std_hw`, spread 1e20 | 9.93e+19 | 2.31e+18 | **inf** |
| `std_hw`, bfloat16, one `nan` present | nan | 2.31e+18 | **0** |

So it fixes `normalize_hw` and not `std_hw` or `var_hw`, which are two of the three ops in its own title and the first row of its own table: they route through `_variance_impl`, where the restored scale is `m²`, which underflows at 1e-20 and overflows at 1e20. Its own comment names that trap and then leaves `_variance_impl` in it.

Applying both gives 16 dispatches and loses the 1e-20 fix, because this PR routes `normalize_hw` through `_variance_impl`. A variant that keeps `_std` and folds only the reciprocal composes with it, at 9 → 8 instead of 9 → 7; say the word and it is a three-line change.

## Tests

`test_normalize_hw.py`, 14 cases: two shapes at three scales on both dtypes against a float64 reference at 0.999 PCC, plus the zero-variance input where the divisor is zero. The two `normalize_hw` doc examples pass unchanged.

## Not covered

- The two reductions. `mean` is two dispatches on its own and the `sum` inside the variance is another two, so four of the remaining seven are reduction work this change does not touch.

