### PR TITLE
ci: scope the release AI summaries and trust the job status on the sim legs

### DIFF
--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -40,6 +40,11 @@ on:
         description: >
           Forwarded to multihost setup. True to put manylinux wheel libs first on
           LD_LIBRARY_PATH; false (T1 inplace) keeps the tarball build/lib.
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
     outputs:
       matrix:
         description: "Filtered matrix of single-host legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)."
@@ -259,7 +264,8 @@ jobs:
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
-              "output_dir": "generated/ai_summaries"
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}
@@ -288,3 +294,4 @@ jobs:
       wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       matrix: ${{ needs.load-test-matrix.outputs.matrix_multihost }}
       prefer-wheel-libs: ${{ inputs.prefer-wheel-libs }}
+      summary-scope: ${{ inputs.summary-scope }}

--- a/.github/workflows/models-e2e-tests-multihost-impl.yaml
+++ b/.github/workflows/models-e2e-tests-multihost-impl.yaml
@@ -33,6 +33,11 @@ on:
         description: >
           Prepend the installed wheel's ttnn/build/lib onto LD_LIBRARY_PATH.
           True for a manylinux wheel (P&R); false for an inplace wheel (T1).
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
 
 # Multihost-ci runner chart may need OIDC. Callers must grant id-token: write on the job that
 # `uses` this workflow (job-level permissions replace inherited defaults) and pass `secrets: inherit`.
@@ -147,7 +152,8 @@ jobs:
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "/home/user/tt-metal",
               "input_dirs": ["generated/test_logs"],
-              "output_dir": "generated/ai_summaries"
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -122,6 +122,7 @@ jobs:
       mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
       tier: "1"
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
+      summary-scope: ${{ inputs.platform }}
 
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
   # expected-jobs is the union of single-host and exabox multihost legs so a
@@ -129,7 +130,7 @@ jobs:
   ai-run-summary:
     name: "AI Run Summary"
     needs: [release-demo-tests]
-    if: always() && !cancelled() && needs.release-demo-tests.result != 'skipped'
+    if: always() && needs.release-demo-tests.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -155,7 +156,8 @@ jobs:
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE",
               "input_dir": "ai_job_summaries",
-              "output_dir": "ai_run_summaries"
+              "output_dir": "ai_run_summaries",
+              "scope": "${{ inputs.platform }}"
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/release-demo-tests-impl.yaml
+++ b/.github/workflows/release-demo-tests-impl.yaml
@@ -38,6 +38,11 @@ on:
         type: string
         default: ""
         description: "URL to gist containing models_e2e_tests.yaml (optional, falls back to local file if not provided). Security: Only GitHub gist/raw URLs allowed, validated before download."
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
     outputs:
       matrix:
         description: "Filtered matrix of single-host legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)."
@@ -155,3 +160,4 @@ jobs:
       # P&R installs the manylinux wheel; put its libs first so pytest does not
       # mix them with the Ubuntu tarball. T1 inplace leaves this false.
       prefer-wheel-libs: true
+      summary-scope: ${{ inputs.summary-scope }}

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -208,7 +208,8 @@ jobs:
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
-              "scope": "${{ inputs.summary-scope }}"
+              "scope": "${{ inputs.summary-scope }}",
+              "authoritative_job_status": true
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}


### PR DESCRIPTION
## Fix for false positives in sanity tests.

Two independent AI-summary fixes.

 **`runtime_sim_cpp_unit_tests` reports crashed while green**

Its C++ negative tests provoke and catch fatal asserts, which the crash patterns read as a
real crash — 24 of 24 runs since the summary landed. Sets `authoritative_job_status`
([tt-github-actions#152](https://github.com/tenstorrent/tt-github-actions/pull/152)) on that
leg, so a green job status settles it. Failed tests, a non-zero exit code and a missing
finish marker still decide.

**Release run summaries clash**

`package-and-release` runs `release-build-test-publish` from a platform matrix, so the whole
reusable workflow — including its `AI Run Summary` job — is instantiated twice and both
wrote `ai_run_summary_r<run>_a<attempt>`. Confirmed on
[run 32360057193](https://github.com/tenstorrent/tt-metal/actions/runs/32360057193): two
artifacts, identical name, from the Ubuntu 22.04 and 24.04 legs.

Also drops `!cancelled()` from that job's `if:`, so a cancelled test matrix still gets a
report. `result != 'skipped'` is kept — upstream skips synthesis for `skipped` anyway, so
the report would be empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/ai-summary-scope-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/ai-summary-scope-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/ai-summary-scope-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/ai-summary-scope-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/ai-summary-scope-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/ai-summary-scope-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/ai-summary-scope-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/ai-summary-scope-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/ai-summary-scope-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/ai-summary-scope-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/ai-summary-scope-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/ai-summary-scope-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/ai-summary-scope-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/ai-summary-scope-release)