### PR TITLE
[PROTOTYPE - DO NOT MERGE] GDN fused producer: SFPU triangle-solve T_inv (w_p -32%)

### DIFF
--- a/tests/tt_metal/tt_metal/llk/sources.cmake
+++ b/tests/tt_metal/tt_metal/llk/sources.cmake
@@ -27,6 +27,7 @@ set(UNIT_TESTS_LLK_SRC
     test_single_core_matmul_int8.cpp
     test_top32_rm_dev.cpp
     test_transpose.cpp
+    test_triangle_solve.cpp
     test_unary_broadcast.cpp
     test_untilize_tilize.cpp
 )

--- a/tests/tt_metal/tt_metal/llk/test_triangle_solve.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_triangle_solve.cpp
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// LLK unit test for the per-tile forward-substitution triangle solve  L X = RHS  (SFPU,
+// Blackhole-only). Exercises the triangle_solve_tile compute API + ckernel_sfpu_triangle_solve
+// microcode directly at the tt_metal level: a single 32x32 bf16 tile through a
+// reader -> triangle_solve compute -> writer pipeline on one core, compared against a host
+// forward-substitution golden with PCC >= 0.99 (bf16 accumulation tolerance).
+//
+// Input convention (matches the ckernel): L is unit lower-triangular (diagonal an implicit 1) and
+// is supplied with its plain (non-negated) strict-lower entries; the solve subtracts them directly
+//   X[row] = RHS[row] - sum_{col<row} L[row][col] * X[col]
+// via an SFPMAD that negates the L[row][col] * X[col] product.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+
+#include "llk_device_fixture.hpp"
+#include "test_golden_impls.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/packing.hpp"
+
+namespace tt::tt_metal {
+
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::compute::sfpu::triangle_solve {
+
+constexpr uint32_t N = 32;                             // tile is 32x32
+constexpr uint32_t TILE_ELEMS = N * N;                 // 1024
+constexpr uint32_t SINGLE_TILE_SIZE = TILE_ELEMS * 2;  // bf16 => 2048 bytes
+
+// Round a float through bf16 (the format the device inputs and DST intermediates use).
+inline float to_bf16(float x) { return static_cast<float>(bfloat16(x)); }
+
+struct SolveInputs {
+    std::vector<bfloat16> l_rm;      // row-major NxN, unit-lower-tri (diagonal = 1)
+    std::vector<bfloat16> rhs_rm;    // row-major NxN
+    std::vector<float> x_golden_rm;  // row-major NxN, fp32
+};
+
+// Build device inputs and the host golden for one case.
+//   strict_lower_scale : magnitude of the random strict-lower entries of L
+//   identity_only      : if true, L == I (strict-lower all zero) => X must equal RHS
+SolveInputs make_inputs(uint32_t seed, float strict_lower_scale, bool identity_only) {
+    std::mt19937 gen(seed);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+
+    // Strict-lower part of L (below the diagonal); diagonal is an implicit 1.
+    std::vector<float> l_strict(TILE_ELEMS, 0.0f);
+    if (!identity_only) {
+        for (uint32_t r = 0; r < N; r++) {
+            for (uint32_t c = 0; c < r; c++) {
+                l_strict[r * N + c] = dist(gen) * strict_lower_scale;
+            }
+        }
+    }
+
+    std::vector<float> rhs(TILE_ELEMS);
+    for (auto& v : rhs) {
+        v = dist(gen);
+    }
+
+    // L = identity + strict-lower, as bf16 (exactly what the device reads).
+    std::vector<bfloat16> l(TILE_ELEMS, bfloat16(0.0f));
+    for (uint32_t r = 0; r < N; r++) {
+        l[r * N + r] = bfloat16(1.0f);
+        for (uint32_t c = 0; c < r; c++) {
+            l[r * N + c] = bfloat16(l_strict[r * N + c]);
+        }
+    }
+    std::vector<bfloat16> rhs_bf(TILE_ELEMS);
+    for (uint32_t i = 0; i < TILE_ELEMS; i++) {
+        rhs_bf[i] = bfloat16(rhs[i]);
+    }
+
+    // Golden forward substitution over the bf16-rounded inputs. Each solved row element is rounded
+    // to bf16 before later rows consume it, mirroring the device re-reading X[col] as bf16 from DST.
+    std::vector<float> x(TILE_ELEMS, 0.0f);
+    for (uint32_t row = 0; row < N; row++) {
+        for (uint32_t j = 0; j < N; j++) {
+            float acc = static_cast<float>(rhs_bf[row * N + j]);
+            for (uint32_t col = 0; col < row; col++) {
+                acc -= static_cast<float>(l[row * N + col]) * x[col * N + j];
+            }
+            x[row * N + j] = to_bf16(acc);
+        }
+    }
+
+    return {std::move(l), std::move(rhs_bf), std::move(x)};
+}
+
+// Run one solve on device and compare against the golden. Combines two checks so a systematic
+// magnitude error cannot slip through (PCC is invariant to affine scaling, e.g. 2*golden):
+//   - check_pcc  : structural-correctness backstop (PCC >= 0.99).
+//   - value check: an elementwise magnitude check. For identity L the solve is exact, so X must
+//                  equal RHS bit-for-bit (require_exact); otherwise a bf16-appropriate is_close
+//                  with tolerance scaled by the forward-substitution accumulation depth.
+bool run_triangle_solve(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SolveInputs& in, bool require_exact) {
+    auto& cq = mesh_device->mesh_command_queue();
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    distributed::MeshWorkload workload;
+    Program program = CreateProgram();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto* const device = mesh_device->get_devices()[0];
+
+    constexpr CoreCoord core = {0, 0};
+
+    // ---- DRAM buffers: two inputs (L, RHS), one output (X). One tile each. ----
+    tt_metal::InterleavedBufferConfig dram_config{
+        .device = device,
+        .size = SINGLE_TILE_SIZE,
+        .page_size = SINGLE_TILE_SIZE,
+        .buffer_type = tt_metal::BufferType::DRAM};
+
+    std::shared_ptr<Buffer> l_dram = CreateBuffer(dram_config);
+    std::shared_ptr<Buffer> rhs_dram = CreateBuffer(dram_config);
+    std::shared_ptr<Buffer> x_dram = CreateBuffer(dram_config);
+
+    // ---- CBs: c_0 = L, c_1 = RHS, c_2 = X. One bf16 tile each. ----
+    auto make_cb = [&](uint32_t cb_index) {
+        CircularBufferConfig cfg = CircularBufferConfig(SINGLE_TILE_SIZE, {{cb_index, tt::DataFormat::Float16_b}})
+                                       .set_page_size(cb_index, SINGLE_TILE_SIZE);
+        tt_metal::CreateCircularBuffer(program_, core, cfg);
+    };
+    make_cb(CBIndex::c_0);
+    make_cb(CBIndex::c_1);
+    make_cb(CBIndex::c_2);
+
+    // ---- Reader: L -> c_0, RHS -> c_1. CT args are the two TensorAccessors. ----
+    std::vector<uint32_t> reader_ct_args;
+    TensorAccessorArgs(l_dram).append_to(reader_ct_args);
+    TensorAccessorArgs(rhs_dram).append_to(reader_ct_args);
+    KernelHandle reader_kernel_id = CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_triangle_solve.cpp",
+        core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_ct_args});
+
+    // ---- Writer: c_2 -> X. ----
+    std::vector<uint32_t> writer_ct_args;
+    TensorAccessorArgs(x_dram).append_to(writer_ct_args);
+    KernelHandle writer_kernel_id = CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_triangle_solve.cpp",
+        core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = writer_ct_args});
+
+    // ---- Compute: SFPU forward-substitution solve for one tile. ----
+    CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/compute/triangle_solve.cpp",
+        core,
+        ComputeConfig{.math_approx_mode = false});
+
+    // ---- Tilize row-major inputs and stage them in DRAM. ----
+    ::unit_tests::compute::GoldenConfig golden_config = {.num_tiles_r_dim = 1, .num_tiles_c_dim = 1};
+    std::vector<uint32_t> l_tilized =
+        ::unit_tests::compute::gold_standard_tilize(pack_vector<uint32_t, bfloat16>(in.l_rm), golden_config);
+    std::vector<uint32_t> rhs_tilized =
+        ::unit_tests::compute::gold_standard_tilize(pack_vector<uint32_t, bfloat16>(in.rhs_rm), golden_config);
+
+    tt_metal::detail::WriteToBuffer(l_dram, l_tilized);
+    tt_metal::detail::WriteToBuffer(rhs_dram, rhs_tilized);
+
+    SetRuntimeArgs(program_, reader_kernel_id, core, {l_dram->address(), rhs_dram->address()});
+    SetRuntimeArgs(program_, writer_kernel_id, core, {x_dram->address()});
+
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    // ---- Read back, untilize to row-major, unpack to fp32, compare. ----
+    std::vector<uint32_t> x_tilized;
+    tt_metal::detail::ReadFromBuffer(x_dram, x_tilized);
+    std::vector<uint32_t> x_rm_packed = ::unit_tests::compute::gold_standard_untilize(x_tilized, golden_config);
+    std::vector<bfloat16> x_bf = unpack_vector<bfloat16, uint32_t>(x_rm_packed);
+
+    std::vector<float> x_dev(TILE_ELEMS);
+    for (uint32_t i = 0; i < TILE_ELEMS; i++) {
+        x_dev[i] = static_cast<float>(x_bf[i]);
+    }
+
+    // Structural backstop.
+    bool pass = check_pcc(in.x_golden_rm, x_dev, /*min_pcc=*/0.99);
+    if (!pass) {
+        log_error(tt::LogTest, "triangle_solve PCC check failed");
+    }
+
+    // Magnitude check — pins the scale that PCC alone cannot.
+    if (require_exact) {
+        // Identity L => X == RHS exactly; both sides are bf16 values, so require bit-exact equality.
+        bool exact = is_close_vectors<float>(in.x_golden_rm, x_dev, [](float a, float b) { return a == b; });
+        if (!exact) {
+            log_error(tt::LogTest, "triangle_solve identity case is not bit-exact (X != RHS)");
+        }
+        pass &= exact;
+    } else {
+        // bf16 forward substitution accumulates up to N terms per element; scale atol with that depth.
+        const float rtol = 0.05f;
+        const float atol = 0.05f + 0.02f * static_cast<float>(N);
+        bool close = is_close_vectors<float>(
+            in.x_golden_rm, x_dev, [&](float a, float b) { return is_close(a, b, rtol, atol); });
+        if (!close) {
+            log_error(tt::LogTest, "triangle_solve value check (is_close) failed");
+        }
+        pass &= close;
+    }
+    return pass;
+}
+
+}  // namespace unit_tests::compute::sfpu::triangle_solve
+
+// Identity L => the solve is a pass-through: X must equal RHS. Isolates the RHS
+// load/transpose/store path from the substitution math.
+TEST_F(LLKBlackholeSingleCardFixture, TensixTriangleSolveIdentity) {
+    namespace ts = unit_tests::compute::sfpu::triangle_solve;
+    auto in = ts::make_inputs(/*seed=*/1, /*strict_lower_scale=*/0.0f, /*identity_only=*/true);
+    EXPECT_TRUE(ts::run_triangle_solve(this->devices_.at(0), in, /*require_exact=*/true));
+}
+
+// Well-conditioned random unit lower-triangular L (small strict-lower entries). Main correctness
+// case; mirrors the previous ttnn pytest.
+TEST_F(LLKBlackholeSingleCardFixture, TensixTriangleSolveWellConditioned) {
+    namespace ts = unit_tests::compute::sfpu::triangle_solve;
+    auto in = ts::make_inputs(/*seed=*/0, /*strict_lower_scale=*/0.1f, /*identity_only=*/false);
+    EXPECT_TRUE(ts::run_triangle_solve(this->devices_.at(0), in, /*require_exact=*/false));
+}
+
+// Larger strict-lower magnitude: exercises real accumulation across many columns.
+TEST_F(LLKBlackholeSingleCardFixture, TensixTriangleSolveLargeStrictLower) {
+    namespace ts = unit_tests::compute::sfpu::triangle_solve;
+    auto in = ts::make_inputs(/*seed=*/7, /*strict_lower_scale=*/0.5f, /*identity_only=*/false);
+    EXPECT_TRUE(ts::run_triangle_solve(this->devices_.at(0), in, /*require_exact=*/false));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/triangle_solve.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/triangle_solve.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Compute kernel for the per-tile triangle-solve LLK test. Loads RHS into DST[0], runs the SFPU
+// forward-substitution solve (triangle_solve_tile) reading the resident unit-lower-tri L
+// tile straight from L1, and packs the solution DST[1] into cb_x.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/triangle_solve.h"
+#include "api/dataflow/circular_buffer.h"
+#include "tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_l = tt::CBIndex::c_0;    // unit-lower-tri L (resident in L1)
+    constexpr uint32_t cb_rhs = tt::CBIndex::c_1;  // RHS
+    constexpr uint32_t cb_x = tt::CBIndex::c_2;    // solution X
+
+    compute_kernel_hw_startup(cb_rhs, cb_l, cb_x);
+
+    CircularBuffer cb_l_o(cb_l);
+    CircularBuffer cb_rhs_o(cb_rhs);
+    CircularBuffer cb_x_o(cb_x);
+
+    cb_l_o.wait_front(1);
+    cb_rhs_o.wait_front(1);
+    cb_x_o.reserve_back(1);
+
+    tile_regs_acquire();
+    copy_tile_init(cb_rhs);
+    copy_tile(cb_rhs, 0, /*dst=*/0);  // RHS -> DST[0]
+    triangle_solve_tile_init();
+    {
+        // Profiler zone: measures the solve alone (excludes the RHS copy_tile and the pack).
+        DeviceZoneScopedN("TRIANGLE_SOLVE");
+        triangle_solve_tile(cb_l_o, /*l_tile_idx=*/0, /*idst_in=*/0, /*idst_out=*/1);
+    }
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(1, cb_x, 0);  // DST[1] -> cb_x
+    tile_regs_release();
+
+    cb_x_o.push_back(1);
+    cb_l_o.pop_front(1);
+    cb_rhs_o.pop_front(1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_triangle_solve.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_triangle_solve.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Reader for the per-tile triangle-solve LLK test. Reads tile 0 of l_neg into cb_l and tile 0 of
+// rhs into cb_rhs. CT args: [<l_neg TensorAccessorArgs...>, <rhs TensorAccessorArgs...>].
+// Runtime args: [l_neg_addr, rhs_addr].
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t l_addr = get_arg_val<uint32_t>(0);
+    const uint32_t rhs_addr = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t cb_l = tt::CBIndex::c_0;
+    constexpr uint32_t cb_rhs = tt::CBIndex::c_1;
+    const uint32_t tile_bytes = get_tile_size(cb_l);
+
+    constexpr auto l_args = TensorAccessorArgs<0>();
+    const auto l_gen = TensorAccessor(l_args, l_addr, tile_bytes);
+    constexpr auto rhs_args = TensorAccessorArgs<l_args.next_compile_time_args_offset()>();
+    const auto rhs_gen = TensorAccessor(rhs_args, rhs_addr, tile_bytes);
+
+    Noc noc;
+    CircularBuffer cb_l_o(cb_l);
+    CircularBuffer cb_rhs_o(cb_rhs);
+
+    cb_l_o.reserve_back(1);
+    noc.async_read(l_gen, cb_l_o, tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_l_o.push_back(1);
+
+    cb_rhs_o.reserve_back(1);
+    noc.async_read(rhs_gen, cb_rhs_o, tile_bytes, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_rhs_o.push_back(1);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_triangle_solve.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_triangle_solve.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Writer for the per-tile triangle-solve LLK test. Reads tile 0 from cb_x and writes it to the
+// output buffer. CT args: [<output TensorAccessorArgs...>]. Runtime args: [out_addr].
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t out_addr = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t cb_x = tt::CBIndex::c_2;
+    const uint32_t tile_bytes = get_tile_size(cb_x);
+
+    constexpr auto out_args = TensorAccessorArgs<0>();
+    const auto out_gen = TensorAccessor(out_args, out_addr, tile_bytes);
+
+    Noc noc;
+    CircularBuffer cb_x_o(cb_x);
+
+    cb_x_o.wait_front(1);
+    noc.async_write(cb_x_o, out_gen, tile_bytes, {.offset_bytes = 0}, {.page_id = 0});
+    noc.async_write_barrier();
+    cb_x_o.pop_front(1);
+}

--- a/tt_metal/hw/inc/api/compute/triangle_solve.h
+++ b/tt_metal/hw/inc/api/compute/triangle_solve.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#include "api/dataflow/circular_buffer.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+// Blackhole-only: the SFPU triangle-solve LLK lives only in the Blackhole tt-llk sfpu section.
+// Gating the include keeps this Compute API header parseable on every architecture (the public
+// entry points below are likewise compiled only for Blackhole), rather than failing JIT on a
+// missing header.
+#if defined(ARCH_BLACKHOLE)
+#include "sfpu/ckernel_sfpu_triangle_solve.h"
+#endif
+#endif
+
+namespace ckernel {
+
+#if defined(ARCH_BLACKHOLE)
+
+// clang-format off
+/**
+ * PROTOTYPE NOTE (local, do not merge): the underlying ckernel is the optimized review-comment
+ * microcode (PR #53437 comment 3802921292), whose contract is PRE-NEGATED L (strict-lower entries
+ * negated offline) — the opposite of the plain-L contract described below, which matches the PR
+ * head. The GDN integration feeds negN directly.
+ *
+ * Per-tile forward-substitution triangle solve of  L X = RHS  for a 32x32 tile. L is the unit
+ * lower-triangular matrix, supplied plain (strict-lower entries NOT negated); the per-column update
+ * subtracts L[row][col] * X[col] directly. L is read element-by-element straight from L1 (not a DST
+ * register), so only the RHS occupies a DST input. The DST register buffer must be in the acquired
+ * state via *tile_regs_acquire*, and the L tile must be resident in cb_l (*cb_wait_front* done).
+ * The solution is left in DST[idst_out] in standard tile layout. Blocking; compute-engine only.
+ *
+ * | Argument     | Description                                                                | Type            |
+ * |--------------|----------------------------------------------------------------------------|-----------------|
+ * | DATA_FORMAT  | Data format of the DST tiles                                               | DataFormat      |
+ * | cb_l         | CircularBuffer holding the unit-lower-tri L tile (bf16)                    | CircularBuffer& |
+ * | l_tile_idx   | Tile index of L within cb_l (front-relative)                              | uint32_t        |
+ * | idst_in      | DST index of the right-hand-side tile (RHS)                               | uint32_t        |
+ * | idst_out     | DST index that receives the solution X of  L X = RHS                       | uint32_t        |
+ */
+// clang-format on
+template <DataFormat DATA_FORMAT = DataFormat::Float16_b>
+ALWI void triangle_solve_tile(CircularBuffer& cb_l, uint32_t l_tile_idx, uint32_t idst_in, uint32_t idst_out) {
+    // First pass supports bf16 only: the SFPU microcode hardcodes bf16 L1 reads and the
+    // SFPLOAD/SFPSTORE SRCB format mode, so any other DATA_FORMAT would silently misinterpret DST.
+    static_assert(
+        DATA_FORMAT == DataFormat::Float16_b, "triangle_solve_tile currently supports only DataFormat::Float16_b");
+    // Resolve L's L1 base on all threads (get_tile_address runs on UNPACK and mailboxes the byte
+    // address to MATH), then run the solve on MATH. The SFPU op does its own absolute DEST addressing
+    // (idst * dst_tile_size), so start_(0) programs a zero base — the same way the binary SFPU macro
+    // drives an SFPU op.
+    const uint32_t l1_tri_base = cb_l.get_tile_address(l_tile_idx);
+    MATH((_llk_math_eltwise_sfpu_start_(0)));
+    MATH((sfpu::triangle_solve<DATA_FORMAT, false /*APPROXIMATE*/>(idst_in, idst_out, l1_tri_base)));
+    MATH((_llk_math_eltwise_sfpu_done_()));
+}
+
+/**
+ * Initialization for triangle_solve_tile. Must be called before triangle_solve_tile.
+ * Reuses SfpuType::unused with a per-op init callback (no dedicated SfpuType enum needed).
+ */
+ALWI void triangle_solve_tile_init() { MATH((SFPU_BINARY_INIT_FN_NO_ARGS(unused, sfpu::triangle_solve_init))); }
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_triangle_solve.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_triangle_solve.h
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SFPU LLK for the per-tile forward-substitution triangle solve  L X = RHS  (unit lower-triangular
+// L). Blackhole-only: the SFPMAD accumulation chain relies on the HW scoreboard.
+//
+// PROTOTYPE NOTE (local, do not merge): this is the OPTIMIZED microcode posted by fvranicTT in
+// PR #53437 review comment id 3802921292 (~1368 issued SFPU instructions vs 2632 in the PR head).
+// CONTRACT DIFFERENCE vs the PR head (6bad73c): L must be supplied PRE-NEGATED (strict-lower
+// entries negated offline; SFPMAD mod1=0 accumulates L_neg[row][col]*X[col] directly). The PR
+// head instead takes plain L and negates in the MAD (mod1=1). GDN's negN tile is exactly the
+// pre-negated input this version wants. HW-unvalidated by the PR author.
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "tensix_types.h"
+
+using namespace sfpi;
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// Pointer to one bf16 element of an L1-resident tile.
+//
+//   tile     : base pointer (element (0,0)) of the tile (bf16, standard TILE layout).
+//   row, col : logical (row, col) in the 32x32 tile, each 0..31.
+//
+// Standard bf16 TILE layout: a 32x32 tile is 4 faces of 16x16 stored [f0, f1, f2, f3], row-major
+// within each face. face = (row/16)*2 + (col/16); uint16 element index = face*256 + (row%16)*16 +
+// (col%16). Consecutive columns in the same face are adjacent; consecutive rows are stride 16.
+inline volatile tt_l1_ptr std::uint16_t* triangle_l1_elem_ptr(volatile tt_l1_ptr std::uint16_t* tile, const std::uint32_t row, const std::uint32_t col)
+{
+    const std::uint32_t face = ((row >> 4) << 1) + (col >> 4);
+    const std::uint32_t elem = (face << 8) + ((row & 15) << 4) + (col & 15);
+    return tile + elem;
+}
+
+inline void broadcast_tile_value_bf16(std::uint32_t l1_tile_base, std::uint32_t x, std::uint32_t y, std::uint32_t out_lreg)
+{
+    volatile tt_l1_ptr std::uint16_t* tile = reinterpret_cast<volatile tt_l1_ptr std::uint16_t*>(l1_tile_base);
+    const std::uint16_t bits               = *triangle_l1_elem_ptr(tile, x, y);
+    // FLOATB: interpret the 16-bit immediate as bf16 and expand it to fp32 across all 32 lanes.
+    TT_SFPLOADI(out_lreg, sfpi::SFPLOADI_MOD0_FLOATB, bits);
+}
+
+// DEST address offset where the solve stashes logical row `row` (0..31) of the output.
+//
+// A single SFPSTORE writes a 4-row x 8-col block, so each row gets its own block slot, and the 32
+// rows are laid out in the SAME face/parity blocks the reshuffle (and input load) use. That way the
+// reshuffle can read 4 rows per block at group_base + {0,2,16,18}, transpose, and emit the standard
+// tile. For row = chunk*4 + r:
+//   group_base = (chunk&3)*4 + (chunk>>2)*32   (4-row group within a face-pair, +32 to next pair)
+//   slot(r)    = (r&1)*2 + (r>>1)*16           (r=0,1 -> first two of face-1 {0,2};
+//                                               r=2,3 -> first two of face-2 {16,18})
+inline constexpr std::uint32_t kTriangleRowOff[32] = {
+    // chunk 0..3 (rows 0..15): group_base = (chunk&3)*4
+    0,
+    2,
+    16,
+    18,
+    4,
+    6,
+    20,
+    22,
+    8,
+    10,
+    24,
+    26,
+    12,
+    14,
+    28,
+    30,
+    // chunk 4..7 (rows 16..31): group_base = (chunk&3)*4 + 32
+    32,
+    34,
+    48,
+    50,
+    36,
+    38,
+    52,
+    54,
+    40,
+    42,
+    56,
+    58,
+    44,
+    46,
+    60,
+    62};
+
+inline constexpr std::uint32_t triangle_solve_row_offset(std::uint32_t row)
+{
+    return kTriangleRowOff[row];
+}
+
+// Right-looking rank-1 update of the live 4-row window: X[col] (LREG4) times L[row0+r][col]
+// (stride-16 in L1) folded into LREG0..3. L1 loads of rows 1..3 are issued in the shadow of the
+// previous SFPLOADI / SFPMAD.
+inline void triangle_apply_prev_col(volatile tt_l1_ptr std::uint16_t* l_col, const std::uint32_t x_addr)
+{
+    const std::uint16_t b0 = l_col[0];
+    TT_SFPLOAD(p_sfpu::LREG4, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, x_addr);
+    const std::uint16_t b1 = l_col[16];
+    // Bring-up: SFPLOAD and SFPLOADI are both load-class and must not issue in adjacent slots.
+    // The SFPLOADI also sits between SFPLOAD and the first SFPMAD, covering the original
+    // SFPLOAD -> SFPMAD load-use of LREG4. Later MADs in this column consume LREG4 after that
+    // gap and consume LREG7 from an SFPLOADI (1-cycle, next-insn-ready); no further NOPs.
+    TTI_SFPNOP;
+    TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b0);
+    const std::uint16_t b2 = l_col[32];
+    TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+
+    TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b1);
+    const std::uint16_t b3 = l_col[48];
+    TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG4, p_sfpu::LREG1, p_sfpu::LREG1, 0);
+
+    TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b2);
+    TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG4, p_sfpu::LREG2, p_sfpu::LREG2, 0);
+
+    TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b3);
+    TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG4, p_sfpu::LREG3, p_sfpu::LREG3, 0);
+}
+
+template <DataFormat DATA_FORMAT, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void triangle_solve(const std::uint32_t dst_in, const std::uint32_t dst_out, const std::uint32_t l1_tri_base)
+{
+    // Each tile occupies 64 rows in DEST.
+    constexpr std::uint32_t dst_tile_size = 64;
+
+    // Logical dimension of the tile (32x32).
+    constexpr std::uint32_t TILE_DIM = 32;
+
+    volatile tt_l1_ptr std::uint16_t* const tile = reinterpret_cast<volatile tt_l1_ptr std::uint16_t*>(l1_tri_base);
+    const std::uint32_t dst_out_base             = dst_out * dst_tile_size;
+
+    // Walk the STRICTLY-lower triangle of the (pre-negated) unit lower-triangular tile L, whose
+    // element (0,0) lives at byte address `l1_tri_base` in L1. (L no longer occupies a DEST
+    // register — it is read straight from L1 here — so the op takes a single DEST input, the RHS,
+    // and a single DEST output.)
+    //
+    // The 32 rows are walked in 8 chunks of 4. After the block transpose, LREG0..3 hold the four
+    // RHS rows of the chunk and become the in-place accumulators X[row0+r]:
+    //   Phase 1 (previous columns): for each col < row0, load X[col] once and MAD it into all 4 rows.
+    //   Phase 2 (within chunk):     row r uses X already sitting in LREG0..r-1; then store the row.
+    // The unit diagonal (row == col) is skipped; only entries with col < row participate.
+    constexpr std::uint32_t ROW_CHUNK  = 4;
+    constexpr std::uint32_t NUM_CHUNKS = TILE_DIM / ROW_CHUNK; // 8
+    for (std::uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++)
+    {
+        // Bring this chunk's 4 rows of the RHS tile (dst_in) into LREG0..3 in row-major form,
+        // mirroring Welford's `_welfords_load_block_`: bracket the 4 loads with a transpose before
+        // and after so the 4-LREG x lane block is flipped and LREG0..3 end up holding 4 whole rows.
+        //
+        // Same offset layout Welford uses: base = (I*32) + (4*J) with I = chunk>>2 (face-column
+        // half, +32 jump) and J = chunk&3 (4-row group within the half, +4 step); the {0,2,16,18}
+        // within-block offsets pick the block's 4 rows across the two stacked faces. Loads use the
+        // SRCB format mode, as Welford does.
+        const std::uint32_t group_base = dst_in * dst_tile_size + (chunk & 3u) * 4u + (chunk >> 2) * 32u;
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        TT_SFPLOAD(p_sfpu::LREG0, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 2);
+        TT_SFPLOAD(p_sfpu::LREG2, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 16);
+        TT_SFPLOAD(p_sfpu::LREG3, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 18);
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        // LREG0..3 now hold rows (chunk*4 + 0..3) of the RHS.
+
+        const std::uint32_t row0 = chunk * ROW_CHUNK;
+
+        // Phase 1: previous-chunk columns. L[row0][col] walks +1 inside a face; the four rows of the
+        // chunk are stride 16. Columns 0..15 and 16..row0-1 live in different faces, so the pointer
+        // is reset at col 16 rather than crossing the 16-wide face boundary.
+        //
+        // Forward substitution: X[row] = RHS[row] - sum_{col < row} L[row][col] * X[col].
+        // The subtraction is folded into an ADD because the L tile is negated offline, so runtime
+        // just accumulates L_neg[row][col] * X[col].
+        if (row0 > 0)
+        {
+            const std::uint32_t nface0                = row0 < 16u ? row0 : 16u;
+            volatile tt_l1_ptr std::uint16_t* l_face0 = triangle_l1_elem_ptr(tile, row0, 0);
+            for (std::uint32_t col = 0; col < nface0; col++)
+            {
+                triangle_apply_prev_col(l_face0 + col, dst_out_base + kTriangleRowOff[col]);
+            }
+            if (row0 > 16u)
+            {
+                volatile tt_l1_ptr std::uint16_t* l_face1 = triangle_l1_elem_ptr(tile, row0, 16);
+                for (std::uint32_t col = 16; col < row0; col++)
+                {
+                    triangle_apply_prev_col(l_face1 + (col - 16u), dst_out_base + kTriangleRowOff[col]);
+                }
+            }
+        }
+
+        // Phase 2: within-chunk lower triangle. Row r of the chunk depends on X[row0+k] for k < r,
+        // which are still live in LREG k. Then stash the solved row in dst_out at its per-row
+        // {0,2,16,18} slot, row-oriented. dst_out address is runtime -> TT_SFPSTORE.
+        // r = 0: no strictly-lower entries in this chunk.
+        TT_SFPSTORE(p_sfpu::LREG0, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, dst_out_base + kTriangleRowOff[row0 + 0]);
+
+        {
+            volatile tt_l1_ptr std::uint16_t* l_row = triangle_l1_elem_ptr(tile, row0 + 1, row0);
+            const std::uint16_t b0                  = l_row[0];
+            TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b0);
+            TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LREG1, 0);
+            TT_SFPSTORE(p_sfpu::LREG1, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, dst_out_base + kTriangleRowOff[row0 + 1]);
+        }
+
+        {
+            volatile tt_l1_ptr std::uint16_t* l_row = triangle_l1_elem_ptr(tile, row0 + 2, row0);
+            const std::uint16_t b0                  = l_row[0];
+            TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b0);
+            const std::uint16_t b1 = l_row[1];
+            TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LREG2, 0);
+            TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b1);
+            TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LREG2, 0);
+            TT_SFPSTORE(p_sfpu::LREG2, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, dst_out_base + kTriangleRowOff[row0 + 2]);
+        }
+
+        {
+            volatile tt_l1_ptr std::uint16_t* l_row = triangle_l1_elem_ptr(tile, row0 + 3, row0);
+            const std::uint16_t b0                  = l_row[0];
+            TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b0);
+            const std::uint16_t b1 = l_row[1];
+            TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LREG3, 0);
+            TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b1);
+            const std::uint16_t b2 = l_row[2];
+            TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpu::LREG3, 0);
+            TT_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, b2);
+            TTI_SFPMAD(p_sfpu::LREG7, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpu::LREG3, 0);
+            TT_SFPSTORE(p_sfpu::LREG3, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, dst_out_base + kTriangleRowOff[row0 + 3]);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Output transpose (in place on dst_out): the solve stashed each row into dst_out row-oriented at
+    // its {0,2,16,18} slot. Read the 4 rows of each block back, SFPTRANSP them into the split-face
+    // layout, and store the standard tile back to the SAME slots.
+    //
+    // A single SFPLOAD/SFPSTORE moves a 4-row x 8-column block; the address decodes as
+    // bits[9:2]=4-row group, bit[1]=even/odd column half, bit[0]=unused. The 4 rows of a block sit at
+    // group_base + {0, 2, 16, 18} (face-1 even/odd, face-2 even/odd), with
+    // group_base = (chunk&3)*4 + (chunk>>2)*32. Each block's 4 loads complete before its 4 stores, and
+    // blocks are disjoint, so the in-place transpose never clobbers data it has not yet read.
+    // -----------------------------------------------------------------------------------------
+    for (std::uint32_t chunk = 0; chunk < NUM_CHUNKS; chunk++)
+    {
+        const std::uint32_t group_base = dst_out_base + (chunk & 3u) * 4u + (chunk >> 2) * 32u;
+
+        TT_SFPLOAD(p_sfpu::LREG0, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 0);
+        TT_SFPLOAD(p_sfpu::LREG1, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 2);
+        TT_SFPLOAD(p_sfpu::LREG2, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 16);
+        TT_SFPLOAD(p_sfpu::LREG3, sfpi::SFPLOAD_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 18);
+
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        TT_SFPSTORE(p_sfpu::LREG0, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 0);
+        TT_SFPSTORE(p_sfpu::LREG1, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 2);
+        TT_SFPSTORE(p_sfpu::LREG2, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 16);
+        TT_SFPSTORE(p_sfpu::LREG3, sfpi::SFPSTORE_MOD0_FMT_SRCB, ADDR_MOD_7, group_base + 18);
+    }
+}
+
+inline void triangle_solve_init()
+{
+    // No SFPU state to program for the scaffold.
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
@@ -281,7 +281,10 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     prep_compute.compile_time_args = prep_compute_ct;
     prep_compute.config = fused_compute_cfg();
     // Fused-only perf: hoisted WY-path reconfigs (see chunk_gdn_math.hpp kGdnHoistReconfig).
-    prep_compute.defines = {{"GDN_HOIST_RECONFIG", "1"}};
+    // GDN_SFPU_TINV (PROTOTYPE): Ct==1 WY inverse via the SFPU triangle solve — NOT bit-exact
+    // with the phased path (see chunk_gdn_math.hpp). Kernel-side ARCH_BLACKHOLE guard makes
+    // non-BH compile-safe (falls back to the Horner path).
+    prep_compute.defines = {{"GDN_HOIST_RECONFIG", "1"}, {"GDN_SFPU_TINV", "1"}};
     prep_compute.runtime_args.reserve(BH);
 
     KernelDescriptor fused_writer;

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_math.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_math.hpp
@@ -48,6 +48,19 @@ inline constexpr bool kGdnHoistReconfig = true;
 inline constexpr bool kGdnHoistReconfig = false;
 #endif
 
+// GDN_SFPU_TINV (PROTOTYPE define, set only by the fused factory on its producer compute kernel):
+// replace the Ct==1 WY inverse (invert_block) with the Blackhole SFPU triangle-solve LLK from
+// PR #53437 (optimized microcode from review comment 3802921292, PRE-NEGATED-L contract — prep's
+// negN tile is fed to the solve unchanged, staged once to a bf16 CB). bf16-quantized L makes this
+// a deliberate violation of the bit-exactness contract above (reviewed PCC-downgrade prototype,
+// measurement only — see gdn_sfpu_study/numerics_ab.py method (d) for the expected error band).
+#if defined(GDN_SFPU_TINV) && defined(ARCH_BLACKHOLE)
+#include "api/compute/triangle_solve.h"
+inline constexpr bool kGdnSfpuTinv = true;
+#else
+inline constexpr bool kGdnSfpuTinv = false;
+#endif
+
 inline void WAIT(uint32_t cb, uint32_t n) { CircularBuffer(cb).wait_front(n); }
 inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
 
@@ -375,6 +388,36 @@ inline void invert_block(
     CircularBuffer(A).pop_front(1);  // + off -> out
 }
 
+#if defined(GDN_SFPU_TINV) && defined(ARCH_BLACKHOLE)
+// PROTOTYPE: T_inv = (I - negN)^-1 for ONE 32x32 tile via the SFPU triangle solve.
+//   negN   : fp32 CB, tile 0 = -strictly_lower(N) (prep's cb.scr3) — exactly the PRE-NEGATED L
+//            the optimized LLK microcode consumes (unit diagonal implicit, never read).
+//   cb_eye : identity tile (RHS = I, so X = (I - negN)^-1 = T_inv directly).
+//   lstage : 1-tile-capable bf16 CB (the LLK reads L element-wise from L1 as bf16) — the fused
+//            producer reuses c_16 (fcb::out, declared bf16, untouched by prep).
+//   out    : cb.Tinv (fp32).
+// Caller: WAIT(out, 1) then POP(lstage, 1) — pop L only after T_inv is committed.
+inline void sfpu_tinv(uint32_t negN, uint32_t cb_eye, uint32_t lstage, uint32_t out) {
+    // Stage negN as bf16 (fp32 -> bf16 rounding happens at this pack — the method-(d) quantization).
+    cpy_t(negN, 0, lstage);
+    WAIT(lstage, 1);
+    CircularBuffer cb_l(lstage);
+    cb_reserve_back(out, 1);
+    tile_regs_acquire();
+    // RHS = I -> DST[0]. srcA was just configured fp32 by cpy_t (negN fp32); eye is fp32 too.
+    copy_tile_to_dst_init_short(cb_eye);
+    copy_tile(cb_eye, 0, 0);
+    triangle_solve_tile_init();
+    triangle_solve_tile(cb_l, 0, /*idst_in=*/0, /*idst_out=*/1);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_reconfig_data_format(out);  // packer is still bf16 from the L staging pack — restore fp32
+    pack_tile(1, out, 0);
+    tile_regs_release();
+    cb_push_back(out, 1);
+}
+#endif
+
 // out[1,Ct] row-form = transpose of col[Ct,1]; produces Ct tiles (each row0 = a 32-chunk of col).
 inline void transpose_col(uint32_t in, uint32_t o, uint32_t Ct) {
     cb_reserve_back(o, Ct);
@@ -450,6 +493,9 @@ struct GdnPrepCbs {
     uint32_t scr1, scr2, scr3, s3;
     uint32_t dl;    // alias of the vnew slot in prep (1 tile used)
     uint32_t mask;  // alias of the u slot in prep (3 quadrant-mask tiles)
+    // bf16 L-staging CB for the GDN_SFPU_TINV prototype (alias of the unused-in-prep cb_out slot;
+    // consumed only when the define is set).
+    uint32_t lstage;
 };
 
 // CB map for scan_step — one field per CB the body touches (the state CBs S/s2/s3/final are
@@ -582,10 +628,19 @@ inline void prep_chunk(
     // writer would wrongly consume). None alias src (cb.scr3), out, or the Ct==2 persistents
     // (cb.supd/cb.stmp).
     if (Ct == 1) {
+#if defined(GDN_SFPU_TINV) && defined(ARCH_BLACKHOLE)
+        // PROTOTYPE: SFPU triangle solve replaces the Horner WY inverse (reviewed PCC-downgrade,
+        // NOT bit-exact with the phased path — measurement only).
+        sfpu_tinv(cb.scr3, cb.eye, cb.lstage, cb.Tinv);
+        WAIT(cb.Tinv, cc);
+        POP(cb.lstage, 1);  // pop L only after T_inv is committed
+        POP(cb.scr3, cc);
+#else
         // Single 32x32 block: T_inv is just its inverse.
         invert_block(cb.scr3, 0, cb.Tinv, cb.scr1, cb.scr2, cb.eye, cb.mask, cb.S, cb.final_s, cb.s2, cb.s3);
         WAIT(cb.Tinv, cc);
         POP(cb.scr3, cc);
+#endif
     } else if (Ct == 2) {
         // 2x2 tile-block lower-triangular. negN tiles: 0=(0,0), 2=(1,0), 3=(1,1); (0,1)=0.
         // Diagonal inverses Mi11, Mi22, then off-diagonal Mi21 = -Mi22 @ A21 @ Mi11.

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_prep.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/compute/chunk_gdn_prep.cpp
@@ -70,7 +70,10 @@ constexpr GdnPrepCbs CBS{
     .scr3 = cb_scr3,
     .s3 = cb_s3,
     .dl = cb_dl,
-    .mask = cb_mask};
+    .mask = cb_mask,
+    // GDN_SFPU_TINV prototype: bf16 L-staging tile. cb_out (c_16) is declared bf16 by both
+    // factories and untouched by prep otherwise; harmless when the define is off.
+    .lstage = cb_out};
 
 }  // namespace
 


### PR DESCRIPTION
# ⚠️ PROTOTYPE — DO NOT MERGE

This PR exists to share a **measured, working prototype** and its numbers; it vendors an unmerged LLK and must not land in this form.

## What it is

The SFPU triangle-solve (#53437) replacing the WY Horner chain (`invert_block`) in the **fused GDN producer** (#53913): `T_inv = triangle_solve(negN, RHS=I)` — one primitive call instead of ~60 MATH-thread helper calls per chunk. `negN` is already the pre-negated unit-lower input the optimized microcode expects, so staging is a single bf16 copy; L1 delta is zero (CB reuse). Fused-producer-only behind `GDN_SFPU_TINV`; the phased path keeps the exact fp32 Horner as the reference.

## Measured (1× p150b, fw 19.11, Tracy device durations)

| | fp32 Horner (#53913) | SFPU solve (this PR) |
|---|---|---|
| producer w_p | 26.9 µs/chunk | **18.24 µs (−32%)** |
| fused prefill core, BH=48/T=4096 | 3440 µs | **2334 µs (1.47× vs #53913; 2.06× vs the phased path as of #53804; 2.40× vs pre-stack main: 3311+2282=5593 µs)** |
| BH=48/T=512 | 503 µs | 384 µs |
| PCC vs phased fp32 reference (o / fs) | bit-exact | **0.9999999 / 0.9999999** (max-abs rel ~1.3e-3) |

This is also the **first hardware validation of the optimized 1368-instruction microcode** posted in https://github.com/tenstorrent/tt-metal/pull/53437#discussion_r3802921292 (the PR head still carries the 2632-instruction version). Results were shared on that thread: https://github.com/tenstorrent/tt-metal/pull/53437#issuecomment-5368250454

## Why DO NOT MERGE

1. **Vendored LLK**: `triangle_solve.h` + `ckernel_sfpu_triangle_solve.h` are cherry-picked from #53437 (author: Vasisht Suresh @vsureshTT), with the ckernel body replaced by @fvranicTT's optimized review-comment microcode (pre-negated-L contract). When #53437 merges, this PR must be rebased to consume the upstream LLK — **minding the sign contract**: the current #53437 head expects *plain* L (in-kernel negate); the optimized microcode expects *pre-negated* L. Our GDN wiring feeds `negN` (pre-negated); if upstream lands plain-L, the staging must become `L = eye − negN`.
2. **Known carried bug**: the vendored gtest feeds plain L to the pre-negated ckernel — its two non-identity cases fail as-is (fix: negate the strict-lower entries in the test's L buffer; golden unchanged).
3. **Gates not frozen**: by design this breaks the fused-vs-phased `torch.equal` gate (documented reviewed-PCC-downgrade path in `chunk_gdn_math.hpp`). The proposed two-tier PCC+max-abs gates are drafted, but the tier-2 adversarial thresholds must be frozen from a **silicon** capture (adversarial recipes in `gdn_sfpu_study/adversarial_cond.py`) — the emulation under-predicts silicon error ~5–25×.
4. Test/CI plumbing for running both fused variants (Horner bit-exact + solve PCC-gated) via a hashed attr is designed but not implemented here.

Stacked on #53913 → #53804 → #53790.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-sfpu-tinv-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-sfpu-tinv-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-sfpu-tinv-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-sfpu-tinv-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-sfpu-tinv-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-sfpu-tinv-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-sfpu-tinv-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-sfpu-tinv-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-sfpu-tinv-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-sfpu-tinv-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-sfpu-tinv-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-sfpu-tinv-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-sfpu-tinv-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-sfpu-tinv-prototype)