### PR TITLE
#51433: Consolidate specless sharded-output shard-spec synthesis into a shared populated-grid helper

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
@@ -816,6 +816,9 @@ def test_fold_from_torch_rejects_specless_sharded_input(device, expect_error):
             (1, 8, 8, 64), ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="H_shrinks"
         ),  # post-fold rows=16 → 16 cores (not 64).
         pytest.param(
+            (1, 4, 4, 8), ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="W_shrinks"
+        ),  # post-fold cols=32 → 32 cores (not 64).
+        pytest.param(
             (1, 4, 4, 64), ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="B_shrinks"
         ),  # post-fold 4×256 → 4x8=32 cores (not 64).
     ],
@@ -834,6 +837,66 @@ def test_fold_specless_sharded_override_grid_shrinks_when_rows_lt_max_cores(shap
     assert (
         mc.shard_spec.grid.num_cores() < max_cores
     ), f"Synthesised grid over-declared cores: {mc.shard_spec.grid.num_cores()} == max {max_cores}"
+    ref = _fold_golden(x, 2, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+@pytest.mark.parametrize(
+    "in_shard_factory, override_layout",
+    [
+        pytest.param(_height_shard_rm, ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="H_col_major_in_W_override"),
+        pytest.param(_width_shard_rm, ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="W_col_major_in_H_override"),
+    ],
+)
+def test_fold_specless_cross_layout_override_col_major_input_enum_col_wise(in_shard_factory, override_layout, device):
+    """COL_MAJOR sharded input + orthogonal-layout override → helper enumerates col-wise CoreRangeSet (locks in post-consolidation change)."""
+    grid = device.compute_with_storage_grid_size()
+    if grid.x < 4 or grid.y < 4:
+        pytest.skip("Need at least 4x4 grid to distinguish row-wise vs col-wise enumeration")
+    shape = (1, 4, 4, 8)
+    in_mc = in_shard_factory(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    out_mc = ttnn.MemoryConfig(override_layout, ttnn.BufferType.L1)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.fold(ttnn_in, 2, 2, override_memory_config=out_mc)
+    mc = result.memory_config()
+    assert mc.shard_spec is not None
+    assert mc.shard_spec.orientation == ttnn.ShardOrientation.COL_MAJOR
+    n_cores = mc.shard_spec.grid.num_cores()
+    expected_crs = ttnn.num_cores_to_corerangeset(n_cores, grid, False)
+    assert (
+        mc.shard_spec.grid == expected_crs
+    ), f"COL_MAJOR input must yield col-wise CoreRangeSet; got {mc.shard_spec.grid}"
+    ref = _fold_golden(x, 2, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert torch.equal(ref, got), f"fold is a lossless bfloat16 reshape; expected bit-equal, got mismatch"
+
+
+def test_fold_specless_block_override_col_major_input_swaps_divisors(device):
+    """COL_MAJOR H input + BLOCK override on asymmetric grid → shard shape follows h_div=grid.x, w_div=grid.y swap."""
+    grid = device.compute_with_storage_grid_size()
+    if grid.x == grid.y:
+        pytest.skip("Divisor swap invisible on square grid; asserts land on asymmetric (BH) grids")
+    shape = (1, 4, 4, 64)
+    in_mc = _height_shard_rm(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.fold(ttnn_in, 2, 2, override_memory_config=out_mc)
+    mc = result.memory_config()
+    assert mc.shard_spec is not None
+    assert mc.shard_spec.orientation == ttnn.ShardOrientation.COL_MAJOR
+    tensor_h, tensor_w = 4, 256
+    expected_h = (tensor_h + grid.x - 1) // grid.x
+    expected_w = (tensor_w + grid.y - 1) // grid.y
+    got_h, got_w = mc.shard_spec.shape[0], mc.shard_spec.shape[1]
+    assert (got_h, got_w) == (expected_h, expected_w), (
+        f"COL_MAJOR BLOCK divisor swap: expected shard ({expected_h}, {expected_w}) "
+        f"[h_div=grid.x={grid.x}, w_div=grid.y={grid.y}]; got ({got_h}, {got_w})"
+    )
     ref = _fold_golden(x, 2, 2)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
     assert_with_pcc(ref.float(), got.float(), 0.9999)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1183,3 +1183,68 @@ def test_repeat_optional_output_mismatched_shard_spec_raises(device, expect_erro
 
     with expect_error(RuntimeError, "shard_spec must match"):
         ttnn.repeat(input_tensor, list(repeat_shape), memory_config=other_mc, optional_output_tensor=optional_output)
+
+
+# Specless sharded output must shrink CoreRangeSet to populated shard count.
+
+
+def _assert_repeat_shrink_h_or_w(device, result_mc, n_used):
+    """Common shrink assertion for H/W: exact core count + row-wise CoreRangeSet."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y <= n_used:
+        pytest.skip(f"Device grid too small to observe shrink (need > {n_used} cores)")
+    grid = result_mc.shard_spec.grid
+    assert grid.num_cores() == n_used, f"Expected {n_used} populated cores, got {grid.num_cores()}"
+    expected = ttnn.num_cores_to_corerangeset(n_used, compute_grid, True)
+    assert grid == expected, f"Expected row-wise CoreRangeSet {expected}, got {grid}"
+
+
+def test_repeat_specless_sharded_output_grid_shrinks_height(device):
+    """HEIGHT_SHARDED no-spec output: (1,1,64,32)×[1,1,2,1] → tensor_h=128, shard_h=32 → 4 populated cores."""
+    shape = (1, 1, 64, 32)
+    reps = [1, 1, 2, 1]
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.repeat(ttnn_in, reps, memory_config=out_mc)
+    _assert_repeat_shrink_h_or_w(device, result.memory_config(), n_used=4)
+    assert_with_pcc(x.repeat(reps).float(), ttnn.to_torch(result).float(), 0.9999)
+
+
+def test_repeat_specless_sharded_output_grid_shrinks_width(device):
+    """WIDTH_SHARDED no-spec output: (1,1,32,32)×[1,1,1,2] → tensor_w=64, shard_w=32 → 2 populated cores."""
+    shape = (1, 1, 32, 32)
+    reps = [1, 1, 1, 2]
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.repeat(ttnn_in, reps, memory_config=out_mc)
+    _assert_repeat_shrink_h_or_w(device, result.memory_config(), n_used=2)
+    assert_with_pcc(x.repeat(reps).float(), ttnn.to_torch(result).float(), 0.9999)
+
+
+def test_repeat_specless_sharded_output_grid_shrinks_block(device):
+    """BLOCK_SHARDED no-spec output: (1,1,32,32)×[1,1,2,2] → 64x64 tiled → 2x2 rectangle = 4 cores."""
+    shape = (1, 1, 32, 32)
+    reps = [1, 1, 2, 2]
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 2:
+        pytest.skip("Device grid too small for 2x2 BLOCK shrink test")
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.repeat(ttnn_in, reps, memory_config=out_mc)
+    grid = result.memory_config().shard_spec.grid
+    assert grid.num_cores() == 4, f"Expected 2x2 = 4 populated cores, got {grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))})
+    assert grid == expected, f"Expected rectangular BLOCK grid {expected}, got {grid}"
+    assert_with_pcc(x.repeat(reps).float(), ttnn.to_torch(result).float(), 0.9999)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_indexed_fill.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_indexed_fill.py
@@ -285,3 +285,64 @@ def test_indexed_fill_dim_out_of_bounds(device, expect_error):
 
     with expect_error(RuntimeError, "is out of bounds for rank"):
         ttnn.indexed_fill(batch_id_ttnn, input_tensor_a, input_tensor_b, dim=-5)  # -5 < -rank=-4
+
+
+# Specless sharded output must shrink CoreRangeSet to populated shard count.
+
+
+@pytest.mark.parametrize(
+    "shape, out_layout, expected_cores",
+    [
+        # HEIGHT_SHARDED: (B=2, ..., H=32, W=64) tiled → tensor_h=64, shard_h=32 → 2 populated cores.
+        pytest.param((2, 1, 32, 64), ttnn.TensorMemoryLayout.HEIGHT_SHARDED, 2, id="H_shrinks"),
+        # WIDTH_SHARDED: W=64 tiled → shard_w=32 → 2 populated cores.
+        pytest.param((2, 1, 32, 64), ttnn.TensorMemoryLayout.WIDTH_SHARDED, 2, id="W_shrinks"),
+        # BLOCK_SHARDED: tensor_h=64, tensor_w=64 on 8x8 grid → 2x2 rectangle = 4 populated cores.
+        pytest.param((2, 1, 32, 64), ttnn.TensorMemoryLayout.BLOCK_SHARDED, 4, id="B_shrinks"),
+    ],
+)
+def test_indexed_fill_specless_sharded_output_grid_shrinks(device, shape, out_layout, expected_cores):
+    """No-spec sharded output MC must synthesise a CoreRangeSet sized to populated shards, not full compute grid."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y <= expected_cores:
+        pytest.skip(f"Device grid too small to observe shrink (need > {expected_cores} cores)")
+    if out_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED and (compute_grid.x < 2 or compute_grid.y < 2):
+        pytest.skip("BLOCK case needs at least a 2x2 compute grid")
+
+    B = shape[0]
+    b = 1
+    batch_id = torch.randint(0, B, (1, 1, 1, b))
+    batch_id_ttnn = ttnn.Tensor(batch_id, ttnn.uint32).to(
+        device, ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    )
+
+    torch_a = torch.rand(shape, dtype=torch.bfloat16)
+    torch_b = torch.rand((b, *shape[1:]), dtype=torch.bfloat16)
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+    )
+    input_b = ttnn.from_torch(
+        torch_b,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+    )
+
+    out_mc = ttnn.MemoryConfig(out_layout, ttnn.BufferType.L1)
+    output = ttnn.indexed_fill(batch_id_ttnn, input_a, input_b, memory_config=out_mc)
+    grid = output.memory_config().shard_spec.grid
+    assert grid.num_cores() == expected_cores, f"Expected {expected_cores} populated cores, got {grid.num_cores()}"
+    if out_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED:
+        # BLOCK: rectangular (0,0)-(nx-1, ny-1); shape=(2,1,32,64) on tile-aligned 8x8 → 2×2.
+        expected_crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))])
+    else:
+        expected_crs = ttnn.num_cores_to_corerangeset(expected_cores, compute_grid, True)
+    assert grid == expected_crs, f"Expected CoreRangeSet {expected_crs}, got {grid}"
+
+    golden = golden_indexed_fill(torch_a, torch_b, batch_id, dim=0)
+    assert_with_pcc(golden, ttnn.to_torch(output), 0.9999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_sharding.py
@@ -473,3 +473,58 @@ def test_unary_rm_block_shard(device, torch_dtype, ttnn_dtype):
 
     ttnn_output = ttnn.to_torch(ttnn.abs(ttnn_input, memory_config=shard_mem_config))
     assert torch.equal(ttnn_output, torch_output)
+
+
+# Specless sharded output must shrink CoreRangeSet to populated shard count.
+
+
+def _assert_unary_shrink_h_or_w(device, result_mc, n_used):
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y <= n_used:
+        pytest.skip(f"Device grid too small to observe shrink (need > {n_used} cores)")
+    grid = result_mc.shard_spec.grid
+    assert grid.num_cores() == n_used, f"Expected {n_used} populated cores, got {grid.num_cores()}"
+    expected = ttnn.num_cores_to_corerangeset(n_used, compute_grid, True)
+    assert grid == expected, f"Expected row-wise CoreRangeSet {expected}, got {grid}"
+
+
+def test_unary_specless_sharded_output_grid_shrinks_height(device):
+    """HEIGHT_SHARDED no-spec output: shape=(2,2,32,64) TILE → tensor_h=128, shard_h=32 → 4 populated cores."""
+    shape = (2, 2, 32, 64)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    result = ttnn.abs(ttnn_in, memory_config=out_mc)
+    _assert_unary_shrink_h_or_w(device, result.memory_config(), n_used=4)
+    assert torch.equal(ttnn.to_torch(result), torch.abs(x))
+
+
+def test_unary_specless_sharded_output_grid_shrinks_width(device):
+    """WIDTH_SHARDED no-spec output: shape=(1,1,32,128) TILE → tensor_w=128, shard_w=32 → 4 populated cores."""
+    shape = (1, 1, 32, 128)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+    result = ttnn.abs(ttnn_in, memory_config=out_mc)
+    _assert_unary_shrink_h_or_w(device, result.memory_config(), n_used=4)
+    assert torch.equal(ttnn.to_torch(result), torch.abs(x))
+
+
+def test_unary_specless_sharded_output_grid_shrinks_block(device):
+    """BLOCK_SHARDED no-spec output: 64x64 TILE → 2x2 rectangle = 4 cores."""
+    shape = (1, 1, 64, 64)
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 2:
+        pytest.skip("Device grid too small for 2x2 BLOCK shrink test")
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    result = ttnn.abs(ttnn_in, memory_config=out_mc)
+    grid = result.memory_config().shard_spec.grid
+    assert grid.num_cores() == 4, f"Expected 2x2 = 4 populated cores, got {grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))})
+    assert grid == expected, f"Expected rectangular BLOCK grid {expected}, got {grid}"
+    assert torch.equal(ttnn.to_torch(result), torch.abs(x))

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(
             clone/device/clone_device_operation.hpp
             # common/
             common/common.hpp
+            common/synthesize_output_shard_spec.hpp
             # concat/
             concat/concat_nanobind.hpp
             concat/device/concat_device_operation.hpp

--- a/ttnn/cpp/ttnn/operations/data_movement/common/synthesize_output_shard_spec.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/synthesize_output_shard_spec.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "synthesize_output_shard_spec.hpp"
+
+#include <algorithm>
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/work_split.hpp>
+
+namespace ttnn::operations::data_movement::common {
+
+using tt::tt_metal::CoreCoord;
+using tt::tt_metal::CoreRange;
+using tt::tt_metal::CoreRangeSet;
+using tt::tt_metal::ShardOrientation;
+using tt::tt_metal::ShardSpec;
+using tt::tt_metal::TensorMemoryLayout;
+
+namespace {
+
+ShardOrientation resolve_orientation(const SynthesizeOutputShardSpecOpts& opts) {
+    if (opts.orientation_hint.has_value()) {
+        return *opts.orientation_hint;
+    }
+    if (opts.input_orientation.has_value()) {
+        return *opts.input_orientation;
+    }
+    return ShardOrientation::ROW_MAJOR;
+}
+
+}  // namespace
+
+ShardSpec synthesize_output_shard_spec(
+    const CoreCoord& compute_grid_size,
+    uint64_t tensor_height,
+    uint64_t tensor_width,
+    TensorMemoryLayout memory_layout,
+    const SynthesizeOutputShardSpecOpts& opts) {
+    // Sharded-only contract — callers filter INTERLEAVED at their wrapper (see repeat_utils.cpp:186-190).
+    TT_FATAL(
+        memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
+            memory_layout == TensorMemoryLayout::BLOCK_SHARDED,
+        "{}: unsupported memory_layout; only HEIGHT/WIDTH/BLOCK sharded.",
+        opts.caller_tag);
+    const CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
+    const uint32_t num_cores = all_cores.num_cores();
+    TT_FATAL(num_cores > 0, "{}: empty compute grid.", opts.caller_tag);
+    // Guards `div_up(_, shard_shape[i])` below; repeat's soft-reject path never reaches here (see
+    // repeat_utils.cpp:202).
+    TT_FATAL(
+        tensor_height > 0 && tensor_width > 0,
+        "{}: tensor dims must be > 0; got ({}, {}).",
+        opts.caller_tag,
+        tensor_height,
+        tensor_width);
+
+    const ShardOrientation orientation = resolve_orientation(opts);
+    const bool row_wise = (orientation == ShardOrientation::ROW_MAJOR);
+    const uint32_t h_align = opts.is_tile ? tt::constants::TILE_HEIGHT : 1u;
+    const uint32_t w_align = opts.is_tile ? tt::constants::TILE_WIDTH : 1u;
+
+    std::array<uint32_t, 2> shard_shape = {0, 0};
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        const auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * h_align);
+        const auto shard_height = tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(num_cores)), h_align);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(tensor_width)};
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        const auto shard_width = tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), w_align);
+        shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
+    } else {
+        // BLOCK: COL_MAJOR swaps h↔grid.x, w↔grid.y (matches conv2d_utils::determine_parallel_config).
+        const uint32_t h_div = row_wise ? compute_grid_size.y : compute_grid_size.x;
+        const uint32_t w_div = row_wise ? compute_grid_size.x : compute_grid_size.y;
+        const auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(h_div) * h_align);
+        const auto shard_height = tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(h_div)), h_align);
+        const auto shard_width = tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(w_div)), w_align);
+        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
+    }
+
+    CoreRangeSet used_cores;
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
+        n_used = std::min(std::max(n_used, 1u), num_cores);
+        used_cores = (n_used == num_cores)
+                         ? all_cores
+                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        n_used = std::min(std::max(n_used, 1u), num_cores);
+        used_cores = (n_used == num_cores)
+                         ? all_cores
+                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
+    } else {
+        const uint32_t n_h = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
+        const uint32_t n_w = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        const uint32_t n_along_x = row_wise ? n_w : n_h;
+        const uint32_t n_along_y = row_wise ? n_h : n_w;
+        TT_FATAL(
+            n_along_x <= static_cast<uint32_t>(compute_grid_size.x) &&
+                n_along_y <= static_cast<uint32_t>(compute_grid_size.y),
+            "{}: BLOCK shard-grid ({}x{} along x/y) exceeds compute grid ({}x{}); shard=({},{}) orientation={}",
+            opts.caller_tag,
+            n_along_x,
+            n_along_y,
+            compute_grid_size.x,
+            compute_grid_size.y,
+            shard_shape[0],
+            shard_shape[1],
+            row_wise ? "ROW_MAJOR" : "COL_MAJOR");
+        const uint32_t phys_x = std::max(n_along_x, 1u);
+        const uint32_t phys_y = std::max(n_along_y, 1u);
+        used_cores = (phys_x == static_cast<uint32_t>(compute_grid_size.x) &&
+                      phys_y == static_cast<uint32_t>(compute_grid_size.y))
+                         ? all_cores
+                         : CoreRangeSet(CoreRange({0, 0}, {phys_x - 1, phys_y - 1}));
+    }
+
+    return ShardSpec(used_cores, shard_shape, orientation);
+}
+
+ShardSpec synthesize_output_shard_spec(
+    const CoreCoord& compute_grid_size,
+    const ttnn::Shape& padded_out_shape,
+    TensorMemoryLayout memory_layout,
+    const SynthesizeOutputShardSpecOpts& opts) {
+    uint64_t tensor_height = 1;
+    for (int32_t i = 0; i < static_cast<int32_t>(padded_out_shape.rank()) - 1; ++i) {
+        tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
+    }
+    const uint64_t tensor_width = padded_out_shape[-1];
+    return synthesize_output_shard_spec(compute_grid_size, tensor_height, tensor_width, memory_layout, opts);
+}
+
+}  // namespace ttnn::operations::data_movement::common

--- a/ttnn/cpp/ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include <tt-metalium/core_coord.hpp>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+
+namespace ttnn::operations::data_movement::common {
+
+// Orientation fallback: hint → input_orientation → ROW_MAJOR; `caller_tag` prefixes FATAL messages.
+struct SynthesizeOutputShardSpecOpts {
+    bool is_tile = true;
+    std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt;
+    std::optional<tt::tt_metal::ShardOrientation> input_orientation = std::nullopt;
+    std::string_view caller_tag = "synthesize_output_shard_spec";
+};
+
+// Populated-shard CoreRangeSet for specless sharded outputs; BLOCK divisors track orientation for asymmetric grids.
+tt::tt_metal::ShardSpec synthesize_output_shard_spec(
+    const tt::tt_metal::CoreCoord& compute_grid_size,
+    uint64_t tensor_height,
+    uint64_t tensor_width,
+    tt::tt_metal::TensorMemoryLayout memory_layout,
+    const SynthesizeOutputShardSpecOpts& opts = {});
+
+// Convenience overload: flattens padded_out_shape into (product-of-leading, last-dim).
+tt::tt_metal::ShardSpec synthesize_output_shard_spec(
+    const tt::tt_metal::CoreCoord& compute_grid_size,
+    const ttnn::Shape& padded_out_shape,
+    tt::tt_metal::TensorMemoryLayout memory_layout,
+    const SynthesizeOutputShardSpecOpts& opts = {});
+
+}  // namespace ttnn::operations::data_movement::common

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -4,6 +4,7 @@
 
 #include "fold_device_op.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -18,44 +19,18 @@ bool is_fast_path_input(const Tensor& t) {
 
 tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(
     const Tensor& input_tensor, tt::tt_metal::TensorMemoryLayout layout, uint32_t rows, uint32_t cols) {
+    // COL_MAJOR input now yields column-wise H/W CoreRangeSet (documented via fold COL_MAJOR H/W shrink test).
     auto* device = input_tensor.device();
-    const auto grid = device->compute_with_storage_grid_size();
-    const uint32_t max_cores = grid.x * grid.y;
-    // Inherit input's orientation when available (mirrors generate_transpose_shard_spec); ROW_MAJOR fallback for
-    // non-sharded inputs.
-    const tt::tt_metal::ShardOrientation orientation = input_tensor.shard_spec().has_value()
-                                                           ? input_tensor.shard_spec()->orientation
-                                                           : tt::tt_metal::ShardOrientation::ROW_MAJOR;
-    std::array<uint32_t, 2> shape = {0, 0};
-    CoreRangeSet cores;
-    switch (layout) {
-        case TensorMemoryLayout::HEIGHT_SHARDED: {
-            shape = {tt::div_up(rows, max_cores), cols};
-            cores = tt::tt_metal::num_cores_to_corerangeset(tt::div_up(rows, shape[0]), grid, /*row_wise=*/true);
-            break;
-        }
-        case TensorMemoryLayout::WIDTH_SHARDED: {
-            shape = {rows, tt::div_up(cols, max_cores)};
-            cores = tt::tt_metal::num_cores_to_corerangeset(tt::div_up(cols, shape[1]), grid, /*row_wise=*/true);
-            break;
-        }
-        default: {  // BLOCK_SHARDED
-            // COL_MAJOR flips axis→core mapping (see TensorSpec validation + conv2d_utils::determine_parallel_config):
-            // height splits across grid.x, width across grid.y — asymmetric grids (e.g. bh_p100 11×10) otherwise
-            // overshoot num_shards_along_width vs shard_grid.y for COL_MAJOR.
-            const bool col_major = orientation == tt::tt_metal::ShardOrientation::COL_MAJOR;
-            const uint32_t h_divisor = col_major ? grid.x : grid.y;
-            const uint32_t w_divisor = col_major ? grid.y : grid.x;
-            shape = {tt::div_up(rows, h_divisor), tt::div_up(cols, w_divisor)};
-            const uint32_t n_shards_h = tt::div_up(rows, shape[0]);
-            const uint32_t n_shards_w = tt::div_up(cols, shape[1]);
-            const uint32_t grid_x = col_major ? n_shards_h : n_shards_w;
-            const uint32_t grid_y = col_major ? n_shards_w : n_shards_h;
-            cores = CoreRangeSet(CoreRange({0, 0}, {grid_x - 1, grid_y - 1}));
-            break;
-        }
-    }
-    return tt::tt_metal::ShardSpec(cores, shape, orientation);
+    return common::synthesize_output_shard_spec(
+        device->compute_with_storage_grid_size(),
+        static_cast<uint64_t>(rows),
+        static_cast<uint64_t>(cols),
+        layout,
+        {.is_tile = false,
+         .input_orientation = input_tensor.shard_spec().has_value()
+                                  ? std::optional{input_tensor.shard_spec()->orientation}
+                                  : std::nullopt,
+         .caller_tag = "Fold"});
 }
 
 Fold::program_factory_t Fold::select_program_factory(

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>
 
+#include "ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 namespace ttnn::operations::data_movement::indexed_fill {
@@ -241,47 +242,19 @@ tt::tt_metal::ShardSpec adjust_to_shape(
     return ret;
 }
 
-tt::tt_metal::ShardSpec generate_shard_spec_all_cores(
+tt::tt_metal::ShardSpec generate_output_shard_spec(
     const Tensor& input_tensor,
     const ttnn::Shape& padded_out_shape,
     tt::tt_metal::TensorMemoryLayout memory_layout,
     bool is_tile) {
-    using namespace tt::tt_metal;
-    auto* device = input_tensor.device();
-    auto compute_grid_size = device->compute_with_storage_grid_size();
-    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
-    uint32_t num_cores = all_cores.num_cores();
-
-    uint32_t tensor_height = 1;
-    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
-        tensor_height *= padded_out_shape[i];
-    }
-    uint32_t tensor_width = padded_out_shape[-1];
-
-    const uint32_t height_align = is_tile ? tt::constants::TILE_HEIGHT : 1u;
-    const uint32_t width_align = is_tile ? tt::constants::TILE_WIDTH : 1u;
-
-    // The div_up + round_up approach distributes pages as uniformly as possible.
-    // When tensor_height (or tensor_width for WIDTH_SHARDED) is less than num_cores,
-    // some cores receive shards that map entirely to padding and are handled by
-    // early-return guards in the reader/writer kernels.  Effective parallelism is
-    // therefore min(total_pages, num_cores), not num_cores.
-    std::array<uint32_t, 2> shard_shape = {0, 0};
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto height_padded = tt::round_up(tensor_height, num_cores * height_align);
-        auto shard_height = tt::round_up(tt::div_up(height_padded, num_cores), height_align);
-        shard_shape = {shard_height, tensor_width};
-    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        auto shard_width = tt::round_up(tt::div_up(tensor_width, num_cores), width_align);
-        shard_shape = {tensor_height, shard_width};
-    } else {
-        CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        auto height_padded = tt::round_up(tensor_height, grid_size.y * height_align);
-        auto shard_height = tt::round_up(tt::div_up(height_padded, grid_size.y), height_align);
-        auto shard_width = tt::round_up(tt::div_up(tensor_width, grid_size.x), width_align);
-        shard_shape = {shard_height, shard_width};
-    }
-    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+    // Force ROW_MAJOR to preserve pre-consolidation behaviour (input inheritance is out of scope here).
+    return common::synthesize_output_shard_spec(
+        input_tensor.device()->compute_with_storage_grid_size(),
+        padded_out_shape,
+        memory_layout,
+        {.is_tile = is_tile,
+         .orientation_hint = tt::tt_metal::ShardOrientation::ROW_MAJOR,
+         .caller_tag = "IndexedFill"});
 }
 
 tt::tt_metal::MemoryConfig resolve_output_memory_config(
@@ -299,7 +272,7 @@ tt::tt_metal::MemoryConfig resolve_output_memory_config(
                   input_tensor_a.padded_shape(),
                   padded_out_shape,
                   input_tensor_a.layout() == tt::tt_metal::Layout::TILE)
-            : generate_shard_spec_all_cores(
+            : generate_output_shard_spec(
                   input_tensor_a,
                   padded_out_shape,
                   output_mem_config.memory_layout(),

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.hpp
@@ -58,18 +58,14 @@ tt::tt_metal::ShardSpec adjust_to_shape(
     const ttnn::Shape& to_shape,
     bool is_tile);
 
-// Build a default shard spec for `padded_out_shape` over the device's full compute grid.
-// `is_tile` controls whether shard heights/widths are rounded to tile boundaries.
-tt::tt_metal::ShardSpec generate_shard_spec_all_cores(
+// Synthesize a populated-shard output ShardSpec for specless sharded indexed_fill outputs.
+tt::tt_metal::ShardSpec generate_output_shard_spec(
     const Tensor& input_tensor,
     const ttnn::Shape& padded_out_shape,
     tt::tt_metal::TensorMemoryLayout memory_layout,
     bool is_tile = true);
 
-// Derive a shard_spec for a sharded output MemoryConfig that has none.
-// Uses adjust_to_shape() when input_tensor_a is sharded, otherwise generate_shard_spec_all_cores().
-// Returns the filled-in MemoryConfig (or the original unchanged if it is not sharded / already
-// has a shard_spec).
+// Fills a specless sharded output MemoryConfig via adjust_to_shape (sharded input) or generate_output_shard_spec.
 tt::tt_metal::MemoryConfig resolve_output_memory_config(
     const Tensor& input_tensor_a,
     const ttnn::Shape& padded_out_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
@@ -3,9 +3,10 @@
 
 #include "ttnn/operations/data_movement/repeat/device/repeat_utils.hpp"
 
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+
+#include "ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp"
 
 namespace ttnn::operations::data_movement::repeat {
 
@@ -183,11 +184,13 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
     const ttnn::Shape& padded_out_shape,
     TensorMemoryLayout memory_layout,
     std::optional<ShardOrientation> orientation_hint) {
+    if (memory_layout != TensorMemoryLayout::HEIGHT_SHARDED && memory_layout != TensorMemoryLayout::WIDTH_SHARDED &&
+        memory_layout != TensorMemoryLayout::BLOCK_SHARDED) {
+        return std::nullopt;
+    }
     auto* device = input_tensor.device();
     auto compute_grid_size = device->compute_with_storage_grid_size();
-    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
-    uint32_t num_cores = all_cores.num_cores();
-    if (num_cores == 0) {
+    if (compute_grid_size.x == 0 || compute_grid_size.y == 0) {
         return std::nullopt;
     }
 
@@ -195,60 +198,37 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
     for (int32_t i = 0; i < static_cast<int32_t>(padded_out_shape.rank()) - 1; ++i) {
         tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
     }
-    uint64_t tensor_width = padded_out_shape[-1];
+    const uint64_t tensor_width = padded_out_shape[-1];
     if (tensor_height == 0 || tensor_width == 0) {
         return std::nullopt;
     }
 
-    std::array<uint32_t, 2> shard_shape = {0, 0};
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
-        auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(num_cores)), tt::constants::TILE_HEIGHT);
-        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(tensor_width)};
-    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
-        shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
-    } else if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        if (grid_size.x == 0 || grid_size.y == 0) {
-            return std::nullopt;
-        }
-        auto height_padded =
-            tt::round_up(tensor_height, static_cast<uint64_t>(grid_size.y) * tt::constants::TILE_HEIGHT);
-        auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(grid_size.y)), tt::constants::TILE_HEIGHT);
-        auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
-        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
-    } else {
-        return std::nullopt;  // INTERLEAVED / unsupported — caller handles.
-    }
+    auto spec = common::synthesize_output_shard_spec(
+        compute_grid_size,
+        tensor_height,
+        tensor_width,
+        memory_layout,
+        {.is_tile = true,
+         .orientation_hint = orientation_hint,
+         .input_orientation = input_tensor.shard_spec().has_value()
+                                  ? std::optional{input_tensor.shard_spec()->orientation}
+                                  : std::nullopt,
+         .caller_tag = "Repeat"});
 
-    // RM: reject if page_size not L1-aligned (16 bytes).
+    // RM-only dispatch guards (page-size L1 alignment + exact width divisibility); not shard-shape math.
     if (input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR) {
         const uint64_t page_size_bytes =
-            static_cast<uint64_t>(shard_shape[1]) * static_cast<uint64_t>(input_tensor.element_size());
+            static_cast<uint64_t>(spec.shape[1]) * static_cast<uint64_t>(input_tensor.element_size());
         constexpr uint64_t kL1Alignment = 16;
         if (page_size_bytes == 0 || (page_size_bytes % kL1Alignment) != 0) {
             return std::nullopt;
         }
-        if (tensor_width % shard_shape[1] != 0) {
+        if (tensor_width % spec.shape[1] != 0) {
             return std::nullopt;
         }
     }
 
-    log_debug(
-        tt::LogOp, "Repeat: synthesised shard spec ({}, {}) over {} cores", shard_shape[0], shard_shape[1], num_cores);
-    // Prefer explicit hint, then input's orientation, else ROW_MAJOR.
-    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
-    if (orientation_hint.has_value()) {
-        orientation = *orientation_hint;
-    } else if (input_tensor.shard_spec().has_value()) {
-        orientation = input_tensor.shard_spec()->orientation;
-    }
-    return ShardSpec(all_cores, shard_shape, orientation);
+    return spec;
 }
 
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -189,6 +189,7 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     gather/device/gather_program_factory.cpp
     gather/tosa/gather_tosa.cpp
     concat/device/concat_tiled_unaligned_program_factory.cpp
+    common/synthesize_output_shard_spec.cpp
 )
 
 set(TTNN_OP_DATA_MOVEMENT_API_HEADERS

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -10,6 +10,8 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 
+#include "ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp"
+
 namespace ttnn::operations::data_movement::transpose {
 
 using namespace tt::tt_metal;
@@ -139,95 +141,23 @@ ShardSpec generate_transpose_shard_spec(
     TensorMemoryLayout memory_layout,
     std::optional<ShardOrientation> orientation_hint) {
     auto* device = input_tensor.device();
-    auto compute_grid_size = device->compute_with_storage_grid_size();
-    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
-    uint32_t num_cores = all_cores.num_cores();
-
-    // uint64 intermediates avoid overflow when leading-dim product exceeds 2^32; final shard
-    // dims are still uint32 (the hardware representation).
-    uint64_t tensor_height = 1;
-    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
-        tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
-    }
-    uint64_t tensor_width = padded_out_shape[-1];
-
-    // Resolve orientation first so BLOCK shard_shape below can pick divisors per COL_MAJOR's axis swap.
-    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
-    if (orientation_hint.has_value()) {
-        orientation = *orientation_hint;
-    } else if (input_tensor.shard_spec().has_value()) {
-        orientation = input_tensor.shard_spec()->orientation;
-    }
-    const bool row_wise = (orientation == ShardOrientation::ROW_MAJOR);
-
-    std::array<uint32_t, 2> shard_shape = {0, 0};
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
-        auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(num_cores)), tt::constants::TILE_HEIGHT);
-        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(tensor_width)};
-    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
-        shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
-    } else {
-        // BLOCK: divisors track orientation (COL_MAJOR swaps h→grid.x, w→grid.y) so n_h/n_w fit physical axes.
-        CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        const uint32_t h_div = row_wise ? grid_size.y : grid_size.x;
-        const uint32_t w_div = row_wise ? grid_size.x : grid_size.y;
-        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(h_div) * tt::constants::TILE_HEIGHT);
-        auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(h_div)), tt::constants::TILE_HEIGHT);
-        auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(w_div)), tt::constants::TILE_WIDTH);
-        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
-    }
-
-    // Populated-shard count → CoreRangeSet; BLOCK stays rectangular for downstream BLOCK factories.
-    CoreRangeSet used_cores;
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
-        n_used = std::min(std::max(n_used, 1u), num_cores);
-        used_cores = (n_used == num_cores)
-                         ? all_cores
-                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
-    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
-        n_used = std::min(std::max(n_used, 1u), num_cores);
-        used_cores = (n_used == num_cores)
-                         ? all_cores
-                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
-    } else {
-        uint32_t n_h = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
-        uint32_t n_w = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
-        const uint32_t n_along_x = row_wise ? n_w : n_h;
-        const uint32_t n_along_y = row_wise ? n_h : n_w;
-        // Guards any regression of the orientation-aware BLOCK divisors.
-        TT_FATAL(
-            n_along_x <= static_cast<uint32_t>(compute_grid_size.x) &&
-                n_along_y <= static_cast<uint32_t>(compute_grid_size.y),
-            "Transpose: BLOCK shard-grid ({}x{} along x/y) exceeds compute grid ({}x{}); shard=({},{}) orientation={}",
-            n_along_x,
-            n_along_y,
-            compute_grid_size.x,
-            compute_grid_size.y,
-            shard_shape[0],
-            shard_shape[1],
-            row_wise ? "ROW_MAJOR" : "COL_MAJOR");
-        const uint32_t phys_x_extent = std::max(n_along_x, 1u);
-        const uint32_t phys_y_extent = std::max(n_along_y, 1u);
-        used_cores = (phys_x_extent == static_cast<uint32_t>(compute_grid_size.x) &&
-                      phys_y_extent == static_cast<uint32_t>(compute_grid_size.y))
-                         ? all_cores
-                         : CoreRangeSet(CoreRange({0, 0}, {phys_x_extent - 1, phys_y_extent - 1}));
-    }
+    auto spec = common::synthesize_output_shard_spec(
+        device->compute_with_storage_grid_size(),
+        padded_out_shape,
+        memory_layout,
+        {.is_tile = true,
+         .orientation_hint = orientation_hint,
+         .input_orientation = input_tensor.shard_spec().has_value()
+                                  ? std::optional{input_tensor.shard_spec()->orientation}
+                                  : std::nullopt,
+         .caller_tag = "Transpose"});
     log_debug(
         tt::LogOp,
         "Transpose: generated shard spec ({}, {}) over {} populated cores",
-        shard_shape[0],
-        shard_shape[1],
-        used_cores.num_cores());
-    return ShardSpec(used_cores, shard_shape, orientation);
+        spec.shape[0],
+        spec.shape[1],
+        spec.grid.num_cores());
+    return spec;
 }
 
 }  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/operations/eltwise/unary/common/unary_utils.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp"
 
 #include <mutex>
 
@@ -189,37 +190,17 @@ CoreRangeSet get_worker_grid(
     return device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
 }
 
-tt::tt_metal::ShardSpec generate_shard_spec_all_cores(
+tt::tt_metal::ShardSpec generate_output_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout) {
-    using namespace tt::tt_metal;
+    // Force ROW_MAJOR to preserve pre-consolidation behaviour (input inheritance is out of scope here).
     auto* device = input_tensor.device();
-    auto compute_grid_size = device->compute_with_storage_grid_size();
-    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
-    uint32_t num_cores = all_cores.num_cores();
-
-    uint32_t tensor_height = 1;
-    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
-        tensor_height *= padded_out_shape[i];
-    }
-    uint32_t tensor_width = padded_out_shape[-1];
-
-    std::array<uint32_t, 2> shard_shape = {0, 0};
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto height_padded = tt::round_up(tensor_height, num_cores * tt::constants::TILE_HEIGHT);
-        auto shard_height = tt::round_up(tt::div_up(height_padded, num_cores), tt::constants::TILE_HEIGHT);
-        shard_shape = {shard_height, tensor_width};
-    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        auto shard_width = tt::round_up(tt::div_up(tensor_width, num_cores), tt::constants::TILE_WIDTH);
-        shard_shape = {tensor_height, shard_width};
-    } else {
-        CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        auto height_padded = tt::round_up(tensor_height, grid_size.y * tt::constants::TILE_HEIGHT);
-        auto shard_height = tt::round_up(tt::div_up(height_padded, grid_size.y), tt::constants::TILE_HEIGHT);
-        auto shard_width = tt::round_up(tt::div_up(tensor_width, grid_size.x), tt::constants::TILE_WIDTH);
-        shard_shape = {shard_height, shard_width};
-    }
-    log_debug(tt::LogOp, "Unary: Generated shard spec using all {} worker cores", num_cores);
-    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+    auto spec = ttnn::operations::data_movement::common::synthesize_output_shard_spec(
+        device->compute_with_storage_grid_size(),
+        padded_out_shape,
+        memory_layout,
+        {.is_tile = true, .orientation_hint = tt::tt_metal::ShardOrientation::ROW_MAJOR, .caller_tag = "Unary"});
+    log_debug(tt::LogOp, "Unary: Generated shard spec over {} populated cores", spec.grid.num_cores());
+    return spec;
 }
 
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_utils.hpp
@@ -37,8 +37,8 @@ CoreRangeSet get_worker_grid(
 tt::tt_metal::ShardSpec adjust_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
 
-/** Generate shard spec over all worker cores for a given output shape and memory layout. */
-tt::tt_metal::ShardSpec generate_shard_spec_all_cores(
+// Synthesize a populated-shard output ShardSpec for specless sharded eltwise-unary outputs.
+tt::tt_metal::ShardSpec generate_output_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
 
 }  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -137,7 +137,7 @@ tt::tt_metal::TensorSpec UnaryDeviceOperation::compute_output_specs(
                     tensor_args.input.padded_shape(),
                     padded_out_shape);
             } else {
-                shard_spec_opt = generate_shard_spec_all_cores(tensor_args.input, padded_out_shape, memory_layout);
+                shard_spec_opt = generate_output_shard_spec(tensor_args.input, padded_out_shape, memory_layout);
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.cpp
@@ -10,6 +10,8 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 
+#include "ttnn/operations/data_movement/common/synthesize_output_shard_spec.hpp"
+
 namespace ttnn::operations::experimental::quasar::transpose_op {
 
 using namespace tt::tt_metal;
@@ -139,95 +141,23 @@ ShardSpec generate_transpose_shard_spec(
     TensorMemoryLayout memory_layout,
     std::optional<ShardOrientation> orientation_hint) {
     auto* device = input_tensor.device();
-    auto compute_grid_size = device->compute_with_storage_grid_size();
-    CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
-    uint32_t num_cores = all_cores.num_cores();
-
-    // uint64 intermediates avoid overflow when leading-dim product exceeds 2^32; final shard
-    // dims are still uint32 (the hardware representation).
-    uint64_t tensor_height = 1;
-    for (int i = 0; i < static_cast<int>(padded_out_shape.rank()) - 1; ++i) {
-        tensor_height *= static_cast<uint64_t>(padded_out_shape[i]);
-    }
-    uint64_t tensor_width = padded_out_shape[-1];
-
-    // Resolve orientation first so BLOCK shard_shape below can pick divisors per COL_MAJOR's axis swap.
-    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
-    if (orientation_hint.has_value()) {
-        orientation = *orientation_hint;
-    } else if (input_tensor.shard_spec().has_value()) {
-        orientation = input_tensor.shard_spec()->orientation;
-    }
-    const bool row_wise = (orientation == ShardOrientation::ROW_MAJOR);
-
-    std::array<uint32_t, 2> shard_shape = {0, 0};
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
-        auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(num_cores)), tt::constants::TILE_HEIGHT);
-        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(tensor_width)};
-    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
-        shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
-    } else {
-        // BLOCK: divisors track orientation (COL_MAJOR swaps h→grid.x, w→grid.y) so n_h/n_w fit physical axes.
-        CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        const uint32_t h_div = row_wise ? grid_size.y : grid_size.x;
-        const uint32_t w_div = row_wise ? grid_size.x : grid_size.y;
-        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(h_div) * tt::constants::TILE_HEIGHT);
-        auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(h_div)), tt::constants::TILE_HEIGHT);
-        auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(w_div)), tt::constants::TILE_WIDTH);
-        shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
-    }
-
-    // Populated-shard count → CoreRangeSet; BLOCK stays rectangular for downstream BLOCK factories.
-    CoreRangeSet used_cores;
-    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
-        n_used = std::min(std::max(n_used, 1u), num_cores);
-        used_cores = (n_used == num_cores)
-                         ? all_cores
-                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
-    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
-        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
-        n_used = std::min(std::max(n_used, 1u), num_cores);
-        used_cores = (n_used == num_cores)
-                         ? all_cores
-                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
-    } else {
-        uint32_t n_h = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
-        uint32_t n_w = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
-        const uint32_t n_along_x = row_wise ? n_w : n_h;
-        const uint32_t n_along_y = row_wise ? n_h : n_w;
-        // Guards any regression of the orientation-aware BLOCK divisors.
-        TT_FATAL(
-            n_along_x <= static_cast<uint32_t>(compute_grid_size.x) &&
-                n_along_y <= static_cast<uint32_t>(compute_grid_size.y),
-            "Transpose: BLOCK shard-grid ({}x{} along x/y) exceeds compute grid ({}x{}); shard=({},{}) orientation={}",
-            n_along_x,
-            n_along_y,
-            compute_grid_size.x,
-            compute_grid_size.y,
-            shard_shape[0],
-            shard_shape[1],
-            row_wise ? "ROW_MAJOR" : "COL_MAJOR");
-        const uint32_t phys_x_extent = std::max(n_along_x, 1u);
-        const uint32_t phys_y_extent = std::max(n_along_y, 1u);
-        used_cores = (phys_x_extent == static_cast<uint32_t>(compute_grid_size.x) &&
-                      phys_y_extent == static_cast<uint32_t>(compute_grid_size.y))
-                         ? all_cores
-                         : CoreRangeSet(CoreRange({0, 0}, {phys_x_extent - 1, phys_y_extent - 1}));
-    }
+    auto spec = ttnn::operations::data_movement::common::synthesize_output_shard_spec(
+        device->compute_with_storage_grid_size(),
+        padded_out_shape,
+        memory_layout,
+        {.is_tile = true,
+         .orientation_hint = orientation_hint,
+         .input_orientation = input_tensor.shard_spec().has_value()
+                                  ? std::optional{input_tensor.shard_spec()->orientation}
+                                  : std::nullopt,
+         .caller_tag = "Transpose (Quasar)"});
     log_debug(
         tt::LogOp,
         "Transpose: generated shard spec ({}, {}) over {} populated cores",
-        shard_shape[0],
-        shard_shape[1],
-        used_cores.num_cores());
-    return ShardSpec(used_cores, shard_shape, orientation);
+        spec.shape[0],
+        spec.shape[1],
+        spec.grid.num_cores());
+    return spec;
 }
 
 }  // namespace ttnn::operations::experimental::quasar::transpose_op


### PR DESCRIPTION
### Ticket
Link to Github Issue #51433

### Problem
Five near-duplicate `generate_*_shard_spec` helpers (`transpose`, `fold`, `repeat`, `indexed_fill`, `unary`) synthesize specless sharded outputs; only transpose shrinks the grid — the other four declare `CoreRangeSet` = full compute grid, wasting L1 and misreporting `.grid.num_cores()`.

### Fix
Extract the transpose logic into `common::synthesize_output_shard_spec` — populated-shard `num_cores_to_corerangeset` for H/W, orientation-aware `(h_div, w_div)` for BLOCK — and route `repeat/fold/indexed_fill/unary` and `experimental/quasar/transpose` through it. Downstream audit (issue step 4): all five kernels drive per-core work from `shard_spec.grid`/`worker_grid` and early-return on zero-work — unary `noop=true` (`unary_program_factory.cpp:291`), indexed_fill `return` on `shard_ppb==0` (`indexed_fill_reader.cpp:83`), repeat `nop=1` (`repeat_higher_dim_rm_sharded.cpp:31`); fold covered by H/W/B shrink test; transpose is the pre-existing reference impl.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/synthesize_output_shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/synthesize_output_shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/synthesize_output_shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/synthesize_output_shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/synthesize_output_shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/synthesize_output_shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/synthesize_output_shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/synthesize_output_shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/synthesize_output_shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/synthesize_output_shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/synthesize_output_shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/synthesize_output_shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/synthesize_output_shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/synthesize_output_shard_spec)
