### PR TITLE
[Bug fix] atan2_bw: drop the hypot that was being squared

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_atan2_bw_magnitudes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_atan2_bw_magnitudes.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+
+def reference(x, y):
+    xd, yd = x.double(), y.double()
+    s = xd * xd + yd * yd
+    return (yd / s).float(), (-xd / s).float()
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("scale", [1.0, 1e-18, 1e18])
+def test_atan2_bw_magnitudes(device, dtype, scale):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch.manual_seed(0)
+    x = ((torch.rand([1, 1, 32, 32]) * 20 - 10) * scale).to(torch_dtype)
+    y = ((torch.rand([1, 1, 32, 32]) * 20 - 10) * scale).to(torch_dtype)
+    grad = torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got_a, got_b = [ttnn.to_torch(t).float() for t in ttnn.atan2_bw(dev(grad), dev(x), dev(y))]
+    want_a, want_b = reference(x.float(), y.float())
+
+    # Only where the reference itself survives the format: at 1e18 and 1e-18 the
+    # sum of squares saturates, which it did before this change as well.
+    keep = torch.isfinite(want_a) & torch.isfinite(got_a) & (want_a.abs() > 0) & (got_a.abs() > 0)
+    if keep.sum() == 0:
+        pytest.skip("no element of this set is representable")
+    rel_a = ((got_a[keep] - want_a[keep]) / want_a[keep]).abs()
+    rel_b = ((got_b[keep] - want_b[keep]) / want_b[keep]).abs()
+    # Away from unit scale the sum of squares is close to the end of the format
+    # and the surviving elements carry more error, which they did before too.
+    tol = 0.05 if (dtype == ttnn.bfloat16 or scale != 1.0) else 1e-3
+    assert rel_a.mean() < tol and rel_b.mean() < tol
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_atan2_bw_origin_is_not_finite(device, dtype):
+    # Both gradients are the nan the where writes in where a and b are both
+    # zero, which is what the logical_and of the two eqz selects. In bfloat16
+    # that nan reaches the tensor as inf, since bfloat16 loses nan through the
+    # pack; this is the case before this change as well.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    zero = torch.zeros([1, 1, 32, 32], dtype=torch_dtype)
+    one = torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got_a, got_b = [ttnn.to_torch(t).float() for t in ttnn.atan2_bw(dev(one), dev(zero), dev(zero))]
+    assert not torch.isfinite(got_a).any() and not torch.isfinite(got_b).any()
+    if dtype == ttnn.float32:
+        assert got_a.isnan().all() and got_b.isnan().all()
+
+    # One of the two being zero is an ordinary point, not the origin.
+    got_a, got_b = [ttnn.to_torch(t).float() for t in ttnn.atan2_bw(dev(one), dev(zero), dev(one))]
+    assert not got_a.isnan().any() and not got_b.isnan().any()

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -4,7 +4,9 @@
 
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 
+#include <array>
 #include <numbers>
+#include <cstdint>
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 
 #include "ttnn/operations/data_movement/slice/slice.hpp"
@@ -100,18 +102,28 @@ std::vector<Tensor> atan2_bw(
     float t_nan = std::nanf("");
     using ttnn::operations::unary::EltwiseUnaryWithParam;
     using ttnn::operations::unary::UnaryOpType;
-    std::vector<EltwiseUnaryWithParam> ops_chain = {
-        EltwiseUnaryWithParam{UnaryOpType::SQUARE}, EltwiseUnaryWithParam{UnaryOpType::RECIP}};
+
+    // The denominator was square(hypot(a, b)). hypot rescales to keep a*a + b*b
+    // from overflowing, and squaring it puts the overflow straight back, so the
+    // rescaling bought nothing and the sqrt inside it was undone by the square.
+    // add squares each operand on the way in, which is the same number.
+    const std::array square_it = {EltwiseUnaryWithParam{UnaryOpType::SQUARE}};
+    const std::array reciprocal_it = {EltwiseUnaryWithParam{UnaryOpType::RECIP}};
+    const std::array is_zero = {EltwiseUnaryWithParam{UnaryOpType::EQZ}};
+    const std::array negate_it = {EltwiseUnaryWithParam{UnaryOpType::NEG}};
+
+    Tensor sum_of_squares =
+        ttnn::add(input_a, other, std::nullopt, output_mem_config, std::nullopt, {}, square_it, square_it);
     Tensor recip_mul = ttnn::multiply(
-        grad_tensor,
-        ttnn::unary_chain(ttnn::hypot(input_a, other, output_mem_config), ops_chain, output_mem_config),
-        std::nullopt,
-        output_mem_config);
+        grad_tensor, sum_of_squares, std::nullopt, output_mem_config, std::nullopt, {}, {}, reciprocal_it);
+    sum_of_squares.deallocate();
     Tensor grad_a = ttnn::multiply(other, recip_mul, std::nullopt, output_mem_config);
-    Tensor cond = ttnn::logical_and(ttnn::eqz(input_a, output_mem_config), ttnn::eqz(other, output_mem_config));
+    Tensor cond =
+        ttnn::logical_and(input_a, other, std::nullopt, output_mem_config, std::nullopt, {}, is_zero, is_zero);
     grad_a = ttnn::where(cond, t_nan, grad_a, output_mem_config);
     grad.emplace_back(grad_a);
-    Tensor grad_b = ttnn::multiply(ttnn::neg(input_a), recip_mul, std::nullopt, output_mem_config);
+    Tensor grad_b =
+        ttnn::multiply(input_a, recip_mul, std::nullopt, output_mem_config, std::nullopt, {}, negate_it, {});
     grad_b = ttnn::where(cond, t_nan, grad_b, output_mem_config);
     recip_mul.deallocate();
     cond.deallocate();
@@ -526,19 +538,19 @@ std::vector<std::optional<Tensor>> concat_bw(
         input_grad, other_grad, input_tensor_a_arg, other, {are_required_outputs[0], are_required_outputs[1]});
 
     if (are_required_outputs[0]) {
-        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttsl::SmallVector<uint32_t> end_index = {
+        ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> end_index = {
             input_tensor_a_arg.logical_shape()[0],
             input_tensor_a_arg.logical_shape()[1],
             input_tensor_a_arg.logical_shape()[2],
             input_tensor_a_arg.logical_shape()[3]};
-        ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttsl::SmallVector<std::uint32_t> step = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index, end_index, step, std::nullopt, input_grad);
         grad_tensor[0] = input_grad;
     }
 
     if (are_required_outputs[1]) {
-        ttsl::SmallVector<uint32_t> start_index_2 = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> start_index_2 = {0, 0, 0, 0};
         if (dim == 0) {
             start_index_2 = {input_tensor_a_arg.logical_shape()[0], 0, 0, 0};
         } else if (dim == 1) {
@@ -548,12 +560,12 @@ std::vector<std::optional<Tensor>> concat_bw(
         } else if (dim == 3) {
             start_index_2 = {0, 0, 0, input_tensor_a_arg.logical_shape()[3]};
         }
-        ttsl::SmallVector<uint32_t> end_index_2 = {
+        ttsl::SmallVector<std::uint32_t> end_index_2 = {
             grad_tensor_arg.logical_shape()[0],
             grad_tensor_arg.logical_shape()[1],
             grad_tensor_arg.logical_shape()[2],
             grad_tensor_arg.logical_shape()[3]};
-        ttsl::SmallVector<uint32_t> step_2 = {1, 1, 1, 1};
+        ttsl::SmallVector<std::uint32_t> step_2 = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index_2, end_index_2, step_2, std::nullopt, other_grad);
         grad_tensor[1] = other_grad;
     }


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53870.

The denominator was `square(hypot(a, b))`. `hypot` rescales so that `a*a + b*b` does not overflow, and squaring the result puts the overflow straight back, so the rescaling bought nothing and the sqrt inside it was undone by the square. `add` squares each operand on the way in, which is the same number in one dispatch and one rounding instead of three.

The rest follows from the same place: the `reciprocal` rides on the multiply that reads it, the two `eqz` become the operand activations of the `logical_and` that reads them, and the `neg` becomes an operand activation of its multiply.

## Accuracy

Six case sets per dtype on each machine, `grad = 1`, against `y / (x² + y²)` in float64. Mean relative error over the elements where the reference is finite and non-zero, and how many elements move each way.

| case | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| ordinary, [-10, 10] | 4.70e-03 → **2.66e-03** | 6.54e-08 → **4.04e-08** | 4.74e-03 → **2.68e-03** | 6.47e-08 → **4.03e-08** |
| x 1e-18 | 4.99e-03 → **2.82e-03** | 6.528e-05 → 6.526e-05 | 5.07e-03 → **2.85e-03** | 6.528e-05 → 6.526e-05 |
| x 1e18 | 3.257e-01 → **3.242e-01** | unchanged | 3.257e-01 → **3.242e-01** | unchanged |
| one huge, one tiny | identical | identical | identical | identical |
| origin | identical | identical | identical | identical |
| inf / ±0 / 1e±6 | identical | identical | identical | identical |

On the ordinary set the fused form is closer to the float64 answer on 397 of the elements that move and farther on 41, in bfloat16 on N300; 355 against 78 in float32. No set is worse in the mean on either machine.

`a*a + b*b` still saturates near 1e18 and 1e-18 and both forms lose the answer there. The hypot never protected it, which is the point.

**Exhaustive.** Every one of the 65536 bfloat16 bit patterns, in each of the three operand positions, against five settings of the other two — the ordinary case, either operand zero, mixed signs, and 1e30 against 1e-30 — both gradients. 1966080 comparisons. The same structure over 4194304 float32 bit patterns drawn uniformly from the 2^32 space gives 125829120. Every difference is scored against `y / (x² + y²)` in float64:

| | P300 bfloat16 | P300 float32 | N300 bfloat16 | N300 float32 |
|---|---|---|---|---|
| identical to the composite | 1816098 | 116138518 | 1946043 | 116111329 |
| differ, **this branch closer** | **147996** | **9323152** | **17920** | **9330810** |
| differ, composite closer | 1986 | 367450 | 1990 | 373422 |
| of those, by more than 1 ULP | **850** | 11115 | **854** | 11801 |

The float32 column is rounding: the worst of the 11115 is 1.92e-07, 1.6 ULP, and there is no structure to them.

The bfloat16 850 are not. 762 of them are one thing: **a subnormal operand with the other operand zero, where the origin guard fires and returns NaN for a gradient that is defined.** `atan2_bw(grad=1, a=9.18e-41, b=0)` is `0` on the composite and on `torch`, and NaN — `inf` through a bfloat16 DST — here. The remaining 88 are 4 elements that underflow at the bottom of the bfloat16 normal range and 84 that sit within 1.4 ULP.

## The origin guard, and whether folding it is allowed

The 762 come from `eqz` being folded onto `logical_and` as an operand activation rather than run as its own op. Those are not the same test. Measured on P300 with the activation arguments exposed through a local binding, for a subnormal operand:

| | `ttnn.eqz(x)` | `ttnn.eq(x, 0.0)` | EQZ folded as an operand activation | exact |
|---|---|---|---|---|
| bfloat16 | 0 | **1** | **1** | 0 |
| float32 | 0 | **1** | 0 | 0 |

`nez`, `lez` and `gtz` behave the same way. So the fold reads a bfloat16 subnormal as zero where the standalone `eqz` does not, and that is the whole of the bfloat16 column above. It is a question about the activation contract rather than about this op, and it is the same question in #53873.

If folding a zero test is not allowed, the guard goes back to standalone `eqz` and the count is 11 → 9 rather than 11 → 7. It is one hunk:

```diff
-    const std::array is_zero = {EltwiseUnaryWithParam{UnaryOpType::EQZ}};
...
-    Tensor cond =
-        ttnn::logical_and(input_a, other, std::nullopt, output_mem_config, std::nullopt, {}, is_zero, is_zero);
+    Tensor cond = ttnn::logical_and(
+        ttnn::eqz(input_a, output_mem_config), ttnn::eqz(other, output_mem_config), std::nullopt, output_mem_config);
```

Measured with that applied, the bfloat16 differences beyond 1 ULP go from 850 to **88** on P300 and 854 to **92** on N300 — the 762 exactly — and the float32 columns do not move. Say which one you want.

## Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, TRISC_1 cycles summed over the cores in a call.

| | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| dispatches per call | 11 → **7** | 11 → **7** | 11 → **7** | 11 → **7** |
| TRISC_1, before | 13,213,363 | 27,402,543 | 10,593,452 | 16,958,407 |
| TRISC_1, after | **10,557,385** | **21,447,381** | **8,337,765** | **13,248,811** |
| | **1.25x** | **1.28x** | **1.27x** | **1.28x** |

## Tests

`test_atan2_bw_magnitudes.py`, 8 cases: three magnitude scales on both dtypes against a float64 reference, and the origin, where both gradients are the nan the `where` writes. The 3 existing `test_backward_atan2.py` cases pass unchanged.

## Not covered

- At the origin, bfloat16 returns inf rather than nan, since bfloat16 loses nan through the pack. Unchanged by this PR, and the test records it.
- The saturation at extreme magnitudes, which needs the expression reorganised rather than the hypot restored.

