### PR TITLE
[Bug fix] Allow sharded L1 buffers on claimed service cores

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_shard_grid_validation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shard_grid_validation.cpp
@@ -25,6 +25,10 @@
 //
 // The invalid coordinates are derived from the device rather than hardcoded, because both grids
 // shrink under harvesting: a core that is out of range on a harvested part is legal on a stock one.
+//
+// The one core that has no bank and is still legal is a claimed service core; that case needs the
+// arch and fast-dispatch gating those fixtures carry, so it lives in
+// tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp.
 
 namespace tt::tt_metal {
 namespace {

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -376,6 +377,57 @@ TEST_F(ServiceCoreFdFixture, ServiceCoreShardedL1BufferOnClaimedCore) {
 
     // Released, it is rejected again -- the exception is the claim, not the coordinate.
     EXPECT_ANY_THROW(tt::tt_metal::CreateBuffer(config));
+}
+
+// The same exception reached through MeshBuffer::create(), which is how every socket path actually
+// builds its config buffer. Without an explicit address the backing buffer is constructed against
+// the MeshDevice itself (mesh_buffer.cpp:149), so this covers the flatten-and-union branch of the
+// validation that the device-local case above cannot reach; initialize_device_buffers() then
+// re-validates the same shard spec per coordinate, against that coordinate's own device.
+//
+// Buffer shape mirrors create_socket_config_buffer() with one core, so what is under test is the
+// claim lookup rather than an incidental layout difference.
+TEST_F(ServiceCoreFdFixture, ServiceCoreShardedL1MeshBufferOnClaimedCore) {
+    auto& mesh_device = this->devices_[0];
+    const auto devices = mesh_device->get_devices();
+    auto& svc = MetalContext::instance().get_service_core_manager();
+
+    // One coordinate for the whole mesh: MeshBuffer applies a single shard spec on every device, so
+    // the core has to be claimable -- and claimed -- on all of them.
+    const CoreCoord core = svc.get_claimable_cores(devices[0]).front();
+    for (IDevice* device : devices) {
+        const auto claimable = svc.get_claimable_cores(device);
+        if (std::find(claimable.begin(), claimable.end(), core) == claimable.end()) {
+            GTEST_SKIP() << "service core " << core.str() << " is not claimable on device " << device->id()
+                         << "; a mesh-wide shard spec needs one coordinate valid everywhere";
+        }
+    }
+
+    constexpr uint32_t kPageSize = 1024;
+    const DeviceLocalBufferConfig local_config{
+        .page_size = kPageSize,
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(
+            ShardSpecBuffer(CoreRangeSet(CoreRange(core, core)), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1}),
+            TensorMemoryLayout::HEIGHT_SHARDED),
+        .bottom_up = std::nullopt,
+        .sub_device_id = std::nullopt,
+    };
+    const MeshBufferConfig mesh_config = ReplicatedBufferConfig{.size = kPageSize};
+
+    // Unclaimed, it is just a core the allocator knows nothing about.
+    EXPECT_ANY_THROW(MeshBuffer::create(mesh_config, local_config, mesh_device.get()));
+
+    for (IDevice* device : devices) {
+        svc.claim(device, {core});
+    }
+    EXPECT_NO_THROW(MeshBuffer::create(mesh_config, local_config, mesh_device.get()));
+    for (IDevice* device : devices) {
+        svc.release(device, {core});
+    }
+
+    // Released, it is rejected again -- the exception is the claim, not the coordinate.
+    EXPECT_ANY_THROW(MeshBuffer::create(mesh_config, local_config, mesh_device.get()));
 }
 
 // Actual use case: Launch a persistent service kernel on a claimed FD idle core while simultaneously

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/tt_metal.hpp>
 
+#include "impl/allocator/allocator.hpp"
 #include "impl/context/metal_context.hpp"
 #include "llrt/llrt.hpp"
 #include "llrt/tt_cluster.hpp"
@@ -335,6 +336,46 @@ TEST_F(ServiceCoreFdFixture, ServiceCoreAllocatorCorrectness) {
         MetalContext::instance().get_service_core_manager().allocate_l1(device, core, k1p5MB), std::runtime_error);
 
     MetalContext::instance().get_service_core_manager().release(device, {core});
+}
+
+// A sharded L1 buffer may live on a claimed service core. Such a core has L1 but no allocator
+// bank -- it is a dispatch-column core, outside the compute grid -- and buffer construction
+// validates shard cores against the bank map, so it has to ask ServiceCoreManager before rejecting
+// one. This is how MeshSocket places its config buffer (see create_socket_config_buffer), which
+// then reserves that span via reserve_l1_to_top so the two allocators stay disjoint.
+TEST_F(ServiceCoreFdFixture, ServiceCoreShardedL1BufferOnClaimedCore) {
+    auto& mesh_device = this->devices_[0];
+    IDevice* device = mesh_device->get_device(MeshCoordinate(0, 0));
+
+    auto claimable = MetalContext::instance().get_service_core_manager().get_claimable_cores(device);
+    const CoreCoord core = claimable[0];
+    ASSERT_FALSE(device->allocator_impl()->has_bank(BufferType::L1, core))
+        << "a claimable dispatch-column core is not expected to own an L1 bank";
+
+    // Qualified: in this namespace an unqualified ShardedBufferConfig is the mesh-level one.
+    constexpr uint32_t kPageSize = 1024;
+    const tt::tt_metal::ShardedBufferConfig config{
+        .device = device,
+        .size = kPageSize,
+        .page_size = kPageSize,
+        .buffer_type = BufferType::L1,
+        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
+        .shard_parameters = ShardSpecBuffer(
+            CoreRangeSet(CoreRange(core, core)),
+            {1, kPageSize / sizeof(uint32_t)},
+            ShardOrientation::ROW_MAJOR,
+            {1, 1},
+            {1, kPageSize / sizeof(uint32_t)})};
+
+    // Unclaimed, it is just a core the allocator knows nothing about.
+    EXPECT_ANY_THROW(tt::tt_metal::CreateBuffer(config));
+
+    MetalContext::instance().get_service_core_manager().claim(device, {core});
+    EXPECT_NO_THROW(tt::tt_metal::CreateBuffer(config));
+    MetalContext::instance().get_service_core_manager().release(device, {core});
+
+    // Released, it is rejected again -- the exception is the claim, not the coordinate.
+    EXPECT_ANY_THROW(tt::tt_metal::CreateBuffer(config));
 }
 
 // Actual use case: Launch a persistent service kernel on a claimed FD idle core while simultaneously

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include "context/context_types.hpp"
 #include "fmt/base.h"
@@ -27,6 +28,9 @@
 #include <tt_stl/strong_type.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/allocator/allocator.hpp"
+#include "impl/internal/service/service_core_manager_impl.hpp"
+#include <internal/service/service_core_manager.hpp>
+#include "tt-metalium/mesh_device.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_align.hpp"
@@ -87,6 +91,35 @@ inline bool is_emule_device(const IDevice* device) {
     }
 }
 
+// Cores claimed through ServiceCoreManager, or an empty set when no service is running.
+// A claimed core is a free FD dispatch-column core: it has real L1, but the allocator gives it no
+// bank because it sits outside the compute grid, so the bank lookup below cannot speak for it.
+// MeshSocket puts its config buffer on such cores and then reserves that span in the core's own
+// allocator (ServiceCoreManager::reserve_l1_to_top), which is what keeps the two allocators from
+// handing out the same address -- so a shard there is deliberate, not a bad grid.
+//
+// ServiceCoreManager is keyed by ChipId, so a MeshDevice -- the usual caller -- has to be flattened
+// to its local physical devices, the same way validate_circular_buffer_core_ranges() does it. The
+// union produces an answer for the mesh as a whole rather than for one chip, which is as precise
+// as a mesh-wide shard grid can be asked to be; MeshBuffer then re-creates a Buffer per coordinate
+// against that coordinate's own device, and those get an exact per-chip answer.
+std::unordered_set<CoreCoord> claimed_service_cores(const IDevice* device) {
+    const auto& service_cores = MetalContext::instance(extract_context_id(device)).get_service_core_manager().impl();
+    std::unordered_set<CoreCoord> claimed;
+    if (!service_cores.has_any_claims()) {
+        return claimed;
+    }
+    if (const auto* mesh = dynamic_cast<const distributed::MeshDevice*>(device)) {
+        for (const IDevice* chip : mesh->get_devices()) {
+            const auto chip_claimed = service_cores.claimed_cores(chip->id());
+            claimed.insert(chip_claimed.begin(), chip_claimed.end());
+        }
+    } else {
+        claimed = service_cores.claimed_cores(device->id());
+    }
+    return claimed;
+}
+
 void validate_buffer_parameters(
     DeviceAddr size,
     DeviceAddr page_size,
@@ -94,7 +127,8 @@ void validate_buffer_parameters(
     const TensorMemoryLayout& buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_spec,
     const std::optional<BufferDistributionSpec>& buffer_distribution_spec,
-    const AllocatorImpl& allocator) {
+    const AllocatorImpl& allocator,
+    const IDevice* device) {
     if (is_sharded(buffer_layout)) {
         TT_FATAL(
             shard_spec.has_value() || buffer_distribution_spec.has_value(),
@@ -105,7 +139,8 @@ void validate_buffer_parameters(
         // core survives construction and is only caught later by whichever op happens to resolve a
         // bank id for it -- or not caught at all, in which case the shard lands on a bank that does
         // not exist. Applies to both the ND (BufferDistributionSpec) and legacy (ShardSpecBuffer)
-        // paths.
+        // paths. The one exception is a core claimed via ServiceCoreManager -- see
+        // claimed_service_cores() above.
         //
         // L1_SMALL is checked against the L1 bank map. The two are filled by the same loop over the
         // same logical cores, so they agree on which coordinates are legal, but the L1_SMALL map is
@@ -123,6 +158,21 @@ void validate_buffer_parameters(
             } else if (shard_spec.has_value()) {
                 shard_cores = corerange_to_cores(shard_spec->grid());
             }
+
+            // Reached only for a core the allocator has no bank for, so the ServiceCoreManager
+            // lookup stays off the buffer-construction path every valid shard grid takes.
+            std::optional<std::unordered_set<CoreCoord>> service_cores;
+            auto is_claimed_service_core = [&](const CoreCoord& core) {
+                // Service cores are Tensix, so only L1 can have one. A DRAM coordinate that happens
+                // to match a claimed core is still a DRAM core with no bank behind it.
+                if (bank_type != BufferType::L1) {
+                    return false;
+                }
+                if (!service_cores.has_value()) {
+                    service_cores = claimed_service_cores(device);
+                }
+                return service_cores->contains(core);
+            };
             for (const auto& core : shard_cores) {
                 // Checked separately from the bank lookup below because a DRAM core off row 0 is a
                 // real coordinate -- logical y indexes a DRAM view's subchannels -- it is just not a
@@ -137,11 +187,13 @@ void validate_buffer_parameters(
                         core.y);
                 }
                 TT_FATAL(
-                    allocator.has_bank(bank_type, core),
+                    allocator.has_bank(bank_type, core) || is_claimed_service_core(core),
                     "Invalid shard grid: shard core ({}, {}) has no {} bank on this device, which has "
                     "{} of them. Derive the shard grid from the device (dram_grid_size() for DRAM, "
                     "compute_with_storage_grid_size() for L1) rather than assuming a fixed size -- a "
-                    "harvested device exposes fewer banks than an unharvested one of the same type.",
+                    "harvested device exposes fewer banks than an unharvested one of the same type. An "
+                    "L1 shard core outside the compute grid is legal only while it is claimed via "
+                    "ServiceCoreManager.",
                     core.x,
                     core.y,
                     enchantum::to_string(bank_type),
@@ -387,7 +439,14 @@ Buffer::Buffer(
         this->allocator_ = device->allocator_impl().get();
     }
     validate_buffer_parameters(
-        size, page_size, buffer_type, buffer_layout_, shard_spec_, buffer_distribution_spec_, *this->allocator_);
+        size,
+        page_size,
+        buffer_type,
+        buffer_layout_,
+        shard_spec_,
+        buffer_distribution_spec_,
+        *this->allocator_,
+        this->device_);
     unique_id_ = next_unique_id.fetch_add(1);
 }
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

#53263 made buffer construction reject any shard core the allocator has no bank for. That is
right for DRAM, where a bad core aliases onto a real bank and silently corrupts it, but too
strict for L1, and it broke every service-core socket path on Blackhole.

A **service core** is a free FD dispatch-column core (`ServiceCoreManager::get_claimable_cores`
-> `dispatch_core_manager::get_available_dispatch_cores`). It has real L1 but no bank, because
the L1 bank map only takes cores tagged `AllocCoreType::ComputeAndStore`
(`l1_banking_allocator.cpp:100`). The socket paths put L1 `HEIGHT_SHARDED` config buffers on
such cores deliberately, and coordinate addresses so the global and per-core allocators stay
disjoint -- two different ways:

- **D2D** lets the global allocator pick, then fences the per-core allocator off it:
  `svc.reserve_l1_to_top(...)` with the config buffer's address
  (`ttnn/core/tensor/d2d_stream_service.cpp:1063`).
- **H2D / D2H** allocate *from* the service allocator and pass the address in, so they are
  disjoint by construction (`h2d_socket.cpp:157`, `d2h_socket.cpp:187`).

Both shapes still run the validating `Buffer` ctor, so both started aborting. The two failures
tracked in #53921 are the same bug reached through different callers on differently harvested
parts, which is why this is fixed once at the validation site rather than per caller:

| | D2D nightly | Kimi-K2 prefill |
| --- | --- | --- |
| job | `bh_qb2_DeepSeek_D2D_SOCKET_SYNC` | `Kimi-K2.6-1T prefill ... [bh_sc1]` |
| rejected core | (11, 2) | (12, 2) |
| L1 banks | 110 | 120 |
| harvesting | 2x (12-wide worker grid) | 1x (13-wide) |
| caller | `MeshSocket` config buffer | `H2DStreamService` -> `H2DSocket::init_config_buffer` |

Both cores are in the dispatch column. The fix asks `ServiceCoreManager` rather than doing
arithmetic on grid sizes, so it is geometry-independent and covers both.

Note for anyone reading those jobs' auto-generated summaries: both blame "a hardcoded shard
grid". They are service cores handed out at runtime, not hardcoded coordinates.

Closes #53921

### Notes for reviewers

**Shaped after existing precedent.** `ProgramImpl::validate_circular_buffer_core_ranges`
(`tt_metal/impl/program/program.cpp:2079`) already faces the same problem -- a check keyed on
`compute_with_storage_grid_size()` that must not reject service cores -- and solves it the same
way, including the `has_any_claims()` gate and the MeshDevice flatten. `ServiceCoreManager` is
keyed by `ChipId`, so there is no mesh-level query to ask instead.

**DRAM is untouched.** `is_claimed_service_core()` returns false for DRAM before looking anything
up. Service cores are Tensix, so without that guard a DRAM coordinate that happens to equal a
claimed core -- (11, 0) on the failing part -- would be waved through, punching a hole in exactly
the arm the original silent-corruption evidence came from.

**Off the hot path.** The lookup sits behind `||`, so it is reached only for a core the allocator
has no bank for, which in normal operation is never. No `dynamic_cast` added to buffer
construction.

**Mesh vs per-chip precision.** `validate_buffer_parameters` is usually called with a MeshDevice,
so the helper unions claims across `get_devices()` (local devices only). That answers for the mesh
as a whole rather than one chip, which is as precise as a mesh-wide shard grid can be; `MeshBuffer`
then re-creates a `Buffer` per coordinate against that coordinate's own device
(`mesh_buffer.cpp:177`), and those get an exact per-chip answer.

**Known limitation.** If two chips in a mesh claim *different* service cores, the socket config
buffer shards onto the union, and per-coordinate validation would reject the sibling chip's core.
Not reachable today -- fresh claims on identical chips all pick `claimable[0]` -- but if we want
that case supported, the non-mesh branch should widen to union across the owning mesh.

**Message wording.** The `TT_FATAL` message is shared by both arms, so a DRAM failure also prints
the trailing `An L1 shard core outside the compute grid is legal only while it is claimed via
ServiceCoreManager.` It is explicitly scoped to L1 so it is not wrong, but if you would rather see
two messages than one shared five-line one, say so and I will split it.

**Not addressed here.** Claim status alone does not make the two L1 allocators disjoint -- both
grow top-down over the same range with no shared state, and only the caller's own
`reserve_l1_to_top()` or preallocation makes them safe. That hazard predates #53263, which masked
it only by breaking all three callers; it cannot be enforced at this site because
`validate_buffer_parameters` runs before `allocate_impl()` assigns an address. The real fix is to
have the allocator auto-reserve the span in the per-core allocator when an L1 sharded buffer lands
on a claimed core, which would let D2D drop its manual `reserve_l1_to_top`. Worth a follow-up
issue.

### Testing

Two new cases in `tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp`, both running
reject -> claim -> accept -> release -> reject so the exception is pinned to the claim rather than
the coordinate. They cover the two validation branches, and each mirrors a real caller:

| test | branch covered | caller it mirrors |
| --- | --- | --- |
| `ServiceCoreShardedL1BufferOnClaimedCore` | device-local | H2D / D2H (explicit preallocated address -> per-coordinate `Buffer` against a physical device) |
| `ServiceCoreShardedL1MeshBufferOnClaimedCore` | MeshDevice flatten-and-union | D2D (no address -> backing buffer against the `MeshDevice`) |

They live beside the other service-core tests rather than with the shard-grid tests because
`ServiceCoreFdFixture` already carries the BH/UBB arch guard and FD gating they need;
`test_shard_grid_validation.cpp` gets a pointer comment. No CI wiring needed --
`runtime_unit_tests.yaml`'s `service_core_manager` job already runs `ServiceCoreFdFixture.*` on
`bh_p150b_civ2`, `bh_p100a_civ2_viommu` and `bh_loudbox`.

Both pass on Blackhole (`service_core_manager [bh_p150b_civ2]`):

```
[       OK ] ServiceCoreFdFixture.ServiceCoreShardedL1BufferOnClaimedCore (7 ms)
[       OK ] ServiceCoreFdFixture.ServiceCoreShardedL1MeshBufferOnClaimedCore (7 ms)
```

`runtime_api` and `runtime_sd_api` are green on `bh_p150b_civ2`, covering the existing shard-grid
tests on Blackhole geometry in both dispatch modes. The only red job on that SKU is
`runtime_noc_debugging`, failing on `NOCDebuggingFixture.SemaphoreIncMulticastWithBarrier` -- the
same single test fails on main's scheduled runs for the same SKU, so it is pre-existing.

Also verified on an n300 (`unit_tests_api --gtest_filter='*ShardGridValidation*'`, 7/7 in both
dispatch modes). Not just a smoke test there: on n300 the compute grid is (8, 7) with dispatch on
row -1, so the existing reject case's `CoreCoord(0, grid.y)` is (0, 7) -- a real worker core with
L1, no bank, and unclaimed. It rejects correctly against 56 banks, which exercises the new
short-circuit's false branch and confirms the `ServiceCoreManager` query is safe on a non-BH
cluster, the one way this change could have affected other arches.

The end-to-end repro (`bh_qb2_DeepSeek_D2D_SOCKET_SYNC` on a 2xP300 QuietBox) has been dispatched
on this branch and is pending a runner.
