### PR TITLE
Improve topk_large_indices with kernel-only fused reduction

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -144,6 +144,7 @@ def test_topk_large_indices_random_bfloat16_ties_return_distinct_indices(device)
     ],
 )
 def test_topk_large_indices_fused_segment_boundaries(device, k, num_chunks, tail_trim):
+    # The input has num_chunks K-wide chunks; tail_trim shortens the final chunk.
     n = num_chunks * k - tail_trim
     torch_input = _make_large_index_input(num_rows=1, n=n, k=k)
     tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -35,6 +35,17 @@ def _make_large_index_input(num_rows: int, n: int, k: int) -> torch.Tensor:
     return values
 
 
+def _make_spread_large_index_input(n: int, k: int) -> torch.Tensor:
+    """Place k unique winners across the row so index decoding is checked in every segment."""
+    values = torch.zeros((1, n), dtype=torch.bfloat16)
+    stride = n // k
+    winner_indices = torch.arange(k, dtype=torch.int64) * stride + stride // 2
+    hi16 = (0x3F80 + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+    winner_values = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+    values[0, winner_indices] = winner_values
+    return values
+
+
 def _to_device(torch_input: torch.Tensor, device) -> ttnn.Tensor:
     return ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
@@ -106,6 +117,75 @@ def test_topk_large_indices_random_bfloat16_ties_return_distinct_indices(device)
     actual_values = torch.gather(torch_input.float()[0, 0], dim=-1, index=indices)
     ref_values, _ = torch.topk(torch_input.float()[0, 0], k, dim=-1, largest=True, sorted=True)
     assert_equal(actual_values.sort(dim=-1).values, ref_values.sort(dim=-1).values)
+
+
+@pytest.mark.parametrize(
+    "k,num_chunks,tail_trim",
+    [
+        (512, 1, 0),
+        (512, 2, 0),
+        (512, 31, 0),
+        (512, 32, 17),  # chunk id 31 and a partial final chunk
+        (512, 33, 0),  # first width that keeps the classic body for small K
+        (1024, 1, 0),
+        (1024, 31, 0),
+        (1024, 32, 0),
+        (1024, 33, 0),
+        (1024, 64, 0),
+        (1024, 65, 0),
+        (2048, 1, 0),
+        (2048, 25, 0),  # GLM warm-context chunk count
+        (2048, 31, 0),
+        (2048, 32, 0),
+        (2048, 33, 1),
+        (2048, 64, 0),
+        (2048, 65, 0),
+        (2048, 250, 0),  # GLM long-context chunk count
+    ],
+)
+def test_topk_large_indices_fused_segment_boundaries(device, k, num_chunks, tail_trim):
+    n = num_chunks * k - tail_trim
+    torch_input = _make_large_index_input(num_rows=1, n=n, k=k)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+@pytest.mark.parametrize(
+    "k,llk_k,num_chunks,tail_trim",
+    [
+        (512, 512, 32, 7),  # fused end-to-end: winners span all chunk stamps
+        (768, 1024, 40, 7),  # snapped K: segmented mode and a multi-chunk partial final segment
+        (2048, 2048, 40, 7),  # direct segmented mode with winners in both segments
+    ],
+)
+def test_topk_large_indices_spread_winners_decode_global_indices(device, k, llk_k, num_chunks, tail_trim):
+    n = num_chunks * llk_k - tail_trim
+    torch_input = _make_spread_large_index_input(n=n, k=k)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+def test_topk_large_indices_program_cache_separates_compute_body_modes(device):
+    k = 512
+    fused_input = _make_large_index_input(num_rows=1, n=32 * k, k=k)
+    classic_input = _make_large_index_input(num_rows=1, n=33 * k, k=k)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        fused = ttnn.experimental.topk_large_indices(_to_device(fused_input, device), k=k)
+        entries_after_fused = device.num_program_cache_entries()
+        classic = ttnn.experimental.topk_large_indices(_to_device(classic_input, device), k=k)
+        entries_after_classic = device.num_program_cache_entries()
+
+        assert entries_after_fused > 0
+        assert entries_after_classic == entries_after_fused + 1
+        _assert_topk_matches_torch(fused_input, fused, k)
+        _assert_topk_matches_torch(classic_input, classic, k)
+    finally:
+        device.disable_and_clear_program_cache()
 
 
 @pytest.mark.parametrize(
@@ -181,8 +261,8 @@ TOPK_LARGE_INDICES_PERF_MARGIN = 0.01
 # regressions and unexpected speedups that should trigger baseline review.
 TOPK_LARGE_INDICES_PRODUCTION_PERF_CONFIGS = [
     # (case_id, num_rows, allocated_length, valid_length, k, expected_duration_ns)
-    ("prefill", 640, 51200, None, 1536, 1_652_800),
-    ("bounded_cache", 2, 102400, 56320, 1536, 310_724),
+    ("prefill", 640, 51200, None, 1536, 1_286_400),
+    ("bounded_cache", 2, 102400, 56320, 1536, 242_560),
 ]
 
 
@@ -434,9 +514,10 @@ def test_topk_large_indices_valid_length_mixed_prefix_ignores_finite_tail(device
 
 def test_topk_large_indices_valid_length_program_cache_reuse_while_growing(device):
     # A serving loop grows valid_length each step; because valid_length is a runtime arg (hash-excluded),
-    # every step must reuse a single cached program.
-    k = 1536
-    n = 102400
+    # every step must reuse a single cached program. Exercise the exact fused-segment boundary and the
+    # first partial chunk of the next segment while high-valued stale data remains at the physical row's end.
+    k = 2048
+    n = 65 * k
     torch_input = _make_large_index_input(num_rows=2, n=n, k=k)
     tt_input = _to_device(torch_input, device)
 
@@ -444,9 +525,16 @@ def test_topk_large_indices_valid_length_program_cache_reuse_while_growing(devic
     device.clear_program_cache()
     try:
         entries = []
-        for valid_length in (2048, 20480, 56320, n):
-            ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+        for valid_length in (31 * k, 32 * k, 32 * k + 17, 33 * k, n):
+            tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
             entries.append(device.num_program_cache_entries())
+
+            indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)
+            assert indices.min() >= 0
+            assert indices.max() < valid_length
+            for row_indices in indices:
+                assert row_indices.unique().numel() == k
+
         assert entries[0] > 0
         assert max(entries) == min(entries)  # no recompile as valid_length grew
     finally:

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
@@ -5,27 +5,34 @@
 #include <cstdint>
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/compute_kernel_hw_startup.h"
-#include "api/compute/pack_untilize.h"
 #include "api/compute/experimental/topk_xl.h"
+#include "api/compute/pack_untilize.h"
 #include "api/compute/transpose_dest.h"
 #include "api/dataflow/circular_buffer.h"
+#include "topk_large_indices_compute_body_mode.hpp"
 
 #ifdef TRISC_MATH
 namespace ckernel::sfpu {
 
-// topk_large_indices keeps final values and indices in the TopK XL LLK DST
-// layout until the last rank-order materialization step. The generic compute
-// APIs (`isneginf_tile` + `where_tile`) operate on normal tile layouts and do
-// not line up with this intermediate value/index pairing, so they only replaced
-// a subset of the final -inf lanes during validation.
-//
-// Keep this as op-local SFPU functionality for now instead of exporting a
-// public LLK API: it is tied to the final TopK XL LLK DST contract below,
-// where the value words start at the normal `idst` base and the UINT32 index
-// words start at `indices_offset`. The helper walks that layout directly,
-// compares final values against exact BF16 -inf stored in the FP32 DST
-// container (`0xFF800000`), and conditionally writes the sentinel index
-// `0xFFFFFFFF`.
+// The first fused chunk in each row runs the full TopK init. Later chunks can
+// use this hot-path reinit because copy init only clobbers ADDR_MOD_0/3 and the
+// MOP, while index stamping additionally changes ADDR_MOD_6 from +32 to +4.
+// Fused sort/merge never consumes ADDR_MOD_0/3/4; ADDR_MOD_1/5 and the other
+// TopK state remain live. Restoring +32 and the fused MOP therefore avoids the
+// two redundant ADDR_MOD writes in every subsequent chunk's full init.
+inline void _topk_large_indices_reinit_fused_after_stamp_() {
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 32},
+    }
+        .set(ADDR_MOD_6);
+    topk_mop_config<true>();
+}
+
+// The final TopK XL survivor stores FP32 value words followed by UINT32 index
+// words. Mark indices paired with exact -inf values as invalid without
+// disturbing the engine-specific survivor layout.
 inline void _topk_large_indices_mark_neginf_indices_init_() {
     addr_mod_t{
         .srca = {.incr = 0},
@@ -63,43 +70,170 @@ namespace {
 
 constexpr uint32_t elements_per_tile = TILE_R_DIM * TILE_C_DIM;
 
-template <uint32_t K>
-FORCE_INLINE void materialize_index_rank_order(uint32_t idst, uint32_t indices_cb) {
-    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
-    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+using ttnn::operations::experimental::topk_large_indices::program::ComputeBodyMode;
 
-    transpose_dest_init<true, false>(indices_cb);
-    for (uint32_t t = 0; t < tiles_per_sequence; ++t) {
-        transpose_dest<true, false>(idst + tiles_per_sequence + t);
+template <uint32_t K>
+FORCE_INLINE void copy_chunk(CircularBuffer& input, uint32_t dst, uint32_t active_elements) {
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    const uint32_t input_cb = input.get_cb_id();
+
+    input.wait_front(tiles_per_sequence);
+    topk_xl_copy_tile_init(input_cb);
+    topk_xl_copy_tile<K>(input_cb, dst, 0, active_elements);
+    input.pop_front(tiles_per_sequence);
+}
+
+template <uint32_t K>
+FORCE_INLINE void sort_classic_chunk(CircularBuffer& input, uint32_t dst, uint32_t active_elements, bool ascending) {
+    copy_chunk<K>(input, dst, active_elements);
+
+    topk_xl_add_lsb_indices_init();
+    topk_xl_add_lsb_indices<K, 0>(dst);
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(dst, ascending);
+
+    topk_xl_separate_indices_row_major_reinit();
+    topk_xl_separate_indices_row_major<K>(dst);
+    topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+}
+
+// FullInit is compile-time and this helper is force-inlined so the hot loop has
+// neither a mode branch nor a repeated full TopK configuration sequence.
+template <uint32_t K, bool FullInit>
+FORCE_INLINE void sort_fused_chunk(
+    CircularBuffer& input, uint32_t dst, uint32_t active_elements, bool ascending, uint32_t local_chunk_id) {
+    copy_chunk<K>(input, dst, active_elements);
+
+    topk_xl_add_lsb_indices_init();
+    topk_xl_add_lsb_indices_rt<K>(dst, local_chunk_id);
+    if constexpr (FullInit) {
+        topk_xl_init<K, true>();
+    } else {
+        MATH((ckernel::sfpu::_topk_large_indices_reinit_fused_after_stamp_()));
+    }
+    topk_xl_local_sort<K>(dst, ascending);
+}
+
+template <uint32_t K>
+FORCE_INLINE void reduce_classic_row(CircularBuffer& input, uint32_t num_chunks, uint32_t tail_elements) {
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    constexpr uint32_t survivor_slot = 0;
+    constexpr uint32_t incoming_slot = 2 * tiles_per_sequence;
+
+    topk_xl_separate_indices_row_major_init_static<0, 0>();
+    sort_classic_chunk<K>(input, survivor_slot, num_chunks == 1 ? tail_elements : K, false);
+
+    if (num_chunks == 1) {
+        topk_xl_init<K, false>();
+        topk_xl_rebuild<K, false>(survivor_slot, false);
+        return;
+    }
+
+    for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
+        const uint32_t active_elements = chunk + 1 == num_chunks ? tail_elements : K;
+        sort_classic_chunk<K>(input, incoming_slot, active_elements, true);
+
+        topk_xl_init<K, false>();
+        topk_xl_merge<K, false>(survivor_slot);
+        topk_xl_rebuild<K, false>(survivor_slot, false);
     }
 }
 
 template <uint32_t K>
-FORCE_INLINE void mark_neginf_indices(uint32_t idst) {
-    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
-    MATH((ckernel::sfpu::_topk_large_indices_mark_neginf_indices_init_()));
-    MATH((_llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_large_indices_mark_neginf_indices_<K>, idst, VectorMode::RC_custom)));
+FORCE_INLINE void reduce_fused_row(CircularBuffer& input, uint32_t num_chunks, uint32_t tail_elements) {
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    constexpr uint32_t survivor_slot = 0;
+    // A fused survivor has no separate index tiles. Its merge operand is
+    // therefore adjacent at one sequence, rather than two sequences, away.
+    constexpr uint32_t incoming_slot = tiles_per_sequence;
+
+    sort_fused_chunk<K, true>(input, survivor_slot, num_chunks == 1 ? tail_elements : K, false, 0);
+
+    if (num_chunks == 1) {
+        topk_xl_rebuild<K, true>(survivor_slot, false);
+    } else {
+        for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
+            const uint32_t active_elements = chunk + 1 == num_chunks ? tail_elements : K;
+            sort_fused_chunk<K, false>(input, incoming_slot, active_elements, true, chunk);
+            topk_xl_merge<K, true>(survivor_slot);
+            topk_xl_rebuild<K, true>(survivor_slot, false);
+        }
+    }
+
+    // Decode the five-bit chunk stamp once, after the final fused survivor is
+    // known, and leave the standard [values, indices] epilogue layout.
+    topk_xl_separate_indices_row_major_global_init();
+    topk_xl_separate_indices_row_major_global<K>(survivor_slot);
 }
 
 template <uint32_t K>
-FORCE_INLINE void process_chunk(CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements, bool ascending) {
+FORCE_INLINE void reduce_segmented_row(CircularBuffer& input, uint32_t num_chunks, uint32_t tail_elements) {
     constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
-    const uint32_t input_cb_id = input_cb.get_cb_id();
-    input_cb.wait_front(tiles_per_sequence);
-    topk_xl_copy_tile_init(input_cb_id);
-    topk_xl_copy_tile<K>(input_cb_id, dst_base, 0, active_elements);
-    input_cb.pop_front(tiles_per_sequence);
+    constexpr uint32_t segment_capacity = 32;
+    constexpr uint32_t accumulator_slot = 0;
+    constexpr uint32_t segment_slot = 2 * tiles_per_sequence;
 
-    topk_xl_add_lsb_indices_init();
-    topk_xl_add_lsb_indices<K, 0>(dst_base);
+    const uint32_t num_segments = (num_chunks + segment_capacity - 1) / segment_capacity;
+    for (uint32_t segment = 0; segment < num_segments; ++segment) {
+        const uint32_t first_chunk = segment * segment_capacity;
+        const uint32_t end_chunk =
+            first_chunk + segment_capacity < num_chunks ? first_chunk + segment_capacity : num_chunks;
+        const uint32_t last_chunk = end_chunk - 1;
 
-    topk_xl_init<K, true>();
-    topk_xl_local_sort<K>(dst_base, ascending);
+        // Segment zero is already in the final accumulator slot. Later
+        // segments use the second unfused sequence. Their fused input chunk
+        // is adjacent to the fused survivor at base + tiles_per_sequence.
+        const uint32_t base = segment == 0 ? accumulator_slot : segment_slot;
+        const uint32_t chunk_slot = base + tiles_per_sequence;
+        const bool mirror_final_survivor = segment != 0;
 
-    topk_xl_separate_indices_row_major_reinit();
-    topk_xl_separate_indices_row_major<K>(dst_base);
-    topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+        const uint32_t first_elements = first_chunk + 1 == num_chunks ? tail_elements : K;
+        if (segment == 0) {
+            sort_fused_chunk<K, true>(input, base, first_elements, false, 0);
+        } else {
+            sort_fused_chunk<K, false>(input, base, first_elements, false, 0);
+        }
+
+        if (first_chunk == last_chunk) {
+            topk_xl_rebuild<K, true>(base, mirror_final_survivor);
+        } else {
+            for (uint32_t chunk = first_chunk + 1; chunk <= last_chunk; ++chunk) {
+                const uint32_t active_elements = chunk + 1 == num_chunks ? tail_elements : K;
+                sort_fused_chunk<K, false>(input, chunk_slot, active_elements, true, chunk - first_chunk);
+                topk_xl_merge<K, true>(base);
+                topk_xl_rebuild<K, true>(base, mirror_final_survivor && chunk == last_chunk);
+            }
+        }
+
+        // Split once per segment. The base is a multiple of 32*K, so it does
+        // not overlap the decoded segment-local index bits.
+        topk_xl_separate_indices_row_major_global_init();
+        topk_xl_separate_indices_row_major_global_base<K>(base, segment * (segment_capacity * K));
+
+        if (segment != 0) {
+            // Operand zero is descending and each later segment was rebuilt
+            // ascending, satisfying the unfused bitonic merge precondition.
+            topk_xl_init<K, false>();
+            topk_xl_merge<K, false>(accumulator_slot);
+            topk_xl_rebuild<K, false>(accumulator_slot, false);
+        }
+    }
+}
+
+template <uint32_t K>
+FORCE_INLINE void mark_neginf_indices(uint32_t dst) {
+    MATH((ckernel::sfpu::_topk_large_indices_mark_neginf_indices_init_()));
+    MATH((_llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_large_indices_mark_neginf_indices_<K>, dst, VectorMode::RC_custom)));
+}
+
+template <uint32_t K>
+FORCE_INLINE void materialize_index_rank_order(uint32_t dst, uint32_t indices_cb) {
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    transpose_dest_init<true, false>(indices_cb);
+    for (uint32_t tile = 0; tile < tiles_per_sequence; ++tile) {
+        transpose_dest<true, false>(dst + tiles_per_sequence + tile);
+    }
 }
 
 }  // namespace
@@ -112,50 +246,43 @@ void kernel_main() {
     constexpr uint32_t input_cb = get_compile_time_arg_val(0);
     constexpr uint32_t indices_cb = get_compile_time_arg_val(1);
     constexpr uint32_t K = get_compile_time_arg_val(2);
-
+    constexpr auto body_mode = static_cast<ComputeBodyMode>(get_compile_time_arg_val(3));
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    static_assert(
+        body_mode == ComputeBodyMode::Classic || body_mode == ComputeBodyMode::FusedEndToEnd ||
+            body_mode == ComputeBodyMode::FusedSegmented,
+        "invalid TopK compute body mode");
+
     constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
-    constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
-    constexpr uint32_t slot0 = 0;
-    constexpr uint32_t slot1 = sequence_tiles;
+    constexpr uint32_t final_survivor = 0;
 
     compute_kernel_hw_startup(input_cb, indices_cb);
     pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(indices_cb);
 
-    CircularBuffer input_cb_obj(input_cb);
-    CircularBuffer indices_cb_obj(indices_cb);
+    CircularBuffer input(input_cb);
+    CircularBuffer indices(indices_cb);
 
     for (uint32_t row = 0; row < num_rows; ++row) {
         tile_regs_acquire();
 
-        topk_xl_separate_indices_row_major_init_static<0, 0>();
-
-        const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
-        process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
-
-        if (num_chunks == 1) {
-            topk_xl_init<K, false>();
-            topk_xl_rebuild<K, false>(slot0, false);
+        if constexpr (body_mode == ComputeBodyMode::FusedSegmented) {
+            reduce_segmented_row<K>(input, num_chunks, tail_elements);
+        } else if constexpr (body_mode == ComputeBodyMode::FusedEndToEnd) {
+            reduce_fused_row<K>(input, num_chunks, tail_elements);
+        } else {
+            reduce_classic_row<K>(input, num_chunks, tail_elements);
         }
 
-        for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
-            const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
-            process_chunk<K>(input_cb_obj, slot1, active_elements, true);
-
-            topk_xl_init<K, false>();
-            topk_xl_merge<K, false>(slot0);
-            topk_xl_rebuild<K, false>(slot0, false);
-        }
-
-        mark_neginf_indices<K>(slot0);
-        materialize_index_rank_order<K>(slot0, indices_cb);
+        mark_neginf_indices<K>(final_survivor);
+        materialize_index_rank_order<K>(final_survivor, indices_cb);
 
         tile_regs_commit();
         tile_regs_wait();
 
-        indices_cb_obj.reserve_back(1);
-        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(indices_cb, 1, 0, slot0 + tiles_per_sequence);
-        indices_cb_obj.push_back(1);
+        indices.reserve_back(1);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(
+            indices_cb, 1, 0, final_survivor + tiles_per_sequence);
+        indices.push_back(1);
 
         tile_regs_release();
     }

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_compute_body_mode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_compute_body_mode.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace ttnn::operations::experimental::topk_large_indices::program {
+
+// Shared host/device encoding for the compile-time row-reduction body.
+enum class ComputeBodyMode : uint32_t {
+    Classic = 0,
+    FusedEndToEnd = 1,
+    FusedSegmented = 2,
+};
+
+}  // namespace ttnn::operations::experimental::topk_large_indices::program

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -99,7 +99,8 @@ ttsl::hash::hash_t TopkLargeIndicesDeviceOperation::compute_program_hash(
         input.memory_config().memory_layout(),
         input.memory_config().buffer_type(),
         grid.x,
-        grid.y);
+        grid.y,
+        static_cast<uint32_t>(program::compute_body_mode(attrs.k, input.logical_shape()[-1])));
 }
 
 spec_return_value_t TopkLargeIndicesDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
@@ -134,6 +134,21 @@ void set_runtime_args(
 
 }  // namespace
 
+ComputeBodyMode compute_body_mode(uint32_t k, uint32_t input_last_dim) {
+    const uint32_t llk_k = to_uint32(snap_to_llk_target_k(k));
+
+    // For an internal K >= 1024, segmented fusion handles every width with
+    // one binary; rows of at most 32 chunks naturally execute as one segment.
+    // Gate on the snapped LLK K so public k values in [528, 1008] get the same
+    // fused body as k=1024 instead of silently falling back to classic.
+    if (llk_k >= to_uint32(LlkTargetK::K1024)) {
+        return ComputeBodyMode::FusedSegmented;
+    }
+
+    const uint32_t physical_chunks = tt::div_up(input_last_dim, llk_k);
+    return physical_chunks <= 32 ? ComputeBodyMode::FusedEndToEnd : ComputeBodyMode::Classic;
+}
+
 TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
@@ -198,7 +213,8 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
 
-    std::vector<uint32_t> compute_compile_args = {cb_in, cb_indices, llk_k};
+    const auto body_mode = compute_body_mode(k, input.logical_shape()[-1]);
+    std::vector<uint32_t> compute_compile_args = {cb_in, cb_indices, llk_k, static_cast<uint32_t>(body_mode)};
     auto compute_kernel = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp",

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "kernels/topk_large_indices_compute_body_mode.hpp"
 #include "topk_large_indices_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 
@@ -33,5 +34,7 @@ struct TopkLargeIndicesProgramFactory {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
 };
+
+ComputeBodyMode compute_body_mode(uint32_t k, uint32_t input_last_dim);
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::program


### PR DESCRIPTION
## Summary

Speed up the existing row-parallel `topk_large_indices` compute kernel without changing its API, reader/writer kernels, core assignment, runtime protocol, outputs, or tie semantics.

## Credit

The fused-reduction design and original implementation were developed by [Nachiket Kapre (@nkapreTT)](https://github.com/nkapreTT) in [PR #53457](https://github.com/tenstorrent/tt-metal/pull/53457). This PR extracts Nachiket’s row-parallel fused-reduction work, cleans it up, and narrows its scope for an easier standalone review.

## How the speedup works

The classic path splits every sorted chunk from a packed BF16-value/u16-index key into separate values and u32 indices before merging. This change keeps keys packed for more of the reduction:

- **Fused end-to-end:** for rows up to 32 internal chunks, sort and merge packed keys and decode indices once after the final survivor.
- **Segmented fusion:** for wider rows whose snapped LLK K is at least 1024, reduce each 32-chunk group in fused form, decode once with the segment global-index base, then merge segment survivors through the classic u32 path.
- **Classic fallback:** for snapped LLK K=512, rows wider than 32 chunks retain the existing classic reduction.

The 32-chunk boundary comes from the packed 16-bit index: 11 position bits plus a 5-bit chunk ID. The body mode is shared by host and kernel through one kernel-safe C++ header and supplied as a hashed compile-time argument; chunk count and tail length stay runtime-only, preserving program-cache reuse within each mode.

The first fused chunk performs the full TopK initialization. Later chunks restore only ADDR_MOD_6 and the fused MOP state clobbered by copy/index stamping, avoiding redundant address-modifier writes.

No multi-core merge trees, column splitting, scheduler changes, transport changes, chunk skipping, stable-tie changes, or unrelated LLK refactoring are included.

## Performance

Isolated Blackhole TopK:

| Shape | Classic | Fused | Speedup |
| --- | ---: | ---: | ---: |
| 160 x 51,200, K=2048 | 0.554868 ms | 0.432813 ms | 1.282x |
| 160 x 512,000, K=2048 | 5.524972 ms | 4.294144 ms | 1.287x |

GLM 5.2 traced integration:

| Scenario | Sparse BF16 | Sparse scaled FP8 | Dense control |
| --- | ---: | ---: | ---: |
| Warm | -3.44% | -5.66% | -0.13% |
| Cold | -1.35% | -1.23% | +0.16% |
| Long | -5.88% | -6.54% | -0.28% |

Both classic and fused measurements retain the shipping 16-issue SFPLOADMACRO.

## Validation

- 124/124 `test_topk_large_indices.py` tests passed on Blackhole, including 1/2/25/31/32/33/40/64/65/250-chunk boundaries, spread winners, snapped-K segmented selection, partial final segments, and cache-mode separation.
- 18/18 TopK XL LLK tests passed.
- 9/9 GLM 5.2 warm/cold/long x BF16/FP8/dense cases passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/topk-kernel-fusion-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/topk-kernel-fusion-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/topk-kernel-fusion-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/topk-kernel-fusion-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/topk-kernel-fusion-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/topk-kernel-fusion-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/topk-kernel-fusion-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/topk-kernel-fusion-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/topk-kernel-fusion-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/topk-kernel-fusion-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/topk-kernel-fusion-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/topk-kernel-fusion-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/topk-kernel-fusion-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/topk-kernel-fusion-clean)