### PR TITLE
[skip ci] Re-enable the watcher for Mixtral and Llama

### DIFF
--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -15,6 +15,7 @@
 
 - name: Llama 3.1-8B unit tests
   cmd: |
+    export TT_METAL_WATCHER=15
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
     pytest --timeout 300 models/tt_transformers/tests/test_embedding.py
     pytest --timeout 300 models/tt_transformers/tests/test_rms_norm.py
@@ -69,6 +70,7 @@
 
 - name: Llama 3.2-11B Vision unit tests
   cmd: |
+    export TT_METAL_WATCHER=15
     export HF_MODEL=meta-llama/Llama-3.2-11B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-11B-Vision-Instruct
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
@@ -83,6 +85,7 @@
 
 - name: Llama 3.2-90B-Vision unit tests
   cmd: |
+    export TT_METAL_WATCHER=15
     export HF_MODEL=meta-llama/Llama-3.2-90B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-90B-Vision-Instruct MESH_DEVICE=T3K
     pytest --timeout 900 models/tt_transformers/tests/test_decoder.py  # text module only
     pytest --timeout 900 models/tt_transformers/tests/test_decoder_prefill.py  # text module only
@@ -108,6 +111,7 @@
 
 - name: Llama 3.3-70B unit tests
   cmd: |
+    export TT_METAL_WATCHER=15
     export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
     pytest --timeout 900 models/tt_transformers/tests/test_embedding.py
     pytest --timeout 900 models/tt_transformers/tests/test_rms_norm.py
@@ -582,6 +586,7 @@
 
 - name: Mixtral-8x7B unit tests
   cmd: |
+    export TT_METAL_WATCHER=15
     export HF_MODEL=mistralai/Mixtral-8x7B-v0.1 TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/mistralai/Mixtral-8x7B-v0.1
     pytest --timeout 300 models/tt_transformers/tests/mixtral/test_mixtral_rms_norm.py  # PREFILL-4096 layernorm first-compile can exceed 120s
     pytest --timeout 120 models/tt_transformers/tests/mixtral/test_mixtral_mlp.py

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -15,7 +15,6 @@
 
 - name: Llama 3.1-8B unit tests
   cmd: |
-    unset TT_METAL_WATCHER  # blocked by #50886
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
     pytest --timeout 300 models/tt_transformers/tests/test_embedding.py
     pytest --timeout 300 models/tt_transformers/tests/test_rms_norm.py
@@ -70,7 +69,6 @@
 
 - name: Llama 3.2-11B Vision unit tests
   cmd: |
-    unset TT_METAL_WATCHER  # blocked by #50886
     export HF_MODEL=meta-llama/Llama-3.2-11B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-11B-Vision-Instruct
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
@@ -85,7 +83,6 @@
 
 - name: Llama 3.2-90B-Vision unit tests
   cmd: |
-    unset TT_METAL_WATCHER  # blocked by #50886
     export HF_MODEL=meta-llama/Llama-3.2-90B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-90B-Vision-Instruct MESH_DEVICE=T3K
     pytest --timeout 900 models/tt_transformers/tests/test_decoder.py  # text module only
     pytest --timeout 900 models/tt_transformers/tests/test_decoder_prefill.py  # text module only
@@ -111,7 +108,6 @@
 
 - name: Llama 3.3-70B unit tests
   cmd: |
-    unset TT_METAL_WATCHER  # blocked by #50886
     export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
     pytest --timeout 900 models/tt_transformers/tests/test_embedding.py
     pytest --timeout 900 models/tt_transformers/tests/test_rms_norm.py

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -586,7 +586,6 @@
 
 - name: Mixtral-8x7B unit tests
   cmd: |
-    unset TT_METAL_WATCHER  # blocked by #50886
     export HF_MODEL=mistralai/Mixtral-8x7B-v0.1 TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/mistralai/Mixtral-8x7B-v0.1
     pytest --timeout 300 models/tt_transformers/tests/mixtral/test_mixtral_rms_norm.py  # PREFILL-4096 layernorm first-compile can exceed 120s
     pytest --timeout 120 models/tt_transformers/tests/mixtral/test_mixtral_mlp.py

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -398,4 +398,11 @@ void kernel_main() {
     }
 
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
+
+    // Flush any outstanding NOC transactions before the kernel exits. In the fused path
+    // OpSignaler issues non-posted atomic semaphore increments over NOC; without waiting for
+    // their acknowledgement the watcher trips an inter-kernel data race. Mirror the writer's
+    // ending which barriers both writes and non-posted atomics.
+    noc_obj.async_write_barrier();
+    noc_obj.async_atomic_barrier();
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
- Re-enable watcher for Llama and  Mixtral-8x7B [wh_llmbox_perf]
- [Bug fix](https://github.com/tenstorrent/tt-metal/actions/runs/32192337075/job/95890915852):
```
#### Error Message
TT_THROW: Watcher detected tripped assert and stopped device.

#### Root Cause
The TT-Metal Watcher detected a tripped assert on a device (likely related to the all_gather_async CCL kernel running on BRISC/NCRISC) and forcibly stopped the device, causing a fatal abort. This occurred during Mixtral inference with the watcher enabled, consistent with the branch name '50886-re-enable-watcher-for-Mixtral'.

#### Suggested Action
Investigate the watcher assert in the all_gather_async CCL kernels (minimal_default_writer.cpp / minimal_default_reader.cpp). Check watcher log output for the specific assert location and core coordinates. The assert may be a pre-existing issue exposed by re-enabling the watcher for Mixtral.
```

Relates to https://github.com/tenstorrent/tt-metal/issues/50886
 
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Pipeline runs:
- llama: https://github.com/tenstorrent/tt-metal/actions/runs/32364754037
- mixtral:  https://github.com/tenstorrent/tt-metal/actions/runs/32365395228
- https://github.com/tenstorrent/tt-metal/actions/runs/32488273326

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=50886-Re-enable-watcher-for-Mixtral-and-Llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:50886-Re-enable-watcher-for-Mixtral-and-Llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=50886-Re-enable-watcher-for-Mixtral-and-Llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:50886-Re-enable-watcher-for-Mixtral-and-Llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=50886-Re-enable-watcher-for-Mixtral-and-Llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:50886-Re-enable-watcher-for-Mixtral-and-Llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=50886-Re-enable-watcher-for-Mixtral-and-Llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:50886-Re-enable-watcher-for-Mixtral-and-Llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=50886-Re-enable-watcher-for-Mixtral-and-Llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:50886-Re-enable-watcher-for-Mixtral-and-Llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=50886-Re-enable-watcher-for-Mixtral-and-Llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:50886-Re-enable-watcher-for-Mixtral-and-Llama)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=50886-Re-enable-watcher-for-Mixtral-and-Llama)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:50886-Re-enable-watcher-for-Mixtral-and-Llama)