### PR TITLE
Add do_extra_scale to the generic_moe_gate LLK family

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_generic_moe_gate_topk_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_generic_moe_gate_topk_api.h
@@ -22,8 +22,9 @@ template <
     int num_total_experts,
     bool zero_tail = false,
     bool full_sort = false,
-    bool generate_indices = true>
-inline void llk_math_sfpu_generic_moe_gate_topk(uint32_t eps, uint32_t scale) {
+    bool generate_indices = true,
+    bool do_extra_scale = false>
+inline void llk_math_sfpu_generic_moe_gate_topk(uint32_t eps, uint32_t scale, uint32_t extra_scale = 0) {
     _llk_math_eltwise_unary_sfpu_params_(
         _generic_moe_gate_topk_<
             normalize,
@@ -31,11 +32,13 @@ inline void llk_math_sfpu_generic_moe_gate_topk(uint32_t eps, uint32_t scale) {
             num_total_experts,
             zero_tail,
             full_sort,
-            generate_indices>,
+            generate_indices,
+            do_extra_scale>,
         0,
         VectorMode::RC_custom,
         eps,
-        scale);
+        scale,
+        extra_scale);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/inc/api/compute/experimental/generic_moe_gate.h
+++ b/tt_metal/hw/inc/api/compute/experimental/generic_moe_gate.h
@@ -38,8 +38,9 @@ template <
     int num_total_experts = 256,
     bool zero_tail = false,
     bool full_sort = false,
-    bool generate_indices = true>
-ALWI void generic_moe_gate(uint32_t icb0, uint32_t icb1, uint32_t eps, uint32_t scale) {
+    bool generate_indices = true,
+    bool do_extra_scale = false>
+ALWI void generic_moe_gate(uint32_t icb0, uint32_t icb1, uint32_t eps, uint32_t scale, uint32_t extra_scale = 0) {
     static_assert(num_selected_experts >= 1 && num_selected_experts <= 16);
 
     // Copy add (FPU)
@@ -54,7 +55,8 @@ ALWI void generic_moe_gate(uint32_t icb0, uint32_t icb1, uint32_t eps, uint32_t 
           num_total_experts,
           zero_tail,
           full_sort,
-          generate_indices>(eps, scale)));
+          generate_indices,
+          do_extra_scale>(eps, scale, extra_scale)));
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -888,11 +888,13 @@ class MOE_GATE_NORMALIZE_PARAMS(TemplateParameter):
 
     eps_bits: int = 0x00000000  # 0.0f
     scale_bits: int = 0x3F800000  # 1.0f
+    extra_scale_bits: int = 0x3F800000  # 1.0f, identity for the do_extra_scale path
 
     def convert_to_cpp(self) -> str:
         lines = [
             f"constexpr std::uint32_t MOE_GATE_EPS_BITS = {self.eps_bits}u;",
             f"constexpr std::uint32_t MOE_GATE_SCALE_BITS = {self.scale_bits}u;",
+            f"constexpr std::uint32_t MOE_GATE_EXTRA_SCALE_BITS = {self.extra_scale_bits}u;",
         ]
         return "\n".join(lines)
 

--- a/tt_metal/tt-llk/tests/sources/sfpu_generic_moe_gate_topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_generic_moe_gate_topk_test.cpp
@@ -134,7 +134,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         MOE_GATE_SCORES_DST_TILE,
         VectorMode::RC_custom,
         MOE_GATE_EPS_BITS,
-        MOE_GATE_SCALE_BITS);
+        MOE_GATE_SCALE_BITS,
+        MOE_GATE_EXTRA_SCALE_BITS);
 
     _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk.h
@@ -180,8 +180,8 @@ inline void _generic_moe_gate_bitonic8_steps_3_to_1_()
     TTI_SFPTRANSP(0, 0, 0, 0);
 }
 
-template <int num_rows, int scores_offset>
-inline void _generic_moe_gate_normalize_(std::uint32_t eps, std::uint32_t scale)
+template <int num_rows, int scores_offset, bool do_extra_scale = false>
+inline void _generic_moe_gate_normalize_(std::uint32_t eps, std::uint32_t scale, std::uint32_t extra_scale = 0)
 {
     TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
     TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
@@ -204,11 +204,16 @@ inline void _generic_moe_gate_normalize_(std::uint32_t eps, std::uint32_t scale)
     TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
 
     TTI_SFPCONFIG(0, 0xF, 1);
-    sfpi::vFloat l0                 = sfpi::l_reg[sfpi::LRegs::LReg0];
-    sfpi::vFloat eps_value          = Converter::as_float(eps);
-    l0                              = l0 + eps_value;
-    l0                              = sfpu_reciprocal<false>(l0);
-    sfpi::vFloat scale_value        = Converter::as_float(scale);
+    sfpi::vFloat l0          = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vFloat eps_value   = Converter::as_float(eps);
+    l0                       = l0 + eps_value;
+    l0                       = sfpu_reciprocal<false>(l0);
+    sfpi::vFloat scale_value = Converter::as_float(scale);
+    if constexpr (do_extra_scale)
+    {
+        sfpi::vFloat es = Converter::as_float(extra_scale);
+        scale_value     = scale_value * es;
+    }
     l0                              = l0 * scale_value;
     sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
     TTI_SFPNOP;
@@ -280,8 +285,15 @@ inline void _init_generic_moe_gate_topk_()
 // caller has already loaded DST[1] with its own mapping (e.g. bit-15-flagged SRAM slots) via
 // copy_tile(input_indices, 0, 1): the sort's LREG4-7 LO16 load then reads those values verbatim and the
 // paired sort carries them through to out_indices.
-template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort, bool generate_indices = true>
-inline void _generic_moe_gate_topk_(std::uint32_t eps, std::uint32_t scale)
+template <
+    bool normalize,
+    int num_selected_experts,
+    int num_total_experts,
+    bool zero_tail,
+    bool full_sort,
+    bool generate_indices = true,
+    bool do_extra_scale   = false>
+inline void _generic_moe_gate_topk_(std::uint32_t eps, std::uint32_t scale, std::uint32_t extra_scale = 0)
 {
     if constexpr (generate_indices)
     {
@@ -291,11 +303,11 @@ inline void _generic_moe_gate_topk_(std::uint32_t eps, std::uint32_t scale)
 
     if constexpr (num_selected_experts > 8)
     {
-        _generic_moe_gate_top16_<normalize, num_selected_experts, num_total_experts, zero_tail, full_sort>(eps, scale);
+        _generic_moe_gate_top16_<normalize, num_selected_experts, num_total_experts, zero_tail, full_sort, do_extra_scale>(eps, scale, extra_scale);
     }
     else
     {
-        _generic_moe_gate_top8_<normalize, num_selected_experts, num_total_experts, zero_tail, full_sort>(eps, scale);
+        _generic_moe_gate_top8_<normalize, num_selected_experts, num_total_experts, zero_tail, full_sort, do_extra_scale>(eps, scale, extra_scale);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top16.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top16.h
@@ -259,8 +259,8 @@ inline void _generic_moe_gate_top16_merge_instances_()
     _generic_moe_gate_top16_store_outputs_();
 }
 
-template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort>
-inline void _generic_moe_gate_top16_(std::uint32_t eps, std::uint32_t scale)
+template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort, bool do_extra_scale = false>
+inline void _generic_moe_gate_top16_(std::uint32_t eps, std::uint32_t scale, std::uint32_t extra_scale = 0)
 {
     static_assert(num_selected_experts >= 9 && num_selected_experts <= 16);
 
@@ -280,7 +280,7 @@ inline void _generic_moe_gate_top16_(std::uint32_t eps, std::uint32_t scale)
 
     if constexpr (normalize)
     {
-        _generic_moe_gate_normalize_<16, generic_moe_gate_scores_tile>(eps, scale);
+        _generic_moe_gate_normalize_<16, generic_moe_gate_scores_tile, do_extra_scale>(eps, scale, extra_scale);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top8.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top8.h
@@ -196,8 +196,8 @@ inline void _generic_moe_gate_top8_sort_to_instance_()
     }
 }
 
-template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort>
-inline void _generic_moe_gate_top8_(std::uint32_t eps, std::uint32_t scale)
+template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort, bool do_extra_scale = false>
+inline void _generic_moe_gate_top8_(std::uint32_t eps, std::uint32_t scale, std::uint32_t extra_scale = 0)
 {
     _generic_moe_gate_top8_sort_to_instance_<num_total_experts>();
     _generic_moe_gate_top8_merge_instances_();
@@ -216,7 +216,7 @@ inline void _generic_moe_gate_top8_(std::uint32_t eps, std::uint32_t scale)
 
     if constexpr (normalize)
     {
-        _generic_moe_gate_normalize_<8, generic_moe_gate_scores_tile>(eps, scale);
+        _generic_moe_gate_normalize_<8, generic_moe_gate_scores_tile, do_extra_scale>(eps, scale, extra_scale);
     }
 
     if constexpr (zero_tail)


### PR DESCRIPTION
### PR Category

LLK reconciliation (additive)

### Summary

tt-blaze's copy of the generic_moe_gate family carries a `do_extra_scale` template parameter and a matching `extra_scale` argument that tt-metal's copy does not have. This ports it, so blaze can rewire onto the tt-metal headers without losing the behavior.

The parameter gates one multiply inside `_generic_moe_gate_normalize_`: when set, the normalization scale is multiplied by a second caller-supplied scalar before it is applied.

```cpp
if constexpr (do_extra_scale) {
    sfpi::vFloat es = Converter::as_float(extra_scale);
    scale_value     = scale_value * es;
}
```

Threaded through all four layers, defaulted off at every level:

- `ckernel_sfpu_generic_moe_gate_topk.h` — `_generic_moe_gate_normalize_` (the gated multiply) and the `_generic_moe_gate_topk_` dispatcher
- `ckernel_sfpu_generic_moe_gate_topk_top8.h` / `_top16.h` — forward it to `_generic_moe_gate_normalize_`
- `llk_math_generic_moe_gate_topk_api.h` — forwards it to `_generic_moe_gate_topk_`
- `generic_moe_gate.h` — the public compute API

### Impact on existing callers

None. `do_extra_scale` defaults to `false` and `extra_scale` defaults to `0`, so every existing call site binds exactly as before and the new branch is discarded at compile time. No existing signature changed.

### Provenance

Added to tt-blaze on 2026-08-12 in tt-blaze#3061, eight days after the family was promoted here in #51361, and used by `blaze/ops/kimi_moe_gate/kernels/op.hpp`. Verified against tt-blaze main and tt-metal main: `extra_scale` appears in zero files anywhere in tt-metal today.

Same tt-blaze PR also drifted `clamped_silu`, which was reconciled in #53753.

### Testing

No behavioral change on any existing path, so no new coverage is added here. LLK tests for the family exercise the default (`do_extra_scale = false`) path unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/generic-moe-gate-extra-scale)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/generic-moe-gate-extra-scale)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/generic-moe-gate-extra-scale)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/generic-moe-gate-extra-scale)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/generic-moe-gate-extra-scale)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/generic-moe-gate-extra-scale)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/generic-moe-gate-extra-scale)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/generic-moe-gate-extra-scale)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/generic-moe-gate-extra-scale)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/generic-moe-gate-extra-scale)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/generic-moe-gate-extra-scale)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/generic-moe-gate-extra-scale)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/generic-moe-gate-extra-scale)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/generic-moe-gate-extra-scale)