### PR TITLE
Test CI triage aggregate run selection fix

### DIFF
--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -35,6 +35,10 @@ on:
         description: "Repository to check workflow run history against"
         type: string
         default: "tenstorrent/tt-metal"
+      dry-run:
+        description: "Draft and analyze candidates without creating issues"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -49,7 +53,7 @@ jobs:
       target-repo: ${{ inputs.target-repo }}
       max-issues: ${{ fromJSON(inputs.max-issues) }}
       llm-backend: ${{ inputs.llm-backend }}
-      dry-run: true
+      dry-run: ${{ fromJSON(inputs.dry-run) }}
       auto-triage-ref: ebanerjee/fix-auto-triage-run-selection
       workflow-filter: ${{ inputs.workflow-filter }}
       consecutive-failures-high-volume: ${{ fromJSON(inputs.consecutive-failures-high-volume) }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   create-issues:
-    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-create-issues.yaml@main
+    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-create-issues.yaml@ebanerjee/fix-auto-triage-run-selection
     with:
       issue-repo: ${{ inputs.issue-repo }}
       target-repo: ${{ inputs.target-repo }}

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -49,6 +49,8 @@ jobs:
       target-repo: ${{ inputs.target-repo }}
       max-issues: ${{ fromJSON(inputs.max-issues) }}
       llm-backend: ${{ inputs.llm-backend }}
+      dry-run: true
+      auto-triage-ref: ebanerjee/fix-auto-triage-run-selection
       workflow-filter: ${{ inputs.workflow-filter }}
       consecutive-failures-high-volume: ${{ fromJSON(inputs.consecutive-failures-high-volume) }}
       consecutive-failures-low-volume: ${{ fromJSON(inputs.consecutive-failures-low-volume) }}


### PR DESCRIPTION
## Summary
- point CI triage at `tenstorrent/tt-auto-triage@ebanerjee/fix-auto-triage-run-selection`
- check out that same ref inside the reusable workflow
- default manual dispatches to `dry-run: true` while allowing an explicit live override

## Test plan
- [x] Dispatch `.github/workflows/triage-ci.yaml` from this branch in dry-run mode
- [x] Confirm `CREATE_ISSUES=false`
- [x] Confirm the latest available `workflow-data` artifact downloads successfully
- [x] Complete candidate analysis without creating an issue
- [x] Dispatch one explicitly authorized live run with `dry-run: false` and `max-issues: 3`
- [x] Confirm the live run created exactly three issues and completed successfully
- [ ] Restore the reusable workflow ref to `@main` after the upstream fix merges

Depends on https://github.com/tenstorrent/tt-auto-triage/pull/2580

Dry-run validation: https://github.com/tenstorrent/tt-metal/actions/runs/32498028275

Live validation: https://github.com/tenstorrent/tt-metal/actions/runs/32500130717