### PR TITLE
[Perf] logaddexp_bw / logaddexp2_bw / ldexp_bw: fold the unary steps into their neighbours

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_logaddexp_bw_ranges.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_logaddexp_bw_ranges.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+OPS = [
+    (ttnn.logaddexp_bw, torch.logaddexp),
+    (ttnn.logaddexp2_bw, torch.logaddexp2),
+    (ttnn.ldexp_bw, torch.ldexp),
+]
+
+
+def spread(name, dtype):
+    torch.manual_seed(0)
+    if name == "ordinary":
+        return (torch.rand([1, 1, 32, 32]) * 10 - 5), (torch.rand([1, 1, 32, 32]) * 10 - 5)
+    if name == "far apart":
+        return (torch.rand([1, 1, 32, 32]) * 10 + 40), (torch.rand([1, 1, 32, 32]) * 10 - 50)
+    a = torch.rand([1, 1, 32, 32]) * 4 - 2
+    return a, a.clone()
+
+
+@pytest.mark.parametrize("ttnn_op, torch_op", OPS)
+@pytest.mark.parametrize("case", ["ordinary", "far apart", "equal"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_backward_matches_torch(device, ttnn_op, torch_op, case, dtype):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    a32, b32 = spread(case, dtype)
+    a, b = a32.to(torch_dtype), b32.to(torch_dtype)
+    grad = (torch.rand([1, 1, 32, 32]) * 2 - 1).to(torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got_a, got_b = [ttnn.to_torch(t).float() for t in ttnn_op(dev(grad), dev(a), dev(b))]
+
+    ta = a.float().clone().requires_grad_(True)
+    tb = b.float().clone().requires_grad_(True)
+    torch_op(ta, tb).backward(grad.float())
+
+    tol = 0.05 if dtype == ttnn.bfloat16 else 1e-4
+    keep = torch.isfinite(ta.grad) & torch.isfinite(got_a)
+    assert ((got_a[keep] - ta.grad[keep]).abs() / ta.grad[keep].abs().clamp(min=1.0)).max() < tol
+    keep = torch.isfinite(tb.grad) & torch.isfinite(got_b)
+    assert ((got_b[keep] - tb.grad[keep]).abs() / tb.grad[keep].abs().clamp(min=1.0)).max() < tol

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 
 #include <numbers>
+#include <cstdint>
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 
 #include "ttnn/operations/data_movement/slice/slice.hpp"
@@ -342,9 +343,17 @@ std::vector<Tensor> ldexp_bw(
     const Tensor& other,
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
     auto output_memory_config = output_mem_config.value_or(input_a.memory_config());
+
+    // The 2^b is the right operand of the multiply that reads it, so it needs no
+    // dispatch of its own. The scaling by ln2 stays a multiply: as an SFPU
+    // activation on bfloat16 the constant is rounded into the operand and the
+    // answer moves.
+    const std::array two_to_the = {EltwiseUnaryWithParam{UnaryOpType::RPOW, 2.0f}};
     Tensor tpow_o =
-        ttnn::multiply(grad_tensor, ttnn::rpow(other, 2.0f, output_memory_config), std::nullopt, output_memory_config);
+        ttnn::multiply(grad_tensor, other, std::nullopt, output_memory_config, std::nullopt, {}, {}, two_to_the);
     grad.emplace_back(tpow_o);
     Tensor result = ttnn::multiply(
         input_a,
@@ -366,21 +375,31 @@ std::vector<Tensor> logaddexp_bw(
         "BFLOAT8_B/BFLOAT4_B dtypes are not supported !!");
 
     std::vector<Tensor> grad;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
+
+    // The exp is the subtract's post-activation and the reciprocal is the right
+    // operand of the multiply that reads it, so neither needs a dispatch. The
+    // add of 1 stays a binary op: as an SFPU activation on bfloat16 the constant
+    // is rounded into the operand and the answer moves.
+    const std::array to_exp = {EltwiseUnaryWithParam{UnaryOpType::EXP, 0.0f}};
+    const std::array reciprocal_it = {EltwiseUnaryWithParam{UnaryOpType::RECIP}};
+
     Tensor opexp = ttnn::add(
-        ttnn::exp(ttnn::subtract(other, input_a, std::nullopt, output_mem_config), false, output_mem_config),
+        ttnn::subtract(other, input_a, std::nullopt, output_mem_config, std::nullopt, to_exp),
         1,
         std::nullopt,
         output_mem_config);
     Tensor grad_a =
-        ttnn::multiply(grad_tensor, ttnn::reciprocal(opexp, output_mem_config), std::nullopt, output_mem_config);
+        ttnn::multiply(grad_tensor, opexp, std::nullopt, output_mem_config, std::nullopt, {}, {}, reciprocal_it);
     grad.emplace_back(grad_a);
     opexp = ttnn::add(
-        ttnn::exp(ttnn::subtract(input_a, other, std::nullopt, output_mem_config), false, output_mem_config),
+        ttnn::subtract(input_a, other, std::nullopt, output_mem_config, std::nullopt, to_exp),
         1,
         std::nullopt,
         output_mem_config);
     Tensor grad_b =
-        ttnn::multiply(grad_tensor, ttnn::reciprocal(opexp, output_mem_config), std::nullopt, output_mem_config);
+        ttnn::multiply(grad_tensor, opexp, std::nullopt, output_mem_config, std::nullopt, {}, {}, reciprocal_it);
     grad.emplace_back(grad_b);
     return grad;
 }
@@ -396,22 +415,31 @@ std::vector<Tensor> logaddexp2_bw(
         "BFLOAT8_B/BFLOAT4_B dtypes are not supported !!");
 
     std::vector<Tensor> grad;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
     auto output_memory_config = output_mem_config.value_or(input_a.memory_config());
+
+    // 2 to the difference is the subtract's post-activation. The add of 1 and
+    // the reciprocal stay where they were: as SFPU activations on bfloat16 they
+    // round the intermediate a second time, which moves the answer.
+    const std::array to_two_to_the = {EltwiseUnaryWithParam{UnaryOpType::RPOW, 2.0f}};
+
     Tensor oppow = ttnn::add(
-        ttnn::rpow(ttnn::subtract(other, input_a, std::nullopt, output_memory_config), 2, output_memory_config),
+        ttnn::subtract(other, input_a, std::nullopt, output_memory_config, std::nullopt, to_two_to_the),
         1,
         std::nullopt,
         output_memory_config);
+    const std::array reciprocal_it = {EltwiseUnaryWithParam{UnaryOpType::RECIP}};
     Tensor grad_a =
-        ttnn::multiply(grad_tensor, ttnn::reciprocal(oppow, output_memory_config), std::nullopt, output_memory_config);
+        ttnn::multiply(grad_tensor, oppow, std::nullopt, output_memory_config, std::nullopt, {}, {}, reciprocal_it);
     grad.emplace_back(grad_a);
     oppow = ttnn::add(
-        ttnn::rpow(ttnn::subtract(input_a, other, std::nullopt, output_memory_config), 2, output_memory_config),
+        ttnn::subtract(input_a, other, std::nullopt, output_memory_config, std::nullopt, to_two_to_the),
         1,
         std::nullopt,
         output_memory_config);
     Tensor grad_b =
-        ttnn::multiply(grad_tensor, ttnn::reciprocal(oppow, output_memory_config), std::nullopt, output_memory_config);
+        ttnn::multiply(grad_tensor, oppow, std::nullopt, output_memory_config, std::nullopt, {}, {}, reciprocal_it);
     grad.emplace_back(grad_b);
     return grad;
 }
@@ -526,19 +554,19 @@ std::vector<std::optional<Tensor>> concat_bw(
         input_grad, other_grad, input_tensor_a_arg, other, {are_required_outputs[0], are_required_outputs[1]});
 
     if (are_required_outputs[0]) {
-        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttsl::SmallVector<uint32_t> end_index = {
+        ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> end_index = {
             input_tensor_a_arg.logical_shape()[0],
             input_tensor_a_arg.logical_shape()[1],
             input_tensor_a_arg.logical_shape()[2],
             input_tensor_a_arg.logical_shape()[3]};
-        ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttsl::SmallVector<std::uint32_t> step = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index, end_index, step, std::nullopt, input_grad);
         grad_tensor[0] = input_grad;
     }
 
     if (are_required_outputs[1]) {
-        ttsl::SmallVector<uint32_t> start_index_2 = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> start_index_2 = {0, 0, 0, 0};
         if (dim == 0) {
             start_index_2 = {input_tensor_a_arg.logical_shape()[0], 0, 0, 0};
         } else if (dim == 1) {
@@ -548,12 +576,12 @@ std::vector<std::optional<Tensor>> concat_bw(
         } else if (dim == 3) {
             start_index_2 = {0, 0, 0, input_tensor_a_arg.logical_shape()[3]};
         }
-        ttsl::SmallVector<uint32_t> end_index_2 = {
+        ttsl::SmallVector<std::uint32_t> end_index_2 = {
             grad_tensor_arg.logical_shape()[0],
             grad_tensor_arg.logical_shape()[1],
             grad_tensor_arg.logical_shape()[2],
             grad_tensor_arg.logical_shape()[3]};
-        ttsl::SmallVector<uint32_t> step_2 = {1, 1, 1, 1};
+        ttsl::SmallVector<std::uint32_t> step_2 = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index_2, end_index_2, step_2, std::nullopt, other_grad);
         grad_tensor[1] = other_grad;
     }


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Closes #53877.

Each of the three spends dispatches on unary steps that the binary op next to them already applies. `subtract` then `exp`, `subtract` then `2^x`, `reciprocal` then `multiply`, `2^b` then `multiply`: each is one operand's activation and needs no dispatch of its own.

The `+ 1` and the `* ln2` are deliberately left as binary ops. As SFPU activations on bfloat16 the constant is rounded into the operand and the answer moves — measurably away from the correctly rounded value, mean relative error 3.97e-03 against 4.34e-03 on `logaddexp_bw` — so keeping them where they are is what makes this a no-op on results.

## Accuracy

Four case sets per dtype on each machine, both gradients of all three ops — 24 sets per machine — against what the composites returned.

| case | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|
| ordinary, [-5, 5] | identical | identical | identical | identical |
| far apart, a ≈ 45, b ≈ -45 | identical | identical | identical | identical |
| a == b | identical | identical | identical | identical |
| inf / nan / ±0 / ±80 | identical | identical | identical | identical |

**Exhaustive.** Every one of the 65536 bfloat16 bit patterns, in each of the three operand positions, against five settings of the other two — the ordinary case, either operand zero, mixed signs, and 1e30 against 1e-30 — both gradients of all three ops. 1966080 comparisons per op. The same structure with 4194304 float32 bit patterns drawn uniformly from the 2^32 space gives 125829120 per op. Output bits compared as integers against the composite:

| | bfloat16 | float32 |
|---|---|---|
| `logaddexp_bw` | **1966080 identical** | **125829120 identical** |
| `logaddexp2_bw` | **1966080 identical** | **125829120 identical** |
| `ldexp_bw` | **1966080 identical** | **125829120 identical** |

The same on P300 and on N300: no pattern in either dtype, in any operand position, comes back different.

## Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, TRISC_1 cycles summed over the cores in a call.

| | dispatches | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|---|
| logaddexp_bw | 10 → **6** | 9,364,967 → **7,339,865** (1.28x) | 20,977,850 → **15,507,835** (1.35x) | 6,388,943 → **5,433,183** (1.18x) | 13,565,863 → **10,024,177** (1.35x) |
| logaddexp2_bw | 10 → **6** | 11,819,335 → **8,901,081** (1.33x) | 26,007,021 → **18,470,927** (1.41x) | 9,047,601 → **7,578,144** (1.19x) | 17,498,261 → **13,355,835** (1.31x) |
| ldexp_bw | 4 → **3** | 5,918,150 → **5,203,472** (1.14x) | 11,630,878 → **9,258,053** (1.26x) | 5,045,563 → **4,716,138** (1.07x) | 7,757,711 → **6,698,724** (1.16x) |

Wall clock, 100 calls with one synchronise at the end, profiler off, microseconds per call.

| | | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|---|
| logaddexp_bw | 1 tile | 356.9 → **274.4** | 384.5 → **289.9** | 177.8 → **134.0** | 177.8 → **138.6** |
| | 256 tiles | 377.8 → **277.3** | 365.1 → **271.0** | 196.5 → **151.1** | 195.6 → **153.0** |
| | 1024 tiles | 367.8 → **271.4** | 670.2 → **436.7** | 193.3 → **151.6** | 260.7 → **174.0** |
| logaddexp2_bw | 1 tile | 355.5 → **276.0** | 381.2 → **280.9** | 174.2 → **133.7** | 179.8 → **135.7** |
| | 256 tiles | 363.4 → **269.6** | 367.9 → **271.4** | 191.5 → **144.7** | 193.4 → **145.8** |
| | 1024 tiles | 402.9 → **270.3** | 788.7 → **535.7** | 193.4 → **146.9** | 298.3 → **205.7** |
| ldexp_bw | 1 tile | 191.4 → **174.3** | 200.9 → **172.6** | 79.0 → **70.9** | 79.8 → **71.3** |
| | 256 tiles | 160.9 → **138.3** | 163.4 → **143.6** | 83.7 → **72.9** | 87.9 → **74.6** |
| | 1024 tiles | 178.1 → **153.9** | 342.3 → **275.1** | 85.3 → **74.1** | 128.7 → **104.2** |

The two logaddexp backwards run 1.28x to 1.53x faster and `ldexp_bw` 1.10x to 1.24x. The before column barely moves between one tile and 256, so at those shapes the ops are bound by how many programs they enqueue; at 1024 tiles in float32 the compute starts to show and the ratio holds anyway.

## Tests

`test_logaddexp_bw_ranges.py`, 18 cases: three input spreads across the three ops on both dtypes, against the torch backward. The 12 existing cases in `test_backward_logaddexp.py`, `test_backward_logaddexp2.py` and `test_backward_ldexp.py` pass unchanged.

## Not covered

- `1 / (1 + exp(b - a))` is `sigmoid(a - b)`, which would take `logaddexp_bw` to 4 rather than 6. The SFPU sigmoid is closer to torch in bfloat16 and farther in float32; the issue carries the numbers. Left out so that this PR changes no results.

