### PR TITLE
hc: upload pre-reboot failure as discard=1 so reboots are visible without skewing stats

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
@@ -254,7 +254,7 @@ def _testcases(check: dict):
     return (int(m.group(1)), int(m.group(2))) if m else ("", "")
 
 
-def machine_meta(report, hostname, job_id, jira_ticket, ts, versions=None):
+def machine_meta(report, hostname, job_id, jira_ticket, ts, versions=None, run_id_suffix=""):
     versions = versions or {}
     # fw can be missing from the primary snapshot when a run fails early. Fall
     # back to a post-reset snapshot, then the console log, ignoring 0xFF reads.
@@ -277,7 +277,7 @@ def machine_meta(report, hostname, job_id, jira_ticket, ts, versions=None):
     dry = bool(report.get("dry_run"))
     return {
         "schema_version": SCHEMA_VERSION,
-        "run_id": f"{hostname}:{job_id}",
+        "run_id": f"{hostname}:{job_id}{run_id_suffix}",
         "date": ts[:10],
         "timestamp": ts,
         "hostname": hostname,
@@ -431,13 +431,13 @@ def runs_row(report, meta, checks, telemetry=None):
     }
 
 
-def error_runs_row(hostname, job_id, ts, reason, jira_ticket=""):
+def error_runs_row(hostname, job_id, ts, reason, jira_ticket="", run_id_suffix=""):
     row, rack, slot = parse_host(hostname)
     r = {c: "" for c in RUNS_COLS}
     r.update(
         {
             "schema_version": SCHEMA_VERSION,
-            "run_id": f"{hostname}:{job_id}",
+            "run_id": f"{hostname}:{job_id}{run_id_suffix}",
             "date": ts[:10],
             "timestamp": ts,
             "hostname": hostname,
@@ -518,6 +518,7 @@ def analyze(
     telemetry=None,
     discard=None,
     discard_reason=None,
+    run_id_suffix="",
 ):
     """Translate a normalized diag_report.json dict into runs.csv (+ checks.csv).
 
@@ -531,7 +532,9 @@ def analyze(
     """
     os.makedirs(csv_output_dir, exist_ok=True)
     ts = now_iso()
-    base = os.path.join(csv_output_dir, f"health_check_{hostname}_{slurm_job_id}")
+    # run_id_suffix disambiguates the pre-reboot row from the post-reboot one
+    # (Slurm reuses the job id on requeue); slurm_job_id column stays the raw id.
+    base = os.path.join(csv_output_dir, f"health_check_{hostname}_{slurm_job_id}{run_id_suffix}")
     runs_path, checks_path = base + ".runs.csv", base + ".checks.csv"
 
     def _apply_exclusion(row):
@@ -542,12 +545,14 @@ def analyze(
 
     if not report:
         print("WARNING: no diag_report.json - writing fail-closed ERROR runs row")
-        row = _apply_exclusion(error_runs_row(hostname, slurm_job_id, ts, "no diag_report.json", jira_ticket))
+        row = _apply_exclusion(
+            error_runs_row(hostname, slurm_job_id, ts, "no diag_report.json", jira_ticket, run_id_suffix=run_id_suffix)
+        )
         _validate([row], [])
         _write_csv(runs_path, RUNS_COLS, [row])
         return [runs_path]
 
-    meta = machine_meta(report, hostname, slurm_job_id, jira_ticket, ts, versions)
+    meta = machine_meta(report, hostname, slurm_job_id, jira_ticket, ts, versions, run_id_suffix=run_id_suffix)
     checks = checks_rows(report, meta)
     runs = _apply_exclusion(runs_row(report, meta, checks, telemetry))
     _validate([runs], checks)

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -207,6 +207,7 @@ def run_csv_analysis(
     telemetry: dict | None = None,
     discard: int | None = None,
     discard_reason: str | None = None,
+    run_id_suffix: str = "",
 ) -> str | None:
     """Translate the diag_report.json into the runs/checks CSVs for Superset.
 
@@ -243,6 +244,7 @@ def run_csv_analysis(
             telemetry=telemetry,
             discard=discard,
             discard_reason=discard_reason,
+            run_id_suffix=run_id_suffix,
         )
     except Exception as exc:
         log.warning("CSV analysis failed: %s", exc)
@@ -406,6 +408,23 @@ def main() -> int:
             restart_count,
             REBOOT_CAP,
         )
+        # Upload the failing run as discard=1 (visible but out of fleet stats)
+        # before rebooting; suffix avoids colliding with the post-reboot row.
+        pre_reboot_csv = run_csv_analysis(
+            json_report=json_report,
+            node=node,
+            slurm_job_id=slurm_job_id,
+            ticket_key=None,
+            versions=versions,
+            telemetry=telemetry_summary,
+            discard=1,
+            discard_reason="reboot_pending",
+            run_id_suffix="-pre-reboot",
+        )
+        if pre_reboot_csv and args.upload_sftp and sftp_user and sftp_host:
+            upload_csv_sftp(pre_reboot_csv, sftp_user, sftp_host, log_dir=log_dir, launch_mode=launch_mode)
+        if args.cleanup and pre_reboot_csv:
+            remove_path(tempfile.gettempdir(), pre_reboot_csv)
         if reboot_and_requeue(node, slurm_job_id):
             log.info("Reboot armed and job requeued; exiting so the node reboots and reruns")
             return effective_code

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/health_check_models.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/health_check_models.py
@@ -158,7 +158,7 @@ class RunRecord(BaseModel):
     # exclude non-real runs (dry-run / maintenance / manual) from fleet stats.
     discard: Flag = Field(description="1 = exclude this run from fleet statistics.")
     discard_reason: Optional[str] = Field(
-        None, description="Reason when discard=1 (dry_run/maintenance/manual_test/…)."
+        None, description="Reason when discard=1 (dry_run/maintenance/manual_test/reboot_pending/…)."
     )
 
     # history: computed by the Data team across the day-series; empty on a lone run.


### PR DESCRIPTION
On a self-heal reboot the failing run now uploads (flagged `discard=1`, `discard_reason=reboot_pending`) before rebooting; the post-reboot rerun uploads normally. Previously only the final run landed, so reboots were invisible.

To avoid the pre/post rows colliding (Slurm reuses the job id on requeue), the pre-reboot row gets a `-pre-reboot` suffix on `run_id` and the CSV filename only, the `slurm_job_id` column stays the raw id, and the SFTP drop no longer
overwrites itself.

Managed to run it

<img width="2548" height="120" alt="image" src="https://github.com/user-attachments/assets/f713d0c6-e5d8-428f-ae0b-be95e4f32738" />


u can see reboot_pending on the first run

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc_reboot_upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/hc_reboot_upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc_reboot_upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/hc_reboot_upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/hc_reboot_upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/hc_reboot_upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/hc_reboot_upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/hc_reboot_upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/hc_reboot_upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/hc_reboot_upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/hc_reboot_upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/hc_reboot_upload)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/hc_reboot_upload)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/hc_reboot_upload)