### PR TITLE
[sweeps] Classify UMD routing-firmware error as infrastructure

### DIFF
--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -850,6 +850,18 @@ _FABRIC_INFRA_SIGNATURES = (
     # produced both phantom failures and a correct NOT_RUN, purely by ordering.
     # Matched on the invariant phrase, not on an ASIC ID or core coordinate, both of which vary.
     "timed out waiting for eth heartbeat",
+    # The sibling error from the same UMD file, raised by the same discovery step: an ETH core's
+    # routing firmware is in the wrong state, so the cluster never comes up. UMD reports it as
+    # UnexpectedRoutingFirmwareConfigError from verify_routing_firmware_state
+    # (topology_discovery_wormhole.cpp:200):
+    #   Routing firmware for device ASIC ID: 87033183734870352 ETH core e9-0 (NOC0) is
+    #   unexpectedly enabled.
+    # It was named as a candidate when the heartbeat signature went in but deliberately left out
+    # until it was actually seen, rather than added on speculation. Scheduled lead-models run
+    # 32439829508 saw it: 3 vectors (2 add, 1 linear) booked as FAIL_ASSERT_EXCEPTION on one host,
+    # for a fault that happens before any op kernel runs.
+    # Matched on the invariant phrase -- the ASIC ID, the core and enabled/disabled all vary.
+    "routing firmware for device asic id",
     # The host came up with fewer chips than the traced topology needs, so mesh open fails
     # before any kernel runs. Seen on main run 30681057227 job 91319472767 (runner g03glx03):
     #   TT_FATAL @ tt_metal/distributed/system_mesh.cpp:159: requested_size <= system_size


### PR DESCRIPTION
### Problem

Scheduled lead-models run [32439829508](https://github.com/tenstorrent/tt-metal/actions/runs/32439829508) booked 3 test failures (2 `add`, 1 `linear`) on one host, all with the same message:

```
Routing firmware for device ASIC ID: 87033183734870352 ETH core e9-0 (NOC0) is unexpectedly enabled.
Location: .../umd/device/topology/topology_discovery_wormhole.cpp:200
```

That's UMD's `UnexpectedRoutingFirmwareConfigError`, raised from `verify_routing_firmware_state` **during topology discovery** — the sibling of the `EthFirmwareHeartbeatError` already in `_FABRIC_INFRA_SIGNATURES`, from the same source file and the same discovery step. An ETH core whose routing firmware is in the wrong state means the cluster never came up, so no op kernel ran and the failure says nothing about `add` or `linear`.

### Change

One entry added to `_FABRIC_INFRA_SIGNATURES`, matched on the invariant phrase (`routing firmware for device asic id`) — the ASIC ID, the core coordinate and enabled/disabled all vary between occurrences.

This one was named as a candidate when the heartbeat signature went in and deliberately left out until it was actually seen, rather than added on speculation. It has now been seen, so it goes in on evidence.

### Verification

Classifies as infra: the exact message, and its `disabled` variant.

Still matches: the sibling heartbeat signature, the topology-mapper failures, `run_mailbox`, and TLB-window exhaustion.

**Still classified as genuine test failures** (i.e. not swallowed): PCC `0.0`, the `split` chunk PCC failure, the `pytensor.cpp:300 buffers.size() == 1` multi-buffer error, and the `all_gather` exact-equality failure.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/infra-routing-firmware-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/infra-routing-firmware-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/infra-routing-firmware-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/infra-routing-firmware-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/infra-routing-firmware-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/infra-routing-firmware-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/infra-routing-firmware-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/infra-routing-firmware-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/infra-routing-firmware-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/infra-routing-firmware-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/infra-routing-firmware-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/infra-routing-firmware-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/infra-routing-firmware-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/infra-routing-firmware-signature)