### PR TITLE
[cleanup] Make light weight assertion trap a dedicated function

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4405,67 +4405,6 @@ TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKern
     EXPECT_NE(kernel_a->compute_hash(), kernel_b->compute_hash());
 }
 
-// These two tests pin both halves of the contract with asserts turned on:
-//   1. an in-range index still folds in a constant expression (the accessor stays constexpr), and
-//   2. an out-of-range index in a constant expression is still rejected at build time.
-//
-// Lightweight (hacky) simulation of assertion-on environment to verify vararg CTA work with assertion.
-
-TEST_F(ProgramSpecTestGen1, InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
-    NodeCoord node{0, 0};
-
-    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
-    dm_kernel.compiler_options.defines = {{"LIGHTWEIGHT_KERNEL_ASSERTS", "1"}, {"FORCE_WATCHER_OFF", "1"}};
-    dm_kernel.source = KernelSpec::SourceCode{R"(
-void kernel_main() {
-    // Constant-evaluated: proves the accessor is still usable in a constant expression while the
-    // out-of-range path carries a (non-constexpr) assert.
-    static_assert(get_compile_time_vararg(0) == 0xCAFEBABEu);
-    static_assert(get_compile_time_vararg(2) == 0x11112222u);
-    // Runtime-evaluated: the index is not a constant expression, so this is the path that actually
-    // emits the bounds check and the ebreak.
-    volatile uint32_t idx = 1;
-    volatile uint32_t sink = get_compile_time_vararg(idx);
-    (void)sink;
-}
-)"};
-    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
-
-    ProgramSpec spec;
-    spec.name = "cta_varargs_in_range_asserts_on";
-    spec.kernels = {dm_kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
-
-    Program program = MakeProgramFromSpec(*mesh_device_, spec);
-    IDevice* device = mesh_device_->get_devices()[0];
-    EXPECT_NO_THROW(detail::CompileProgram(device, program));
-}
-
-// Out-of-range index in a constant expression, asserts on: must still fail the build. Constant
-// evaluation reaches the non-constexpr out-of-range report, which is not a constant expression --
-// so this is a clean build failure rather than a read past kernel_compile_time_args.
-TEST_F(ProgramSpecTestGen1, OutOfRangeCompileTimeVarargFailsToCompileWithAssertsEnabled) {
-    NodeCoord node{0, 0};
-
-    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
-    dm_kernel.compiler_options.defines = {{"LIGHTWEIGHT_KERNEL_ASSERTS", "1"}, {"FORCE_WATCHER_OFF", "1"}};
-    dm_kernel.source = KernelSpec::SourceCode{R"(
-void kernel_main() {
-    // Only 1 vararg is baked, so index 1 is out of range. Should not compile.
-    static_assert(get_compile_time_vararg(1) == 0u);
-}
-)"};
-    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu};
-
-    ProgramSpec spec;
-    spec.name = "cta_varargs_oob_asserts_on";
-    spec.kernels = {dm_kernel};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
-
-    // MakeProgramFromSpec compiles; the OOB constant evaluation must fail that build.
-    EXPECT_ANY_THROW(MakeProgramFromSpec(*mesh_device_, spec));
-}
-
 // ============================================================================
 // Kernel hash sensitivity to TensorParameter spec
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4405,6 +4405,67 @@ TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKern
     EXPECT_NE(kernel_a->compute_hash(), kernel_b->compute_hash());
 }
 
+// These two tests pin both halves of the contract with asserts turned on:
+//   1. an in-range index still folds in a constant expression (the accessor stays constexpr), and
+//   2. an out-of-range index in a constant expression is still rejected at build time.
+//
+// Lightweight (hacky) simulation of assertion-on environment to verify vararg CTA work with assertion.
+
+TEST_F(ProgramSpecTestGen1, InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
+    NodeCoord node{0, 0};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.compiler_options.defines = {{"LIGHTWEIGHT_KERNEL_ASSERTS", "1"}, {"FORCE_WATCHER_OFF", "1"}};
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    // Constant-evaluated: proves the accessor is still usable in a constant expression while the
+    // out-of-range path carries a (non-constexpr) assert.
+    static_assert(get_compile_time_vararg(0) == 0xCAFEBABEu);
+    static_assert(get_compile_time_vararg(2) == 0x11112222u);
+    // Runtime-evaluated: the index is not a constant expression, so this is the path that actually
+    // emits the bounds check and the ebreak.
+    volatile uint32_t idx = 1;
+    volatile uint32_t sink = get_compile_time_vararg(idx);
+    (void)sink;
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_in_range_asserts_on";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+// Out-of-range index in a constant expression, asserts on: must still fail the build. Constant
+// evaluation reaches the non-constexpr out-of-range report, which is not a constant expression --
+// so this is a clean build failure rather than a read past kernel_compile_time_args.
+TEST_F(ProgramSpecTestGen1, OutOfRangeCompileTimeVarargFailsToCompileWithAssertsEnabled) {
+    NodeCoord node{0, 0};
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.compiler_options.defines = {{"LIGHTWEIGHT_KERNEL_ASSERTS", "1"}, {"FORCE_WATCHER_OFF", "1"}};
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    // Only 1 vararg is baked, so index 1 is out of range. Should not compile.
+    static_assert(get_compile_time_vararg(1) == 0u);
+}
+)"};
+    dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu};
+
+    ProgramSpec spec;
+    spec.name = "cta_varargs_oob_asserts_on";
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    // MakeProgramFromSpec compiles; the OOB constant evaluation must fail that build.
+    EXPECT_ANY_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
 // ============================================================================
 // Kernel hash sensitivity to TensorParameter spec
 // ============================================================================

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -27,8 +27,7 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
 
 #elif defined(LIGHTWEIGHT_KERNEL_ASSERTS)
 
-// Non-constexpr on purpose: C++17 forbids asm in a constexpr function body.
-// FORCE_INLINE keeps the ebreak at the ASSERT site in the binary (debug PC).
+// Trap wrapped as a function to avoid inline assembly at ASSERT macro's use site.
 FORCE_INLINE void lightweight_assert_trap() { asm("ebreak"); }
 
 #define ASSERT(condition, ...) (void(not(condition) ? lightweight_assert_trap(), 0 : 0))

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -27,7 +27,11 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
 
 #elif defined(LIGHTWEIGHT_KERNEL_ASSERTS)
 
-#define ASSERT(condition, ...) (void(not(condition) ? ({ asm("ebreak"); }), 0 : 0))
+// Non-constexpr on purpose: C++17 forbids asm in a constexpr function body.
+// FORCE_INLINE keeps the ebreak at the ASSERT site in the binary (debug PC).
+FORCE_INLINE void lightweight_assert_trap() { asm("ebreak"); }
+
+#define ASSERT(condition, ...) (void(not(condition) ? lightweight_assert_trap(), 0 : 0))
 
 #define ASSERT_ENABLED 1
 #define LIGHTWEIGHT_ASSERT_ENABLED 1


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Device-side `ASSERT(cond, ...)` in `tt_metal/hw/inc/api/debug/assert.h` has three expansions:

1. asserts off: `sizeof` of the condition (no-op)
2. lightweight asserts: `!cond ? asm("ebreak") : 0`
3. watcher: `!cond ? assert_and_hang(...) : 0`

Variant 2 pastes inline asm into every caller. Kernels build as C++17, and C++17 forbids asm in a `constexpr` function **even if the failing branch is never taken**. 

```cpp
constexpr void assert_1_plus_1() {
    // Never trips — but with lightweight asserts this function is still ill-formed.
    ASSERT(1 + 1 == 2);
    // expands to: (1 + 1 != 2) ? asm("ebreak") : 0
    //                            ^ not allowed in a C++17 constexpr function
}
```

This PR wraps `asm("ebreak")` in a non-`constexpr` `lightweight_assert_trap()` function. A C++17 `constexpr` function may contain a call to a non-`constexpr` function as long as constant evaluation never reaches it, so `ASSERT` is usable in constant expressions when the condition holds. Runtime failure is still `ebreak`. Watcher and the disabled no-op are unchanged.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

I am not familiar to device side & I have no idea if this indirection may break any stack trace. Please advise.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/assert-as-func)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/assert-as-func)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/assert-as-func)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/assert-as-func)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/assert-as-func)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/assert-as-func)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/assert-as-func)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/assert-as-func)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/assert-as-func)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/assert-as-func)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/assert-as-func)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/assert-as-func)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/assert-as-func)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/assert-as-func)
