### PR TITLE
[Cleanup] Forward output_mem_config on the outer multiply in addcdiv_bw

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -47,7 +47,10 @@ std::vector<Tensor> addcdiv_bw(
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
     Tensor grad_a = ttnn::multiply(
-        ttnn::multiply(grad, value, std::nullopt, output_mem_config), ttnn::reciprocal(tensor2, output_mem_config));
+        ttnn::multiply(grad, value, std::nullopt, output_mem_config),
+        ttnn::reciprocal(tensor2, output_mem_config),
+        std::nullopt,
+        output_mem_config);
     grad_tensor.emplace_back(ttnn::where(
         ttnn::eqz(tensor2, output_mem_config),
         ttnn::where(ttnn::eqz(grad, output_mem_config), t_nan, t_inf, output_mem_config),

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -43,6 +43,9 @@ std::vector<Tensor> addcdiv_bw(
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     std::vector<Tensor> grad_tensor;
     grad_tensor.reserve(3);
+    // grad is passed through unchanged, so output[0] keeps grad's memory config rather
+    // than output_mem_config. Intentional: no eltwise backward op relocates the
+    // passthrough gradient. See #53874.
     grad_tensor.emplace_back(grad);
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/53874

### Summary
`output_mem_config` is threaded through all 12 other op calls in `addcdiv_bw`, but the outer `ttnn::multiply` that builds `grad_a` omitted it -- the only call in the function that does. The two structurally identical multiplies right below it (`tmp` and `grad_b`) both pass `std::nullopt, output_mem_config`.

This is a consistency fix, not a behaviour fix. `ttnn::multiply` with no memory_config inherits `input_a`'s config, and here `input_a` is the inner multiply's result, which was already placed in `output_mem_config`. Because a single `output_mem_config` value feeds both, the inherited and requested configs cannot diverge, so `grad_a` already landed in the right place.

Verified: reverting this change and re-running the same probe gives identical results --

  requested L1   -> outputs [DRAM, L1, L1]     (both with and without the fix)
  requested DRAM -> outputs [DRAM, DRAM, DRAM] (both with and without the fix)

and test_backward_addcdiv.py passes 12/12 either way. The value is that the call no longer depends on the inner call's placement happening to match, so a later refactor of the inner call cannot silently move `grad_a`.

Addresses item 11 of #48240, which is filed as a Medium-severity memory-config bug; it is really a no-op inconsistency, and worth reclassifying there.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/addcdiv_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/addcdiv_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/addcdiv_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/addcdiv_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/addcdiv_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/addcdiv_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/addcdiv_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/addcdiv_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/addcdiv_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/addcdiv_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/addcdiv_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/addcdiv_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/addcdiv_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/addcdiv_bw_check)