### PR TITLE
Merge the changes from PR 52822 back to llk_helper_library

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.hpp
@@ -135,16 +135,16 @@ enum class ReduceInputPolicy { WaitAndPopPerTile, BulkWaitBulkPop, WaitUpfrontNo
  *   file-level note); reduce() runs no heavy per-call hw_configure — per call it does only light format reconfig
  *   (per reconfig_mode) + the SFPU-macro load, exactly like ReduceTile relies on boot + light reduce_init.
  *   RESTRICTED — guarded by static_assert / ASSERT in reduce():
- *     - SUM only (this datapath computes a SUM; for a MEAN use compute_kernel_lib::reduce_mean, which
- *       applies an explicit caller-supplied 1/N — the divisor is NOT derived from tile geometry). MAX/MIN
- *       are not expressible via additive accumulate,
+ *     - SUM, or standalone AVG for a tile-aligned reduction (1/N is derived from tile geometry). For partial,
+ *       cross-chunk, sharded, or uneven means use compute_kernel_lib::reduce_mean with an explicit
+ *       caller-supplied 1/N. MAX/MIN are not expressible via additive accumulate,
  *     - float only (no Int32),
  *     - BulkWaitBulkPop (resident block, indexed) or WaitAndPopPerTile (streaming: DST is the accumulator,
  *       so only ~2 input tiles resident at a time — contiguous row/scalar, aligned only).
  *   PARTIAL (non-tile-aligned) reduce dims are supported standalone (NoAccumulation), ROW/COL only, under
  *   BulkWaitBulkPop: the last reduce-dim tile is folded in with a masked accumulating broadcast-mul so the
- *   padding contributes 0. The scaler CB is otherwise unused. (For a partial MEAN, reduce_mean's n_reduced
- *   is the true count = full_tiles*32 + valid_elems_in_last_tile.)
+ *   padding contributes 0. The scaler CB is otherwise unused. Direct AVG is rejected for partial tiles; a
+ *   partial MEAN uses reduce_mean with the true n_reduced = full_tiles*32 + valid_elems_in_last_tile.
  *   Cross-call Accumulate (CB accumulator across reduce() calls) IS supported: the accumulator CB holds the
  *   RAW partial-sum tile (not a reduced tile), each chunk folds it into the pairwise add NATIVELY (no
  *   binary_dest_reuse) via a parity rule, and sfpu_reduce finalizes only on the last chunk (Accumulate::at_last).
@@ -182,9 +182,8 @@ enum class ReduceAlgorithm { Auto, ReduceTile, AccumulateViaAdd };
  * <op>_tile_init — the normal contract, but note that under Collapse a post-op can free-ride on the
  * finalize's sfpu_reduce init, and under Skip it cannot.
  *
- * PARTIAL IS REJECTED (asserted): `valid_reduce_dim_elements` counts valid LANES along the reduce axis inside
- * the last tile, which only means something while that axis is being collapsed. Skip's inputs are already
- * collapsed on it, so there is nothing for a 0/1 lane mask to mask.
+ * PARTIAL IS REJECTED (asserted): `use_partial` means the last tile needs a lane mask along the reduce axis.
+ * Skip's inputs are already collapsed on that axis, so there is nothing for a 0/1 lane mask to mask.
  *
  * ReduceTile cannot express Skip: there the reduce_tile matmul-with-ones IS the collapse, so there is nothing
  * to skip (asserted).
@@ -304,46 +303,52 @@ struct ReduceInputBlockShape {
 /**
  * @brief Partial-scaler descriptor for non-tile-aligned reduce dimensions
  *
- * When the reduce dimension is not a multiple of TILE_DIM, the reader emits
- * TWO scaler tiles into scaler_cb: tile 0 has the full scaler (all positions
- * filled), and tile 1 has the partial scaler (only the valid positions filled,
- * the rest zeroed). The compute kernel must use tile 1 for the *last* tile
- * along the reduce dimension and tile 0 for every other tile.
+ * ReduceTile and AccumulateViaAdd mask padding differently:
  *
- * This struct selects which scaler-tile index to use on the last reduce-dim
- * iteration. The default (`none()`) keeps the legacy behavior of using tile 0
- * everywhere. Use `last_tile_at(1)` (or any non-zero idx) to switch to the
- * partial scaler on the last tile.
+ * - ReduceTile: the reader emits a full scaler followed by a partial scaler.
+ *   `with_partial()` selects the second scaler for the last tile along the
+ *   reduce dimension.
+ * - AccumulateViaAdd: the reader emits only a 0/1 mask tile at scaler-CB index 0.
+ *   `only_partial()` selects that tile for the last input tile.
  *
- * Pair with dataflow_kernel_lib::prepare_partial_reduce_scalers (or
- * calculate_and_prepare_partial_reduce_scalers) on the reader side.
+ * In both cases the padding lanes multiply by zero and contribute nothing.
+ * The default (`none()`) is the tile-aligned path.
  *
- * REDUCE_SCALAR does not support partial scalers — it applies the scaler
- * twice (row then col), which a single partial tile cannot encode. The
- * runtime asserts that REDUCE_SCALAR callers pass none().
+ * Pair `with_partial()` with dataflow_kernel_lib::prepare_partial_reduce_scalers
+ * (or calculate_and_prepare_partial_reduce_scalers). Pair `only_partial()` with
+ * dataflow_kernel_lib::prepare_reduce_mask.
+ *
+ * REDUCE_SCALAR does not support either partial representation: ReduceTile
+ * applies its scaler twice (row then col), while one AccumulateViaAdd row/column
+ * mask cannot encode a 2-D partial corner.
+ *
+ * The ReduceTile SFPU path (see is_sfpu_reduce_path) folds tiles without reading
+ * the scaler CB, so it cannot honor `with_partial()` either.
+ *
+ * IMPORTANT: `with_partial()` describes the last tile of this reduce() call. If
+ * the caller collapses several tiles into one before calling ReduceTile, masking
+ * that combined tile would also erase valid lanes from earlier tiles. Mask the
+ * ragged tile before accumulating instead; AccumulateViaAdd's `only_partial()`
+ * path does exactly that.
  *
  * Usage:
  *   constexpr auto partial = has_partial
- *       ? ReducePartialScaler::last_tile_at(1)
+ *       ? ReducePartialScaler::with_partial()
  *       : ReducePartialScaler::none();
  *   reduce<SUM, REDUCE_ROW>(cb_in, cb_scaler, cb_out, shape, ..., partial);
  */
 struct ReducePartialScaler {
-    // ReduceTile: scaler-tile index to use for the LAST reduce-dim iteration. 0 = no partial (use tile 0
-    // everywhere); >0 = index of the partial scaler tile.
-    // AccumulateViaAdd: index of the 0/1 MASK tile in the scaler CB (may be 0).
-    std::uint32_t last_tile_scaler_idx = 0;
-    // AccumulateViaAdd only: valid reduce-dim elements in the LAST tile (1..31). >0 signals a partial
-    // reduce and gives the true count for the mean's 1/N. 0 = tile-aligned (unused by ReduceTile).
-    std::uint32_t valid_reduce_dim_elements = 0;
+    // Whether the last reduce-dim tile needs a partial scaler or mask.
+    bool use_partial = false;
+    // Index of that tile: 0 for a mask-only CB, 1 for a [full, partial] scaler pair.
+    std::uint32_t partial_tile_idx = 0;
 
-    static constexpr ReducePartialScaler none() { return {0, 0}; }
-    static constexpr ReducePartialScaler last_tile_at(std::uint32_t idx = 1) { return {idx, 0}; }
-    // AccumulateViaAdd: `valid` real elements in the last reduce-dim tile; 0/1 mask tile at scaler-CB index
-    // `mask_idx`.
-    static constexpr ReducePartialScaler partial_mask(std::uint32_t valid, std::uint32_t mask_idx = 0) {
-        return {mask_idx, valid};
-    }
+    static constexpr ReducePartialScaler none() { return {false, 0}; }
+    static constexpr ReducePartialScaler with_partial() { return {true, 1}; }
+    static constexpr ReducePartialScaler only_partial() { return {true, 0}; }
+
+    constexpr std::uint32_t scaler_tile_count() const { return partial_tile_idx + 1; }
+    constexpr std::uint32_t partial_scaler_idx() const { return partial_tile_idx; }
 };
 
 /**
@@ -376,6 +381,11 @@ struct AccumulationConfig {
  * - MAX + REDUCE_SCALAR: the running max cannot be reproduced by the copy_tile reload.
  * - MAX + REDUCE_ROW on Quasar: the reload needs a within-16x16-face transpose that
  *   copy_tile_to_dst_init_short asserts against on Quasar.
+ *
+ * NOTE on ReducePartialScaler: partial metadata applies to the last reduce-dim tile of
+ * EACH reduce() call, not of the whole accumulated reduction. When only the final chunk
+ * is short, pass with_partial() (ReduceTile) or only_partial() (AccumulateViaAdd) on that
+ * call only and none() on the others.
  *
  * Usage:
  *   const auto cfg = AccumulationConfig::with_cb(cb_accum);
@@ -529,11 +539,11 @@ inline constexpr bool is_post_reduce_op_v = is_post_reduce_op<T>::value;
  * is NoWaitNoPop or WaitUpfrontNoPop.
  * @param accumulate Accumulation configuration (default: NoAccumulation)
  * @param post_reduce_op Callback after each reduction (default: NoOp)
- * @param partial_scaler Partial-scaler selector for non-tile-aligned reduce
- *        dimensions (default: ReducePartialScaler::none()). When set to
- *        last_tile_at(idx), the helper waits for `idx + 1` scaler tiles and
- *        uses scaler tile `idx` for the last reduce-dim iteration. Pair with
- *        dataflow_kernel_lib::prepare_partial_reduce_scalers on the reader.
+ * @param partial_scaler Partial-scaler descriptor for non-tile-aligned reduce
+ *        dimensions (default: ReducePartialScaler::none()). Use with_partial()
+ *        with ReduceTile when the reader emits [full, partial], or only_partial()
+ *        with AccumulateViaAdd when the reader emits a 0/1 mask tile.
+ *        Not supported for REDUCE_SCALAR or the Int32 SFPU reduce path.
  *
  * @example
  *   // Reduce entire HxW grid to single tile (REDUCE_SCALAR)

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_compute.inl
@@ -170,7 +170,8 @@ ALWI bool dfb_unpacks_to_dest(uint32_t dfb_id) {
 // SUM, which reads DST in place), and for AVG multiply by 1/N once. One DST register per output tile, so
 // an arbitrary (Ht, Wt, NC) block is handled without the REDUCE_COL DST/chunk limit.
 //
-// Restrictions (enforced by reduce()): float SUM, or standalone AVG (1/N derived from tile geometry).
+// Restrictions (enforced by reduce()): float SUM, or standalone AVG for tile-aligned input (1/N derived from
+// tile geometry). Partial, cross-chunk, sharded, or uneven means use reduce_mean() with caller-supplied 1/N.
 // ALL FOUR ReduceInputPolicy values are supported — BulkWaitBulkPop / WaitUpfrontNoPop / NoWaitNoPop index a
 // resident block; WaitAndPopPerTile streams the reduce dim through DST. should_pop policies (Bulk / WaitAndPop)
 // pop the input and pack per output; no-pop policies (WaitUpfront / NoWait) leave the input resident and
@@ -178,16 +179,15 @@ ALWI bool dfb_unpacks_to_dest(uint32_t dfb_id) {
 // (sfpu_reduce_init) is hoisted OUT of the per-output loop; only the light MOP inits (add_tiles/copy) run per
 // output.
 //
-// PARTIAL (non-tile-aligned) reduce dims — ROW/COL only, signalled by partial_scaler.valid_reduce_dim_elements
-// (= P valid elements in the LAST reduce-dim tile): the last tile is folded in with a DEST-ACCUMULATING
-// masked broadcast-mul (0/1 mask tile at scaler_dfb_id[last_tile_scaler_idx]; row-0 mask for ROW,
-// col-0 for COL) via fold_partial_last(), so the padding contributes 0. The bulk stays pure add_tiles
-// (fidelity-flat, 2 tiles/op); only the one partial tile is a (fidelity-affected) mul, and a mean divides by
-// the true count (full_cnt*32 + P). The bcast shorthands overwrite DEST (clear_fp32_dst_acc=true), so the
-// accumulating variant is the LLK directly with acc_to_dest=1 at init and clear_fp32_dst_acc=false at the op.
-// Partial is supported standalone (any should_pop / no-pop policy), under ROW streaming, and folded into
-// cross-call Accumulate (ROW/COL). SCALAR partial is rejected (a 2-D corner mask a single row/col tile can't
-// encode).
+// PARTIAL (non-tile-aligned) reduce dims — ROW/COL only, signalled by partial_scaler.use_partial: the last tile
+// is folded in with a DEST-ACCUMULATING masked broadcast-mul (0/1 mask at
+// scaler_dfb_id[partial_tile_idx]; row-0 mask for ROW, col-0 for COL) via fold_partial_last(), so the padding
+// contributes 0. The bulk stays pure add_tiles (fidelity-flat, 2 tiles/op); only the one partial tile is a
+// (fidelity-affected) mul. The bcast shorthands overwrite DEST (clear_fp32_dst_acc=true), so the accumulating
+// variant is the LLK directly with acc_to_dest=1 at init and clear_fp32_dst_acc=false at the op.
+// Partial is supported for SUM/reduce_mean standalone (any should_pop / no-pop policy), under ROW streaming,
+// and folded into cross-call Accumulate (ROW/COL). Direct AVG rejects partial input. SCALAR partial is rejected
+// (a 2-D corner mask a single row/col tile can't encode).
 //
 // CROSS-CALL ACCUMULATE (AccumulateT == Accumulate, BulkWaitBulkPop) — the accumulator CB holds the RAW
 // partial-sum tile per output (NOT a reduced tile). On the first chunk (is_first) we sum this chunk's tiles
@@ -251,13 +251,10 @@ ALWI void reduce_accumulate_via_add(
     const uint32_t stride = is_col ? row_pitch : 1u;  // COL steps down a column by the row pitch
     const uint32_t n_out = is_row ? (Ht * NC) : (is_col ? (Wt * NC) : NC);
 
-    // This datapath produces a SUM (per output tile). The mean is NOT computed here — normalization is a
-    // caller-owned quantity (the true reduced-element count is a property of the whole logical reduction,
-    // not of a single call's tile geometry, and it cannot be derived across cross-call accumulate chunks or
-    // for uneven shards). Callers get a mean via compute_kernel_lib::reduce_mean, which runs this SUM and
-    // applies 1/N with a caller-supplied N in a finalize post_reduce_op.
-    const bool has_partial = (partial_scaler.valid_reduce_dim_elements > 0);
-    const uint32_t mask_idx = partial_scaler.last_tile_scaler_idx;
+    // The pairwise accumulation and within-tile finalize produce a SUM. Standalone direct AVG applies a
+    // geometry-derived 1/N below; partial/cross-chunk/sharded/uneven means use reduce_mean with caller-owned N.
+    const bool has_partial = partial_scaler.use_partial;
+    const uint32_t mask_idx = partial_scaler.partial_tile_idx;
     const uint32_t full_cnt = has_partial ? (cnt - 1u) : cnt;  // tiles summed via pure add_tiles
 
     DataflowBuffer input_dfb(input_dfb_id), scaler_dfb(scaler_dfb_id), output_dfb(output_dfb_id);
@@ -580,23 +577,18 @@ ALWI void reduce_accumulate_via_add(
                     sfpu_reduce<PoolType::SUM, dst_fmt, ReduceDim::REDUCE_ROW>(0, 1, 1);
                     sfpu_reduce<PoolType::SUM, dst_fmt, ReduceDim::REDUCE_COL>(0, 1, 1);
                 }
-                // Standalone AVG: divide by the element count from tile geometry (aligned ROW/COL = cnt*32,
-                // SCALAR = Ht*Wt*1024, partial ROW/COL = full_cnt*32 + P). Emits the same sfpu_reduce ->
-                // mul_unary_tile sequence as reduce_mean, so reduce<AVG> and reduce_mean are bit-identical for
-                // the standalone case. Cross-chunk / sharded / uneven mean uses reduce_mean (caller N); AVG +
-                // Accumulate is rejected in reduce() (the geometry N cannot span chunks).
+                // Standalone direct AVG is tile-aligned only. For ROW/COL, full_cnt == cnt because partial
+                // input is rejected below; SCALAR reduces cnt whole tiles, each containing 32 * 32 elements.
                 if constexpr (reduce_type == PoolType::AVG) {
-                    const uint32_t n_geom =
-                        (is_row || is_col) ? (full_cnt * 32u + partial_scaler.valid_reduce_dim_elements)
-                                           : (cnt * 1024u);
+                    const uint32_t n_geom = (is_row || is_col) ? (full_cnt * 32u) : (cnt * 1024u);
                     float inv_f = 1.0f / static_cast<float>(n_geom);
                     uint32_t inv_bits = 0;
                     __builtin_memcpy(&inv_bits, &inv_f, sizeof(inv_bits));
                     mul_unary_tile(0, inv_bits);  // no binop_with_scalar init needed after sfpu_reduce
                 }
             }
-            // DST now holds the reduced value (raw SUM, or the mean for AVG). A caller post_reduce_op (e.g.
-            // reduce_mean's caller 1/N, or recip for softmax) then sees the finalized value.
+            // DST now holds the reduced value (raw SUM, or the mean for direct AVG). A caller post_reduce_op
+            // (e.g. reduce_mean's caller 1/N, or recip for softmax) then sees the finalized value.
             post_reduce_op(0);
         }
 
@@ -810,19 +802,19 @@ ALWI void reduce(
 
     // =============================================================================
     // Algorithm selection. Auto resolves to a concrete datapath (for now always ReduceTile; a cost
-    // heuristic will choose later). AccumulateViaAdd is a restricted, faster datapath for wide float
-    // SUM reduces; anything it cannot express is rejected here (compile-time where possible) and must use
-    // ReduceTile. ReduceTile (and Auto) fall through to the standard body below.
+    // heuristic will choose later). AccumulateViaAdd is a restricted, faster datapath for wide float SUM and
+    // standalone aligned AVG reduces; anything it cannot express is rejected here (compile-time where possible)
+    // and must use ReduceTile. ReduceTile (and Auto) fall through to the standard body below.
     // =============================================================================
     constexpr ReduceAlgorithm resolved_algorithm =
         (algorithm == ReduceAlgorithm::Auto) ? ReduceAlgorithm::ReduceTile : algorithm;
     if constexpr (resolved_algorithm == ReduceAlgorithm::AccumulateViaAdd) {
         static_assert(
             reduce_type == PoolType::SUM || reduce_type == PoolType::AVG,
-            "AccumulateViaAdd computes SUM, or standalone AVG (1/N derived from tile geometry: aligned ROW/COL "
-            "= cnt*32, SCALAR = Ht*Wt*1024, partial ROW/COL = full_cnt*32 + P). A cross-chunk / sharded / uneven "
-            "mean must use compute_kernel_lib::reduce_mean (caller-supplied N — not derivable from one call's "
-            "geometry). MAX/MIN are not expressible via additive accumulate; use ReduceTile.");
+            "AccumulateViaAdd computes SUM, or standalone AVG for tile-aligned input (1/N derived from "
+            "geometry: ROW/COL = full_cnt*32, SCALAR = Ht*Wt*1024). Partial, cross-chunk, sharded, or uneven "
+            "means must use compute_kernel_lib::reduce_mean with caller-supplied N. MAX/MIN are not "
+            "expressible via additive accumulate; use ReduceTile.");
         static_assert(
             reduce_format != DataFormat::Int32,
             "AccumulateViaAdd: float only (add_tiles + sfpu_reduce). Int32 must use ReduceTile.");
@@ -836,12 +828,12 @@ ALWI void reduce(
         // All four ReduceInputPolicy values are supported: BulkWaitBulkPop / WaitUpfrontNoPop / NoWaitNoPop
         // index a resident block (should_pop vs bulk-reserve output); WaitAndPopPerTile streams the reduce dim.
         // Cross-call Accumulate (CB accumulator holding the RAW partial sum, folded into the pairwise add):
-        // SUM only (the internal AVG 1/N is per-call and cannot span chunks — use SUM + a 1/N post_reduce_op
-        // on the last chunk), BulkWaitBulkPop only, and tile-aligned only (asserted below).
+        // SUM only (direct AVG's geometry is per call), BulkWaitBulkPop only. A cross-chunk mean uses
+        // reduce_mean with the grand-total N on the last chunk.
         static_assert(
             !is_accumulate_v<AccumulateT> || reduce_type == PoolType::SUM,
-            "AccumulateViaAdd + Accumulate: SUM only. For a cross-chunk mean, use SUM and apply 1/N in a "
-            "post_reduce_op on the last chunk (see reduce_rm).");
+            "AccumulateViaAdd + Accumulate: SUM only. For a cross-chunk mean, use reduce_mean with the "
+            "grand-total N on the last chunk.");
         static_assert(
             !is_accumulate_v<AccumulateT> || input_policy == ReduceInputPolicy::BulkWaitBulkPop,
             "AccumulateViaAdd + Accumulate: BulkWaitBulkPop only (the accumulator fold indexes a resident "
@@ -856,19 +848,19 @@ ALWI void reduce(
         // Streaming (WaitAndPopPerTile) + partial is supported for ROW (the masked last tile folds in as the
         // final streamed op). COL streaming is rejected above; SCALAR partial is rejected below.
         // Partial (non-tile-aligned) reduce dims are supported for ROW/COL under BulkWaitBulkPop (the last
-        // reduce-dim tile is folded in with a masked accumulating broadcast-mul; valid_reduce_dim_elements =
-        // P + a 0/1 mask tile in scaler_dfb). REDUCE_SCALAR can be partial in BOTH axes at once (a single
-        // row/col mask can't express the corner), so it is rejected — use ReduceTile.
-        if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
-            ASSERT(partial_scaler.valid_reduce_dim_elements == 0);
+        // reduce-dim tile is folded in with a masked accumulating broadcast-mul and a 0/1 mask tile in
+        // scaler_dfb). REDUCE_SCALAR can be partial in BOTH axes at once (a single row/col mask can't express
+        // the corner), so it is rejected — use ReduceTile.
+        if constexpr (reduce_type == PoolType::AVG) {
+            ASSERT(!partial_scaler.use_partial);
         }
-        // Skip + partial is a contradiction, not a supported combination. valid_reduce_dim_elements counts
-        // valid LANES along the reduce axis inside the last tile — a quantity that only means something when
-        // that axis is being collapsed. Under Skip the inputs are already collapsed on it (one valid lane per
-        // tile), so a 0/1 lane mask has nothing to mask: it multiplies the one valid lane by 1 and the garbage
-        // by 0, at the cost of a fidelity-affected bcast-mul. Reject it rather than pretend it did something.
+        if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
+            ASSERT(!partial_scaler.use_partial);
+        }
+        // Skip + partial is a contradiction: use_partial requests a lane mask along an axis whose inputs are
+        // already collapsed. Reject it rather than pretend the mask did useful work.
         if constexpr (within_tile == ReduceWithinTile::Skip) {
-            ASSERT(partial_scaler.valid_reduce_dim_elements == 0);
+            ASSERT(!partial_scaler.use_partial);
         }
         // Cross-call Accumulate + partial is supported for ROW/COL (the masked last tile folds into each
         // chunk's sum via fold_partial_last). SCALAR partial is rejected above (622-ish) regardless of accumulate.
@@ -973,9 +965,9 @@ ALWI void reduce(
     // Partial scaler: REDUCE_SCALAR can't use it (applies the scaler twice).
     // Other reduce dims may add a partial-fill tile at index >0; wait for both.
     if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR) {
-        ASSERT(partial_scaler.last_tile_scaler_idx == 0);
+        ASSERT(!partial_scaler.use_partial);
     }
-    scaler_dfb.wait_front(partial_scaler.last_tile_scaler_idx + 1);
+    scaler_dfb.wait_front(partial_scaler.scaler_tile_count());
     if constexpr (is_sfpu) {
         PACK((llk_pack_reduce_mask_config<reduce_dim, PackMode::Default>(output_dfb_id)));
     }
@@ -1104,7 +1096,7 @@ ALWI void reduce(
                         }
                     } else {
                         // Last W-tile picks up the partial scaler when one was prepared by the reader.
-                        const uint32_t scaler_idx = (wt == Wt - 1) ? partial_scaler.last_tile_scaler_idx : 0;
+                        const uint32_t scaler_idx = (wt == Wt - 1) ? partial_scaler.partial_scaler_idx() : 0;
                         if constexpr (waits_per_tile(input_policy)) {
                             // One-at-a-time: wait/pop per tile
                             input_dfb.wait_front(onetile);
@@ -1207,7 +1199,7 @@ ALWI void reduce(
                     // Base dst_index: from accumulation config or 0 for multi-column output
                     uint32_t dst_idx = get_dst_index(accumulate);
                     // Last H-tile picks up the partial scaler when one was prepared by the reader.
-                    const uint32_t scaler_idx = (ht == Ht - 1) ? partial_scaler.last_tile_scaler_idx : 0;
+                    [[maybe_unused]] const uint32_t scaler_idx = (ht == Ht - 1) ? partial_scaler.partial_scaler_idx() : 0;
                     for (uint32_t i = wt; i < chunk_end; ++i) {
                         if constexpr (is_sfpu) {
                             const bool is_first_tile = detail::sfpu_is_first_tile(ht, accumulate);

--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp
@@ -109,7 +109,7 @@ FORCE_INLINE void calculate_and_prepare_reduce_scaler(
 //   tile 0 → full scaler
 //   tile 1 → partial scaler
 //
-// Pair with compute_kernel_lib::ReducePartialScaler::last_tile_at(1) on the
+// Pair with compute_kernel_lib::ReducePartialScaler::with_partial() on the
 // compute side. REDUCE_SCALAR is not supported (scaler is applied twice).
 // =============================================================================
 

--- a/ttnn/ttnn/operations/examples/reduce_block/program_descriptor_with_inline_kernels.py
+++ b/ttnn/ttnn/operations/examples/reduce_block/program_descriptor_with_inline_kernels.py
@@ -265,7 +265,7 @@ void kernel_main() {
 # Helper kernel — the reduce library over the general (Ht, Wt, NC) block, AVG pool. The `algo` CT arg
 # selects the library datapath: 0 = ReduceTile (Auto default, FPU matmul-with-ones), 1 = AccumulateViaAdd.
 # `policy` selects one of the four ReduceInputPolicy values for BOTH datapaths; `avg_direct` makes the
-# AccumulateViaAdd path use reduce<AVG> (geometry 1/N) instead of reduce_mean (explicit N).
+# AccumulateViaAdd path use reduce<AVG> (aligned geometry 1/N) instead of reduce_mean (explicit N).
 #
 # The per-iter reduce dispatch is hoisted into a TEMPLATE (do_reduce_block) so `if constexpr (algo)` GENUINELY
 # discards the dead branch. kernel_main is not a template, so an `if constexpr (algo)` there would still
@@ -315,8 +315,8 @@ ALWI void do_reduce_block(
     constexpr ReduceWithinTile WT = (skip_within == 1u) ? ReduceWithinTile::Skip : ReduceWithinTile::Collapse;
     if constexpr (algo == 1u) {
         // AccumulateViaAdd. recfg==1 exercises RECFG::NONE after the first call (reusing the first call's
-        // config). avg_direct==1: reduce<AVG> derives 1/N from geometry; else reduce_mean applies the explicit
-        // caller N (which is cross-chunk / uneven-shard safe).
+        // config). avg_direct==1: reduce<AVG> derives 1/N from aligned geometry; else reduce_mean applies the
+        // explicit caller N (which supports partial, cross-chunk, and uneven-shard means).
         const bool none_now = (recfg == 1u) && (iter > 0u);
         if constexpr (avg_direct == 1u) {
             if (none_now)
@@ -361,9 +361,9 @@ void kernel_main() {
     constexpr bool pops_input = (policy_id <= 1u);  // Bulk + WaitAndPop pop the input; no-pop policies do not
 
     using namespace compute_kernel_lib;
-    // AccumulateViaAdd partial: 0/1 mask tile at scaler-CB index 0 + valid element count for the mean.
+    // AccumulateViaAdd partial: one 0/1 mask tile at scaler-CB index 0.
     const ReducePartialScaler PS =
-        (partial_elems > 0u) ? ReducePartialScaler::partial_mask(partial_elems, 0) : ReducePartialScaler::none();
+        (partial_elems > 0u) ? ReducePartialScaler::only_partial() : ReducePartialScaler::none();
     const auto SHAPE = ReduceInputBlockShape::of(Ht, Wt, NC);
     const auto ML = (row_stride > 0u) ? ReduceInputMemoryLayout::with_row_stride(row_stride)
                                       : ReduceInputMemoryLayout::contiguous();
@@ -476,7 +476,7 @@ void kernel_main() {
                                             : (reload_id == 4u) ? AccumulateReloadMode::CopySeedZeroPair
                                                                 : AccumulateReloadMode::CopySeedPairs;
     const ReducePartialScaler PS =
-        (partial_elems > 0u) ? ReducePartialScaler::partial_mask(partial_elems, 0) : ReducePartialScaler::none();
+        (partial_elems > 0u) ? ReducePartialScaler::only_partial() : ReducePartialScaler::none();
     const auto SHAPE = ReduceInputBlockShape::of(Ht, Wt, NC);
     const auto ML = (row_stride > 0u) ? ReduceInputMemoryLayout::with_row_stride(row_stride)
                                       : ReduceInputMemoryLayout::contiguous();
@@ -683,6 +683,8 @@ def create_program_descriptor(
             raise ValueError("no-pop policies are exercised aligned + contiguous in this example")
     if avg_direct and variant != "accumulate_via_add":
         raise ValueError("avg_direct (reduce<AVG> geometry 1/N) is an accumulate_via_add lever")
+    if avg_direct and partial_elems:
+        raise ValueError("avg_direct requires a tile-aligned reduce dimension; use reduce_mean for partial input")
     if reconfig not in (None, "none_after_first"):
         raise ValueError(f"reconfig must be None or 'none_after_first', got {reconfig!r}")
     if reconfig and variant != "accumulate_via_add":
@@ -751,9 +753,9 @@ def create_program_descriptor(
         )
         return ttnn.ProgramDescriptor(kernels=[mask, compute], semaphores=[], cbs=cbs)
 
-    # library paths (reduce_tile = algo 0 -> Auto/ReduceTile matmul-reduce; accumulate_via_add = algo 1 ->
-    # the opt-in AccumulateViaAdd). AccumulateViaAdd ignores the AVG scaler for aligned reduces (computes
-    # 1/N itself); for a PARTIAL reduce it consumes a 0/1 MASK tile from the scaler CB instead.
+    # Library paths: reduce_tile = algo 0 -> Auto/ReduceTile matmul-reduce; accumulate_via_add = algo 1 ->
+    # the opt-in AccumulateViaAdd. Direct AVG derives 1/N from aligned geometry; reduce_mean supplies N for
+    # other means. For a partial reduce, AccumulateViaAdd consumes a 0/1 mask tile from the scaler CB.
     algo = 1 if path == "accumulate_via_add" else 0
     use_mask = bool(partial_elems)
     if partial_elems:

--- a/ttnn/ttnn/operations/toy_reduce_partial/kernels/compute.cpp
+++ b/ttnn/ttnn/operations/toy_reduce_partial/kernels/compute.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_in, cb_scaler, cb_out);
 
-    constexpr auto partial_scaler = has_partial ? compute_kernel_lib::ReducePartialScaler::last_tile_at(1)
+    constexpr auto partial_scaler = has_partial ? compute_kernel_lib::ReducePartialScaler::with_partial()
                                                 : compute_kernel_lib::ReducePartialScaler::none();
 
     constexpr auto block_shape = compute_kernel_lib::ReduceInputBlockShape::of(Ht, Wt, NC);

--- a/ttnn/ttnn/operations/toy_variance/kernels/compute.cpp
+++ b/ttnn/ttnn/operations/toy_variance/kernels/compute.cpp
@@ -61,7 +61,7 @@ void kernel_main() {
     // last W-tile. Only the LAST block holds that tile, so the partial scaler
     // is passed on the last block and ::none() on every earlier one.
     constexpr auto partial_scaler =
-        HAS_PARTIAL_W ? ckl::ReducePartialScaler::last_tile_at(1) : ckl::ReducePartialScaler::none();
+        HAS_PARTIAL_W ? ckl::ReducePartialScaler::with_partial() : ckl::ReducePartialScaler::none();
 
     // ---------- Pass 1: streaming mean ----------
     // Scaler = 1/N (with partial-scaler-zeroed padded positions) converts SUM

--- a/ttnn/ttnn/operations/toy_variance/kernels/reader.cpp
+++ b/ttnn/ttnn/operations/toy_variance/kernels/reader.cpp
@@ -38,7 +38,7 @@ void kernel_main() {
     // Scaler = 1/N → SUM reduce produces means directly. For non-tile-aligned
     // W, also emit a partial scaler tile that zeros out positions beyond
     // partial_w; the compute kernel selects it for the last W-tile of the
-    // last block via ReducePartialScaler::last_tile_at(1).
+    // last block via ReducePartialScaler::with_partial().
     float scaler_f = __builtin_bit_cast(float, scaler_bits);
     if constexpr (has_partial_w) {
         dataflow_kernel_lib::prepare_partial_reduce_scalers<


### PR DESCRIPTION
Adding the changes to the PartialScaler made in PR 52822 back to llk_helper_library, and reconciling those changes with the PartialScaler support for AccumulateViaAdd

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=malimpic/reduce-partial-scaler-llk-helper-library)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:malimpic/reduce-partial-scaler-llk-helper-library)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=malimpic/reduce-partial-scaler-llk-helper-library)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:malimpic/reduce-partial-scaler-llk-helper-library)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=malimpic/reduce-partial-scaler-llk-helper-library)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:malimpic/reduce-partial-scaler-llk-helper-library)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=malimpic/reduce-partial-scaler-llk-helper-library)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:malimpic/reduce-partial-scaler-llk-helper-library)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=malimpic/reduce-partial-scaler-llk-helper-library)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:malimpic/reduce-partial-scaler-llk-helper-library)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=malimpic/reduce-partial-scaler-llk-helper-library)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:malimpic/reduce-partial-scaler-llk-helper-library)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=malimpic/reduce-partial-scaler-llk-helper-library)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:malimpic/reduce-partial-scaler-llk-helper-library)