### PR TITLE
[TTML] Expose GELU approximation variant in ttml.ops.unary.gelu

### DIFF
--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -13,7 +13,6 @@
 #include <span>
 #include <string>
 #include <ttnn/distributed/distributed_tensor.hpp>
-#include <variant>
 
 #include "autograd/autocast_tensor.hpp"
 #include "autograd/tensor.hpp"
@@ -561,24 +560,14 @@ void py_module(nb::module_& m) {
     {
         auto py_unary = static_cast<nb::module_>(m.attr("unary"));
         py_unary.def("relu", &ttml::ops::relu, nb::arg("tensor"));
-        // `variant` accepts ttnn.GeluVariant (GeluVariant is an alias of ttnn's enum, so it is that
-        // exact Python type) or one of the strings "none"/"accurate", "tanh", "fast_lut".
         py_unary.def(
             "gelu",
-            [](const autograd::TensorPtr& tensor, const std::variant<GeluVariant, std::string>& variant) {
-                return ttml::ops::gelu(
-                    tensor,
-                    std::holds_alternative<GeluVariant>(variant)
-                        ? std::get<GeluVariant>(variant)
-                        : ttml::ops::gelu_variant_from_string(std::get<std::string>(variant)));
-            },
+            &ttml::ops::gelu,
             nb::arg("tensor"),
             nb::kw_only(),
             nb::arg("variant") = GeluVariant::ACCURATE,
-            "GELU activation. `variant` takes a ttnn.GeluVariant or one of the strings\n"
-            "\"none\"/\"accurate\", \"tanh\", \"fast_lut\". FastLut is forward-only -- there is no\n"
-            "LUT backward kernel -- so it raises ValueError when `tensor` requires grad and gradient\n"
-            "mode is enabled. Use it for inference, or Tanh for a trainable approximation.");
+            "GELU activation. `variant` takes a ttnn.GeluVariant. Unlike ttnn, the FastLut variant is\n"
+            "not supported.");
         py_unary.def("silu", &ttml::ops::silu, nb::arg("tensor"), nb::arg("use_composite_bw") = false);
         py_unary.def("exp", &ttml::ops::exp, nb::arg("tensor"));
         py_unary.def("clip", &ttml::ops::clip, nb::arg("tensor"), nb::arg("lo"), nb::arg("hi"));

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -5,11 +5,15 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 
 #include <span>
+#include <string>
 #include <ttnn/distributed/distributed_tensor.hpp>
+#include <variant>
 
 #include "autograd/autocast_tensor.hpp"
 #include "autograd/tensor.hpp"
@@ -26,8 +30,8 @@
 #include "ops/linear_op.hpp"
 #include "ops/losses.hpp"
 #include "ops/matmul_op.hpp"
-#include "ops/mla_qkv_assemble_op.hpp"
 #include "ops/mla_q_rope.hpp"
+#include "ops/mla_qkv_assemble_op.hpp"
 #include "ops/moe_ffn_swiglu_op.hpp"
 #include "ops/moe_group_op.hpp"
 #include "ops/moe_ungroup_op.hpp"
@@ -557,7 +561,23 @@ void py_module(nb::module_& m) {
     {
         auto py_unary = static_cast<nb::module_>(m.attr("unary"));
         py_unary.def("relu", &ttml::ops::relu, nb::arg("tensor"));
-        py_unary.def("gelu", &ttml::ops::gelu, nb::arg("tensor"));
+        // `variant` accepts ttnn.GeluVariant (GeluVariant is an alias of ttnn's enum, so it is that
+        // exact Python type) or one of the strings "none"/"accurate", "tanh", "fast_lut".
+        py_unary.def(
+            "gelu",
+            [](const autograd::TensorPtr& tensor, const std::variant<GeluVariant, std::string>& variant) {
+                return ttml::ops::gelu(
+                    tensor,
+                    std::holds_alternative<GeluVariant>(variant)
+                        ? std::get<GeluVariant>(variant)
+                        : ttml::ops::gelu_variant_from_string(std::get<std::string>(variant)));
+            },
+            nb::arg("tensor"),
+            nb::kw_only(),
+            nb::arg("variant") = GeluVariant::ACCURATE,
+            "GELU activation. `variant` takes a ttnn.GeluVariant or one of the strings\n"
+            "\"none\"/\"accurate\", \"tanh\", \"fast_lut\". FastLut approximates only the forward\n"
+            "pass; its backward uses the exact GELU derivative.");
         py_unary.def("silu", &ttml::ops::silu, nb::arg("tensor"), nb::arg("use_composite_bw") = false);
         py_unary.def("exp", &ttml::ops::exp, nb::arg("tensor"));
         py_unary.def("clip", &ttml::ops::clip, nb::arg("tensor"), nb::arg("lo"), nb::arg("hi"));

--- a/tt-train/sources/ttml/nanobind/nb_ops.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_ops.cpp
@@ -576,8 +576,9 @@ void py_module(nb::module_& m) {
             nb::kw_only(),
             nb::arg("variant") = GeluVariant::ACCURATE,
             "GELU activation. `variant` takes a ttnn.GeluVariant or one of the strings\n"
-            "\"none\"/\"accurate\", \"tanh\", \"fast_lut\". FastLut approximates only the forward\n"
-            "pass; its backward uses the exact GELU derivative.");
+            "\"none\"/\"accurate\", \"tanh\", \"fast_lut\". FastLut is forward-only -- there is no\n"
+            "LUT backward kernel -- so it raises ValueError when `tensor` requires grad and gradient\n"
+            "mode is enabled. Use it for inference, or Tanh for a trainable approximation.");
         py_unary.def("silu", &ttml::ops::silu, nb::arg("tensor"), nb::arg("use_composite_bw") = false);
         py_unary.def("exp", &ttml::ops::exp, nb::arg("tensor"));
         py_unary.def("clip", &ttml::ops::clip, nb::arg("tensor"), nb::arg("lo"), nb::arg("hi"));

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -33,10 +33,8 @@ namespace ttml::ops {
 
 namespace {
 
-// ttnn::experimental::gelu_bw takes a string, not a GeluVariant, and only special-cases the exact
-// string "tanh" -- anything else selects the exact-derivative polynomial kernel. FAST_LUT never
-// reaches here: gelu() rejects it when a gradient would be built, because ttnn has no LUT backward
-// kernel to pair with the LUT forward.
+// Unlike ttnn::gelu, ttnn::experimental::gelu_bw takes a string rather than a GeluVariant, so
+// we have to handle the string case explicitly.
 const std::string& gelu_bw_approximate(GeluVariant variant) {
     static const std::string k_none = "none";
     static const std::string k_tanh = "tanh";
@@ -59,32 +57,11 @@ autograd::TensorPtr relu(const autograd::TensorPtr& tensor) {
     return out;
 }
 
-GeluVariant gelu_variant_from_string(std::string_view name) {
-    if (name == "none" || name == "accurate") {
-        return GeluVariant::ACCURATE;
-    }
-    if (name == "tanh") {
-        return GeluVariant::TANH;
-    }
-    if (name == "fast_lut") {
-        return GeluVariant::FAST_LUT;
-    }
-    throw std::invalid_argument(
-        fmt::format("Unknown GELU variant: {}. Supported variants [none, accurate, tanh, fast_lut]", name));
-}
-
 autograd::TensorPtr gelu(const autograd::TensorPtr& tensor, GeluVariant variant) {
-    // FAST_LUT is forward-only: its backward would run the exact GELU derivative, which is not the
-    // derivative of the piecewise-linear forward, so training through it descends the wrong
-    // objective. Reject it exactly when add_backward_node() would create a node, so inference paths
-    // (GradMode::DISABLED) keep the fast kernel.
+    // Unlike ttnn, fast_lut variant is not supported (no fast-lut backward kernel)
     if (variant == GeluVariant::FAST_LUT && autograd::ctx().get_gradient_mode() == autograd::GradMode::ENABLED &&
         autograd::any_requires_grad(tensor)) {
-        throw std::invalid_argument(
-            "gelu: GeluVariant::FAST_LUT is forward-only -- ttnn has no LUT backward kernel, so the "
-            "gradient would be the exact GELU derivative rather than the derivative of the LUT "
-            "forward. Use GeluVariant::TANH for a trainable approximation, or run with gradient mode "
-            "disabled.");
+        throw std::invalid_argument("gelu: GeluVariant::FAST_LUT is not supported for training");
     }
 
     auto out = autograd::create_tensor();

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -34,8 +34,9 @@ namespace ttml::ops {
 namespace {
 
 // ttnn::experimental::gelu_bw takes a string, not a GeluVariant, and only special-cases the exact
-// string "tanh" -- anything else selects the exact-derivative polynomial kernel. There is no LUT
-// backward kernel, so FAST_LUT shares ACCURATE's backward.
+// string "tanh" -- anything else selects the exact-derivative polynomial kernel. FAST_LUT never
+// reaches here: gelu() rejects it when a gradient would be built, because ttnn has no LUT backward
+// kernel to pair with the LUT forward.
 const std::string& gelu_bw_approximate(GeluVariant variant) {
     static const std::string k_none = "none";
     static const std::string k_tanh = "tanh";
@@ -73,6 +74,19 @@ GeluVariant gelu_variant_from_string(std::string_view name) {
 }
 
 autograd::TensorPtr gelu(const autograd::TensorPtr& tensor, GeluVariant variant) {
+    // FAST_LUT is forward-only: its backward would run the exact GELU derivative, which is not the
+    // derivative of the piecewise-linear forward, so training through it descends the wrong
+    // objective. Reject it exactly when add_backward_node() would create a node, so inference paths
+    // (GradMode::DISABLED) keep the fast kernel.
+    if (variant == GeluVariant::FAST_LUT && autograd::ctx().get_gradient_mode() == autograd::GradMode::ENABLED &&
+        autograd::any_requires_grad(tensor)) {
+        throw std::invalid_argument(
+            "gelu: GeluVariant::FAST_LUT is forward-only -- ttnn has no LUT backward kernel, so the "
+            "gradient would be the exact GELU derivative rather than the derivative of the LUT "
+            "forward. Use GeluVariant::TANH for a trainable approximation, or run with gradient mode "
+            "disabled.");
+    }
+
     auto out = autograd::create_tensor();
     out->set_value(ttnn::gelu(tensor->get_value(), variant));
     autograd::GradFunction grad = [tensor, out, variant]() {

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -59,8 +59,7 @@ autograd::TensorPtr relu(const autograd::TensorPtr& tensor) {
 
 autograd::TensorPtr gelu(const autograd::TensorPtr& tensor, GeluVariant variant) {
     // Unlike ttnn, fast_lut variant is not supported (no fast-lut backward kernel)
-    if (variant == GeluVariant::FAST_LUT && autograd::ctx().get_gradient_mode() == autograd::GradMode::ENABLED &&
-        autograd::any_requires_grad(tensor)) {
+    if (variant == GeluVariant::FAST_LUT) {
         throw std::invalid_argument("gelu: GeluVariant::FAST_LUT is not supported for training");
     }
 

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <optional>
+#include <stdexcept>
+#include <string>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/graph.hpp"
@@ -29,6 +31,19 @@
 
 namespace ttml::ops {
 
+namespace {
+
+// ttnn::experimental::gelu_bw takes a string, not a GeluVariant, and only special-cases the exact
+// string "tanh" -- anything else selects the exact-derivative polynomial kernel. There is no LUT
+// backward kernel, so FAST_LUT shares ACCURATE's backward.
+const std::string& gelu_bw_approximate(GeluVariant variant) {
+    static const std::string k_none = "none";
+    static const std::string k_tanh = "tanh";
+    return variant == GeluVariant::TANH ? k_tanh : k_none;
+}
+
+}  // namespace
+
 autograd::TensorPtr relu(const autograd::TensorPtr& tensor) {
     auto out = autograd::create_tensor();
     out->set_value(ttnn::relu(tensor->get_value()));
@@ -43,12 +58,25 @@ autograd::TensorPtr relu(const autograd::TensorPtr& tensor) {
     return out;
 }
 
-autograd::TensorPtr gelu(const autograd::TensorPtr& tensor) {
+GeluVariant gelu_variant_from_string(std::string_view name) {
+    if (name == "none" || name == "accurate") {
+        return GeluVariant::ACCURATE;
+    }
+    if (name == "tanh") {
+        return GeluVariant::TANH;
+    }
+    if (name == "fast_lut") {
+        return GeluVariant::FAST_LUT;
+    }
+    throw std::invalid_argument(
+        fmt::format("Unknown GELU variant: {}. Supported variants [none, accurate, tanh, fast_lut]", name));
+}
+
+autograd::TensorPtr gelu(const autograd::TensorPtr& tensor, GeluVariant variant) {
     auto out = autograd::create_tensor();
-    out->set_value(ttnn::gelu(tensor->get_value()));
-    autograd::GradFunction grad = [tensor, out]() {
-        static const std::string approx_mode = "none";
-        auto dL_dt = ttnn::experimental::gelu_bw(out->get_grad(), tensor->get_value(), approx_mode);
+    out->set_value(ttnn::gelu(tensor->get_value(), variant));
+    autograd::GradFunction grad = [tensor, out, variant]() {
+        auto dL_dt = ttnn::experimental::gelu_bw(out->get_grad(), tensor->get_value(), gelu_bw_approximate(variant));
         tensor->add_grad(dL_dt);
     };
 

--- a/tt-train/sources/ttml/ops/unary_ops.hpp
+++ b/tt-train/sources/ttml/ops/unary_ops.hpp
@@ -4,26 +4,15 @@
 
 #pragma once
 
-#include <string_view>
-
 #include "autograd/tensor.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 
 namespace ttml::ops {
 
+// Map to ttnn.GeluVariant.
 using GeluVariant = ttnn::operations::unary::GeluVariant;
 
-// Parses a GELU variant name. Accepted spellings (lowercase, exact):
-//   "none", "accurate" -> ACCURATE   ("none" mirrors torch's and gelu_bw's `approximate=` vocabulary)
-//   "tanh"             -> TANH
-//   "fast_lut"         -> FAST_LUT
-// Throws std::invalid_argument otherwise; nanobind maps that to a Python ValueError.
-GeluVariant gelu_variant_from_string(std::string_view name);
-
 autograd::TensorPtr relu(const autograd::TensorPtr& tensor);
-// ACCURATE and TANH each pair their forward with a matching backward kernel. FAST_LUT is
-// forward-only -- ttnn has no LUT backward kernel -- so it throws std::invalid_argument if the input
-// requires grad while gradient mode is enabled; use it only for inference.
 autograd::TensorPtr gelu(const autograd::TensorPtr& tensor, GeluVariant variant = GeluVariant::ACCURATE);
 autograd::TensorPtr silu(const autograd::TensorPtr& tensor, bool use_composite_bw = false);
 autograd::TensorPtr mean(const autograd::TensorPtr& tensor);

--- a/tt-train/sources/ttml/ops/unary_ops.hpp
+++ b/tt-train/sources/ttml/ops/unary_ops.hpp
@@ -4,12 +4,24 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "autograd/tensor.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
 
 namespace ttml::ops {
 
+using GeluVariant = ttnn::operations::unary::GeluVariant;
+
+// Parses a GELU variant name. Accepted spellings (lowercase, exact):
+//   "none", "accurate" -> ACCURATE   ("none" mirrors torch's and gelu_bw's `approximate=` vocabulary)
+//   "tanh"             -> TANH
+//   "fast_lut"         -> FAST_LUT
+// Throws std::invalid_argument otherwise; nanobind maps that to a Python ValueError.
+GeluVariant gelu_variant_from_string(std::string_view name);
+
 autograd::TensorPtr relu(const autograd::TensorPtr& tensor);
-autograd::TensorPtr gelu(const autograd::TensorPtr& tensor);
+autograd::TensorPtr gelu(const autograd::TensorPtr& tensor, GeluVariant variant = GeluVariant::ACCURATE);
 autograd::TensorPtr silu(const autograd::TensorPtr& tensor, bool use_composite_bw = false);
 autograd::TensorPtr mean(const autograd::TensorPtr& tensor);
 // autograd::TensorPtr sum(const autograd::TensorPtr& tensor);

--- a/tt-train/sources/ttml/ops/unary_ops.hpp
+++ b/tt-train/sources/ttml/ops/unary_ops.hpp
@@ -21,6 +21,9 @@ using GeluVariant = ttnn::operations::unary::GeluVariant;
 GeluVariant gelu_variant_from_string(std::string_view name);
 
 autograd::TensorPtr relu(const autograd::TensorPtr& tensor);
+// ACCURATE and TANH each pair their forward with a matching backward kernel. FAST_LUT is
+// forward-only -- ttnn has no LUT backward kernel -- so it throws std::invalid_argument if the input
+// requires grad while gradient mode is enabled; use it only for inference.
 autograd::TensorPtr gelu(const autograd::TensorPtr& tensor, GeluVariant variant = GeluVariant::ACCURATE);
 autograd::TensorPtr silu(const autograd::TensorPtr& tensor, bool use_composite_bw = false);
 autograd::TensorPtr mean(const autograd::TensorPtr& tensor);

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -13,6 +13,8 @@
 #include <random>
 #include <ranges>
 #include <span>
+#include <stdexcept>
+#include <string_view>
 #include <vector>
 
 #include "autograd/auto_context.hpp"
@@ -21,6 +23,7 @@
 #include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
+#include "xtensor/core/xmath.hpp"
 
 namespace ttml::ops::tests {
 
@@ -61,6 +64,63 @@ void load_random_data_from_os(std::span<float> data) {
         return normalized * 2.0F - 1.0F;
     });
 }
+
+// Constants below match the ones the SFPU kernels use, see
+// tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+constexpr float kSqrt2 = 1.41421356237309504880F;
+constexpr float kInvSqrt2Pi = 0.3989422804014327F;   // 1 / sqrt(2 * pi)
+constexpr float kSqrt2OverPi = 0.7978845608028654F;  // sqrt(2 / pi)
+constexpr float kGeluTanhK = 0.044715F;
+
+// Exact GELU: 0.5 * x * (1 + erf(x / sqrt(2)))
+xt::xarray<float> gelu_exact_reference(const xt::xarray<float>& x) {
+    return 0.5F * x * (1.0F + xt::erf(x / kSqrt2));
+}
+
+// d/dx of exact GELU: Phi(x) + x * phi(x)
+xt::xarray<float> gelu_exact_grad_reference(const xt::xarray<float>& x) {
+    xt::xarray<float> phi_cdf = 0.5F * (1.0F + xt::erf(x / kSqrt2));
+    xt::xarray<float> phi_pdf = kInvSqrt2Pi * xt::exp(-0.5F * x * x);
+    return phi_cdf + x * phi_pdf;
+}
+
+// Hendrycks tanh approximation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+xt::xarray<float> gelu_tanh_reference(const xt::xarray<float>& x) {
+    xt::xarray<float> t = xt::tanh(kSqrt2OverPi * (x + kGeluTanhK * x * x * x));
+    return 0.5F * x * (1.0F + t);
+}
+
+// d/dx of the tanh approximation: 0.5*(1 + t) + 0.5*x*(1 - t^2)*sqrt(2/pi)*(1 + 3*0.044715*x^2)
+xt::xarray<float> gelu_tanh_grad_reference(const xt::xarray<float>& x) {
+    xt::xarray<float> t = xt::tanh(kSqrt2OverPi * (x + kGeluTanhK * x * x * x));
+    return 0.5F * (1.0F + t) + 0.5F * x * (1.0F - t * t) * kSqrt2OverPi * (1.0F + 3.0F * kGeluTanhK * x * x);
+}
+
+// Same contract as xt::allclose, but reports the observed max absolute difference on failure so that
+// tolerances can be tuned from measurements instead of guesses.
+void expect_allclose(
+    const xt::xarray<float>& got, const xt::xarray<float>& expected, float rtol, float atol, std::string_view label) {
+    EXPECT_TRUE(xt::allclose(got, expected, rtol, atol))
+        << label << ": rtol=" << rtol << " atol=" << atol << " max_abs_diff=" << xt::amax(xt::abs(got - expected))();
+}
+
+xt::xarray<float> random_input(const std::vector<std::size_t>& shape) {
+    xt::xarray<float> data = xt::empty<float>(shape);
+    load_random_data_from_os(std::span{data.data(), data.size()});
+    return data;
+}
+
+// GELU tolerances. On uniform [-1, 1] inputs the measured max absolute error against the references
+// above is stable run to run: ~3.7e-3 (ACCURATE fw), ~4.2e-3 (ACCURATE bw), ~3.7e-3 (TANH fw),
+// ~1.2e-2 (TANH bw), ~2.4e-2 (FAST_LUT fw, a ~1% approximation by construction). Repeating the same
+// measurement with FLOAT32 tensors gives the same numbers, so this is the SFPU approximation itself,
+// not bf16/fp32 dest accumulation -- absorb it with atol rather than tightening rtol. GELU is
+// ill-conditioned in relative terms on small negative inputs (the value goes to zero while the
+// absolute error does not), so rtol alone cannot bound it. rtol matches the Silu test above.
+constexpr float kGeluRtol = 8e-3F;
+constexpr float kGeluAtol = 2e-2F;
+constexpr float kGeluTanhBwAtol = 3e-2F;
+constexpr float kGeluFastLutAtol = 5e-2F;
 
 }  // namespace
 
@@ -199,6 +259,115 @@ TEST_F(UnaryOpsTest, Silu) {
     auto grad_kernel = core::to_xtensor(a_kernel->get_grad());
     auto grad_composite = core::to_xtensor(a_composite->get_grad());
     EXPECT_TRUE(xt::allclose(grad_kernel, grad_composite, 8e-3F, 4e-2F));
+}
+
+TEST_F(UnaryOpsTest, GeluVariantFromString) {
+    EXPECT_EQ(gelu_variant_from_string("none"), GeluVariant::ACCURATE);
+    EXPECT_EQ(gelu_variant_from_string("accurate"), GeluVariant::ACCURATE);
+    EXPECT_EQ(gelu_variant_from_string("tanh"), GeluVariant::TANH);
+    EXPECT_EQ(gelu_variant_from_string("fast_lut"), GeluVariant::FAST_LUT);
+
+    EXPECT_THROW((void)gelu_variant_from_string("Tanh"), std::invalid_argument);
+    EXPECT_THROW((void)gelu_variant_from_string(""), std::invalid_argument);
+    EXPECT_THROW((void)gelu_variant_from_string("approximate"), std::invalid_argument);
+}
+
+// Default variant (== GeluVariant::ACCURATE) against the exact GELU and its derivative.
+// backward() seeds dL/dout = 1, so the input gradient is GELU'(x) directly.
+TEST_F(UnaryOpsTest, Gelu) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
+    auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+
+    auto result = gelu(tensor_ptr);
+    expect_allclose(core::to_xtensor(result->get_value()), gelu_exact_reference(data), kGeluRtol, kGeluAtol, "gelu fw");
+
+    result->backward();
+    expect_allclose(
+        core::to_xtensor(tensor_ptr->get_grad()), gelu_exact_grad_reference(data), kGeluRtol, kGeluAtol, "gelu bw");
+}
+
+// The default must stay ACCURATE: this is what keeps GPT numerics unchanged by this feature.
+TEST_F(UnaryOpsTest, GeluDefaultVariantIsAccurate) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
+    auto default_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+    auto explicit_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+
+    auto default_result = gelu(default_ptr);
+    auto explicit_result = gelu(explicit_ptr, GeluVariant::ACCURATE);
+    EXPECT_EQ(
+        xt::amax(
+            xt::abs(core::to_xtensor(default_result->get_value()) - core::to_xtensor(explicit_result->get_value())))(),
+        0.0F);
+
+    default_result->backward();
+    explicit_result->backward();
+    EXPECT_EQ(
+        xt::amax(xt::abs(core::to_xtensor(default_ptr->get_grad()) - core::to_xtensor(explicit_ptr->get_grad())))(),
+        0.0F);
+}
+
+TEST_F(UnaryOpsTest, GeluTanh) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
+    auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+
+    auto result = gelu(tensor_ptr, GeluVariant::TANH);
+    expect_allclose(
+        core::to_xtensor(result->get_value()), gelu_tanh_reference(data), kGeluRtol, kGeluAtol, "gelu_tanh fw");
+
+    result->backward();
+    expect_allclose(
+        core::to_xtensor(tensor_ptr->get_grad()),
+        gelu_tanh_grad_reference(data),
+        kGeluRtol,
+        kGeluTanhBwAtol,
+        "gelu_tanh bw");
+}
+
+// FAST_LUT is a forward-only approximation: ttnn has no LUT backward kernel, so its gradient is the
+// exact GELU derivative, bit-identical to the ACCURATE path.
+TEST_F(UnaryOpsTest, GeluFastLut) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
+    auto fast_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+    auto accurate_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+
+    auto fast_result = gelu(fast_ptr, GeluVariant::FAST_LUT);
+    // ~1% absolute error against the exact GELU by construction, hence the looser bound.
+    expect_allclose(
+        core::to_xtensor(fast_result->get_value()),
+        gelu_exact_reference(data),
+        kGeluRtol,
+        kGeluFastLutAtol,
+        "fast_lut fw");
+
+    auto accurate_result = gelu(accurate_ptr, GeluVariant::ACCURATE);
+    fast_result->backward();
+    accurate_result->backward();
+    EXPECT_EQ(
+        xt::amax(xt::abs(core::to_xtensor(fast_ptr->get_grad()) - core::to_xtensor(accurate_ptr->get_grad())))(), 0.0F);
+}
+
+// The two variants only separate above bfloat16 resolution in the negative tail: for |x| >= 1 the
+// exact/tanh gap is below one bf16 ULP, so the [-1, 1] data used by the tests above cannot
+// distinguish them. atol must stay 0 here or it swallows the signal.
+TEST_F(UnaryOpsTest, GeluAccurateVsTanhDiffer) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data = {{{{-4.F, -3.5F, -3.F, -2.5F}}}};
+    auto accurate_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+    auto tanh_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+
+    auto accurate_xt = core::to_xtensor(gelu(accurate_ptr, GeluVariant::ACCURATE)->get_value());
+    auto tanh_xt = core::to_xtensor(gelu(tanh_ptr, GeluVariant::TANH)->get_value());
+
+    // Each variant tracks its own reference far more tightly than it tracks the other one.
+    expect_allclose(accurate_xt, gelu_exact_reference(data), 5e-2F, 0.F, "accurate tail");
+    expect_allclose(tanh_xt, gelu_tanh_reference(data), 5e-2F, 0.F, "tanh tail");
+
+    EXPECT_GT(xt::amax(xt::abs(accurate_xt - tanh_xt))(), 1e-4F);
+    EXPECT_FALSE(xt::allclose(accurate_xt, tanh_xt, 1e-2F, 0.F));
 }
 
 }  // namespace ttml::ops::tests

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -64,8 +64,7 @@ void load_random_data_from_os(std::span<float> data) {
     });
 }
 
-// Constants below match the ones the SFPU kernels use, see
-// tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+// GELU-related constants (compare to the ones in sfpu kernels)
 constexpr float kSqrt2 = 1.41421356237309504880F;
 constexpr float kInvSqrt2Pi = 0.3989422804014327F;   // 1 / sqrt(2 * pi)
 constexpr float kSqrt2OverPi = 0.7978845608028654F;  // sqrt(2 / pi)
@@ -101,17 +100,6 @@ xt::xarray<float> random_input(const std::vector<std::size_t>& shape) {
     load_random_data_from_os(std::span{data.data(), data.size()});
     return data;
 }
-
-// GELU tolerances. On uniform [-1, 1] inputs the measured max absolute error against the references
-// above is stable run to run: ~3.7e-3 (ACCURATE fw), ~4.2e-3 (ACCURATE bw), ~3.7e-3 (TANH fw),
-// ~1.2e-2 (TANH bw). Repeating the same measurement with FLOAT32 tensors gives the same numbers, so
-// this is the SFPU approximation itself, not bf16/fp32 dest accumulation -- absorb it with atol
-// rather than tightening rtol. GELU is ill-conditioned in relative terms on small negative inputs
-// (the value goes to zero while the absolute error does not), so rtol alone cannot bound it. rtol
-// matches the Silu test above.
-constexpr float kGeluRtol = 8e-3F;
-constexpr float kGeluAtol = 2e-2F;
-constexpr float kGeluTanhBwAtol = 3e-2F;
 
 }  // namespace
 
@@ -252,40 +240,16 @@ TEST_F(UnaryOpsTest, Silu) {
     EXPECT_TRUE(xt::allclose(grad_kernel, grad_composite, 8e-3F, 4e-2F));
 }
 
-// Default variant (== GeluVariant::ACCURATE) against the exact GELU and its derivative.
-// backward() seeds dL/dout = 1, so the input gradient is GELU'(x) directly.
 TEST_F(UnaryOpsTest, Gelu) {
     auto* device = &autograd::ctx().get_device();
     xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
 
     auto result = gelu(tensor_ptr);
-    EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_exact_reference(data), kGeluRtol, kGeluAtol));
+    EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_exact_reference(data), 8e-3F, 2e-2F));
 
     result->backward();
-    EXPECT_TRUE(
-        xt::allclose(core::to_xtensor(tensor_ptr->get_grad()), gelu_exact_grad_reference(data), kGeluRtol, kGeluAtol));
-}
-
-// The default must stay ACCURATE: this is what keeps GPT numerics unchanged by this feature.
-TEST_F(UnaryOpsTest, GeluDefaultVariantIsAccurate) {
-    auto* device = &autograd::ctx().get_device();
-    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
-    auto default_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-    auto explicit_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-
-    auto default_result = gelu(default_ptr);
-    auto explicit_result = gelu(explicit_ptr, GeluVariant::ACCURATE);
-    EXPECT_EQ(
-        xt::amax(
-            xt::abs(core::to_xtensor(default_result->get_value()) - core::to_xtensor(explicit_result->get_value())))(),
-        0.0F);
-
-    default_result->backward();
-    explicit_result->backward();
-    EXPECT_EQ(
-        xt::amax(xt::abs(core::to_xtensor(default_ptr->get_grad()) - core::to_xtensor(explicit_ptr->get_grad())))(),
-        0.0F);
+    EXPECT_TRUE(xt::allclose(core::to_xtensor(tensor_ptr->get_grad()), gelu_exact_grad_reference(data), 8e-3F, 2e-2F));
 }
 
 TEST_F(UnaryOpsTest, GeluTanh) {
@@ -294,48 +258,10 @@ TEST_F(UnaryOpsTest, GeluTanh) {
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
 
     auto result = gelu(tensor_ptr, GeluVariant::TANH);
-    EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_tanh_reference(data), kGeluRtol, kGeluAtol));
+    EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_tanh_reference(data), 8e-3F, 2e-2F));
 
     result->backward();
-    EXPECT_TRUE(xt::allclose(
-        core::to_xtensor(tensor_ptr->get_grad()), gelu_tanh_grad_reference(data), kGeluRtol, kGeluTanhBwAtol));
-}
-
-// FAST_LUT is forward-only: ttnn has no LUT backward kernel, so pairing it with autograd would give
-// the exact GELU derivative instead of the derivative of the LUT forward. gelu() rejects that
-// combination. Forward accuracy of the LUT itself is ttnn's to test, so it is not re-checked here.
-TEST_F(UnaryOpsTest, GeluFastLutRejectsGrad) {
-    auto* device = &autograd::ctx().get_device();
-    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
-    auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-
-    EXPECT_THROW(gelu(tensor_ptr, GeluVariant::FAST_LUT), std::invalid_argument);
-    // The other two variants have matching backward kernels and stay available.
-    EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::ACCURATE));
-    EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::TANH));
-}
-
-// The two variants only separate above bfloat16 resolution in the negative tail. On [-2, 1] -- and
-// for every positive x -- the exact/tanh gap stays below one bf16 ULP of the value (at x=-1: gap
-// 1.5e-4 vs ULP 4.9e-4), so the [-1, 1] data used by the tests above cannot distinguish them. By
-// x=-2.5 the gap is ~14 ULP (4.4e-4 vs 3.1e-5) and by x=-4 it is ~118 ULP, because GELU's value
-// collapses toward zero while the absolute gap does not. atol must stay 0 here or it swallows the
-// signal.
-TEST_F(UnaryOpsTest, GeluAccurateVsTanhDiffer) {
-    auto* device = &autograd::ctx().get_device();
-    xt::xarray<float> data = {{{{-4.F, -3.5F, -3.F, -2.5F}}}};
-    auto accurate_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-    auto tanh_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-
-    auto accurate_xt = core::to_xtensor(gelu(accurate_ptr, GeluVariant::ACCURATE)->get_value());
-    auto tanh_xt = core::to_xtensor(gelu(tanh_ptr, GeluVariant::TANH)->get_value());
-
-    // Each variant tracks its own reference far more tightly than it tracks the other one.
-    EXPECT_TRUE(xt::allclose(accurate_xt, gelu_exact_reference(data), 5e-2F, 0.F));
-    EXPECT_TRUE(xt::allclose(tanh_xt, gelu_tanh_reference(data), 5e-2F, 0.F));
-
-    EXPECT_GT(xt::amax(xt::abs(accurate_xt - tanh_xt))(), 1e-4F);
-    EXPECT_FALSE(xt::allclose(accurate_xt, tanh_xt, 1e-2F, 0.F));
+    EXPECT_TRUE(xt::allclose(core::to_xtensor(tensor_ptr->get_grad()), gelu_tanh_grad_reference(data), 8e-3F, 3e-2F));
 }
 
 }  // namespace ttml::ops::tests

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -260,17 +260,6 @@ TEST_F(UnaryOpsTest, Silu) {
     EXPECT_TRUE(xt::allclose(grad_kernel, grad_composite, 8e-3F, 4e-2F));
 }
 
-TEST_F(UnaryOpsTest, GeluVariantFromString) {
-    EXPECT_EQ(gelu_variant_from_string("none"), GeluVariant::ACCURATE);
-    EXPECT_EQ(gelu_variant_from_string("accurate"), GeluVariant::ACCURATE);
-    EXPECT_EQ(gelu_variant_from_string("tanh"), GeluVariant::TANH);
-    EXPECT_EQ(gelu_variant_from_string("fast_lut"), GeluVariant::FAST_LUT);
-
-    EXPECT_THROW((void)gelu_variant_from_string("Tanh"), std::invalid_argument);
-    EXPECT_THROW((void)gelu_variant_from_string(""), std::invalid_argument);
-    EXPECT_THROW((void)gelu_variant_from_string("approximate"), std::invalid_argument);
-}
-
 // Default variant (== GeluVariant::ACCURATE) against the exact GELU and its derivative.
 // backward() seeds dL/dout = 1, so the input gradient is GELU'(x) directly.
 TEST_F(UnaryOpsTest, Gelu) {

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -112,15 +112,14 @@ xt::xarray<float> random_input(const std::vector<std::size_t>& shape) {
 
 // GELU tolerances. On uniform [-1, 1] inputs the measured max absolute error against the references
 // above is stable run to run: ~3.7e-3 (ACCURATE fw), ~4.2e-3 (ACCURATE bw), ~3.7e-3 (TANH fw),
-// ~1.2e-2 (TANH bw), ~2.4e-2 (FAST_LUT fw, a ~1% approximation by construction). Repeating the same
-// measurement with FLOAT32 tensors gives the same numbers, so this is the SFPU approximation itself,
-// not bf16/fp32 dest accumulation -- absorb it with atol rather than tightening rtol. GELU is
-// ill-conditioned in relative terms on small negative inputs (the value goes to zero while the
-// absolute error does not), so rtol alone cannot bound it. rtol matches the Silu test above.
+// ~1.2e-2 (TANH bw). Repeating the same measurement with FLOAT32 tensors gives the same numbers, so
+// this is the SFPU approximation itself, not bf16/fp32 dest accumulation -- absorb it with atol
+// rather than tightening rtol. GELU is ill-conditioned in relative terms on small negative inputs
+// (the value goes to zero while the absolute error does not), so rtol alone cannot bound it. rtol
+// matches the Silu test above.
 constexpr float kGeluRtol = 8e-3F;
 constexpr float kGeluAtol = 2e-2F;
 constexpr float kGeluTanhBwAtol = 3e-2F;
-constexpr float kGeluFastLutAtol = 5e-2F;
 
 }  // namespace
 
@@ -326,33 +325,46 @@ TEST_F(UnaryOpsTest, GeluTanh) {
         "gelu_tanh bw");
 }
 
-// FAST_LUT is a forward-only approximation: ttnn has no LUT backward kernel, so its gradient is the
-// exact GELU derivative, bit-identical to the ACCURATE path.
-TEST_F(UnaryOpsTest, GeluFastLut) {
+// FAST_LUT is forward-only: ttnn has no LUT backward kernel, so pairing it with autograd would give
+// the exact GELU derivative instead of the derivative of the LUT forward. gelu() rejects that
+// combination. Forward accuracy of the LUT itself is ttnn's to test, so it is not re-checked here.
+TEST_F(UnaryOpsTest, GeluFastLutRejectsGrad) {
     auto* device = &autograd::ctx().get_device();
     xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
-    auto fast_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-    auto accurate_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+    auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
 
-    auto fast_result = gelu(fast_ptr, GeluVariant::FAST_LUT);
-    // ~1% absolute error against the exact GELU by construction, hence the looser bound.
-    expect_allclose(
-        core::to_xtensor(fast_result->get_value()),
-        gelu_exact_reference(data),
-        kGeluRtol,
-        kGeluFastLutAtol,
-        "fast_lut fw");
-
-    auto accurate_result = gelu(accurate_ptr, GeluVariant::ACCURATE);
-    fast_result->backward();
-    accurate_result->backward();
-    EXPECT_EQ(
-        xt::amax(xt::abs(core::to_xtensor(fast_ptr->get_grad()) - core::to_xtensor(accurate_ptr->get_grad())))(), 0.0F);
+    EXPECT_THROW(gelu(tensor_ptr, GeluVariant::FAST_LUT), std::invalid_argument);
+    // The other two variants have matching backward kernels and stay available.
+    EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::ACCURATE));
+    EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::TANH));
 }
 
-// The two variants only separate above bfloat16 resolution in the negative tail: for |x| >= 1 the
-// exact/tanh gap is below one bf16 ULP, so the [-1, 1] data used by the tests above cannot
-// distinguish them. atol must stay 0 here or it swallows the signal.
+// Inference paths disable gradient mode but leave requires_grad set on parameters, and no backward
+// node is created there, so FAST_LUT must remain usable.
+TEST_F(UnaryOpsTest, GeluFastLutAllowedUnderNoGrad) {
+    auto* device = &autograd::ctx().get_device();
+    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
+    auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
+
+    // Restore the mode even if the assertion below throws -- the fixture only sets up per-suite, so a
+    // leaked GradMode would corrupt every later test.
+    struct GradModeGuard {
+        autograd::GradMode previous = autograd::ctx().get_gradient_mode();
+        ~GradModeGuard() {
+            autograd::ctx().set_gradient_mode(previous);
+        }
+    } guard;
+    autograd::ctx().set_gradient_mode(autograd::GradMode::DISABLED);
+
+    EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::FAST_LUT));
+}
+
+// The two variants only separate above bfloat16 resolution in the negative tail. On [-2, 1] -- and
+// for every positive x -- the exact/tanh gap stays below one bf16 ULP of the value (at x=-1: gap
+// 1.5e-4 vs ULP 4.9e-4), so the [-1, 1] data used by the tests above cannot distinguish them. By
+// x=-2.5 the gap is ~14 ULP (4.4e-4 vs 3.1e-5) and by x=-4 it is ~118 ULP, because GELU's value
+// collapses toward zero while the absolute gap does not. atol must stay 0 here or it swallows the
+// signal.
 TEST_F(UnaryOpsTest, GeluAccurateVsTanhDiffer) {
     auto* device = &autograd::ctx().get_device();
     xt::xarray<float> data = {{{{-4.F, -3.5F, -3.F, -2.5F}}}};

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -242,7 +242,16 @@ TEST_F(UnaryOpsTest, Silu) {
 
 TEST_F(UnaryOpsTest, Gelu) {
     auto* device = &autograd::ctx().get_device();
-    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
+
+    auto N = 4;
+    auto C = 1;
+    auto H = 20;
+    auto W = 5;
+
+    // Load random data from OS using getrandom and copy into tensor
+    xt::xarray<float> data = xt::empty<float>({N, C, H, W});
+    load_random_data_from_os(std::span{data.data(), data.size()});
+
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
 
     auto result = gelu(tensor_ptr);
@@ -254,7 +263,16 @@ TEST_F(UnaryOpsTest, Gelu) {
 
 TEST_F(UnaryOpsTest, GeluTanh) {
     auto* device = &autograd::ctx().get_device();
-    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
+
+    auto N = 4;
+    auto C = 1;
+    auto H = 20;
+    auto W = 5;
+
+    // Load random data from OS using getrandom and copy into tensor
+    xt::xarray<float> data = xt::empty<float>({N, C, H, W});
+    load_random_data_from_os(std::span{data.data(), data.size()});
+
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
 
     auto result = gelu(tensor_ptr, GeluVariant::TANH);

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -14,7 +14,6 @@
 #include <ranges>
 #include <span>
 #include <stdexcept>
-#include <string_view>
 #include <vector>
 
 #include "autograd/auto_context.hpp"
@@ -86,7 +85,8 @@ xt::xarray<float> gelu_exact_grad_reference(const xt::xarray<float>& x) {
 
 // Hendrycks tanh approximation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
 xt::xarray<float> gelu_tanh_reference(const xt::xarray<float>& x) {
-    xt::xarray<float> t = xt::tanh(kSqrt2OverPi * (x + kGeluTanhK * x * x * x));
+    constexpr float kSqrt2OverPi = 0.7978845608028654F;  // sqrt(2 / pi)
+    xt::xarray<float> t = xt::tanh(kSqrt2OverPi * (x + 0.044715F * x * x * x));
     return 0.5F * x * (1.0F + t);
 }
 
@@ -94,14 +94,6 @@ xt::xarray<float> gelu_tanh_reference(const xt::xarray<float>& x) {
 xt::xarray<float> gelu_tanh_grad_reference(const xt::xarray<float>& x) {
     xt::xarray<float> t = xt::tanh(kSqrt2OverPi * (x + kGeluTanhK * x * x * x));
     return 0.5F * (1.0F + t) + 0.5F * x * (1.0F - t * t) * kSqrt2OverPi * (1.0F + 3.0F * kGeluTanhK * x * x);
-}
-
-// Same contract as xt::allclose, but reports the observed max absolute difference on failure so that
-// tolerances can be tuned from measurements instead of guesses.
-void expect_allclose(
-    const xt::xarray<float>& got, const xt::xarray<float>& expected, float rtol, float atol, std::string_view label) {
-    EXPECT_TRUE(xt::allclose(got, expected, rtol, atol))
-        << label << ": rtol=" << rtol << " atol=" << atol << " max_abs_diff=" << xt::amax(xt::abs(got - expected))();
 }
 
 xt::xarray<float> random_input(const std::vector<std::size_t>& shape) {
@@ -268,11 +260,11 @@ TEST_F(UnaryOpsTest, Gelu) {
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
 
     auto result = gelu(tensor_ptr);
-    expect_allclose(core::to_xtensor(result->get_value()), gelu_exact_reference(data), kGeluRtol, kGeluAtol, "gelu fw");
+    EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_exact_reference(data), kGeluRtol, kGeluAtol));
 
     result->backward();
-    expect_allclose(
-        core::to_xtensor(tensor_ptr->get_grad()), gelu_exact_grad_reference(data), kGeluRtol, kGeluAtol, "gelu bw");
+    EXPECT_TRUE(
+        xt::allclose(core::to_xtensor(tensor_ptr->get_grad()), gelu_exact_grad_reference(data), kGeluRtol, kGeluAtol));
 }
 
 // The default must stay ACCURATE: this is what keeps GPT numerics unchanged by this feature.
@@ -302,16 +294,11 @@ TEST_F(UnaryOpsTest, GeluTanh) {
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
 
     auto result = gelu(tensor_ptr, GeluVariant::TANH);
-    expect_allclose(
-        core::to_xtensor(result->get_value()), gelu_tanh_reference(data), kGeluRtol, kGeluAtol, "gelu_tanh fw");
+    EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_tanh_reference(data), kGeluRtol, kGeluAtol));
 
     result->backward();
-    expect_allclose(
-        core::to_xtensor(tensor_ptr->get_grad()),
-        gelu_tanh_grad_reference(data),
-        kGeluRtol,
-        kGeluTanhBwAtol,
-        "gelu_tanh bw");
+    EXPECT_TRUE(xt::allclose(
+        core::to_xtensor(tensor_ptr->get_grad()), gelu_tanh_grad_reference(data), kGeluRtol, kGeluTanhBwAtol));
 }
 
 // FAST_LUT is forward-only: ttnn has no LUT backward kernel, so pairing it with autograd would give
@@ -326,26 +313,6 @@ TEST_F(UnaryOpsTest, GeluFastLutRejectsGrad) {
     // The other two variants have matching backward kernels and stay available.
     EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::ACCURATE));
     EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::TANH));
-}
-
-// Inference paths disable gradient mode but leave requires_grad set on parameters, and no backward
-// node is created there, so FAST_LUT must remain usable.
-TEST_F(UnaryOpsTest, GeluFastLutAllowedUnderNoGrad) {
-    auto* device = &autograd::ctx().get_device();
-    xt::xarray<float> data = random_input({4U, 1U, 20U, 5U});
-    auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-
-    // Restore the mode even if the assertion below throws -- the fixture only sets up per-suite, so a
-    // leaked GradMode would corrupt every later test.
-    struct GradModeGuard {
-        autograd::GradMode previous = autograd::ctx().get_gradient_mode();
-        ~GradModeGuard() {
-            autograd::ctx().set_gradient_mode(previous);
-        }
-    } guard;
-    autograd::ctx().set_gradient_mode(autograd::GradMode::DISABLED);
-
-    EXPECT_NO_THROW(gelu(tensor_ptr, GeluVariant::FAST_LUT));
 }
 
 // The two variants only separate above bfloat16 resolution in the negative tail. On [-2, 1] -- and
@@ -364,8 +331,8 @@ TEST_F(UnaryOpsTest, GeluAccurateVsTanhDiffer) {
     auto tanh_xt = core::to_xtensor(gelu(tanh_ptr, GeluVariant::TANH)->get_value());
 
     // Each variant tracks its own reference far more tightly than it tracks the other one.
-    expect_allclose(accurate_xt, gelu_exact_reference(data), 5e-2F, 0.F, "accurate tail");
-    expect_allclose(tanh_xt, gelu_tanh_reference(data), 5e-2F, 0.F, "tanh tail");
+    EXPECT_TRUE(xt::allclose(accurate_xt, gelu_exact_reference(data), 5e-2F, 0.F));
+    EXPECT_TRUE(xt::allclose(tanh_xt, gelu_tanh_reference(data), 5e-2F, 0.F));
 
     EXPECT_GT(xt::amax(xt::abs(accurate_xt - tanh_xt))(), 1e-4F);
     EXPECT_FALSE(xt::allclose(accurate_xt, tanh_xt, 1e-2F, 0.F));

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -95,12 +95,6 @@ xt::xarray<float> gelu_tanh_grad_reference(const xt::xarray<float>& x) {
     return 0.5F * (1.0F + t) + 0.5F * x * (1.0F - t * t) * kSqrt2OverPi * (1.0F + 3.0F * kGeluTanhK * x * x);
 }
 
-xt::xarray<float> random_input(const std::vector<std::size_t>& shape) {
-    xt::xarray<float> data = xt::empty<float>(shape);
-    load_random_data_from_os(std::span{data.data(), data.size()});
-    return data;
-}
-
 }  // namespace
 
 class UnaryOpsTest : public ::testing::Test {
@@ -253,7 +247,6 @@ TEST_F(UnaryOpsTest, Gelu) {
     load_random_data_from_os(std::span{data.data(), data.size()});
 
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-
     auto result = gelu(tensor_ptr);
     EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_exact_reference(data), 8e-3F, 2e-2F));
 
@@ -274,7 +267,6 @@ TEST_F(UnaryOpsTest, GeluTanh) {
     load_random_data_from_os(std::span{data.data(), data.size()});
 
     auto tensor_ptr = autograd::create_tensor(core::from_xtensor(data, device), /* requires_grad */ true);
-
     auto result = gelu(tensor_ptr, GeluVariant::TANH);
     EXPECT_TRUE(xt::allclose(core::to_xtensor(result->get_value()), gelu_tanh_reference(data), 8e-3F, 2e-2F));
 

--- a/tt-train/tests/python/test_gelu.py
+++ b/tt-train/tests/python/test_gelu.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Python binding coverage for ``ttml.ops.unary.gelu``.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import ttnn
+import ttml
+
+pytestmark = pytest.mark.requires_device
+
+SHAPE = (2, 1, 32, 32)
+
+
+@pytest.fixture(autouse=True)
+def _reset_graph():
+    yield
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+
+def _torch_gelu_and_grad(data, approximate):
+    """Reference forward and d/dx, seeded with dL/dout = 1 to match ``backward()``."""
+    x = torch.from_numpy(data).requires_grad_(True)
+    out = torch.nn.functional.gelu(x, approximate=approximate)
+    out.backward(torch.ones_like(out))
+    return out.detach().numpy(), x.grad.numpy()
+
+
+# Same tolerances as the C++ tests
+RTOL = 8e-3
+ATOL = 2e-2
+TANH_BW_ATOL = 3e-2
+
+
+@pytest.mark.parametrize(
+    "variant, approximate, bw_atol",
+    [
+        (ttnn.GeluVariant.Accurate, "none", ATOL),
+        (ttnn.GeluVariant.Tanh, "tanh", TANH_BW_ATOL),
+    ],
+    ids=["accurate", "tanh"],
+)
+def test_gelu_variant_forward_backward(variant, approximate, bw_atol):
+    """A ttnn.GeluVariant passed through the binding selects the matching kernel pair."""
+
+    data = np.random.uniform(-1.0, 1.0, SHAPE).astype(np.float32)
+    tensor = ttml.autograd.Tensor.from_numpy(data, layout=ttnn.Layout.TILE)
+    tensor.set_requires_grad(True)
+
+    result = ttml.ops.unary.gelu(tensor, variant=variant)
+    expected, expected_grad = _torch_gelu_and_grad(data, approximate)
+    np.testing.assert_allclose(result.to_numpy(ttnn.DataType.FLOAT32), expected, rtol=RTOL, atol=ATOL)
+
+    result.backward(False)
+    assert tensor.is_grad_initialized()
+    grad = tensor.get_grad_tensor().to_numpy(ttnn.DataType.FLOAT32)
+    np.testing.assert_allclose(grad, expected_grad, rtol=RTOL, atol=bw_atol)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
#53776

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Clean-up PR

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Right now, GeLU in ttml does not expose a parameter to pick between approximation variants (e.g. tanh). 
This PR changes this to resolve compatibility between inference gelu and gelu in html. 

PR also add tests for gelu in ttml's C++ tests. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

- It may seem like a lot of code for forwarding arguments. But most of it comes from adding new tests + a bit of string <-> enum helpers. 
- Unlike ttnn.gelu which takes a `ttnn.GeluVariant` parameter, `ttnn.experimental.gelu_bw` takes a string input. Here, the variant parameter is a `ttnn.GeluVariant`. 
- Yes, there are two variants of `gelu_bw` in ttnn. I've raised the following issue: https://github.com/tenstorrent/tt-metal/issues/54152

On testing: C++ tt-train tests works on CI. But L2 Nightly fails due to an unrelated GRPO errors (also on main).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/tt-train-gelu-tanh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/tt-train-gelu-tanh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/tt-train-gelu-tanh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/tt-train-gelu-tanh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/tt-train-gelu-tanh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/tt-train-gelu-tanh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/tt-train-gelu-tanh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/tt-train-gelu-tanh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/tt-train-gelu-tanh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/tt-train-gelu-tanh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/tt-train-gelu-tanh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/tt-train-gelu-tanh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/tt-train-gelu-tanh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/tt-train-gelu-tanh)