### PR TITLE
[Perf] erfinv_bw / erf_bw / reciprocal_bw: fold the unary steps into their multiplies

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_erfinv_reciprocal_bw.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_erfinv_reciprocal_bw.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+OPS = [
+    (ttnn.erfinv_bw, torch.erfinv, "inside"),
+    (ttnn.erf_bw, torch.erf, "wide"),
+    (ttnn.reciprocal_bw, torch.reciprocal, "wide"),
+]
+
+
+def inputs(where, dtype):
+    torch.manual_seed(0)
+    if where == "inside":
+        return (torch.rand([1, 1, 32, 32]) * 1.8 - 0.9).to(dtype)
+    return (torch.rand([1, 1, 32, 32]) * 8 - 4).to(dtype)
+
+
+@pytest.mark.parametrize("ttnn_op, torch_op, domain", OPS)
+@pytest.mark.parametrize("which_grad", ["ones", "mixed", "negative"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_backward_matches_torch(device, ttnn_op, torch_op, domain, which_grad, dtype):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    x = inputs(domain, torch_dtype)
+    if which_grad == "ones":
+        grad = torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+    elif which_grad == "negative":
+        grad = -torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+    else:
+        torch.manual_seed(1)
+        grad = (torch.rand([1, 1, 32, 32]) * 2 - 1).to(torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got = ttnn.to_torch(ttnn_op(dev(grad), dev(x))[0]).float()
+
+    tx = x.float().clone().requires_grad_(True)
+    torch_op(tx).backward(grad.float())
+
+    keep = torch.isfinite(tx.grad) & torch.isfinite(got)
+    tol = 0.05 if dtype == ttnn.bfloat16 else 1e-3
+    assert ((got[keep] - tx.grad[keep]).abs() / tx.grad[keep].abs().clamp(min=1.0)).max() < tol
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_erfinv_bw_at_the_boundary(device, dtype):
+    # |x| == 1 takes sign(grad) * inf, |x| > 1 takes nan. Both boundaries were
+    # written as a pair of tests against 1 and -1, which is abs(x) == 1.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    one = torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    assert (ttnn.to_torch(ttnn.erfinv_bw(dev(one), dev(one))[0]).float() == float("inf")).all()
+    assert (ttnn.to_torch(ttnn.erfinv_bw(dev(one), dev(-one))[0]).float() == float("inf")).all()
+    assert (ttnn.to_torch(ttnn.erfinv_bw(dev(-one), dev(one))[0]).float() == float("-inf")).all()
+    outside = ttnn.to_torch(ttnn.erfinv_bw(dev(one), dev(2 * one))[0]).float()
+    # bfloat16 loses the nan through the pack and carries inf instead, before
+    # this change as well.
+    assert not torch.isfinite(outside).any()
+    if dtype == ttnn.float32:
+        assert outside.isnan().all()
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_reciprocal_bw_at_zero(device, dtype):
+    # x == 0 takes -sign(grad) * inf, and nan when the gradient is zero too.
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    zero = torch.zeros([1, 1, 32, 32], dtype=torch_dtype)
+    one = torch.ones([1, 1, 32, 32], dtype=torch_dtype)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    assert (ttnn.to_torch(ttnn.reciprocal_bw(dev(one), dev(zero))[0]).float() == float("-inf")).all()
+    assert (ttnn.to_torch(ttnn.reciprocal_bw(dev(-one), dev(zero))[0]).float() == float("inf")).all()
+    both_zero = ttnn.to_torch(ttnn.reciprocal_bw(dev(zero), dev(zero))[0]).float()
+    assert not torch.isfinite(both_zero).any()
+    if dtype == ttnn.float32:
+        assert both_zero.isnan().all()

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <array>
 #include <numbers>
 #include <utility>
 #include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
@@ -30,6 +31,7 @@
 #include "tanh_bw/device/tanh_bw_device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/hal.hpp>
+#include <cstdint>
 
 namespace ttnn {
 
@@ -1334,24 +1336,28 @@ std::vector<Tensor> expm1_bw(
 std::vector<Tensor> reciprocal_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
+
+    // -sign(grad) * inf is sign(grad) * -inf, and the square and reciprocal of
+    // the input are one operand's activation, so seven of the dispatches were
+    // unary steps feeding a multiply that applies a unary chain anyway.
+    const std::array sign_of_it = {EltwiseUnaryWithParam{UnaryOpType::SIGN}};
+    const std::array negate_it = {EltwiseUnaryWithParam{UnaryOpType::NEG}};
+    const std::array square_then_reciprocal = {
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE}, EltwiseUnaryWithParam{UnaryOpType::RECIP}};
+
     grad_tensor.emplace_back(where(
         ttnn::eqz(input, output_mem_config),
         where(
             ttnn::eqz(grad, output_mem_config),
             t_nan,
-            ttnn::multiply(
-                ttnn::neg(ttnn::sign(grad, output_mem_config), output_mem_config),
-                t_inf,
-                std::nullopt,
-                output_mem_config),
+            ttnn::multiply(grad, -t_inf, std::nullopt, output_mem_config, std::nullopt, {}, sign_of_it),
             output_mem_config),
         ttnn::multiply(
-            ttnn::neg(grad, output_mem_config),
-            ttnn::reciprocal(ttnn::square(input, output_mem_config), output_mem_config),
-            std::nullopt,
-            output_mem_config),
+            grad, input, std::nullopt, output_mem_config, std::nullopt, {}, negate_it, square_then_reciprocal),
         output_mem_config));
     return grad_tensor;
 }
@@ -1493,36 +1499,40 @@ std::vector<Tensor> polygamma_bw(
 std::vector<Tensor> erfinv_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
     float m_sqrtpi = 1.77245385090551602792981f;
+
+    // erfinv, its square and the exp are one operand's activation on the
+    // multiply by grad. The halving folds into the sqrt(pi): scaling by a power
+    // of two is exact, so one multiply rounds where two did.
+    const std::array to_exp_of_erfinv_squared = {
+        EltwiseUnaryWithParam{UnaryOpType::ERFINV},
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE},
+        EltwiseUnaryWithParam{UnaryOpType::EXP, 0.0f}};
+    const std::array sign_of_it = {EltwiseUnaryWithParam{UnaryOpType::SIGN}};
+    const std::array below_minus_one = {EltwiseUnaryWithParam{UnaryOpType::UNARY_LT, -1.0f}};
+    const std::array above_one = {EltwiseUnaryWithParam{UnaryOpType::UNARY_GT, 1.0f}};
+    // x == 1 or x == -1 is abs(x) == 1, and both wheres wrote the same value.
+    const std::array abs_is_one = {
+        EltwiseUnaryWithParam{UnaryOpType::ABS}, EltwiseUnaryWithParam{UnaryOpType::UNARY_EQ, 1.0f}};
+
     Tensor result = ttnn::multiply(
-        ttnn::multiply(
-            ttnn::multiply(
-                ttnn::exp(
-                    ttnn::square(ttnn::erfinv(input, output_mem_config), output_mem_config), false, output_mem_config),
-                grad,
-                std::nullopt,
-                output_mem_config),
-            m_sqrtpi,
-            std::nullopt,
-            output_mem_config),
-        0.5f,
+        ttnn::multiply(input, grad, std::nullopt, output_mem_config, std::nullopt, {}, to_exp_of_erfinv_squared),
+        m_sqrtpi * 0.5f,
         std::nullopt,
         output_mem_config);
     Tensor t_inf = ttnn::multiply(
-        ttnn::sign(grad, output_mem_config), std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config);
+        grad, std::numeric_limits<float>::infinity(), std::nullopt, output_mem_config, std::nullopt, {}, sign_of_it);
     result = ttnn::where(
-        ttnn::logical_or(
-            ttnn::lt(input, -1.0f, std::nullopt, output_mem_config),
-            ttnn::gt(input, 1.0f, std::nullopt, output_mem_config),
-            std::nullopt,
-            output_mem_config),
+        ttnn::logical_or(input, input, std::nullopt, output_mem_config, std::nullopt, {}, below_minus_one, above_one),
         std::nanf(" "),
         result,
         output_mem_config);
     result = ttnn::where(
-        ttnn::eq(input, -1.0f, std::nullopt, output_mem_config),
+        ttnn::eq(input, 1.0f, std::nullopt, output_mem_config, std::nullopt, {}, abs_is_one),
         t_inf,
-        ttnn::where(ttnn::eq(input, 1.0f, std::nullopt, output_mem_config), t_inf, result, output_mem_config),
+        result,
         output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
@@ -1531,12 +1541,16 @@ std::vector<Tensor> erfinv_bw(
 std::vector<Tensor> erf_bw(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
+    using ttnn::operations::unary::EltwiseUnaryWithParam;
+    using ttnn::operations::unary::UnaryOpType;
+    // The square, the negate and the exp are one operand's activation on the
+    // multiply by grad.
+    const std::array to_exp_of_minus_square = {
+        EltwiseUnaryWithParam{UnaryOpType::SQUARE},
+        EltwiseUnaryWithParam{UnaryOpType::NEG},
+        EltwiseUnaryWithParam{UnaryOpType::EXP, 0.0f}};
     Tensor result = ttnn::multiply(
-        ttnn::multiply(
-            ttnn::exp(ttnn::neg(ttnn::square(input, output_mem_config), output_mem_config), false, output_mem_config),
-            grad,
-            std::nullopt,
-            output_mem_config),
+        ttnn::multiply(input, grad, std::nullopt, output_mem_config, std::nullopt, {}, to_exp_of_minus_square),
         2.0f * std::numbers::inv_sqrtpi_v<float>,
         std::nullopt,
         output_mem_config);
@@ -1596,7 +1610,7 @@ std::vector<Tensor> repeat_bw(
         return grad_tensor;
     }
     if (shape[0] > 1) {
-        ttsl::SmallVector<int64_t> dim = {0};
+        ttsl::SmallVector<std::int64_t> dim = {0};
         TT_FATAL(shape[1] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[1], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {1, shape_wh[1], shape_wh[2], shape_wh[3]};
         const auto required = ttnn::Shape(intended_shape_array);
@@ -1611,7 +1625,7 @@ std::vector<Tensor> repeat_bw(
         return grad_tensor;
     }
     if (shape[1] > 1) {
-        ttsl::SmallVector<int64_t> dim = {1};
+        ttsl::SmallVector<std::int64_t> dim = {1};
         TT_FATAL(shape[0] == 1 && shape[2] == 1 && shape[3] == 1, "repeat[0], [2], [3] should be 1");
         std::array<std::uint32_t, 4> intended_shape_array = {shape_wh[0], 1, shape_wh[2], shape_wh[3]};
         const auto required = ttnn::Shape(intended_shape_array);
@@ -1651,7 +1665,7 @@ namespace ttnn {
 std::vector<Tensor> prod_bw(
     const Tensor& grad,
     const Tensor& input,
-    const std::optional<int64_t> dim,
+    const std::optional<std::int64_t> dim,
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(
@@ -1678,13 +1692,13 @@ std::vector<Tensor> prod_bw(
 
     // all_dimensions = False
     Tensor updated_grad = prod_result;
-    auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
+    auto step = ttsl::SmallVector<std::uint32_t>({1, 1, 1, 1});
     if (prod_result.logical_shape() != grad.padded_shape()) {
         if (*dim == 3 || *dim == -1) {
-            ttsl::SmallVector<int64_t> after_permute_dims = {0, 3, 1, 2};
+            ttsl::SmallVector<std::int64_t> after_permute_dims = {0, 3, 1, 2};
             Tensor required = ttnn::permute(grad, after_permute_dims, output_memory_config);
-            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttsl::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<std::uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[2]};
             Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             after_permute_dims = {0, 2, 3, 1};
@@ -1695,10 +1709,10 @@ std::vector<Tensor> prod_bw(
                 updated_grad = pad_updated_grad.to_device(input.device());
             }
         } else if (*dim == 2 || *dim == -2) {
-            ttsl::SmallVector<int64_t> after_permute_dims = {0, 2, 1, 3};
+            ttsl::SmallVector<std::int64_t> after_permute_dims = {0, 2, 1, 3};
             Tensor required = ttnn::permute(grad, after_permute_dims, output_memory_config);
-            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttsl::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<std::uint32_t> end_index = {
                 grad.padded_shape()[0], 1, grad.padded_shape()[1], grad.padded_shape()[3]};
             Tensor new_slice_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
             updated_grad = ttnn::permute(new_slice_tensor, after_permute_dims, output_memory_config);
@@ -1732,11 +1746,11 @@ std::vector<Tensor> prod_bw(
     if (*dim == 1 || *dim == -3) {
         Tensor tensor_1_temp = reciprocal_input;
         if (reciprocal_input.padded_shape()[1] % 32 != 0) {
-            ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+            ttsl::SmallVector<std::array<std::uint32_t, 2>> padding = {
                 {0, 0}, {0, 32 - (reciprocal_input.padded_shape()[1] % 32)}, {0, 0}, {0, 0}};
             tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0, true, std::nullopt);
         }
-        ttsl::SmallVector<int64_t> after_permute_dims = {0, 2, 3, 1};
+        ttsl::SmallVector<std::int64_t> after_permute_dims = {0, 2, 3, 1};
         Tensor tensor_1 = ttnn::permute(tensor_1_temp, after_permute_dims, output_memory_config);
         Tensor tensor_2 = ttnn::permute(temp, after_permute_dims, output_memory_config);
 
@@ -1770,10 +1784,10 @@ std::vector<Tensor> prod_bw(
             output_memory_config);
         Tensor grad_result = result;
         if (reciprocal_input.padded_shape()[1] % 32 != 0) {
-            ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-            ttsl::SmallVector<uint32_t> end_index = {
+            ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+            ttsl::SmallVector<std::uint32_t> end_index = {
                 input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
-            auto step = ttsl::SmallVector<uint32_t>({1, 1, 1, 1});
+            auto step = ttsl::SmallVector<std::uint32_t>({1, 1, 1, 1});
             grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
         }
         grad_tensor.emplace_back(grad_result);
@@ -1782,11 +1796,11 @@ std::vector<Tensor> prod_bw(
     // dim 0
     Tensor tensor_1_temp = reciprocal_input;
     if (reciprocal_input.padded_shape()[0] % 32 != 0) {
-        ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+        ttsl::SmallVector<std::array<std::uint32_t, 2>> padding = {
             {0, (32 - (reciprocal_input.padded_shape()[0] % 32))}, {0, 0}, {0, 0}, {0, 0}};
         tensor_1_temp = ttnn::pad(reciprocal_input, padding, 0, false, std::nullopt);
     }
-    ttsl::SmallVector<int64_t> after_permute_dims = {3, 1, 2, 0};
+    ttsl::SmallVector<std::int64_t> after_permute_dims = {3, 1, 2, 0};
     Tensor tensor_1 = ttnn::permute(tensor_1_temp, after_permute_dims, output_memory_config);
     Tensor tensor_2 = ttnn::permute(temp, after_permute_dims, output_memory_config);
 
@@ -1819,8 +1833,8 @@ std::vector<Tensor> prod_bw(
         output_memory_config);
     Tensor grad_result = result;
     if (reciprocal_input.padded_shape()[0] % 32 != 0) {
-        ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttsl::SmallVector<uint32_t> end_index = {
+        ttsl::SmallVector<std::uint32_t> start_index = {0, 0, 0, 0};
+        ttsl::SmallVector<std::uint32_t> end_index = {
             input.padded_shape()[0], input.padded_shape()[1], input.padded_shape()[2], input.padded_shape()[3]};
         grad_result = ttnn::slice(result, start_index, end_index, step, std::nullopt);
     }


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Closes #53887.
Closes #53888.

Each of the three walks its input through a run of unary ops and then multiplies by grad. `erfinv`, `square`, `exp`, `neg`, `sign` and `reciprocal` are all one operand's activation on that multiply, so none of them needs a dispatch.

Two more collapse on their own terms. `erfinv_bw` scaled by `sqrt(pi)` and then by `0.5` in two dispatches; halving is exact, so one multiply by half of `sqrt(pi)` rounds where two did and lands on the same number. `x == 1 or x == -1` is `abs(x) == 1`, so a pair of tests and a pair of `where`s writing the same value become one of each.

`erf_bw` is not in either issue. It is the same three-line change in the function below `erfinv_bw`.

## Accuracy

**Exhaustive, not sampled. Every number below is this branch against the composite it replaces** — the `04cf22f7ee` build and this build, run on the same device, output bits compared exactly as integers. It is not a comparison against IEEE or against torch; where torch enters it is named.

**bfloat16: every one of the 65536 bit patterns, against six gradients** (1, -1, 0, 0.5, 1e30, 1e-30), P300, 393216 input points per op.

| op | patterns differing from the composite | where |
|---|---|---|
| erfinv_bw | 508 | the 254 nan bit patterns, at two gradients |
| erf_bw | 1270 | the 254 nan bit patterns, at five gradients |
| reciprocal_bw | **0** | — |

**float32: every one of the 2^32 bit patterns, against three gradients** (1, 0, -1), P300, 12.9 billion input points per op.

| op | chunks differing from the composite |
|---|---|
| erfinv_bw | **0 of 12288** |
| erf_bw | **0 of 12288** |
| reciprocal_bw | **0 of 12288** |

Nothing moves in float32, and nothing moves on a finite bfloat16 input.

The 254 patterns are the complete set of bfloat16 nan encodings. Neither form returns nan there, because bfloat16 loses nan through the pack; they disagree about which non-nan value comes out. `torch` returns nan for all of them.

**Improvement or regression?** Every differing pattern, classified against a float64 reference for the same formula torch uses:

| op | patterns differing | fused closer to torch | base closer to torch | reference is nan, neither can match |
|---|---|---|---|---|
| erfinv_bw | 508 | 0 | **0** | 508 |
| erf_bw | 1270 | 0 | **0** | 1270 |
| reciprocal_bw | 0 | — | — | — |

Nothing regresses. All 1778 differing patterns are nan inputs, where the reference is nan and neither build can return one, because bfloat16 loses nan through the pack — base answers 0 or -inf and this branch answers inf, and both are wrong.

For scale, against the correctly rounded torch answer over all 65536 bfloat16 inputs at `grad = 1`, the two builds agree exactly with each other and land on the reference for `erfinv_bw` 31852 times, `erf_bw` 63724, `reciprocal_bw` 35534. Those counts are unchanged by this PR; how far the composites sit from torch is a separate matter from what this PR moves.

## Cost

Device profiler, `[1, 1, 512, 512]`, 33 invocations, TRISC_1 cycles summed over the cores in a call.

| | dispatches | N300 bfloat16 | N300 float32 | P300 bfloat16 | P300 float32 |
|---|---|---|---|---|---|
| erfinv_bw | 16 → **7** | 18,473,919 → **11,641,933** (1.59x) | 34,922,236 → **18,685,336** (1.87x) | 15,547,681 → **10,120,639** (1.54x) | 24,406,573 → **14,004,066** (1.74x) |
| erf_bw | 5 → **2** | 4,436,359 → **2,608,743** (1.70x) | 9,278,876 → **4,829,166** (1.92x) | 3,762,250 → **2,437,282** (1.54x) | 5,887,491 → **3,240,074** (1.82x) |
| reciprocal_bw | 11 → **6** | 10,820,110 → **7,848,949** (1.38x) | 23,286,397 → **15,511,234** (1.50x) | 8,649,116 → **6,463,801** (1.34x) | 14,059,958 → **10,108,046** (1.39x) |

Wall clock on N300, 100 calls with one synchronise at the end, profiler off, microseconds per call.

| | | bfloat16 | float32 |
|---|---|---|---|
| erfinv_bw | 1 tile | 556.7 → **272.5** (2.04x) | 574.0 → **320.8** (1.79x) |
| | 256 tiles | 599.6 → **309.6** (1.94x) | 595.6 → **321.8** (1.85x) |
| | 1024 tiles | 620.3 → **327.8** (1.89x) | 1103.2 → **562.7** (1.96x) |
| erf_bw | 1 tile | 165.0 → **123.2** (1.34x) | 166.3 → **126.6** (1.31x) |
| | 256 tiles | 174.9 → **96.3** (1.82x) | 175.3 → **101.4** (1.73x) |
| | 1024 tiles | 178.0 → **100.5** (1.77x) | 321.5 → **167.0** (1.93x) |
| reciprocal_bw | 1 tile | 386.0 → **238.8** (1.62x) | 385.4 → **250.3** (1.54x) |
| | 256 tiles | 358.3 → **229.8** (1.56x) | 359.6 → **233.2** (1.54x) |
| | 1024 tiles | 358.2 → **234.9** (1.52x) | 713.8 → **436.0** (1.64x) |

## Tests

`test_erfinv_reciprocal_bw.py`, 22 cases: each op against its torch backward across three gradient shapes on both dtypes, the `|x| == 1` and `|x| > 1` boundaries of `erfinv_bw`, and the `x == 0` corner of `reciprocal_bw` including the zero gradient. The 12 existing cases in `test_backward_erfinv.py`, `test_backward_erf.py` and `test_backward_reciprocal.py` pass unchanged.

## Not covered

- At the nan boundaries bfloat16 carries inf rather than nan, since bfloat16 loses nan through the pack. Unchanged by this PR, and the test records it.
- The remaining dispatches are mostly `where`s. `ttnn::where` takes no activations on its predicate.
