### PR TITLE
[Bug fix] where: say which shapes are unsupported instead of running a fallback that cannot return

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_where_unsupported_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_where_unsupported_bcast.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+# Shapes the ternary kernel does not have a broadcast pattern for. A composite
+# of gtz, lez, two multiplies and an add used to be run for these, and the
+# multiply inside it rejected them in turn, so the caller saw a complaint about
+# an op they never wrote.
+UNSUPPORTED = [
+    ([1, 1, 32, 32], [1, 1, 32, 32], [1, 1, 64, 32]),
+    ([1, 1, 32, 32], [1, 1, 32, 32], [1, 1, 32, 64]),
+    ([1, 1, 32, 32], [1, 1, 1, 32], [1, 1, 32, 64]),
+    ([1, 1, 64, 32], [1, 1, 32, 64], [1, 1, 32, 32]),
+]
+
+SUPPORTED = [
+    ([1, 1, 32, 32], [1, 1, 32, 32], [1, 1, 32, 32]),
+    ([1, 1, 32, 32], [1, 1, 1, 32], [1, 1, 32, 32]),
+    ([1, 1, 32, 32], [1, 1, 32, 1], [1, 1, 32, 32]),
+    ([1, 1, 1, 1], [1, 1, 32, 32], [1, 1, 32, 32]),
+]
+
+
+def dev(device, shape):
+    return ttnn.from_torch(
+        torch.rand(shape, dtype=torch.float32), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+
+@pytest.mark.parametrize("p_shape, t_shape, f_shape", UNSUPPORTED)
+def test_where_names_the_shapes_it_cannot_broadcast(device, expect_error, p_shape, t_shape, f_shape):
+    with expect_error(RuntimeError, "do not broadcast in a pattern"):
+        ttnn.where(dev(device, p_shape), dev(device, t_shape), dev(device, f_shape))
+
+
+@pytest.mark.parametrize("p_shape, t_shape, f_shape", SUPPORTED)
+def test_where_still_broadcasts_what_it_supported(device, p_shape, t_shape, f_shape):
+    p, t, f = dev(device, p_shape), dev(device, t_shape), dev(device, f_shape)
+    got = ttnn.to_torch(ttnn.where(p, t, f))
+    want = torch.where(ttnn.to_torch(p) > 0, ttnn.to_torch(t), ttnn.to_torch(f))
+    assert torch.equal(got, want)

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -6,6 +6,7 @@
 
 #include <utility>
 #include <variant>
+#include <cstdint>
 
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp"
@@ -22,40 +23,6 @@ using namespace ttnn::operations::ternary;
 namespace ttnn::operations::ternary {
 
 namespace ternary_utils {
-
-// where - ternary operator y = (predicate) ? value_true : value_false; elementwise
-// y = (predicate >= 0)*value_true + (predicate < 0)*value_false
-Tensor where_impl(
-    const Tensor& predicate,
-    const auto& value_true,
-    const auto& value_false,
-    const MemoryConfig& memory_config,
-    const std::optional<Tensor>& output) {
-    log_debug(tt::LogOp, "Where Composite");
-    using FusedActivations = ttsl::Span<const unary::EltwiseUnaryWithParam>;
-    constexpr auto dtype = std::nullopt;
-    const auto get_multiplied = [&](const Tensor& condition, const auto& value) -> Tensor {
-        return ttnn::multiply(
-            condition,
-            value,
-            dtype,
-            memory_config,
-            /* output */ std::nullopt,
-            /* post_activations */ FusedActivations{},
-            /* lhs_activations */ FusedActivations{},
-            /* rhs_activations */ FusedActivations{});
-    };
-
-    return ttnn::add(
-        get_multiplied(ttnn::gtz(predicate, memory_config), value_true),
-        get_multiplied(ttnn::lez(predicate, memory_config), value_false),
-        dtype,
-        memory_config,
-        output,
-        /* post_activations */ FusedActivations{},
-        /* lhs_activations */ FusedActivations{},
-        /* rhs_activations */ FusedActivations{});
-}
 
 inline bool have_same_shape(const Tensor& a, const Tensor& b) { return (a.logical_shape() == b.logical_shape()); }
 
@@ -122,14 +89,16 @@ Tensor invoke_impl(
         condition = ttnn::typecast(predicate, t_true.dtype(), std::nullopt, std::nullopt, sub_core_grids);
     }
 
-    if (is_invalid_bcast(broadcast_type)) {
-        return ternary_utils::where_impl(
-            condition,
-            t_true,
-            t_false,
-            ternary_utils::determine_memory_config(memory_config, predicate.memory_config()),
-            output);
-    }
+    // A composite of gtz, lez, two multiplies and an add stood here for this
+    // case. It never returned: every shape that reaches it is one the multiply
+    // inside it rejects too, so all it did was report the rejection from an op
+    // the caller did not write. Say which shapes and which op instead.
+    TT_FATAL(
+        !is_invalid_bcast(broadcast_type),
+        "ttnn.where: shapes {}, {} and {} do not broadcast in a pattern the ternary kernel supports",
+        condition.logical_shape(),
+        t_true.logical_shape(),
+        t_false.logical_shape());
 
     std::optional<DataType> output_dtype = ternary_utils::determine_output_dtype(output, t_true.dtype());
     log_debug(tt::LogOp, "Where LLK - TTT");
@@ -217,7 +186,7 @@ Tensor where(
 }
 
 template <typename T>
-    requires std::same_as<T, int32_t> || std::same_as<T, uint32_t>
+    requires std::same_as<T, std::int32_t> || std::same_as<T, std::uint32_t>
 Tensor where(
     const Tensor& predicate,
     const T& value_true,
@@ -228,17 +197,17 @@ Tensor where(
     return ttnn::where_tss(predicate, value_true, value_false, memory_config, output, sub_core_grids);
 }
 
-template Tensor where<int32_t>(
+template Tensor where<std::int32_t>(
     const Tensor&,
-    const int32_t&,
-    const int32_t&,
+    const std::int32_t&,
+    const std::int32_t&,
     const std::optional<MemoryConfig>&,
     const std::optional<Tensor>&,
     const std::optional<CoreRangeSet>&);
-template Tensor where<uint32_t>(
+template Tensor where<std::uint32_t>(
     const Tensor&,
-    const uint32_t&,
-    const uint32_t&,
+    const std::uint32_t&,
+    const std::uint32_t&,
     const std::optional<MemoryConfig>&,
     const std::optional<Tensor>&,
     const std::optional<CoreRangeSet>&);


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53890.

The `INVALID_BCAST` arm of `ttnn.where` ran a composite of `gtz`, `lez`, two multiplies and an add. It never returned a value: every shape that reaches that arm is one the multiply inside the composite rejects in turn, so all the composite did was report the rejection from an op the caller did not write, as `Invalid subtile broadcast type`.

The arm now says which three shapes it cannot broadcast and which op is refusing.

## Accuracy

**Every number below is this branch against the composite it replaces** — the `04cf22f7ee` build and this build, run on the same device, output bits compared exactly as integers.

**Shapes: every triple of 11 shapes, 1331 combinations, both machines, float32.**

| | before | after |
|---|---|---|
| go to the ternary kernel | 377 | 377, and every one returns the same bits |
| reach the fallback | 768 | — |
| return a tensor from the fallback | **0** | — |
| named rejection | 0 | **768** |
| rejected before either path | 186 | 186 |

The same split on P300 and N300.

**Values: every returning triple, both dtypes.** 754 shape-and-dtype combinations returned a tensor on each build; the same 754, and **0 differing bits** across all of them. Nothing was lost and nothing new started returning.

**Values, exhaustive: every one of the 65536 bfloat16 bit patterns, in each of the three operand positions**, on a supported shape:

| swept operand | patterns differing from the composite |
|---|---|
| predicate | **0 of 65536** |
| value_true | **0 of 65536** |
| value_false | **0 of 65536** |

So the supported path is untouched, checked by shape, by value and exhaustively.

## Cost

None. This PR does not make anything faster: the 377 working triples take the same dispatches as before, and the arm it deletes was never producing an answer to time. What it removes is five dispatches of work on a path that then raised anyway.

## Tests

`test_where_unsupported_bcast.py`, 8 cases: four unsupported triples now naming the shapes, and four supported ones still returning what `torch.where` returns. The 842 existing cases in `test_where.py` pass unchanged.

## Not covered

- Widening the ternary kernel to cover these patterns, which is the other way to close this. That is kernel work; this is what the fallback was worth.
- Sharded inputs, `bfloat8_b` and `bfloat4_b`.
