### PR TITLE
[diagnostic] Re-verify bug-check.yaml after BUG_CHECKER_API_KEY rotation

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -368,3 +368,5 @@ install(TARGETS ttnn_op_data_movement LIBRARY COMPONENT tar)
 if(TARGET ttnn)
     target_sources(ttnn PRIVATE ${TTNN_OP_DATA_MOVEMENT_NANOBIND_SRCS})
 endif()
+
+# bug-check diagnostic test #2 (post BUG_CHECKER_API_KEY rotation) — safe to revert/ignore, no functional change


### PR DESCRIPTION
**Diagnostic PR — not for merge.**

Follow-up to #53938 (closed), which failed with a 401 `authentication_error` ('API key is invalid') — the old `BUG_CHECKER_API_KEY` was a dead/pre-rotation key, not an IP-allowlist block.

@blozano-tt has rotated `BUG_CHECKER_API_KEY` to a key expected to work. Testing whether the call now succeeds, or whether Anthropic API IP-allowlisting now blocks it instead (this workflow has no Tailscale routing, unlike `llk-pr-review.yaml`).

Trivial comment-only edit, same as before, to match the `reshape-dim-check` rule path glob.

Will close once we've confirmed pass/fail.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/bug-check-diagnostic-test-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/bug-check-diagnostic-test-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/bug-check-diagnostic-test-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/bug-check-diagnostic-test-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/bug-check-diagnostic-test-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/bug-check-diagnostic-test-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/bug-check-diagnostic-test-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/bug-check-diagnostic-test-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/bug-check-diagnostic-test-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/bug-check-diagnostic-test-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/bug-check-diagnostic-test-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/bug-check-diagnostic-test-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/bug-check-diagnostic-test-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/bug-check-diagnostic-test-2)