### PR TITLE
[nextafter] step towards input_b, not away from it

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_nextafter.py
@@ -25,3 +25,63 @@ def test_nextafter(device, shape):
     output_tensor = ttnn.nextafter(input_tensor_a, input_tensor_b)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+
+
+def _nextafter_fp32(device, vals_a, vals_b):
+    """Run ttnn.nextafter on two FLOAT32 value lists, returned as a float32 torch tensor."""
+    # Tile the row to 32 to fill a tile; only the first len(vals_a) columns are compared.
+    a = torch.tensor(vals_a, dtype=torch.float32).reshape(1, -1).expand(32, -1).contiguous()
+    b = torch.tensor(vals_b, dtype=torch.float32).reshape(1, -1).expand(32, -1).contiguous()
+    ta = ttnn.from_torch(a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    tb = ttnn.from_torch(b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    return ttnn.to_torch(ttnn.nextafter(ta, tb))[0, : len(vals_a)]
+
+
+# On [1, 2) the FLOAT32 ULP is exactly hal::get_eps() (2^-23), so this is the one range where
+# ttnn.nextafter agrees with torch.nextafter exactly rather than merely in direction. Values are
+# kept strictly inside the binade in the downward cases: stepping below 1.0 halves the ULP, which
+# the fixed eps step cannot follow.
+FP32_EXACT = [
+    pytest.param(1.0, 2.0, id="1.0_up"),
+    pytest.param(1.25, 2.0, id="1.25_up"),
+    pytest.param(1.5, 2.0, id="1.5_up"),
+    pytest.param(1.9999998807907104, 2.0, id="max_binade_up"),
+    pytest.param(1.25, 1.0, id="1.25_down"),
+    pytest.param(1.5, 1.0, id="1.5_down"),
+    pytest.param(1.75, 1.0, id="1.75_down"),
+]
+
+
+@pytest.mark.parametrize("a, b", FP32_EXACT)
+def test_nextafter_fp32_matches_torch_in_unit_binade(device, a, b):
+    """ttnn.nextafter must step TOWARDS input_b, matching torch.nextafter on [1, 2).
+
+    Guards against the arms of the where-chain being swapped. The pre-existing bfloat16 PCC test
+    above cannot see this: at every bfloat16 magnitude the eps step is far below one ULP, so the op
+    returns input_a unchanged and PCC stays at ~1.0 whichever direction the arms select.
+    """
+    got = _nextafter_fp32(device, [a], [b])[0].item()
+    expected = torch.nextafter(torch.tensor(a), torch.tensor(b)).item()
+    assert got == expected, f"nextafter({a}, {b}) = {got!r}, expected {expected!r}"
+
+
+@pytest.mark.parametrize("a", [1.0, 1.5, 0.5, 0.001, -1.0, -1.5, -0.001])
+def test_nextafter_fp32_moves_towards_other(device, a):
+    """The defining directional property, over magnitudes where the eps step is not absorbed.
+
+    Magnitude is deliberately not asserted here -- away from [1, 2) the fixed eps step is not one
+    ULP (it overshoots below 1.0), so only the direction is well-defined. |a| >= 2 is excluded
+    because there eps is under half a ULP and rounds away entirely, leaving input_a unchanged.
+    """
+    got_up = _nextafter_fp32(device, [a], [a + 10.0])[0].item()
+    got_down = _nextafter_fp32(device, [a], [a - 10.0])[0].item()
+
+    assert got_up > a, f"nextafter({a}, {a + 10.0}) = {got_up!r} did not move up"
+    assert got_down < a, f"nextafter({a}, {a - 10.0}) = {got_down!r} did not move down"
+
+
+@pytest.mark.parametrize("a", [1.0, 1.5, -1.5, 0.0, 100.0])
+def test_nextafter_fp32_equal_inputs_unchanged(device, a):
+    """nextafter(a, a) == a -- neither where-chain arm may fire when the inputs are equal."""
+    got = _nextafter_fp32(device, [a], [a])[0].item()
+    assert got == a, f"nextafter({a}, {a}) = {got!r}, expected {a!r}"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -31,6 +31,9 @@ namespace ttnn {
 using namespace operations;
 
 // nextafter
+// Steps input_a TOWARDS input_b: a > b moves down, a < b moves up, a == b is unchanged. The step is
+// hal::get_eps() (2^-23), which equals one FLOAT32 ULP only on [1, 2) -- elsewhere it overshoots
+// (below 1.0) or is absorbed by rounding (from 2.0 up, and at every BFLOAT16 magnitude).
 Tensor nextafter(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     const float eps = tt::tt_metal::hal::get_eps();
     Tensor result(input_a);
@@ -39,12 +42,12 @@ Tensor nextafter(const Tensor& input_a, const Tensor& input_b, const std::option
         {
             eps_gt = ttnn::where(
                 ttnn::gt(input_a, input_b, std::nullopt, output_mem_config),
-                ttnn::add(input_a, eps, std::nullopt, output_mem_config),
+                ttnn::subtract(input_a, eps, std::nullopt, output_mem_config),
                 input_a);
         }
         result = ttnn::where(
             ttnn::lt(input_a, input_b, std::nullopt, output_mem_config),
-            ttnn::subtract(input_a, eps, std::nullopt, output_mem_config),
+            ttnn::add(input_a, eps, std::nullopt, output_mem_config),
             eps_gt);
     }
     return result;


### PR DESCRIPTION

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Related  #51218 (closes Item 1.)
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

The two arms of the `where` chain were inverted: `input_a > input_b` added `eps` (moving
*away* from `b`) and `input_a < input_b` subtracted it. Swapped, so the op steps towards
`input_b` as documented.

**Why no existing test caught it.** Both `test_nextafter.py` and
`test_binary_composite.py:43` are bfloat16 + PCC. The step is `hal::get_eps()` (2^-23), which
at every bfloat16 magnitude is ~1/32000 of a ULP — so the op returns `input_a` unchanged
whichever direction the arms select, and PCC sits at ~1.0 either way. The defect was
unobservable in the dtype it was tested in.

**New tests** (`test_nextafter.py`, all FLOAT32):
- `test_nextafter_fp32_matches_torch_in_unit_binade` — bit-exact vs `torch.nextafter` on
  `[1, 2)`, the one binade where `eps` equals exactly one FLOAT32 ULP. Downward params stay
  strictly inside the binade: stepping below 1.0 halves the ULP, which a fixed `eps` step
  cannot follow.
- `test_nextafter_fp32_moves_towards_other` — the directional property, `|a| < 2`. Magnitude
  deliberately unasserted; away from `[1, 2)` the step is not one ULP.
- `test_nextafter_fp32_equal_inputs_unchanged` — `nextafter(a, a) == a`.

**Verification.** 14 of 20 fail against the pre-fix binary, 20/20 pass after. Plus
`test_binary_composite.py` 392 passed / 6 skipped.

### Known remaining defect — NOT addressed here

`eps` is an **absolute** step, not a ULP step, so even with the direction fixed the op only
matches `torch.nextafter` on the FLOAT32 `[1, 2)` binade:

| `a` (FLOAT32) | behaviour |
|---|---|
| 1.0, 1.5 | exactly 1 ULP — correct |
| 0.5 | 2 ULPs — overshoots |
| 0.001 | ~2000 ULPs — overshoots badly |
| >= 2.0 | unchanged — `eps` < 1/2 ULP, absorbed by rounding |
| any BFLOAT16 | unchanged — total no-op |

This PR fixes the reported direction bug only. A correct `nextafter` needs ULP stepping via
bitcast-to-int32 with zero/inf/NaN/subnormal handling — a rewrite, not a sign change, and
worth its own issue. A comment on the function records the limitation.

### Note on the issue text

The reported symptom is not reproducible as written: #51218 claims bfloat16
`nextafter(1.0, 2.0)` returns `~0.992`; measured on device it returns exactly `1.0` (per the
absorption above). The "caller" cited at `test_binary_comp_fp32.py:116` uses
`torch.nextafter`, not `ttnn.nextafter`. The underlying bug and the suggested fix are both
real — only the evidence in the issue is wrong.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iklemenskiTT/51218/nextafter-direction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iklemenskiTT/51218/nextafter-direction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iklemenskiTT/51218/nextafter-direction)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iklemenskiTT/51218/nextafter-direction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iklemenskiTT/51218/nextafter-direction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iklemenskiTT/51218/nextafter-direction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iklemenskiTT/51218/nextafter-direction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iklemenskiTT/51218/nextafter-direction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iklemenskiTT/51218/nextafter-direction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iklemenskiTT/51218/nextafter-direction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iklemenskiTT/51218/nextafter-direction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iklemenskiTT/51218/nextafter-direction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iklemenskiTT/51218/nextafter-direction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iklemenskiTT/51218/nextafter-direction)