### PR TITLE
[Bug fix] Fix active-ERISC kernel link: define __global_pointer$ unconditionally

### DIFF
--- a/tt_metal/hw/toolchain/main.ld
+++ b/tt_metal/hw/toolchain/main.ld
@@ -198,7 +198,9 @@ SECTIONS
 
 /* Begin the data area.  */
 #if defined(TYPE_FIRMWARE)
-  PROVIDE(__global_pointer$ = DATA_START + 0x7f0);
+  /* kernels get __global_pointer$ from the firmware ELF via --just-symbols, so it must be in the firmware's symbol
+     table even when the firmware itself never references it.  */
+  __global_pointer$ = DATA_START + 0x7f0;
   .data DATA_START :
 #define SECTION(NEW, PREV) NEW :
 #else


### PR DESCRIPTION
### PR Category
Bug fix 

### Summary
Cold-cache active-ERISC kernel links on Blackhole failed with:

    undefined reference to `__global_pointer$'

main.ld declared the symbol with PROVIDE(), which emits it only when something in the link references it. That assumption holds for every processor except one.

Kernel linker scripts do not define __global_pointer$; they import it from the firmware ELF via --just-symbols. 

Define the symbol unconditionally for TYPE_FIRMWARE instead. Addresses are unchanged and firmware that already referenced the symbol is unaffected -- the change only adds it to the symbol table where it was previously elided.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/global-pointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/global-pointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/global-pointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/global-pointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/global-pointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/global-pointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/global-pointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/global-pointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/global-pointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/global-pointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/global-pointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/global-pointer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/global-pointer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/global-pointer)