### PR TITLE
[skip ci] test: deselect two multi-minute core ttnn tests on ttsim

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -10,6 +10,11 @@ wormhole_b0:
   - tests/ttnn/unit_tests/base_functionality/test_copy.py::test_copy_rm_interleaved_to_legacy_2D_sharded_large_row
   - tests/ttnn/unit_tests/base_functionality/test_copy.py::test_copy_rm_nd_sharded_to_interleaved_large_row
   - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::test_resnet50_e2e_graph_capture
+  # #53228: these two are ~72 of the core ttnn group's ~109 worker-minutes on their own --
+  # test_to_layout_low_perf is 8 params at ~9 min each, and the single reshape param below took
+  # 754s while its siblings take ~1s, so only that id is deselected.
+  - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_rm_nonclean_large_odd_dest_page_l1_cb[dest_page_200002B_issue_width]
+  - tests/ttnn/unit_tests/base_functionality/test_to_layout.py::test_to_layout_low_perf
   - tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py::test_to_memory_config_rm_interleaved_to_nd_sharded_large_row
   - tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py::test_to_memory_config_rm_interleaved_to_legacy_2D_sharded_large_row
   - tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py::test_to_memory_config_rm_nd_sharded_to_interleaved_large_row
@@ -32,6 +37,11 @@ wormhole_b0:
 
 blackhole:
   # Job-level timeouts
+  # #53228: these two are ~72 of the core ttnn group's ~109 worker-minutes on their own --
+  # test_to_layout_low_perf is 8 params at ~9 min each, and the single reshape param below took
+  # 754s while its siblings take ~1s, so only that id is deselected.
+  - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_rm_nonclean_large_odd_dest_page_l1_cb[dest_page_200002B_issue_width]
+  - tests/ttnn/unit_tests/base_functionality/test_to_layout.py::test_to_layout_low_perf
   - tests/ttnn/unit_tests/operations/conv/test_conv2d.py
   - tests/ttnn/unit_tests/operations/conv/test_conv3d.py
   - tests/ttnn/unit_tests/operations/conv/test_conv_transpose2d.py


### PR DESCRIPTION
### Ticket

Closes #53228

### Problem description

`core ttnn unit test group [sim_wh_n150]` and `[sim_bh_p150]` have never passed. The suite
needs ~109 worker-minutes across 4 xdist workers and the step budget is 40 minutes, so the job
is killed mid-run and reports failure with zero actual test failures.

Two tests account for ~72 of those 109 worker-minutes:

| test | cost under ttsim |
|---|---|
| `test_to_layout.py::test_to_layout_low_perf` | ~60 worker-min (8 params at ~9 min) |
| `test_reshape.py::test_reshape_rm_nonclean_large_odd_dest_page_l1_cb[dest_page_200002B_issue_width]` | 754.6 s (sibling param: 1.2 s) |

### What's changed

Added both to the `# Job-level timeouts` section of `ttsim-skip-list.yaml` (both arches), which
the sanity workflow turns into `--deselect=` args for every `sim_*` sku. No
`TT_METAL_SIMULATOR` checks in the tests — #49633 removed those repo-wide and moved timeout
cases here.

Both paths are arch independent and still run on silicon, so no coverage is lost. Leaves
~73 worker-minutes ≈ 18 wall-minutes, inside the budget.

### CI

[Run 32462374313](https://github.com/tenstorrent/tt-metal/actions/runs/32462374313) with these
two removed: `[sim_wh_n150]` **success, 24.2 min** and `[sim_bh_p150]` **success, 31.4 min**,
against failure on every main nightly. Re-run on this revision:
[32470849641](https://github.com/tenstorrent/tt-metal/actions/runs/32470849641).
