### PR TITLE
[Performance] GDN: fused prep->scan prim - zero DRAM intermediates, default at BH>=24

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_chunk_gated_delta_rule.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_chunk_gated_delta_rule.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Whole-op correctness gate for ttnn.transformer.chunk_gated_delta_rule (F0 test pyramid, tier 3).
+
+The public op is asserted against a torch golden of the WHOLE computation, inlined from
+models/experimental/gated_attention_gated_deltanet/torch_functional/delta_rule_ops.py:149-245
+(tests must not import models/), for BOTH dispatch paths: phased (QWEN_GDN_PHASED=1, the default
+prep->scan split) and monolithic (QWEN_GDN_PHASED=0, single-kernel fallback; 4D inputs only —
+the flat-QKV OPT-A inputs are phased-only).
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+CHUNK = 32  # Ct=1: the production chunk size
+KDIM = 128
+VDIM = 128
+
+
+def _pcc(golden, actual):
+    g = golden.to(torch.float64).flatten()
+    a = actual.to(torch.float64).flatten()
+    assert torch.isfinite(a).all(), "device output contains non-finite values"
+    if torch.equal(g, a):
+        return 1.0
+    vg = g - g.mean()
+    va = a - a.mean()
+    denom = vg.norm() * va.norm()
+    if denom == 0:
+        return 0.0
+    return float((vg @ va) / denom)
+
+
+def _const_tiles(device, chunk_size=CHUNK):
+    """The op's constant tiles (mirrors chunk_gated_delta_rule.cpp build_const_tiles)."""
+    c = chunk_size
+    eye = torch.eye(c, dtype=torch.float32)
+    tril = torch.tril(torch.ones(c, c, dtype=torch.float32))
+    ones = torch.ones(c, c, dtype=torch.float32)
+    ii = torch.arange(32).unsqueeze(1)
+    jj = torch.arange(32).unsqueeze(0)
+    lo_i, lo_j = ii < 16, jj < 16
+    qtl = (lo_i & lo_j).float()
+    qbr = (~lo_i & ~lo_j).float()
+    qbl = (~lo_i & lo_j).float()
+    masks = torch.cat([qtl, qbr, qbl], dim=1)  # [32, 96]
+
+    def _up(t):
+        return ttnn.from_torch(t.reshape(1, 1, *t.shape), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    return (_up(eye), _up(tril), _up(ones), _up(masks))
+
+
+# ---------------------------------------------------------------------------
+# Inlined torch golden (delta_rule_ops.py:149-245, use_qk_l2norm handled by the caller:
+# the ttnn op requires host-normalized q/k, so the golden gets the already-normalized,
+# bf16-rounded values the device sees)
+# ---------------------------------------------------------------------------
+
+
+def _golden_chunk_gdn(q, k, v, g, beta, scale, s0, C):
+    """q,k: [B,T,H,K] fp32 (exact bf16-rounded, L2-normalized); v: [B,T,HV,V] fp32 (bf16-rounded);
+    g,beta: [B,T,HV] fp32; s0: [B,HV,K,V] fp32 or None. T must be a multiple of C (no padding).
+    Returns o [B,T,HV,V], final_state [B,HV,K,V]."""
+    B, T, H, K = q.shape
+    HV, V = v.shape[2], v.shape[3]
+    G = HV // H
+    if G > 1:  # the op's GQA head expand (repeat_interleave over the head dim)
+        q = q.repeat_interleave(G, dim=2)
+        k = k.repeat_interleave(G, dim=2)
+    # The op folds scale into q ON DEVICE in bf16 (ttnn::multiply on the bf16 tensor packs back
+    # to bf16) — mirror that rounding so it doesn't count against the gates below.
+    q = (q * scale).to(torch.bfloat16).to(torch.float32)
+
+    BH, NC = B * HV, T // C
+    q_c, k_c, v_c = (x.permute(0, 2, 1, 3).reshape(BH, NC, C, x.shape[-1]) for x in (q, k, v))
+    g_c, beta_c = (x.permute(0, 2, 1).reshape(BH, NC, C) for x in (g, beta))
+
+    decay = g_c.cumsum(-1)  # :189
+    decay_exp = decay.exp().unsqueeze(-1)  # :190
+    v_beta = v_c * beta_c.unsqueeze(-1)  # :171
+    k_beta = k_c * beta_c.unsqueeze(-1)  # :172
+    l_mask = (decay.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().tril()  # :193
+    # :196-201 — WY inverse via forward substitution
+    mask_upper = torch.triu(torch.ones(C, C, dtype=torch.bool), diagonal=0)
+    attn = -((k_beta @ k_c.transpose(-1, -2)) * l_mask).masked_fill(mask_upper, 0)
+    for i in range(1, C):
+        attn[..., i, :i] = attn[..., i, :i].clone() + (attn[..., i, :i, None].clone() * attn[..., :i, :i].clone()).sum(
+            -2
+        )
+    t_inv = attn + torch.eye(C, dtype=torch.float32)  # :201
+
+    kd = k_beta * decay_exp
+    q_decay = q_c * decay_exp  # :229
+    mask_causal = torch.triu(torch.ones(C, C, dtype=torch.bool), diagonal=1)
+    intra = (q_c @ k_c.transpose(-1, -2) * l_mask).masked_fill(mask_causal, 0)  # :222
+    k_dec_t = (k_c * (decay[..., -1:] - decay).exp().unsqueeze(-1)).transpose(-1, -2)  # :237
+    dl = decay[..., -1].exp()  # [BH,NC]
+
+    # :216-238 scan loop in the phased op's un-premultiplied form — mathematically identical to
+    # v_corrected/k_cumdecay premultiplication (v_new = t_inv @ (v_beta - kd@S) == u - w@S).
+    S = s0.reshape(BH, K, V).clone() if s0 is not None else torch.zeros(BH, K, V, dtype=torch.float32)
+    o = torch.zeros(BH, NC, C, V, dtype=torch.float32)
+    for c in range(NC):
+        v_new = t_inv[:, c] @ (v_beta[:, c] - kd[:, c] @ S)
+        o[:, c] = q_decay[:, c] @ S + intra[:, c] @ v_new  # :229-232
+        S = S * dl[:, c, None, None] + k_dec_t[:, c] @ v_new  # :235-238
+    o = o.reshape(B, HV, T, V).permute(0, 2, 1, 3).contiguous()  # :243-244
+    return o, S.reshape(B, HV, K, V)
+
+
+# ---------------------------------------------------------------------------
+
+
+# (1,256,8,8): MHA, BH=8. (1,512,4,8): GQA G=2 — exercises the repeat_interleave head expand.
+@pytest.mark.parametrize("batch, seq, num_k_heads, num_v_heads", [(1, 256, 8, 8), (1, 512, 4, 8)])
+@pytest.mark.parametrize("with_initial_state", [False, True])
+@pytest.mark.parametrize("phased", [True, False], ids=["phased", "monolithic"])
+def test_chunk_gated_delta_rule_vs_torch(
+    device, monkeypatch, batch, seq, num_k_heads, num_v_heads, with_initial_state, phased
+):
+    torch.manual_seed(20260823)
+    B, T, H, HV = batch, seq, num_k_heads, num_v_heads
+    BH = B * HV
+    grid = device.compute_with_storage_grid_size()
+    if BH > grid.x * grid.y:
+        pytest.skip(f"BH={BH} exceeds the {grid.x}x{grid.y} compute grid (scan needs a core per head)")
+
+    monkeypatch.setenv("QWEN_GDN_PHASED", "1" if phased else "0")
+    monkeypatch.delenv("QWEN_GDN_SCAN_SERIAL", raising=False)
+    monkeypatch.delenv("QWEN_GDN_PREP_SERIAL", raising=False)
+    # Mcast on/off is documented bit-exact, but pin the shipped default topology anyway.
+    monkeypatch.delenv("QWEN_GDN_SCAN_MCAST", raising=False)
+    # QWEN_GDN_DUMP is read once via a function-local static; delenv helps only if the op has not
+    # run yet in this process — kept for hygiene.
+    monkeypatch.delenv("QWEN_GDN_DUMP", raising=False)
+
+    # The op's numeric regime: q/k L2-normalized on host (the op requires it — unnormalized keys
+    # NaN the recurrence on every path), beta in (0,1), g <= 0, small initial state.
+    q = F.normalize(torch.randn(B, T, H, KDIM), dim=-1).to(torch.bfloat16)
+    k = F.normalize(torch.randn(B, T, H, KDIM), dim=-1).to(torch.bfloat16)
+    v = (0.5 * torch.randn(B, T, HV, VDIM)).to(torch.bfloat16)
+    beta = torch.sigmoid(torch.randn(B, T, HV))
+    g = -F.softplus(torch.randn(B, T, HV)) * 0.5
+    s0 = 0.05 * torch.randn(B, HV, KDIM, VDIM) if with_initial_state else None
+
+    def dev(t, dtype):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    eye, tril, ones, masks = _const_tiles(device)
+    o_d, fs_d = ttnn.transformer.chunk_gated_delta_rule(
+        dev(q, ttnn.bfloat16),
+        dev(k, ttnn.bfloat16),
+        dev(v, ttnn.bfloat16),
+        dev(g, ttnn.float32),
+        dev(beta, ttnn.float32),
+        initial_state=dev(s0, ttnn.float32) if s0 is not None else None,
+        output_final_state=True,
+        chunk_size=CHUNK,
+        eye=eye,
+        tril=tril,
+        ones=ones,
+        masks=masks,
+    )
+    o = ttnn.to_torch(o_d).float()  # phased o is fp32; monolithic o is bf16
+    fs = ttnn.to_torch(fs_d).float()
+
+    scale = KDIM**-0.5
+    o_ref, fs_ref = _golden_chunk_gdn(q.float(), k.float(), v.float(), g, beta, scale, s0, CHUNK)
+
+    # Gates: bf16 q/k/v inputs dominate the error on the phased path (kernel math is fp32/HiFi4
+    # end-to-end, o packed fp32; fs accumulates only fp32 rounding, hence the tighter gate).
+    # The monolithic path is looser on BOTH outputs: it uses the older numerics the phased path
+    # abandoned for accuracy — a full-C Horner WY inverse (deep power series, more fp32
+    # cancellation than the quadrant-split/forward-substitution forms) plus the premultiplied
+    # u - w@S hand-off — and packs o to bf16.
+    o_gate, fs_gate = (0.999, 0.9999) if phased else (0.998, 0.998)
+    pcc_o = _pcc(o_ref, o)
+    assert pcc_o >= o_gate, f"o: PCC {pcc_o} < {o_gate}"
+    pcc_fs = _pcc(fs_ref, fs)
+    assert pcc_fs >= fs_gate, f"final_state: PCC {pcc_fs} < {fs_gate}"

--- a/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_fused.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_fused.py
@@ -245,23 +245,19 @@ def test_fused_bit_exact_vs_phased(device, monkeypatch, with_initial_state):
     assert torch.equal(fs_fu, fs_ph), "fused path changed final_state (must be bit-identical to phased)"
 
 
-# The fused path is opt-in at F1: it is bit-exact but producer-math-bound (~34us/chunk measured),
-# 1.11x at BH=48/T=4096 and 0.82x at T=512 — below the ship gate. The default flips to shape-gated
-# fused (BH >= 24 && 2*BH cores fit) once F2's producer-side work clears the w_p <= ~27us
-# checkpoint; re-add a (16, 48, "fused") row here when it does. See gdn-fused-handoff-design.md §8.
 @pytest.mark.parametrize(
     "num_k_heads, num_v_heads, expected_path",
     [
-        (16, 48, "phased"),  # BH=48: fused fits but stays opt-in until F2 clears its perf gate
-        (4, 12, "phased"),  # BH=12: phased regardless
+        (16, 48, "fused"),  # BH=48 >= 24 and 2*BH=96 cores fit -> default engages fused (F2 gate cleared)
+        (4, 12, "phased"),  # BH=12 < 24 -> default falls back to phased
     ],
-    ids=["bh48_phased_default", "bh12_phased"],
+    ids=["bh48_fused", "bh12_phased"],
 )
 def test_fused_default_dispatch(device, monkeypatch, num_k_heads, num_v_heads, expected_path):
-    """With NO path env set, the dispatcher must pick phased (the fused path is opt-in at F1).
-    Since fused and phased are bit-exact, torch.equal cannot discriminate paths: the proof that
-    the default took the expected path is a program-cache delta of ZERO after warming exactly
-    that path explicitly (any other path would compile at least one new prim program)."""
+    """With NO path env set, the dispatcher must pick fused iff (BH >= 24 and 2*BH fits the grid),
+    else phased. Since fused and phased are bit-exact, torch.equal cannot discriminate paths: the
+    proof that the default took the expected path is a program-cache delta of ZERO after warming
+    exactly that path explicitly (any other path would compile at least one new prim program)."""
     B = 1
     BH = B * num_v_heads
     grid = device.compute_with_storage_grid_size()

--- a/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_fused.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_fused.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""F1 gates for the fused GDN prefill path (ttnn::prim::chunk_gdn_fused).
+
+The fused prim runs prep and scan in ONE program: per head, a producer core runs the unchanged
+prep reader+compute and NoC-writes the seven fp32 intermediates (v_beta, kd, q_decay, intra,
+k_dec_t, dl, t_inv) straight into the paired scan core's CBs via the shipped ready/valid
+handshake — zero DRAM intermediates. The compute kernels are byte-identical to the phased path
+and the DRAM round trip they replace was byte-preserving, so the fused op must be BIT-IDENTICAL
+to the phased op — any difference is a bug, not numerical noise.
+
+Path selection is QWEN_GDN_PATH ("fused"|"phased"|"mono"), read fresh per call where the prim is
+chosen (cache-safe: different prims hash to different program-cache entries). With no env set the
+default is fused iff (BH >= 24 and 2*BH fits the compute grid), else phased. Because fused and
+phased are bit-exact by design, torch.equal alone cannot prove WHICH path ran — every path proof
+here rests on program-cache entry deltas (a new prim compiles a new program; a cache hit does not).
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+CHUNK = 32  # Ct=1: the production chunk size
+KDIM = 128
+VDIM = 128
+T_SMALL = 256  # NC=8 — enough chunks to exercise the recurrence, small enough to keep runtime down
+
+
+def _pcc(golden, actual):
+    g = golden.to(torch.float64).flatten()
+    a = actual.to(torch.float64).flatten()
+    assert torch.isfinite(a).all(), "device output contains non-finite values"
+    if torch.equal(g, a):
+        return 1.0
+    vg = g - g.mean()
+    va = a - a.mean()
+    denom = vg.norm() * va.norm()
+    if denom == 0:
+        return 0.0
+    return float((vg @ va) / denom)
+
+
+def _const_tiles(device, chunk_size=CHUNK):
+    """The op's constant tiles (mirrors chunk_gated_delta_rule.cpp build_const_tiles)."""
+    c = chunk_size
+    eye = torch.eye(c, dtype=torch.float32)
+    tril = torch.tril(torch.ones(c, c, dtype=torch.float32))
+    ones = torch.ones(c, c, dtype=torch.float32)
+    ii = torch.arange(32).unsqueeze(1)
+    jj = torch.arange(32).unsqueeze(0)
+    lo_i, lo_j = ii < 16, jj < 16
+    qtl = (lo_i & lo_j).float()
+    qbr = (~lo_i & ~lo_j).float()
+    qbl = (~lo_i & lo_j).float()
+    masks = torch.cat([qtl, qbr, qbl], dim=1)  # [32, 96]
+
+    def _up(t):
+        return ttnn.from_torch(t.reshape(1, 1, *t.shape), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    return (_up(eye), _up(tril), _up(ones), _up(masks))
+
+
+def _clear_gdn_env(monkeypatch):
+    """Neutralize every GDN path/debug knob; each test then sets QWEN_GDN_PATH explicitly (or
+    leaves it unset to probe the default dispatch)."""
+    monkeypatch.delenv("QWEN_GDN_PATH", raising=False)
+    # Legacy selector — superseded by QWEN_GDN_PATH but still honored when PATH is unset.
+    monkeypatch.delenv("QWEN_GDN_PHASED", raising=False)
+    monkeypatch.delenv("QWEN_GDN_SCAN_SERIAL", raising=False)
+    monkeypatch.delenv("QWEN_GDN_PREP_SERIAL", raising=False)
+    monkeypatch.delenv("QWEN_GDN_SCAN_MCAST", raising=False)
+    # QWEN_GDN_DUMP is read once via a function-local static; delenv helps only if the op has not
+    # run yet in this process — kept for hygiene.
+    monkeypatch.delenv("QWEN_GDN_DUMP", raising=False)
+
+
+def _skip_unless_fused_fits(device, bh):
+    grid = device.compute_with_storage_grid_size()
+    if 2 * bh > grid.x * grid.y:
+        pytest.skip(
+            f"2*BH={2 * bh} exceeds the {grid.x}x{grid.y} compute grid (fused needs a producer+receiver pair per head)"
+        )
+
+
+def _make_inputs(device, batch, seq, num_k_heads, num_v_heads, with_initial_state, seed):
+    """Token-major public-op inputs in the op's numeric regime: q/k L2-normalized on host (the op
+    requires it — unnormalized keys NaN the recurrence on every path), beta in (0,1), g <= 0."""
+    torch.manual_seed(seed)
+    B, T, H, HV = batch, seq, num_k_heads, num_v_heads
+    q = F.normalize(torch.randn(B, T, H, KDIM), dim=-1).to(torch.bfloat16)
+    k = F.normalize(torch.randn(B, T, H, KDIM), dim=-1).to(torch.bfloat16)
+    v = (0.5 * torch.randn(B, T, HV, VDIM)).to(torch.bfloat16)
+    beta = torch.sigmoid(torch.randn(B, T, HV))
+    g = -F.softplus(torch.randn(B, T, HV)) * 0.5
+    s0 = 0.05 * torch.randn(B, HV, KDIM, VDIM) if with_initial_state else None
+
+    def dev(t, dtype):
+        return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    tensors = (
+        dev(q, ttnn.bfloat16),
+        dev(k, ttnn.bfloat16),
+        dev(v, ttnn.bfloat16),
+        dev(g, ttnn.float32),
+        dev(beta, ttnn.float32),
+    )
+    s0_dev = dev(s0, ttnn.float32) if s0 is not None else None
+    return (q, k, v, g, beta, s0), tensors, s0_dev
+
+
+def _run_op(device, tensors, const_tiles, initial_state):
+    q, k, v, g, beta = tensors
+    eye, tril, ones, masks = const_tiles
+    o, fs = ttnn.transformer.chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        chunk_size=CHUNK,
+        eye=eye,
+        tril=tril,
+        ones=ones,
+        masks=masks,
+    )
+    o_t = ttnn.to_torch(o)
+    fs_t = ttnn.to_torch(fs)
+    ttnn.deallocate(o)
+    ttnn.deallocate(fs)
+    return o_t, fs_t
+
+
+# ---------------------------------------------------------------------------
+# Inlined torch golden of the WHOLE computation (delta_rule_ops.py:149-245; tests must not import
+# models/, and --import-mode=importlib blocks importing the sibling test module, so the golden is
+# copied verbatim from test_chunk_gated_delta_rule.py::_golden_chunk_gdn).
+# ---------------------------------------------------------------------------
+
+
+def _golden_chunk_gdn(q, k, v, g, beta, scale, s0, C):
+    """q,k: [B,T,H,K] fp32 (exact bf16-rounded, L2-normalized); v: [B,T,HV,V] fp32 (bf16-rounded);
+    g,beta: [B,T,HV] fp32; s0: [B,HV,K,V] fp32 or None. T must be a multiple of C (no padding).
+    Returns o [B,T,HV,V], final_state [B,HV,K,V]."""
+    B, T, H, K = q.shape
+    HV, V = v.shape[2], v.shape[3]
+    G = HV // H
+    if G > 1:  # the op's GQA head expand (repeat_interleave over the head dim)
+        q = q.repeat_interleave(G, dim=2)
+        k = k.repeat_interleave(G, dim=2)
+    # The op folds scale into q ON DEVICE in bf16 (ttnn::multiply on the bf16 tensor packs back
+    # to bf16) — mirror that rounding so it doesn't count against the gates below.
+    q = (q * scale).to(torch.bfloat16).to(torch.float32)
+
+    BH, NC = B * HV, T // C
+    q_c, k_c, v_c = (x.permute(0, 2, 1, 3).reshape(BH, NC, C, x.shape[-1]) for x in (q, k, v))
+    g_c, beta_c = (x.permute(0, 2, 1).reshape(BH, NC, C) for x in (g, beta))
+
+    decay = g_c.cumsum(-1)  # :189
+    decay_exp = decay.exp().unsqueeze(-1)  # :190
+    v_beta = v_c * beta_c.unsqueeze(-1)  # :171
+    k_beta = k_c * beta_c.unsqueeze(-1)  # :172
+    l_mask = (decay.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().tril()  # :193
+    # :196-201 — WY inverse via forward substitution
+    mask_upper = torch.triu(torch.ones(C, C, dtype=torch.bool), diagonal=0)
+    attn = -((k_beta @ k_c.transpose(-1, -2)) * l_mask).masked_fill(mask_upper, 0)
+    for i in range(1, C):
+        attn[..., i, :i] = attn[..., i, :i].clone() + (attn[..., i, :i, None].clone() * attn[..., :i, :i].clone()).sum(
+            -2
+        )
+    t_inv = attn + torch.eye(C, dtype=torch.float32)  # :201
+
+    kd = k_beta * decay_exp
+    q_decay = q_c * decay_exp  # :229
+    mask_causal = torch.triu(torch.ones(C, C, dtype=torch.bool), diagonal=1)
+    intra = (q_c @ k_c.transpose(-1, -2) * l_mask).masked_fill(mask_causal, 0)  # :222
+    k_dec_t = (k_c * (decay[..., -1:] - decay).exp().unsqueeze(-1)).transpose(-1, -2)  # :237
+    dl = decay[..., -1].exp()  # [BH,NC]
+
+    # :216-238 scan loop in the phased op's un-premultiplied form — mathematically identical to
+    # v_corrected/k_cumdecay premultiplication (v_new = t_inv @ (v_beta - kd@S) == u - w@S).
+    S = s0.reshape(BH, K, V).clone() if s0 is not None else torch.zeros(BH, K, V, dtype=torch.float32)
+    o = torch.zeros(BH, NC, C, V, dtype=torch.float32)
+    for c in range(NC):
+        v_new = t_inv[:, c] @ (v_beta[:, c] - kd[:, c] @ S)
+        o[:, c] = q_decay[:, c] @ S + intra[:, c] @ v_new  # :229-232
+        S = S * dl[:, c, None, None] + k_dec_t[:, c] @ v_new  # :235-238
+    o = o.reshape(B, HV, T, V).permute(0, 2, 1, 3).contiguous()  # :243-244
+    return o, S.reshape(B, HV, K, V)
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("with_initial_state", [False, True])
+def test_fused_bit_exact_vs_phased(device, monkeypatch, with_initial_state):
+    """Primary F1 gate: fused output == phased output, bit for bit. The producer packs the seven
+    intermediates at the same CB boundaries/formats the phased prep packs them at, and the DRAM
+    round trip it eliminates was a byte copy — so torch.equal, not PCC. (F1 uses Option U for
+    v_beta: the producer computes and ships it exactly as prep does, keeping the compute kernels
+    byte-identical; the Option R recompute lands in F2.)"""
+    B, num_k_heads, num_v_heads = 1, 16, 48  # single-device Qwen3.6 shape, GQA G=3
+    BH = B * num_v_heads
+    _skip_unless_fused_fits(device, BH)
+    _clear_gdn_env(monkeypatch)
+
+    _, tensors, s0 = _make_inputs(device, B, T_SMALL, num_k_heads, num_v_heads, with_initial_state, seed=20260820)
+    const_tiles = _const_tiles(device)
+
+    monkeypatch.setenv("QWEN_GDN_PATH", "phased")
+    o_ph, fs_ph = _run_op(device, tensors, const_tiles, s0)
+    n_phased = device.num_program_cache_entries()
+
+    # A second phased run must be a full cache hit: it pins that the pre/postprocessing graph
+    # around the prims is cache-stable, so the fused-run delta below is attributable purely to
+    # the prim the dispatcher picked.
+    o_ph2, fs_ph2 = _run_op(device, tensors, const_tiles, s0)
+    n_phased2 = device.num_program_cache_entries()
+    assert n_phased2 == n_phased, (
+        f"repeated phased run compiled {n_phased2 - n_phased} new programs (expected 0): the op "
+        "graph is not cache-stable, so program-cache deltas cannot prove which prim dispatched"
+    )
+    assert torch.equal(o_ph, o_ph2) and torch.equal(fs_ph, fs_ph2), "phased path is not deterministic"
+
+    monkeypatch.setenv("QWEN_GDN_PATH", "fused")
+    o_fu, fs_fu = _run_op(device, tensors, const_tiles, s0)
+    n_fused = device.num_program_cache_entries()
+
+    # The phased runs compiled prep+scan (2 prim programs) plus the shared pre/postprocessing;
+    # the fused run reuses everything except the prim, which is ONE program (that is the point:
+    # producer and receiver kernels live in a single fused program, zero DRAM intermediates).
+    # A delta of 0 means QWEN_GDN_PATH was not read on this call and the "fused" run silently
+    # reused the phased path — which would make the bit-exact comparison below vacuously compare
+    # the phased op against itself. A delta of 2 means the fused branch dispatched prep+scan.
+    assert n_fused - n_phased2 == 1, (
+        f"QWEN_GDN_PATH phased->fused toggle compiled {n_fused - n_phased2} new programs "
+        "(expected exactly 1, the single fused prim program): 0 => env not read per call "
+        "(comparison vacuous), 2 => the fused branch ran the phased prims"
+    )
+
+    assert torch.equal(o_fu, o_ph), "fused path changed o (must be bit-identical to phased)"
+    assert torch.equal(fs_fu, fs_ph), "fused path changed final_state (must be bit-identical to phased)"
+
+
+# The fused path is opt-in at F1: it is bit-exact but producer-math-bound (~34us/chunk measured),
+# 1.11x at BH=48/T=4096 and 0.82x at T=512 — below the ship gate. The default flips to shape-gated
+# fused (BH >= 24 && 2*BH cores fit) once F2's producer-side work clears the w_p <= ~27us
+# checkpoint; re-add a (16, 48, "fused") row here when it does. See gdn-fused-handoff-design.md §8.
+@pytest.mark.parametrize(
+    "num_k_heads, num_v_heads, expected_path",
+    [
+        (16, 48, "phased"),  # BH=48: fused fits but stays opt-in until F2 clears its perf gate
+        (4, 12, "phased"),  # BH=12: phased regardless
+    ],
+    ids=["bh48_phased_default", "bh12_phased"],
+)
+def test_fused_default_dispatch(device, monkeypatch, num_k_heads, num_v_heads, expected_path):
+    """With NO path env set, the dispatcher must pick phased (the fused path is opt-in at F1).
+    Since fused and phased are bit-exact, torch.equal cannot discriminate paths: the proof that
+    the default took the expected path is a program-cache delta of ZERO after warming exactly
+    that path explicitly (any other path would compile at least one new prim program)."""
+    B = 1
+    BH = B * num_v_heads
+    grid = device.compute_with_storage_grid_size()
+    if BH > grid.x * grid.y:
+        pytest.skip(f"BH={BH} exceeds the {grid.x}x{grid.y} compute grid (scan needs a core per head)")
+    if expected_path == "fused":
+        _skip_unless_fused_fits(device, BH)  # on smaller grids the default itself falls back to phased
+    _clear_gdn_env(monkeypatch)
+
+    _, tensors, s0 = _make_inputs(device, B, T_SMALL, num_k_heads, num_v_heads, True, seed=20260821)
+    const_tiles = _const_tiles(device)
+
+    monkeypatch.setenv("QWEN_GDN_PATH", expected_path)
+    o_exp, fs_exp = _run_op(device, tensors, const_tiles, s0)
+    n_explicit = device.num_program_cache_entries()
+
+    monkeypatch.delenv("QWEN_GDN_PATH", raising=False)
+    o_def, fs_def = _run_op(device, tensors, const_tiles, s0)
+    n_default = device.num_program_cache_entries()
+
+    assert n_default - n_explicit == 0, (
+        f"default dispatch (no QWEN_GDN_PATH) compiled {n_default - n_explicit} new programs after "
+        f"an explicit '{expected_path}' run: the default did NOT take the {expected_path} path for "
+        f"BH={BH} (the delta counts the unexpected branch's prim programs: fused or mono = 1, "
+        "phased prep+scan = 2)"
+    )
+    assert torch.equal(o_def, o_exp), f"default dispatch o differs from explicit '{expected_path}' run"
+    assert torch.equal(fs_def, fs_exp), f"default dispatch final_state differs from explicit '{expected_path}' run"
+
+
+def test_fused_vs_torch_golden(device, monkeypatch):
+    """Whole-computation correctness of the fused path against the inlined torch golden. The
+    bit-exact gate above anchors fused==phased; this gate anchors the pair to the math (bf16
+    q/k/v inputs dominate the error; kernel math is fp32/HiFi4 end-to-end). Initial state is
+    exercised here (s0 flows through the receiver's DRAM read — the one input the producer does
+    not ship); the s0=None case is covered bit-exactly vs phased above."""
+    B, num_k_heads, num_v_heads = 1, 8, 24  # BH=24: the smallest default-fused shape; GQA G=3
+    BH = B * num_v_heads
+    _skip_unless_fused_fits(device, BH)
+    _clear_gdn_env(monkeypatch)
+    monkeypatch.setenv("QWEN_GDN_PATH", "fused")
+
+    host, tensors, s0_dev = _make_inputs(device, B, T_SMALL, num_k_heads, num_v_heads, True, seed=20260822)
+    q, k, v, g, beta, s0 = host
+    const_tiles = _const_tiles(device)
+
+    o_d, fs_d = _run_op(device, tensors, const_tiles, s0_dev)
+    o = o_d.float()  # o is [B,T,HV,V]; final_state is [B,HV,K,V] — same shapes the golden returns
+    fs = fs_d.float()
+
+    scale = KDIM**-0.5
+    o_ref, fs_ref = _golden_chunk_gdn(q.float(), k.float(), v.float(), g, beta, scale, s0, CHUNK)
+
+    pcc_o = _pcc(o_ref, o)
+    assert pcc_o >= 0.999, f"o: PCC {pcc_o} < 0.999"
+    # fs gate is 0.999, looser than the phased whole-op test's 0.9999: fused==phased bit-exact is
+    # pinned above, so this gate only anchors the math to torch — the looser bound avoids a flake
+    # on this shape (BH=24, G=3), which the phased golden test does not cover at 0.9999.
+    pcc_fs = _pcc(fs_ref, fs)
+    assert pcc_fs >= 0.999, f"final_state: PCC {pcc_fs} < 0.999"

--- a/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_prims.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_prims.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Part-level tests for the phased GDN prims (F0 test pyramid, tier 2).
+
+ttnn.transformer.chunk_gdn_prep produces the seven per-(head,chunk) fp32 intermediates
+{v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv}; ttnn.transformer.chunk_gdn_scan consumes them
+plus the initial state and carries the recurrence. Each prim is asserted against torch formulas
+inlined from models/experimental/gated_attention_gated_deltanet/torch_functional/
+delta_rule_ops.py:170-238 (tests must not import models/), and the composition prep->scan is
+asserted BIT-IDENTICAL to the public op on the phased path — the seven intermediates are rounded
+at pack time and the DRAM round trip is a byte copy, so any composition difference is a bug in
+the prims' plumbing, not numerical noise.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ttnn
+
+CHUNK = 32  # Ct=1: the production chunk size; the prims' in-kernel WY inverse is exact here
+KDIM = 128
+VDIM = 128
+
+
+def _pcc(golden, actual):
+    g = golden.to(torch.float64).flatten()
+    a = actual.to(torch.float64).flatten()
+    assert torch.isfinite(a).all(), "device output contains non-finite values"
+    if torch.equal(g, a):
+        return 1.0
+    vg = g - g.mean()
+    va = a - a.mean()
+    denom = vg.norm() * va.norm()
+    if denom == 0:
+        return 0.0
+    return float((vg @ va) / denom)
+
+
+def _const_tiles(device, chunk_size=CHUNK):
+    """The op's constant tiles (mirrors chunk_gated_delta_rule.cpp build_const_tiles)."""
+    c = chunk_size
+    eye = torch.eye(c, dtype=torch.float32)
+    tril = torch.tril(torch.ones(c, c, dtype=torch.float32))
+    ones = torch.ones(c, c, dtype=torch.float32)
+    ii = torch.arange(32).unsqueeze(1)
+    jj = torch.arange(32).unsqueeze(0)
+    lo_i, lo_j = ii < 16, jj < 16
+    qtl = (lo_i & lo_j).float()
+    qbr = (~lo_i & ~lo_j).float()
+    qbl = (~lo_i & lo_j).float()
+    masks = torch.cat([qtl, qbr, qbl], dim=1)  # [32, 96]
+
+    def _up(t):
+        return ttnn.from_torch(t.reshape(1, 1, *t.shape), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    return (_up(eye), _up(tril), _up(ones), _up(masks))
+
+
+def _make_inputs(bh, nc, seed, scale):
+    """Head-major prim inputs in the op's numeric regime: q/k L2-normalized over the last dim
+    (unnormalized keys NaN the recurrence on every path), q pre-scaled on host (the prim applies
+    NO scale when qk_norm=False — mirroring the public op, which folds scale into q before prep),
+    beta in (0,1), g <= 0."""
+    torch.manual_seed(seed)
+    q = F.normalize(torch.randn(bh, nc, CHUNK, KDIM), dim=-1)
+    k = F.normalize(torch.randn(bh, nc, CHUNK, KDIM), dim=-1)
+    q = (q * scale).to(torch.bfloat16)
+    k = k.to(torch.bfloat16)
+    v = (0.5 * torch.randn(bh, nc, CHUNK, VDIM)).to(torch.bfloat16)
+    beta = torch.sigmoid(torch.randn(bh, nc, CHUNK))
+    g = -F.softplus(torch.randn(bh, nc, CHUNK)) * 0.5
+    s0 = 0.05 * torch.randn(bh, KDIM, VDIM)
+    return q, k, v, g, beta, s0
+
+
+# ---------------------------------------------------------------------------
+# Inlined torch reference (delta_rule_ops.py:170-205 prep formulas, :216-238 scan loop)
+# ---------------------------------------------------------------------------
+
+
+def _prep_reference(q, k, v, g, beta):
+    """The seven prep outputs, fp32, from head-major per-chunk inputs.
+    q,k,v: [BH,NC,C,D] fp32 (the exact bf16-rounded values fed to the device, q pre-scaled);
+    g,beta: [BH,NC,C] fp32. Mirrors delta_rule_ops.py:170-205 with the phased op's
+    UN-premultiplied WY hand-off: kd/v_beta are NOT multiplied by t_inv (the scan applies t_inv
+    after the v_beta - kd@S subtraction)."""
+    C = q.shape[-2]
+    decay = g.cumsum(-1)  # [BH,NC,C]  (:189)
+    decay_exp = decay.exp().unsqueeze(-1)  # [BH,NC,C,1]  (:190)
+    v_beta = v * beta.unsqueeze(-1)  # :171
+    k_beta = k * beta.unsqueeze(-1)  # :172
+    # :193 — double-tril exp decay mask
+    l_mask = (decay.unsqueeze(-1) - decay.unsqueeze(-2)).tril().exp().tril()
+    # :196-201 — WY inverse via forward substitution
+    mask_upper = torch.triu(torch.ones(C, C, dtype=torch.bool), diagonal=0)
+    attn = -((k_beta @ k.transpose(-1, -2)) * l_mask).masked_fill(mask_upper, 0)
+    for i in range(1, C):
+        attn[..., i, :i] = attn[..., i, :i].clone() + (attn[..., i, :i, None].clone() * attn[..., :i, :i].clone()).sum(
+            -2
+        )
+    t_inv = attn + torch.eye(C, dtype=torch.float32)  # :201
+    kd = k_beta * decay_exp  # :205's operand, un-premultiplied
+    q_decay = q * decay_exp  # :229 (scale already folded into q)
+    mask_causal = torch.triu(torch.ones(C, C, dtype=torch.bool), diagonal=1)
+    intra = (q @ k.transpose(-1, -2) * l_mask).masked_fill(mask_causal, 0)  # :222
+    # :237 — k * exp(decay_last - decay), transposed to [K,C]
+    k_dec_t = (k * (decay[..., -1:] - decay).exp().unsqueeze(-1)).transpose(-1, -2)
+    dl = decay[..., -1].exp().reshape(*decay.shape[:2], 1, 1)  # exp(g_sum): the scan's state decay
+    return v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv
+
+
+def _scan_reference(v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv, s0):
+    """The scan recurrence (delta_rule_ops.py:216-238 semantics in the phased prims'
+    un-premultiplied form): v_new = t_inv @ (v_beta - kd@S) — mathematically identical to
+    u - w@S with u=t_inv@v_beta, w=t_inv@kd."""
+    bh, nc = v_beta.shape[:2]
+    S = s0.clone()
+    o = torch.zeros(bh, nc, CHUNK, v_beta.shape[-1], dtype=torch.float32)
+    for c in range(nc):
+        v_new = t_inv[:, c] @ (v_beta[:, c] - kd[:, c] @ S)
+        o[:, c] = q_decay[:, c] @ S + intra[:, c] @ v_new  # :229-232
+        S = S * dl[:, c] + k_dec_t[:, c] @ v_new  # :235-238
+    return o, S
+
+
+def _dev(device, t, dtype):
+    return ttnn.from_torch(t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+
+def _clean_env(monkeypatch):
+    # Neutralize ambient GDN debug/perf knobs that fork the kernel topology or corrupt outputs.
+    monkeypatch.delenv("QWEN_GDN_SCAN_SERIAL", raising=False)
+    monkeypatch.delenv("QWEN_GDN_PREP_SERIAL", raising=False)
+    # Mcast on/off is documented bit-exact, but pin the shipped default topology anyway.
+    monkeypatch.delenv("QWEN_GDN_SCAN_MCAST", raising=False)
+    # QWEN_GDN_DUMP is read once via a function-local static; delenv helps only if the op has not
+    # run yet in this process — kept for hygiene.
+    monkeypatch.delenv("QWEN_GDN_DUMP", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# (1) prep prim vs torch, each of the seven outputs
+# ---------------------------------------------------------------------------
+
+
+# (16, 8) = 128 (head, chunk) work-items: exercises the multi-core fan-out of distribute_prep
+# (fills a full 8x8+ grid); (4, 4) is the small-shape smoke.
+@pytest.mark.parametrize("bh, nc", [(4, 4), (16, 8)])
+def test_prep_outputs_vs_torch(device, monkeypatch, bh, nc):
+    _clean_env(monkeypatch)
+    scale = KDIM**-0.5
+    q, k, v, g, beta, _ = _make_inputs(bh, nc, seed=20260820, scale=scale)
+
+    outs = ttnn.transformer.chunk_gdn_prep(
+        _dev(device, q, ttnn.bfloat16),
+        _dev(device, k, ttnn.bfloat16),
+        _dev(device, v, ttnn.bfloat16),
+        _dev(device, g.unsqueeze(-1), ttnn.float32),
+        _dev(device, beta.unsqueeze(-1), ttnn.float32),
+        *_const_tiles(device),
+        chunk_size=CHUNK,
+    )
+    refs = _prep_reference(q.float(), k.float(), v.float(), g, beta)
+
+    # Max-abs bounds. Golden is torch fp32 on the IDENTICAL bf16-rounded inputs, so the only
+    # divergence sources are: the SFPU exp (non-approx, ~1e-6 relative vs libm), fp32 matmul
+    # ki-accumulation-order rounding, reduced srcA/srcB precision on fp32 eltwise operands, and
+    # fp32 pack rounding. Bounds are sized to each output's magnitude and op chain:
+    #   v_beta  5e-3: one broadcast mul, |v_beta| <= |v| ~ 3 (0.5*randn tails); no exp involved
+    #   kd      2e-3: |k_beta| <= 1 (normalized k, beta < 1) times decay_exp <= 1 (g <= 0); one exp
+    #   q_decay 1e-3: |q*scale| <= ~0.1 (normalized rows), decay_exp <= 1; exp error dominates
+    #   intra   1e-3: |q@k^T| <= scale (Cauchy-Schwarz on L2-normalized rows), L_mask <= 1;
+    #                 128-term fp32 accumulation + one exp in the mask
+    #   k_dec_t 5e-3: |k| <= 1 elementwise, decay factor exp(<=0) <= 1; one exp
+    #   dl      1e-4: exp(sum g) <= 1; device forms it as exp(gsum-d0)*exp(d0) (two exps + a mul)
+    #                 vs torch's single exp — pure relative error on a value <= 1
+    #   t_inv   2.5e-3: both sides are mathematically exact inverses of the same matrix (device:
+    #                 quadrant-split bounded Horner; golden: forward substitution); the device's
+    #                 exp-derived L_mask feeds the matrix being inverted, so its ~1e-3 input error
+    #                 is amplified through the inverse chain
+    # k_dec_t and t_inv were calibrated on p150b hardware (fw 19.11): measured max-abs 2.2e-3 and
+    # 1.1e-3 across the parametrized shapes; bounds carry ~2x headroom. PCC >= 0.999 remains the
+    # primary gate for every output.
+    names = ["v_beta", "kd", "q_decay", "intra", "k_dec_t", "dl", "t_inv"]
+    bounds = [5e-3, 2e-3, 1e-3, 1e-3, 5e-3, 1e-4, 2.5e-3]
+    assert len(outs) == 7
+    for name, out, ref, bound in zip(names, outs, refs, bounds):
+        got = ttnn.to_torch(out)
+        assert got.shape == ref.shape, f"{name}: shape {got.shape} != {ref.shape}"
+        pcc = _pcc(ref, got)
+        assert pcc >= 0.999, f"{name}: PCC {pcc} < 0.999"
+        max_abs = (got - ref).abs().max().item()
+        assert max_abs <= bound, f"{name}: max-abs {max_abs} > {bound}"
+        ttnn.deallocate(out)
+
+
+# ---------------------------------------------------------------------------
+# (2) scan prim vs torch, with torch-built (exact fp32) intermediates
+# ---------------------------------------------------------------------------
+
+
+def test_scan_vs_torch(device, monkeypatch):
+    _clean_env(monkeypatch)
+    bh, nc = 4, 4
+    q, k, v, g, beta, s0 = _make_inputs(bh, nc, seed=20260821, scale=KDIM**-0.5)
+    seven = _prep_reference(q.float(), k.float(), v.float(), g, beta)
+
+    dev_seven = [_dev(device, t, ttnn.float32) for t in seven]
+    o_d, fs_d = ttnn.transformer.chunk_gdn_scan(
+        *dev_seven,
+        initial_state=_dev(device, s0, ttnn.float32),
+        chunk_size=CHUNK,
+        output_final_state=True,
+    )
+    o = ttnn.to_torch(o_d)
+    fs = ttnn.to_torch(fs_d)
+
+    o_ref, fs_ref = _scan_reference(*seven, s0)
+    # The seven inputs are bit-identical fp32 on both sides, and the scan is pure fp32 HiFi4
+    # matmul/eltwise (no exp, no bf16 rounding) — only accumulation-order rounding differs.
+    pcc_o = _pcc(o_ref, o)
+    assert pcc_o >= 0.9999, f"o: PCC {pcc_o} < 0.9999"
+    pcc_fs = _pcc(fs_ref, fs)
+    assert pcc_fs >= 0.9999, f"final_state: PCC {pcc_fs} < 0.9999"
+
+
+# ---------------------------------------------------------------------------
+# (3) prep prim -> scan prim composition == public phased op, bit-exact
+# ---------------------------------------------------------------------------
+
+
+def test_composition_bit_exact(device, monkeypatch):
+    """prep->scan on head-major inputs must be BYTE-IDENTICAL to the public op on the equivalent
+    token-major inputs: the op's preprocessing is all bit-reproducible data movement (typecasts
+    skipped for already-bf16/fp32 inputs; permute/reshape; pad==0 since T % 32 == 0), except the
+    on-device q*scale multiply — neutralized here by passing scale=1.0, which is a numerical
+    identity in bf16 (x*1.0 repacks to the same bits for the normal values randn+l2norm makes).
+    G=1 (H==HV) so the GQA repeat_interleave is not in the path either."""
+    torch.manual_seed(20260822)
+    B, T, H = 1, 256, 8
+    BH, NC = B * H, T // CHUNK
+    grid = device.compute_with_storage_grid_size()
+    if BH > grid.x * grid.y:
+        pytest.skip(f"BH={BH} exceeds the {grid.x}x{grid.y} compute grid (scan needs a core per head)")
+
+    monkeypatch.setenv("QWEN_GDN_PHASED", "1")
+    _clean_env(monkeypatch)
+
+    # Token-major op inputs (bf16 q/k/v so the op's typecast is a no-op; q/k host-normalized).
+    q = F.normalize(torch.randn(B, T, H, KDIM), dim=-1).to(torch.bfloat16)
+    k = F.normalize(torch.randn(B, T, H, KDIM), dim=-1).to(torch.bfloat16)
+    v = (0.5 * torch.randn(B, T, H, VDIM)).to(torch.bfloat16)
+    beta = torch.sigmoid(torch.randn(B, T, H))
+    g = -F.softplus(torch.randn(B, T, H)) * 0.5
+    s0 = 0.05 * torch.randn(B, H, KDIM, VDIM)
+
+    const_tiles = _const_tiles(device)
+    # output_head_major=True: with pad==0 the op's o is a metadata-only reshape of the scan
+    # prim's [BH,NC,C,V] output — no relayout between the compared tensors.
+    o_op_d, fs_op_d = ttnn.transformer.chunk_gated_delta_rule(
+        _dev(device, q, ttnn.bfloat16),
+        _dev(device, k, ttnn.bfloat16),
+        _dev(device, v, ttnn.bfloat16),
+        _dev(device, g, ttnn.float32),
+        _dev(device, beta, ttnn.float32),
+        scale=1.0,
+        initial_state=_dev(device, s0, ttnn.float32),
+        output_final_state=True,
+        chunk_size=CHUNK,
+        output_head_major=True,
+        eye=const_tiles[0],
+        tril=const_tiles[1],
+        ones=const_tiles[2],
+        masks=const_tiles[3],
+    )
+    o_op = ttnn.to_torch(o_op_d)  # [BH, T, V] fp32
+    fs_op = ttnn.to_torch(fs_op_d)  # [B, H, K, V] fp32
+
+    # Replicate the op's preprocessing in torch (chunk_gated_delta_rule.cpp head_split_tile /
+    # headvec_split_tile / to_chunks_tile): [B,T,H,D] -> [B,H,T,D] -> [BH,NC,C,D]; values are
+    # moved, never re-rounded, so from_torch of these feeds prep bit-identical inputs.
+    def head_major(x):
+        return x.permute(0, 2, 1, 3).reshape(BH, NC, CHUNK, x.shape[-1]).contiguous()
+
+    def headvec_major(x):
+        return x.permute(0, 2, 1).reshape(BH, NC, CHUNK, 1).contiguous()
+
+    prep = ttnn.transformer.chunk_gdn_prep(
+        _dev(device, head_major(q), ttnn.bfloat16),
+        _dev(device, head_major(k), ttnn.bfloat16),
+        _dev(device, head_major(v), ttnn.bfloat16),
+        _dev(device, headvec_major(g), ttnn.float32),
+        _dev(device, headvec_major(beta), ttnn.float32),
+        *const_tiles,
+        chunk_size=CHUNK,
+    )
+    o_pr_d, fs_pr_d = ttnn.transformer.chunk_gdn_scan(
+        *prep,
+        initial_state=_dev(device, s0.reshape(BH, KDIM, VDIM), ttnn.float32),
+        chunk_size=CHUNK,
+        output_final_state=True,
+    )
+    o_pr = ttnn.to_torch(o_pr_d)  # [BH, NC, C, V] fp32
+    fs_pr = ttnn.to_torch(fs_pr_d)  # [BH, K, V] fp32
+
+    # The seven intermediates are rounded at pack time and the DRAM round trip is a byte copy:
+    # composition must match the phased op bit-for-bit, not just numerically.
+    assert torch.equal(o_pr.reshape(BH, T, VDIM), o_op), "prep->scan composition changed o (must be bit-identical)"
+    assert torch.equal(
+        fs_pr, fs_op.reshape(BH, KDIM, VDIM)
+    ), "prep->scan composition changed final_state (must be bit-identical)"

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 #include <map>
 #include <mutex>
 #include <tuple>
@@ -12,6 +13,7 @@
 #include <vector>
 
 #include "device/chunk_gated_delta_rule_device_operation.hpp"
+#include "device/chunk_gdn_fused.hpp"
 #include "device/chunk_gdn_phased.hpp"
 
 #include "ttnn/operations/core/core.hpp"
@@ -272,23 +274,81 @@ std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>> chunk_gated_delta_rule(
         /*default_fp32_acc=*/true,
         /*default_l1_acc=*/false);
 
-    // Phase-split path: prep -> (DRAM hand-off) -> scan. The prep phase does all state-independent
-    // per-chunk work (incl. the WY inverse) fanned across the grid; the scan phase carries the
-    // recurrent state. Same math as the monolithic op. This is the DEFAULT; QWEN_GDN_PHASED=0 falls
-    // back to the single-kernel monolithic op (benchmark/debug only). Read fresh (not static) so a
-    // caller toggling it between calls is honored.
-    const bool phased = [] {
-        const char* e = std::getenv("QWEN_GDN_PHASED");
-        return e == nullptr || e[0] != '0';
+    // Path selection. Three device implementations, same math:
+    //   fused  — ONE program: per head a producer core runs prep and NoC-writes the 7
+    //            intermediates straight into a receiver core's CBs (zero DRAM intermediates).
+    //            Needs 2 cores/head.
+    //   phased — prep -> (7 fp32 DRAM tensors) -> scan, two prims. The bit-exact reference.
+    //   mono   — the original single-kernel op, 1 core/head (benchmark/debug only).
+    // Precedence: QWEN_GDN_PATH=fused|phased|mono if set; else the legacy QWEN_GDN_PHASED
+    // ('0' -> mono, else phased) if set; else DEFAULT phased. The fused path is bit-exact vs
+    // phased and eliminates the seven-tensor DRAM round trip, but at F1 (one producer per head)
+    // it is producer-math-bound at ~34us/chunk: measured 1.11x at BH=48/T=4096 and 0.82x at
+    // BH=48/T=512 — below the ship gate. It stays opt-in until the F2 producer-side work
+    // (input pipelining, init batching, HiFi2/SFPU on the now math-bound producers) clears the
+    // w_p <= ~27us checkpoint; then the default becomes shape-gated fused (BH >= 24 && 2*BH
+    // cores fit). See gdn-fused-handoff-design.md sections 6 and 8.
+    // Envs are read fresh per call — op-level env dispatch is cache-safe (each branch launches a
+    // DIFFERENT prim with its own program-cache hash), unlike an env read inside a factory.
+    enum class GdnPath { Fused, Phased, Mono };
+    const GdnPath path = [&] {
+        if (const char* p = std::getenv("QWEN_GDN_PATH")) {
+            if (std::strcmp(p, "fused") == 0) {
+                return GdnPath::Fused;
+            }
+            if (std::strcmp(p, "phased") == 0) {
+                return GdnPath::Phased;
+            }
+            if (std::strcmp(p, "mono") == 0) {
+                return GdnPath::Mono;
+            }
+            TT_FATAL(false, "QWEN_GDN_PATH must be one of fused|phased|mono (got '{}')", p);
+            return GdnPath::Phased;  // unreachable — TT_FATAL(false, ...) throws
+        }
+        if (const char* e = std::getenv("QWEN_GDN_PHASED")) {
+            return e[0] == '0' ? GdnPath::Mono : GdnPath::Phased;
+        }
+        return GdnPath::Phased;
     }();
 
     ttnn::Tensor o_c;          // [BH, NC, C, V]
     ttnn::Tensor final_state;  // [BH, K, V]
-    TT_FATAL(!flat_v || phased, "OPT-A flat v is only supported on the phased path (set QWEN_GDN_PHASED=1)");
+    // OPT-A/OPT-B are handled by the prep reader/compute, which both the phased and fused paths
+    // run unchanged; only the monolithic kernel lacks them.
+    TT_FATAL(!flat_v || path != GdnPath::Mono, "OPT-A flat v is not supported on the mono path");
     TT_FATAL(!flat_v || pad == 0, "OPT-A flat v requires T ({}) to be a multiple of chunk_size ({})", T, C);
-    TT_FATAL(!flat_qk || (phased && qk_norm), "OPT-A flat q/k needs the phased path + in-kernel norm (Ct==1)");
+    TT_FATAL(
+        !flat_qk || (path != GdnPath::Mono && qk_norm),
+        "OPT-A flat q/k needs the phased or fused path + in-kernel norm (Ct==1)");
     TT_FATAL(!flat_qk || pad == 0, "OPT-A flat q/k requires T ({}) to be a multiple of chunk_size ({})", T, C);
-    if (phased) {
+    if (path == GdnPath::Fused) {
+        // Same preprocessed inputs the phased branch feeds prep (incl. s0, which the host ALWAYS
+        // provides — zeros built above when the caller passed none), same outputs scan produces;
+        // the postprocessing below is shared.
+        auto fused = ttnn::prim::chunk_gdn_fused(
+            q_c,
+            k_c,
+            v_c,
+            g_c,
+            beta_c,
+            eye_c,
+            tril_c,
+            ones_c,
+            masks_c,
+            s0,
+            C,
+            output_final_state,
+            out_mem,
+            kernel_cfg,
+            flat_v,
+            HV,
+            qk_norm,
+            scale,
+            flat_qk,
+            H);
+        o_c = fused[0];
+        final_state = fused[1];
+    } else if (path == GdnPath::Phased) {
         auto prep = ttnn::prim::chunk_gdn_prep(
             q_c,
             k_c,

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
@@ -281,13 +281,12 @@ std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>> chunk_gated_delta_rule(
     //   phased — prep -> (7 fp32 DRAM tensors) -> scan, two prims. The bit-exact reference.
     //   mono   — the original single-kernel op, 1 core/head (benchmark/debug only).
     // Precedence: QWEN_GDN_PATH=fused|phased|mono if set; else the legacy QWEN_GDN_PHASED
-    // ('0' -> mono, else phased) if set; else DEFAULT phased. The fused path is bit-exact vs
-    // phased and eliminates the seven-tensor DRAM round trip, but at F1 (one producer per head)
-    // it is producer-math-bound at ~34us/chunk: measured 1.11x at BH=48/T=4096 and 0.82x at
-    // BH=48/T=512 — below the ship gate. It stays opt-in until the F2 producer-side work
-    // (input pipelining, init batching, HiFi2/SFPU on the now math-bound producers) clears the
-    // w_p <= ~27us checkpoint; then the default becomes shape-gated fused (BH >= 24 && 2*BH
-    // cores fit). See gdn-fused-handoff-design.md sections 6 and 8.
+    // ('0' -> mono, else phased) if set; else DEFAULT fused iff it both pays (BH >= 24 — below
+    // that one producer per head cannot keep up with the phased grid-wide prep fan-out) and fits
+    // (2*BH cores), else phased. The fused path is bit-exact vs phased, eliminates the
+    // seven-tensor DRAM round trip, and after the F2 producer work (input+hand-off double
+    // buffering, reconfig hoisting in the WY hot path) measures w_p = 26.9us/chunk ->
+    // 1.40x at BH=48/T=4096 (3440 vs 4816us), no regression at T=512.
     // Envs are read fresh per call — op-level env dispatch is cache-safe (each branch launches a
     // DIFFERENT prim with its own program-cache hash), unlike an env read inside a factory.
     enum class GdnPath { Fused, Phased, Mono };
@@ -308,7 +307,8 @@ std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>> chunk_gated_delta_rule(
         if (const char* e = std::getenv("QWEN_GDN_PHASED")) {
             return e[0] == '0' ? GdnPath::Mono : GdnPath::Phased;
         }
-        return GdnPath::Phased;
+        const auto grid = dev->compute_with_storage_grid_size();
+        return (BH >= 24 && 2 * BH <= grid.x * grid.y) ? GdnPath::Fused : GdnPath::Phased;
     }();
 
     ttnn::Tensor o_c;          // [BH, NC, C, V]

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule_nanobind.cpp
@@ -3,13 +3,147 @@
 
 #include "chunk_gated_delta_rule_nanobind.hpp"
 #include "chunk_gated_delta_rule.hpp"
+#include "device/chunk_gdn_phased.hpp"
 
 #include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/device.hpp"
 
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 
 namespace ttnn::operations::transformer {
+
+namespace {
+
+// The ONE default-construction site for the GDN compute config, shared by all three bindings
+// (public op + the two phased prims) so the defaults cannot drift. Must stay identical to the
+// default the C++ op builds for C++ callers at chunk_gated_delta_rule.cpp:267-273:
+// HiFi4, fp32 dest acc, no approx, no L1 acc.
+ttnn::DeviceComputeKernelConfig gdn_default_compute_kernel_config(
+    tt::ARCH arch, const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    return ttnn::init_device_compute_kernel_config(
+        arch,
+        compute_kernel_config,
+        tt::tt_metal::MathFidelity::HiFi4,
+        /*default_approx_mode=*/false,
+        /*default_fp32_acc=*/true,
+        /*default_l1_acc=*/false);
+}
+
+// Public-op launcher: pre-resolves the compute config through the shared helper above, then
+// forwards. Behavior-identical to binding the op directly (init_device_compute_kernel_config
+// returns a provided config unchanged, so the op's internal default site is bypassed with the
+// same value it would have built).
+std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>> chunk_gated_delta_rule_launch(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& v,
+    const ttnn::Tensor& g,
+    const ttnn::Tensor& beta,
+    std::optional<float> scale,
+    const std::optional<ttnn::Tensor>& initial_state,
+    bool output_final_state,
+    uint32_t chunk_size,
+    bool use_qk_l2norm,
+    bool output_head_major,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    const std::optional<ttnn::Tensor>& eye,
+    const std::optional<ttnn::Tensor>& tril,
+    const std::optional<ttnn::Tensor>& ones,
+    const std::optional<ttnn::Tensor>& masks) {
+    return ttnn::transformer::chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state,
+        output_final_state,
+        chunk_size,
+        use_qk_l2norm,
+        output_head_major,
+        memory_config,
+        gdn_default_compute_kernel_config(q.device()->arch(), compute_kernel_config),
+        eye,
+        tril,
+        ones,
+        masks);
+}
+
+// Prim launchers: apply the public op's defaults (DRAM interleaved, shared compute config)
+// so a part test that omits the kwargs exercises exactly the configs the op dispatches.
+std::vector<ttnn::Tensor> chunk_gdn_prep_launch(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& v,
+    const ttnn::Tensor& g,
+    const ttnn::Tensor& beta,
+    const ttnn::Tensor& eye,
+    const ttnn::Tensor& tril,
+    const ttnn::Tensor& ones,
+    const ttnn::Tensor& masks,
+    uint32_t chunk_size,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    bool v_flat,
+    uint32_t HV,
+    bool qk_norm,
+    float scale,
+    bool qk_flat,
+    uint32_t Hk) {
+    return ttnn::prim::chunk_gdn_prep(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        eye,
+        tril,
+        ones,
+        masks,
+        chunk_size,
+        memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG),
+        gdn_default_compute_kernel_config(q.device()->arch(), compute_kernel_config),
+        v_flat,
+        HV,
+        qk_norm,
+        scale,
+        qk_flat,
+        Hk);
+}
+
+std::vector<ttnn::Tensor> chunk_gdn_scan_launch(
+    const ttnn::Tensor& v_beta,
+    const ttnn::Tensor& kd,
+    const ttnn::Tensor& q_decay,
+    const ttnn::Tensor& intra,
+    const ttnn::Tensor& k_dec_t,
+    const ttnn::Tensor& dl,
+    const ttnn::Tensor& t_inv,
+    const std::optional<ttnn::Tensor>& initial_state,
+    uint32_t chunk_size,
+    bool output_final_state,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    return ttnn::prim::chunk_gdn_scan(
+        v_beta,
+        kd,
+        q_decay,
+        intra,
+        k_dec_t,
+        dl,
+        t_inv,
+        initial_state,
+        chunk_size,
+        output_final_state,
+        memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG),
+        gdn_default_compute_kernel_config(v_beta.device()->arch(), compute_kernel_config));
+}
+
+}  // namespace
 
 void bind_chunk_gated_delta_rule(nb::module_& mod) {
     const auto* doc =
@@ -51,7 +185,7 @@ void bind_chunk_gated_delta_rule(nb::module_& mod) {
     ttnn::bind_function<"chunk_gated_delta_rule", "ttnn.transformer.">(
         mod,
         doc,
-        &ttnn::transformer::chunk_gated_delta_rule,
+        &chunk_gated_delta_rule_launch,
         nb::arg("q").noconvert(),
         nb::arg("k").noconvert(),
         nb::arg("v").noconvert(),
@@ -70,6 +204,118 @@ void bind_chunk_gated_delta_rule(nb::module_& mod) {
         nb::arg("tril") = nb::none(),
         nb::arg("ones") = nb::none(),
         nb::arg("masks") = nb::none());
+
+    const auto* prep_doc =
+        R"doc(
+        Phased-GDN PREP prim — testing/debug surface for the phased path's first stage
+        (the public op composes prep -> DRAM hand-off -> scan; this exposes prep alone).
+
+        All state-independent per-(head,chunk) work of chunk_gated_delta_rule, fanned across
+        cores. Inputs are HEAD-MAJOR per-chunk tensors [BH, NC, C, *]; exact shapes/dtypes are
+        ChunkGdnPrepInputs, device/chunk_gdn_phased.hpp:53-63.
+
+        Args:
+            q (ttnn.Tensor):     [BH, NC, C, K] bf16
+            k (ttnn.Tensor):     [BH, NC, C, K] bf16
+            v (ttnn.Tensor):     [BH, NC, C, V] bf16 (or FLAT [B, T, HV*V] when v_flat)
+            g (ttnn.Tensor):     [BH, NC, C, 1] fp32 column (log-space decay)
+            beta (ttnn.Tensor):  [BH, NC, C, 1] fp32 column
+            eye (ttnn.Tensor):   [1,1,C,C] fp32 TILE identity
+            tril (ttnn.Tensor):  [1,1,C,C] fp32 TILE lower-triangular ones
+            ones (ttnn.Tensor):  [1,1,C,C] fp32 TILE all-ones
+            masks (ttnn.Tensor): [1,1,32,96] fp32 TILE WY-inverse quadrant masks (Qtl|Qbr|Q10)
+
+        Keyword Args:
+            chunk_size (int): default 32 (C; Ct==1 is the only qk_norm-capable config).
+            memory_config (ttnn.MemoryConfig, optional): default DRAM interleaved (the public
+                op's default).
+            compute_kernel_config (optional): default HiFi4 + fp32 dest acc, no approx — built
+                by the same helper as the public op's default.
+            v_flat (bool) / HV (int): OPT-A flat token-major v, chunk_gdn_phased.hpp:34-40.
+            qk_norm (bool) / scale (float): OPT-B in-kernel q/k L2 norm with scale folded into
+                q's norm, chunk_gdn_phased.hpp:45-48.
+            qk_flat (bool) / Hk (int): OPT-A flat token-major q/k, chunk_gdn_phased.hpp:41-44.
+
+        Returns:
+            list[ttnn.Tensor]: the 7 fp32 per-chunk DRAM intermediates the scan consumes —
+                [v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv]; shapes/dtypes are
+                ChunkGdnScanInputs, device/chunk_gdn_phased.hpp:133-142 (dl is a per-chunk
+                scalar in tile position [0,0]).
+        )doc";
+
+    ttnn::bind_function<"chunk_gdn_prep", "ttnn.transformer.">(
+        mod,
+        prep_doc,
+        &chunk_gdn_prep_launch,
+        nb::arg("q").noconvert(),
+        nb::arg("k").noconvert(),
+        nb::arg("v").noconvert(),
+        nb::arg("g").noconvert(),
+        nb::arg("beta").noconvert(),
+        nb::arg("eye").noconvert(),
+        nb::arg("tril").noconvert(),
+        nb::arg("ones").noconvert(),
+        nb::arg("masks").noconvert(),
+        nb::kw_only(),
+        nb::arg("chunk_size") = 32,
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("v_flat") = false,
+        nb::arg("HV") = 0,
+        nb::arg("qk_norm") = false,
+        nb::arg("scale") = 1.0f,
+        nb::arg("qk_flat") = false,
+        nb::arg("Hk") = 0);
+
+    const auto* scan_doc =
+        R"doc(
+        Phased-GDN SCAN prim — testing/debug surface for the phased path's second stage
+        (sequential over chunks, carrying the recurrent state S [K,V]; parallel over heads).
+
+        Consumes the 7 fp32 HEAD-MAJOR per-chunk intermediates chunk_gdn_prep produced; exact
+        shapes/dtypes are ChunkGdnScanInputs, device/chunk_gdn_phased.hpp:133-142.
+
+        Args:
+            v_beta (ttnn.Tensor):  [BH, NC, C, V] fp32 (= v * beta)
+            kd (ttnn.Tensor):      [BH, NC, C, K] fp32 (= k_beta * decay_exp)
+            q_decay (ttnn.Tensor): [BH, NC, C, K] fp32
+            intra (ttnn.Tensor):   [BH, NC, C, C] fp32
+            k_dec_t (ttnn.Tensor): [BH, NC, K, C] fp32
+            dl (ttnn.Tensor):      [BH, NC, 1, 1] fp32 (per-chunk scalar in tile [0,0])
+            t_inv (ttnn.Tensor):   [BH, NC, C, C] fp32 (WY inverse)
+
+        Keyword Args:
+            initial_state (ttnn.Tensor, optional): [BH, K, V] fp32; absent means zeros.
+            chunk_size (int): default 32 (C).
+            output_final_state (bool): default True; when False the final_state slot's
+                contents are unspecified.
+            memory_config (ttnn.MemoryConfig, optional): default DRAM interleaved (the public
+                op's default).
+            compute_kernel_config (optional): default HiFi4 + fp32 dest acc, no approx — built
+                by the same helper as the public op's default.
+
+        Returns:
+            list[ttnn.Tensor]: [o [BH, NC, C, V] fp32, final_state [BH, K, V] fp32]
+                (o is fp32 — see the factory's compute_output_specs, which is authoritative).
+        )doc";
+
+    ttnn::bind_function<"chunk_gdn_scan", "ttnn.transformer.">(
+        mod,
+        scan_doc,
+        &chunk_gdn_scan_launch,
+        nb::arg("v_beta").noconvert(),
+        nb::arg("kd").noconvert(),
+        nb::arg("q_decay").noconvert(),
+        nb::arg("intra").noconvert(),
+        nb::arg("k_dec_t").noconvert(),
+        nb::arg("dl").noconvert(),
+        nb::arg("t_inv").noconvert(),
+        nb::kw_only(),
+        nb::arg("initial_state") = nb::none(),
+        nb::arg("chunk_size") = 32,
+        nb::arg("output_final_state") = true,
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none());
 }
 
 }  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.cpp
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "chunk_gdn_fused.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+
+namespace {
+// Uniquely named (vs the phased prim's `check`) so it does not clash under unity builds.
+void check_fused(const Tensor& t, const char* name, DataType dt) {
+    TT_FATAL(t.layout() == Layout::TILE, "chunk_gdn_fused: {} must be TILE layout", name);
+    TT_FATAL(t.dtype() == dt, "chunk_gdn_fused: {} has wrong dtype", name);
+    TT_FATAL(t.buffer() != nullptr, "chunk_gdn_fused: {} must be on device", name);
+}
+}  // namespace
+
+ChunkGdnFusedOperation::program_factory_t ChunkGdnFusedOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return ChunkGdnFusedProgramFactory{};
+}
+
+void ChunkGdnFusedOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& in) {
+    using namespace tt::constants;
+    // Input-side checks: identical to the phased PREP prim (the fused producer runs the unchanged
+    // prep reader/compute, so its input contract is prep's).
+    check_fused(in.q, "q", DataType::BFLOAT16);
+    check_fused(in.k, "k", DataType::BFLOAT16);
+    check_fused(in.v, "v", DataType::BFLOAT16);  // flat [B,T,HV*V] when attrs.v_flat; else [BH,NC,C,V]
+    if (attrs.v_flat) {
+        TT_FATAL(attrs.HV > 0, "v_flat requires HV > 0");
+        const auto& vs = in.v.logical_shape();
+        TT_FATAL(vs.rank() == 3, "v_flat expects a flat [B,T,HV*V] v (got rank {})", vs.rank());
+        TT_FATAL(vs[2] == attrs.HV * attrs.val_dim, "v_flat width {} != HV*V ({}*{})", vs[2], attrs.HV, attrs.val_dim);
+    }
+    if (attrs.qk_flat) {
+        TT_FATAL(attrs.Hk > 0, "qk_flat requires Hk > 0");
+        const auto& qsf = in.q.logical_shape();
+        TT_FATAL(qsf.rank() == 3, "qk_flat expects a flat [B,T,Hk*K] q (got rank {})", qsf.rank());
+        TT_FATAL(
+            qsf[2] == attrs.Hk * attrs.key_dim, "qk_flat width {} != Hk*K ({}*{})", qsf[2], attrs.Hk, attrs.key_dim);
+        TT_FATAL(attrs.qk_norm, "qk_flat requires qk_norm (flat q/k are unnormalized; norm is in-kernel)");
+    }
+    check_fused(in.g, "g", DataType::FLOAT32);
+    check_fused(in.beta, "beta", DataType::FLOAT32);
+    check_fused(in.eye_c, "eye_c", DataType::FLOAT32);
+    check_fused(in.tril_c, "tril_c", DataType::FLOAT32);
+    check_fused(in.ones_c, "ones_c", DataType::FLOAT32);
+    check_fused(in.masks_c, "masks_c", DataType::FLOAT32);
+    if (in.initial_state.has_value()) {
+        check_fused(*in.initial_state, "initial_state", DataType::FLOAT32);
+    }
+    TT_FATAL(attrs.chunk_size % TILE_HEIGHT == 0, "chunk_size must be a multiple of 32");
+    TT_FATAL(attrs.key_dim % TILE_WIDTH == 0, "key_dim must be a multiple of 32");
+    TT_FATAL(attrs.val_dim % TILE_WIDTH == 0, "val_dim must be a multiple of 32");
+    // One producer + one receiver core per head (NP=1, NV=1).
+    const auto grid = in.q.device()->compute_with_storage_grid_size();
+    TT_FATAL(
+        2 * attrs.BH <= grid.x * grid.y,
+        "chunk_gdn_fused needs 2*BH ({}) cores, grid has {}x{}={}",
+        2 * attrs.BH,
+        grid.x,
+        grid.y,
+        grid.x * grid.y);
+}
+
+ChunkGdnFusedOperation::spec_return_value_t ChunkGdnFusedOperation::compute_output_specs(
+    const operation_attributes_t& attrs, const tensor_args_t&) {
+    // EXACTLY ChunkGdnScanOperation::compute_output_specs: o and final_state are both fp32 (a bf16
+    // o degraded full-model quality and was removed — see the phased scan op).
+    const auto o_layout = TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), attrs.output_mem_config);
+    const auto s_layout = TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), attrs.output_mem_config);
+    ttnn::Shape o_shape({attrs.BH, attrs.num_chunks, attrs.chunk_size, attrs.val_dim});
+    ttnn::Shape s_shape({attrs.BH, attrs.key_dim, attrs.val_dim});
+    return {tt::tt_metal::TensorSpec(o_shape, o_layout), tt::tt_metal::TensorSpec(s_shape, s_layout)};
+}
+
+ChunkGdnFusedOperation::tensor_return_value_t ChunkGdnFusedOperation::create_output_tensors(
+    const operation_attributes_t& attrs, const tensor_args_t& in) {
+    auto specs = compute_output_specs(attrs, in);
+    auto* device = in.q.device();
+    std::vector<Tensor> outs;
+    outs.reserve(specs.size());
+    for (const auto& spec : specs) {
+        outs.push_back(create_device_tensor(spec, device));
+    }
+    return outs;
+}
+
+std::vector<Tensor> chunk_gdn_fused(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& g,
+    const Tensor& beta,
+    const Tensor& eye_c,
+    const Tensor& tril_c,
+    const Tensor& ones_c,
+    const Tensor& masks_c,
+    const std::optional<Tensor>& initial_state,
+    uint32_t chunk_size,
+    bool output_final_state,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    bool v_flat,
+    uint32_t HV,
+    bool qk_norm,
+    float scale,
+    bool qk_flat,
+    uint32_t Hk) {
+    const auto& q_shape = q.logical_shape();  // [BH,NC,C,K] head-major, or flat [B,T,Hk*K] when qk_flat
+    const auto& v_shape = v.logical_shape();  // [BH,NC,C,V] head-major, or flat [B,T,HV*V] when v_flat
+    // Dim derivation identical to chunk_gdn_prep (the fused op consumes prep's inputs).
+    const uint32_t BH = qk_flat ? (q_shape[0] * HV) : q_shape[0];
+    const uint32_t num_chunks = qk_flat ? (q_shape[1] / chunk_size) : q_shape[1];
+    const uint32_t key_dim = qk_flat ? (q_shape[2] / Hk) : q_shape[3];
+    const uint32_t val_dim = v_flat ? (v_shape[2] / HV) : v_shape[3];
+    auto attrs = ChunkGdnFusedOperation::operation_attributes_t{
+        .BH = BH,
+        .num_chunks = num_chunks,
+        .chunk_size = chunk_size,
+        .key_dim = key_dim,
+        .val_dim = val_dim,
+        .v_flat = v_flat,
+        .HV = HV,
+        .qk_flat = qk_flat,
+        .Hk = Hk,
+        .qk_norm = qk_norm,
+        .scale = scale,
+        .has_initial_state = initial_state.has_value(),
+        .output_final_state = output_final_state,
+        .output_mem_config = output_mem_config,
+        .compute_kernel_config = compute_kernel_config,
+    };
+    auto tensor_args = ChunkGdnFusedOperation::tensor_args_t{
+        .q = q,
+        .k = k,
+        .v = v,
+        .g = g,
+        .beta = beta,
+        .eye_c = eye_c,
+        .tril_c = tril_c,
+        .ones_c = ones_c,
+        .masks_c = masks_c,
+        .initial_state = initial_state};
+    return ttnn::device_operation::launch<ChunkGdnFusedOperation>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.hpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused prep→scan chunked Gated Delta Rule (ONE prim, ONE program, zero DRAM intermediates):
+// per head, a dedicated PRODUCER core runs the unchanged prep reader+compute and a writer that
+// NoC-writes the 7 computed intermediates (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv)
+// straight into its paired RECEIVER core's CBs via the shipped ready/valid handshake; the
+// receiver runs the unchanged scan compute+writer. NP=1 producer and NV=1 (full V) per head.
+// Takes prep's inputs, returns scan's outputs — the seven fp32 DRAM tensors of the phased
+// hand-off simply never exist. The phased prims (chunk_gdn_phased.hpp) stay in-tree as the
+// bit-exact reference: the DRAM round trip they perform is a byte copy, so fused == phased
+// bit-for-bit as long as the shared math bodies and CB pack boundaries are untouched.
+
+#pragma once
+
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::prim {
+
+// Union of the prep and scan params (see chunk_gdn_phased.hpp for per-field semantics of the
+// prep-side v_flat/HV/qk_flat/Hk/qk_norm/scale block and the scan-side state flags).
+struct ChunkGdnFusedParams {
+    uint32_t BH;
+    uint32_t num_chunks;
+    uint32_t chunk_size;
+    uint32_t key_dim;
+    uint32_t val_dim;
+    bool v_flat = false;
+    uint32_t HV = 0;
+    bool qk_flat = false;
+    uint32_t Hk = 0;
+    bool qk_norm = false;
+    float scale = 1.0f;
+    bool has_initial_state = false;
+    bool output_final_state = false;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    DeviceComputeKernelConfig compute_kernel_config;
+};
+
+struct ChunkGdnFusedInputs {
+    Tensor q;                             // [BH, NC, C, K] bf16 (or FLAT [B, T, Hk*K] bf16 when params.qk_flat)
+    Tensor k;                             // [BH, NC, C, K] bf16 (or FLAT, as q)
+    Tensor v;                             // [BH, NC, C, V] bf16 (or FLAT [B, T, HV*V] bf16 when params.v_flat)
+    Tensor g;                             // [BH, NC, C, 1] fp32 (column)
+    Tensor beta;                          // [BH, NC, C, 1] fp32 (column)
+    Tensor eye_c;                         // [1,1,C,C] fp32
+    Tensor tril_c;                        // [1,1,C,C] fp32
+    Tensor ones_c;                        // [1,1,C,C] fp32
+    Tensor masks_c;                       // [1,1,32,96] fp32 — three 32x32 WY-inverse quadrant masks (Qtl|Qbr|Q10)
+    std::optional<Tensor> initial_state;  // [BH, K, V] fp32 or absent (zeros)
+};
+
+struct ChunkGdnFusedProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ChunkGdnFusedParams&, const ChunkGdnFusedInputs&, std::vector<Tensor>&);
+};
+
+struct ChunkGdnFusedOperation {
+    using operation_attributes_t = ChunkGdnFusedParams;
+    using tensor_args_t = ChunkGdnFusedInputs;
+    using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+    using program_factory_t = std::variant<ChunkGdnFusedProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+// Returns {o [BH,NC,C,V] fp32, final_state [BH,K,V] fp32} — exactly the scan prim's output specs.
+// Needs 2*BH cores (one producer + one receiver per head); validate FATALs otherwise, so the
+// op-level dispatch must gate on grid size before choosing this path.
+std::vector<Tensor> chunk_gdn_fused(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& g,
+    const Tensor& beta,
+    const Tensor& eye_c,
+    const Tensor& tril_c,
+    const Tensor& ones_c,
+    const Tensor& masks_c,
+    const std::optional<Tensor>& initial_state,
+    uint32_t chunk_size,
+    bool output_final_state,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    bool v_flat = false,
+    uint32_t HV = 0,
+    bool qk_norm = false,
+    float scale = 1.0f,
+    bool qk_flat = false,
+    uint32_t Hk = 0);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
@@ -142,27 +142,34 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     };
 
     // (1) The 7 hand-off CBs FIRST, on the UNION core set: declared first => same base address on
-    // producer and receiver (the lockstep lemma's precondition). nbuf=1, fp32, in the receiver's
-    // reserve order (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv).
-    add_cb(union_set, fcb::vbeta, cv);
-    add_cb(union_set, fcb::kd, ck);
-    add_cb(union_set, fcb::qdecay, ck);
-    add_cb(union_set, fcb::intra, cc);
-    add_cb(union_set, fcb::kdec_t, kc);
+    // producer and receiver (the lockstep lemma's precondition). fp32, in the receiver's reserve
+    // order (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv). Double-buffered (F2): the producer
+    // runs one chunk ahead of the receiver's consumption instead of alternating with it; the
+    // lockstep addressing survives any equal nbuf on both sides (equal per-chunk push/pop cadence
+    // keeps the pointers in phase, and the writer sources read_ptr, which names the correct slot).
+    add_cb(union_set, fcb::vbeta, cv, 2);
+    add_cb(union_set, fcb::kd, ck, 2);
+    add_cb(union_set, fcb::qdecay, ck, 2);
+    add_cb(union_set, fcb::intra, cc, 2);
+    add_cb(union_set, fcb::kdec_t, kc, 2);
     // dl is 1 tile. (The phased prep factory sized this index cv as cb_vnew for monolithic layout
     // parity, but the prep kernel only ever uses 1 tile of it, as cb_dl.)
-    add_cb(union_set, fcb::dl, 1);
-    add_cb(union_set, fcb::Tinv, cc);
+    add_cb(union_set, fcb::dl, 1, 2);
+    add_cb(union_set, fcb::Tinv, cc, 2);
 
     // (2) The remaining 25 prep CBs on the PRODUCER cores only — same sizes/formats as the phased
     // prep factory (which mirrors the monolithic op's layout). The absolute L1 layout necessarily
     // shifts (the hand-off CBs above allocate first), which prior measurement showed to be
     // perf-neutral for prep; the math is layout-independent.
-    add_cb(prod_set, fcb::q, ck, 1, df_qkv);
-    add_cb(prod_set, fcb::k, ck, 1, df_qkv);
-    add_cb(prod_set, fcb::v, cv, 1, df_qkv);
-    add_cb(prod_set, fcb::g, Ct);
-    add_cb(prod_set, fcb::beta, Ct);
+    // Producer input CBs are double-buffered (F2): the producer has no DRAM writes, so its reader
+    // prefetching item i+1's ~32KB while compute works item i directly shortens the per-chunk
+    // critical path. (The phased prep keeps nbuf=1 — there this prefetch measured harmful in the
+    // write-bound regime; here the producer is math/latency-bound.) +32KB L1 on producer cores.
+    add_cb(prod_set, fcb::q, ck, 2, df_qkv);
+    add_cb(prod_set, fcb::k, ck, 2, df_qkv);
+    add_cb(prod_set, fcb::v, cv, 2, df_qkv);
+    add_cb(prod_set, fcb::g, Ct, 2);
+    add_cb(prod_set, fcb::beta, Ct, 2);
     add_cb(prod_set, fcb::eye, cc);
     add_cb(prod_set, fcb::tril, cc);
     add_cb(prod_set, fcb::ones, cc);
@@ -273,6 +280,8 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     prep_compute.core_ranges = prod_set;
     prep_compute.compile_time_args = prep_compute_ct;
     prep_compute.config = fused_compute_cfg();
+    // Fused-only perf: hoisted WY-path reconfigs (see chunk_gdn_math.hpp kGdnHoistReconfig).
+    prep_compute.defines = {{"GDN_HOIST_RECONFIG", "1"}};
     prep_compute.runtime_args.reserve(BH);
 
     KernelDescriptor fused_writer;

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
@@ -1,0 +1,370 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Program factory for the fused prep→scan chunk_gdn op: ONE program, two disjoint core sets.
+// Per head h, PRODUCER core h runs {unchanged prep reader, unchanged prep compute, NEW fused
+// writer} and RECEIVER core h runs {NEW fused-receiver reader variant, unchanged scan compute,
+// unchanged scan writer}. The producer's writer NoC-writes the 7 computed intermediates
+// (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv) directly into the receiver's CBs via the
+// shipped ready/valid handshake — zero DRAM intermediates. NP=1 producer/head, NV=1 (full V)
+// per receiver.
+//
+// v_beta note (F1 deviates from the design plan's F1 line): the plan recommends Option R
+// (scan-side recompute of v_beta from a DRAM v-slice + mcast beta). F1 ships Option U instead —
+// the producer computes v_beta as today and SENDS it like the other six tensors — because it
+// keeps both compute kernels byte-identical to the phased path (the bit-exactness gate needs
+// that). Option R is deferred to F2.
+//
+// Hand-off CB addressing (the lockstep lemma, shipped in the scan-mcast PR): the 7 hand-off CBs
+// are declared FIRST, on the UNION of producer+receiver cores, so they get identical base
+// addresses on both sides. With nbuf=1 and an equal per-chunk push/pop cadence on both sides,
+// the producer's read pointer always equals the receiver's reserved slot (== base), so the
+// producer's NoC write lands exactly where the receiver reserved. After the F1 scan-side CB
+// renumber (scan v_beta 17->14, dl 11->22, v_new 22->11) the seven hand-off indices coincide
+// with prep's output indices, so the same physical CB is prep's output AND scan's input:
+//   v_beta=14  kd=18  q_decay=19  intra=20  k_dec_t=24  dl=22  t_inv=13
+
+#include "chunk_gdn_fused.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::prim {
+
+// CB index plan — kept in sync with the prep/scan compute + dataflow kernels (post-renumber).
+// Uniquely named (fcb) so it does not ODR-clash with the phased factory's pcb:: under unity builds.
+namespace fcb {
+// The 7 hand-off CBs: prep OUTPUT index == scan INPUT index (that identity is the whole design).
+constexpr uint32_t Tinv = tt::CBIndex::c_13;    // t_inv
+constexpr uint32_t vbeta = tt::CBIndex::c_14;   // v_beta
+constexpr uint32_t kd = tt::CBIndex::c_18;      // kd (prep's cb_w)
+constexpr uint32_t qdecay = tt::CBIndex::c_19;  // q_decay
+constexpr uint32_t intra = tt::CBIndex::c_20;   // intra
+constexpr uint32_t dl = tt::CBIndex::c_22;      // dl (1 tile; prep aliases its cb_vnew slot)
+constexpr uint32_t kdec_t = tt::CBIndex::c_24;  // k_dec_t
+// Producer-only (prep) CBs — same indices/sizes/formats as the phased prep factory.
+constexpr uint32_t q = tt::CBIndex::c_0;
+constexpr uint32_t k = tt::CBIndex::c_1;
+constexpr uint32_t v = tt::CBIndex::c_2;
+constexpr uint32_t g = tt::CBIndex::c_3;
+constexpr uint32_t beta = tt::CBIndex::c_4;
+constexpr uint32_t eye = tt::CBIndex::c_5;
+constexpr uint32_t tril = tt::CBIndex::c_6;
+constexpr uint32_t ones = tt::CBIndex::c_7;
+constexpr uint32_t decay = tt::CBIndex::c_9;
+constexpr uint32_t decay_exp = tt::CBIndex::c_10;
+constexpr uint32_t decayfac = tt::CBIndex::c_11;
+constexpr uint32_t lmask = tt::CBIndex::c_12;
+constexpr uint32_t kbeta = tt::CBIndex::c_15;
+constexpr uint32_t u = tt::CBIndex::c_17;
+constexpr uint32_t scr2 = tt::CBIndex::c_29;
+constexpr uint32_t scr3 = tt::CBIndex::c_30;
+// Shared-index CBs (producer and receiver both declare them, on their own disjoint core sets;
+// sizes may differ per side). Post-renumber scan indices: vnew moved 22 -> 11.
+constexpr uint32_t S = tt::CBIndex::c_8;
+constexpr uint32_t vnew = tt::CBIndex::c_11;  // scan-only (receiver); producer's c_11 is decayfac
+constexpr uint32_t out = tt::CBIndex::c_16;
+constexpr uint32_t s2 = tt::CBIndex::c_21;
+constexpr uint32_t ointer = tt::CBIndex::c_23;
+constexpr uint32_t supd = tt::CBIndex::c_25;
+constexpr uint32_t stmp = tt::CBIndex::c_26;
+constexpr uint32_t final_s = tt::CBIndex::c_27;
+constexpr uint32_t scr1 = tt::CBIndex::c_28;
+constexpr uint32_t s3 = tt::CBIndex::c_31;
+}  // namespace fcb
+
+namespace {
+ComputeConfigDescriptor fused_compute_cfg() {
+    return ComputeConfigDescriptor{
+        .math_fidelity = MathFidelity::HiFi4, .fp32_dest_acc_en = true, .math_approx_mode = false};
+}
+}  // namespace
+
+tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
+    const ChunkGdnFusedParams& attrs, const ChunkGdnFusedInputs& in, std::vector<Tensor>& outputs) {
+    const uint32_t BH = attrs.BH;
+    const uint32_t NC = attrs.num_chunks;
+    const uint32_t Ct = attrs.chunk_size / TILE_HEIGHT;
+    const uint32_t Kt = attrs.key_dim / TILE_WIDTH;
+    const uint32_t Vt = attrs.val_dim / TILE_WIDTH;  // NV=1: per-core Vt == Vt_full everywhere
+    const uint32_t has_s0 = attrs.has_initial_state ? 1u : 0u;
+
+    const uint32_t cc = Ct * Ct, ck = Ct * Kt, cv = Ct * Vt, kv = Kt * Vt, kc = Kt * Ct;
+    const uint32_t scr = std::max({cc, ck, cv, kv, kc});
+
+    const tt::DataFormat df_qkv = tt::DataFormat::Float16_b;  // bf16 q/k/v (prep inputs)
+
+    auto* device = in.q.device();
+    const CoreCoord grid = device->compute_with_storage_grid_size();
+    TT_FATAL(
+        2 * BH <= grid.x * grid.y, "chunk_gdn_fused: 2*BH ({}) cores needed, grid has {}", 2 * BH, grid.x * grid.y);
+
+    // Placement: receivers occupy row-major grid slots 0..BH-1, producers slots BH..2BH-1;
+    // producer i pairs with receiver i (head h == i).
+    auto slot_core = [&](uint32_t slot) { return CoreCoord{slot % grid.x, slot / grid.x}; };
+    std::vector<CoreCoord> rcv_cores(BH), prod_cores(BH);
+    std::set<CoreRange> rcv_crs, prod_crs, union_crs;
+    for (uint32_t i = 0; i < BH; i++) {
+        rcv_cores[i] = slot_core(i);
+        prod_cores[i] = slot_core(BH + i);
+        rcv_crs.insert(CoreRange{rcv_cores[i], rcv_cores[i]});
+        prod_crs.insert(CoreRange{prod_cores[i], prod_cores[i]});
+        union_crs.insert(CoreRange{rcv_cores[i], rcv_cores[i]});
+        union_crs.insert(CoreRange{prod_cores[i], prod_cores[i]});
+    }
+    const CoreRangeSet rcv_set{rcv_crs};
+    const CoreRangeSet prod_set{prod_crs};
+    const CoreRangeSet union_set{union_crs};
+
+    ProgramDescriptor desc;
+    auto add_cb = [&](const CoreRangeSet& on,
+                      uint32_t idx,
+                      uint32_t n_tiles,
+                      uint32_t nbuf = 1,
+                      tt::DataFormat fmt = tt::DataFormat::Float32) {
+        const uint32_t ts = tt::tile_size(fmt);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = n_tiles * nbuf * ts,
+            .core_ranges = on,
+            .format_descriptors = {
+                {CBFormatDescriptor{.buffer_index = static_cast<uint8_t>(idx), .data_format = fmt, .page_size = ts}}}});
+    };
+
+    // (1) The 7 hand-off CBs FIRST, on the UNION core set: declared first => same base address on
+    // producer and receiver (the lockstep lemma's precondition). nbuf=1, fp32, in the receiver's
+    // reserve order (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv).
+    add_cb(union_set, fcb::vbeta, cv);
+    add_cb(union_set, fcb::kd, ck);
+    add_cb(union_set, fcb::qdecay, ck);
+    add_cb(union_set, fcb::intra, cc);
+    add_cb(union_set, fcb::kdec_t, kc);
+    // dl is 1 tile. (The phased prep factory sized this index cv as cb_vnew for monolithic layout
+    // parity, but the prep kernel only ever uses 1 tile of it, as cb_dl.)
+    add_cb(union_set, fcb::dl, 1);
+    add_cb(union_set, fcb::Tinv, cc);
+
+    // (2) The remaining 25 prep CBs on the PRODUCER cores only — same sizes/formats as the phased
+    // prep factory (which mirrors the monolithic op's layout). The absolute L1 layout necessarily
+    // shifts (the hand-off CBs above allocate first), which prior measurement showed to be
+    // perf-neutral for prep; the math is layout-independent.
+    add_cb(prod_set, fcb::q, ck, 1, df_qkv);
+    add_cb(prod_set, fcb::k, ck, 1, df_qkv);
+    add_cb(prod_set, fcb::v, cv, 1, df_qkv);
+    add_cb(prod_set, fcb::g, Ct);
+    add_cb(prod_set, fcb::beta, Ct);
+    add_cb(prod_set, fcb::eye, cc);
+    add_cb(prod_set, fcb::tril, cc);
+    add_cb(prod_set, fcb::ones, cc);
+    add_cb(prod_set, fcb::S, kv, 2);
+    add_cb(prod_set, fcb::decay, Ct);
+    add_cb(prod_set, fcb::decay_exp, Ct);
+    add_cb(prod_set, fcb::decayfac, Ct);
+    add_cb(prod_set, fcb::lmask, cc);
+    add_cb(prod_set, fcb::kbeta, ck);
+    add_cb(prod_set, fcb::out, cv, 2, df_qkv);
+    add_cb(prod_set, fcb::u, cv);
+    add_cb(prod_set, fcb::s2, kv, 2);
+    add_cb(prod_set, fcb::ointer, cv);
+    add_cb(prod_set, fcb::supd, kv);
+    add_cb(prod_set, fcb::stmp, kv);
+    add_cb(prod_set, fcb::final_s, kv);
+    add_cb(prod_set, fcb::scr1, scr);
+    add_cb(prod_set, fcb::scr2, scr);
+    add_cb(prod_set, fcb::scr3, scr);
+    add_cb(prod_set, fcb::s3, kv, 2);
+
+    // (3) The remaining 10 scan CBs on the RECEIVER cores only, with Vtl = Vt_full (NV=1) and the
+    // post-renumber indices (vnew = 11). o is fp32 (see compute_output_specs).
+    add_cb(rcv_set, fcb::S, kv);
+    add_cb(rcv_set, fcb::vnew, cv);
+    add_cb(rcv_set, fcb::out, cv, 2, tt::DataFormat::Float32);
+    add_cb(rcv_set, fcb::s2, kv);
+    add_cb(rcv_set, fcb::ointer, cv);
+    add_cb(rcv_set, fcb::supd, kv);
+    add_cb(rcv_set, fcb::stmp, kv);
+    add_cb(rcv_set, fcb::final_s, kv);
+    add_cb(rcv_set, fcb::scr1, scr);
+    add_cb(rcv_set, fcb::s3, kv);
+
+    // Handshake semaphores, declared on the UNION so each id resolves to the same L1 address on
+    // producer and receiver (the producer multicasts the VALID flag into the receiver's copy;
+    // the receiver atomically incs the producer's ready copy). Ids reach both kernels as trailing
+    // compile-time args — no kernel-side mirror constants to keep in sync.
+    //   id 0 = ready (receiver -> producer: "my hand-off CB slots for this chunk are reserved")
+    //   id 1 = valid (producer -> receiver: "this chunk's 7 tensors are in your CBs")
+    constexpr uint32_t sem_ready_id = 0;
+    constexpr uint32_t sem_valid_id = 1;
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = sem_ready_id, .core_type = tt::CoreType::WORKER, .core_ranges = union_set, .initial_value = 0});
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = sem_valid_id, .core_type = tt::CoreType::WORKER, .core_ranges = union_set, .initial_value = 0});
+
+    const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/";
+
+    // ---- Producer-side CT args: byte-identical to the phased PREP factory's ----
+    const std::vector<uint32_t> ct_prep = {Ct, Kt, Vt};
+
+    std::vector<uint32_t> prep_reader_ct = ct_prep;
+    TensorAccessorArgs(*in.q.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.k.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.v.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.g.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.beta.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.eye_c.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.tril_c.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.ones_c.buffer()).append_to(prep_reader_ct);
+    TensorAccessorArgs(*in.masks_c.buffer()).append_to(prep_reader_ct);
+    // OPT-A: trailing compile args after all TensorAccessorArgs — 1 => read that tensor flat token-major.
+    prep_reader_ct.push_back(attrs.v_flat ? 1u : 0u);
+    prep_reader_ct.push_back(attrs.qk_flat ? 1u : 0u);
+
+    auto f32_bits = [](float f) {
+        uint32_t u;
+        std::memcpy(&u, &f, sizeof(u));
+        return u;
+    };
+    std::vector<uint32_t> prep_compute_ct = ct_prep;
+    prep_compute_ct.push_back(attrs.qk_norm ? 1u : 0u);
+    prep_compute_ct.push_back(f32_bits(attrs.scale));
+    prep_compute_ct.push_back(f32_bits(1e-6f));
+
+    // Fused writer: 5 plain scalars, no accessors (it writes no DRAM at all).
+    const std::vector<uint32_t> fused_writer_ct = {Ct, Kt, Vt, sem_ready_id, sem_valid_id};
+
+    // ---- Receiver-side CT args: the phased SCAN layout with per-core Vt == Vt_full ----
+    const std::vector<uint32_t> ct_scan = {Ct, Kt, Vt, has_s0, Vt};
+
+    // Fused-receiver reader: s0 is its ONLY DRAM tensor (chain of one accessor, starting at CT
+    // index 5), then the semaphore ids at s0_a.next_compile_time_args_offset() and +1 — the same
+    // trailing-args idiom the mcast scan reader variants use.
+    std::vector<uint32_t> receiver_ct = ct_scan;
+    TensorAccessorArgs(in.initial_state.has_value() ? in.initial_state->buffer() : nullptr).append_to(receiver_ct);
+    receiver_ct.push_back(sem_ready_id);
+    receiver_ct.push_back(sem_valid_id);
+
+    std::vector<uint32_t> scan_writer_ct = ct_scan;
+    TensorAccessorArgs(*outputs[0].buffer()).append_to(scan_writer_ct);
+    TensorAccessorArgs(*outputs[1].buffer()).append_to(scan_writer_ct);
+
+    // ---- Kernels. Push order FIXED (part of the program-cache identity):
+    // prep_reader, prep_compute, fused_writer, fused_receiver_reader, scan_compute, scan_writer.
+    KernelDescriptor prep_reader;
+    prep_reader.kernel_source = kdir + "dataflow/reader_chunk_gdn_prep.cpp";
+    prep_reader.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    prep_reader.core_ranges = prod_set;
+    prep_reader.compile_time_args = prep_reader_ct;
+    prep_reader.config = ReaderConfigDescriptor{};
+    prep_reader.runtime_args.reserve(BH);
+
+    KernelDescriptor prep_compute;
+    prep_compute.kernel_source = kdir + "compute/chunk_gdn_prep.cpp";
+    prep_compute.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    prep_compute.core_ranges = prod_set;
+    prep_compute.compile_time_args = prep_compute_ct;
+    prep_compute.config = fused_compute_cfg();
+    prep_compute.runtime_args.reserve(BH);
+
+    KernelDescriptor fused_writer;
+    fused_writer.kernel_source = kdir + "dataflow/writer_chunk_gdn_fused.cpp";
+    fused_writer.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    fused_writer.core_ranges = prod_set;
+    fused_writer.compile_time_args = fused_writer_ct;
+    fused_writer.config = WriterConfigDescriptor{};
+    fused_writer.runtime_args.reserve(BH);
+
+    KernelDescriptor receiver_reader;
+    receiver_reader.kernel_source = kdir + "dataflow/reader_chunk_gdn_scan.cpp";
+    receiver_reader.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    receiver_reader.core_ranges = rcv_set;
+    receiver_reader.compile_time_args = receiver_ct;
+    receiver_reader.defines = {{"GDN_FUSED_RECEIVER", "1"}};
+    receiver_reader.config = ReaderConfigDescriptor{};
+    receiver_reader.runtime_args.reserve(BH);
+
+    KernelDescriptor scan_compute;
+    scan_compute.kernel_source = kdir + "compute/chunk_gdn_scan.cpp";
+    scan_compute.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    scan_compute.core_ranges = rcv_set;
+    scan_compute.compile_time_args = ct_scan;
+    scan_compute.config = fused_compute_cfg();
+    scan_compute.runtime_args.reserve(BH);
+
+    KernelDescriptor scan_writer;
+    scan_writer.kernel_source = kdir + "dataflow/writer_chunk_gdn_scan.cpp";
+    scan_writer.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    scan_writer.core_ranges = rcv_set;
+    scan_writer.compile_time_args = scan_writer_ct;
+    scan_writer.config = WriterConfigDescriptor{};
+    scan_writer.runtime_args.reserve(BH);
+
+    auto* q_buf = in.q.buffer();
+    auto* k_buf = in.k.buffer();
+    auto* v_buf = in.v.buffer();
+    auto* g_buf = in.g.buffer();
+    auto* beta_buf = in.beta.buffer();
+    auto* eye_buf = in.eye_c.buffer();
+    auto* tril_buf = in.tril_c.buffer();
+    auto* ones_buf = in.ones_c.buffer();
+    auto* masks_buf = in.masks_c.buffer();
+    auto* s0_buf = in.initial_state.has_value() ? in.initial_state->buffer() : nullptr;
+    auto* o_buf = outputs[0].buffer();
+    auto* fs_buf = outputs[1].buffer();
+
+    for (uint32_t h = 0; h < BH; h++) {
+        const CoreCoord& pc = prod_cores[h];
+        const CoreCoord& rc = rcv_cores[h];
+        // Virtual worker coords for the cross-core NoC transactions. Each side targets a 1x1
+        // rectangle (its single peer), which is orientation-neutral — no NOC_0/NOC_1 coordinate
+        // swap is needed on either kernel regardless of which NoC the risc runs on.
+        const CoreCoord pv = device->worker_core_from_logical_core(pc);
+        const CoreCoord rv = device->worker_core_from_logical_core(rc);
+
+        // Producer: the phased prep RT layout with a per-head contiguous work slice — head h's NC
+        // chunks are the flat work-items [h*NC, h*NC+NC) (wi = h*NC + c), read/computed in order.
+        prep_reader.emplace_runtime_args(
+            pc,
+            {h * NC,
+             NC,
+             q_buf,
+             k_buf,
+             v_buf,
+             g_buf,
+             beta_buf,
+             eye_buf,
+             tril_buf,
+             ones_buf,
+             masks_buf,
+             NC,
+             attrs.HV,
+             attrs.Hk});
+        prep_compute.emplace_runtime_args(pc, {NC});
+        fused_writer.emplace_runtime_args(pc, {NC, static_cast<uint32_t>(rv.x), static_cast<uint32_t>(rv.y)});
+
+        // Receiver: head h, vb=0 (full V), s0 from DRAM; everything else arrives over the NoC.
+        receiver_reader.emplace_runtime_args(
+            rc, {h, 0u, NC, s0_buf, static_cast<uint32_t>(pv.x), static_cast<uint32_t>(pv.y)});
+        scan_compute.emplace_runtime_args(rc, {NC});
+        scan_writer.emplace_runtime_args(rc, {h, 0u, NC, o_buf, fs_buf});
+    }
+
+    desc.kernels.push_back(std::move(prep_reader));
+    desc.kernels.push_back(std::move(prep_compute));
+    desc.kernels.push_back(std::move(fused_writer));
+    desc.kernels.push_back(std::move(receiver_reader));
+    desc.kernels.push_back(std::move(scan_compute));
+    desc.kernels.push_back(std::move(scan_writer));
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased.hpp
@@ -159,7 +159,9 @@ struct ChunkGdnScanOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
-// Returns {o [BH,NC,C,V] bf16, final_state [BH,K,V] fp32}.
+// Returns {o [BH,NC,C,V] fp32, final_state [BH,K,V] fp32}. o is fp32 — see the scan factory's
+// df_io and ChunkGdnScanOperation::compute_output_specs (a bf16 o degraded full-model quality
+// and was removed).
 std::vector<Tensor> chunk_gdn_scan(
     const Tensor& v_beta,
     const Tensor& kd,

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
@@ -417,6 +417,11 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
     // with; NV == 1 keeps the plain reader on every core (today's behavior, bit-exact either way).
     const bool do_mcast = attrs.use_mcast && sdist.NV > 1;
 
+    // Handshake semaphore ids. Passed to the reader as its two trailing compile-time args (below),
+    // so the kernel-side constants can never drift from the SemaphoreDescriptor ids here.
+    constexpr uint32_t sem_ready_id = 0;
+    constexpr uint32_t sem_valid_id = 1;
+
     const uint32_t nbuf_in = (do_mcast && sdist.NV >= 4) ? 2u : 1u;
     add_cb(pcb::u, cv, nbuf_in);  // v_beta
     add_cb(pcb::w, ck, nbuf_in);  // kd
@@ -455,12 +460,12 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
         // AFTER its write barrier, since its copy is the async mcast payload source). Replay
         // safety does not hinge on the end state: receivers reset valid before every ready inc,
         // and dispatch re-initializes semaphore values on every enqueue.
-        // Ids are mirrored as SEM_READY/SEM_VALID constants in reader_chunk_gdn_scan.cpp — keep
-        // in sync (move to trailing compile-time args before fusing this op with anything).
-        desc.semaphores.push_back(
-            SemaphoreDescriptor{.id = 0, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
-        desc.semaphores.push_back(
-            SemaphoreDescriptor{.id = 1, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
+        // Ids reach reader_chunk_gdn_scan.cpp as its two trailing compile-time args (appended
+        // after the accessor chains below) — no kernel-side mirror constants to keep in sync.
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = sem_ready_id, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = sem_valid_id, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
     }
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/";
@@ -477,6 +482,11 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
     TensorAccessorArgs(*in.dl.buffer()).append_to(reader_ct);
     TensorAccessorArgs(*in.t_inv.buffer()).append_to(reader_ct);
     TensorAccessorArgs(in.initial_state.has_value() ? in.initial_state->buffer() : nullptr).append_to(reader_ct);
+    // Trailing compile-time args AFTER the accessor chain: the handshake semaphore ids. Appended
+    // unconditionally — the plain (no-mcast) reader has no semaphores and ignores them — so the
+    // trailing-arg offsets stay uniform across all three reader compile variants.
+    reader_ct.push_back(sem_ready_id);
+    reader_ct.push_back(sem_valid_id);
 
     // Mcast receivers read only their private V-sliced tensors (v_beta, s0) from DRAM; the shared
     // block arrives over the NoC. Their accessor chain therefore has just those two blocks.
@@ -485,6 +495,8 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
         receiver_ct = ct_args;
         TensorAccessorArgs(*in.v_beta.buffer()).append_to(receiver_ct);
         TensorAccessorArgs(in.initial_state.has_value() ? in.initial_state->buffer() : nullptr).append_to(receiver_ct);
+        receiver_ct.push_back(sem_ready_id);
+        receiver_ct.push_back(sem_valid_id);
     }
 
     std::vector<uint32_t> writer_ct = ct_args;

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
@@ -45,7 +45,7 @@ constexpr uint32_t ones = tt::CBIndex::c_7;
 constexpr uint32_t S = tt::CBIndex::c_8;
 constexpr uint32_t decay = tt::CBIndex::c_9;
 constexpr uint32_t decay_exp = tt::CBIndex::c_10;
-constexpr uint32_t decayfac = tt::CBIndex::c_11;  // prep; reused as cb_dl in scan
+constexpr uint32_t decayfac = tt::CBIndex::c_11;  // prep; reused as scan's v_new scratch
 constexpr uint32_t lmask = tt::CBIndex::c_12;
 constexpr uint32_t Tinv = tt::CBIndex::c_13;
 constexpr uint32_t vbeta = tt::CBIndex::c_14;
@@ -66,7 +66,13 @@ constexpr uint32_t scr1 = tt::CBIndex::c_28;
 constexpr uint32_t scr2 = tt::CBIndex::c_29;
 constexpr uint32_t scr3 = tt::CBIndex::c_30;
 constexpr uint32_t s3 = tt::CBIndex::c_31;
-constexpr uint32_t dl = decayfac;  // scan reads dl into this slot
+// SCAN aliases. The scan-side indices of the seven per-chunk inputs equal PREP'S OUTPUT indices
+// (v_beta=14, kd=18=w, q_decay=19, intra=20, k_dec_t=24, dl=22=vnew — prep's compute pushes dl
+// into its vnew slot — t_inv=13), so the fused program can declare one hand-off CB set on the
+// producer/receiver core union. Scan's v_new scratch took the 11 freed by dl. Pure renumber:
+// the phased path is numerically identical (CB indices never affect the math).
+constexpr uint32_t dl = vnew;             // 22: scan reads dl into prep's dl slot
+constexpr uint32_t scan_vnew = decayfac;  // 11: scan's v_new scratch
 }  // namespace pcb
 
 namespace {
@@ -423,8 +429,8 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
     constexpr uint32_t sem_valid_id = 1;
 
     const uint32_t nbuf_in = (do_mcast && sdist.NV >= 4) ? 2u : 1u;
-    add_cb(pcb::u, cv, nbuf_in);  // v_beta
-    add_cb(pcb::w, ck, nbuf_in);  // kd
+    add_cb(pcb::vbeta, cv, nbuf_in);
+    add_cb(pcb::w, ck, nbuf_in);  // kd (prep's w slot)
     add_cb(pcb::qdecay, ck, nbuf_in);
     add_cb(pcb::intra, cc, nbuf_in);
     add_cb(pcb::kdec_t, kc, nbuf_in);
@@ -438,7 +444,7 @@ tt::tt_metal::ProgramDescriptor ChunkGdnScanProgramFactory::create_descriptor(
     add_cb(pcb::out, cv, 2, df_io);
     add_cb(pcb::final_s, kv);
     // Scratch.
-    add_cb(pcb::vnew, cv);
+    add_cb(pcb::scan_vnew, cv);
     add_cb(pcb::ointer, cv);
     add_cb(pcb::supd, kv);
     add_cb(pcb::stmp, kv);

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_math.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_math.hpp
@@ -34,17 +34,35 @@
 #include "api/compute/reconfig_data_format.h"
 #include "api/dataflow/circular_buffer.h"
 
+// GDN_HOIST_RECONFIG (a per-kernel define, set by the fused factory on its producer compute
+// kernel only): hoist the packer/unpacker format reconfigs out of the WY hot path (invert16 /
+// invert_block — all-fp32 regions where the per-call reconfigs are redundant register writes).
+// Math ops, order, and pack boundaries are identical either way (bit-exact both settings; the
+// phased path measured byte-identical outputs WITH the hoist). It is a per-path PERF switch:
+// the hoist measured -15% on the fused producer's chunk rate but +22-37% on phased prep at
+// low items-per-core shapes (BH=12/T=512) — a timing sensitivity, not a correctness issue —
+// so only the fused producer opts in.
+#ifdef GDN_HOIST_RECONFIG
+inline constexpr bool kGdnHoistReconfig = true;
+#else
+inline constexpr bool kGdnHoistReconfig = false;
+#endif
+
 inline void WAIT(uint32_t cb, uint32_t n) { CircularBuffer(cb).wait_front(n); }
 inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
 
 // out[Mt,Nt] = A[Mt,Kt] @ (tr ? B[Nt,Kt]^T : B[Kt,Nt]). Inputs must be available.
-inline void mm(uint32_t a, uint32_t b, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t Nt, bool tr) {
+inline void mm(
+    uint32_t a, uint32_t b, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t Nt, bool tr, bool skip_reconfig = false) {
     cb_reserve_back(o, Mt * Nt);
-    pack_reconfig_data_format(o);  // mixed bf16/fp32 CBs: set packer to this output's format
-    // matmul_tiles(a,b): in0=a->srcB, in1=b->srcA. Reconfig unpack src formats to match (the op
-    // init only asserts formats, it does not set them), else fp32/bf16 CBs are read at the wrong
-    // format and produce garbage.
-    reconfig_data_format(b, a);
+    if (!skip_reconfig) {
+        pack_reconfig_data_format(o);  // mixed bf16/fp32 CBs: set packer to this output's format
+        // matmul_tiles(a,b): in0=a->srcB, in1=b->srcA. Reconfig unpack src formats to match (the
+        // op init only asserts formats, it does not set them), else fp32/bf16 CBs are read at the
+        // wrong format and produce garbage. skip_reconfig=true is legal ONLY when the caller has
+        // already configured the packer/unpackers for these operands' formats (all-fp32 regions).
+        reconfig_data_format(b, a);
+    }
     matmul_init(a, b, tr ? 1 : 0);
     for (uint32_t mi = 0; mi < Mt; mi++) {
         for (uint32_t ni = 0; ni < Nt; ni++) {
@@ -165,10 +183,12 @@ inline void bcast_scalar_mul(uint32_t a, uint32_t scal, uint32_t o, uint32_t n) 
 }
 
 // out[0] = copy of src[src_tile] (single 32x32 tile). src must be available.
-inline void cpy_t(uint32_t src, uint32_t src_tile, uint32_t o) {
+inline void cpy_t(uint32_t src, uint32_t src_tile, uint32_t o, bool skip_reconfig = false) {
     cb_reserve_back(o, 1);
-    pack_reconfig_data_format(o);
-    reconfig_data_format_srca(src);
+    if (!skip_reconfig) {  // see mm() for the skip_reconfig contract
+        pack_reconfig_data_format(o);
+        reconfig_data_format_srca(src);
+    }
     copy_tile_to_dst_init_short(src);
     tile_regs_acquire();
     copy_tile(src, src_tile, 0);
@@ -180,10 +200,12 @@ inline void cpy_t(uint32_t src, uint32_t src_tile, uint32_t o) {
 }
 
 // out[0] = a[ai] (op) b[bi], single tile. op: 0 add, 2 mul. (Like ew but with free tile indices.)
-inline void ewt(uint32_t a, uint32_t ai, uint32_t b, uint32_t bi, uint32_t o, int op) {
+inline void ewt(uint32_t a, uint32_t ai, uint32_t b, uint32_t bi, uint32_t o, int op, bool skip_reconfig = false) {
     cb_reserve_back(o, 1);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(a, b);
+    if (!skip_reconfig) {  // see mm() for the skip_reconfig contract
+        pack_reconfig_data_format(o);
+        reconfig_data_format(a, b);
+    }
     if (op == 0) {
         add_init(a, b);
     } else {
@@ -207,13 +229,50 @@ inline void ewt(uint32_t a, uint32_t ai, uint32_t b, uint32_t bi, uint32_t o, in
 // Small block + short chain keeps fp32 bounded where a 32x32/31-term Horner cancels.
 // cb_eye holds the identity (tile 0 = I32).
 inline void invert16(uint32_t nq, uint32_t out, uint32_t tmp, uint32_t cb_eye) {
-    ew(cb_eye, nq, out, 1, 0);  // out = I + Nq
+    // Hot path: 15 alternating single-tile matmul/add rounds per call, ~4 calls per chunk. All
+    // four CBs are fp32, so the unpacker/packer format registers never change across the loop —
+    // reconfigure ONCE up front instead of inside every mm()/ew() call (their per-call
+    // reconfig_data_format/pack_reconfig are unconditional register writes). The MOP inits still
+    // alternate per op class. Ops, operands, order, and pack boundaries are identical to the
+    // plain mm/ew composition this replaces — bit-exact with it by construction.
+    if (kGdnHoistReconfig) {
+        pack_reconfig_data_format(out);    // out and tmp are both fp32: one packer config serves all
+        reconfig_data_format(cb_eye, nq);  // all operands fp32: one unpack config serves mm and ew
+    }
+    auto add1 = [&](uint32_t a, uint32_t b, uint32_t o) {  // o = a + b, 1 tile
+        cb_reserve_back(o, 1);
+        if (!kGdnHoistReconfig) {  // per-call reconfigs, exactly as the plain ew() would issue
+            pack_reconfig_data_format(o);
+            reconfig_data_format(a, b);
+        }
+        add_init(a, b);
+        tile_regs_acquire();
+        add_tiles(a, b, 0, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, 0);
+        tile_regs_release();
+        cb_push_back(o, 1);
+    };
+    add1(cb_eye, nq, out);  // out = I + Nq
     CircularBuffer(out).wait_front(1);
     for (uint32_t m = 2; m < 16; m++) {  // sum_{k<16} Nq^k
-        mm(nq, out, tmp, 1, 1, 1, false);
+        cb_reserve_back(tmp, 1);
+        if (!kGdnHoistReconfig) {  // per-call reconfigs, exactly as the plain mm() would issue
+            pack_reconfig_data_format(tmp);
+            reconfig_data_format(out, nq);
+        }
+        matmul_init(nq, out, 0);
+        tile_regs_acquire();
+        matmul_tiles(nq, out, 0, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, tmp, 0);
+        tile_regs_release();
+        cb_push_back(tmp, 1);
         CircularBuffer(tmp).wait_front(1);
         CircularBuffer(out).pop_front(1);
-        ew(cb_eye, tmp, out, 1, 0);  // out = I + Nq @ out
+        add1(cb_eye, tmp, out);  // out = I + Nq @ out
         CircularBuffer(out).wait_front(1);
         CircularBuffer(tmp).pop_front(1);
     }
@@ -268,42 +327,50 @@ inline void invert_block(
     uint32_t B,
     uint32_t C,
     uint32_t D) {
-    cpy_t(src, tile, tmpN);
+    // Every CB this function touches is fp32, so one packer+unpacker format config up front
+    // serves the whole body; the per-call reconfigs inside cpy_t/ewt/mm are skipped (they are
+    // unconditional register writes and this body issues ~9 such calls per invocation, twice per
+    // chunk). Op order and pack boundaries are unchanged — bit-exact with the unhoisted form.
+    if (kGdnHoistReconfig) {
+        pack_reconfig_data_format(out);
+        reconfig_data_format(cb_eye, src);
+    }
+    cpy_t(src, tile, tmpN, kGdnHoistReconfig);
     CircularBuffer(tmpN).wait_front(1);  // negN -> tmpN[0]
     // Bi00 = (I-N00)^-1  (N00 = top-left quadrant of negN; top-right is already 0)
-    ewt(tmpN, 0, cb_mask, 0, A, 2);
+    ewt(tmpN, 0, cb_mask, 0, A, 2, kGdnHoistReconfig);
     CircularBuffer(A).wait_front(1);  // N00
     invert16(A, B, tmpT, cb_eye);
     CircularBuffer(B).wait_front(1);
     CircularBuffer(A).pop_front(1);  // Bi00 -> B
     // Bi11 = (I-N11)^-1  (N11 = bottom-right quadrant)
-    ewt(tmpN, 0, cb_mask, 1, A, 2);
+    ewt(tmpN, 0, cb_mask, 1, A, 2, kGdnHoistReconfig);
     CircularBuffer(A).wait_front(1);  // N11
     invert16(A, C, tmpT, cb_eye);
     CircularBuffer(C).wait_front(1);
     CircularBuffer(A).pop_front(1);  // Bi11 -> C
     // off = Bi11 @ N10 @ Bi00  (N10 = bottom-left quadrant; result lives only there)
-    ewt(tmpN, 0, cb_mask, 2, A, 2);
+    ewt(tmpN, 0, cb_mask, 2, A, 2, kGdnHoistReconfig);
     CircularBuffer(A).wait_front(1);  // N10
     CircularBuffer(tmpN).pop_front(1);
-    mm(C, A, tmpT, 1, 1, 1, false);
+    mm(C, A, tmpT, 1, 1, 1, false, kGdnHoistReconfig);
     CircularBuffer(tmpT).wait_front(1);
     CircularBuffer(A).pop_front(1);  // Bi11@N10
-    mm(tmpT, B, A, 1, 1, 1, false);
+    mm(tmpT, B, A, 1, 1, 1, false, kGdnHoistReconfig);
     CircularBuffer(A).wait_front(1);
     CircularBuffer(tmpT).pop_front(1);  // @Bi00 -> A(off)
     // out = Qtl*Bi00 + Qbr*Bi11 + off
-    ewt(B, 0, cb_mask, 0, D, 2);
+    ewt(B, 0, cb_mask, 0, D, 2, kGdnHoistReconfig);
     CircularBuffer(D).wait_front(1);
     CircularBuffer(B).pop_front(1);  // Bi00_tl -> D
-    ewt(C, 0, cb_mask, 1, B, 2);
+    ewt(C, 0, cb_mask, 1, B, 2, kGdnHoistReconfig);
     CircularBuffer(B).wait_front(1);
     CircularBuffer(C).pop_front(1);  // Bi11_br -> B
-    ewt(D, 0, B, 0, C, 0);
+    ewt(D, 0, B, 0, C, 0, true);
     CircularBuffer(C).wait_front(1);
     CircularBuffer(D).pop_front(1);
     CircularBuffer(B).pop_front(1);
-    ewt(C, 0, A, 0, out, 0);
+    ewt(C, 0, A, 0, out, 0, true);
     CircularBuffer(C).pop_front(1);
     CircularBuffer(A).pop_front(1);  // + off -> out
 }

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_math.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_math.hpp
@@ -1,0 +1,667 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared math bodies for the chunk_gdn prep and scan compute kernels (and any future fused
+// kernel). The kernel .cpp files are thin: compile-arg reads, constexpr CB maps, and loops
+// calling prep_chunk / scan_step below. CB ids are passed in as plain uint32_t (via the
+// GdnPrepCbs / GdnScanCbs structs for the composition functions), so the same bodies run under
+// different CB maps.
+//
+// THE BIT-EXACTNESS CONTRACT: the seven prep intermediates are rounded at *pack* time; the DRAM
+// round trip after that is a byte copy. A kernel composed from these bodies is bit-identical to
+// the phased path end-to-end iff it
+//   (1) reuses these math code bodies unchanged (no op reordering, loop merging, or moving of
+//       init call sites),
+//   (2) keeps the same pack-to-CB boundaries at the same CB data formats,
+//   (3) keeps HiFi4 / fp32-dest-acc / no-approx-mode and the same matmul ki-accumulation order,
+//   (4) keeps the same exp configuration.
+// Any deliberate violation (e.g. keeping T_inv in DEST unpacked) is a reviewed PCC-downgrade,
+// not a silent change.
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "api/compute/matmul.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/exp.h"
+#include "api/compute/eltwise_unary/rsqrt.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/bcast.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/transpose.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/dataflow/circular_buffer.h"
+
+inline void WAIT(uint32_t cb, uint32_t n) { CircularBuffer(cb).wait_front(n); }
+inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
+
+// out[Mt,Nt] = A[Mt,Kt] @ (tr ? B[Nt,Kt]^T : B[Kt,Nt]). Inputs must be available.
+inline void mm(uint32_t a, uint32_t b, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t Nt, bool tr) {
+    cb_reserve_back(o, Mt * Nt);
+    pack_reconfig_data_format(o);  // mixed bf16/fp32 CBs: set packer to this output's format
+    // matmul_tiles(a,b): in0=a->srcB, in1=b->srcA. Reconfig unpack src formats to match (the op
+    // init only asserts formats, it does not set them), else fp32/bf16 CBs are read at the wrong
+    // format and produce garbage.
+    reconfig_data_format(b, a);
+    matmul_init(a, b, tr ? 1 : 0);
+    for (uint32_t mi = 0; mi < Mt; mi++) {
+        for (uint32_t ni = 0; ni < Nt; ni++) {
+            tile_regs_acquire();
+            for (uint32_t ki = 0; ki < Kt; ki++) {
+                uint32_t bi = tr ? (ni * Kt + ki) : (ki * Nt + ni);
+                matmul_tiles(a, b, mi * Kt + ki, bi, 0);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, o, mi * Nt + ni);
+            tile_regs_release();
+        }
+    }
+    cb_push_back(o, Mt * Nt);
+}
+
+// out = A (op) B elementwise, n tiles. op: 0 add, 1 sub, 2 mul.
+inline void ew(uint32_t a, uint32_t b, uint32_t o, uint32_t n, int op) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, b);  // binary(a,b): a->srcA, b->srcB
+    if (op == 0) {
+        add_init(a, b);
+    } else if (op == 1) {
+        sub_init(a, b);
+    } else {
+        mul_init(a, b);
+    }
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        if (op == 0) {
+            add_tiles(a, b, i, i, 0);
+        } else if (op == 1) {
+            sub_tiles(a, b, i, i, 0);
+        } else {
+            mul_tiles(a, b, i, i, 0);
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
+}
+
+inline void expc(uint32_t in, uint32_t o, uint32_t n) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(in);  // unary: in->srcA
+    copy_tile_to_dst_init_short(in);
+    exp_tile_init();
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        copy_tile(in, i, 0);
+        exp_tile(0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
+}
+
+// out[Mt,Nt] = A[Mt,Nt] * col[Mt,1]  (broadcast the single column of `col` across N)
+inline void bcast_cols_mul(uint32_t a, uint32_t col, uint32_t o, uint32_t Mt, uint32_t Nt) {
+    cb_reserve_back(o, Mt * Nt);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, col);  // bcast(a,col): a->srcA, col->srcB
+    mul_bcast_cols_init(a, col);
+    for (uint32_t mi = 0; mi < Mt; mi++) {
+        for (uint32_t ni = 0; ni < Nt; ni++) {
+            tile_regs_acquire();
+            mul_tiles_bcast_cols(a, col, mi * Nt + ni, mi, 0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, o, mi * Nt + ni);
+            tile_regs_release();
+        }
+    }
+    cb_push_back(o, Mt * Nt);
+}
+
+// out[Mt,Nt] = A[Mt,Nt] - row[1,Nt]  (broadcast the single row of `row` across M)
+inline void bcast_rows_sub(uint32_t a, uint32_t row, uint32_t o, uint32_t Mt, uint32_t Nt) {
+    cb_reserve_back(o, Mt * Nt);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, row);  // bcast(a,row): a->srcA, row->srcB
+    sub_bcast_rows_init(a, row);
+    for (uint32_t mi = 0; mi < Mt; mi++) {
+        for (uint32_t ni = 0; ni < Nt; ni++) {
+            tile_regs_acquire();
+            sub_tiles_bcast_rows(a, row, mi * Nt + ni, ni, 0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, o, mi * Nt + ni);
+            tile_regs_release();
+        }
+    }
+    cb_push_back(o, Mt * Nt);
+}
+
+// out = A * scalar, n tiles. scalar is the [0,0] element of the single `scal` tile.
+inline void bcast_scalar_mul(uint32_t a, uint32_t scal, uint32_t o, uint32_t n) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, scal);  // bcast(a,scal): a->srcA, scal->srcB
+    mul_bcast_scalar_init(a, scal);
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        mul_tiles_bcast_scalar(a, scal, i, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
+}
+
+// out[0] = copy of src[src_tile] (single 32x32 tile). src must be available.
+inline void cpy_t(uint32_t src, uint32_t src_tile, uint32_t o) {
+    cb_reserve_back(o, 1);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(src);
+    copy_tile_to_dst_init_short(src);
+    tile_regs_acquire();
+    copy_tile(src, src_tile, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, o, 0);
+    tile_regs_release();
+    cb_push_back(o, 1);
+}
+
+// out[0] = a[ai] (op) b[bi], single tile. op: 0 add, 2 mul. (Like ew but with free tile indices.)
+inline void ewt(uint32_t a, uint32_t ai, uint32_t b, uint32_t bi, uint32_t o, int op) {
+    cb_reserve_back(o, 1);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, b);
+    if (op == 0) {
+        add_init(a, b);
+    } else {
+        mul_init(a, b);
+    }
+    tile_regs_acquire();
+    if (op == 0) {
+        add_tiles(a, b, ai, bi, 0);
+    } else {
+        mul_tiles(a, b, ai, bi, 0);
+    }
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, o, 0);
+    tile_regs_release();
+    cb_push_back(o, 1);
+}
+
+// (I32 - Nq)^-1 for a strictly-lower 16-block Nq isolated in one 16-quadrant (rest zero),
+// nilpotent at 16. Horner in 15 terms -> out (single tile); the other diagonal quadrant is I.
+// Small block + short chain keeps fp32 bounded where a 32x32/31-term Horner cancels.
+// cb_eye holds the identity (tile 0 = I32).
+inline void invert16(uint32_t nq, uint32_t out, uint32_t tmp, uint32_t cb_eye) {
+    ew(cb_eye, nq, out, 1, 0);  // out = I + Nq
+    CircularBuffer(out).wait_front(1);
+    for (uint32_t m = 2; m < 16; m++) {  // sum_{k<16} Nq^k
+        mm(nq, out, tmp, 1, 1, 1, false);
+        CircularBuffer(tmp).wait_front(1);
+        CircularBuffer(out).pop_front(1);
+        ew(cb_eye, tmp, out, 1, 0);  // out = I + Nq @ out
+        CircularBuffer(out).wait_front(1);
+        CircularBuffer(tmp).pop_front(1);
+    }
+}
+
+// Assemble the 2x2 tile-block matrix [[s0[t0], s1[t1]], [s2[t2], s3[t3]]] into o (4 tiles).
+inline void asm4(
+    uint32_t s0,
+    uint32_t t0,
+    uint32_t s1,
+    uint32_t t1,
+    uint32_t s2,
+    uint32_t t2,
+    uint32_t s3,
+    uint32_t t3,
+    uint32_t o) {
+    const uint32_t src[4] = {s0, s1, s2, s3};
+    const uint32_t tl[4] = {t0, t1, t2, t3};
+    cb_reserve_back(o, 4);
+    pack_reconfig_data_format(o);
+    for (uint32_t i = 0; i < 4; i++) {
+        reconfig_data_format_srca(src[i]);
+        copy_tile_to_dst_init_short(src[i]);
+        tile_regs_acquire();
+        copy_tile(src[i], tl[i], 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, 4);
+}
+
+// Invert one 32x32 diagonal tile-block: out[0] = (I32 - negN)^-1, negN = src[tile] (strictly-lower
+// 32x32). Mirrors FLA solve_tril: split into 16-quadrants negN = [[N00,0],[N10,N11]], invert the two
+// diagonal 16-blocks (short, bounded Horners), and form the off-diagonal EXACTLY (one matmul chain,
+// no power series). A single 32x32 Horner instead loses fp32 precision on harder blocks.
+//   Bi00=(I-N00)^-1 (top-left), Bi11=(I-N11)^-1 (bottom-right), off=Bi11@N10@Bi00 (bottom-left).
+//   out = [[Bi00,0],[off,Bi11]].
+// cb_eye = identity; masks (single tiles): cb_mask[0]=Qtl, [1]=Qbr, [2]=Q10 (bottom-left).
+// tmpN/tmpT = scratch. Private scratch A..D: single-tile-capable fp32 CBs, NOT drained by any
+// writer while this runs, and none may alias src, out, tmpN, or tmpT.
+inline void invert_block(
+    uint32_t src,
+    uint32_t tile,
+    uint32_t out,
+    uint32_t tmpN,
+    uint32_t tmpT,
+    uint32_t cb_eye,
+    uint32_t cb_mask,
+    uint32_t A,
+    uint32_t B,
+    uint32_t C,
+    uint32_t D) {
+    cpy_t(src, tile, tmpN);
+    CircularBuffer(tmpN).wait_front(1);  // negN -> tmpN[0]
+    // Bi00 = (I-N00)^-1  (N00 = top-left quadrant of negN; top-right is already 0)
+    ewt(tmpN, 0, cb_mask, 0, A, 2);
+    CircularBuffer(A).wait_front(1);  // N00
+    invert16(A, B, tmpT, cb_eye);
+    CircularBuffer(B).wait_front(1);
+    CircularBuffer(A).pop_front(1);  // Bi00 -> B
+    // Bi11 = (I-N11)^-1  (N11 = bottom-right quadrant)
+    ewt(tmpN, 0, cb_mask, 1, A, 2);
+    CircularBuffer(A).wait_front(1);  // N11
+    invert16(A, C, tmpT, cb_eye);
+    CircularBuffer(C).wait_front(1);
+    CircularBuffer(A).pop_front(1);  // Bi11 -> C
+    // off = Bi11 @ N10 @ Bi00  (N10 = bottom-left quadrant; result lives only there)
+    ewt(tmpN, 0, cb_mask, 2, A, 2);
+    CircularBuffer(A).wait_front(1);  // N10
+    CircularBuffer(tmpN).pop_front(1);
+    mm(C, A, tmpT, 1, 1, 1, false);
+    CircularBuffer(tmpT).wait_front(1);
+    CircularBuffer(A).pop_front(1);  // Bi11@N10
+    mm(tmpT, B, A, 1, 1, 1, false);
+    CircularBuffer(A).wait_front(1);
+    CircularBuffer(tmpT).pop_front(1);  // @Bi00 -> A(off)
+    // out = Qtl*Bi00 + Qbr*Bi11 + off
+    ewt(B, 0, cb_mask, 0, D, 2);
+    CircularBuffer(D).wait_front(1);
+    CircularBuffer(B).pop_front(1);  // Bi00_tl -> D
+    ewt(C, 0, cb_mask, 1, B, 2);
+    CircularBuffer(B).wait_front(1);
+    CircularBuffer(C).pop_front(1);  // Bi11_br -> B
+    ewt(D, 0, B, 0, C, 0);
+    CircularBuffer(C).wait_front(1);
+    CircularBuffer(D).pop_front(1);
+    CircularBuffer(B).pop_front(1);
+    ewt(C, 0, A, 0, out, 0);
+    CircularBuffer(C).pop_front(1);
+    CircularBuffer(A).pop_front(1);  // + off -> out
+}
+
+// out[1,Ct] row-form = transpose of col[Ct,1]; produces Ct tiles (each row0 = a 32-chunk of col).
+inline void transpose_col(uint32_t in, uint32_t o, uint32_t Ct) {
+    cb_reserve_back(o, Ct);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(in);  // unary: in->srcA
+    transpose_init(in);
+    for (uint32_t i = 0; i < Ct; i++) {
+        tile_regs_acquire();
+        transpose_tile(in, i, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, Ct);
+}
+
+// OPT-A/B in-kernel L2-norm over K. rowsum_k: o[Mt,1(broadcast)] = sum over the full K dim of
+// in[Mt,Kt], computed as in @ ones by reusing cb_ones tile 0 as the [K,1] contraction operand
+// (avoids a dedicated ones-column constant). Mirrors the `mm` helper's reconfig/matmul discipline.
+inline void rowsum_k(uint32_t in, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t cb_ones) {
+    cb_reserve_back(o, Mt);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(cb_ones, in);  // matmul(in, cb_ones): in->srcB, cb_ones->srcA
+    matmul_init(in, cb_ones, 0);
+    for (uint32_t mi = 0; mi < Mt; mi++) {
+        tile_regs_acquire();
+        for (uint32_t ki = 0; ki < Kt; ki++) {
+            matmul_tiles(in, cb_ones, mi * Kt + ki, 0, 0);  // reuse ones tile 0 for every ki
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, mi);
+        tile_regs_release();
+    }
+    cb_push_back(o, Mt);
+}
+
+// inv_rms: o[i] = rsqrt(in[i] + eps) [* scale]. in holds per-row sum-of-squares (rowsum_k output);
+// out is the per-row inverse-L2 factor (optionally pre-scaled, for folding q's scale into the norm).
+// eps/scale arrive as fp32-bit-cast uint32 compile args.
+inline void inv_rms(uint32_t in, uint32_t o, uint32_t n, uint32_t eps_bits, uint32_t scale_bits, bool do_scale) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(in);
+    copy_tile_to_dst_init_short(in);
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        copy_tile(in, i, 0);
+        binop_with_scalar_tile_init();
+        add_unary_tile(0, eps_bits);  // + eps
+        rsqrt_tile_init();
+        rsqrt_tile(0);  // 1/sqrt(sumsq + eps)
+        if (do_scale) {
+            binop_with_scalar_tile_init();
+            mul_unary_tile(0, scale_bits);  // * scale (q only)
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
+}
+
+// CB map for prep_chunk — one field per CB the body touches. dl/mask are the prep kernel's
+// aliases (cb_dl = the vnew slot, cb_mask = the u slot); the map carries the resolved ids.
+struct GdnPrepCbs {
+    uint32_t q, k, v, g, beta;
+    uint32_t eye, tril, ones, S;
+    uint32_t decay, decay_exp, decayfac, lmask, Tinv, vbeta, kbeta;
+    uint32_t w, qdecay, intra, s2, ointer, kdec_t, supd, stmp, final_s;
+    uint32_t scr1, scr2, scr3, s3;
+    uint32_t dl;    // alias of the vnew slot in prep (1 tile used)
+    uint32_t mask;  // alias of the u slot in prep (3 quadrant-mask tiles)
+};
+
+// CB map for scan_step — one field per CB the body touches (the state CBs S/s2/s3/final are
+// selected per chunk by the caller and passed as cur_S/dst).
+struct GdnScanCbs {
+    uint32_t dl, Tinv, out;
+    uint32_t vbeta, kd, qdecay, intra;
+    uint32_t vnew, ointer, kdec_t, supd, stmp;
+    uint32_t scr1;
+};
+
+// PHASE A (prep): one state-independent (head, chunk) work-item. No recurrent state here; the
+// sequential state scan lives in scan_step. Outputs (per chunk) v_beta, kd(->cb.w), T_inv,
+// k_dec_t, q_decay, intra, dl are pushed to their CBs and streamed to DRAM by the prep writer.
+inline void prep_chunk(
+    const GdnPrepCbs& cb, uint32_t Ct, uint32_t Kt, uint32_t Vt, bool qk_norm, uint32_t scale_bits, uint32_t eps_bits) {
+    const uint32_t cc = Ct * Ct;
+    const uint32_t ck = Ct * Kt;
+    const uint32_t cv = Ct * Vt;
+    const uint32_t C = Ct * 32;
+
+    WAIT(cb.q, ck);
+    WAIT(cb.k, ck);
+    WAIT(cb.v, cv);
+    WAIT(cb.g, Ct);
+    WAIT(cb.beta, Ct);
+
+    // ---- OPT-B: in-kernel L2-norm of q,k over K (fold q's scale). Consumes the raw reader q/k
+    // and produces normalized q->cb.supd, k->cb.stmp (both free in Ct==1). The rest of the chunk
+    // then reads Q/Kk instead of cb.q/cb.k. scr1/scr2/scr3 are free here (used only later). ----
+    uint32_t Q = cb.q, Kk = cb.k;
+    if (qk_norm) {
+        // q: q^2 -> rowsum_K -> rsqrt(+eps)*scale -> q_normed (cb.supd)
+        ew(cb.q, cb.q, cb.scr1, ck, 2);
+        WAIT(cb.scr1, ck);
+        rowsum_k(cb.scr1, cb.scr2, Ct, Kt, cb.ones);
+        WAIT(cb.scr2, Ct);
+        POP(cb.scr1, ck);
+        inv_rms(cb.scr2, cb.scr3, Ct, eps_bits, scale_bits, /*do_scale=*/true);
+        WAIT(cb.scr3, Ct);
+        POP(cb.scr2, Ct);
+        bcast_cols_mul(cb.q, cb.scr3, cb.supd, Ct, Kt);
+        WAIT(cb.supd, ck);
+        POP(cb.scr3, Ct);
+        POP(cb.q, ck);
+        // k: same, no scale -> k_normed (cb.stmp)
+        ew(cb.k, cb.k, cb.scr1, ck, 2);
+        WAIT(cb.scr1, ck);
+        rowsum_k(cb.scr1, cb.scr2, Ct, Kt, cb.ones);
+        WAIT(cb.scr2, Ct);
+        POP(cb.scr1, ck);
+        inv_rms(cb.scr2, cb.scr3, Ct, eps_bits, scale_bits, /*do_scale=*/false);
+        WAIT(cb.scr3, Ct);
+        POP(cb.scr2, Ct);
+        bcast_cols_mul(cb.k, cb.scr3, cb.stmp, Ct, Kt);
+        WAIT(cb.stmp, ck);
+        POP(cb.scr3, Ct);
+        POP(cb.k, ck);
+        Q = cb.supd;
+        Kk = cb.stmp;
+    }
+
+    // ---- P1: v_beta, k_beta ----
+    bcast_cols_mul(cb.v, cb.beta, cb.vbeta, Ct, Vt);
+    WAIT(cb.vbeta, cv);
+    bcast_cols_mul(Kk, cb.beta, cb.kbeta, Ct, Kt);
+    WAIT(cb.kbeta, ck);
+    POP(cb.beta, Ct);
+    POP(cb.v, cv);
+
+    // ---- P2: decay = tril@g, decay_exp, decay_row ----
+    mm(cb.tril, cb.g, cb.decay, Ct, Ct, 1, false);
+    WAIT(cb.decay, Ct);
+    expc(cb.decay, cb.decay_exp, Ct);
+    WAIT(cb.decay_exp, Ct);
+    transpose_col(cb.decay, cb.scr1, Ct);  // decay_row in scr1
+    WAIT(cb.scr1, Ct);
+
+    // ---- L_mask = tril(exp(decay_i - decay_j)) ----
+    bcast_cols_mul(cb.ones, cb.decay, cb.scr2, Ct, Ct);  // decay_i everywhere
+    WAIT(cb.scr2, cc);
+    bcast_rows_sub(cb.scr2, cb.scr1, cb.scr3, Ct, Ct);  // decay_i - decay_j
+    WAIT(cb.scr3, cc);
+    POP(cb.scr1, Ct);  // decay_row done
+    POP(cb.scr2, cc);
+    ew(cb.scr3, cb.tril, cb.scr2, cc, 2);  // *tril (zero upper)
+    WAIT(cb.scr2, cc);
+    POP(cb.scr3, cc);
+    expc(cb.scr2, cb.scr3, cc);  // exp
+    WAIT(cb.scr3, cc);
+    POP(cb.scr2, cc);
+    ew(cb.scr3, cb.tril, cb.lmask, cc, 2);  // *tril again -> L_mask
+    WAIT(cb.lmask, cc);
+    POP(cb.scr3, cc);
+
+    // ---- decayfac = exp(g_sum - decay) ----
+    // (dl = exp(g_sum) is recomputed at the scan from decayfac[0]*decay_exp[0] so its CB
+    //  slot can be reused as the third ping-pong state buffer cb_s3.)
+    mm(cb.ones, cb.g, cb.scr1, Ct, Ct, 1, false);  // g_sum in every row (col form)
+    WAIT(cb.scr1, Ct);
+    POP(cb.g, Ct);
+    ew(cb.scr1, cb.decay, cb.scr2, Ct, 1);  // g_sum - decay
+    WAIT(cb.scr2, Ct);
+    POP(cb.scr1, Ct);
+    POP(cb.decay, Ct);
+    expc(cb.scr2, cb.decayfac, Ct);
+    WAIT(cb.decayfac, Ct);
+    POP(cb.scr2, Ct);
+
+    // ---- N = strictly_lower(k_beta@k^T * L_mask); T_inv = (I + strictly_lower)^-1 ----
+    // The WY inverse, mirroring FLA's solve_tril: block down to 16x16 (invert_block splits each
+    // 32x32 tile into 16-quadrants), invert the small diagonal blocks with bounded Horners, and
+    // merge off-diagonal blocks EXACTLY. This keeps every intermediate bounded, unlike a single
+    // 32x32/full-matrix Horner whose deep power series loses fp32 precision on harder chunks.
+    mm(cb.kbeta, Kk, cb.scr1, Ct, Kt, Ct, true);  // kk = k_beta @ k^T (Kk = normalized k)
+    WAIT(cb.scr1, cc);
+    ew(cb.scr1, cb.lmask, cb.scr2, cc, 2);  // kk_masked = kk * L_mask
+    WAIT(cb.scr2, cc);
+    POP(cb.scr1, cc);
+    ew(cb.scr2, cb.eye, cb.scr1, cc, 2);  // diag(kk_masked)
+    WAIT(cb.scr1, cc);
+    // negN = diag - kk_masked = -(strictly_lower(kk_masked))  (= -A_strict, kept in cb.scr3)
+    ew(cb.scr1, cb.scr2, cb.scr3, cc, 1);
+    WAIT(cb.scr3, cc);
+    POP(cb.scr1, cc);
+    POP(cb.scr2, cc);
+
+    // invert_block's private scratch A..D = cb.S/cb.final_s/cb.s2/cb.s3 — all fp32 and NOT drained
+    // by the prep writer (unlike the output CBs cb.w/cb.qdecay/cb.intra, whose scratch pushes the
+    // writer would wrongly consume). None alias src (cb.scr3), out, or the Ct==2 persistents
+    // (cb.supd/cb.stmp).
+    if (Ct == 1) {
+        // Single 32x32 block: T_inv is just its inverse.
+        invert_block(cb.scr3, 0, cb.Tinv, cb.scr1, cb.scr2, cb.eye, cb.mask, cb.S, cb.final_s, cb.s2, cb.s3);
+        WAIT(cb.Tinv, cc);
+        POP(cb.scr3, cc);
+    } else if (Ct == 2) {
+        // 2x2 tile-block lower-triangular. negN tiles: 0=(0,0), 2=(1,0), 3=(1,1); (0,1)=0.
+        // Diagonal inverses Mi11, Mi22, then off-diagonal Mi21 = -Mi22 @ A21 @ Mi11.
+        // (A21 = -negN21, so -Mi22@A21@Mi11 = Mi22 @ negN21 @ Mi11.)
+        // Mi11 -> cb.supd, Mi22 -> cb.stmp, Mi21 -> cb.ointer (all free in prep).
+        invert_block(cb.scr3, 0, cb.supd, cb.scr1, cb.scr2, cb.eye, cb.mask, cb.S, cb.final_s, cb.s2, cb.s3);  // Mi11
+        invert_block(cb.scr3, 3, cb.stmp, cb.scr1, cb.scr2, cb.eye, cb.mask, cb.S, cb.final_s, cb.s2, cb.s3);  // Mi22
+        cpy_t(cb.scr3, 2, cb.scr1);  // negN21 -> cb.scr1[0]
+        WAIT(cb.scr1, 1);
+        mm(cb.scr1, cb.supd, cb.scr2, 1, 1, 1, false);  // tmp = negN21 @ Mi11
+        WAIT(cb.scr2, 1);
+        POP(cb.scr1, 1);
+        mm(cb.stmp, cb.scr2, cb.ointer, 1, 1, 1, false);  // Mi21 = Mi22 @ tmp
+        WAIT(cb.ointer, 1);
+        POP(cb.scr2, 1);
+        POP(cb.scr3, cc);  // negN done
+        // T_inv = [[Mi11, 0], [Mi21, Mi22]]  (cb.eye[1] is the zero block)
+        asm4(cb.supd, 0, cb.eye, 1, cb.ointer, 0, cb.stmp, 0, cb.Tinv);
+        WAIT(cb.Tinv, cc);
+        POP(cb.supd, 1);
+        POP(cb.stmp, 1);
+        POP(cb.ointer, 1);
+    } else {
+        // Fallback (C>64, currently xfail): full-matrix Horner.
+        ew(cb.eye, cb.scr3, cb.Tinv, cc, 0);
+        WAIT(cb.Tinv, cc);
+        for (uint32_t m = 2; m < C; m++) {
+            mm(cb.scr3, cb.Tinv, cb.scr1, Ct, Ct, Ct, false);
+            WAIT(cb.scr1, cc);
+            POP(cb.Tinv, cc);
+            ew(cb.eye, cb.scr1, cb.Tinv, cc, 0);
+            WAIT(cb.Tinv, cc);
+            POP(cb.scr1, cc);
+        }
+        POP(cb.scr3, cc);
+    }
+
+    // ---- un-premultiplied WY hand-off: output v_beta (cb.vbeta), kd=k_beta*decay_exp (cb.w),
+    // T_inv (cb.Tinv). The scan computes v_new = T_inv @ (v_beta - kd@S), applying the inverse
+    // AFTER the subtraction so its fp error is not amplified by the u - w@S cancellation.
+    bcast_cols_mul(cb.kbeta, cb.decay_exp, cb.w, Ct, Kt);  // kd -> cb.w (output)
+    WAIT(cb.w, ck);
+    POP(cb.kbeta, ck);
+    // cb.vbeta (v_beta) and cb.Tinv (T_inv) remain pushed for the writer; NOT popped here.
+
+    // ---- intra = (q@k^T) * L_mask ; q_decay = q*decay_exp ; k_dec_t ----
+    mm(Q, Kk, cb.scr1, Ct, Kt, Ct, true);  // qk = q @ k^T (Q/Kk = normalized q,k)
+    WAIT(cb.scr1, cc);
+    ew(cb.scr1, cb.lmask, cb.intra, cc, 2);
+    WAIT(cb.intra, cc);
+    POP(cb.scr1, cc);
+    POP(cb.lmask, cc);
+    bcast_cols_mul(Q, cb.decay_exp, cb.qdecay, Ct, Kt);
+    WAIT(cb.qdecay, ck);
+    POP(Q, ck);
+    // decay_exp kept alive: reused at the scan to recompute dl = exp(g_sum).
+    bcast_cols_mul(Kk, cb.decayfac, cb.scr1, Ct, Kt);  // k * exp(decay_last-decay)
+    WAIT(cb.scr1, ck);
+    POP(Kk, ck);
+    // decayfac kept alive: reused at the scan to recompute dl = exp(g_sum).
+    // k_dec_t = transpose(k_dec) [K,C]: transpose each [Ct,Kt] tile block into [Kt,Ct].
+    cb_reserve_back(cb.kdec_t, Kt * Ct);
+    pack_reconfig_data_format(cb.kdec_t);
+    reconfig_data_format_srca(cb.scr1);  // unary: in->srcA
+    transpose_init(cb.scr1);
+    for (uint32_t ki = 0; ki < Kt; ki++) {
+        for (uint32_t ci = 0; ci < Ct; ci++) {
+            tile_regs_acquire();
+            transpose_tile(cb.scr1, ci * Kt + ki, 0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb.kdec_t, ki * Ct + ci);
+            tile_regs_release();
+        }
+    }
+    cb_push_back(cb.kdec_t, Kt * Ct);
+    POP(cb.scr1, ck);
+
+    // ---- dl = exp(g_sum) = decayfac[i]*decay_exp[i] (same for all i); 1 tile, [0,0] holds dl.
+    // The scan kernel uses it to decay the recurrent state: S <- S*dl + k_dec_t@v_new.
+    ew(cb.decayfac, cb.decay_exp, cb.dl, 1, 2);
+    WAIT(cb.dl, 1);
+    POP(cb.decayfac, Ct);
+    POP(cb.decay_exp, Ct);
+    // u, w, k_dec_t, q_decay, intra, dl remain pushed in their CBs -> prep writer -> DRAM.
+    // (They are NOT popped here; the writer drains them per chunk.)
+}
+
+// PHASE B (scan): one chunk of the sequential recurrence. cur_S = the state input CB for this
+// chunk (reader-fed cb_S at chunk 0, then the compute-only ping-pong), dst = where the updated
+// state goes (the other ping-pong CB, or the final-state CB on the last chunk).
+inline void scan_step(const GdnScanCbs& cb, uint32_t cur_S, uint32_t dst, uint32_t Ct, uint32_t Kt, uint32_t Vt) {
+    const uint32_t cc = Ct * Ct;
+    const uint32_t ck = Ct * Kt;
+    const uint32_t cv = Ct * Vt;
+    const uint32_t kv = Kt * Vt;
+    const uint32_t kc = Kt * Ct;
+
+    // v_new = T_inv @ (v_beta - kd@S)  -- apply the inverse AFTER the subtraction so the WY
+    // inverse's fp error is not amplified by the cancellation (vs the u - w@S form).
+    WAIT(cb.kd, ck);
+    WAIT(cur_S, kv);
+    mm(cb.kd, cur_S, cb.scr1, Ct, Kt, Vt, false);  // kdS = kd @ S -> scr1
+    WAIT(cb.scr1, cv);
+    POP(cb.kd, ck);
+    WAIT(cb.vbeta, cv);
+    ew(cb.vbeta, cb.scr1, cb.ointer, cv, 1);  // diff = v_beta - kdS -> ointer
+    WAIT(cb.ointer, cv);
+    POP(cb.vbeta, cv);
+    POP(cb.scr1, cv);
+    WAIT(cb.Tinv, cc);
+    mm(cb.Tinv, cb.ointer, cb.vnew, Ct, Ct, Vt, false);  // v_new = T_inv @ diff -> vnew
+    WAIT(cb.vnew, cv);
+    POP(cb.Tinv, cc);
+    POP(cb.ointer, cv);
+
+    // o = q_decay @ S + intra @ v_new
+    WAIT(cb.qdecay, ck);
+    mm(cb.qdecay, cur_S, cb.ointer, Ct, Kt, Vt, false);  // o_inter = q_decay @ S
+    WAIT(cb.ointer, cv);
+    POP(cb.qdecay, ck);
+    WAIT(cb.intra, cc);
+    mm(cb.intra, cb.vnew, cb.scr1, Ct, Ct, Vt, false);  // intra_v = intra @ v_new
+    WAIT(cb.scr1, cv);
+    POP(cb.intra, cc);
+    ew(cb.ointer, cb.scr1, cb.out, cv, 0);  // o -> cb_out (drained by writer)
+    POP(cb.ointer, cv);
+    POP(cb.scr1, cv);
+
+    // s_upd = k_dec_t @ v_new
+    WAIT(cb.kdec_t, kc);
+    mm(cb.kdec_t, cb.vnew, cb.supd, Kt, Ct, Vt, false);
+    WAIT(cb.supd, kv);
+    POP(cb.kdec_t, kc);
+    POP(cb.vnew, cv);
+
+    // S_new = cur_S * dl + s_upd  (dl scalar in cb_dl tile [0,0])
+    WAIT(cb.dl, 1);
+    bcast_scalar_mul(cur_S, cb.dl, cb.stmp, kv);
+    WAIT(cb.stmp, kv);
+    POP(cb.dl, 1);
+    POP(cur_S, kv);
+    ew(cb.stmp, cb.supd, dst, kv, 0);
+    POP(cb.stmp, kv);
+    POP(cb.supd, kv);
+}

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_prep.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_prep.cpp
@@ -15,20 +15,13 @@
 //   q_decay = q*decay_exp ; k_dec_t = transpose(k * exp(decay_last - decay))
 //   v_prime = w@S ; v_new = u - v_prime ; o = q_decay@S + intra@v_new
 //   S = S*exp(decay_last) + k_dec_t@v_new
+//
+// The math bodies live in chunk_gdn_math.hpp (shared with the scan kernel); this file is just
+// the CB map and the work-item loop calling prep_chunk().
 
 #include <cstdint>
 #include "api/compute/common.h"
-#include "api/compute/matmul.h"
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/exp.h"
-#include "api/compute/eltwise_unary/rsqrt.h"
-#include "api/compute/eltwise_unary/binop_with_scalar.h"
-#include "api/compute/bcast.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/transpose.h"
-#include "api/compute/reconfig_data_format.h"
-#include "api/dataflow/circular_buffer.h"
+#include "chunk_gdn_math.hpp"
 
 namespace {
 
@@ -46,317 +39,38 @@ constexpr uint32_t cb_dl = cb_vnew;
 // the stable-form prep); the reader loads them once. Used only by invert_block.
 constexpr uint32_t cb_mask = cb_u;
 
-inline void WAIT(uint32_t cb, uint32_t n) { CircularBuffer(cb).wait_front(n); }
-inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
-
-// out[Mt,Nt] = A[Mt,Kt] @ (tr ? B[Nt,Kt]^T : B[Kt,Nt]). Inputs must be available.
-void mm(uint32_t a, uint32_t b, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t Nt, bool tr) {
-    cb_reserve_back(o, Mt * Nt);
-    pack_reconfig_data_format(o);  // mixed bf16/fp32 CBs: set packer to this output's format
-    // matmul_tiles(a,b): in0=a->srcB, in1=b->srcA. Reconfig unpack src formats to match (the op
-    // init only asserts formats, it does not set them), else fp32/bf16 CBs are read at the wrong
-    // format and produce garbage.
-    reconfig_data_format(b, a);
-    matmul_init(a, b, tr ? 1 : 0);
-    for (uint32_t mi = 0; mi < Mt; mi++) {
-        for (uint32_t ni = 0; ni < Nt; ni++) {
-            tile_regs_acquire();
-            for (uint32_t ki = 0; ki < Kt; ki++) {
-                uint32_t bi = tr ? (ni * Kt + ki) : (ki * Nt + ni);
-                matmul_tiles(a, b, mi * Kt + ki, bi, 0);
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, o, mi * Nt + ni);
-            tile_regs_release();
-        }
-    }
-    cb_push_back(o, Mt * Nt);
-}
-
-// out = A (op) B elementwise, n tiles. op: 0 add, 1 sub, 2 mul.
-void ew(uint32_t a, uint32_t b, uint32_t o, uint32_t n, int op) {
-    cb_reserve_back(o, n);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(a, b);  // binary(a,b): a->srcA, b->srcB
-    if (op == 0) {
-        add_init(a, b);
-    } else if (op == 1) {
-        sub_init(a, b);
-    } else {
-        mul_init(a, b);
-    }
-    for (uint32_t i = 0; i < n; i++) {
-        tile_regs_acquire();
-        if (op == 0) {
-            add_tiles(a, b, i, i, 0);
-        } else if (op == 1) {
-            sub_tiles(a, b, i, i, 0);
-        } else {
-            mul_tiles(a, b, i, i, 0);
-        }
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, i);
-        tile_regs_release();
-    }
-    cb_push_back(o, n);
-}
-
-void expc(uint32_t in, uint32_t o, uint32_t n) {
-    cb_reserve_back(o, n);
-    pack_reconfig_data_format(o);
-    reconfig_data_format_srca(in);  // unary: in->srcA
-    copy_tile_to_dst_init_short(in);
-    exp_tile_init();
-    for (uint32_t i = 0; i < n; i++) {
-        tile_regs_acquire();
-        copy_tile(in, i, 0);
-        exp_tile(0);
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, i);
-        tile_regs_release();
-    }
-    cb_push_back(o, n);
-}
-
-// out[Mt,Nt] = A[Mt,Nt] * col[Mt,1]  (broadcast the single column of `col` across N)
-void bcast_cols_mul(uint32_t a, uint32_t col, uint32_t o, uint32_t Mt, uint32_t Nt) {
-    cb_reserve_back(o, Mt * Nt);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(a, col);  // bcast(a,col): a->srcA, col->srcB
-    mul_bcast_cols_init(a, col);
-    for (uint32_t mi = 0; mi < Mt; mi++) {
-        for (uint32_t ni = 0; ni < Nt; ni++) {
-            tile_regs_acquire();
-            mul_tiles_bcast_cols(a, col, mi * Nt + ni, mi, 0);
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, o, mi * Nt + ni);
-            tile_regs_release();
-        }
-    }
-    cb_push_back(o, Mt * Nt);
-}
-
-// out[Mt,Nt] = A[Mt,Nt] - row[1,Nt]  (broadcast the single row of `row` across M)
-void bcast_rows_sub(uint32_t a, uint32_t row, uint32_t o, uint32_t Mt, uint32_t Nt) {
-    cb_reserve_back(o, Mt * Nt);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(a, row);  // bcast(a,row): a->srcA, row->srcB
-    sub_bcast_rows_init(a, row);
-    for (uint32_t mi = 0; mi < Mt; mi++) {
-        for (uint32_t ni = 0; ni < Nt; ni++) {
-            tile_regs_acquire();
-            sub_tiles_bcast_rows(a, row, mi * Nt + ni, ni, 0);
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, o, mi * Nt + ni);
-            tile_regs_release();
-        }
-    }
-    cb_push_back(o, Mt * Nt);
-}
-
-// out[0] = copy of src[src_tile] (single 32x32 tile). src must be available.
-void cpy_t(uint32_t src, uint32_t src_tile, uint32_t o) {
-    cb_reserve_back(o, 1);
-    pack_reconfig_data_format(o);
-    reconfig_data_format_srca(src);
-    copy_tile_to_dst_init_short(src);
-    tile_regs_acquire();
-    copy_tile(src, src_tile, 0);
-    tile_regs_commit();
-    tile_regs_wait();
-    pack_tile(0, o, 0);
-    tile_regs_release();
-    cb_push_back(o, 1);
-}
-
-// out[0] = a[ai] (op) b[bi], single tile. op: 0 add, 2 mul. (Like ew but with free tile indices.)
-void ewt(uint32_t a, uint32_t ai, uint32_t b, uint32_t bi, uint32_t o, int op) {
-    cb_reserve_back(o, 1);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(a, b);
-    if (op == 0) {
-        add_init(a, b);
-    } else {
-        mul_init(a, b);
-    }
-    tile_regs_acquire();
-    if (op == 0) {
-        add_tiles(a, b, ai, bi, 0);
-    } else {
-        mul_tiles(a, b, ai, bi, 0);
-    }
-    tile_regs_commit();
-    tile_regs_wait();
-    pack_tile(0, o, 0);
-    tile_regs_release();
-    cb_push_back(o, 1);
-}
-
-// (I32 - Nq)^-1 for a strictly-lower 16-block Nq isolated in one 16-quadrant (rest zero),
-// nilpotent at 16. Horner in 15 terms -> out (single tile); the other diagonal quadrant is I.
-// Small block + short chain keeps fp32 bounded where a 32x32/31-term Horner cancels.
-void invert16(uint32_t nq, uint32_t out, uint32_t tmp) {
-    ew(cb_eye, nq, out, 1, 0);  // out = I + Nq
-    CircularBuffer(out).wait_front(1);
-    for (uint32_t m = 2; m < 16; m++) {  // sum_{k<16} Nq^k
-        mm(nq, out, tmp, 1, 1, 1, false);
-        CircularBuffer(tmp).wait_front(1);
-        CircularBuffer(out).pop_front(1);
-        ew(cb_eye, tmp, out, 1, 0);  // out = I + Nq @ out
-        CircularBuffer(out).wait_front(1);
-        CircularBuffer(tmp).pop_front(1);
-    }
-}
-
-// Assemble the 2x2 tile-block matrix [[s0[t0], s1[t1]], [s2[t2], s3[t3]]] into o (4 tiles).
-void asm4(
-    uint32_t s0,
-    uint32_t t0,
-    uint32_t s1,
-    uint32_t t1,
-    uint32_t s2,
-    uint32_t t2,
-    uint32_t s3,
-    uint32_t t3,
-    uint32_t o) {
-    const uint32_t src[4] = {s0, s1, s2, s3};
-    const uint32_t tl[4] = {t0, t1, t2, t3};
-    cb_reserve_back(o, 4);
-    pack_reconfig_data_format(o);
-    for (uint32_t i = 0; i < 4; i++) {
-        reconfig_data_format_srca(src[i]);
-        copy_tile_to_dst_init_short(src[i]);
-        tile_regs_acquire();
-        copy_tile(src[i], tl[i], 0);
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, i);
-        tile_regs_release();
-    }
-    cb_push_back(o, 4);
-}
-
-// Invert one 32x32 diagonal tile-block: out[0] = (I32 - negN)^-1, negN = src[tile] (strictly-lower
-// 32x32). Mirrors FLA solve_tril: split into 16-quadrants negN = [[N00,0],[N10,N11]], invert the two
-// diagonal 16-blocks (short, bounded Horners), and form the off-diagonal EXACTLY (one matmul chain,
-// no power series). A single 32x32 Horner instead loses fp32 precision on harder blocks.
-//   Bi00=(I-N00)^-1 (top-left), Bi11=(I-N11)^-1 (bottom-right), off=Bi11@N10@Bi00 (bottom-left).
-//   out = [[Bi00,0],[off,Bi11]].
-// Masks (single tiles): cb_mask[0]=Qtl, [1]=Qbr, [2]=Q10 (bottom-left). tmpN/tmpT = scratch.
-// Private scratch A..D use cb_ointer/cb_final/cb_s2/cb_s3 — all fp32 and NOT drained by the prep
-// writer (unlike the output CBs cb_w/cb_qdecay/cb_intra, whose scratch pushes the writer would
-// wrongly consume). None alias src (cb_scr3), out, or the Ct==2 persistents (cb_supd/cb_stmp).
-void invert_block(uint32_t src, uint32_t tile, uint32_t out, uint32_t tmpN, uint32_t tmpT) {
-    const uint32_t A = cb_S, B = cb_final, C = cb_s2, D = cb_s3;
-    cpy_t(src, tile, tmpN);
-    CircularBuffer(tmpN).wait_front(1);  // negN -> tmpN[0]
-    // Bi00 = (I-N00)^-1  (N00 = top-left quadrant of negN; top-right is already 0)
-    ewt(tmpN, 0, cb_mask, 0, A, 2);
-    CircularBuffer(A).wait_front(1);  // N00
-    invert16(A, B, tmpT);
-    CircularBuffer(B).wait_front(1);
-    CircularBuffer(A).pop_front(1);  // Bi00 -> B
-    // Bi11 = (I-N11)^-1  (N11 = bottom-right quadrant)
-    ewt(tmpN, 0, cb_mask, 1, A, 2);
-    CircularBuffer(A).wait_front(1);  // N11
-    invert16(A, C, tmpT);
-    CircularBuffer(C).wait_front(1);
-    CircularBuffer(A).pop_front(1);  // Bi11 -> C
-    // off = Bi11 @ N10 @ Bi00  (N10 = bottom-left quadrant; result lives only there)
-    ewt(tmpN, 0, cb_mask, 2, A, 2);
-    CircularBuffer(A).wait_front(1);  // N10
-    CircularBuffer(tmpN).pop_front(1);
-    mm(C, A, tmpT, 1, 1, 1, false);
-    CircularBuffer(tmpT).wait_front(1);
-    CircularBuffer(A).pop_front(1);  // Bi11@N10
-    mm(tmpT, B, A, 1, 1, 1, false);
-    CircularBuffer(A).wait_front(1);
-    CircularBuffer(tmpT).pop_front(1);  // @Bi00 -> A(off)
-    // out = Qtl*Bi00 + Qbr*Bi11 + off
-    ewt(B, 0, cb_mask, 0, D, 2);
-    CircularBuffer(D).wait_front(1);
-    CircularBuffer(B).pop_front(1);  // Bi00_tl -> D
-    ewt(C, 0, cb_mask, 1, B, 2);
-    CircularBuffer(B).wait_front(1);
-    CircularBuffer(C).pop_front(1);  // Bi11_br -> B
-    ewt(D, 0, B, 0, C, 0);
-    CircularBuffer(C).wait_front(1);
-    CircularBuffer(D).pop_front(1);
-    CircularBuffer(B).pop_front(1);
-    ewt(C, 0, A, 0, out, 0);
-    CircularBuffer(C).pop_front(1);
-    CircularBuffer(A).pop_front(1);  // + off -> out
-}
-
-// out[1,Ct] row-form = transpose of col[Ct,1]; produces Ct tiles (each row0 = a 32-chunk of col).
-void transpose_col(uint32_t in, uint32_t o, uint32_t Ct) {
-    cb_reserve_back(o, Ct);
-    pack_reconfig_data_format(o);
-    reconfig_data_format_srca(in);  // unary: in->srcA
-    transpose_init(in);
-    for (uint32_t i = 0; i < Ct; i++) {
-        tile_regs_acquire();
-        transpose_tile(in, i, 0);
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, i);
-        tile_regs_release();
-    }
-    cb_push_back(o, Ct);
-}
-
-// OPT-A/B in-kernel L2-norm over K. rowsum_k: o[Mt,1(broadcast)] = sum over the full K dim of
-// in[Mt,Kt], computed as in @ ones by reusing cb_ones tile 0 as the [K,1] contraction operand
-// (avoids a dedicated ones-column constant). Mirrors the `mm` helper's reconfig/matmul discipline.
-void rowsum_k(uint32_t in, uint32_t o, uint32_t Mt, uint32_t Kt) {
-    cb_reserve_back(o, Mt);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(cb_ones, in);  // matmul(in, cb_ones): in->srcB, cb_ones->srcA
-    matmul_init(in, cb_ones, 0);
-    for (uint32_t mi = 0; mi < Mt; mi++) {
-        tile_regs_acquire();
-        for (uint32_t ki = 0; ki < Kt; ki++) {
-            matmul_tiles(in, cb_ones, mi * Kt + ki, 0, 0);  // reuse ones tile 0 for every ki
-        }
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, mi);
-        tile_regs_release();
-    }
-    cb_push_back(o, Mt);
-}
-
-// inv_rms: o[i] = rsqrt(in[i] + eps) [* scale]. in holds per-row sum-of-squares (rowsum_k output);
-// out is the per-row inverse-L2 factor (optionally pre-scaled, for folding q's scale into the norm).
-// eps/scale arrive as fp32-bit-cast uint32 compile args.
-void inv_rms(uint32_t in, uint32_t o, uint32_t n, uint32_t eps_bits, uint32_t scale_bits, bool do_scale) {
-    cb_reserve_back(o, n);
-    pack_reconfig_data_format(o);
-    reconfig_data_format_srca(in);
-    copy_tile_to_dst_init_short(in);
-    for (uint32_t i = 0; i < n; i++) {
-        tile_regs_acquire();
-        copy_tile(in, i, 0);
-        binop_with_scalar_tile_init();
-        add_unary_tile(0, eps_bits);  // + eps
-        rsqrt_tile_init();
-        rsqrt_tile(0);  // 1/sqrt(sumsq + eps)
-        if (do_scale) {
-            binop_with_scalar_tile_init();
-            mul_unary_tile(0, scale_bits);  // * scale (q only)
-        }
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, i);
-        tile_regs_release();
-    }
-    cb_push_back(o, n);
-}
+constexpr GdnPrepCbs CBS{
+    .q = cb_q,
+    .k = cb_k,
+    .v = cb_v,
+    .g = cb_g,
+    .beta = cb_beta,
+    .eye = cb_eye,
+    .tril = cb_tril,
+    .ones = cb_ones,
+    .S = cb_S,
+    .decay = cb_decay,
+    .decay_exp = cb_decay_exp,
+    .decayfac = cb_decayfac,
+    .lmask = cb_lmask,
+    .Tinv = cb_Tinv,
+    .vbeta = cb_vbeta,
+    .kbeta = cb_kbeta,
+    .w = cb_w,
+    .qdecay = cb_qdecay,
+    .intra = cb_intra,
+    .s2 = cb_s2,
+    .ointer = cb_ointer,
+    .kdec_t = cb_kdec_t,
+    .supd = cb_supd,
+    .stmp = cb_stmp,
+    .final_s = cb_final,
+    .scr1 = cb_scr1,
+    .scr2 = cb_scr2,
+    .scr3 = cb_scr3,
+    .s3 = cb_s3,
+    .dl = cb_dl,
+    .mask = cb_mask};
 
 }  // namespace
 
@@ -376,10 +90,6 @@ void kernel_main() {
     const uint32_t NC = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t cc = Ct * Ct;
-    constexpr uint32_t ck = Ct * Kt;
-    constexpr uint32_t cv = Ct * Vt;
-    constexpr uint32_t kv = Kt * Vt;
-    constexpr uint32_t C = Ct * 32;
 
     compute_kernel_hw_startup(cb_q, cb_k, cb_u);
 
@@ -393,202 +103,6 @@ void kernel_main() {
     // sequential state scan lives in the separate scan kernel. Outputs (per chunk) u, w, k_dec_t,
     // q_decay, intra, dl are pushed to their CBs and streamed to DRAM by the prep writer.
     for (uint32_t c = 0; c < NC; c++) {
-        WAIT(cb_q, ck);
-        WAIT(cb_k, ck);
-        WAIT(cb_v, cv);
-        WAIT(cb_g, Ct);
-        WAIT(cb_beta, Ct);
-
-        // ---- OPT-B: in-kernel L2-norm of q,k over K (fold q's scale). Consumes the raw reader q/k
-        // and produces normalized q->cb_supd, k->cb_stmp (both free in Ct==1). The rest of the chunk
-        // then reads Q/Kk instead of cb_q/cb_k. scr1/scr2/scr3 are free here (used only later). ----
-        uint32_t Q = cb_q, Kk = cb_k;
-        if constexpr (QK_NORM) {
-            // q: q^2 -> rowsum_K -> rsqrt(+eps)*scale -> q_normed (cb_supd)
-            ew(cb_q, cb_q, cb_scr1, ck, 2);
-            WAIT(cb_scr1, ck);
-            rowsum_k(cb_scr1, cb_scr2, Ct, Kt);
-            WAIT(cb_scr2, Ct);
-            POP(cb_scr1, ck);
-            inv_rms(cb_scr2, cb_scr3, Ct, EPS_BITS, SCALE_BITS, /*do_scale=*/true);
-            WAIT(cb_scr3, Ct);
-            POP(cb_scr2, Ct);
-            bcast_cols_mul(cb_q, cb_scr3, cb_supd, Ct, Kt);
-            WAIT(cb_supd, ck);
-            POP(cb_scr3, Ct);
-            POP(cb_q, ck);
-            // k: same, no scale -> k_normed (cb_stmp)
-            ew(cb_k, cb_k, cb_scr1, ck, 2);
-            WAIT(cb_scr1, ck);
-            rowsum_k(cb_scr1, cb_scr2, Ct, Kt);
-            WAIT(cb_scr2, Ct);
-            POP(cb_scr1, ck);
-            inv_rms(cb_scr2, cb_scr3, Ct, EPS_BITS, SCALE_BITS, /*do_scale=*/false);
-            WAIT(cb_scr3, Ct);
-            POP(cb_scr2, Ct);
-            bcast_cols_mul(cb_k, cb_scr3, cb_stmp, Ct, Kt);
-            WAIT(cb_stmp, ck);
-            POP(cb_scr3, Ct);
-            POP(cb_k, ck);
-            Q = cb_supd;
-            Kk = cb_stmp;
-        }
-
-        // ---- P1: v_beta, k_beta ----
-        bcast_cols_mul(cb_v, cb_beta, cb_vbeta, Ct, Vt);
-        WAIT(cb_vbeta, cv);
-        bcast_cols_mul(Kk, cb_beta, cb_kbeta, Ct, Kt);
-        WAIT(cb_kbeta, ck);
-        POP(cb_beta, Ct);
-        POP(cb_v, cv);
-
-        // ---- P2: decay = tril@g, decay_exp, decay_row ----
-        mm(cb_tril, cb_g, cb_decay, Ct, Ct, 1, false);
-        WAIT(cb_decay, Ct);
-        expc(cb_decay, cb_decay_exp, Ct);
-        WAIT(cb_decay_exp, Ct);
-        transpose_col(cb_decay, cb_scr1, Ct);  // decay_row in scr1
-        WAIT(cb_scr1, Ct);
-
-        // ---- L_mask = tril(exp(decay_i - decay_j)) ----
-        bcast_cols_mul(cb_ones, cb_decay, cb_scr2, Ct, Ct);  // decay_i everywhere
-        WAIT(cb_scr2, cc);
-        bcast_rows_sub(cb_scr2, cb_scr1, cb_scr3, Ct, Ct);  // decay_i - decay_j
-        WAIT(cb_scr3, cc);
-        POP(cb_scr1, Ct);  // decay_row done
-        POP(cb_scr2, cc);
-        ew(cb_scr3, cb_tril, cb_scr2, cc, 2);  // *tril (zero upper)
-        WAIT(cb_scr2, cc);
-        POP(cb_scr3, cc);
-        expc(cb_scr2, cb_scr3, cc);  // exp
-        WAIT(cb_scr3, cc);
-        POP(cb_scr2, cc);
-        ew(cb_scr3, cb_tril, cb_lmask, cc, 2);  // *tril again -> L_mask
-        WAIT(cb_lmask, cc);
-        POP(cb_scr3, cc);
-
-        // ---- decayfac = exp(g_sum - decay) ----
-        // (dl = exp(g_sum) is recomputed at the scan from decayfac[0]*decay_exp[0] so its CB
-        //  slot can be reused as the third ping-pong state buffer cb_s3.)
-        mm(cb_ones, cb_g, cb_scr1, Ct, Ct, 1, false);  // g_sum in every row (col form)
-        WAIT(cb_scr1, Ct);
-        POP(cb_g, Ct);
-        ew(cb_scr1, cb_decay, cb_scr2, Ct, 1);  // g_sum - decay
-        WAIT(cb_scr2, Ct);
-        POP(cb_scr1, Ct);
-        POP(cb_decay, Ct);
-        expc(cb_scr2, cb_decayfac, Ct);
-        WAIT(cb_decayfac, Ct);
-        POP(cb_scr2, Ct);
-
-        // ---- N = strictly_lower(k_beta@k^T * L_mask); T_inv = (I + strictly_lower)^-1 ----
-        // The WY inverse, mirroring FLA's solve_tril: block down to 16x16 (invert_block splits each
-        // 32x32 tile into 16-quadrants), invert the small diagonal blocks with bounded Horners, and
-        // merge off-diagonal blocks EXACTLY. This keeps every intermediate bounded, unlike a single
-        // 32x32/full-matrix Horner whose deep power series loses fp32 precision on harder chunks.
-        mm(cb_kbeta, Kk, cb_scr1, Ct, Kt, Ct, true);  // kk = k_beta @ k^T (Kk = normalized k)
-        WAIT(cb_scr1, cc);
-        ew(cb_scr1, cb_lmask, cb_scr2, cc, 2);  // kk_masked = kk * L_mask
-        WAIT(cb_scr2, cc);
-        POP(cb_scr1, cc);
-        ew(cb_scr2, cb_eye, cb_scr1, cc, 2);  // diag(kk_masked)
-        WAIT(cb_scr1, cc);
-        // negN = diag - kk_masked = -(strictly_lower(kk_masked))  (= -A_strict, kept in cb_scr3)
-        ew(cb_scr1, cb_scr2, cb_scr3, cc, 1);
-        WAIT(cb_scr3, cc);
-        POP(cb_scr1, cc);
-        POP(cb_scr2, cc);
-
-        if constexpr (Ct == 1) {
-            // Single 32x32 block: T_inv is just its inverse.
-            invert_block(cb_scr3, 0, cb_Tinv, cb_scr1, cb_scr2);
-            WAIT(cb_Tinv, cc);
-            POP(cb_scr3, cc);
-        } else if constexpr (Ct == 2) {
-            // 2x2 tile-block lower-triangular. negN tiles: 0=(0,0), 2=(1,0), 3=(1,1); (0,1)=0.
-            // Diagonal inverses Mi11, Mi22, then off-diagonal Mi21 = -Mi22 @ A21 @ Mi11.
-            // (A21 = -negN21, so -Mi22@A21@Mi11 = Mi22 @ negN21 @ Mi11.)
-            // Mi11 -> cb_supd, Mi22 -> cb_stmp, Mi21 -> cb_ointer (all free in prep).
-            invert_block(cb_scr3, 0, cb_supd, cb_scr1, cb_scr2);  // Mi11
-            invert_block(cb_scr3, 3, cb_stmp, cb_scr1, cb_scr2);  // Mi22
-            cpy_t(cb_scr3, 2, cb_scr1);                           // negN21 -> cb_scr1[0]
-            WAIT(cb_scr1, 1);
-            mm(cb_scr1, cb_supd, cb_scr2, 1, 1, 1, false);  // tmp = negN21 @ Mi11
-            WAIT(cb_scr2, 1);
-            POP(cb_scr1, 1);
-            mm(cb_stmp, cb_scr2, cb_ointer, 1, 1, 1, false);  // Mi21 = Mi22 @ tmp
-            WAIT(cb_ointer, 1);
-            POP(cb_scr2, 1);
-            POP(cb_scr3, cc);  // negN done
-            // T_inv = [[Mi11, 0], [Mi21, Mi22]]  (cb_eye[1] is the zero block)
-            asm4(cb_supd, 0, cb_eye, 1, cb_ointer, 0, cb_stmp, 0, cb_Tinv);
-            WAIT(cb_Tinv, cc);
-            POP(cb_supd, 1);
-            POP(cb_stmp, 1);
-            POP(cb_ointer, 1);
-        } else {
-            // Fallback (C>64, currently xfail): full-matrix Horner.
-            ew(cb_eye, cb_scr3, cb_Tinv, cc, 0);
-            WAIT(cb_Tinv, cc);
-            for (uint32_t m = 2; m < C; m++) {
-                mm(cb_scr3, cb_Tinv, cb_scr1, Ct, Ct, Ct, false);
-                WAIT(cb_scr1, cc);
-                POP(cb_Tinv, cc);
-                ew(cb_eye, cb_scr1, cb_Tinv, cc, 0);
-                WAIT(cb_Tinv, cc);
-                POP(cb_scr1, cc);
-            }
-            POP(cb_scr3, cc);
-        }
-
-        // ---- un-premultiplied WY hand-off: output v_beta (cb_vbeta), kd=k_beta*decay_exp (cb_w),
-        // T_inv (cb_Tinv). The scan computes v_new = T_inv @ (v_beta - kd@S), applying the inverse
-        // AFTER the subtraction so its fp error is not amplified by the u - w@S cancellation.
-        bcast_cols_mul(cb_kbeta, cb_decay_exp, cb_w, Ct, Kt);  // kd -> cb_w (output)
-        WAIT(cb_w, ck);
-        POP(cb_kbeta, ck);
-        // cb_vbeta (v_beta) and cb_Tinv (T_inv) remain pushed for the writer; NOT popped here.
-
-        // ---- intra = (q@k^T) * L_mask ; q_decay = q*decay_exp ; k_dec_t ----
-        mm(Q, Kk, cb_scr1, Ct, Kt, Ct, true);  // qk = q @ k^T (Q/Kk = normalized q,k)
-        WAIT(cb_scr1, cc);
-        ew(cb_scr1, cb_lmask, cb_intra, cc, 2);
-        WAIT(cb_intra, cc);
-        POP(cb_scr1, cc);
-        POP(cb_lmask, cc);
-        bcast_cols_mul(Q, cb_decay_exp, cb_qdecay, Ct, Kt);
-        WAIT(cb_qdecay, ck);
-        POP(Q, ck);
-        // decay_exp kept alive: reused at the scan to recompute dl = exp(g_sum).
-        bcast_cols_mul(Kk, cb_decayfac, cb_scr1, Ct, Kt);  // k * exp(decay_last-decay)
-        WAIT(cb_scr1, ck);
-        POP(Kk, ck);
-        // decayfac kept alive: reused at the scan to recompute dl = exp(g_sum).
-        // k_dec_t = transpose(k_dec) [K,C]: transpose each [Ct,Kt] tile block into [Kt,Ct].
-        cb_reserve_back(cb_kdec_t, Kt * Ct);
-        pack_reconfig_data_format(cb_kdec_t);
-        reconfig_data_format_srca(cb_scr1);  // unary: in->srcA
-        transpose_init(cb_scr1);
-        for (uint32_t ki = 0; ki < Kt; ki++) {
-            for (uint32_t ci = 0; ci < Ct; ci++) {
-                tile_regs_acquire();
-                transpose_tile(cb_scr1, ci * Kt + ki, 0);
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile(0, cb_kdec_t, ki * Ct + ci);
-                tile_regs_release();
-            }
-        }
-        cb_push_back(cb_kdec_t, Kt * Ct);
-        POP(cb_scr1, ck);
-
-        // ---- dl = exp(g_sum) = decayfac[i]*decay_exp[i] (same for all i); 1 tile, [0,0] holds dl.
-        // The scan kernel uses it to decay the recurrent state: S <- S*dl + k_dec_t@v_new.
-        ew(cb_decayfac, cb_decay_exp, cb_dl, 1, 2);
-        WAIT(cb_dl, 1);
-        POP(cb_decayfac, Ct);
-        POP(cb_decay_exp, Ct);
-        // u, w, k_dec_t, q_decay, intra, dl remain pushed in their CBs -> prep writer -> DRAM.
-        // (They are NOT popped here; the writer drains them per chunk.)
+        prep_chunk(CBS, Ct, Kt, Vt, QK_NORM != 0, SCALE_BITS, EPS_BITS);
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_scan.cpp
@@ -11,15 +11,13 @@
 //   s_upd   = k_dec_t @ v_new
 //   S       = S * dl + s_upd        (dl = exp(g_sum), scalar in dl tile [0,0])
 // No matrix inverse here — that (the expensive part) lives entirely in the prep phase.
+//
+// The math bodies live in chunk_gdn_math.hpp (shared with the prep kernel); this file is just
+// the CB map and the chunk loop calling scan_step().
 
 #include <cstdint>
 #include "api/compute/common.h"
-#include "api/compute/matmul.h"
-#include "api/compute/eltwise_binary.h"
-#include "api/compute/bcast.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/reconfig_data_format.h"
-#include "api/dataflow/circular_buffer.h"
+#include "chunk_gdn_math.hpp"
 
 namespace {
 
@@ -30,78 +28,20 @@ constexpr uint32_t cb_s2 = 21, cb_vnew = 22, cb_ointer = 23, cb_kdec_t = 24;
 constexpr uint32_t cb_supd = 25, cb_stmp = 26, cb_final = 27;
 constexpr uint32_t cb_scr1 = 28, cb_s3 = 31;
 
-inline void WAIT(uint32_t cb, uint32_t n) { CircularBuffer(cb).wait_front(n); }
-inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
-
-// out[Mt,Nt] = A[Mt,Kt] @ (tr ? B[Nt,Kt]^T : B[Kt,Nt]). Inputs must be available.
-void mm(uint32_t a, uint32_t b, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t Nt, bool tr) {
-    cb_reserve_back(o, Mt * Nt);
-    pack_reconfig_data_format(o);  // mixed bf16/fp32 CBs: set packer to this output's format
-    // matmul_tiles(a,b): in0=a->srcB, in1=b->srcA. The op init only asserts formats, it does not
-    // set them, so reconfig the unpack src formats explicitly (else CBs read at the wrong format).
-    reconfig_data_format(b, a);
-    matmul_init(a, b, tr ? 1 : 0);
-    for (uint32_t mi = 0; mi < Mt; mi++) {
-        for (uint32_t ni = 0; ni < Nt; ni++) {
-            tile_regs_acquire();
-            for (uint32_t ki = 0; ki < Kt; ki++) {
-                uint32_t bi = tr ? (ni * Kt + ki) : (ki * Nt + ni);
-                matmul_tiles(a, b, mi * Kt + ki, bi, 0);
-            }
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, o, mi * Nt + ni);
-            tile_regs_release();
-        }
-    }
-    cb_push_back(o, Mt * Nt);
-}
-
-// out = A (op) B elementwise, n tiles. op: 0 add, 1 sub, 2 mul.
-void ew(uint32_t a, uint32_t b, uint32_t o, uint32_t n, int op) {
-    cb_reserve_back(o, n);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(a, b);  // binary(a,b): a->srcA, b->srcB
-    if (op == 0) {
-        add_init(a, b);
-    } else if (op == 1) {
-        sub_init(a, b);
-    } else {
-        mul_init(a, b);
-    }
-    for (uint32_t i = 0; i < n; i++) {
-        tile_regs_acquire();
-        if (op == 0) {
-            add_tiles(a, b, i, i, 0);
-        } else if (op == 1) {
-            sub_tiles(a, b, i, i, 0);
-        } else {
-            mul_tiles(a, b, i, i, 0);
-        }
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, i);
-        tile_regs_release();
-    }
-    cb_push_back(o, n);
-}
-
-// out = A * scalar, n tiles. scalar is the [0,0] element of the single `scal` tile.
-void bcast_scalar_mul(uint32_t a, uint32_t scal, uint32_t o, uint32_t n) {
-    cb_reserve_back(o, n);
-    pack_reconfig_data_format(o);
-    reconfig_data_format(a, scal);  // bcast(a,scal): a->srcA, scal->srcB
-    mul_bcast_scalar_init(a, scal);
-    for (uint32_t i = 0; i < n; i++) {
-        tile_regs_acquire();
-        mul_tiles_bcast_scalar(a, scal, i, 0, 0);
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, o, i);
-        tile_regs_release();
-    }
-    cb_push_back(o, n);
-}
+constexpr GdnScanCbs CBS{
+    .dl = cb_dl,
+    .Tinv = cb_Tinv,
+    .out = cb_out,
+    .vbeta = cb_vbeta,
+    .kd = cb_kd,
+    .qdecay = cb_qdecay,
+    .intra = cb_intra,
+    .vnew = cb_vnew,
+    .ointer = cb_ointer,
+    .kdec_t = cb_kdec_t,
+    .supd = cb_supd,
+    .stmp = cb_stmp,
+    .scr1 = cb_scr1};
 
 }  // namespace
 
@@ -110,12 +50,6 @@ void kernel_main() {
     constexpr uint32_t Kt = get_compile_time_arg_val(1);
     constexpr uint32_t Vt = get_compile_time_arg_val(2);
     const uint32_t NC = get_arg_val<uint32_t>(0);
-
-    constexpr uint32_t cc = Ct * Ct;
-    constexpr uint32_t ck = Ct * Kt;
-    constexpr uint32_t cv = Ct * Vt;
-    constexpr uint32_t kv = Kt * Vt;
-    constexpr uint32_t kc = Kt * Ct;
 
     compute_kernel_hw_startup(cb_kd, cb_vbeta, cb_out);
 
@@ -129,52 +63,6 @@ void kernel_main() {
         const bool last = (c == NC - 1);
         const uint32_t dst = last ? cb_final : nxt_S;
 
-        // v_new = T_inv @ (v_beta - kd@S)  -- apply the inverse AFTER the subtraction so the WY
-        // inverse's fp error is not amplified by the cancellation (vs the u - w@S form).
-        WAIT(cb_kd, ck);
-        WAIT(cur_S, kv);
-        mm(cb_kd, cur_S, cb_scr1, Ct, Kt, Vt, false);  // kdS = kd @ S -> scr1
-        WAIT(cb_scr1, cv);
-        POP(cb_kd, ck);
-        WAIT(cb_vbeta, cv);
-        ew(cb_vbeta, cb_scr1, cb_ointer, cv, 1);  // diff = v_beta - kdS -> ointer
-        WAIT(cb_ointer, cv);
-        POP(cb_vbeta, cv);
-        POP(cb_scr1, cv);
-        WAIT(cb_Tinv, cc);
-        mm(cb_Tinv, cb_ointer, cb_vnew, Ct, Ct, Vt, false);  // v_new = T_inv @ diff -> vnew
-        WAIT(cb_vnew, cv);
-        POP(cb_Tinv, cc);
-        POP(cb_ointer, cv);
-
-        // o = q_decay @ S + intra @ v_new
-        WAIT(cb_qdecay, ck);
-        mm(cb_qdecay, cur_S, cb_ointer, Ct, Kt, Vt, false);  // o_inter = q_decay @ S
-        WAIT(cb_ointer, cv);
-        POP(cb_qdecay, ck);
-        WAIT(cb_intra, cc);
-        mm(cb_intra, cb_vnew, cb_scr1, Ct, Ct, Vt, false);  // intra_v = intra @ v_new
-        WAIT(cb_scr1, cv);
-        POP(cb_intra, cc);
-        ew(cb_ointer, cb_scr1, cb_out, cv, 0);  // o -> cb_out (drained by writer)
-        POP(cb_ointer, cv);
-        POP(cb_scr1, cv);
-
-        // s_upd = k_dec_t @ v_new
-        WAIT(cb_kdec_t, kc);
-        mm(cb_kdec_t, cb_vnew, cb_supd, Kt, Ct, Vt, false);
-        WAIT(cb_supd, kv);
-        POP(cb_kdec_t, kc);
-        POP(cb_vnew, cv);
-
-        // S_new = cur_S * dl + s_upd  (dl scalar in cb_dl tile [0,0])
-        WAIT(cb_dl, 1);
-        bcast_scalar_mul(cur_S, cb_dl, cb_stmp, kv);
-        WAIT(cb_stmp, kv);
-        POP(cb_dl, 1);
-        POP(cur_S, kv);
-        ew(cb_stmp, cb_supd, dst, kv, 0);
-        POP(cb_stmp, kv);
-        POP(cb_supd, kv);
+        scan_step(CBS, cur_S, dst, Ct, Kt, Vt);
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_scan.cpp
@@ -21,10 +21,15 @@
 
 namespace {
 
-constexpr uint32_t cb_dl = 11, cb_Tinv = 13;
+// The seven per-chunk inputs live at PREP'S OUTPUT indices (v_beta=14, kd=18, q_decay=19,
+// intra=20, k_dec_t=24, dl=22, t_inv=13) so the fused program can declare ONE hand-off CB set on
+// the producer/receiver core union. That put dl at 22 (the slot prep's compute pushes dl into)
+// and moved the v_new scratch to the freed 11. Indices are plumbing only — the phased path stays
+// numerically identical across this renumber.
+constexpr uint32_t cb_dl = 22, cb_Tinv = 13;
 constexpr uint32_t cb_S = 8, cb_out = 16;
-constexpr uint32_t cb_vbeta = 17, cb_kd = 18, cb_qdecay = 19, cb_intra = 20;
-constexpr uint32_t cb_s2 = 21, cb_vnew = 22, cb_ointer = 23, cb_kdec_t = 24;
+constexpr uint32_t cb_vbeta = 14, cb_kd = 18, cb_qdecay = 19, cb_intra = 20;
+constexpr uint32_t cb_s2 = 21, cb_vnew = 11, cb_ointer = 23, cb_kdec_t = 24;
 constexpr uint32_t cb_supd = 25, cb_stmp = 26, cb_final = 27;
 constexpr uint32_t cb_scr1 = 28, cb_s3 = 31;
 

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
@@ -33,11 +33,8 @@
 #include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "hostdevcommon/common_values.hpp"
-// Semaphore ids fixed by the scan program factory (SemaphoreDescriptors, init 0). Must stay in
-// sync with the ids in chunk_gdn_phased_program_factory.cpp — drift compiles clean and deadlocks
-// at runtime; move to trailing compile-time args before this op is ever fused with another.
-constexpr uint32_t SEM_READY = 0;  // receivers -> sender: "my CB space for this chunk is reserved"
-constexpr uint32_t SEM_VALID = 1;  // sender -> receivers: "this chunk's shared data is in your CBs"
+// Semaphore ids (SEM_READY/SEM_VALID) arrive as the two trailing compile-time args after the
+// accessor chain — read in kernel_main below, so factory and kernel cannot drift.
 #endif
 
 constexpr uint32_t cb_dl = 11, cb_S = 8, cb_Tinv = 13;
@@ -64,6 +61,18 @@ void kernel_main() {
     constexpr auto dl_a = TensorAccessorArgs<kc_a.next_compile_time_args_offset()>();
     constexpr auto ti_a = TensorAccessorArgs<dl_a.next_compile_time_args_offset()>();
     constexpr auto s0_a = TensorAccessorArgs<ti_a.next_compile_time_args_offset()>();
+#endif
+
+#if defined(GDN_MCAST_SENDER) || defined(GDN_MCAST_RECEIVER)
+    // Handshake semaphore ids: the two trailing compile-time args the factory appends AFTER the
+    // TensorAccessorArgs chain (unconditionally, on every variant, so the offsets stay uniform;
+    // the plain reader has no semaphores and simply doesn't read them). s0_a is the LAST accessor
+    // on both the sender's 8-accessor chain and the receiver's 2-accessor chain, so the same
+    // offset expression is correct in both variants.
+    // SEM_READY: receivers -> sender: "my CB space for this chunk is reserved"
+    // SEM_VALID: sender -> receivers: "this chunk's shared data is in your CBs"
+    constexpr uint32_t SEM_READY = get_compile_time_arg_val(s0_a.next_compile_time_args_offset());
+    constexpr uint32_t SEM_VALID = get_compile_time_arg_val(s0_a.next_compile_time_args_offset() + 1);
 #endif
 
     // This core handles head h, V-block vb (columns [vb*Vt, vb*Vt+Vt) of the full V dimension).

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
@@ -4,7 +4,7 @@
 // Phase B (scan) reader: the initial state S [K,V] once, then per chunk the seven prep
 // intermediates v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv from DRAM. All fp32.
 //
-// Three compile variants (host selects via defines; no define = the plain reader):
+// Four compile variants (host selects via defines; no define = the plain reader):
 //   GDN_MCAST_SENDER   — this core is its head's v-block-0. It reads the six SHARED V-independent
 //                        tensors (kd, q_decay, intra, k_dec_t, dl, t_inv) from DRAM once per chunk
 //                        and multicasts them into the sibling v-block cores' CBs (identical CB
@@ -12,6 +12,12 @@
 //   GDN_MCAST_RECEIVER — a sibling v-block core. Reads only its private V-sliced tensors (v_beta,
 //                        s0) from DRAM; the shared block arrives over the NoC. Handshake:
 //                        reserve CB space -> ready.up(sender) -> wait(valid) -> push.
+//   GDN_FUSED_RECEIVER — chunk_gdn_fused consumer: zero DRAM intermediates. Reads only s0; ALL
+//                        seven per-chunk tensors — v_beta included (Option U for F1: the paired
+//                        producer core computes and sends it, keeping the compute kernels
+//                        byte-identical; Option R scan-side recompute is deferred to F2) — arrive
+//                        over the NoC from the producer's writer via the same handshake as
+//                        GDN_MCAST_RECEIVER. NV=1: this core holds the head's full V width.
 // The handshake follows the production matmul in0 mcast idiom (reader_bmm_tile_layout_in0_
 // sender_padding.cpp / _receiver.cpp): ready counts receivers that RESERVED space (so the sender
 // can never overwrite unconsumed data), the data mcasts and the valid-flag mcast share one NOC /
@@ -28,7 +34,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 
-#if defined(GDN_MCAST_SENDER) || defined(GDN_MCAST_RECEIVER)
+#if defined(GDN_MCAST_SENDER) || defined(GDN_MCAST_RECEIVER) || defined(GDN_FUSED_RECEIVER)
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc_semaphore.h"
@@ -37,8 +43,11 @@
 // accessor chain — read in kernel_main below, so factory and kernel cannot drift.
 #endif
 
-constexpr uint32_t cb_dl = 11, cb_S = 8, cb_Tinv = 13;
-constexpr uint32_t cb_vbeta = 17, cb_kd = 18, cb_qdecay = 19, cb_intra = 20, cb_kdec_t = 24;
+// The seven per-chunk input CBs sit at PREP'S OUTPUT indices (v_beta=14, dl=22; the rest were
+// already aligned) so the fused program declares one hand-off CB set on the producer/receiver
+// union. Must match chunk_gdn_scan.cpp (compute) and both program factories.
+constexpr uint32_t cb_dl = 22, cb_S = 8, cb_Tinv = 13;
+constexpr uint32_t cb_vbeta = 14, cb_kd = 18, cb_qdecay = 19, cb_intra = 20, cb_kdec_t = 24;
 
 void kernel_main() {
     constexpr uint32_t Ct = get_compile_time_arg_val(0);
@@ -48,7 +57,10 @@ void kernel_main() {
     constexpr uint32_t Vt_full = get_compile_time_arg_val(4);  // full V (tiles) for row stride
     (void)has_s0;
 
-#if defined(GDN_MCAST_RECEIVER)
+#if defined(GDN_FUSED_RECEIVER)
+    // Fused receivers touch DRAM only for s0; the accessor chain is a single block.
+    constexpr auto s0_a = TensorAccessorArgs<5>();
+#elif defined(GDN_MCAST_RECEIVER)
     // Receivers only access their private V-sliced tensors; the accessor chain has two blocks.
     constexpr auto vb_a = TensorAccessorArgs<5>();
     constexpr auto s0_a = TensorAccessorArgs<vb_a.next_compile_time_args_offset()>();
@@ -63,12 +75,12 @@ void kernel_main() {
     constexpr auto s0_a = TensorAccessorArgs<ti_a.next_compile_time_args_offset()>();
 #endif
 
-#if defined(GDN_MCAST_SENDER) || defined(GDN_MCAST_RECEIVER)
+#if defined(GDN_MCAST_SENDER) || defined(GDN_MCAST_RECEIVER) || defined(GDN_FUSED_RECEIVER)
     // Handshake semaphore ids: the two trailing compile-time args the factory appends AFTER the
     // TensorAccessorArgs chain (unconditionally, on every variant, so the offsets stay uniform;
     // the plain reader has no semaphores and simply doesn't read them). s0_a is the LAST accessor
-    // on both the sender's 8-accessor chain and the receiver's 2-accessor chain, so the same
-    // offset expression is correct in both variants.
+    // on the sender's 8-accessor chain, the mcast receiver's 2-accessor chain, and the fused
+    // receiver's 1-accessor chain alike, so the same offset expression is correct everywhere.
     // SEM_READY: receivers -> sender: "my CB space for this chunk is reserved"
     // SEM_VALID: sender -> receivers: "this chunk's shared data is in your CBs"
     constexpr uint32_t SEM_READY = get_compile_time_arg_val(s0_a.next_compile_time_args_offset());
@@ -79,7 +91,11 @@ void kernel_main() {
     const uint32_t h = get_arg_val<uint32_t>(0);
     const uint32_t vb = get_arg_val<uint32_t>(1);
     const uint32_t NC = get_arg_val<uint32_t>(2);
-#if defined(GDN_MCAST_RECEIVER)
+#if defined(GDN_FUSED_RECEIVER)
+    const uint32_t s0_addr = get_arg_val<uint32_t>(3);
+    const uint32_t prod_x = get_arg_val<uint32_t>(4);  // virtual worker coords of the producer
+    const uint32_t prod_y = get_arg_val<uint32_t>(5);
+#elif defined(GDN_MCAST_RECEIVER)
     const uint32_t vb_addr = get_arg_val<uint32_t>(3);
     const uint32_t s0_addr = get_arg_val<uint32_t>(4);
     const uint32_t sender_x = get_arg_val<uint32_t>(5);  // virtual worker coords of the sender
@@ -104,9 +120,11 @@ void kernel_main() {
 #endif
 
     const uint32_t tb = get_tile_size(cb_vbeta);  // all inputs fp32 -> same tile size
+#if !defined(GDN_FUSED_RECEIVER)
     const auto vb_acc = TensorAccessor(vb_a, vb_addr, tb);
+#endif
     const auto s0_acc = TensorAccessor(s0_a, s0_addr, tb);
-#if !defined(GDN_MCAST_RECEIVER)
+#if !defined(GDN_MCAST_RECEIVER) && !defined(GDN_FUSED_RECEIVER)
     const auto kd_acc = TensorAccessor(kd_a, kd_addr, tb);
     const auto qd_acc = TensorAccessor(qd_a, qd_addr, tb);
     const auto it_acc = TensorAccessor(it_a, it_addr, tb);
@@ -122,7 +140,7 @@ void kernel_main() {
 
     Noc noc;
 
-#if !defined(GDN_MCAST_RECEIVER) && !defined(GDN_MCAST_SENDER)
+#if !defined(GDN_MCAST_RECEIVER) && !defined(GDN_MCAST_SENDER) && !defined(GDN_FUSED_RECEIVER)
     // Full (V-independent) read: n contiguous tiles from `base` into the CB.
     auto read_into = [&](const auto& acc, uint32_t cb_id, uint32_t base, uint32_t n) {
         CircularBuffer cb(cb_id);
@@ -152,7 +170,8 @@ void kernel_main() {
         cb.push_back(R * Vt);
     };
 
-    // initial state S [K, V] (once) — host always provides it (zeros if none). V-sliced.
+    // initial state S [K, V] (once) — host always provides it (zeros if none). V-sliced
+    // (degenerates to the full state on fused receivers: vb = 0, Vt = Vt_full).
     read_vslice(s0_acc, cb_S, h * Kt * Vt_full, Kt);
 
 #if defined(GDN_MCAST_SENDER)
@@ -262,6 +281,44 @@ void kernel_main() {
         valid.wait(VALID);
 
         // The shared bytes are in our CBs; make them visible to compute.
+        CircularBuffer(cb_kd).push_back(ck);
+        CircularBuffer(cb_qdecay).push_back(ck);
+        CircularBuffer(cb_intra).push_back(cc);
+        CircularBuffer(cb_kdec_t).push_back(kc);
+        CircularBuffer(cb_dl).push_back(1);
+        CircularBuffer(cb_Tinv).push_back(cc);
+    }
+
+    valid.set(INVALID);  // local store: restore the initial value (the last wait left it VALID)
+    // Drain the ready atomics: no non-posted inc may be in flight at kernel exit.
+    noc.async_atomic_barrier();
+
+#elif defined(GDN_FUSED_RECEIVER)
+    Semaphore<> ready(SEM_READY);
+    Semaphore<> valid(SEM_VALID);
+
+    constexpr uint32_t cv = Ct * Vt;  // v_beta arrives whole: Vt == Vt_full on fused receivers
+
+    for (uint32_t c = 0; c < NC; c++) {
+        // Reserve this chunk's space in ALL SEVEN hand-off CBs FIRST — the ready inc is the
+        // producer's proof that every slot is writable (compute has popped the previous chunk).
+        // v_beta included: it is a hand-off CB here (Option U), not a DRAM read.
+        CircularBuffer(cb_vbeta).reserve_back(cv);
+        CircularBuffer(cb_kd).reserve_back(ck);
+        CircularBuffer(cb_qdecay).reserve_back(ck);
+        CircularBuffer(cb_intra).reserve_back(cc);
+        CircularBuffer(cb_kdec_t).reserve_back(kc);
+        CircularBuffer(cb_dl).reserve_back(1);
+        CircularBuffer(cb_Tinv).reserve_back(cc);
+
+        // Reset our valid flag BEFORE signalling ready: a fast producer may mcast VALID
+        // immediately after the inc, and a late reset would overwrite it (lost wakeup -> deadlock).
+        valid.set(INVALID);
+        ready.up(noc, prod_x, prod_y, 1);
+        valid.wait(VALID);
+
+        // The chunk's seven blocks are in our CBs; make them visible to compute.
+        CircularBuffer(cb_vbeta).push_back(cv);
         CircularBuffer(cb_kd).push_back(ck);
         CircularBuffer(cb_qdecay).push_back(ck);
         CircularBuffer(cb_intra).push_back(cc);

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/writer_chunk_gdn_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/writer_chunk_gdn_fused.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused-program (chunk_gdn_fused) PRODUCER writer: replaces the prep writer's DRAM drain with a
+// direct NoC hand-off. Per chunk it waits for the seven compute-pushed intermediates
+//   v_beta [C,V], t_inv [C,C], kd [C,K], intra [C,C], q_decay [C,K], k_dec_t [K,C], dl [1 tile]
+// and writes them into the paired RECEIVER (scan) core's CBs under the shipped ready/valid
+// handshake of reader_chunk_gdn_scan.cpp — the receiver (GDN_FUSED_RECEIVER) cannot tell this
+// computing sender from the phased DRAM-reading one. v_beta ships whole (Option U for F1: the
+// producer computes and sends it, keeping both compute kernels byte-identical to the phased
+// path; Option R — scan-side recompute from v and beta — is deferred to F2).
+//
+// Addressing: the seven hand-off CBs are declared on the UNION of producer+receiver cores
+// (identical base addresses both sides) with nbuf=1 and an equal per-chunk push/pop cadence, so
+// this core's read_ptr == the receiver's reserved slot == the CB base (the shipped lockstep
+// lemma) — each mcast writes source address -> same destination address. The destination is a
+// 1x1 rectangle (one receiver), which is orientation-neutral: start == end, so this writer's NOC
+// (whichever the WriterConfig assigns) needs no coordinate swap.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "hostdevcommon/common_values.hpp"
+
+// CB indices (prep compute's output slots == the scan side's hand-off slots after the F1 renumber;
+// must match chunk_gdn_prep.cpp, chunk_gdn_scan.cpp and the fused program factory).
+constexpr uint32_t cb_Tinv = 13, cb_vbeta = 14, cb_kd = 18, cb_qdecay = 19, cb_intra = 20;
+constexpr uint32_t cb_kdec_t = 24, cb_dl = 22;
+
+void kernel_main() {
+    constexpr uint32_t Ct = get_compile_time_arg_val(0);
+    constexpr uint32_t Kt = get_compile_time_arg_val(1);
+    constexpr uint32_t Vt = get_compile_time_arg_val(2);
+    // Handshake semaphore ids straight from the factory's SemaphoreDescriptors (no accessor
+    // chain on this kernel — nothing touches DRAM).
+    // SEM_READY: receiver -> producer: "my CB space for this chunk is reserved"
+    // SEM_VALID: producer -> receiver: "this chunk's seven blocks are in your CBs"
+    constexpr uint32_t SEM_READY = get_compile_time_arg_val(3);
+    constexpr uint32_t SEM_VALID = get_compile_time_arg_val(4);
+
+    const uint32_t NC = get_arg_val<uint32_t>(0);
+    const uint32_t rcv_x = get_arg_val<uint32_t>(1);  // virtual worker coords of the receiver
+    const uint32_t rcv_y = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cc = Ct * Ct;
+    constexpr uint32_t ck = Ct * Kt;
+    constexpr uint32_t cv = Ct * Vt;
+    constexpr uint32_t kc = Kt * Ct;
+
+    const uint32_t tb = get_tile_size(cb_vbeta);  // all hand-off CBs are fp32 -> same tile size
+
+    Noc noc;
+    Semaphore<> ready(SEM_READY);
+    Semaphore<> valid(SEM_VALID);
+    // set_multicast sources its 4-byte value from this core's LOCAL copy of `valid` — read
+    // asynchronously, when the NIU processes the command. Preset it to VALID once; any later
+    // write to this word must be preceded by a flush/barrier (see the teardown, where the
+    // barrier deliberately comes BEFORE the reset).
+    valid.set(VALID);
+
+    // One linked 1x1-rect mcast per hand-off CB, sourced from the CB's front slot (== the
+    // receiver's reserved slot, lockstep lemma). linked=true chains the data mcasts with the
+    // valid-flag mcast on one static VC (data-before-flag ordering).
+    MulticastEndpoint mcast_dst;
+    auto send = [&](uint32_t cb_id, uint32_t n) {
+        const uint32_t addr = CircularBuffer(cb_id).get_read_ptr();
+        noc.async_write_multicast(
+            CoreLocalMem<uint32_t>(addr),
+            mcast_dst,
+            n * tb,
+            1,
+            {},
+            {.noc_x_start = rcv_x, .noc_y_start = rcv_y, .noc_x_end = rcv_x, .noc_y_end = rcv_y, .addr = addr},
+            /*linked=*/true);
+    };
+
+    for (uint32_t c = 0; c < NC; c++) {
+        // Wait for the chunk's outputs in the phased prep writer's drain order (roughly
+        // compute's push order), so producer-side backpressure matches that writer exactly.
+        CircularBuffer(cb_vbeta).wait_front(cv);
+        CircularBuffer(cb_Tinv).wait_front(cc);
+        CircularBuffer(cb_kd).wait_front(ck);
+        CircularBuffer(cb_intra).wait_front(cc);
+        CircularBuffer(cb_qdecay).wait_front(ck);
+        CircularBuffer(cb_kdec_t).wait_front(kc);
+        CircularBuffer(cb_dl).wait_front(1);
+
+        // The receiver has reserved this chunk's CB space (its slots are writable).
+        ready.wait(1);
+        ready.set(0);
+
+        send(cb_vbeta, cv);
+        send(cb_Tinv, cc);
+        send(cb_kd, ck);
+        send(cb_intra, cc);
+        send(cb_qdecay, ck);
+        send(cb_kdec_t, kc);
+        send(cb_dl, 1);
+        // Flush on EVERY arch, for two reasons. Blackhole: NoC latency exceeds L1<->RISCV
+        // latency, so without it the receiver could see VALID with data still in flight. All
+        // arches: the flush proves every data mcast has read its L1 source slot; only then may
+        // the pops below let compute overwrite the slots with chunk c+1 (nbuf=1 — the flag
+        // mcast runs on a different cmd buf and provides no such ordering).
+        noc.async_writes_flushed();
+        valid.set_multicast(noc, rcv_x, rcv_y, rcv_x, rcv_y, 1);  // unlinked: ends the chain
+
+        // Free the slots for compute's next chunk only now (the mcasts sourced them).
+        CircularBuffer(cb_vbeta).pop_front(cv);
+        CircularBuffer(cb_Tinv).pop_front(cc);
+        CircularBuffer(cb_kd).pop_front(ck);
+        CircularBuffer(cb_intra).pop_front(cc);
+        CircularBuffer(cb_qdecay).pop_front(ck);
+        CircularBuffer(cb_kdec_t).pop_front(kc);
+        CircularBuffer(cb_dl).pop_front(1);
+    }
+
+    // Barrier BEFORE resetting the local valid word: set_multicast reads its payload from that
+    // word asynchronously, so resetting first could multicast INVALID for the final chunk and
+    // deadlock the receiver at valid.wait(VALID). Only after all nonposted writes are acked is
+    // the local reset safe (payload-source rule).
+    noc.async_write_barrier();
+    valid.set(INVALID);  // restore the semaphore's initial value
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/transformer/sources.cmake
@@ -35,6 +35,8 @@ set(TTNN_OP_TRANSFORMER_SRCS
     chunk_gated_delta_rule/device/chunk_gated_delta_rule_program_factory.cpp
     chunk_gated_delta_rule/device/chunk_gdn_phased.cpp
     chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
+    chunk_gated_delta_rule/device/chunk_gdn_fused.cpp
+    chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
     chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
 )
 


### PR DESCRIPTION
## What

Stages F0–F2 of the fused prep→scan hand-off plan for `chunk_gated_delta_rule` (design doc: *gdn-fused-handoff-design.md*, from a 19-agent design study + device experiments). Net effect: a new fused prim that eliminates the seven fp32 DRAM intermediates entirely and becomes the **default at BH ≥ 24**, measuring **1.40×** on the prefill core at BH=48/T=4096 (4816 → 3440 µs) with **456 MB less transient DRAM** and **912 MB less DRAM traffic** per layer call — bit-exact against the phased path at every step.

Stacked on #53804 → #53790.

## The three commits

**F0 — bit-identical refactor + test pyramid** (`9af3ce2`): math bodies hoisted into `chunk_gdn_math.hpp` (`prep_chunk`/`scan_step`, CB-parameterized helpers); prep/scan prims exposed as `ttnn.transformer.chunk_gdn_prep/chunk_gdn_scan` for part-level testing; semaphore ids → compile-time args; three new test files (each of prep's 7 outputs vs inlined torch references, scan vs the recurrence, prep→scan composition at `torch.equal`, whole-op golden on phased AND monolithic — the monolithic path's first coverage). Gated by fixed-seed byte-identity of the phased path (`torch.equal` pre/post on o and final_state, on silicon).

**F1 — the fused prim** (`8c5c8cf`): `chunk_gdn_fused` — one program, two core sets: per head a producer core runs the unchanged prep reader+compute plus a new writer that NoC-writes the seven computed intermediates into the paired scan core's CBs via the shipped ready/valid handshake (1×1-rect mcasts, flush-before-flag, barrier-before-reset); receiver is byte-identical to the mcast receiver. Scan-side CB renumber makes hand-off indices equal prep's output indices; the hand-off CBs are union-declared so the shipped lockstep addressing applies verbatim. Dispatch: `QWEN_GDN_PATH=fused|phased|mono` (op-level env → different prims → cache-safe); measured **bit-exact vs phased on silicon**. Shipped opt-in at F1 (perf below gate).

**F2 — producer perf, default flip** (`04b7d68`): the producer measured MATH-thread *issue-bound* (HiFi2 probe: −1.4 µs only). Changes: input+hand-off double buffering, and reconfig hoisting in the WY hot path (the per-call packer/unpacker format reconfigs are unconditional register writes; all WY CBs are fp32). w_p 33.8 → **26.9 µs/chunk**, clearing the design plan's ≤27 µs checkpoint → default flips to fused at BH ≥ 24. The hoist is gated to the fused producer only (`GDN_HOIST_RECONFIG`) after measuring a +22–37% regression on *phased* prep at low-occupancy shapes; phased keeps its original instruction stream (verified restored).

## Validation (all on p150b, fw 19.11)

- Phased-path **byte-identity** (fixed-seed `torch.equal`) held after every change, F0 through F2
- Fused-vs-phased **bit-exactness** 5/5 (with/without initial_state, default-dispatch proof via program-cache deltas)
- **23/23** GDN unit tests across four suites
- Perf: fused 3440 µs (1.40×) at single; small 503 µs (1.31× vs current phased); no default-path regression at any benched shape (tp4/single/small = 1152/3440/503 vs pre-series 1117/4816/488)

## Still TODO before un-drafting

- [ ] qwen36 CI-with-weights suite against the new default (`test_gdn_tp_fused_chunk_prefill`, traced long-prefill for trace-replay semaphore safety)
- [ ] F3 (not in this PR): multi-producer for BH<24, monolithic numerics port for BH=96
- Follow-on prototype (separate DO-NOT-MERGE PR): SFPU triangle-solve T_inv — measured w_p 18.24 µs / 2334 µs (2.06× cumulative); blocked on #53437

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-fused-prim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-fused-prim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-fused-prim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-fused-prim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-fused-prim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-fused-prim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-fused-prim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-fused-prim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-fused-prim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-fused-prim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-fused-prim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-fused-prim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-fused-prim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-fused-prim)