### PR TITLE
[LLK] Bind test harness silu/clamp/log/hardtanh/abs to production metal kernels

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -102,18 +102,23 @@
 #include "llk_sfpu/ckernel_sfpu_tanhshrink.h"
 #include "llk_sfpu/ckernel_sfpu_trigonometry.h"
 #include "llk_sfpu/ckernel_sfpu_typecast.h"
-#include "sfpu/ckernel_sfpu_abs.h"
+// abs/clamp/hardtanh/log/silu: production (ttnn -> compute API *_tile) uses the
+// metal implementations, NOT the same-named legacy tt-llk kernels, so the
+// harness binds the metal headers for them (issue #53912). The tt-llk
+// tanh_derivative header stays: it backs the explicit legacy-variant
+// SfpuType::tanh_derivative_lut row.
+#include "llk_sfpu/ckernel_sfpu_abs.h"
+#include "llk_sfpu/ckernel_sfpu_clamp.h"
+#include "llk_sfpu/ckernel_sfpu_hardtanh.h"
+#include "llk_sfpu/ckernel_sfpu_log.h"
+#include "llk_sfpu/ckernel_sfpu_silu.h"
 #include "sfpu/ckernel_sfpu_add_int.h"
-#include "sfpu/ckernel_sfpu_clamp.h"
 #include "sfpu/ckernel_sfpu_comp.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
 #include "sfpu/ckernel_sfpu_fill.h"
-#include "sfpu/ckernel_sfpu_hardtanh.h"
 #include "sfpu/ckernel_sfpu_isinf_isnan.h"
-#include "sfpu/ckernel_sfpu_log.h"
 #include "sfpu/ckernel_sfpu_relu.h"
 #include "sfpu/ckernel_sfpu_rounding_ops.h"
-#include "sfpu/ckernel_sfpu_silu.h"
 #include "sfpu/ckernel_sfpu_sub_int.h"
 #include "sfpu/ckernel_sfpu_tanh_derivative.h"
 #include "sfpu/ckernel_sfpu_threshold.h"
@@ -592,13 +597,18 @@ void call_unary_sfpu_operation_init()
     {
         llk_math_eltwise_unary_sfpu_init<OPERATION>(hardsigmoid_init<APPROX_MODE>);
     }
-    else if constexpr (OPERATION == SfpuType::log)
+    else if constexpr (OPERATION == SfpuType::log || OPERATION == SfpuType::log_with_base)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(_init_log_<APPROX_MODE>);
+        // Production log_tile_init: metal log_init seeds vConstFloatPrgm0-2 with the
+        // constants the metal calculate_log polynomial reads (fp32/bf16 sets differ
+        // by dest-accum mode, so the flag must be forwarded).
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(log_init<APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en>);
     }
-    else if constexpr (OPERATION == SfpuType::log_with_base)
+    else if constexpr (OPERATION == SfpuType::silu)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(_init_log_<APPROX_MODE>);
+        // Production silu_tile_init: silu_init routes to sigmoid_init<false>, which
+        // seeds the reciprocal's vConstFloatPrgm0 that calculate_silu depends on.
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(silu_init<APPROX_MODE>);
     }
     else if constexpr (OPERATION == SfpuType::log1p)
     {
@@ -645,24 +655,22 @@ void call_unary_sfpu_operation_init()
     }
     else if constexpr (
         OPERATION == SfpuType::floor || OPERATION == SfpuType::ceil || OPERATION == SfpuType::trunc || OPERATION == SfpuType::frac ||
-        OPERATION == SfpuType::round || OPERATION == SfpuType::add1 || OPERATION == SfpuType::silu || OPERATION == SfpuType::relu_max ||
-        OPERATION == SfpuType::relu_min || OPERATION == SfpuType::lrelu || OPERATION == SfpuType::hardtanh || OPERATION == SfpuType::clamp ||
-        OPERATION == SfpuType::identity || OPERATION == SfpuType::cast_fp32_to_fp16a || OPERATION == SfpuType::tanh_derivative ||
-        OPERATION == SfpuType::sqrt_custom || OPERATION == SfpuType::rsqrt_compat || OPERATION == SfpuType::expm1_cw)
+        OPERATION == SfpuType::round || OPERATION == SfpuType::add1 || OPERATION == SfpuType::relu_max || OPERATION == SfpuType::relu_min ||
+        OPERATION == SfpuType::lrelu || OPERATION == SfpuType::hardtanh || OPERATION == SfpuType::clamp || OPERATION == SfpuType::identity ||
+        OPERATION == SfpuType::cast_fp32_to_fp16a || OPERATION == SfpuType::tanh_derivative || OPERATION == SfpuType::sqrt_custom ||
+        OPERATION == SfpuType::rsqrt_compat || OPERATION == SfpuType::expm1_cw)
     {
-        // These ops execute via self-contained tt-llk primitives that need only the generic per-op init (SFPU config
-        // reg + ADDR_MOD_7 from llk_math_sfpu_init_once() above, plus a dest RWC counter reset), so route them through
+        // These ops need only the generic per-op init (SFPU config reg + ADDR_MOD_7 from
+        // llk_math_sfpu_init_once() above, plus a dest RWC counter reset), so route them through
         // the bare `unused` init. The reason each op is safe to route this way varies:
-        //   - floor/ceil/trunc/frac/round/relu_max/relu_min: their production/metal <op>_init()
-        //     (rounding_op_tile_init, relu_max_tile_init, relu_min_tile_init) genuinely reduces to
-        //     math::reset_counters, so the bare init here matches production behavior.
+        //   - floor/ceil/trunc/frac/round/relu_max/relu_min/hardtanh/clamp: their production/metal
+        //     <op>_init() (rounding_op_tile_init, relu_max_tile_init, relu_min_tile_init,
+        //     hardtanh_init, clamp_init) genuinely reduces to math::reset_counters, so the bare
+        //     init here matches production behavior.
         //   - add1/identity/cast_fp32_to_fp16a/tanh_derivative/sqrt_custom/rsqrt_compat/expm1_cw: the
         //     OPERATION-keyed bare init has no delegate branch.
-        //   - lrelu/hardtanh/clamp: no linkable definition in this test build, since only the
-        //     tt-llk common (not the metal llk_api) header is included.
-        //   - silu: production silu_tile_init is NOT trivial (it wires sfpu::silu_init -> sigmoid_init<false>()),
-        //     but this harness uses the self-contained legacy _calculate_silu_ (piecewise-linear, no LUT/
-        //     reciprocal), which needs no op-specific init.
+        //   - lrelu: no linkable definition in this test build, since only the tt-llk common
+        //     (not the metal llk_api) header is included.
         llk_math_eltwise_unary_sfpu_init<SfpuType::unused, is_fp32_dest_acc_en>();
     }
     else if constexpr (
@@ -741,7 +749,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
 
     if constexpr (OPERATION == SfpuType::abs)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_abs_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode, ITERATIONS);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_abs, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::abs_int32)
     {
@@ -933,11 +941,10 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
         SFPU_UNARY_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
-            _calculate_log_,
-            (APPROX_MODE, false, ITERATIONS),
+            calculate_log,
+            (APPROX_MODE, FAST_MODE, false /* HAS_BASE_SCALING */, is_fp32_dest_acc_en, ITERATIONS),
             dst_index,
             vector_mode,
-            ITERATIONS,
             0u /* log_base_scale_factor */);
     }
     else if constexpr (OPERATION == SfpuType::log_with_base)
@@ -945,12 +952,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
         SFPU_UNARY_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
-            _calculate_log_,
-            (APPROX_MODE, true, ITERATIONS),
+            calculate_log,
+            (APPROX_MODE, FAST_MODE, true /* HAS_BASE_SCALING */, is_fp32_dest_acc_en, ITERATIONS),
             dst_index,
             vector_mode,
-            ITERATIONS,
-            0x3DC5u /* 1/ln(2) in fp16a -> log2(x) */);
+            0x3FB8AA3Bu /* 1/ln(2) in fp32 -> log2(x) */);
     }
     else if constexpr (OPERATION == SfpuType::log1p)
     {
@@ -999,7 +1005,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::silu)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_silu_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_silu, (is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::tanhshrink)
     {
@@ -1213,28 +1219,24 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
         SFPU_UNARY_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
-            _calculate_clamp_,
+            calculate_clamp,
             (APPROX_MODE, ITERATIONS),
             dst_index,
             vector_mode,
-            ITERATIONS,
-            0xBC00u /* min = -1.0 (fp16) */,
-            0x3C00u /* max =  1.0 (fp16) */,
-            0x0000u /* offset = 0 (bf16) */);
+            0xBF800000u /* min = -1.0f (fp32) */,
+            0x3F800000u /* max =  1.0f (fp32) */);
     }
     else if constexpr (OPERATION == SfpuType::hardtanh)
     {
         SFPU_UNARY_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
-            _calculate_hardtanh_,
+            calculate_hardtanh,
             (APPROX_MODE, ITERATIONS),
             dst_index,
             vector_mode,
-            ITERATIONS,
-            0x3F80u /* p0 = -min = 1.0 (bf16) */,
-            0xC000u /* p1 = -(max-min) = -2.0 (bf16) */,
-            0x3F80u /* p2 = max = 1.0 (bf16) */);
+            0xBF800000u /* min = -1.0f (fp32) */,
+            0x3F800000u /* max =  1.0f (fp32) */);
     }
     else if constexpr (
         OPERATION == SfpuType::equal_zero || OPERATION == SfpuType::not_equal_zero || OPERATION == SfpuType::less_than_zero ||

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -33,6 +33,7 @@
 #include "llk_sfpu/ckernel_sfpu_bitwise_not.h"
 #include "llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h"
 #include "llk_sfpu/ckernel_sfpu_cbrt.h"
+#include "llk_sfpu/ckernel_sfpu_clamp.h"
 // Metal comparison-to-zero / unary-int-compare kernels (calculate_comp,
 // calculate_comp_int, calculate_comp_uint16, calculate_eqz_uint32,
 // calculate_nez_uint32, calculate_comp_unary_int + their *_init). Distinct from
@@ -49,11 +50,13 @@
 #include "llk_sfpu/ckernel_sfpu_gcd.h"
 #include "llk_sfpu/ckernel_sfpu_hardmish.h"
 #include "llk_sfpu/ckernel_sfpu_hardshrink.h"
+#include "llk_sfpu/ckernel_sfpu_hardtanh.h"
 #include "llk_sfpu/ckernel_sfpu_i1.h"
 #include "llk_sfpu/ckernel_sfpu_identity.h"
 #include "llk_sfpu/ckernel_sfpu_isclose.h"
 #include "llk_sfpu/ckernel_sfpu_lcm.h"
 #include "llk_sfpu/ckernel_sfpu_lgamma.h"
+#include "llk_sfpu/ckernel_sfpu_log.h"
 #include "llk_sfpu/ckernel_sfpu_logical_not.h"
 #include "llk_sfpu/ckernel_sfpu_logsigmoid.h"
 #include "llk_sfpu/ckernel_sfpu_mask.h"
@@ -67,6 +70,7 @@
 #include "llk_sfpu/ckernel_sfpu_sigmoid_appx.h"
 #include "llk_sfpu/ckernel_sfpu_sign.h"
 #include "llk_sfpu/ckernel_sfpu_signbit.h"
+#include "llk_sfpu/ckernel_sfpu_silu.h"
 #include "llk_sfpu/ckernel_sfpu_softplus.h"
 #include "llk_sfpu/ckernel_sfpu_sqrt_custom.h"
 #include "llk_sfpu/ckernel_sfpu_tanh_derivative.h"
@@ -102,16 +106,6 @@
 #include "llk_sfpu/ckernel_sfpu_tanhshrink.h"
 #include "llk_sfpu/ckernel_sfpu_trigonometry.h"
 #include "llk_sfpu/ckernel_sfpu_typecast.h"
-// clamp/hardtanh/log/silu: production (ttnn -> compute API *_tile) uses the
-// metal implementations, NOT the same-named legacy tt-llk kernels, so the
-// harness binds the metal headers for them (issue #53912). abs made the same
-// dispatch switch, but its metal header was already included above -- only its
-// legacy include was dropped. The tt-llk tanh_derivative header stays: it
-// backs the explicit legacy-variant SfpuType::tanh_derivative_lut row.
-#include "llk_sfpu/ckernel_sfpu_clamp.h"
-#include "llk_sfpu/ckernel_sfpu_hardtanh.h"
-#include "llk_sfpu/ckernel_sfpu_log.h"
-#include "llk_sfpu/ckernel_sfpu_silu.h"
 #include "sfpu/ckernel_sfpu_add_int.h"
 #include "sfpu/ckernel_sfpu_comp.h"
 #include "sfpu/ckernel_sfpu_expm1_cw.h"
@@ -599,15 +593,14 @@ void call_unary_sfpu_operation_init()
     }
     else if constexpr (OPERATION == SfpuType::log || OPERATION == SfpuType::log_with_base)
     {
-        // Production log_tile_init: metal log_init seeds vConstFloatPrgm0-2 with the
-        // constants the metal calculate_log polynomial reads (fp32/bf16 sets differ
-        // by dest-accum mode, so the flag must be forwarded).
+        // log_init seeds the vConstFloatPrgm0-2 constants calculate_log reads; the
+        // fp32/bf16 sets differ by dest-accum mode, so the flag must be forwarded.
         llk_math_eltwise_unary_sfpu_init<OPERATION>(log_init<APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::silu)
     {
-        // Production silu_tile_init: silu_init routes to sigmoid_init<false>, which
-        // seeds the reciprocal's vConstFloatPrgm0 that calculate_silu depends on.
+        // silu_init routes to sigmoid_init<false>, seeding the reciprocal's
+        // vConstFloatPrgm0 that calculate_silu depends on.
         llk_math_eltwise_unary_sfpu_init<OPERATION>(silu_init<APPROX_MODE>);
     }
     else if constexpr (OPERATION == SfpuType::log1p)
@@ -664,9 +657,8 @@ void call_unary_sfpu_operation_init()
         // llk_math_sfpu_init_once() above, plus a dest RWC counter reset), so route them through
         // the bare `unused` init. The reason each op is safe to route this way varies:
         //   - floor/ceil/trunc/frac/round/relu_max/relu_min/hardtanh/clamp: their production/metal
-        //     <op>_init() (rounding_op_tile_init, relu_max_tile_init, relu_min_tile_init,
-        //     hardtanh_init, clamp_init) genuinely reduces to math::reset_counters, so the bare
-        //     init here matches production behavior.
+        //     <op>_init() genuinely reduces to math::reset_counters, so the bare init here
+        //     matches production behavior.
         //   - add1/identity/cast_fp32_to_fp16a/tanh_derivative/sqrt_custom/rsqrt_compat/expm1_cw: the
         //     OPERATION-keyed bare init has no delegate branch.
         //   - lrelu: no linkable definition in this test build, since only the tt-llk common
@@ -746,9 +738,8 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     // calculate_comp_unary_int. Shared with the golden (golden_generators.py:
     // _unary_comp_int_scalar); the two sides must move together.
     constexpr int UNARY_COMP_INT_SCALAR = 5;
-    // Clamp/Hardtanh bounds, fp32-encoded as the metal kernels take them. Shared with
-    // the golden (sfpu_dispatch_constants.py: CLAMP_MIN / CLAMP_MAX); the two sides
-    // must move together.
+    // Clamp/Hardtanh fp32-encoded bounds. Shared with the golden
+    // (sfpu_dispatch_constants.py: CLAMP_MIN / CLAMP_MAX); the two sides must move together.
     constexpr std::uint32_t CLAMP_MIN_FP32 = 0xBF800000u; // -1.0f
     constexpr std::uint32_t CLAMP_MAX_FP32 = 0x3F800000u; //  1.0f
 

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -102,12 +102,12 @@
 #include "llk_sfpu/ckernel_sfpu_tanhshrink.h"
 #include "llk_sfpu/ckernel_sfpu_trigonometry.h"
 #include "llk_sfpu/ckernel_sfpu_typecast.h"
-// abs/clamp/hardtanh/log/silu: production (ttnn -> compute API *_tile) uses the
+// clamp/hardtanh/log/silu: production (ttnn -> compute API *_tile) uses the
 // metal implementations, NOT the same-named legacy tt-llk kernels, so the
-// harness binds the metal headers for them (issue #53912). The tt-llk
-// tanh_derivative header stays: it backs the explicit legacy-variant
-// SfpuType::tanh_derivative_lut row.
-#include "llk_sfpu/ckernel_sfpu_abs.h"
+// harness binds the metal headers for them (issue #53912). abs made the same
+// dispatch switch, but its metal header was already included above -- only its
+// legacy include was dropped. The tt-llk tanh_derivative header stays: it
+// backs the explicit legacy-variant SfpuType::tanh_derivative_lut row.
 #include "llk_sfpu/ckernel_sfpu_clamp.h"
 #include "llk_sfpu/ckernel_sfpu_hardtanh.h"
 #include "llk_sfpu/ckernel_sfpu_log.h"
@@ -746,6 +746,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     // calculate_comp_unary_int. Shared with the golden (golden_generators.py:
     // _unary_comp_int_scalar); the two sides must move together.
     constexpr int UNARY_COMP_INT_SCALAR = 5;
+    // Clamp/Hardtanh bounds, fp32-encoded as the metal kernels take them. Shared with
+    // the golden (sfpu_dispatch_constants.py: CLAMP_MIN / CLAMP_MAX); the two sides
+    // must move together.
+    constexpr std::uint32_t CLAMP_MIN_FP32 = 0xBF800000u; // -1.0f
+    constexpr std::uint32_t CLAMP_MAX_FP32 = 0x3F800000u; //  1.0f
 
     if constexpr (OPERATION == SfpuType::abs)
     {
@@ -953,7 +958,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_log,
-            (APPROX_MODE, FAST_MODE, true /* HAS_BASE_SCALING */, is_fp32_dest_acc_en, ITERATIONS),
+            (APPROX_MODE, FAST_MODE, true /* HAS_BASE_SCALING */, is_fp32_dest_acc_en, ITERATIONS, true /* IS_BASE_TWO */),
             dst_index,
             vector_mode,
             0x3FB8AA3Bu /* 1/ln(2) in fp32 -> log2(x) */);
@@ -1216,27 +1221,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::clamp)
     {
-        SFPU_UNARY_CALL(
-            DST_SYNC_MODE,
-            DST_ACCUM_MODE,
-            calculate_clamp,
-            (APPROX_MODE, ITERATIONS),
-            dst_index,
-            vector_mode,
-            0xBF800000u /* min = -1.0f (fp32) */,
-            0x3F800000u /* max =  1.0f (fp32) */);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_clamp, (APPROX_MODE, ITERATIONS), dst_index, vector_mode, CLAMP_MIN_FP32, CLAMP_MAX_FP32);
     }
     else if constexpr (OPERATION == SfpuType::hardtanh)
     {
-        SFPU_UNARY_CALL(
-            DST_SYNC_MODE,
-            DST_ACCUM_MODE,
-            calculate_hardtanh,
-            (APPROX_MODE, ITERATIONS),
-            dst_index,
-            vector_mode,
-            0xBF800000u /* min = -1.0f (fp32) */,
-            0x3F800000u /* max =  1.0f (fp32) */);
+        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_hardtanh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode, CLAMP_MIN_FP32, CLAMP_MAX_FP32);
     }
     else if constexpr (
         OPERATION == SfpuType::equal_zero || OPERATION == SfpuType::not_equal_zero || OPERATION == SfpuType::less_than_zero ||

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2813,11 +2813,11 @@ class UnarySFPUGolden:
     def _log(self, x):
         return self._torch_unary(x, torch.log)
 
-    # log_with_base dispatches _calculate_log_ with base_scale = fp16a bits of
-    # 1/ln(2) (0x3DC5). sFloat16a rounds it to the fp16 value below, so the golden
-    # multiplies ln(x) by that exact rounded scale (=> log2(x) modulo the kernel's
-    # own ln approximation, which is within the same tolerance as plain log).
-    _LOG_WITH_BASE_SCALE = 1.4423828125  # fp16(1/ln 2)
+    # log_with_base dispatches the production metal calculate_log with
+    # base_scale = fp32 bits of 1/ln(2) (0x3FB8AA3B), mirroring log_with_base_tile,
+    # so the golden multiplies ln(x) by the same fp32 scale (=> log2(x) modulo the
+    # kernel's own ln approximation, which is within the same tolerance as plain log).
+    _LOG_WITH_BASE_SCALE = 1.4426950408889634  # 1/ln(2), rounds to fp32 0x3FB8AA3B
 
     def _log_with_base(self, x):
         return self._torch_unary(x, lambda t: torch.log(t) * self._LOG_WITH_BASE_SCALE)
@@ -2973,23 +2973,19 @@ class UnarySFPUGolden:
         return self._torch_unary(x, lambda t: value / t)
 
     def _clamp(self, x, min_val=CLAMP_MIN, max_val=CLAMP_MAX):
-        # tt-llk clamp with min/max fixed to the dispatch constants and offset 0. Clamped
-        # under the SFPU's total order, not torch's IEEE one: _calculate_clamp_ applies the
-        # bounds as `v_if (val < min)` then `v_if (val > max)`, so a NaN falls through the
-        # first and lands on max. See sfpu_clamp.
+        # Production metal calculate_clamp with min/max fixed to the dispatch constants.
+        # The kernel is a max(x, min) -> min(x, max) chain of SFPU max/min bodies, i.e.
+        # exactly sfpu_clamp's composition under the SFPU total order (a +NaN survives
+        # the max and lands on max_val via the min). See sfpu_clamp.
         return sfpu_clamp(x, min_val, max_val)
 
     def _hardtanh(self, x, min_val=CLAMP_MIN, max_val=CLAMP_MAX):
-        # Modelled as a clamp because it *agrees* with one, not because it is one. The kernel is
-        # `_calculate_hardtanh_`, a different function from `_calculate_clamp_` with differently
-        # formatted constants (bf16 p0/p1/p2 = 1.0/-2.0/1.0 against clamp's fp16 min/max/offset):
-        # `val += p0; v_if (val < 0) val = 0; val += p1; v_if (val >= 0) val = 0; val += p2`.
-        #
-        # The two coincide on every special this op is enrolled for, and on the finite range they
-        # implement the same function, so sfpu_clamp is a faithful golden here. They agree by
-        # arithmetic rather than by construction, though, so the agreement is pinned in
-        # test_sfpu_domains rather than assumed -- see
-        # test_hardtanh_golden_matches_the_hardtanh_kernel_chain.
+        # Production metal calculate_hardtanh is sfpi::clamp(v, min, max) with fp32 bounds,
+        # i.e. the same SFPU max/min composition sfpu_clamp models, so the golden is faithful
+        # by construction (unlike the legacy tt-llk bf16 offset-chain kernel this harness
+        # bound before, whose agreement was arithmetic -- see
+        # test_hardtanh_golden_matches_the_hardtanh_kernel_chain in test_sfpu_domains,
+        # kept as a regression pin for that equivalence).
         return sfpu_clamp(x, min_val, max_val)
 
     def _elu(self, x):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -320,16 +320,10 @@ def sfpu_relu_max(value: float, threshold: float) -> float:
 def sfpu_clamp(value: float, low: float, high: float) -> float:
     """clamp under the SFPU's total order, in the kernel's order of operations.
 
-    Both bound kernels are the same max-then-min composition of SFPSWAP min/max, which
-    orders on the total order: metal `calculate_clamp` chains the unary_max_min bodies
-    (`max(x, min_val)` then `min(x, max_val)`), and metal `calculate_hardtanh` is
-    `sfpi::clamp(v, min, max)` = `min(max(val, lower), upper)` over the same SFPSWAP
-    min/max. A +NaN outranks every value, so the max leaves it in place and the min
-    replaces it with *high*. Composing torch.clamp instead would keep IEEE semantics
-    and return NaN.
-
-    _clamp and _hardtanh both call this; their agreement is pinned in
-    test_sfpu_domains (test_hardtanh_golden_matches_the_clamp_golden).
+    Metal `calculate_clamp` and `calculate_hardtanh` (`sfpi::clamp`) are both this same
+    max-then-min composition of SFPSWAP min/max, so one golden models both. A +NaN
+    outranks every value: the max leaves it in place and the min lands it on *high*,
+    where torch.clamp would keep IEEE semantics and return NaN.
     """
     return sfpu_min(sfpu_max(value, low), high)
 
@@ -2816,12 +2810,8 @@ class UnarySFPUGolden:
     def _log(self, x):
         return self._torch_unary(x, torch.log)
 
-    # log_with_base dispatches the production metal calculate_log with
-    # IS_BASE_TWO=true and base_scale = fp32 bits of 1/ln(2) (0x3FB8AA3B), the only
-    # pairing ttnn emits for that constant (log_with_base_tile<..., true>, i.e. log2).
-    # IS_BASE_TWO applies the base change to the mantissa term only and keeps the
-    # exponent contribution exact, so the kernel is log2 to within its own ln
-    # approximation and torch.log2 is the faithful golden.
+    # The dispatch is metal calculate_log with IS_BASE_TWO=true and base_scale = fp32
+    # 1/ln(2), i.e. log2 with an exact exponent term, so torch.log2 is the golden.
     def _log_with_base(self, x):
         return self._torch_unary(x, torch.log2)
 
@@ -2976,18 +2966,12 @@ class UnarySFPUGolden:
         return self._torch_unary(x, lambda t: value / t)
 
     def _clamp(self, x, min_val=CLAMP_MIN, max_val=CLAMP_MAX):
-        # Production metal calculate_clamp with min/max fixed to the dispatch constants.
-        # The kernel is a max(x, min) -> min(x, max) chain of SFPU max/min bodies, i.e.
-        # exactly sfpu_clamp's composition under the SFPU total order (a +NaN survives
-        # the max and lands on max_val via the min). See sfpu_clamp.
+        # Metal calculate_clamp is the composition sfpu_clamp models -- see its docstring.
         return sfpu_clamp(x, min_val, max_val)
 
     def _hardtanh(self, x, min_val=CLAMP_MIN, max_val=CLAMP_MAX):
-        # Production metal calculate_hardtanh is sfpi::clamp(v, min, max) with fp32 bounds,
-        # i.e. the same SFPU max/min composition sfpu_clamp models, so the golden is faithful
-        # by construction (unlike the legacy tt-llk bf16 offset-chain kernel this harness
-        # bound before, whose agreement was arithmetic). Faithful-by-construction now means
-        # Hardtanh's golden IS Clamp's; that identity is pinned in test_sfpu_domains
+        # Metal calculate_hardtanh is sfpi::clamp, the same composition sfpu_clamp models,
+        # so Hardtanh's golden IS Clamp's. The identity is pinned in test_sfpu_domains
         # (test_hardtanh_golden_matches_the_clamp_golden).
         return sfpu_clamp(x, min_val, max_val)
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -320,13 +320,16 @@ def sfpu_relu_max(value: float, threshold: float) -> float:
 def sfpu_clamp(value: float, low: float, high: float) -> float:
     """clamp under the SFPU's total order, in the kernel's order of operations.
 
-    `_calculate_clamp_` applies the bounds as `v_if (val < min)` then `v_elseif (val >= max)`,
-    both two-vector compares and so both on the total order, which sends a +NaN through the first
-    and onto *high* via the second. Composing torch.clamp instead would keep IEEE semantics and
-    return NaN.
+    Both bound kernels are the same max-then-min composition of SFPSWAP min/max, which
+    orders on the total order: metal `calculate_clamp` chains the unary_max_min bodies
+    (`max(x, min_val)` then `min(x, max_val)`), and metal `calculate_hardtanh` is
+    `sfpi::clamp(v, min, max)` = `min(max(val, lower), upper)` over the same SFPSWAP
+    min/max. A +NaN outranks every value, so the max leaves it in place and the min
+    replaces it with *high*. Composing torch.clamp instead would keep IEEE semantics
+    and return NaN.
 
-    The `>=` matters: tightening it to a strict `>` would change the answer at +NaN, and
-    _hardtanh's golden calls this too even though its kernel is a different one.
+    _clamp and _hardtanh both call this; their agreement is pinned in
+    test_sfpu_domains (test_hardtanh_golden_matches_the_clamp_golden).
     """
     return sfpu_min(sfpu_max(value, low), high)
 
@@ -2814,13 +2817,13 @@ class UnarySFPUGolden:
         return self._torch_unary(x, torch.log)
 
     # log_with_base dispatches the production metal calculate_log with
-    # base_scale = fp32 bits of 1/ln(2) (0x3FB8AA3B), mirroring log_with_base_tile,
-    # so the golden multiplies ln(x) by the same fp32 scale (=> log2(x) modulo the
-    # kernel's own ln approximation, which is within the same tolerance as plain log).
-    _LOG_WITH_BASE_SCALE = 1.4426950408889634  # 1/ln(2), rounds to fp32 0x3FB8AA3B
-
+    # IS_BASE_TWO=true and base_scale = fp32 bits of 1/ln(2) (0x3FB8AA3B), the only
+    # pairing ttnn emits for that constant (log_with_base_tile<..., true>, i.e. log2).
+    # IS_BASE_TWO applies the base change to the mantissa term only and keeps the
+    # exponent contribution exact, so the kernel is log2 to within its own ln
+    # approximation and torch.log2 is the faithful golden.
     def _log_with_base(self, x):
-        return self._torch_unary(x, lambda t: torch.log(t) * self._LOG_WITH_BASE_SCALE)
+        return self._torch_unary(x, torch.log2)
 
     def _log1p(self, x):
         return self._torch_unary(x, torch.log1p)
@@ -2983,9 +2986,9 @@ class UnarySFPUGolden:
         # Production metal calculate_hardtanh is sfpi::clamp(v, min, max) with fp32 bounds,
         # i.e. the same SFPU max/min composition sfpu_clamp models, so the golden is faithful
         # by construction (unlike the legacy tt-llk bf16 offset-chain kernel this harness
-        # bound before, whose agreement was arithmetic -- see
-        # test_hardtanh_golden_matches_the_hardtanh_kernel_chain in test_sfpu_domains,
-        # kept as a regression pin for that equivalence).
+        # bound before, whose agreement was arithmetic). Faithful-by-construction now means
+        # Hardtanh's golden IS Clamp's; that identity is pinned in test_sfpu_domains
+        # (test_hardtanh_golden_matches_the_clamp_golden).
         return sfpu_clamp(x, min_val, max_val)
 
     def _elu(self, x):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -2102,12 +2102,12 @@ SPECIALS_READY_OPS.update(
         MathOperation.UnaryGe: "As UnaryGt.",
         MathOperation.UnaryMin: "min(x, 0.0) under the total order. +NaN is the maximum, so "
         "the minimum is the other operand -- which is why this diverged where UnaryMax did not.",
-        MathOperation.Clamp: "clamp(x, -1, 1) applied as the kernel applies it: `v_if (val < "
-        "min)` then `v_if (val > max)`, both total-order compares, so a NaN falls through the "
-        "first and lands on max.",
-        MathOperation.Hardtanh: "clamp(x, -1, 1), but via `_calculate_hardtanh_` rather than "
-        "Clamp's `_calculate_clamp_` -- a different kernel with differently formatted constants "
-        "that happens to agree at every special here. The agreement is pinned host-side.",
+        MathOperation.Clamp: "clamp(x, -1, 1) applied as metal `calculate_clamp` applies it: "
+        "max(x, min) then min(x, max), both SFPSWAP total-order folds, so a +NaN outranks "
+        "everything, survives the max, and lands on max via the min.",
+        MathOperation.Hardtanh: "clamp(x, -1, 1) via metal `calculate_hardtanh`, i.e. "
+        "`sfpi::clamp` -- the same SFPSWAP max-then-min composition as Clamp's kernel, so the "
+        "two share one golden by construction. The identity is pinned host-side.",
         MathOperation.ReluMax: "_relu_max_body_: a total-order `> threshold` replaces a NaN "
         "with the threshold, and the relu clamp then sees a finite value.",
         MathOperation.Hardsigmoid: "x * (1/6) + 0.5 through the same _relu_max_body_ the "

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
@@ -610,13 +610,10 @@ def test_exp_with_base_ceiling_is_currently_unreachable():
 def test_hardtanh_golden_matches_the_clamp_golden():
     """Hardtanh's golden must stay Clamp's golden -- pin the identity.
 
-    The harness binds both ops to metal kernels that are the same max-then-min SFPSWAP
-    composition (`calculate_clamp` chains the unary_max_min bodies; `calculate_hardtanh`
-    is `sfpi::clamp`, i.e. `min(max(val, lower), upper)` over the same SFPSWAP min/max),
-    so one golden -- sfpu_clamp -- models both by construction. This pins the two golden
-    methods to each other: if either is ever remodelled independently (say _hardtanh to
-    IEEE torch semantics), the divergence surfaces here instead of as a silent split
-    between two ops whose kernels still agree.
+    Both ops bind metal kernels that are the same SFPSWAP max-then-min composition
+    (calculate_clamp's unary_max_min chain; calculate_hardtanh's sfpi::clamp), so one
+    golden -- sfpu_clamp -- models both. If either golden is ever remodelled
+    independently, the divergence surfaces here.
     """
     from helpers.golden_generators import UnarySFPUGolden
 
@@ -638,9 +635,8 @@ def test_hardtanh_golden_matches_the_clamp_golden():
         want = float(golden._clamp(x, low, high))
         got = float(golden._hardtanh(x, low, high))
         assert got == want or (got != got and want != want), (
-            f"hardtanh({x}) golden gives {got} but the clamp golden gives {want}. Both ops "
-            "bind the same SFPU max/min composition, so their goldens must move together; "
-            "if the kernels have genuinely diverged, split the goldens and retire this pin."
+            f"hardtanh({x}) golden gives {got} but the clamp golden gives {want}; "
+            "the two goldens must move together while both ops bind the same composition."
         )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_domains.py
@@ -607,26 +607,18 @@ def test_exp_with_base_ceiling_is_currently_unreachable():
     )
 
 
-def test_hardtanh_golden_matches_the_hardtanh_kernel_chain():
-    """_hardtanh models a clamp, but its kernel is not one -- pin the agreement.
+def test_hardtanh_golden_matches_the_clamp_golden():
+    """Hardtanh's golden must stay Clamp's golden -- pin the identity.
 
-    `SfpuType::hardtanh` dispatches to `_calculate_hardtanh_`, three adds with two clamps-at-zero
-    and bf16 constants, where Clamp dispatches to `_calculate_clamp_` with fp16 min/max. They
-    agree on the finite range and at every special this op is enrolled for, but by arithmetic
-    rather than by sharing code, so the golden's use of sfpu_clamp is only sound while that holds.
+    The harness binds both ops to metal kernels that are the same max-then-min SFPSWAP
+    composition (`calculate_clamp` chains the unary_max_min bodies; `calculate_hardtanh`
+    is `sfpi::clamp`, i.e. `min(max(val, lower), upper)` over the same SFPSWAP min/max),
+    so one golden -- sfpu_clamp -- models both by construction. This pins the two golden
+    methods to each other: if either is ever remodelled independently (say _hardtanh to
+    IEEE torch semantics), the divergence surfaces here instead of as a silent split
+    between two ops whose kernels still agree.
     """
-    from helpers.golden_generators import UnarySFPUGolden, sfpu_total_order_key
-
-    def kernel_chain(x: float, low: float, high: float) -> float:
-        # val += p0; v_if (val < 0) val = 0; val += p1; v_if (val >= 0) val = 0; val += p2
-        p0, p1, p2 = -low, -(high - low), high
-        val = x + p0
-        if sfpu_total_order_key(val) < 0:
-            val = 0.0
-        val = val + p1
-        if sfpu_total_order_key(val) >= 0:
-            val = 0.0
-        return val + p2
+    from helpers.golden_generators import UnarySFPUGolden
 
     golden = UnarySFPUGolden()
     low, high = -1.0, 1.0
@@ -643,11 +635,12 @@ def test_hardtanh_golden_matches_the_hardtanh_kernel_chain():
         float("nan"),
     ]
     for x in probes:
-        want = kernel_chain(x, low, high)
+        want = float(golden._clamp(x, low, high))
         got = float(golden._hardtanh(x, low, high))
         assert got == want or (got != got and want != want), (
-            f"hardtanh({x}) golden gives {got} but the kernel chain gives {want}. The golden "
-            "models _calculate_clamp_; if the two have stopped agreeing, model the chain."
+            f"hardtanh({x}) golden gives {got} but the clamp golden gives {want}. Both ops "
+            "bind the same SFPU max/min composition, so their goldens must move together; "
+            "if the kernels have genuinely diverged, split the goldens and retire this pin."
         )
 
 


### PR DESCRIPTION
## Problem
Fixes #53912.

The shared unary-SFPU test dispatch (`tests/helpers/include/sfpu_operations.h`, used by both `test_sfpu_unary.py` and the LLK perf pipeline's `perf_eltwise_unary_sfpu.py`) bound five ops to legacy tt-llk kernels with **zero production consumers on BH/WH** — production (ttnn → Compute API `*_tile`) uses the metal `llk_sfpu` implementations, which differ materially (silu: piecewise-linear vs exp-based; hardtanh: bf16 offset-chain vs fp32 `sfpi::clamp`; log: entirely different polynomial). For these ops, correctness goldens validated dead code and metal-kernel changes were invisible to perf CI.

## Change
- Rebind `SfpuType::{silu, clamp, log, log_with_base, abs}` (and hardtanh's calculate) to the metal kernels, mirroring the compute-API call shapes exactly (template args, fp32-encoded min/max and log-base runtime params).
- Wire the load-bearing metal inits: `log_init` (seeds `vConstFloatPrgm0-2`) and `silu_init` (→ `sigmoid_init<false>`, reciprocal's Prgm0 seed). clamp/hardtanh/abs metal inits reduce to `reset_counters`, so they stay on the bare init (comment updated).
- `log_with_base` golden scale updated to the fp32 encoding (`0x3FB8AA3B` = 1/ln 2), matching `log_with_base_tile`.
- `SfpuType::tanh_derivative_lut` deliberately keeps the tt-llk LUT variant as a labeled legacy row (production sech2 is already swept as `tanh_derivative`).
- Quasar unaffected: separate driver + `sfpu_operations_quasar.h`, and its tt-llk silu/log **are** production there.

## Validation (silicon)
- **BH** (P150): `test_sfpu_unary.py -k '(Silu or Clamp or Hardtanh or Log or Abs) and Float16_b …'` → **203 passed, 0 failed** (43 pre-existing config skips)
- **WH** (N300): same filter → **238 passed, 0 failed** (8 skips)
- Perf smoke (BH): the Silu perf row now measures the metal kernel — MATH_ISOLATE 167,985 cy vs the legacy kernel's 176,305 cy, consistent with metal silu = sigmoid stream (160k) + the `x·σ(x)` multiply.

## Notes for review
- Goldens needed no change beyond the log-base scale: they are torch-based, and `sfpu_clamp` (total-order `min(max(x,lo),hi)`) mirrors the metal max→min chains by construction.
- Known follow-up not in this PR: `logsigmoid` (a harness BinaryOp) is absent from the binary perf sweep entirely.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/llk-harness-production-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/llk-harness-production-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/llk-harness-production-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/llk-harness-production-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/llk-harness-production-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/llk-harness-production-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/llk-harness-production-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/llk-harness-production-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/llk-harness-production-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/llk-harness-production-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/llk-harness-production-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/llk-harness-production-bindings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/llk-harness-production-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/llk-harness-production-bindings)