### PR TITLE
[Performance] GDN fused: NP>1 producers per head - 1.87x at BH=24 (opt-in QWEN_GDN_NP)

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_fused.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_chunk_gdn_fused.py
@@ -66,6 +66,8 @@ def _clear_gdn_env(monkeypatch):
     """Neutralize every GDN path/debug knob; each test then sets QWEN_GDN_PATH explicitly (or
     leaves it unset to probe the default dispatch)."""
     monkeypatch.delenv("QWEN_GDN_PATH", raising=False)
+    # F3a producer split (fused prim only; hashed into the program cache via attrs.np).
+    monkeypatch.delenv("QWEN_GDN_NP", raising=False)
     # Legacy selector — superseded by QWEN_GDN_PATH but still honored when PATH is unset.
     monkeypatch.delenv("QWEN_GDN_PHASED", raising=False)
     monkeypatch.delenv("QWEN_GDN_SCAN_SERIAL", raising=False)
@@ -286,6 +288,119 @@ def test_fused_default_dispatch(device, monkeypatch, num_k_heads, num_v_heads, e
     )
     assert torch.equal(o_def, o_exp), f"default dispatch o differs from explicit '{expected_path}' run"
     assert torch.equal(fs_def, fs_exp), f"default dispatch final_state differs from explicit '{expected_path}' run"
+
+
+# ---------------------------------------------------------------------------
+# F3a: NP > 1 producers per head (QWEN_GDN_NP). Producer p owns the round-robin chunks
+# c = p, p+NP, ...; the receiver credits producers in rotation and the writer mcasts each chunk
+# into an explicitly computed hand-off slot (global c % nbuf). Correctness is silent-failure
+# territory (a wrong slot corrupts in-flight data without hanging), so the gate is torch.equal
+# vs phased at NC values that stress the slot/rotation arithmetic: NC < NP (clamp), NC == NP,
+# NC == NP+1 (first wraparound), NC == 2*NP+1 (odd/even slot alternation across producers), and
+# a long-ish NC.
+# ---------------------------------------------------------------------------
+
+NP_BH_KV_HEADS = (4, 12)  # BH=12 (GQA G=3): leaves room for NP up to 8 on a 110-core grid
+
+
+def _skip_unless_fused_np_fits(device, bh, np_req, nc):
+    grid = device.compute_with_storage_grid_size()
+    np_eff = min(np_req, nc)  # the op host clamps NP to NC
+    if bh * (1 + np_eff) > grid.x * grid.y:
+        pytest.skip(f"BH*(1+NP)={bh * (1 + np_eff)} exceeds the {grid.x}x{grid.y} compute grid")
+
+
+@pytest.mark.parametrize(
+    "np_producers, nc",
+    [
+        (2, 1),  # NC < NP: host clamps to NP=1 (degenerate, must still be exact)
+        (2, 2),  # NC == NP: one chunk per producer
+        (2, 3),  # NC == NP+1: first slot wraparound (chunk 2 reuses slot 0)
+        (2, 5),  # NC == 2*NP+1
+        (3, 4),  # NC == NP+1 at odd NP (producer/receiver slot parity diverges — the F2
+        #          lockstep-breaking case the explicit destination addressing exists for)
+        (3, 7),  # NC == 2*NP+1 at odd NP
+        (5, 16),  # long run, NP does not divide NC
+        (8, 16),  # max NP that fits BH=12 on a 110-core grid (12*9=108)
+    ],
+    ids=lambda v: str(v),
+)
+def test_fused_np_bit_exact_vs_phased(device, monkeypatch, np_producers, nc):
+    """F3a primary gate: fused with NP>1 producers == phased, bit for bit, across the NC
+    boundary cases. The compute kernels are untouched by the split (prep is chunk-independent),
+    so as with F1 any difference is a protocol/addressing bug, not numerical noise."""
+    B = 1
+    num_k_heads, num_v_heads = NP_BH_KV_HEADS
+    BH = B * num_v_heads
+    _skip_unless_fused_np_fits(device, BH, np_producers, nc)
+    _clear_gdn_env(monkeypatch)
+
+    _, tensors, s0 = _make_inputs(device, B, nc * CHUNK, num_k_heads, num_v_heads, True, seed=20260823)
+    const_tiles = _const_tiles(device)
+
+    monkeypatch.setenv("QWEN_GDN_PATH", "phased")
+    o_ph, fs_ph = _run_op(device, tensors, const_tiles, s0)
+    o_ph2, fs_ph2 = _run_op(device, tensors, const_tiles, s0)
+    n_phased = device.num_program_cache_entries()
+    assert torch.equal(o_ph, o_ph2) and torch.equal(fs_ph, fs_ph2), "phased path is not deterministic"
+
+    monkeypatch.setenv("QWEN_GDN_PATH", "fused")
+    monkeypatch.setenv("QWEN_GDN_NP", str(np_producers))
+    o_fu, fs_fu = _run_op(device, tensors, const_tiles, s0)
+    n_fused = device.num_program_cache_entries()
+    assert n_fused - n_phased == 1, (
+        f"phased->fused(NP={np_producers}) toggle compiled {n_fused - n_phased} new programs "
+        "(expected exactly 1, the fused prim): 0 => an env was not read per call and the "
+        "comparison below is vacuous"
+    )
+
+    assert torch.equal(o_fu, o_ph), f"fused NP={np_producers} changed o (must be bit-identical to phased)"
+    assert torch.equal(fs_fu, fs_ph), f"fused NP={np_producers} changed final_state (must be bit-identical to phased)"
+
+
+def test_fused_np_cache_identity(device, monkeypatch):
+    """Vacuity canary for the NP knob itself: QWEN_GDN_NP must be read fresh per call AND hashed
+    (attrs.np), so each distinct NP compiles its own fused program, repeats are cache hits, and
+    toggling back recompiles nothing. If the env were read in the factory instead of at attrs
+    construction, the toggle deltas would be 0 and every NP 'A/B' would silently compare one
+    cached program against itself. Deltas are asserted EXACTLY (never >=)."""
+    B = 1
+    num_k_heads, num_v_heads = NP_BH_KV_HEADS
+    BH = B * num_v_heads
+    nc = 16
+    _skip_unless_fused_np_fits(device, BH, 3, nc)
+    _clear_gdn_env(monkeypatch)
+    monkeypatch.setenv("QWEN_GDN_PATH", "fused")
+
+    _, tensors, s0 = _make_inputs(device, B, nc * CHUNK, num_k_heads, num_v_heads, True, seed=20260824)
+    const_tiles = _const_tiles(device)
+
+    o1, fs1 = _run_op(device, tensors, const_tiles, s0)  # NP unset -> np=1
+    n1 = device.num_program_cache_entries()
+
+    monkeypatch.setenv("QWEN_GDN_NP", "2")
+    o2, fs2 = _run_op(device, tensors, const_tiles, s0)
+    n2 = device.num_program_cache_entries()
+    assert n2 - n1 == 1, f"np 1->2 compiled {n2 - n1} programs (expected 1: np must be hashed)"
+
+    monkeypatch.setenv("QWEN_GDN_NP", "3")
+    o3, fs3 = _run_op(device, tensors, const_tiles, s0)
+    n3 = device.num_program_cache_entries()
+    assert n3 - n2 == 1, f"np 2->3 compiled {n3 - n2} programs (expected 1)"
+
+    monkeypatch.setenv("QWEN_GDN_NP", "2")
+    _run_op(device, tensors, const_tiles, s0)
+    n4 = device.num_program_cache_entries()
+    assert n4 - n3 == 0, f"np 3->2 (already compiled) compiled {n4 - n3} programs (expected 0: cache hit)"
+
+    monkeypatch.delenv("QWEN_GDN_NP")
+    _run_op(device, tensors, const_tiles, s0)
+    n5 = device.num_program_cache_entries()
+    assert n5 - n4 == 0, f"np 2->unset (np=1, already compiled) compiled {n5 - n4} programs (expected 0)"
+
+    # All NP variants of the same head must agree bit-for-bit with each other.
+    assert torch.equal(o1, o2) and torch.equal(o1, o3), "o differs across NP values"
+    assert torch.equal(fs1, fs2) and torch.equal(fs1, fs3), "final_state differs across NP values"
 
 
 def test_fused_vs_torch_golden(device, monkeypatch):

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
@@ -275,9 +275,10 @@ std::tuple<ttnn::Tensor, std::optional<ttnn::Tensor>> chunk_gated_delta_rule(
         /*default_l1_acc=*/false);
 
     // Path selection. Three device implementations, same math:
-    //   fused  — ONE program: per head a producer core runs prep and NoC-writes the 7
+    //   fused  — ONE program: per head NP producer cores run prep and NoC-write the 7
     //            intermediates straight into a receiver core's CBs (zero DRAM intermediates).
-    //            Needs 2 cores/head.
+    //            Needs (1+NP) cores/head; NP defaults to 1, QWEN_GDN_NP opts into the F3a
+    //            round-robin producer split (read inside the prim at attrs construction, hashed).
     //   phased — prep -> (7 fp32 DRAM tensors) -> scan, two prims. The bit-exact reference.
     //   mono   — the original single-kernel op, 1 core/head (benchmark/debug only).
     // Precedence: QWEN_GDN_PATH=fused|phased|mono if set; else the legacy QWEN_GDN_PHASED

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.cpp
@@ -3,6 +3,9 @@
 
 #include "chunk_gdn_fused.hpp"
 
+#include <algorithm>
+#include <cstdlib>
+
 #include <tt-metalium/constants.hpp>
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -59,12 +62,15 @@ void ChunkGdnFusedOperation::validate_on_program_cache_miss(
     TT_FATAL(attrs.chunk_size % TILE_HEIGHT == 0, "chunk_size must be a multiple of 32");
     TT_FATAL(attrs.key_dim % TILE_WIDTH == 0, "key_dim must be a multiple of 32");
     TT_FATAL(attrs.val_dim % TILE_WIDTH == 0, "val_dim must be a multiple of 32");
-    // One producer + one receiver core per head (NP=1, NV=1).
+    // NP producers + one receiver core per head (NV=1). NP=1 unless QWEN_GDN_NP opted in.
+    TT_FATAL(attrs.np >= 1, "chunk_gdn_fused: np must be >= 1 (got {})", attrs.np);
     const auto grid = in.q.device()->compute_with_storage_grid_size();
     TT_FATAL(
-        2 * attrs.BH <= grid.x * grid.y,
-        "chunk_gdn_fused needs 2*BH ({}) cores, grid has {}x{}={}",
-        2 * attrs.BH,
+        attrs.BH * (1 + attrs.np) <= grid.x * grid.y,
+        "chunk_gdn_fused needs BH*(1+NP) = {}*{} = {} cores, grid has {}x{}={}",
+        attrs.BH,
+        1 + attrs.np,
+        attrs.BH * (1 + attrs.np),
         grid.x,
         grid.y,
         grid.x * grid.y);
@@ -121,6 +127,16 @@ std::vector<Tensor> chunk_gdn_fused(
     const uint32_t num_chunks = qk_flat ? (q_shape[1] / chunk_size) : q_shape[1];
     const uint32_t key_dim = qk_flat ? (q_shape[2] / Hk) : q_shape[3];
     const uint32_t val_dim = v_flat ? (v_shape[2] / HV) : v_shape[3];
+    // F3a producers per head: read HERE (attrs construction), never in the factory — np is hashed,
+    // so an env toggle compiles a fresh program instead of silently serving a stale cached one.
+    // Clamped to num_chunks: a producer beyond NC would own no chunks (wasted core, and the
+    // receiver's rotating credit c % NP would skip it anyway).
+    uint32_t np = 1;
+    if (const char* e = std::getenv("QWEN_GDN_NP")) {
+        const int v_np = std::atoi(e);
+        TT_FATAL(v_np >= 1, "QWEN_GDN_NP must be a positive integer (got '{}')", e);
+        np = std::min<uint32_t>(static_cast<uint32_t>(v_np), num_chunks);
+    }
     auto attrs = ChunkGdnFusedOperation::operation_attributes_t{
         .BH = BH,
         .num_chunks = num_chunks,
@@ -133,6 +149,7 @@ std::vector<Tensor> chunk_gdn_fused(
         .Hk = Hk,
         .qk_norm = qk_norm,
         .scale = scale,
+        .np = np,
         .has_initial_state = initial_state.has_value(),
         .output_final_state = output_final_state,
         .output_mem_config = output_mem_config,

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused.hpp
@@ -5,7 +5,8 @@
 // per head, a dedicated PRODUCER core runs the unchanged prep reader+compute and a writer that
 // NoC-writes the 7 computed intermediates (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv)
 // straight into its paired RECEIVER core's CBs via the shipped ready/valid handshake; the
-// receiver runs the unchanged scan compute+writer. NP=1 producer and NV=1 (full V) per head.
+// receiver runs the unchanged scan compute+writer. NP >= 1 producers (QWEN_GDN_NP, default 1)
+// and NV=1 (full V) per head.
 // Takes prep's inputs, returns scan's outputs — the seven fp32 DRAM tensors of the phased
 // hand-off simply never exist. The phased prims (chunk_gdn_phased.hpp) stay in-tree as the
 // bit-exact reference: the DRAM round trip they perform is a byte copy, so fused == phased
@@ -37,6 +38,11 @@ struct ChunkGdnFusedParams {
     uint32_t Hk = 0;
     bool qk_norm = false;
     float scale = 1.0f;
+    // F3a: producers per head (NP). Producer p of a head owns chunks c = p, p+NP, ... and NoC-
+    // writes them into the head's single receiver in order (receiver-driven rotating ready
+    // credits). Read from QWEN_GDN_NP at attrs construction (never in the factory — this field
+    // being hashed is what keeps the program cache honest) and clamped to num_chunks.
+    uint32_t np = 1;
     bool has_initial_state = false;
     bool output_final_state = false;
     tt::tt_metal::MemoryConfig output_mem_config;
@@ -75,8 +81,9 @@ struct ChunkGdnFusedOperation {
 };
 
 // Returns {o [BH,NC,C,V] fp32, final_state [BH,K,V] fp32} — exactly the scan prim's output specs.
-// Needs 2*BH cores (one producer + one receiver per head); validate FATALs otherwise, so the
-// op-level dispatch must gate on grid size before choosing this path.
+// Needs BH*(1+NP) cores (NP producers + one receiver per head; NP defaults to 1 and is an
+// explicit QWEN_GDN_NP opt-in); validate FATALs otherwise, so the op-level dispatch must gate on
+// grid size before choosing this path.
 std::vector<Tensor> chunk_gdn_fused(
     const Tensor& q,
     const Tensor& k,

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_fused_program_factory.cpp
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Program factory for the fused prep→scan chunk_gdn op: ONE program, two disjoint core sets.
-// Per head h, PRODUCER core h runs {unchanged prep reader, unchanged prep compute, NEW fused
-// writer} and RECEIVER core h runs {NEW fused-receiver reader variant, unchanged scan compute,
-// unchanged scan writer}. The producer's writer NoC-writes the 7 computed intermediates
+// Per head h, NP PRODUCER cores run {unchanged prep reader, unchanged prep compute, NEW fused
+// writer} and one RECEIVER core runs {NEW fused-receiver reader variant, unchanged scan compute,
+// unchanged scan writer}. Each producer's writer NoC-writes the 7 computed intermediates
 // (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv) directly into the receiver's CBs via the
-// shipped ready/valid handshake — zero DRAM intermediates. NP=1 producer/head, NV=1 (full V)
-// per receiver.
+// shipped ready/valid handshake — zero DRAM intermediates. NP >= 1 producers/head (attrs.np,
+// F3a: producer p owns chunks c = p, p+NP, ... round-robin; prep is chunk-independent, so the
+// split is free of cross-chunk state), NV=1 (full V) per receiver.
+//
+// F3a in-order protocol (P1): the RECEIVER drives ordering — per chunk c it reserves the
+// hand-off slots, then credits SEM_READY on producer (c % NP) only. At most one hand-off is in
+// flight per receiver, so the single SEM_VALID flag never mixes chunks across producers.
 //
 // v_beta note (F1 deviates from the design plan's F1 line): the plan recommends Option R
 // (scan-side recompute of v_beta from a DRAM v-slice + mcast beta). F1 ships Option U instead —
@@ -15,11 +20,14 @@
 // keeps both compute kernels byte-identical to the phased path (the bit-exactness gate needs
 // that). Option R is deferred to F2.
 //
-// Hand-off CB addressing (the lockstep lemma, shipped in the scan-mcast PR): the 7 hand-off CBs
-// are declared FIRST, on the UNION of producer+receiver cores, so they get identical base
-// addresses on both sides. With nbuf=1 and an equal per-chunk push/pop cadence on both sides,
-// the producer's read pointer always equals the receiver's reserved slot (== base), so the
-// producer's NoC write lands exactly where the receiver reserved. After the F1 scan-side CB
+// Hand-off CB addressing: the 7 hand-off CBs are declared FIRST, on the UNION of producer+
+// receiver cores, so they get identical base addresses on both sides. The receiver reserves/
+// pushes each CB exactly once per GLOBAL chunk c, so its reserved slot for chunk c is
+// base + (c % nbuf)*slot_bytes; the writer computes that destination explicitly from the global
+// chunk index (F3a). At NP=1 this degenerates to the F2 lockstep lemma (the producer's own read
+// pointer names the same address); at NP>1 the producer's local slot index diverges from the
+// receiver's — sourcing from read_ptr stays correct, but the DESTINATION must come from the
+// global c, which is exactly what writer_chunk_gdn_fused.cpp does. After the F1 scan-side CB
 // renumber (scan v_beta 17->14, dl 11->22, v_new 22->11) the seven hand-off indices coincide
 // with prep's output indices, so the same physical CB is prep's output AND scan's input:
 //   v_beta=14  kd=18  q_decay=19  intra=20  k_dec_t=24  dl=22  t_inv=13
@@ -105,22 +113,29 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
 
     const tt::DataFormat df_qkv = tt::DataFormat::Float16_b;  // bf16 q/k/v (prep inputs)
 
+    const uint32_t NP = attrs.np;  // producers per head (F3a); the op host clamps it to NC
     auto* device = in.q.device();
     const CoreCoord grid = device->compute_with_storage_grid_size();
     TT_FATAL(
-        2 * BH <= grid.x * grid.y, "chunk_gdn_fused: 2*BH ({}) cores needed, grid has {}", 2 * BH, grid.x * grid.y);
+        BH * (1 + NP) <= grid.x * grid.y,
+        "chunk_gdn_fused: BH*(1+NP) ({}) cores needed, grid has {}",
+        BH * (1 + NP),
+        grid.x * grid.y);
 
-    // Placement: receivers occupy row-major grid slots 0..BH-1, producers slots BH..2BH-1;
-    // producer i pairs with receiver i (head h == i).
+    // Placement: receivers occupy row-major grid slots 0..BH-1, producers slots BH..BH+BH*NP-1;
+    // producer j of head h sits at slot BH + h*NP + j and pairs with receiver h. (NV=1: 1x1
+    // NoC rectangles everywhere, so the geometry is orientation-neutral and packing is free.)
     auto slot_core = [&](uint32_t slot) { return CoreCoord{slot % grid.x, slot / grid.x}; };
-    std::vector<CoreCoord> rcv_cores(BH), prod_cores(BH);
+    std::vector<CoreCoord> rcv_cores(BH), prod_cores(BH * NP);
     std::set<CoreRange> rcv_crs, prod_crs, union_crs;
     for (uint32_t i = 0; i < BH; i++) {
         rcv_cores[i] = slot_core(i);
-        prod_cores[i] = slot_core(BH + i);
         rcv_crs.insert(CoreRange{rcv_cores[i], rcv_cores[i]});
-        prod_crs.insert(CoreRange{prod_cores[i], prod_cores[i]});
         union_crs.insert(CoreRange{rcv_cores[i], rcv_cores[i]});
+    }
+    for (uint32_t i = 0; i < BH * NP; i++) {
+        prod_cores[i] = slot_core(BH + i);
+        prod_crs.insert(CoreRange{prod_cores[i], prod_cores[i]});
         union_crs.insert(CoreRange{prod_cores[i], prod_cores[i]});
     }
     const CoreRangeSet rcv_set{rcv_crs};
@@ -142,20 +157,21 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     };
 
     // (1) The 7 hand-off CBs FIRST, on the UNION core set: declared first => same base address on
-    // producer and receiver (the lockstep lemma's precondition). fp32, in the receiver's reserve
+    // producer and receiver (the slot-addressing precondition). fp32, in the receiver's reserve
     // order (v_beta, kd, q_decay, intra, k_dec_t, dl, t_inv). Double-buffered (F2): the producer
-    // runs one chunk ahead of the receiver's consumption instead of alternating with it; the
-    // lockstep addressing survives any equal nbuf on both sides (equal per-chunk push/pop cadence
-    // keeps the pointers in phase, and the writer sources read_ptr, which names the correct slot).
-    add_cb(union_set, fcb::vbeta, cv, 2);
-    add_cb(union_set, fcb::kd, ck, 2);
-    add_cb(union_set, fcb::qdecay, ck, 2);
-    add_cb(union_set, fcb::intra, cc, 2);
-    add_cb(union_set, fcb::kdec_t, kc, 2);
+    // runs one chunk ahead of the receiver's consumption instead of alternating with it. The
+    // writer's explicit destination slot (global c % nbuf) must be computed against THIS depth,
+    // so kHandoffNbuf also travels to the writer as a compile-time arg — one source of truth.
+    constexpr uint32_t kHandoffNbuf = 2;
+    add_cb(union_set, fcb::vbeta, cv, kHandoffNbuf);
+    add_cb(union_set, fcb::kd, ck, kHandoffNbuf);
+    add_cb(union_set, fcb::qdecay, ck, kHandoffNbuf);
+    add_cb(union_set, fcb::intra, cc, kHandoffNbuf);
+    add_cb(union_set, fcb::kdec_t, kc, kHandoffNbuf);
     // dl is 1 tile. (The phased prep factory sized this index cv as cb_vnew for monolithic layout
     // parity, but the prep kernel only ever uses 1 tile of it, as cb_dl.)
-    add_cb(union_set, fcb::dl, 1, 2);
-    add_cb(union_set, fcb::Tinv, cc, 2);
+    add_cb(union_set, fcb::dl, 1, kHandoffNbuf);
+    add_cb(union_set, fcb::Tinv, cc, kHandoffNbuf);
 
     // (2) The remaining 25 prep CBs on the PRODUCER cores only — same sizes/formats as the phased
     // prep factory (which mirrors the monolithic op's layout). The absolute L1 layout necessarily
@@ -246,8 +262,9 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     prep_compute_ct.push_back(f32_bits(attrs.scale));
     prep_compute_ct.push_back(f32_bits(1e-6f));
 
-    // Fused writer: 5 plain scalars, no accessors (it writes no DRAM at all).
-    const std::vector<uint32_t> fused_writer_ct = {Ct, Kt, Vt, sem_ready_id, sem_valid_id};
+    // Fused writer: 6 plain scalars, no accessors (it writes no DRAM at all). kHandoffNbuf feeds
+    // the writer's explicit destination-slot arithmetic (global c % nbuf).
+    const std::vector<uint32_t> fused_writer_ct = {Ct, Kt, Vt, sem_ready_id, sem_valid_id, kHandoffNbuf};
 
     // ---- Receiver-side CT args: the phased SCAN layout with per-core Vt == Vt_full ----
     const std::vector<uint32_t> ct_scan = {Ct, Kt, Vt, has_s0, Vt};
@@ -272,7 +289,7 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     prep_reader.core_ranges = prod_set;
     prep_reader.compile_time_args = prep_reader_ct;
     prep_reader.config = ReaderConfigDescriptor{};
-    prep_reader.runtime_args.reserve(BH);
+    prep_reader.runtime_args.reserve(BH * NP);
 
     KernelDescriptor prep_compute;
     prep_compute.kernel_source = kdir + "compute/chunk_gdn_prep.cpp";
@@ -282,7 +299,7 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     prep_compute.config = fused_compute_cfg();
     // Fused-only perf: hoisted WY-path reconfigs (see chunk_gdn_math.hpp kGdnHoistReconfig).
     prep_compute.defines = {{"GDN_HOIST_RECONFIG", "1"}};
-    prep_compute.runtime_args.reserve(BH);
+    prep_compute.runtime_args.reserve(BH * NP);
 
     KernelDescriptor fused_writer;
     fused_writer.kernel_source = kdir + "dataflow/writer_chunk_gdn_fused.cpp";
@@ -290,7 +307,7 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     fused_writer.core_ranges = prod_set;
     fused_writer.compile_time_args = fused_writer_ct;
     fused_writer.config = WriterConfigDescriptor{};
-    fused_writer.runtime_args.reserve(BH);
+    fused_writer.runtime_args.reserve(BH * NP);
 
     KernelDescriptor receiver_reader;
     receiver_reader.kernel_source = kdir + "dataflow/reader_chunk_gdn_scan.cpp";
@@ -331,38 +348,49 @@ tt::tt_metal::ProgramDescriptor ChunkGdnFusedProgramFactory::create_descriptor(
     auto* fs_buf = outputs[1].buffer();
 
     for (uint32_t h = 0; h < BH; h++) {
-        const CoreCoord& pc = prod_cores[h];
         const CoreCoord& rc = rcv_cores[h];
-        // Virtual worker coords for the cross-core NoC transactions. Each side targets a 1x1
-        // rectangle (its single peer), which is orientation-neutral — no NOC_0/NOC_1 coordinate
-        // swap is needed on either kernel regardless of which NoC the risc runs on.
-        const CoreCoord pv = device->worker_core_from_logical_core(pc);
+        // Virtual worker coords for the cross-core NoC transactions. Every rectangle here is 1x1
+        // (a single peer), which is orientation-neutral — no NOC_0/NOC_1 coordinate swap is
+        // needed on either kernel regardless of which NoC the risc runs on.
         const CoreCoord rv = device->worker_core_from_logical_core(rc);
 
-        // Producer: the phased prep RT layout with a per-head contiguous work slice — head h's NC
-        // chunks are the flat work-items [h*NC, h*NC+NC) (wi = h*NC + c), read/computed in order.
-        prep_reader.emplace_runtime_args(
-            pc,
-            {h * NC,
-             NC,
-             q_buf,
-             k_buf,
-             v_buf,
-             g_buf,
-             beta_buf,
-             eye_buf,
-             tril_buf,
-             ones_buf,
-             masks_buf,
-             NC,
-             attrs.HV,
-             attrs.Hk});
-        prep_compute.emplace_runtime_args(pc, {NC});
-        fused_writer.emplace_runtime_args(pc, {NC, static_cast<uint32_t>(rv.x), static_cast<uint32_t>(rv.y)});
+        // Receiver RT prefix: head h, vb=0 (full V), s0 from DRAM; then NP and the producers'
+        // coords (appended in the producer loop below) for the rotating ready credit.
+        std::vector<std::variant<uint32_t, Buffer*>> rcv_args = {h, 0u, NC, s0_buf, NP};
 
-        // Receiver: head h, vb=0 (full V), s0 from DRAM; everything else arrives over the NoC.
-        receiver_reader.emplace_runtime_args(
-            rc, {h, 0u, NC, s0_buf, static_cast<uint32_t>(pv.x), static_cast<uint32_t>(pv.y)});
+        for (uint32_t j = 0; j < NP; j++) {
+            const CoreCoord& pc = prod_cores[h * NP + j];
+            const CoreCoord pv = device->worker_core_from_logical_core(pc);
+            rcv_args.push_back(static_cast<uint32_t>(pv.x));
+            rcv_args.push_back(static_cast<uint32_t>(pv.y));
+
+            // Producer j of head h owns the interleaved chunks c = j, j+NP, ... — as flat
+            // work-items wi = h*NC + c that is start h*NC + j with stride NP (trailing reader
+            // arg). The op host clamps NP <= NC, so every producer owns at least one chunk.
+            const uint32_t cnt = (NC - j + NP - 1) / NP;
+            prep_reader.emplace_runtime_args(
+                pc,
+                {h * NC + j,
+                 cnt,
+                 q_buf,
+                 k_buf,
+                 v_buf,
+                 g_buf,
+                 beta_buf,
+                 eye_buf,
+                 tril_buf,
+                 ones_buf,
+                 masks_buf,
+                 NC,
+                 attrs.HV,
+                 attrs.Hk,
+                 NP});
+            prep_compute.emplace_runtime_args(pc, {cnt});
+            fused_writer.emplace_runtime_args(
+                pc, {NC, NP, j, static_cast<uint32_t>(rv.x), static_cast<uint32_t>(rv.y)});
+        }
+
+        receiver_reader.emplace_runtime_args(rc, rcv_args);
         scan_compute.emplace_runtime_args(rc, {NC});
         scan_writer.emplace_runtime_args(rc, {h, 0u, NC, o_buf, fs_buf});
     }

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
@@ -339,7 +339,8 @@ tt::tt_metal::ProgramDescriptor ChunkGdnPrepProgramFactory::create_descriptor(
         const auto& core = dist.cores[i];
         const uint32_t wi_start = dist.wi_start[i];
         const uint32_t wi_count = dist.wi_count[i];
-        // Trailing runtime args NC, HV, Hk are consumed by the reader's flat branches (V_FLAT/QK_FLAT).
+        // Trailing runtime args NC, HV, Hk are consumed by the reader's flat branches (V_FLAT/QK_FLAT);
+        // the final 1 is the work-item stride (contiguous here; the fused NP>1 split strides by NP).
         reader.emplace_runtime_args(
             core,
             {wi_start,
@@ -355,7 +356,8 @@ tt::tt_metal::ProgramDescriptor ChunkGdnPrepProgramFactory::create_descriptor(
              masks_buf,
              NC,
              attrs.HV,
-             attrs.Hk});
+             attrs.Hk,
+             1u});
         writer.emplace_runtime_args(
             core, {wi_start, wi_count, vb_buf, kd_buf, qd_buf, it_buf, kdec_buf, dl_buf, ti_buf});
         compute.emplace_runtime_args(core, {wi_count});

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_prep.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_prep.cpp
@@ -50,6 +50,10 @@ void kernel_main() {
     const uint32_t NC = get_arg_val<uint32_t>(11);
     const uint32_t HV = get_arg_val<uint32_t>(12);
     const uint32_t Hk = get_arg_val<uint32_t>(13);
+    // Work-item stride: 1 for a contiguous slice (phased prep), NP for the fused NP>1 producer
+    // split, where producer p of head h owns the interleaved chunks c = p, p+NP, ... (wi stays the
+    // flat h*NC + c, so every DRAM index below is unchanged).
+    const uint32_t wi_stride = get_arg_val<uint32_t>(14);
 
     // Mixed precision: q/k/v are bf16; g/beta and the constants are fp32.
     const uint32_t tb_io = get_tile_size(cb_q);
@@ -134,7 +138,7 @@ void kernel_main() {
     };
 
     for (uint32_t i = 0; i < wi_count; i++) {
-        const uint32_t hc = wi_start + i;  // flat (head, chunk) index
+        const uint32_t hc = wi_start + i * wi_stride;  // flat (head, chunk) index
         if constexpr (QK_FLAT) {
             read_qk_flat(q_acc, cb_q, hc);
             read_qk_flat(k_acc, cb_k, hc);

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/reader_chunk_gdn_scan.cpp
@@ -18,6 +18,8 @@
 //                        byte-identical; Option R scan-side recompute is deferred to F2) — arrive
 //                        over the NoC from the producer's writer via the same handshake as
 //                        GDN_MCAST_RECEIVER. NV=1: this core holds the head's full V width.
+//                        F3a generalizes to NP >= 1 producers per head (round-robin over chunks);
+//                        the ready credit rotates to the owner of each chunk — see kernel_main.
 // The handshake follows the production matmul in0 mcast idiom (reader_bmm_tile_layout_in0_
 // sender_padding.cpp / _receiver.cpp): ready counts receivers that RESERVED space (so the sender
 // can never overwrite unconsumed data), the data mcasts and the valid-flag mcast share one NOC /
@@ -93,8 +95,12 @@ void kernel_main() {
     const uint32_t NC = get_arg_val<uint32_t>(2);
 #if defined(GDN_FUSED_RECEIVER)
     const uint32_t s0_addr = get_arg_val<uint32_t>(3);
-    const uint32_t prod_x = get_arg_val<uint32_t>(4);  // virtual worker coords of the producer
-    const uint32_t prod_y = get_arg_val<uint32_t>(5);
+    // F3a: NP producers share this head's prep work round-robin (producer p owns chunks
+    // c = p, p+NP, ...). Their virtual worker coords follow as NP (x, y) pairs from arg 5; the
+    // per-chunk ready credit below rotates to producer (c % NP) — that rotation IS the in-order
+    // delivery mechanism (P1): a producer may only mcast chunk c once this receiver has reserved
+    // chunk c's slots, so at most one hand-off is in flight and VALIDs cannot interleave.
+    const uint32_t NP = get_arg_val<uint32_t>(4);
 #elif defined(GDN_MCAST_RECEIVER)
     const uint32_t vb_addr = get_arg_val<uint32_t>(3);
     const uint32_t s0_addr = get_arg_val<uint32_t>(4);
@@ -314,7 +320,10 @@ void kernel_main() {
         // Reset our valid flag BEFORE signalling ready: a fast producer may mcast VALID
         // immediately after the inc, and a late reset would overwrite it (lost wakeup -> deadlock).
         valid.set(INVALID);
-        ready.up(noc, prod_x, prod_y, 1);
+        // Credit the producer that owns chunk c (rotating target, P1). The coords live in the
+        // runtime-arg array at 5 + 2*(c % NP); reading them per chunk is two L1 loads.
+        const uint32_t pi = c % NP;
+        ready.up(noc, get_arg_val<uint32_t>(5 + 2 * pi), get_arg_val<uint32_t>(6 + 2 * pi), 1);
         valid.wait(VALID);
 
         // The chunk's seven blocks are in our CBs; make them visible to compute.

--- a/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/writer_chunk_gdn_fused.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/chunk_gated_delta_rule/device/kernels/dataflow/writer_chunk_gdn_fused.cpp
@@ -10,12 +10,21 @@
 // producer computes and sends it, keeping both compute kernels byte-identical to the phased
 // path; Option R — scan-side recompute from v and beta — is deferred to F2).
 //
-// Addressing: the seven hand-off CBs are declared on the UNION of producer+receiver cores
-// (identical base addresses both sides) with nbuf=1 and an equal per-chunk push/pop cadence, so
-// this core's read_ptr == the receiver's reserved slot == the CB base (the shipped lockstep
-// lemma) — each mcast writes source address -> same destination address. The destination is a
-// 1x1 rectangle (one receiver), which is orientation-neutral: start == end, so this writer's NOC
-// (whichever the WriterConfig assigns) needs no coordinate swap.
+// Addressing (F3a): the seven hand-off CBs are declared on the UNION of producer+receiver cores
+// (identical base addresses both sides), so this core's CB base == the receiver's CB base. The
+// receiver reserves/pushes every CB exactly once per GLOBAL chunk c, so its reserved slot for
+// chunk c is base + (c % NBUF)*slot_bytes — and that is where each mcast must land. At NP=1 that
+// equals this core's read_ptr (the F2 lockstep lemma), but at NP>1 producer p only pushes/pops
+// its OWNED chunks c = p, p+NP, ..., so its local slot index (owned-chunk count % NBUF) diverges
+// from the receiver's (c % NBUF): sourcing stays read_ptr (correct local data), the DESTINATION
+// is computed explicitly from the global c. The destination is a 1x1 rectangle (one receiver),
+// which is orientation-neutral: start == end, so this writer's NOC (whichever the WriterConfig
+// assigns) needs no coordinate swap.
+//
+// Ordering at NP>1 (P1): the receiver drives in-order delivery by crediting SEM_READY on
+// producer (c % NP) only when chunk c's slots are reserved — each producer's ready.wait(1)
+// therefore fires exactly for its own next owned chunk, and at most one hand-off is in flight
+// per receiver at any time (VALID mcasts cannot interleave across producers).
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -40,10 +49,15 @@ void kernel_main() {
     // SEM_VALID: producer -> receiver: "this chunk's seven blocks are in your CBs"
     constexpr uint32_t SEM_READY = get_compile_time_arg_val(3);
     constexpr uint32_t SEM_VALID = get_compile_time_arg_val(4);
+    // Hand-off CB depth (slots per CB) — the factory passes the same value it sizes the CBs with,
+    // so the explicit slot arithmetic below can never drift from the allocation.
+    constexpr uint32_t NBUF = get_compile_time_arg_val(5);
 
-    const uint32_t NC = get_arg_val<uint32_t>(0);
-    const uint32_t rcv_x = get_arg_val<uint32_t>(1);  // virtual worker coords of the receiver
-    const uint32_t rcv_y = get_arg_val<uint32_t>(2);
+    const uint32_t NC = get_arg_val<uint32_t>(0);     // GLOBAL chunk count of this head
+    const uint32_t NP = get_arg_val<uint32_t>(1);     // producers for this head
+    const uint32_t p = get_arg_val<uint32_t>(2);      // this producer's index: owns c = p, p+NP, ...
+    const uint32_t rcv_x = get_arg_val<uint32_t>(3);  // virtual worker coords of the receiver
+    const uint32_t rcv_y = get_arg_val<uint32_t>(4);
 
     constexpr uint32_t cc = Ct * Ct;
     constexpr uint32_t ck = Ct * Kt;
@@ -61,11 +75,22 @@ void kernel_main() {
     // barrier deliberately comes BEFORE the reset).
     valid.set(VALID);
 
-    // One linked 1x1-rect mcast per hand-off CB, sourced from the CB's front slot (== the
-    // receiver's reserved slot, lockstep lemma). linked=true chains the data mcasts with the
-    // valid-flag mcast on one static VC (data-before-flag ordering).
+    // Hand-off CB base addresses, captured BEFORE any pop (read_ptr starts at the CB base, and
+    // the union declaration makes each base identical on the receiver). The explicit destination
+    // for global chunk c is base + (c % NBUF)*slot_bytes — the slot the receiver reserved.
+    const uint32_t base_vbeta = CircularBuffer(cb_vbeta).get_read_ptr();
+    const uint32_t base_Tinv = CircularBuffer(cb_Tinv).get_read_ptr();
+    const uint32_t base_kd = CircularBuffer(cb_kd).get_read_ptr();
+    const uint32_t base_intra = CircularBuffer(cb_intra).get_read_ptr();
+    const uint32_t base_qdecay = CircularBuffer(cb_qdecay).get_read_ptr();
+    const uint32_t base_kdec_t = CircularBuffer(cb_kdec_t).get_read_ptr();
+    const uint32_t base_dl = CircularBuffer(cb_dl).get_read_ptr();
+
+    // One linked 1x1-rect mcast per hand-off CB, sourced from the CB's front slot (this core's
+    // local data for the chunk) into the receiver's explicitly computed slot. linked=true chains
+    // the data mcasts with the valid-flag mcast on one static VC (data-before-flag ordering).
     MulticastEndpoint mcast_dst;
-    auto send = [&](uint32_t cb_id, uint32_t n) {
+    auto send = [&](uint32_t cb_id, uint32_t n, uint32_t dst_addr) {
         const uint32_t addr = CircularBuffer(cb_id).get_read_ptr();
         noc.async_write_multicast(
             CoreLocalMem<uint32_t>(addr),
@@ -73,11 +98,12 @@ void kernel_main() {
             n * tb,
             1,
             {},
-            {.noc_x_start = rcv_x, .noc_y_start = rcv_y, .noc_x_end = rcv_x, .noc_y_end = rcv_y, .addr = addr},
+            {.noc_x_start = rcv_x, .noc_y_start = rcv_y, .noc_x_end = rcv_x, .noc_y_end = rcv_y, .addr = dst_addr},
             /*linked=*/true);
     };
 
-    for (uint32_t c = 0; c < NC; c++) {
+    for (uint32_t c = p; c < NC; c += NP) {
+        const uint32_t slot = c % NBUF;  // the receiver's reserved slot for GLOBAL chunk c
         // Wait for the chunk's outputs in the phased prep writer's drain order (roughly
         // compute's push order), so producer-side backpressure matches that writer exactly.
         CircularBuffer(cb_vbeta).wait_front(cv);
@@ -88,22 +114,23 @@ void kernel_main() {
         CircularBuffer(cb_kdec_t).wait_front(kc);
         CircularBuffer(cb_dl).wait_front(1);
 
-        // The receiver has reserved this chunk's CB space (its slots are writable).
+        // The receiver has reserved chunk c's CB space (its slots are writable) and credited
+        // THIS producer (it targets producer c % NP == p — that's how we own this credit).
         ready.wait(1);
         ready.set(0);
 
-        send(cb_vbeta, cv);
-        send(cb_Tinv, cc);
-        send(cb_kd, ck);
-        send(cb_intra, cc);
-        send(cb_qdecay, ck);
-        send(cb_kdec_t, kc);
-        send(cb_dl, 1);
+        send(cb_vbeta, cv, base_vbeta + slot * cv * tb);
+        send(cb_Tinv, cc, base_Tinv + slot * cc * tb);
+        send(cb_kd, ck, base_kd + slot * ck * tb);
+        send(cb_intra, cc, base_intra + slot * cc * tb);
+        send(cb_qdecay, ck, base_qdecay + slot * ck * tb);
+        send(cb_kdec_t, kc, base_kdec_t + slot * kc * tb);
+        send(cb_dl, 1, base_dl + slot * 1 * tb);
         // Flush on EVERY arch, for two reasons. Blackhole: NoC latency exceeds L1<->RISCV
         // latency, so without it the receiver could see VALID with data still in flight. All
         // arches: the flush proves every data mcast has read its L1 source slot; only then may
-        // the pops below let compute overwrite the slots with chunk c+1 (nbuf=1 — the flag
-        // mcast runs on a different cmd buf and provides no such ordering).
+        // the pops below let compute reuse the slots for this producer's NEXT owned chunk (the
+        // flag mcast runs on a different cmd buf and provides no such ordering).
         noc.async_writes_flushed();
         valid.set_multicast(noc, rcv_x, rcv_y, rcv_x, rcv_y, 1);  // unlinked: ends the chain
 


### PR DESCRIPTION
## What

**F3a of the fused-GDN plan: NP > 1 prep producers per head**, opt-in via `QWEN_GDN_NP` (default `np=1` — zero change to any shipping path). Stacked on #53913 (F0–F2 fused prim).

At BH < 48 the fused prim has spare cores but its single producer is the bottleneck (w_p ≈ 26.9 µs/chunk vs receiver-busy 7.4–9 µs). Prep is chunk-independent, so this PR splits it: producer `p` of a head owns chunks `c = p, p+NP, …` round-robin and NoC-writes them into the head's single receiver **in order**. No math changes; compute kernels untouched.

## Protocol (the load-bearing part)

Two things change in the hand-off, both reviewed line-by-line in an adversarial pass against the CB implementation (`circular_buffer_init.h`, `dataflow_api.h` push/pop wrap semantics):

1. **Explicit destination slots.** The F2 lockstep lemma (mcast dest == the writer's own `read_ptr`) breaks for **any NP ≥ 2**: producer p's local slot index (owned-chunk count mod nbuf) diverges from the receiver's (global `c` mod nbuf), and every mismatch is a *silent* corruption of the in-flight slot — no hang, no watcher signature. The writer now computes every destination as `cb_base + (c % nbuf) * slot_bytes` (bases equal by the union-first CB declaration; `nbuf` travels as a CT arg from the factory's `kHandoffNbuf` so the arithmetic can't drift from the allocation). At NP=1 the computed addresses equal the F2 ones exactly, chunk by chunk.
2. **Rotating ready credit (P1).** Per chunk `c` the receiver reserves all seven hand-off CBs, resets its VALID flag, then credits `SEM_READY` on producer `c % NP` **only**. At most one hand-off is in flight per receiver, so the single `SEM_VALID` flag never mixes chunks across producers, the ready equality-wait can never see 2, and the reserve-before-credit chain closes the WAR window (a producer can't overwrite the slot scan-compute still reads for chunk c−2).

Host side: `attrs.np` is **hashed** (reflective hash); `QWEN_GDN_NP` is read at attrs construction — never in the factory — and clamped to `num_chunks`. `validate` FATALs unless `BH*(1+NP)` cores fit the grid. The shared prep reader gains a trailing work-item-stride RT arg (the phased factory passes 1).

## Measured (BH p150b, 11×10 grid, fw 19.11.0.0, T=4096, fused prim device time, mean of 10 after 2 warmups)

| Shape | phased | fused NP=1 | fused best F3a | F3a vs NP=1 | F3a vs phased |
|---|---|---|---|---|---|
| BH=48 (tp1) | 4585 | **3438** (no-regress vs F2's 3440) | n/a — NP=1 is all that fits | — | 1.33× (unchanged) |
| BH=24 (tp2) | 2330 | 3379 | **1249** (NP=3) | **2.71×** | **1.87×** |
| BH=12 (tp4) | 1149 | 3367 | **1050** (NP=4) | 3.21× | 1.09× |

- The plan's F3a perf gate was *fused(NP=3) ≤ 0.45× fused(NP=1) at BH=24*: measured **0.37×**. NP=2 at BH=24: 1774 µs (producer-bound at 13.9 µs/chunk, matching w_p/2 — the analytic model holds).
- BH=12 NP=8 measures 1068 µs ≈ NP=4's 1050: the receiver is the floor (s(4)=7.4–9 µs/chunk), exactly as modeled. The real tp4 win needs the F3b V-split (NV=4), as planned — F3a alone reaches parity+9% there.
- **Correction to the F3 plan doc:** forced-fused NP=1 at BH=12 measures 3367 µs today (26.3 µs/chunk), not the 2189 µs recorded earlier — w_p is effectively shape-**independent** (26.3–26.9 across BH=12/24/48). The plan's "w_p ≈ 17.1 at BH=12" inference came from that stale number; the pick table's conclusions are unaffected (they were conservative), but the tp4 row's NP=1 baseline is now pinned.

## ⚠ Pre-existing default-dispatch finding (not changed here)

The F2 default (fused when BH ≥ 24) **loses to phased at BH=24**: 3379 vs 2330 µs on this bench. That gate was validated at BH=48 only. F3a's NP=3 recovers BH=24 decisively (1249 µs, 1.87× over phased), but per the staged plan the default flip (auto-picked NP) waits for the F3b dispatch rule + qwen36 model-run gate. Flagged here and on #53913 so the default isn't un-drafted as-is at BH=24 shapes.

## Tests (all pass on p150b)

- **NP × NC bit-exact matrix vs phased** (`test_fused_np_bit_exact_vs_phased`, 8 cases): NP ∈ {2,3,5,8} at BH=12, NC at the boundary cases — clamp (NC<NP), NC=NP, NP+1 (first slot wraparound), 2NP+1 (odd/even slot parity divergence across producers — the exact case the lockstep lemma fails on). Gate is `torch.equal`, because every failure mode here is silent corruption, not noise.
- **NP cache-identity canary** (`test_fused_np_cache_identity`): exact program-cache deltas across np 1→2→3→2→unset (+1/+1/0/0). This is the only detection if `QWEN_GDN_NP` ever migrates into the factory — a factory env read makes every NP A/B silently vacuous.
- Full existing suites unchanged and green: `test_chunk_gdn_fused` (14), `test_chunk_gdn_prims` (4), `test_chunk_gated_delta_rule` (8), `test_chunk_gated_delta_rule_mcast` (6).
- NP smoke re-run clean under `TT_METAL_WATCHER=10`.
- Adversarial protocol review (slot arithmetic vs CB wrap semantics, WAR chain, VALID races incl. early producer teardown, ready equality-wait bound, RT-arg index audit of both factories, placement injectivity, NP=1 address-sequence identity): all items verified, no findings beyond one stale comment (fixed).

## Review guide

- `writer_chunk_gdn_fused.cpp` — the slot addressing + ownership loop (the whole risk lives here).
- `reader_chunk_gdn_scan.cpp` (GDN_FUSED_RECEIVER) — rotating credit.
- `chunk_gdn_fused_program_factory.cpp` — placement (producers at slots `BH + h*NP + j`), `kHandoffNbuf` single source of truth, per-producer RT args.
- `chunk_gdn_fused.{hpp,cpp}` — hashed `np`, env-at-attrs-build, feasibility FATAL.
- `reader_chunk_gdn_prep.cpp` + phased factory — the stride arg (phased passes 1; behavior identical).

Draft until: the F3b staging decision (NV>1 + default dispatch rule) and the qwen36 CI suite run against the stack.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-f3a-np-producers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-f3a-np-producers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-f3a-np-producers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-f3a-np-producers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-f3a-np-producers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-f3a-np-producers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-f3a-np-producers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-f3a-np-producers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-f3a-np-producers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-f3a-np-producers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-f3a-np-producers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-f3a-np-producers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-f3a-np-producers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-f3a-np-producers)