### PR TITLE
[Bug fix] ttnn.hypot returns inf or 0 where hypot is an ordinary finite number

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_hypot_extremes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hypot_extremes.py
@@ -2,101 +2,107 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression tests for ttnn.hypot at operand magnitudes where the naive sqrt(a^2 + b^2)
-composition overflows or underflows even though hypot itself is a finite normal value.
+"""ttnn.hypot at the magnitudes where a^2 leaves the format.
 
-The naive composite returns inf for |a| >= 2^64 and 0 for 0 < |a| < 2^-63 in bfloat16
-(same magnitude bounds apply to float32; only the representable set differs). torch.hypot
-returns a finite value across both bands (see issue #51861).
-
-Also exercises the ±inf edge cases that follow from the rescaled formulation: hypot(inf, inf)
-must be inf (the raw m * sqrt(1 + (n/m)²) yields NaN via inf/inf without the override).
+hypot(a, b) is a finite normal for every pair a plain sqrt(a^2 + b^2) cannot
+reach: the square overflows for |x| >= 2^64 and stops being normal for
+0 < |x| < 2^-63, while hypot itself is still representable. These tests pin the
+two bands, the special values, and an exhaustive bfloat16 sweep.
 """
 
 import math
 
 import pytest
 import torch
+
 import ttnn
 
+# Everything a bfloat16 can hold, as one 64-tile input.
+ALL_BF16 = torch.arange(0, 65536, dtype=torch.int64).to(torch.int32).to(torch.int16).view(torch.bfloat16)
 
-def _one_pair(a, b, device, dtype):
-    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
-    padded_a = torch.zeros((1, 1, 32, 32), dtype=torch_dtype)
-    padded_b = torch.zeros((1, 1, 32, 32), dtype=torch_dtype)
-    padded_a.view(-1)[0] = float(a)
-    padded_b.view(-1)[0] = float(b)
-    ta = ttnn.from_torch(padded_a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
-    tb = ttnn.from_torch(padded_b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
-    return ta, tb, padded_a, padded_b
+TORCH_DTYPE = {ttnn.bfloat16: torch.bfloat16, ttnn.float32: torch.float32}
 
 
-def _rel_ulp(got, ref, mantissa_bits):
-    """|got - ref| in units of 1 ULP of |ref| at the target precision."""
-    if not math.isfinite(ref) or ref == 0:
+def _hypot(device, a, b, dtype):
+    ta = ttnn.from_torch(a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    return ttnn.to_torch(ttnn.hypot(ta, tb))
+
+
+def _pair(a, b, dtype):
+    t = TORCH_DTYPE[dtype]
+    ta = torch.full((1, 1, 32, 32), float(a), dtype=t)
+    tb = torch.full((1, 1, 32, 32), float(b), dtype=t)
+    return ta, tb
+
+
+def _ulps(got, ref, mantissa_bits):
+    """|got - ref| in units of one ULP of ref."""
+    if not math.isfinite(ref) or ref == 0.0:
         return 0.0 if got == ref else float("inf")
-    ulp = 2.0 ** (math.floor(math.log2(abs(ref))) - mantissa_bits)
-    return abs(got - ref) / ulp
+    return abs(got - ref) / 2.0 ** (math.floor(math.log2(abs(ref))) - mantissa_bits)
 
 
+@pytest.mark.parametrize("other", [0.0, 1.0, 1e-30, 1e30, -3.0])
+@pytest.mark.parametrize("swap", [False, True])
+def test_hypot_bf16_exhaustive(device, other, swap):
+    """Every bfloat16 bit pattern against one fixed operand, both orders."""
+    swept = ALL_BF16.reshape(1, 1, 256, 256)
+    fixed = torch.full((1, 1, 256, 256), other, dtype=torch.bfloat16)
+    a, b = (fixed, swept) if swap else (swept, fixed)
+
+    got = _hypot(device, a, b, ttnn.bfloat16).flatten()
+    ref = torch.hypot(a.to(torch.float64), b.to(torch.float64)).to(torch.bfloat16).flatten()
+
+    # A bfloat16 DST cannot carry a NaN, and subnormal operands are flushed
+    # before the kernel sees them; both are true of the composite this replaces.
+    interesting = ~ALL_BF16.isnan() & ~((ALL_BF16 != 0) & (ALL_BF16.abs().to(torch.float32) < 2**-126))
+
+    # The square root is a polynomial, not a correctly rounded operation, so the
+    # last bit is allowed to move; nothing beyond it is.
+    g, r = got.to(torch.float64), ref.to(torch.float64)
+    within = (g == r) | ((r != 0) & torch.isfinite(r) & ((g - r).abs() <= r.abs() * 2**-7))
+    wrong = ~within & interesting
+    assert not wrong.any(), (
+        f"{int(wrong.sum())} of {int(interesting.sum())} patterns off by more than one ULP, "
+        f"first at 0x{int(ALL_BF16.view(torch.int16)[wrong.nonzero()[0, 0]].item()) & 0xffff:04x}: "
+        f"got {got[wrong][0].item()}, expected {ref[wrong][0].item()}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize(
     "a, b",
     [
+        # a^2 overflows, hypot does not
         (1e25, 0.0),
         (3e38, 0.0),
-        (1e-20, 0.0),
         (1e25, 1e25),
         (1e30, 1e30),
-        (1e20, 1e20),
-        (1e-20, 1e-20),
-        (3.0, 4.0),
-    ],
-)
-def test_hypot_extremes_bf16(device, a, b):
-    ta, tb, torch_a, torch_b = _one_pair(a, b, device, ttnn.bfloat16)
-    got = ttnn.to_torch(ttnn.hypot(ta, tb)).float().view(-1)[0].item()
-    ref = torch.hypot(torch_a.float(), torch_b.float()).view(-1)[0].item()
-    assert math.isfinite(got), f"hypot({a}, {b}) = {got}, expected finite {ref}"
-    if ref == 0.0:
-        assert got == 0.0
-    else:
-        u = _rel_ulp(got, ref, mantissa_bits=7)
-        assert u <= 4.0, f"hypot({a}, {b}) = {got}, ref {ref}, {u:.2f} bf16 ULP"
-
-
-@pytest.mark.parametrize(
-    "a, b",
-    [
-        # Overflow band, |x| > 2^64 ~= 1.84e19
-        (1e25, 0.0),
-        (3e38, 0.0),
-        (2e30, 0.0),
-        (1e25, 1e25),
-        (1e30, 1e30),
-        # Underflow band, |x| < 2^-63 ~= 1.08e-19
+        (1.9e19, 1.0),
+        # a^2 stops being normal, hypot does not
         (1e-20, 0.0),
         (1e-30, 0.0),
-        (1e-35, 0.0),
+        (1e-35, 1e-35),
         (1e-20, 1e-20),
-        (1e-30, 1e-30),
-        # Ordinary controls
+        (1.0e-19, 1.0e-19),
+        # in band
         (3.0, 4.0),
         (1.0, 0.0),
         (100.0, 100.0),
     ],
 )
-def test_hypot_extremes_fp32(device, a, b):
-    ta, tb, torch_a, torch_b = _one_pair(a, b, device, ttnn.float32)
-    got = ttnn.to_torch(ttnn.hypot(ta, tb)).view(-1)[0].item()
-    ref = torch.hypot(torch_a.double(), torch_b.double()).view(-1)[0].item()
-    # The rewrite adds no rounding beyond an fp32 sqrt/mul/div chain; ~4 fp32 ULP covers
-    # the natural error of the formulation.
-    assert math.isfinite(got), f"hypot({a}, {b}) = {got}, expected finite {ref}"
-    u = _rel_ulp(got, ref, mantissa_bits=23)
-    assert u <= 16.0, f"hypot({a}, {b}) = {got}, ref {ref}, {u:.2f} fp32 ULP"
+def test_hypot_bands(device, dtype, a, b):
+    ta, tb = _pair(a, b, dtype)
+    got = _hypot(device, ta, tb, dtype).float().view(-1)[0].item()
+    ref = torch.hypot(ta.double(), tb.double()).view(-1)[0].item()
+    bits = 7 if dtype == ttnn.bfloat16 else 23
+    ref = float(torch.tensor(ref, dtype=TORCH_DTYPE[dtype]))
+    assert math.isfinite(got), f"hypot({a}, {b}) = {got}, expected {ref}"
+    u = _ulps(got, ref, bits)
+    assert u <= 1.0, f"hypot({a}, {b}) = {got}, expected {ref}, off by {u:.2f} ULP"
 
 
-@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize(
     "a, b, expected",
     [
@@ -106,18 +112,18 @@ def test_hypot_extremes_fp32(device, a, b):
         (float("inf"), float("inf"), float("inf")),
         (float("-inf"), float("inf"), float("inf")),
         (float("-inf"), float("-inf"), float("inf")),
+        # IEEE 754: an inf operand wins over a NaN one.
+        (float("inf"), float("nan"), float("inf")),
+        (float("nan"), float("inf"), float("inf")),
+        (float("nan"), 1.0, float("nan")),
+        (float("nan"), float("nan"), float("nan")),
+        (0.0, 0.0, 0.0),
     ],
 )
-def test_hypot_inf(device, dtype, a, b, expected):
-    """torch.hypot with any ±inf operand returns +inf. The rescaled formula's inf/inf
-    resolves to NaN without the override; verify the override handles it."""
-    ta, tb, _, _ = _one_pair(a, b, device, dtype)
-    got = ttnn.to_torch(ttnn.hypot(ta, tb)).float().view(-1)[0].item()
-    assert math.isinf(got) and got > 0, f"hypot({a}, {b}, dtype={dtype}) = {got}, expected +inf"
-
-
-def test_hypot_zero_zero(device):
-    """hypot(0, 0) = 0; the rescaled form must handle max == 0 without NaN."""
-    ta, tb, _, _ = _one_pair(0.0, 0.0, device, ttnn.bfloat16)
-    got = ttnn.to_torch(ttnn.hypot(ta, tb)).float().view(-1)[0].item()
-    assert got == 0.0, f"hypot(0, 0) = {got}, expected 0.0"
+def test_hypot_specials_fp32(device, a, b, expected):
+    ta, tb = _pair(a, b, ttnn.float32)
+    got = _hypot(device, ta, tb, ttnn.float32).view(-1)[0].item()
+    if math.isnan(expected):
+        assert math.isnan(got), f"hypot({a}, {b}) = {got}, expected NaN"
+    else:
+        assert got == expected, f"hypot({a}, {b}) = {got}, expected {expected}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_hypot_extremes.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_hypot_extremes.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for ttnn.hypot at operand magnitudes where the naive sqrt(a^2 + b^2)
+composition overflows or underflows even though hypot itself is a finite normal value.
+
+The naive composite returns inf for |a| >= 2^64 and 0 for 0 < |a| < 2^-63 in bfloat16
+(same magnitude bounds apply to float32; only the representable set differs). torch.hypot
+returns a finite value across both bands (see issue #51861).
+
+Also exercises the ±inf edge cases that follow from the rescaled formulation: hypot(inf, inf)
+must be inf (the raw m * sqrt(1 + (n/m)²) yields NaN via inf/inf without the override).
+"""
+
+import math
+
+import pytest
+import torch
+import ttnn
+
+
+def _one_pair(a, b, device, dtype):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    padded_a = torch.zeros((1, 1, 32, 32), dtype=torch_dtype)
+    padded_b = torch.zeros((1, 1, 32, 32), dtype=torch_dtype)
+    padded_a.view(-1)[0] = float(a)
+    padded_b.view(-1)[0] = float(b)
+    ta = ttnn.from_torch(padded_a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(padded_b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    return ta, tb, padded_a, padded_b
+
+
+def _rel_ulp(got, ref, mantissa_bits):
+    """|got - ref| in units of 1 ULP of |ref| at the target precision."""
+    if not math.isfinite(ref) or ref == 0:
+        return 0.0 if got == ref else float("inf")
+    ulp = 2.0 ** (math.floor(math.log2(abs(ref))) - mantissa_bits)
+    return abs(got - ref) / ulp
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        (1e25, 0.0),
+        (3e38, 0.0),
+        (1e-20, 0.0),
+        (1e25, 1e25),
+        (1e30, 1e30),
+        (1e20, 1e20),
+        (1e-20, 1e-20),
+        (3.0, 4.0),
+    ],
+)
+def test_hypot_extremes_bf16(device, a, b):
+    ta, tb, torch_a, torch_b = _one_pair(a, b, device, ttnn.bfloat16)
+    got = ttnn.to_torch(ttnn.hypot(ta, tb)).float().view(-1)[0].item()
+    ref = torch.hypot(torch_a.float(), torch_b.float()).view(-1)[0].item()
+    assert math.isfinite(got), f"hypot({a}, {b}) = {got}, expected finite {ref}"
+    if ref == 0.0:
+        assert got == 0.0
+    else:
+        u = _rel_ulp(got, ref, mantissa_bits=7)
+        assert u <= 4.0, f"hypot({a}, {b}) = {got}, ref {ref}, {u:.2f} bf16 ULP"
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        # Overflow band, |x| > 2^64 ~= 1.84e19
+        (1e25, 0.0),
+        (3e38, 0.0),
+        (2e30, 0.0),
+        (1e25, 1e25),
+        (1e30, 1e30),
+        # Underflow band, |x| < 2^-63 ~= 1.08e-19
+        (1e-20, 0.0),
+        (1e-30, 0.0),
+        (1e-35, 0.0),
+        (1e-20, 1e-20),
+        (1e-30, 1e-30),
+        # Ordinary controls
+        (3.0, 4.0),
+        (1.0, 0.0),
+        (100.0, 100.0),
+    ],
+)
+def test_hypot_extremes_fp32(device, a, b):
+    ta, tb, torch_a, torch_b = _one_pair(a, b, device, ttnn.float32)
+    got = ttnn.to_torch(ttnn.hypot(ta, tb)).view(-1)[0].item()
+    ref = torch.hypot(torch_a.double(), torch_b.double()).view(-1)[0].item()
+    # The rewrite adds no rounding beyond an fp32 sqrt/mul/div chain; ~4 fp32 ULP covers
+    # the natural error of the formulation.
+    assert math.isfinite(got), f"hypot({a}, {b}) = {got}, expected finite {ref}"
+    u = _rel_ulp(got, ref, mantissa_bits=23)
+    assert u <= 16.0, f"hypot({a}, {b}) = {got}, ref {ref}, {u:.2f} fp32 ULP"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        (float("inf"), 0.0, float("inf")),
+        (float("inf"), 5.0, float("inf")),
+        (0.0, float("inf"), float("inf")),
+        (float("inf"), float("inf"), float("inf")),
+        (float("-inf"), float("inf"), float("inf")),
+        (float("-inf"), float("-inf"), float("inf")),
+    ],
+)
+def test_hypot_inf(device, dtype, a, b, expected):
+    """torch.hypot with any ±inf operand returns +inf. The rescaled formula's inf/inf
+    resolves to NaN without the override; verify the override handles it."""
+    ta, tb, _, _ = _one_pair(a, b, device, dtype)
+    got = ttnn.to_torch(ttnn.hypot(ta, tb)).float().view(-1)[0].item()
+    assert math.isinf(got) and got > 0, f"hypot({a}, {b}, dtype={dtype}) = {got}, expected +inf"
+
+
+def test_hypot_zero_zero(device):
+    """hypot(0, 0) = 0; the rescaled form must handle max == 0 without NaN."""
+    ta, tb, _, _ = _one_pair(0.0, 0.0, device, ttnn.bfloat16)
+    got = ttnn.to_torch(ttnn.hypot(ta, tb)).float().view(-1)[0].item()
+    assert got == 0.0, f"hypot(0, 0) = {got}, expected 0.0"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
@@ -12,36 +12,47 @@
 namespace ckernel {
 namespace sfpu {
 
+// hypot(a, b) = sqrt(a^2 + b^2), evaluated after scaling the pair by a power of
+// two so that neither square can leave the format. The scale is exact, so the
+// answer is the one the plain formula would give in a wider format.
+//
+// The plain formula needs |x| < 2^64 to keep x^2 finite and |x| > 2^-63 to keep
+// x^2 normal. Everything outside that band is brought into it by one multiply,
+// which keeps the single square root the plain formula already had.
+//
+// inf and NaN are settled before the arithmetic rather than repaired after it:
+// hypot(inf, NaN) is +inf, so the inf is promoted into the maximum and every
+// other special case then falls out of the square root itself. Nothing but the
+// undo scale stays live across the square root, which is what keeps the SFPU
+// from spilling.
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_hypot_(sfpi::vFloat a, sfpi::vFloat b) {
+    // setsgn preserves the NaN payload while zeroing the sign, so a NaN stays
+    // distinguishable from +inf by its bits below.
     auto [n, m] = sfpi::min_max(sfpi::setsgn(a, 0), sfpi::setsgn(b, 0));
 
-    sfpi::vFloat s;
-    {
-        sfpi::vFloat rsqrt_m = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/true, /*FAST_APPROX=*/true>(m);
-        sfpi::vFloat r = n * (rsqrt_m * rsqrt_m);
-        s = 1.0f + r * r;
-    }
-
-    sfpi::vFloat sqrt_s = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/false, /*FAST_APPROX=*/true>(s);
-
-    sfpi::vFloat result = m * sqrt_s;
-
-    v_if(m == 0.0f) { result = 0.0f; }
-    v_endif;
-
     sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
-    sfpi::vInt inf_bits = sfpi::as<sfpi::vInt>(infinity);
 
-    v_if(sfpi::as<sfpi::vInt>(m) > inf_bits) {
-        v_if(sfpi::as<sfpi::vInt>(n) == inf_bits) { result = infinity; }
-        v_else { result = std::numeric_limits<float>::quiet_NaN(); }
-        v_endif;
+    // IEEE 754 hypot(inf, NaN) = +inf. n == +inf can only happen when the other
+    // operand is +inf or NaN, so promoting m here settles both.
+    v_if(sfpi::as<sfpi::vInt>(n) == sfpi::as<sfpi::vInt>(infinity)) { m = infinity; }
+    v_endif;
+
+    sfpi::vFloat undo = 1.0f;
+    v_if(m > 0x1p63f) {
+        m = m * 0x1p-100f;
+        n = n * 0x1p-100f;
+        undo = 0x1p100f;
+    }
+    v_elseif(m < 0x1p-63f) {
+        m = m * 0x1p100f;
+        n = n * 0x1p100f;
+        undo = 0x1p-100f;
     }
     v_endif;
 
-    v_if(sfpi::as<sfpi::vInt>(m) == inf_bits) { result = infinity; }
-    v_endif;
+    sfpi::vFloat result =
+        _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/false, /*FAST_APPROX=*/true>(m * m + n * n) * undo;
 
     if constexpr (!is_fp32_dest_acc_en) {
         result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_sqrt.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_hypot_(sfpi::vFloat a, sfpi::vFloat b) {
+    auto [n, m] = sfpi::min_max(sfpi::setsgn(a, 0), sfpi::setsgn(b, 0));
+
+    sfpi::vFloat s;
+    {
+        sfpi::vFloat rsqrt_m = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/true, /*FAST_APPROX=*/true>(m);
+        sfpi::vFloat r = n * (rsqrt_m * rsqrt_m);
+        s = 1.0f + r * r;
+    }
+
+    sfpi::vFloat sqrt_s = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/false, /*FAST_APPROX=*/true>(s);
+
+    sfpi::vFloat result = m * sqrt_s;
+
+    v_if(m == 0.0f) { result = 0.0f; }
+    v_endif;
+
+    sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
+    sfpi::vInt inf_bits = sfpi::as<sfpi::vInt>(infinity);
+
+    v_if(sfpi::as<sfpi::vInt>(m) > inf_bits) {
+        v_if(sfpi::as<sfpi::vInt>(n) == inf_bits) { result = infinity; }
+        v_else { result = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+    }
+    v_endif;
+
+    v_if(sfpi::as<sfpi::vInt>(m) == inf_bits) { result = infinity; }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_hypot(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_hypot_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_hypot_init() {
+    sqrt_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
@@ -12,65 +12,47 @@
 namespace ckernel {
 namespace sfpu {
 
-// Numerically-stable hypot: m * sqrt(1 + (n/m)^2), m=max(|a|,|b|), n=min(|a|,|b|).
-// The naive sqrt(a^2 + b^2) form overflows for |x| > 2^64 and underflows for
-// 0 < |x| < 2^-63 even when hypot itself is finite normal. The rescale keeps the
-// intermediate `1 + (n/m)^2` in [1, 2] regardless of the magnitude of m.
+// hypot(a, b) = sqrt(a^2 + b^2), evaluated after scaling the pair by a power of
+// two so that neither square can leave the format. The scale is exact, so the
+// answer is the one the plain formula would give in a wider format.
 //
-// Both `1/m` and `sqrt(1 + r^2)` are computed via the shared rsqrt polynomial
-// (sqrt_init constants): `1/m = rsqrt(m)^2` avoids needing a separate reciprocal
-// init that would clobber the sqrt constants.
+// The plain formula needs |x| < 2^64 to keep x^2 finite and |x| > 2^-63 to keep
+// x^2 normal. Everything outside that band is brought into it by one multiply,
+// which keeps the single square root the plain formula already had.
 //
-// Register-pressure notes (SFPU has no spill slot — any spill is a fatal compile
-// error): raw_a and raw_b are consumed by min_max immediately, and the NaN/inf
-// guards later derive their information from m and n (not the raw inputs), so no
-// extra live values are carried across the two sqrt-body calls. Scoped blocks
-// tell the compiler when intermediates die.
+// inf and NaN are settled before the arithmetic rather than repaired after it:
+// hypot(inf, NaN) is +inf, so the inf is promoted into the maximum and every
+// other special case then falls out of the square root itself. Nothing but the
+// undo scale stays live across the square root, which is what keeps the SFPU
+// from spilling.
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_hypot_(sfpi::vFloat a, sfpi::vFloat b) {
-    // setsgn preserves NaN payload while zeroing the sign; guards below detect
-    // NaN via bits(m) > bits(+inf), which requires the setsgn form (abs alone
-    // does not preserve NaN).
+    // setsgn preserves the NaN payload while zeroing the sign, so a NaN stays
+    // distinguishable from +inf by its bits below.
     auto [n, m] = sfpi::min_max(sfpi::setsgn(a, 0), sfpi::setsgn(b, 0));
 
-    // Compute the rescaled ratio n/m, its square, and 1 + r^2 in a scoped block
-    // so rsqrt_m and r die before the second sqrt-body call. Both sqrt-body
-    // calls MUST use the same APPROXIMATION_MODE — the polynomial constants
-    // configured by sqrt_init are keyed on APPROXIMATION_MODE, so mixing modes
-    // silently uses the wrong constants and produces garbage.
-    sfpi::vFloat s;
-    {
-        sfpi::vFloat rsqrt_m = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/true, /*FAST_APPROX=*/true>(m);
-        // 1/m = rsqrt(m)^2 — this is why we can skip a separate reciprocal init.
-        sfpi::vFloat r = n * (rsqrt_m * rsqrt_m);
-        s = 1.0f + r * r;
-    }
-
-    sfpi::vFloat sqrt_s = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/false, /*FAST_APPROX=*/true>(s);
-
-    sfpi::vFloat result = m * sqrt_s;
-
-    // Special cases. Order: 0/0 → 0 first (baseline); then NaN; then inf (inf
-    // wins over NaN per IEEE 754 hypot).
-    v_if(m == 0.0f) { result = 0.0f; }
-    v_endif;
-
     sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
-    sfpi::vInt inf_bits = sfpi::as<sfpi::vInt>(infinity);
 
-    // NaN in max: any input was NaN.
-    v_if(sfpi::as<sfpi::vInt>(m) > inf_bits) {
-        // IEEE 754 hypot(inf, NaN) = +inf. min_max with (inf, NaN) yields
-        // (inf, NaN), so n == +inf signals the disambiguated inf case.
-        v_if(sfpi::as<sfpi::vInt>(n) == inf_bits) { result = infinity; }
-        v_else { result = std::numeric_limits<float>::quiet_NaN(); }
-        v_endif;
+    // IEEE 754 hypot(inf, NaN) = +inf. n == +inf can only happen when the other
+    // operand is +inf or NaN, so promoting m here settles both.
+    v_if(sfpi::as<sfpi::vInt>(n) == sfpi::as<sfpi::vInt>(infinity)) { m = infinity; }
+    v_endif;
+
+    sfpi::vFloat undo = 1.0f;
+    v_if(m > 0x1p63f) {
+        m = m * 0x1p-100f;
+        n = n * 0x1p-100f;
+        undo = 0x1p100f;
+    }
+    v_elseif(m < 0x1p-63f) {
+        m = m * 0x1p100f;
+        n = n * 0x1p100f;
+        undo = 0x1p-100f;
     }
     v_endif;
 
-    // m is exactly +inf: at least one input was ±inf, no NaN present.
-    v_if(sfpi::as<sfpi::vInt>(m) == inf_bits) { result = infinity; }
-    v_endif;
+    sfpi::vFloat result =
+        _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/false, /*FAST_APPROX=*/true>(m * m + n * n) * undo;
 
     if constexpr (!is_fp32_dest_acc_en) {
         result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
@@ -95,8 +77,6 @@ inline void calculate_sfpu_hypot(const uint dst_index_in0, const uint dst_index_
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void calculate_sfpu_hypot_init() {
-    // Reuses the sqrt polynomial constants (vConstIntPrgm0, vConstFloatPrgm1/2).
-    // Both `1/m` (via rsqrt^2) and `sqrt(1+r^2)` share this single init.
     sqrt_init<APPROXIMATION_MODE>();
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_hypot.h
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_sqrt.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// Numerically-stable hypot: m * sqrt(1 + (n/m)^2), m=max(|a|,|b|), n=min(|a|,|b|).
+// The naive sqrt(a^2 + b^2) form overflows for |x| > 2^64 and underflows for
+// 0 < |x| < 2^-63 even when hypot itself is finite normal. The rescale keeps the
+// intermediate `1 + (n/m)^2` in [1, 2] regardless of the magnitude of m.
+//
+// Both `1/m` and `sqrt(1 + r^2)` are computed via the shared rsqrt polynomial
+// (sqrt_init constants): `1/m = rsqrt(m)^2` avoids needing a separate reciprocal
+// init that would clobber the sqrt constants.
+//
+// Register-pressure notes (SFPU has no spill slot — any spill is a fatal compile
+// error): raw_a and raw_b are consumed by min_max immediately, and the NaN/inf
+// guards later derive their information from m and n (not the raw inputs), so no
+// extra live values are carried across the two sqrt-body calls. Scoped blocks
+// tell the compiler when intermediates die.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_hypot_(sfpi::vFloat a, sfpi::vFloat b) {
+    // setsgn preserves NaN payload while zeroing the sign; guards below detect
+    // NaN via bits(m) > bits(+inf), which requires the setsgn form (abs alone
+    // does not preserve NaN).
+    auto [n, m] = sfpi::min_max(sfpi::setsgn(a, 0), sfpi::setsgn(b, 0));
+
+    // Compute the rescaled ratio n/m, its square, and 1 + r^2 in a scoped block
+    // so rsqrt_m and r die before the second sqrt-body call. Both sqrt-body
+    // calls MUST use the same APPROXIMATION_MODE — the polynomial constants
+    // configured by sqrt_init are keyed on APPROXIMATION_MODE, so mixing modes
+    // silently uses the wrong constants and produces garbage.
+    sfpi::vFloat s;
+    {
+        sfpi::vFloat rsqrt_m = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/true, /*FAST_APPROX=*/true>(m);
+        // 1/m = rsqrt(m)^2 — this is why we can skip a separate reciprocal init.
+        sfpi::vFloat r = n * (rsqrt_m * rsqrt_m);
+        s = 1.0f + r * r;
+    }
+
+    sfpi::vFloat sqrt_s = _calculate_sqrt_body_<APPROXIMATION_MODE, /*RECIPROCAL=*/false, /*FAST_APPROX=*/true>(s);
+
+    sfpi::vFloat result = m * sqrt_s;
+
+    // Special cases. Order: 0/0 → 0 first (baseline); then NaN; then inf (inf
+    // wins over NaN per IEEE 754 hypot).
+    v_if(m == 0.0f) { result = 0.0f; }
+    v_endif;
+
+    sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
+    sfpi::vInt inf_bits = sfpi::as<sfpi::vInt>(infinity);
+
+    // NaN in max: any input was NaN.
+    v_if(sfpi::as<sfpi::vInt>(m) > inf_bits) {
+        // IEEE 754 hypot(inf, NaN) = +inf. min_max with (inf, NaN) yields
+        // (inf, NaN), so n == +inf signals the disambiguated inf case.
+        v_if(sfpi::as<sfpi::vInt>(n) == inf_bits) { result = infinity; }
+        v_else { result = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+    }
+    v_endif;
+
+    // m is exactly +inf: at least one input was ±inf, no NaN present.
+    v_if(sfpi::as<sfpi::vInt>(m) == inf_bits) { result = infinity; }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_hypot(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_hypot_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_hypot_init() {
+    // Reuses the sqrt polynomial constants (vConstIntPrgm0, vConstFloatPrgm1/2).
+    // Both `1/m` (via rsqrt^2) and `sqrt(1+r^2)` share this single init.
+    sqrt_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/hypot.h
+++ b/tt_metal/hw/inc/api/compute/hypot.h
@@ -16,8 +16,8 @@ namespace ckernel {
 /**
  * Performs an elementwise numerically-stable hypot on two inputs:
  *   y = hypot(x0, x1) = sqrt(x0^2 + x1^2),
- * evaluated via the rescaled form m * sqrt(1 + (n/m)^2) to avoid overflow
- * and underflow in the intermediate squares. Output overwrites odst in DST.
+ * evaluated after scaling the pair by a power of two so that neither square
+ * can overflow or leave the normal range. Output overwrites odst in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
  * on the compute engine.

--- a/tt_metal/hw/inc/api/compute/hypot.h
+++ b/tt_metal/hw/inc/api/compute/hypot.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_hypot.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise numerically-stable hypot on two inputs:
+ *   y = hypot(x0, x1) = sqrt(x0^2 + x1^2),
+ * evaluated via the rescaled form m * sqrt(1 + (n/m)^2) to avoid overflow
+ * and underflow in the intermediate squares. Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void hypot_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_sfpu_hypot,
+        (APPROX, 8 /* ITERATIONS */, DST_ACCUM_MODE),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void hypot_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(unused, sfpu::calculate_sfpu_hypot_init, (APPROX, DST_ACCUM_MODE))));
+}
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -33,8 +33,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
         case LOGADDEXP:
         case LOGADDEXP2:
         case LDEXP:
-        case BIAS_GELU:
-        case HYPOT: return (a == FLOAT32 && b == FLOAT32);
+        case BIAS_GELU: return (a == FLOAT32 && b == FLOAT32);
+        case HYPOT: return (a == b) && (a == FLOAT32 || a == BFLOAT16);
         case EQ:
         case NE:
         case GT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -387,12 +387,12 @@ OpConfig::OpConfig(
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
-        // sqrt(a^2 + b^2)
         case BinaryOpType::HYPOT:
-            process_lhs = unary::UnaryOpType::SQUARE;
-            process_rhs = unary::UnaryOpType::SQUARE;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::SQRT;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::HYPOT;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
             break;
         case BinaryOpType::ISCLOSE: binary_op = SfpuBinaryOp::ISCLOSE; break;
         default: TT_THROW("Unsupported binary op {}", binary_op_type);
@@ -501,6 +501,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             return {"dequant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "dequant_tile"};
         case XLOGY: return {"xlogy_binary_tile_init();", "xlogy_binary_tile"};
         case ATAN2: return {"atan2_binary_tile_init();", "atan2_binary_tile"};
+        case HYPOT: return {"hypot_binary_tile_init();", "hypot_binary_tile"};
         case LT:
             if (int_data_format) {
                 return {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/hypot.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/hypot.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -20,6 +20,7 @@
 #include "api/compute/quantization.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/hypot.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #51861.

`ttnn.hypot` decomposed into `SQUARE, ADD, SQUARE, SQRT`. The squares leave the format long before `hypot` does: `x²` is `inf` for `|x| >= 2^64` and stops being normal for `0 < |x| < 2^-63`, while `hypot(x, y)` at those magnitudes is an ordinary finite number. Both dtypes have an 8-bit exponent, so both are affected.

Scaling the pair by a power of two before squaring fixes it. The scale is exact, so the answer is the one the plain formula would give in a wider format, and the single square root the plain formula already had is the only one there is.

```
n, m = min_max(|a|, |b|)
if m > 2^63:   m, n, undo = m·2^-100, n·2^-100, 2^100
elif m < 2^-63: m, n, undo = m·2^100,  n·2^100,  2^-100
result = sqrt(m² + n²) · undo
```

`HYPOT` becomes a dedicated SFPU binary op for fp32 and bf16 pairs; the composite pattern in `binary_ng_utils.cpp` is deleted.

## Accuracy

**Every number below compares against `torch.hypot` evaluated in float64 and rounded to the output dtype.** `main` is this branch's base, `04cf22f7ee`; both builds ran on the same two machines.

**bfloat16, exhaustive.** All 65536 bit patterns in each operand position, against seven fixed second operands — 917504 pairs, identical results on P300 and N300:

| | exact | 1 ULP | > 1 ULP | `inf` for a finite answer | `0` for a nonzero answer |
|---|---|---|---|---|---|
| main | 505828 | 15420 | 0 | **327168** | **65532** |
| this branch | **913420** | 20 | 0 | **0** | 508 |

392700 of the 917504 pairs — 42.8% — come back from `main` as `inf` or `0` when the answer is neither. The 508 that still come back as `0` are the bfloat16 subnormal operands, which the SFPU flushes on the way in; `main` returns `0` for those too.

The 3556 patterns with a NaN operand are excluded: a bfloat16 DST cannot carry a NaN and returns `inf` instead, on this branch and on `main` alike.

**float32, exhaustive.** All 2^32 bit patterns of `x`, three fixed second operands, 4294967296 pairs each. Same counts on both machines:

| | | main | this branch |
|---|---|---|---|
| `hypot(x, 0)` | exact | 2121671154 | 4226565090 |
| | 1 ULP | 25812496 | 51624992 |
| | `inf` for a finite answer | **1073741824** | 0 |
| | `0` for a nonzero answer | **1073741822** | 16777214 |
| `hypot(x, 1)` | `inf` for a finite answer | **1073741824** | 0 |
| `hypot(x, 1e30)` | exact | 16777216 | 4166355260 |
| | `inf` for a finite answer | **4278190080** | 0 |

Half of every `hypot(x, 0)` input fails on `main`: a quarter overflow, a quarter underflow. With the second operand at `1e30` all but 16777216 of the 4.29 billion come back `inf`. Nothing on this branch exceeds 1 ULP, and the 16777214 that return `0` are the float32 subnormals, again matching `main`.

**Special values.** `hypot(±inf, anything)` is `+inf` and `hypot(NaN, finite)` is NaN on both. One case changes: IEEE 754 says an `inf` operand wins over a NaN one, and `main` returns NaN for `hypot(inf, NaN)` in float32. This branch returns `+inf`.

## Cost

One dispatch before and one after — a single `BinaryNgDeviceOperation` either way. Wall clock is 5 warm-up calls then 50 timed calls with one `synchronize_device` at the end, median of five such runs, profiler off.

**P300, µs per call:**

| tiles | dtype | main | this branch |
|---|---|---|---|
| 4096 | bfloat16 | 62.8 | **60.6** |
| 4096 | float32 | 122.0 | **121.1** |
| 16384 | bfloat16 | 238.5 | **227.8** |
| 16384 | float32 | 474.1 | **470.6** |

**N300, µs per call:**

| tiles | dtype | main | this branch |
|---|---|---|---|
| 4096 | bfloat16 | 137.3 | 155.8 |
| 4096 | float32 | 268.8 | **269.5** |
| 16384 | bfloat16 | 510.1 | 586.2 |
| 16384 | float32 | 985.0 | **979.0** |

float32 already ran in the SFPU, and there the fix is free on both machines. bfloat16 did not: `is_binary_sfpu_op` refused it, so it ran the composite on the FPU. Moving it to the SFPU is what makes the fix possible for bfloat16 at all, and it is 4% cheaper than the FPU composite on P300 and 15% dearer on N300.

At 64 tiles the call is host-bound on both machines — 25 µs on P300 and 50 µs on N300 for every build measured, with a spread wider than the difference.

### Against the first version of this branch

The first version evaluated `m · sqrt(1 + (n/m)²)` and built `1/m` as `rsqrt(m)²`, which calls the square-root body twice where the plain formula calls it once. That is the whole of the difference:

| 16384 tiles, bfloat16 | first version | this version |
|---|---|---|
| P300 | 302.1 | **227.8** (1.33×) |
| N300 | 763.5 | **586.2** (1.30×) |

It was also less accurate than the form it replaced in two ways the exhaustive sweeps found: 3623120 patterns of `hypot(x, 1)` and 4723276 of `hypot(x, 1e30)` landed more than 1 ULP out, worst case 2.38e-07, and all 16777214 float32 subnormal operands came back NaN — `main` returns `0` for those, so it was a regression rather than a residual gap. The reciprocal is where both came from, and there is no reciprocal here.

## Tests

`test_hypot_extremes.py`, 47 cases: the exhaustive bfloat16 sweep in both operand orders against five fixed operands, the two magnitude bands in both dtypes, and the IEEE special values. 32 of the 47 fail on `main`, all 47 pass here, on P300 and on N300.

## Not covered

- Subnormal operands. The SFPU flushes them, so `hypot(2^-140, 0)` returns `0` in float32 and in bfloat16. Unchanged from `main`, and fixing it means normalising by hand in the kernel.
- NaN through a bfloat16 DST, which comes back as `inf`. Also unchanged from `main`, and not specific to this op.
