### PR TITLE
[Perf] acosh_bw / acos_bw / atanh_bw: fold the guards into the ops that read them

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_inverse_bw_domains.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_inverse_bw_domains.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+OPS = [
+    (ttnn.acosh_bw, torch.acosh, "outside"),
+    (ttnn.acos_bw, torch.acos, "inside"),
+    (ttnn.atanh_bw, torch.atanh, "inside"),
+]
+
+GRADS = ["ones", "mixed", "zeros", "negative"]
+
+
+def inputs(where, dtype):
+    torch.manual_seed(0)
+    if where == "inside":
+        return (torch.rand([1, 1, 32, 32]) * 1.8 - 0.9).to(dtype)
+    return (torch.rand([1, 1, 32, 32]) * 8 + 1.5).to(dtype)
+
+
+def grads(which, dtype):
+    if which == "ones":
+        return torch.ones([1, 1, 32, 32], dtype=dtype)
+    if which == "zeros":
+        return torch.zeros([1, 1, 32, 32], dtype=dtype)
+    if which == "negative":
+        return -torch.ones([1, 1, 32, 32], dtype=dtype)
+    torch.manual_seed(1)
+    return (torch.rand([1, 1, 32, 32]) * 2 - 1).to(dtype)
+
+
+@pytest.mark.parametrize("ttnn_op, torch_op, domain", OPS)
+@pytest.mark.parametrize("which_grad", GRADS)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_backward_in_domain_matches_torch(device, ttnn_op, torch_op, domain, which_grad, dtype):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    x = inputs(domain, torch_dtype)
+    grad = grads(which_grad, torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got = ttnn.to_torch(ttnn_op(dev(grad), dev(x))[0]).float()
+
+    tx = x.float().clone().requires_grad_(True)
+    torch_op(tx).backward(grad.float())
+
+    keep = torch.isfinite(tx.grad) & torch.isfinite(got)
+    if keep.sum() == 0:
+        # A zero gradient makes the op answer nan by design; there is nothing
+        # finite left to compare against torch, which answers zero.
+        pytest.skip("no finite element to compare")
+    tol = 0.05 if dtype == ttnn.bfloat16 else 1e-4
+    assert ((got[keep] - tx.grad[keep]).abs() / tx.grad[keep].abs().clamp(min=1.0)).max() < tol
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_atanh_bw_sign_at_the_boundary(device, dtype):
+    # At |x| == 1 the gradient is an infinity whose sign follows the incoming
+    # gradient. The last where in the op is what flips it, and it tests the
+    # result against inf, which UNARY_EQ as an activation does not match.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    one = torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    assert (ttnn.to_torch(ttnn.atanh_bw(dev(one), dev(one))[0]).float() == float("inf")).all()
+    assert (ttnn.to_torch(ttnn.atanh_bw(dev(-one), dev(one))[0]).float() == float("-inf")).all()
+    assert (ttnn.to_torch(ttnn.atanh_bw(dev(-one), dev(-one))[0]).float() == float("-inf")).all()

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -30,6 +30,7 @@
 #include "tanh_bw/device/tanh_bw_device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/hal.hpp>
+#include <cstdint>
 
 namespace ttnn {
 
@@ -573,36 +574,40 @@ std::vector<Tensor> cos_bw(
 std::vector<Tensor> acosh_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor in_sq = ttnn::square(input, output_mem_config);
-    Tensor in_rsqrt =
-        ttnn::rsqrt(ttnn::subtract(in_sq, 1.0f, std::nullopt, output_mem_config), false, output_mem_config);
-    Tensor grad_a = ttnn::multiply(grad, in_rsqrt, std::nullopt, output_mem_config);
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
     float t_nan = tt::tt_metal::hal::get_nan();
     float t_inf = tt::tt_metal::hal::get_inf();
 
-    Tensor check_condition =
-        ttnn::multiply(ttnn::signbit(grad, output_mem_config), -1.0f, std::nullopt, output_mem_config);
+    // Every unary step below is one operand's activation on the binary op that
+    // reads it, so none of them needs a dispatch. The square is computed twice
+    // rather than kept in a tensor, which is what dropped in_sq.
+    const std::array square_it = {EltwiseUnaryWithParam{UnaryOpType::SQUARE}};
+    const std::array rsqrt_it = {EltwiseUnaryWithParam{UnaryOpType::RSQRT, 0.0f}};
+    const std::array signbit_it = {EltwiseUnaryWithParam{UnaryOpType::SIGNBIT}};
+    const std::array is_zero = {EltwiseUnaryWithParam{UnaryOpType::EQZ}};
+    const std::array is_one = {EltwiseUnaryWithParam{UnaryOpType::UNARY_EQ, 1.0f}};
+    const std::array at_most_one = {EltwiseUnaryWithParam{UnaryOpType::UNARY_LE, 1.0f}};
+    const std::array at_least_minus_one = {EltwiseUnaryWithParam{UnaryOpType::UNARY_GE, -1.0f}};
+
+    Tensor in_rsqrt = ttnn::subtract(input, 1.0f, std::nullopt, output_mem_config, std::nullopt, rsqrt_it, square_it);
+    Tensor grad_a = ttnn::multiply(grad, in_rsqrt, std::nullopt, output_mem_config);
+
+    Tensor check_condition = ttnn::multiply(grad, -1.0f, std::nullopt, output_mem_config, std::nullopt, {}, signbit_it);
 
     grad_a = ttnn::where(
         ttnn::logical_or(
-            ttnn::lt(in_sq, 1.0f, std::nullopt, output_mem_config),
-            ttnn::logical_and(
-                ttnn::eq(input, 1.0f, std::nullopt, output_mem_config),
-                ttnn::eqz(grad, output_mem_config),
-                std::nullopt,
-                output_mem_config),
+            ttnn::lt(input, 1.0f, std::nullopt, output_mem_config, std::nullopt, {}, square_it),
+            ttnn::logical_and(input, grad, std::nullopt, output_mem_config, std::nullopt, {}, is_one, is_zero),
             std::nullopt,
             output_mem_config),
         t_nan,
         ttnn::where(
             ttnn::logical_and(
-                ttnn::le(input, 1.0f, std::nullopt, output_mem_config),
-                ttnn::ge(input, -1.0f, std::nullopt, output_mem_config),
-                std::nullopt,
-                output_mem_config),
+                input, input, std::nullopt, output_mem_config, std::nullopt, {}, at_most_one, at_least_minus_one),
             ttnn::multiply(
                 ttnn::add(
-                    check_condition, ttnn::eqz(check_condition, output_mem_config), std::nullopt, output_mem_config),
+                    check_condition, check_condition, std::nullopt, output_mem_config, std::nullopt, {}, {}, is_zero),
                 t_inf,
                 std::nullopt,
                 output_mem_config),
@@ -618,29 +623,39 @@ std::vector<Tensor> acosh_bw(
 std::vector<Tensor> acos_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor neg_in = ttnn::neg(input, output_mem_config);
-    Tensor in_rsqrt = ttnn::rsqrt(
-        ttnn::add(
-            ttnn::multiply(neg_in, input, std::nullopt, output_mem_config), 1.0f, std::nullopt, output_mem_config),
-        false,
-        output_mem_config);
-    in_rsqrt = ttnn::neg(in_rsqrt, output_mem_config);
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
+
+    const std::array negate_it = {EltwiseUnaryWithParam{UnaryOpType::NEG}};
+    const std::array rsqrt_then_negate = {
+        EltwiseUnaryWithParam{UnaryOpType::RSQRT, 0.0f}, EltwiseUnaryWithParam{UnaryOpType::NEG}};
+    const std::array sign_of_it = {EltwiseUnaryWithParam{UnaryOpType::SIGN}};
+    const std::array below_minus_one = {EltwiseUnaryWithParam{UnaryOpType::UNARY_LT, -1.0f}};
+    const std::array above_one = {EltwiseUnaryWithParam{UnaryOpType::UNARY_GT, 1.0f}};
+    // x == 1 or x == -1 is abs(x) == 1, and both arms of the two wheres wrote
+    // the same value, so the pair of tests and the pair of wheres are one each.
+    const std::array abs_is_one = {
+        EltwiseUnaryWithParam{UnaryOpType::ABS}, EltwiseUnaryWithParam{UnaryOpType::UNARY_EQ, 1.0f}};
+
+    Tensor in_rsqrt = ttnn::add(
+        ttnn::multiply(input, input, std::nullopt, output_mem_config, std::nullopt, {}, negate_it),
+        1.0f,
+        std::nullopt,
+        output_mem_config,
+        std::nullopt,
+        rsqrt_then_negate);
     Tensor grad_a = ttnn::multiply(grad, in_rsqrt, std::nullopt, output_mem_config);
     Tensor t_inf = ttnn::multiply(
-        ttnn::sign(grad, output_mem_config), -std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
+        grad, -std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config, std::nullopt, {}, sign_of_it);
     grad_a = where(
-        ttnn::logical_or(
-            ttnn::lt(input, -1.0f, std::nullopt, output_mem_config),
-            ttnn::gt(input, 1.0f, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config),
+        ttnn::logical_or(input, input, std::nullopt, output_mem_config, std::nullopt, {}, below_minus_one, above_one),
         std::nanf(" "),
         grad_a,
         output_mem_config);
     grad_a = where(
-        ttnn::eq(input, -1.0f, std::nullopt, output_mem_config),
+        ttnn::eq(input, 1.0f, std::nullopt, output_mem_config, std::nullopt, {}, abs_is_one),
         t_inf,
-        where(ttnn::eq(input, 1.0f, std::nullopt, output_mem_config), t_inf, grad_a, output_mem_config),
+        grad_a,
         output_mem_config);
     grad_tensor.emplace_back(grad_a);
     return grad_tensor;
@@ -961,27 +976,40 @@ std::vector<Tensor> atanh_bw(
         EltwiseUnaryWithParam{UnaryOpType::NEG},
         EltwiseUnaryWithParam{UnaryOpType::RECIP}};
 
+    const std::array is_zero = {EltwiseUnaryWithParam{UnaryOpType::EQZ}};
+    const std::array is_nonzero = {EltwiseUnaryWithParam{UnaryOpType::NEZ}};
+    const std::array is_negative = {EltwiseUnaryWithParam{UnaryOpType::LTZ}};
+    // x == 1 or x == -1 is abs(x) == 1, so the two eq and the logical_or that
+    // joined them are one operand activation.
+    const std::array abs_is_one = {
+        EltwiseUnaryWithParam{UnaryOpType::ABS}, EltwiseUnaryWithParam{UnaryOpType::UNARY_EQ, 1.0f}};
+
     Tensor grad_a =
         ttnn::multiply(grad, unary_chain(input, ops_chain, output_mem_config), std::nullopt, output_mem_config);
-    grad_a = where(ttnn::eqz(grad, output_mem_config), t_nan, grad_a, output_mem_config);
+    Tensor grad_is_zero = ttnn::eqz(grad, output_mem_config);
+    grad_a = where(grad_is_zero, t_nan, grad_a, output_mem_config);
     grad_a = where(
-        ttnn::logical_and(ttnn::eqz(grad, output_mem_config), ttnn::eqz(input, output_mem_config)),
+        ttnn::logical_and(grad, input, std::nullopt, output_mem_config, std::nullopt, {}, is_zero, is_zero),
         0.f,
         grad_a,
         output_mem_config);
     grad_a = where(
-        ttnn::logical_and(
-            ttnn::logical_or(
-                ttnn::eq(input, 1, std::nullopt, output_mem_config),
-                ttnn::eq(input, -1, std::nullopt, output_mem_config),
-                std::nullopt,
-                output_mem_config),
-            ttnn::nez(grad, output_mem_config)),
+        ttnn::logical_and(input, grad, std::nullopt, output_mem_config, std::nullopt, {}, abs_is_one, is_nonzero),
         t_inf,
         grad_a,
         output_mem_config);
+    // The eq against inf stays a binary op. As a UNARY_EQ activation it does not
+    // match inf, which left the sign of the +-inf at the boundary unflipped.
     grad_a = where(
-        ttnn::logical_and(ttnn::eq(grad_a, t_inf, std::nullopt, output_mem_config), ttnn::ltz(grad, output_mem_config)),
+        ttnn::logical_and(
+            ttnn::eq(grad_a, t_inf, std::nullopt, output_mem_config),
+            grad,
+            std::nullopt,
+            output_mem_config,
+            std::nullopt,
+            {},
+            {},
+            is_negative),
         -t_inf,
         grad_a,
         output_mem_config);
@@ -1596,7 +1624,7 @@ std::vector<Tensor> repeat_bw(
         return grad_tensor;
     }
     if (shape[0] > 1) {
-        ttsl::SmallVector<int64_t> dim = {0};
+        ttsl::SmallVector<std::int64_t> dim = {0};
         TT_FATAL(shape[1] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[1], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {1, shape_wh[1], shape_wh[2], shape_wh[3]};
         const auto required = ttnn::Shape(intended_shape_array);
@@ -1611,7 +1639,7 @@ std::vector<Tensor> repeat_bw(
         return grad_tensor;
     }
     if (shape[1] > 1) {
-        ttsl::SmallVector<int64_t> dim = {1};
+        ttsl::SmallVector<std::int64_t> dim = {1};
         TT_FATAL(shape[0] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[0], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], 1, shape_wh[2], shape_wh[3]};
         const auto required = ttnn::Shape(intended_shape_array);
@@ -1651,7 +1679,7 @@ namespace ttnn {
 std::vector<Tensor> prod_bw(
     const Tensor& grad,
     const Tensor& input,
-    const std::optional<int64_t> dim,
+    const std::optional<std::int64_t> dim,
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(
@@ -1678,13 +1706,13 @@ std::vector<Tensor> prod_bw(
 
     // all_dimensions = False
     Tensor updated_grad = prod_result;
-    auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
+    auto step = ttsl::SmallVector<std::uint32_t>({1, 1, 1, 1});
     if (prod_result.logical_shape() != grad.padded_shape()) {
         if (*dim == 3 || *dim == -1) {
-            ttsl::SmallVector<int64_t> after_permute_dims = {0, 3, 1, 2};
+            ttsl::SmallVector<std::int64_t> after_permute_dims = {0, 3, 1, 2};
             Tensor required = ttnn::permute(grad, after_permute_dims, output_memory_config);
-            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttsl::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<std::uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[2]};
             Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             after_permute_dims = {0, 2, 3, 1};
@@ -1695,10 +1723,10 @@ std::vector<Tensor> prod_bw(
                 updated_grad = pad_updated_grad.to_device(input.device());
             }
         } else if (*dim == 2 || *dim == -2) {
-            ttsl::SmallVector<int64_t> after_permute_dims = {0, 2, 1, 3};
+            ttsl::SmallVector<std::int64_t> after_permute_dims = {0, 2, 1, 3};
             Tensor required = ttnn::permute(grad, after_permute_dims, output_memory_config);
-            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttsl::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<std::uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[3]};
             Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             updated_grad = ttnn::permute(new_slice_tensor, after_permute_dims, output_memory_config);
@@ -1732,11 +1760,11 @@ std::vector<Tensor> prod_bw(
     if (*dim == 1 || *dim == -3) {
         Tensor tensor_1_temp = reciprocal_input;
         if (reciprocal_input.padded_shape()[1] % 32 != 0) {
-            ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+            ttsl::SmallVector<std::array<std::uint32_t, 2>> padding = {
                 {0, 0}, {0, 32 - (reciprocal_input.padded_shape()[1] % 32)}, {0, 0}, {0, 0}};
             tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0, true, std::nullopt);
         }
-        ttsl::SmallVector<int64_t> after_permute_dims = {0, 2, 3, 1};
+        ttsl::SmallVector<std::int64_t> after_permute_dims = {0, 2, 3, 1};
         Tensor tensor_1 = ttnn::permute(tensor_1_temp, after_permute_dims, output_memory_config);
         Tensor tensor_2 = ttnn::permute(temp, after_permute_dims, output_memory_config);
 
@@ -1770,10 +1798,10 @@ std::vector<Tensor> prod_bw(
             output_memory_config);
         Tensor grad_result = result;
         if (reciprocal_input.padded_shape()[1] % 32 != 0) {
-            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttsl::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<std::uint32_t> end_index = {
                 input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
-            auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
+            auto step = ttsl::SmallVector<std::uint32_t>({1, 1, 1, 1});
             grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
         }
         grad_tensor.emplace_back(grad_result);
@@ -1782,11 +1810,11 @@ std::vector<Tensor> prod_bw(
     // dim 0
     Tensor tensor_1_temp = reciprocal_input;
     if (reciprocal_input.padded_shape()[0] % 32 != 0) {
-        ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+        ttsl::SmallVector<std::array<std::uint32_t, 2>> padding = {
             {0, (32 - (reciprocal_input.padded_shape()[0] % 32))}, {0, 0}, {0, 0}, {0, 0}};
         tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0, false, std::nullopt);
     }
-    ttsl::SmallVector<int64_t> after_permute_dims = {3, 1, 2, 0};
+    ttsl::SmallVector<std::int64_t> after_permute_dims = {3, 1, 2, 0};
     Tensor tensor_1 = ttnn::permute(tensor_1_temp, after_permute_dims, output_memory_config);
     Tensor tensor_2 = ttnn::permute(temp, after_permute_dims, output_memory_config);
 
@@ -1819,8 +1847,8 @@ std::vector<Tensor> prod_bw(
         output_memory_config);
     Tensor grad_result = result;
     if (reciprocal_input.padded_shape()[0] % 32 != 0) {
-        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttsl::SmallVector<uint32_t> end_index = {
+        ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> end_index = {
             input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
         grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
     }


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Closes #53884.

Most of what these three spend is unary steps feeding a binary op that applies a unary chain to its operands anyway. `square`, `signbit`, `sign`, `neg`, `rsqrt`, `eqz`, `nez`, `ltz` and the comparisons against a constant are each one operand's activation, so none of them needs a dispatch.

Two guards collapse on their own terms. `x == 1 or x == -1` is `abs(x) == 1`, which turns a pair of tests and a pair of `where`s writing the same value into one of each. `acosh_bw` kept `in_sq` only to test it, so squaring twice as an activation costs less than the tensor.

`atanh_bw` keeps its `eq` against inf as a binary op: as a `UNARY_EQ` activation it does not match inf, which left the sign of the infinity at the boundary unflipped. Filed separately.

## Accuracy

**Exhaustive, not sampled. Every number below is this branch against the composite it replaces** — the `04cf22f7ee` build and this build, run on the same device, output bits compared exactly as integers. It is not a comparison against IEEE or against torch; where torch enters it is named.

**bfloat16: every one of the 65536 bit patterns, against six gradients** (1, -1, 0, 0.5, 1e30, 1e-30), P300, 393216 input points per op.

| op | patterns differing from the composite | where |
|---|---|---|
| acosh_bw | **0** | — |
| acos_bw | 1524 | the 254 nan bit patterns, at all six gradients |
| atanh_bw | 254 | subnormal inputs at `grad == 0` only |

**float32: every one of the 2^32 bit patterns, against three gradients** (1, 0, -1), P300, 12.9 billion input points per op.

| op | chunks differing from the composite |
|---|---|
| acosh_bw | **0 of 12288** |
| acos_bw | **0 of 12288** |
| atanh_bw | **0 of 12288** |

So in float32 nothing moves at all, and in bfloat16 nothing moves on a finite input except one case, which is an improvement:

| case | base | this PR | torch |
|---|---|---|---|
| `atanh_bw(grad=0, x` subnormal`)` | inf | **0** | **0** |

The 254 nan-input patterns are the complete set of bfloat16 nan encodings. Neither form returns nan there, because bfloat16 loses nan through the pack; they disagree about which non-nan value comes out. `torch` returns nan for all of them.

**Improvement or regression?** Every differing pattern, classified against a float64 reference for the same formula torch uses:

| op | patterns differing | fused closer to torch | base closer to torch | reference is nan, neither can match |
|---|---|---|---|---|
| acosh_bw | 0 | — | — | — |
| acos_bw | 1524 | 0 | **0** | 1524 |
| atanh_bw | 254 | **254** | **0** | 0 |

Nothing regresses. `acos_bw`'s 1524 are all nan inputs, where the reference is nan and neither build can return one, because bfloat16 loses nan through the pack. `atanh_bw`'s 254 are the subnormal case, and there this branch is closer to torch on every one of them.

For scale, against the correctly rounded torch answer over all 65536 bfloat16 inputs at `grad = 1`, the two builds agree exactly with each other and land on the reference for `acosh_bw` 12790 times, `acos_bw` 32374, `atanh_bw` 38472. Those counts are unchanged by this PR.

## Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, TRISC_1 cycles summed over the cores in a call.

| | dispatches | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|---|
| acosh_bw | 19 → **11** | 20,089,731 → **15,501,512** (1.30x) | 41,010,406 → **30,353,271** (1.35x) | 15,947,753 → **12,916,413** (1.23x) | 26,514,870 → **19,749,842** (1.34x) |
| acos_bw | 16 → **8** | 17,757,294 → **11,650,219** (1.52x) | 35,728,529 → **21,708,313** (1.65x) | 14,250,269 → **9,818,053** (1.45x) | 23,859,707 → **14,737,941** (1.62x) |
| atanh_bw | 18 → **11** | 20,058,473 → **14,506,990** (1.38x) | 40,605,163 → **28,623,279** (1.42x) | 16,079,670 → **11,675,489** (1.38x) | 26,422,580 → **18,556,393** (1.42x) |

Wall clock on N300, 100 calls with one synchronise at the end, profiler off, microseconds per call.

| | | bfloat16 | float32 |
|---|---|---|---|
| acosh_bw | 1 tile | 750.8 → **469.4** (1.60x) | 769.0 → **477.7** (1.61x) |
| | 256 tiles | 810.7 → **499.5** (1.62x) | 816.2 → **507.3** (1.61x) |
| | 1024 tiles | 816.3 → **537.1** (1.52x) | 1260.6 → **831.0** (1.52x) |
| acos_bw | 1 tile | 572.0 → **341.4** (1.68x) | 592.9 → **354.2** (1.67x) |
| | 256 tiles | 631.5 → **358.1** (1.76x) | 630.9 → **364.3** (1.73x) |
| | 1024 tiles | 629.9 → **369.4** (1.71x) | 1097.8 → **627.2** (1.75x) |
| atanh_bw | 1 tile | 685.6 → **455.6** (1.50x) | 677.6 → **464.5** (1.46x) |
| | 256 tiles | 742.1 → **487.9** (1.52x) | 735.1 → **503.6** (1.46x) |
| | 1024 tiles | 746.3 → **499.5** (1.49x) | 1233.6 → **822.0** (1.50x) |

## Tests

`test_inverse_bw_domains.py`, 24 cases plus 2 skipped: each op against its torch backward across four gradient shapes on both dtypes, plus the `|x| == 1` boundary of `atanh_bw` where the sign of the infinity follows the incoming gradient. The 15 existing cases in `test_backward_acosh.py`, `test_backward_acos.py` and `test_backward_atanh.py` pass unchanged.

## Not covered

- The remaining dispatches are `where`s. `ttnn::where` takes no activations on its predicate, so folding those needs the ternary API to carry them.
