### PR TITLE
[Bug fix] SFPU unary comparisons: compare on the comparison instructions, not on a subtract

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_comparison_specials.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_comparison_specials.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The unary comparison activations against infinities and NaNs.
+
+A float comparison on the SFPU is a subtract and a test on the result, which is
+not an IEEE comparison: two equal infinities subtract to NaN so they never
+compare equal, and a NaN operand subtracts to a NaN that reads as positive so
+`NaN > x` answers true. The binary comparisons do not have either hole, so each
+case here is checked against the binary op as well as against torch.
+"""
+
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 32, 32)
+INF = float("inf")
+NAN = float("nan")
+
+# activation, binary op, and the python answer
+OPS = [
+    ("UNARY_EQ", ttnn.UnaryOpType.UNARY_EQ, ttnn.eq, lambda a, b: a == b),
+    ("UNARY_NE", ttnn.UnaryOpType.UNARY_NE, ttnn.ne, lambda a, b: a != b),
+    ("UNARY_GT", ttnn.UnaryOpType.UNARY_GT, ttnn.gt, lambda a, b: a > b),
+    ("UNARY_LT", ttnn.UnaryOpType.UNARY_LT, ttnn.lt, lambda a, b: a < b),
+    ("UNARY_GE", ttnn.UnaryOpType.UNARY_GE, ttnn.ge, lambda a, b: a >= b),
+    ("UNARY_LE", ttnn.UnaryOpType.UNARY_LE, ttnn.le, lambda a, b: a <= b),
+]
+
+OPERANDS = [INF, -INF, 1.0, 0.0, -1.0, 2.0, NAN]
+
+
+def _to_device(values, dtype, torch_dtype, device):
+    t = torch.zeros(SHAPE, dtype=torch_dtype)
+    for i, v in enumerate(values):
+        t[0, 0, 0, i] = v
+    return t, ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("parameter", [INF, -INF, NAN, 1.0], ids=["inf", "neg_inf", "nan", "one"])
+@pytest.mark.parametrize("name, op, binary, expected", OPS, ids=[o[0] for o in OPS])
+def test_unary_comparison_specials(device, dtype, parameter, name, op, binary, expected):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    n = len(OPERANDS)
+
+    host, x = _to_device(OPERANDS, dtype, torch_dtype, device)
+    _, zeros = _to_device([0.0] * n, dtype, torch_dtype, device)
+
+    got = ttnn.to_torch(ttnn.add(x, zeros, input_tensor_a_activations=[ttnn.UnaryWithParam(op, parameter)])).flatten()[
+        :n
+    ]
+    from_binary = ttnn.to_torch(binary(x, parameter)).flatten()[:n]
+
+    # the reference is taken from what the device actually holds, so that a
+    # bfloat16 operand that rounded on the way in is not counted as a difference
+    held = host.flatten()[:n].to(torch.float64)
+    want = expected(held, torch.tensor(parameter, dtype=torch.float64)).to(torch.float64)
+
+    for i, operand in enumerate(OPERANDS):
+        label = f"{name}({operand}, {parameter}) in {dtype}"
+        assert got[i].item() == want[i].item(), f"{label}: got {got[i].item()}, expected {want[i].item()}"
+        assert (
+            got[i].item() == from_binary[i].item()
+        ), f"{label}: activation says {got[i].item()}, the binary op says {from_binary[i].item()}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_unary_comparison_exhaustive_bfloat16_patterns(device, dtype):
+    """Every bfloat16 bit pattern against an infinite parameter, both directions.
+
+    The infinities are what the subtract cannot express, so this is where a
+    regression would land; 254 of the patterns are NaN and they are the other.
+    """
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    patterns = (
+        torch.arange(0, 65536, dtype=torch.int64)
+        .to(torch.int32)
+        .to(torch.int16)
+        .view(torch.bfloat16)
+        .reshape(1, 1, 256, 256)
+    )
+    x = ttnn.from_torch(patterns.to(torch_dtype), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    zeros = ttnn.from_torch(
+        torch.zeros((1, 1, 256, 256), dtype=torch_dtype), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    for name, op, binary, expected in OPS:
+        for parameter in (INF, -INF):
+            got = ttnn.to_torch(
+                ttnn.add(x, zeros, input_tensor_a_activations=[ttnn.UnaryWithParam(op, parameter)])
+            ).flatten()
+            want = expected(
+                patterns.to(torch_dtype).flatten().to(torch.float64), torch.tensor(parameter, dtype=torch.float64)
+            ).to(torch.float64)
+            wrong = got.to(torch.float64) != want
+            assert not wrong.any(), (
+                f"{name} against {parameter} in {dtype}: {int(wrong.sum())} of 65536 patterns differ, "
+                f"first at 0x{int(patterns.flatten().view(torch.int16)[wrong.nonzero()[0, 0]].item()) & 0xffff:04x}"
+            )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "ckernel.h"
+#include "ckernel_addrmod.h"
 #include "ckernel_defs.h"
+#include "ckernel_ops.h"
 #include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpi.h"
@@ -13,124 +15,185 @@
 namespace ckernel {
 namespace sfpu {
 
+// The six comparisons against a scalar, on the comparison instructions rather
+// than on a subtract.
+//
+// `v_if(v == s)` is a subtract and an SFPSETCC on the difference, and SFPSETCC
+// reads its register as an int32: -0.0 is negative and non-zero to it. On top of
+// that, inf - inf is NaN, so two equal infinities never compare equal and their
+// ordering is the sign of that NaN, which is not the same on Blackhole and
+// Wormhole; and a NaN operand subtracts to a NaN that reads as positive, so
+// NaN > x answers true.
+//
+// SFPGT and SFPLE compare properly: sign-magnitude is handled, ±0 compare equal,
+// and the only departure from IEEE is that a NaN is ordered by its sign rather
+// than unordered — which one `abs(v) + abs(s) <= inf` test removes. This is the
+// treatment ckernel_sfpu_binary_comp.h already gives the two-tensor forms, and
+// the answers now agree with it, subnormals included: the SFPU add flushes them,
+// so `abs(v) + abs(s) == 0` reads them as zero, deliberately and as before.
+//
+// The scalar and everything derived from it are loop invariant, so the only
+// per-element cost over the subtract is the sign and the sum.
+
+// v == s (IS_EQUAL) or v != s.
+template <int ITERATIONS, bool IS_EQUAL>
+inline void _calculate_unary_comp_equal_(uint value) {
+    constexpr uint v = p_sfpu::LREG0;
+    constexpr uint s = p_sfpu::LREG1;
+    constexpr uint abs_v = p_sfpu::LREG2;
+    constexpr uint abs_s = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+    constexpr uint unequal_result = IS_EQUAL ? p_sfpu::LCONST_0 : p_sfpu::LCONST_1;
+    constexpr uint equal_result = IS_EQUAL ? p_sfpu::LCONST_1 : p_sfpu::LCONST_0;
+
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_UPPER, (value >> 16) & 0xFFFF);
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_LOWER, value & 0xFFFF);
+    TTI_SFPSETSGN(0, s, abs_s, 1);  // SFPSETSGN_MOD1_ARG_IMM
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(v, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(unequal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+
+        TTI_SFPSETSGN(0, v, abs_v, 1);  // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_v, abs_s, sum, 0);
+
+        // if abs(v) + abs(s) == 0; treats every ±subnormal as equal to zero
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+        TTI_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // if v <= s and s <= v
+        TTI_SFPLE(0, s, v, 1);  // SFPLE_MOD1_SET_CC
+        TTI_SFPLE(0, v, s, 1);  // SFPLE_MOD1_SET_CC
+        // if abs(v) + abs(s) <= inf; rejects NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+        TTI_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+}
+
+// v > s (IS_GREATER) or v < s.
+template <int ITERATIONS, bool IS_GREATER>
+inline void _calculate_unary_comp_strict_(uint value) {
+    constexpr uint v = p_sfpu::LREG0;
+    constexpr uint s = p_sfpu::LREG1;
+    constexpr uint abs_v = p_sfpu::LREG2;
+    constexpr uint abs_s = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_UPPER, (value >> 16) & 0xFFFF);
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_LOWER, value & 0xFFFF);
+    TTI_SFPSETSGN(0, s, abs_s, 1);  // SFPSETSGN_MOD1_ARG_IMM
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(v, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+
+        TTI_SFPSETSGN(0, v, abs_v, 1);  // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_v, abs_s, sum, 0);
+
+        // if v > s, or if v < s
+        if constexpr (IS_GREATER) {
+            TTI_SFPGT(0, s, v, 1);  // SFPGT_MOD1_SET_CC
+        } else {
+            TTI_SFPGT(0, v, s, 1);  // SFPGT_MOD1_SET_CC
+        }
+        // if abs(v) + abs(s) != 0; rejects if both are zero or ±subnormal
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        // if abs(v) + abs(s) <= inf; rejects NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+        TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+}
+
+// v >= s (IS_GREATER) or v <= s.
+template <int ITERATIONS, bool IS_GREATER>
+inline void _calculate_unary_comp_weak_(uint value) {
+    constexpr uint v = p_sfpu::LREG0;
+    constexpr uint s = p_sfpu::LREG1;
+    constexpr uint abs_v = p_sfpu::LREG2;
+    constexpr uint abs_s = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_UPPER, (value >> 16) & 0xFFFF);
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_LOWER, value & 0xFFFF);
+    TTI_SFPSETSGN(0, s, abs_s, 1);  // SFPSETSGN_MOD1_ARG_IMM
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(v, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+
+        TTI_SFPSETSGN(0, v, abs_v, 1);  // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_v, abs_s, sum, 0);
+
+        // if the strict comparison the other way holds: v < s for >=, v > s for <=
+        if constexpr (IS_GREATER) {
+            TTI_SFPGT(0, v, s, 1);  // SFPGT_MOD1_SET_CC
+        } else {
+            TTI_SFPGT(0, s, v, 1);  // SFPGT_MOD1_SET_CC
+        }
+        // if abs(v) + abs(s) != 0; every ±subnormal stays equal to zero
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // if abs(v) + abs(s) > inf; v or s is NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
+        TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+}
+
 inline void unary_ne_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ne(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_equal_<ITERATIONS, /*IS_EQUAL=*/false>(value);
 }
 
 inline void unary_eq_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_eq(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_equal_<ITERATIONS, /*IS_EQUAL=*/true>(value);
 }
 
 inline void unary_gt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_gt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_strict_<ITERATIONS, /*IS_GREATER=*/true>(value);
 }
 
 inline void unary_lt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_lt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_strict_<ITERATIONS, /*IS_GREATER=*/false>(value);
 }
 
 inline void unary_ge_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ge(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_weak_<ITERATIONS, /*IS_GREATER=*/true>(value);
 }
 
 inline void unary_le_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_le(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_weak_<ITERATIONS, /*IS_GREATER=*/false>(value);
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "ckernel.h"
+#include "ckernel_addrmod.h"
 #include "ckernel_defs.h"
+#include "ckernel_ops.h"
 #include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
 #include "sfpi.h"
@@ -13,124 +15,212 @@
 namespace ckernel {
 namespace sfpu {
 
+// The six comparisons against a scalar, on the comparison instructions rather
+// than on a subtract.
+//
+// `v_if(v == s)` is a subtract and an SFPSETCC on the difference, and SFPSETCC
+// reads its register as an int32: -0.0 is negative and non-zero to it. On top of
+// that, inf - inf is NaN, so two equal infinities never compare equal and their
+// ordering is the sign of that NaN, which is not the same on Blackhole and
+// Wormhole; and a NaN operand subtracts to a NaN that reads as positive, so
+// NaN > x answers true.
+//
+// Wormhole has no SFPGT or SFPLE, so the ordering comes from SFPSWAP, whose
+// min/max is the same sign-magnitude comparison: swap a copy of the value
+// against the scalar and XOR it back to see whether it moved. ±0 compare equal,
+// and the only departure from IEEE is that a NaN is ordered by its sign rather
+// than unordered — which one `abs(v) + abs(s) <= inf` test removes. This is the
+// treatment ckernel_sfpu_binary_comp.h already gives the two-tensor forms, and
+// the answers now agree with it, subnormals included: the SFPU add flushes them,
+// so `abs(v) + abs(s) == 0` reads them as zero, deliberately and as before.
+//
+// The scalar and everything derived from it are loop invariant, so the only
+// per-element cost over the subtract is the sign and the sum.
+
+// v == s (IS_EQUAL) or v != s.
+template <int ITERATIONS, bool IS_EQUAL>
+inline void _calculate_unary_comp_equal_(uint value) {
+    constexpr uint v = p_sfpu::LREG0;
+    constexpr uint s = p_sfpu::LREG1;
+    constexpr uint abs_v = p_sfpu::LREG2;
+    constexpr uint abs_s = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+    constexpr uint unequal_result = IS_EQUAL ? p_sfpu::LCONST_0 : p_sfpu::LCONST_1;
+    constexpr uint equal_result = IS_EQUAL ? p_sfpu::LCONST_1 : p_sfpu::LCONST_0;
+
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_UPPER, (value >> 16) & 0xFFFF);
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_LOWER, value & 0xFFFF);
+    TTI_SFPSETSGN(0, s, abs_s, 1);  // SFPSETSGN_MOD1_ARG_IMM
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(v, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(unequal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+
+        TTI_SFPSETSGN(0, v, abs_v, 1);  // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_v, abs_s, sum, 0);
+        TTI_SFPXOR(0, s, v, 0);
+
+        // if abs(v) + abs(s) == 0; treats every ±subnormal as equal to zero
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+        TTI_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // if abs(v) + abs(s) <= inf; rejects NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+        // if v ^ s == 0; the two are bitwise identical
+        TTI_SFPSETCC(0, v, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+        TTI_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+}
+
+// v > s (IS_GREATER) or v < s.
+template <int ITERATIONS, bool IS_GREATER>
+inline void _calculate_unary_comp_strict_(uint value) {
+    constexpr uint v = p_sfpu::LREG0;
+    constexpr uint s = p_sfpu::LREG1;
+    constexpr uint abs_v = p_sfpu::LREG2;
+    constexpr uint abs_s = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+    constexpr uint copy = p_sfpu::LREG6;
+    constexpr uint work = p_sfpu::LREG7;
+
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_UPPER, (value >> 16) & 0xFFFF);
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_LOWER, value & 0xFFFF);
+    TTI_SFPSETSGN(0, s, abs_s, 1);  // SFPSETSGN_MOD1_ARG_IMM
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(v, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+
+        TTI_SFPSETSGN(0, v, abs_v, 1);  // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_v, abs_s, sum, 0);
+
+        if constexpr (IS_GREATER) {
+            // if v > s: swap a copy of v against a copy of s and see whether v was the
+            // maximum. SFPSWAP writes both operands, so the scalar goes in through a copy.
+            TTI_SFPMOV(0, s, work, 0);
+            TTI_SFPMOV(0, v, copy, 0);
+            TTI_SFPSWAP(0, work, copy, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
+            TTI_SFPXOR(0, v, copy, 0);
+            TTI_SFPSETCC(0, copy, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        } else {
+            // if v < s: same, reading the maximum instead.
+            TTI_SFPMOV(0, s, work, 0);
+            TTI_SFPMOV(0, v, copy, 0);
+            TTI_SFPSWAP(0, work, copy, sfpi::SFPSWAP_MOD1_VEC_MAX_MIN);
+            TTI_SFPXOR(0, v, copy, 0);
+            TTI_SFPSETCC(0, copy, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        }
+        // if abs(v) + abs(s) != 0; rejects if both are zero or ±subnormal
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        // if abs(v) + abs(s) <= inf; rejects NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+        TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+}
+
+// v >= s (IS_GREATER) or v <= s.
+template <int ITERATIONS, bool IS_GREATER>
+inline void _calculate_unary_comp_weak_(uint value) {
+    constexpr uint v = p_sfpu::LREG0;
+    constexpr uint s = p_sfpu::LREG1;
+    constexpr uint abs_v = p_sfpu::LREG2;
+    constexpr uint abs_s = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+    constexpr uint copy = p_sfpu::LREG6;
+    constexpr uint work = p_sfpu::LREG7;
+
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_UPPER, (value >> 16) & 0xFFFF);
+    TT_SFPLOADI(s, sfpi::SFPLOADI_MOD0_LOWER, value & 0xFFFF);
+    TTI_SFPSETSGN(0, s, abs_s, 1);  // SFPSETSGN_MOD1_ARG_IMM
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        TTI_SFPLOAD(v, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+
+        TTI_SFPSETSGN(0, v, abs_v, 1);  // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_v, abs_s, sum, 0);
+
+        // if the strict comparison the other way holds: v < s for >=, v > s for <=
+        if constexpr (IS_GREATER) {
+            // if v < s: same, reading the maximum instead.
+            TTI_SFPMOV(0, s, work, 0);
+            TTI_SFPMOV(0, v, copy, 0);
+            TTI_SFPSWAP(0, work, copy, sfpi::SFPSWAP_MOD1_VEC_MAX_MIN);
+            TTI_SFPXOR(0, v, copy, 0);
+            TTI_SFPSETCC(0, copy, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        } else {
+            // if v > s: swap a copy of v against a copy of s and see whether v was the
+            // maximum. SFPSWAP writes both operands, so the scalar goes in through a copy.
+            TTI_SFPMOV(0, s, work, 0);
+            TTI_SFPMOV(0, v, copy, 0);
+            TTI_SFPSWAP(0, work, copy, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
+            TTI_SFPXOR(0, v, copy, 0);
+            TTI_SFPSETCC(0, copy, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        }
+        // if abs(v) + abs(s) != 0; every ±subnormal stays equal to zero
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_3, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // if abs(v) + abs(s) > inf; v or s is NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
+        TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_2, 0);
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+}
+
 inline void unary_ne_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ne(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_equal_<ITERATIONS, /*IS_EQUAL=*/false>(value);
 }
 
 inline void unary_eq_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_eq(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v == s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_equal_<ITERATIONS, /*IS_EQUAL=*/true>(value);
 }
 
 inline void unary_gt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_gt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_strict_<ITERATIONS, /*IS_GREATER=*/true>(value);
 }
 
 inline void unary_lt_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_lt(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 1.0f; }
-        v_else { v = 0.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_strict_<ITERATIONS, /*IS_GREATER=*/false>(value);
 }
 
 inline void unary_ge_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_ge(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v < s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_weak_<ITERATIONS, /*IS_GREATER=*/true>(value);
 }
 
 inline void unary_le_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void calculate_unary_le(uint value) {
-    // SFPU microcode
-    sfpi::vFloat s = Converter::as_float(value);
-
-#pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat v = sfpi::dst_reg[0];
-        v_if(v > s) { v = 0.0f; }
-        v_else { v = 1.0f; }
-        v_endif;
-
-        sfpi::dst_reg[0] = v;
-
-        sfpi::dst_reg++;
-    }
+    _calculate_unary_comp_weak_<ITERATIONS, /*IS_GREATER=*/false>(value);
 }
 
 }  // namespace sfpu


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53908.

The six unary comparison activations compared with `v_if(v == s)`, which is `SFPMAD` then `SFPSETCC` on the difference. `SFPSETCC` reads its register as an int32, so `-0.0` is negative and non-zero to it; `inf - inf` is NaN, so two equal infinities never compare equal and their ordering is the sign of that NaN, which is not the same on Blackhole and Wormhole; and a NaN operand reads as positive, so `NaN > x` answers true.

Blackhole has `SFPGT` and `SFPLE`, which compare properly: sign-magnitude handled, `±0` equal, and the only departure from IEEE is that a NaN is ordered by its sign, which one `abs(v) + abs(s) <= inf` test removes. Wormhole B0 has neither and gets the same ordering from `SFPSWAP`'s min/max. Both are what `ckernel_sfpu_binary_comp.h` does for the two-tensor forms, so the unary answers are now the binary answers by construction. The scalar and its magnitude are loop invariant and hoisted; the per-element cost over the subtract is one sign and one add.

The two architecture copies of the file were byte-identical and now differ, as the two `binary_comp.h` copies already do.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device, scored against the binary comparison.

Every one of the 65536 bfloat16 bit patterns, and 4194304 float32 bit patterns drawn uniformly from the 2^32 space, against seven parameters — `±inf`, `nan`, `0`, `1`, `-2.5`, `3.4e38` — for all six ops. 178913280 comparisons.

| | P300 before | P300 after | N300 before | N300 after |
|---|---|---|---|---|
| disagree with the binary op | 8752592 | **4** | 8720020 | **4** |

The four are one bfloat16 case where the activation is right and the binary op is not, identical on both machines.

| | before | after |
|---|---|---|
| `-0.0 < 0` | true | false |
| `-0.0 == 0` | false | true |
| `x == inf` for `x = inf` | never true | true |
| `x <= inf` for `x = inf` | false | true |
| `inf > inf` | true on P300, false on N300 | false on both |
| `inf >= inf` | true on P300, false on N300 | true on both |
| `nan > x`, any `x` | true | false |
| `x > nan`, every element | true | false |

Subnormal operands are unchanged: the SFPU add flushes them, so `abs(v) + abs(s) == 0` reads them as equal to zero, which is what `binary_comp.h` does and says it does.

## Cost

Wall clock through `ttnn.add` with the activation attached, 5 warm-up then 50 timed calls with one `synchronize_device` at the end, median of five runs, profiler off, µs per call.

| | | main | this branch |
|---|---|---|---|
| P300 | 1024 tiles, bfloat16 | 26.1 | **25.6** |
| | 16384 tiles, bfloat16 | 225.8 | **225.4** |
| | 16384 tiles, float32 | 455.2 | 455.3 |
| N300 | 1024 tiles, bfloat16 | 55.0 | **54.0** |
| | 16384 tiles, bfloat16 | 510.1 | 515.4 |
| | 16384 tiles, float32 | 960.4 | **960.4** |

The 1% on N300 bfloat16 is the `SFPMOV` that `SFPSWAP` needs. Instruction choice is not what costs: 256 copies of a pair inserted into the kernel give 1928.2 µs for `SFPGT`+`SFPENCC`, 1925.9 for `SFPSETCC`+`SFPENCC` and 1926.9 for two `SFPNOP`.

## Tests

`test_unary_comparison_specials.py`, 50 cases: the six ops against `±inf`, `nan` and a finite parameter in both dtypes, each checked against the binary op as well as against the exact answer, plus an exhaustive sweep of every bfloat16 bit pattern against `±inf`. 30 of the 50 fail on `main`; all 50 pass here, on P300 and on N300.

## Not covered

- Subnormal operands, as above.
- The integer comparison paths.
- Quasar. The change is in the Blackhole and Wormhole `llk_api` headers.
