### PR TITLE
[Perf] xlogy_bw: drop the two wheres on eq(x, nan) and fold the guards

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_xlogy_bw_edges.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_xlogy_bw_edges.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+NAN = float("nan")
+
+
+def run(device, dtype, grad, a, b):
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    return [ttnn.to_torch(t).float() for t in ttnn.xlogy_bw(dev(grad), dev(a), dev(b))]
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_xlogy_bw_matches_torch(device, dtype):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch.manual_seed(0)
+    a = (torch.rand([1, 1, 32, 32]) * 10 - 5).to(torch_dtype)
+    b = (torch.rand([1, 1, 32, 32]) * 10 + 0.5).to(torch_dtype)
+    grad = (torch.rand([1, 1, 32, 32]) * 2 - 1).to(torch_dtype)
+
+    got_a, got_b = run(device, dtype, grad, a, b)
+
+    ta = a.float().clone().requires_grad_(True)
+    tb = b.float().clone().requires_grad_(True)
+    torch.xlogy(ta, tb).backward(grad.float())
+
+    tol = 0.05 if dtype == ttnn.bfloat16 else 1e-4
+    assert (got_a - ta.grad).abs().max() < tol
+    assert ((got_b - tb.grad).abs() / tb.grad.abs().clamp(min=1.0)).max() < tol
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_xlogy_bw_a_zero_b_not_positive(device, dtype):
+    # The logical_and of eqz(a) and le(b, 0) selects zero for grad_a here, and
+    # the ltz(b) below it selects nan where only b is negative.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    zero = torch.zeros([1, 1, 32, 32], dtype=torch_dtype)
+    one = torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+
+    got_a, _ = run(device, dtype, one, zero, -one)
+    assert (got_a == 0).all()
+
+    got_a, _ = run(device, dtype, one, one, -one)
+    assert not torch.isfinite(got_a).any()
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_xlogy_bw_b_zero(device, dtype):
+    # grad_b is sign(grad) * inf where b is zero.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    zero = torch.zeros([1, 1, 32, 32], dtype=torch_dtype)
+    a = torch.full([1, 1, 32, 32], 2.0, dtype=torch_dtype)
+    grad = torch.full([1, 1, 32, 32], -1.0, dtype=torch_dtype)
+
+    _, got_b = run(device, dtype, grad, a, zero)
+    assert (got_b == float("-inf")).all()

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 
 #include <numbers>
+#include <cstdint>
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 
 #include "ttnn/operations/data_movement/slice/slice.hpp"
@@ -274,41 +275,46 @@ std::vector<Tensor> xlogy_bw(
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
+    const std::array is_zero = {EltwiseUnaryWithParam{UnaryOpType::EQZ}};
+    const std::array is_le_zero = {EltwiseUnaryWithParam{UnaryOpType::LEZ}};
+    const std::array reciprocal_it = {EltwiseUnaryWithParam{UnaryOpType::RECIP}};
+    const std::array sign_of_it = {EltwiseUnaryWithParam{UnaryOpType::SIGN}};
+
     Tensor grad1_result = ttnn::log(other, true, output_mem_config);
+    // eqz(a) and le(b, 0) are the operand activations of the logical_and that
+    // reads them, so the three dispatches are one.
     grad1_result = ttnn::where(
-        ttnn::logical_and(
-            ttnn::eqz(input_a, output_mem_config),
-            ttnn::le(other, 0.0f, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config),
+        ttnn::logical_and(input_a, other, std::nullopt, output_mem_config, std::nullopt, {}, is_zero, is_le_zero),
         0.0f,
         ttnn::where(ttnn::ltz(other, output_mem_config), std::nanf(" "), grad1_result, output_mem_config),
         output_mem_config);
-    grad1_result = ttnn::where(
-        ttnn::eq(input_a, std::nanf(" "), std::nullopt, output_mem_config),
-        std::nanf(" "),
-        grad1_result,
-        output_mem_config);
+    // A where on eq(input_a, nan) stood here. Nothing is equal to nan, itself
+    // included, so it never selected and cost two dispatches to never select.
+    // Removing it is not a behaviour change; torch.xlogy takes log(b) as the
+    // gradient in a whatever a is, so it would have been wrong if it had fired.
     grad1_result = ttnn::multiply(grad_tensor, grad1_result, std::nullopt, output_mem_config);
 
     grad.emplace_back(grad1_result);
     Tensor div_result =
-        ttnn::multiply(input_a, ttnn::reciprocal(other, output_mem_config), std::nullopt, output_mem_config);
+        ttnn::multiply(input_a, other, std::nullopt, output_mem_config, std::nullopt, {}, {}, reciprocal_it);
     Tensor grad2_result = ttnn::multiply(grad_tensor, div_result, std::nullopt, output_mem_config);
     grad2_result = where(
         ttnn::eqz(other, output_mem_config),
         ttnn::multiply(
-            ttnn::sign(grad_tensor, output_mem_config),
+            grad_tensor,
             std::numeric_limits<float>::infinity(),
             std::nullopt,
-            output_mem_config),
+            output_mem_config,
+            std::nullopt,
+            {},
+            sign_of_it),
         grad2_result,
         output_mem_config);
-    grad2_result = ttnn::where(
-        ttnn::eq(other, std::nanf(" "), std::nullopt, output_mem_config),
-        std::nanf(" "),
-        grad2_result,
-        output_mem_config);
+    // The matching where on eq(other, nan) is gone for the same reason. What it
+    // was reaching for is a real gap and is filed on its own: grad_b is 0 or inf
+    // where other is nan and torch.xlogy has nan.
     grad.emplace_back(grad2_result);
     return grad;
 }
@@ -526,19 +532,19 @@ std::vector<std::optional<Tensor>> concat_bw(
         input_grad, other_grad, input_tensor_a_arg, other, {are_required_outputs[0], are_required_outputs[1]});
 
     if (are_required_outputs[0]) {
-        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttsl::SmallVector<uint32_t> end_index = {
+        ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> end_index = {
             input_tensor_a_arg.logical_shape()[0],
             input_tensor_a_arg.logical_shape()[1],
             input_tensor_a_arg.logical_shape()[2],
             input_tensor_a_arg.logical_shape()[3]};
-        ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttsl::SmallVector<std::uint32_t> step = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index, end_index, step, std::nullopt, input_grad);
         grad_tensor[0] = input_grad;
     }
 
     if (are_required_outputs[1]) {
-        ttsl::SmallVector<uint32_t> start_index_2 = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> start_index_2 = {0, 0, 0, 0};
         if (dim == 0) {
             start_index_2 = {input_tensor_a_arg.logical_shape()[0], 0, 0, 0};
         } else if (dim == 1) {
@@ -548,12 +554,12 @@ std::vector<std::optional<Tensor>> concat_bw(
         } else if (dim == 3) {
             start_index_2 = {0, 0, 0, input_tensor_a_arg.logical_shape()[3]};
         }
-        ttsl::SmallVector<uint32_t> end_index_2 = {
+        ttsl::SmallVector<std::uint32_t> end_index_2 = {
             grad_tensor_arg.logical_shape()[0],
             grad_tensor_arg.logical_shape()[1],
             grad_tensor_arg.logical_shape()[2],
             grad_tensor_arg.logical_shape()[3]};
-        ttsl::SmallVector<uint32_t> step_2 = {1, 1, 1, 1};
+        ttsl::SmallVector<std::uint32_t> step_2 = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index_2, end_index_2, step_2, std::nullopt, other_grad);
         grad_tensor[1] = other_grad;
     }


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Closes #53872.

Both gradients were guarded with `where(eq(x, nan), nan, ...)`. Nothing is equal to nan, itself included, so neither where ever selected, and four of the nineteen dispatches could not affect the result. Removing them changes nothing.

The `grad_a` guard would have been wrong if it had fired: `torch.xlogy` takes `log(b)` as the gradient in `a` whatever `a` is, nan included.

The rest is operand activations. `eqz(a)` and `le(b, 0)` are the two operands of the `logical_and` that reads them, the `reciprocal` is the right operand of the multiply that reads it, and the `sign` is the left operand of the multiply by inf.

## Accuracy

Five case sets per dtype on each machine, both gradients, against what the composite returned.

| case | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| ordinary | identical | identical | identical | identical |
| b negative | identical | identical | identical | identical |
| a zero, b not positive | identical | identical | identical | identical |
| b zero | identical | identical | identical | identical |
| nan, ±0, ±1 | identical | identical | identical | identical |

**Exhaustive.** Every one of the 65536 bfloat16 bit patterns, in each of the three operand positions, against five settings of the other two — the ordinary case, either operand zero, mixed signs, and 1e30 against 1e-30 — both gradients. 1966080 comparisons; and 125829120 more over 4194304 float32 bit patterns drawn uniformly from the 2^32 space. Output bits compared as integers against the composite:

| | P300 bfloat16 | P300 float32 | N300 bfloat16 | N300 float32 |
|---|---|---|---|---|
| identical to the composite | 1965826 | 125820943 | 1965826 | 125820943 |
| differ | **254** | **8177** | **254** | **8177** |

The case sets above did not reach them and the two machines agree exactly. Every one has a subnormal operand:

| | composite | this branch | `torch` |
|---|---|---|---|
| bfloat16, `grad=1, a=9.18e-41, b=0`, `grad_a` | `-inf` | `0` | `-inf` |
| float32, `grad=1, a=0, b=9.32e-39`, `grad_a` | `0` | `nan` | `-87.5686` |

Neither build is right in the float32 row. Both are answering a question about whether `b` is non-positive, and neither the composite's spelling of that question nor this branch's gives the right answer for a subnormal.

## Whether folding a zero test is allowed

`eqz(a)` and `le(b, 0)` are folded onto `logical_and` as operand activations. Those are not the same tests as the standalone ops. Measured on P300 with the activation arguments exposed through a local binding, for a subnormal operand:

| | `ttnn.eqz(x)` | `ttnn.eq(x, 0.0)` | EQZ folded as an operand activation | exact |
|---|---|---|---|---|
| bfloat16 | 0 | **1** | **1** | 0 |
| float32 | 0 | **1** | 0 | 0 |

`nez`, `lez` and `gtz` behave the same way. Two separate things are visible here. **A comparison against the scalar 0 reads a subnormal as zero in both dtypes** — that is what the composite's `le(b, 0.0f)` does, and it is why the composite is also wrong in the float32 row above, before this PR touches anything. **The fold follows the scalar spelling in bfloat16 and the unary spelling in float32**, which is where the 254 come from.

So the three spellings of `x == 0` give three answers, and this PR moves from one to another. That is a question about the activation contract rather than about this op, and it is the same question in #53871.

If folding a zero test is not allowed, the guard goes back to the standalone ops and the count is 19 → 13 rather than 19 → 11. It is one hunk:

```diff
-        ttnn::logical_and(input_a, other, std::nullopt, output_mem_config, std::nullopt, {}, is_zero, is_le_zero),
+        ttnn::logical_and(
+            ttnn::eqz(input_a, output_mem_config),
+            ttnn::le(other, 0.0f, std::nullopt, output_mem_config),
+            std::nullopt,
+            output_mem_config),
```

Measured with that applied, all 254 and all 8177 go away: **bit-identical to the composite on every pattern, in both dtypes, on both machines.** Say which one you want.

## Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, TRISC_1 cycles summed over the cores in a call.

| | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| dispatches per call | 19 → **11** | 19 → **11** | 19 → **11** | 19 → **11** |
| TRISC_1, before | 21,226,376 | 42,105,950 | 17,332,175 | 27,684,022 |
| TRISC_1, after | **14,626,791** | **27,682,324** | **11,765,047** | **18,197,155** |
| | **1.45x** | **1.52x** | **1.47x** | **1.52x** |

Wall clock on P300, 100 calls with one synchronise at the end, profiler off:

| | 1 tile | 256 tiles | 1024 tiles |
|---|---|---|---|
| bfloat16 | 339.8 → **225.9** µs | 374.6 → **249.0** µs | 378.0 → **232.8** µs |
| float32 | 342.0 → **203.7** µs | 368.3 → **228.5** µs | 512.3 → **319.0** µs |

The ratio is the same at one tile as at 1024, and the before column barely moves with size, so at these shapes the op is bound by how many programs it enqueues rather than by what they compute. That is 14 to 24 µs per dropped dispatch.

## Tests

`test_xlogy_bw_edges.py`, 6 cases: against `torch.xlogy` backward on both dtypes, plus the `a == 0, b <= 0` corner the `logical_and` selects and the `b == 0` corner the `sign(grad) * inf` selects. The 3 existing `test_backward_xlogy.py` cases pass unchanged.

## Not covered

- `grad_b` is 0 or inf where `other` is nan and `torch.xlogy` has nan. That is what the removed wheres were reaching for; `eq` is not the test for it and `isnan` is. Left out so that this PR stays a no-op on results.

