### PR TITLE
Use valid 1D DRAM shard grid in CopyToDeviceFiltered_EmptyFilter_NoChange

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -651,7 +651,9 @@ TEST_F(MeshTensorTest2x4, CopyToDeviceFiltered_WritesOnlyFilteredCores) {
 
 TEST_F(MeshTensorTest2x4, CopyToDeviceFiltered_EmptyFilter_NoChange) {
     const ttnn::Shape shape{1, 1, 64, 32};
-    CoreRangeSet shard_grid(CoreRange(CoreCoord(0, 0), CoreCoord(0, 1)));
+    // DRAM grids are 1D and only grow in X (bank_id == logical x-coordinate), so the grid is a
+    // single row: (0,0)-(1,0), not (0,0)-(0,1).
+    CoreRangeSet shard_grid(CoreRange(CoreCoord(0, 0), CoreCoord(1, 0)));
     ShardSpec shard_spec(shard_grid, {32, 32});
     MemoryConfig mem_cfg(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::DRAM, shard_spec);
     tt::tt_metal::TensorSpec spec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, mem_cfg));


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #53623.

The gtest built a DRAM HEIGHT_SHARDED tensor on a vertical shard grid `(0,0)-(0,1)`. DRAM banks are 1D (bank_id == logical x-coordinate), and the validation added in #51542 rejects shard cores with `y != 0`, so `Buffer::create` throws `TT_FATAL: Invalid DRAM shard grid: shard core (0, 1) is not on row 0`.

Grow the grid in X instead: `(0,0)-(1,0)`. Shard count, shard shape, and HEIGHT_SHARDED semantics are unchanged. The sibling `copy_to_device_filtered` tests use L1 and keep their 2D grid.

### Notes for reviewers
One-line test-grid fix plus a comment. Verified on hardware: the previously failing gtest passes on a 2x4 mesh.

### CI
- [(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/32439559750) — manual dispatch on this branch, covers the failing job `t3000-unit-tests / t3k_ttnn_tests [wh_llmbox]`