### PR TITLE
[LLK] Allow setup_external_testing_env on newer Python versions

### DIFF
--- a/tt_metal/tt-llk/tests/setup_external_testing_env.sh
+++ b/tt_metal/tt-llk/tests/setup_external_testing_env.sh
@@ -5,6 +5,8 @@
 
 # --- Configuration ---
 VENV_DIR=".venv"
+# Minimum supported Python version; newer versions are allowed.
+PYTHON_MIN_VERSION="3.10"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- Functions ---
@@ -30,12 +32,12 @@ check_deps() {
 
 # Check for supported Python version
 check_python_version() {
-    PYTHON_VERSION=$(python3 --version 2>&1 | cut -d' ' -f2)
-    if [[ "$PYTHON_VERSION" != "3.10"* ]]; then
-        echo "Error: Only Python 3.10 is supported. Detected: $PYTHON_VERSION" >&2
+    PYTHON_VERSION=$(python3 -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])')
+    if ! python3 -c "import sys; sys.exit(sys.version_info[:2] < tuple(map(int, '$PYTHON_MIN_VERSION'.split('.'))))"; then
+        echo "Error: Python $PYTHON_MIN_VERSION or newer is required. Detected: $PYTHON_VERSION" >&2
         exit 1
     fi
-    echo "Supported Python version detected: $PYTHON_VERSION"
+    echo "Supported Python version detected: $PYTHON_VERSION (minimum: $PYTHON_MIN_VERSION)"
 }
 
 # --- Main Script ---


### PR DESCRIPTION
### PR Category
Test Only

### Summary
We run this script issue-free regularly on Ubuntu 24.04, which uses Python 3.12, and in general we need to be able to run it on newer distros, e.g., I now also do some work on Ubuntu 26.04, which uses Python 3.14. Replace the exact 3.10 check (which used a fragile bash comparison) with a Python-native comparison using sys.version_info and a Python comparison.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-python-version)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-python-version)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-python-version)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-python-version)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-python-version)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-python-version)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-python-version)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-python-version)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-python-version)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-python-version)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-python-version)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-python-version)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-python-version)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-python-version)