### PR TITLE
[Bug fix] unary: hash the preallocated output tensor's dtype

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_preallocated_output_dtype.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_preallocated_output_dtype.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A preallocated output_tensor of a different dtype gets its own cached program.
+
+The unary program hash was built from the input dtype and attributes.output_dtype,
+which carries the input's dtype when a preallocated output is given. Two calls that
+differed only in the output tensor's dtype collided, and the second was served the
+first one's packer: it wrote every other element, or read the wrong stride.
+"""
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 32, 32)
+TORCH_DTYPE = {ttnn.bfloat16: torch.bfloat16, ttnn.float32: torch.float32}
+
+OPS = [(ttnn.neg, 1.5, -1.5), (ttnn.abs, -2.0, 2.0), (ttnn.relu, 1.5, 1.5)]
+
+
+def _t(v, dtype, device):
+    return ttnn.from_torch(
+        torch.full(SHAPE, v, dtype=TORCH_DTYPE[dtype]), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+
+@pytest.mark.parametrize("op, value, expected", OPS)
+@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.float32])
+def test_preallocated_output_dtype_survives_a_warmed_cache(device, op, value, expected, in_dtype, out_dtype):
+    # Warm the cache with an output of the input's own dtype, which is what the hash saw.
+    warm = _t(0.0, in_dtype, device)
+    op(_t(value, in_dtype, device), output_tensor=warm)
+
+    out = _t(0.0, out_dtype, device)
+    op(_t(value, in_dtype, device), output_tensor=out)
+    got = ttnn.to_torch(out).float()
+    assert (got == expected).all(), f"{(got != expected).sum().item()} of {got.numel()} elements are not {expected}"
+
+
+@pytest.mark.parametrize("op, value, expected", OPS)
+def test_both_output_dtypes_in_either_order(device, op, value, expected):
+    for first, second in ((ttnn.bfloat16, ttnn.float32), (ttnn.float32, ttnn.bfloat16)):
+        a, b = _t(0.0, first, device), _t(0.0, second, device)
+        op(_t(value, ttnn.float32, device), output_tensor=a)
+        op(_t(value, ttnn.float32, device), output_tensor=b)
+        assert (ttnn.to_torch(a).float() == expected).all(), f"{first} first"
+        assert (ttnn.to_torch(b).float() == expected).all(), f"{second} second"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -168,11 +168,6 @@ Tensor UnaryDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-// The output dtype is hashed from the output spec, not from attributes.output_dtype:
-// with a preallocated output the spec comes from the caller's tensor (compute_output_specs
-// above), while attributes.output_dtype still carries the input's dtype. Without it, two
-// calls that differ only in the output tensor's dtype collide and the second is served the
-// first one's packer.
 ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -168,6 +168,11 @@ Tensor UnaryDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
+// The output dtype is hashed from the output spec, not from attributes.output_dtype:
+// with a preallocated output the spec comes from the caller's tensor (compute_output_specs
+// above), while attributes.output_dtype still carries the input's dtype. Without it, two
+// calls that differ only in the output tensor's dtype collide and the second is served the
+// first one's packer.
 ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
@@ -196,6 +201,7 @@ ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
             input_tensor.layout(),
             input_tensor.memory_config(),
             input_tensor.padded_shape(),
+            output_spec.data_type(),
             src_shard_vol,
             dst_shard_vol);
     }
@@ -205,6 +211,7 @@ ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
         input_tensor.dtype(),
         input_tensor.layout(),
         input_tensor.memory_config(),
+        output_spec.data_type(),
         src_shard_vol,
         dst_shard_vol);
 }


### PR DESCRIPTION

## PR Category

Bug fix.

## Summary

Closes #53963.

`compute_program_hash` never saw the preallocated output tensor's dtype, so two calls that differed only in that dtype collided and the second was served the first one's packer. `compute_output_specs` already resolves the output spec from the caller's tensor; the hash now takes the dtype from that spec rather than from `attributes.output_dtype`, which carries the input's dtype on this path because `unary_impl` sets it there and only reads the preallocated tensor for its memory config.

One term added to each of the two `hash_operation` calls. The program is built the same way, the flags are the same, and the number of programs built for any one dtype combination is unchanged — one per combination, where before two combinations shared one.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device, output bits compared as integers. Twelve ops: neg, abs, relu, sqrt, exp, reciprocal, gelu, tanh, sigmoid, log, square, rsqrt.

The paths that were already right must not move — no `output_tensor`, every one of the 65536 bfloat16 bit patterns and 4194304 float32 patterns drawn uniformly from the 2^32 space; and with an `output_tensor`, one dtype combination per process so nothing warms the cache:

| | values compared | P300 | N300 |
|---|---|---|---|
| no `output_tensor`, 24 sweeps | 51118080 | **0** | **0** |
| one combination per process, 48 cases | 3145728 | **0** | **0** |

What changes is the second call in a process. The same 48 cases run in one process in the order bf16→bf16, bf16→fp32, fp32→fp32, fp32→bf16 per op, each scored against its own uncontaminated reference:

| | P300 before | P300 after | N300 before | N300 after |
|---|---|---|---|---|
| 24 cross-dtype cases, 1572864 values | 1409911 | **0** | 1403192 | **0** |
| 24 same-dtype cases, 1572864 values | 0 | 0 | 0 | 0 |

## Cost

Wall clock through `ttnn.exp` with a preallocated output, 5 warm-up then 50 timed calls with one `synchronize_device` at the end, median of five runs, profiler off, µs per call.

| | | main | this branch |
|---|---|---|---|
| P300 | 1024 tiles, bfloat16 | 12.3 | 12.3 |
| | 1024 tiles, float32 | 25.2 | 25.3 |
| | 16384 tiles, bfloat16 | 180.5 | 181.2 |
| | 16384 tiles, float32 | 375.4 | **375.2** |
| N300 | 1024 tiles, bfloat16 | 33.2 | 33.2 |
| | 1024 tiles, float32 | 66.5 | 66.5 |
| | 16384 tiles, bfloat16 | 382.5 | 382.8 |
| | 16384 tiles, float32 | 870.3 | **869.6** |

Dispatch count is 1 on both branches.

## Tests

`test_unary_preallocated_output_dtype.py`, 15 cases: neg, abs and relu, each with both input dtypes and both output dtypes, every one preceded by a same-dtype call that warms the entry the hash used to collide with, plus the two orders back to back. 9 of the 15 fail on `04cf22f7ee` with `512 of 1024 elements are not -1.5`; all 15 pass here, on P300 and on N300.

`test_unary_program_cache.py`, the existing regression file for this hash, passes unchanged: 19 of 19.

## Not covered

- The wider repair, in `unary_impl` (`unary.cpp:22`):

  ```cpp
  -    DataType output_dtype = input_dtype;
  +    DataType output_dtype = optional_output_tensor.has_value() ? optional_output_tensor->dtype() : input_dtype;
  ```

  It fixes the same collision and also feeds `fp32_dest_acc_en`, so `op(bfloat16, output_tensor=float32)` starts computing in a float32 dest. Mean relative error against a float64 golden over all 65536 bfloat16 patterns: exp 2.40e-04 → 5.06e-09, reciprocal 1.40e-03 → 2.28e-08, sigmoid 1.17e-04 → 5.52e-09, tanh 4.18e-05 → 2.40e-09, square 2.24e-03 → 0. It also moves 326871 values for callers who are correct today, and on the exact ops it inherits the existing bfloat16→float32 widening defect for the eleven smallest binades — `neg(1.175494e-38)` returns `-1.763242e-38`, which is what `ttnn.typecast(bfloat16, float32)` returns for that input on both branches. That is a numerics policy question; this PR takes the narrow repair so the cache-key bug can land without one.
- Binary and ternary ops, which key correctly today.
