### PR TITLE
[Bug fix] backward ops: the auto-allocated gradient takes the caller's memory config

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_memory_config.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_memory_config.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A gradient the caller did not preallocate still lands where the caller asked.
+
+The backward ops allocate their outputs with empty_like(input), which inherits the
+input's memory config and ignores the memory_config argument. div_bw went further:
+with the request unmet, its second gradient came back as -inf.
+"""
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 32, 32)
+
+# op name, number of tensor arguments, trailing scalar arguments
+OPS = [
+    ("abs_bw", 2, []),
+    ("exp_bw", 2, []),
+    ("neg_bw", 2, []),
+    ("sqrt_bw", 2, []),
+    ("silu_bw", 2, []),
+    ("rsqrt_bw", 2, []),
+    ("frac_bw", 2, []),
+    ("pow_bw", 2, [2.0]),
+    ("add_bw", 3, []),
+    ("sub_bw", 3, []),
+    ("mul_bw", 3, []),
+    ("div_bw", 3, []),
+    ("rsub_bw", 3, []),
+    ("assign_bw", 3, []),
+    ("addalpha_bw", 3, [2.0]),
+    ("subalpha_bw", 3, [2.0]),
+    ("addcmul_bw", 4, [2.0]),
+    ("addcdiv_bw", 4, [2.0]),
+]
+
+VALUES = (1.5, 2.5, 0.5, 3.0)
+
+
+def _t(v, device, memory_config):
+    return ttnn.from_torch(
+        torch.full(SHAPE, v, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=memory_config,
+    )
+
+
+def _call(op, arity, scalars, device, memory_config):
+    args = [_t(VALUES[i], device, ttnn.DRAM_MEMORY_CONFIG) for i in range(arity)]
+    kwargs = {} if memory_config is None else {"memory_config": memory_config}
+    out = getattr(ttnn, op)(*args, *scalars, **kwargs)
+    out = out if isinstance(out, (list, tuple)) else [out]
+    return [x for x in out if x is not None]
+
+
+@pytest.mark.parametrize("op, arity, scalars", OPS)
+def test_gradients_land_in_the_requested_memory(device, op, arity, scalars):
+    for i, out in enumerate(_call(op, arity, scalars, device, ttnn.L1_MEMORY_CONFIG)):
+        assert out.memory_config().buffer_type == ttnn.BufferType.L1, f"{op} output {i} is in {out.memory_config()}"
+
+
+@pytest.mark.parametrize("op, arity, scalars", OPS)
+def test_requesting_a_memory_config_does_not_move_any_value(device, op, arity, scalars):
+    default = _call(op, arity, scalars, device, None)
+    asked = _call(op, arity, scalars, device, ttnn.L1_MEMORY_CONFIG)
+    for i, (a, b) in enumerate(zip(default, asked)):
+        x, y = ttnn.to_torch(a).float(), ttnn.to_torch(b).float()
+        moved = ((x != y) & ~(torch.isnan(x) & torch.isnan(y))).sum().item()
+        assert moved == 0, f"{op} output {i}: {moved} of {x.numel()} values move when L1 is requested"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -31,14 +31,16 @@ void preallocated_tensors_check(
     std::optional<Tensor>& other_grad,
     const Tensor& input,
     const Tensor& other,
-    const std::array<bool, 2>& required_outputs) {
+    const std::array<bool, 2>& required_outputs,
+    const std::optional<MemoryConfig>& output_mem_config) {
     TT_FATAL(required_outputs[0] || required_outputs[1], "At least one gradient is expected to be calculated.");
 
+    // A gradient the caller did not preallocate still has to land where the caller asked.
     if (required_outputs[0] && !input_grad.has_value()) {
-        input_grad = ttnn::empty_like(input);
+        input_grad = ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
     if (required_outputs[1] && !other_grad.has_value()) {
-        other_grad = ttnn::empty_like(other);
+        other_grad = ttnn::empty_like(other, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
 }
 
@@ -131,7 +133,8 @@ std::vector<std::optional<Tensor>> addalpha_bw(
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
 
     if (are_required_outputs[0]) {
         ttnn::assign(grad_tensor, input_grad.value());
@@ -155,7 +158,8 @@ std::vector<std::optional<Tensor>> subalpha_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
     if (are_required_outputs.at(0)) {
         ttnn::assign(grad_tensor, input_grad.value());
         result[0] = input_grad;
@@ -173,10 +177,10 @@ std::vector<std::optional<Tensor>> add_bw(
     const Tensor& grad_tensor,
     const Tensor& input_tensor,
     float /*alpha*/,
-    const std::optional<MemoryConfig>& /*output_mem_config*/,
+    const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
-    input_grad = input_grad.value_or(ttnn::empty_like(input_tensor));
+    input_grad = input_grad.value_or(ttnn::empty_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
     ttnn::assign(grad_tensor, input_grad.value());
     result.emplace_back(input_grad);
     return result;
@@ -192,7 +196,8 @@ std::vector<std::optional<Tensor>> add_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
     if (are_required_outputs.at(0)) {
         ttnn::assign(grad_tensor, input_grad.value());
         result[0] = input_grad;
@@ -226,12 +231,12 @@ std::vector<std::optional<Tensor>> sub_bw(
     const Tensor& grad_tensor,
     const Tensor& input_tensor,
     float /*alpha*/,
-    const std::optional<MemoryConfig>& /*output_mem_config*/,
+    const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     result.emplace_back(
         input_grad.has_value() ? ttnn::assign(grad_tensor, input_grad.value())
-                               : ttnn::assign(grad_tensor, ttnn::empty_like(input_tensor)));
+                               : ttnn::assign(grad_tensor, ttnn::empty_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, output_mem_config)));
     return result;
 }
 
@@ -492,13 +497,14 @@ std::vector<std::optional<Tensor>> assign_bw(
     const Tensor& input_tensor,
     const Tensor& other_tensor,
     const std::vector<bool>& are_required_outputs,
-    const std::optional<MemoryConfig>& /*output_mem_config*/,
+    const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<ttnn::Tensor>> grad_tensor_res = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_tensor, other_tensor, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_tensor, other_tensor, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
 
     if (are_required_outputs[0]) {
         ttnn::assign(grad_tensor, input_grad.value());
@@ -517,13 +523,14 @@ std::vector<std::optional<Tensor>> concat_bw(
     const Tensor& other,
     int dim,
     const std::vector<bool>& are_required_outputs,
-    const std::optional<MemoryConfig>& /*memory_config*/,
+    const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> grad_tensor = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_tensor_a_arg, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_tensor_a_arg, other, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
 
     if (are_required_outputs[0]) {
         ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
@@ -572,7 +579,8 @@ std::vector<std::optional<Tensor>> rsub_bw(
     std::vector<std::optional<ttnn::Tensor>> result = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, grad_tensor, grad_tensor, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, grad_tensor, grad_tensor, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
     if (are_required_outputs.at(0)) {
         ttnn::neg(grad_tensor, output_mem_config, input_grad);
         result[0] = input_grad;
@@ -649,7 +657,7 @@ std::vector<std::optional<Tensor>> div_bw(
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
 
     std::vector<std::optional<Tensor>> result;
-    input_grad = input_grad.value_or(ttnn::empty_like(input_tensor));
+    input_grad = input_grad.value_or(ttnn::empty_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
 
     if (rounding_mode == std::nullopt) {
         float t_inf = std::numeric_limits<float>::infinity();
@@ -686,7 +694,8 @@ std::vector<std::optional<Tensor>> div_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
     TT_FATAL(
         (rounding_mode == std::nullopt || rounding_mode == "trunc" || rounding_mode == "floor"),
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
@@ -802,7 +811,7 @@ std::vector<std::optional<Tensor>> mul_bw(
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     if (!input_grad.has_value()) {
-        input_grad = ttnn::empty_like(grad_tensor_arg);
+        input_grad = ttnn::empty_like(grad_tensor_arg, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
     ttnn::multiply(grad_tensor_arg, scalar, std::nullopt, output_mem_config, input_grad);
     result.push_back(input_grad);
@@ -819,7 +828,8 @@ std::vector<std::optional<Tensor>> mul_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_tensor_arg, other_tensor_arg, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_tensor_arg, other_tensor_arg, {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
 
     if (are_required_outputs.at(0)) {
         ttnn::multiply(grad_tensor_arg, other_tensor_arg, std::nullopt, output_mem_config, input_grad);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/data_movement/bcast/bcast.hpp"
 #include "ttnn/operations/eltwise/ternary/ternary.hpp"
+#include "ttnn/operations/core/to_memory_config/to_memory_config_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "tools/profiler/op_profiler.hpp"
 #include "ttnn/operations/eltwise/ternary_backward/ternary_backward.hpp"
@@ -23,7 +24,9 @@ std::vector<Tensor> addcmul_bw(
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     std::vector<Tensor> grad_tensor;
     grad_tensor.reserve(3);
-    grad_tensor.emplace_back(grad);
+    // d/d(input_a) is grad itself, but it still has to land where the caller asked.
+    // to_memory_config returns the tensor unchanged, with no dispatch, when it already has.
+    grad_tensor.emplace_back(ttnn::to_memory_config(grad, output_mem_config));
     Tensor grad_a = ttnn::multiply(
         ttnn::multiply(grad, tensor2, std::nullopt, output_mem_config), value, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(std::move(grad_a));
@@ -43,7 +46,9 @@ std::vector<Tensor> addcdiv_bw(
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     std::vector<Tensor> grad_tensor;
     grad_tensor.reserve(3);
-    grad_tensor.emplace_back(grad);
+    // d/d(input_a) is grad itself, but it still has to land where the caller asked.
+    // to_memory_config returns the tensor unchanged, with no dispatch, when it already has.
+    grad_tensor.emplace_back(ttnn::to_memory_config(grad, output_mem_config));
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
     Tensor grad_a = ttnn::multiply(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/constants.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
+#include "ttnn/operations/core/to_memory_config/to_memory_config_op.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/moreh/moreh_sum/moreh_sum.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
@@ -251,7 +252,7 @@ std::vector<std::optional<Tensor>> pow_bw(
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> grad_tensor;
-    input_grad = input_grad.value_or(ttnn::empty_like(input));
+    input_grad = input_grad.value_or(ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
     const float ZERO_THRESHOLD = std::numeric_limits<float>::epsilon() * 10.0f;
     TT_FATAL(exponent >= 0.0, "negative exponents are not supported; use recip(pow(input,abs(exponent)))");
     if (std::abs(exponent) < ZERO_THRESHOLD) {
@@ -282,7 +283,7 @@ std::vector<std::optional<Tensor>> exp_bw(
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> grad_tensor;
 
-    input_grad = input_grad.value_or(ttnn::empty_like(input));
+    input_grad = input_grad.value_or(ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
     Tensor exp_result = ttnn::exp(input, false, output_mem_config);
     Tensor result = ttnn::multiply(grad, exp_result, std::nullopt, output_mem_config, input_grad);
     grad_tensor.emplace_back(input_grad);
@@ -314,7 +315,7 @@ std::vector<std::optional<Tensor>> sqrt_bw(
     float t_nan = std::nanf("");
     float t_inf = std::numeric_limits<float>::infinity();
 
-    input_grad = input_grad.value_or(ttnn::empty_like(input));
+    input_grad = input_grad.value_or(ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
     ttnn::sqrt(input, false, output_mem_config, input_grad);
     ttnn::multiply(
         grad,
@@ -383,9 +384,9 @@ std::vector<Tensor> lgamma_bw(
 }
 
 std::vector<Tensor> frac_bw(
-    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& /*output_mem_config*/) {
+    const Tensor& grad, const Tensor& /*input*/, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    grad_tensor.emplace_back(grad);
+    grad_tensor.emplace_back(ttnn::to_memory_config(grad, output_mem_config.value_or(grad.memory_config())));
     return grad_tensor;
 }
 
@@ -477,7 +478,7 @@ std::vector<std::optional<ttnn::Tensor>> rsqrt_bw(
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     if (!input_grad.has_value()) {
-        input_grad = ttnn::empty_like(grad);
+        input_grad = ttnn::empty_like(grad, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
     float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
@@ -510,7 +511,7 @@ std::vector<std::optional<Tensor>> neg_bw(
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt};
-    input_grad = input_grad.value_or(ttnn::empty_like(input));
+    input_grad = input_grad.value_or(ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
     result[0] = ttnn::neg(grad, output_mem_config, input_grad);
     return result;
 }
@@ -874,7 +875,7 @@ std::vector<std::optional<Tensor>> silu_bw(
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt};
 
-    input_grad = input_grad.value_or(ttnn::empty_like(input));
+    input_grad = input_grad.value_or(ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
     Tensor sigmoid_res = ttnn::sigmoid(
         input,
         (int)ttnn::operations::unary::VecMode::RC,
@@ -1561,7 +1562,7 @@ std::vector<std::optional<ttnn::Tensor>> gelu_bw(
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     if (!input_grad.has_value()) {
-        input_grad = ttnn::empty_like(grad);
+        input_grad = ttnn::empty_like(grad, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
 
     auto output_memory_config =


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53969.

A gradient the caller did not preallocate was built with `empty_like(input)`, which copies the input's memory config and ignores the caller's. `preallocated_tensors_check` now takes `output_mem_config` and hands it to both allocations, the thirteen `empty_like` sites in the three backward files pass it too, and the three ops that return the incoming gradient unchanged — `addcmul_bw`, `addcdiv_bw`, `frac_bw` — route it through `to_memory_config`, which returns the tensor untouched and dispatches nothing when the config already matches.

Four parameters that were name-commented out — `add_bw` and `sub_bw` (scalar overloads), `assign_bw`, `concat_bw` — are named again and used.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device, output bits compared as integers.

With no `memory_config` — every existing caller — nothing may move. 22 ops, all 65536 bfloat16 bit patterns in each operand position:

| | sweeps | values compared | P300 | N300 |
|---|---|---|---|---|
| default config | 76 | 8781824 | **0 differ** | **0 differ** |

With `memory_config=ttnn.L1_MEMORY_CONFIG` on DRAM inputs, one op per process:

| | P300 before | P300 after | N300 before | N300 after |
|---|---|---|---|---|
| ops placing every gradient in L1 | 5 of 22 | **22 of 22** | 5 of 22 | **22 of 22** |
| ops whose values move between the default config and L1 | 1 — `div_bw` | **0** | 1 — `div_bw` | **0** |

`div_bw` is the one that mattered. Its intermediates were told L1 while the buffer they wrote was DRAM, and the second gradient came back as `-inf`. Every bfloat16 bit pattern in each operand position:

| second gradient, swept operand | P300 before | N300 before | after, both |
|---|---|---|---|
| grad | 64717 / 65536 | 64717 / 65536 | **identical to the default config** |
| input | 64940 / 65536 | 65067 / 65536 | **identical** |
| other | 49152 / 65536 | 49152 / 65536 | **identical** |

`div_bw(grad=1.5, input=2.5, other=0.5)` goes from `-inf` back to `-15`, which is what torch returns.

## Cost

Wall clock, 5 warm-up then 50 timed calls with one `synchronize_device` at the end, median of five runs, profiler off, µs per call, `[1, 1, 1024, 1024]`.

| | | main | this branch |
|---|---|---|---|
| P300 | `div_bw`, bfloat16 | 390.2 | **385.0** |
| | `div_bw`, float32 | 605.8 | 609.6 |
| | `add_bw`, bfloat16 | 33.1 | 34.8 |
| | `add_bw`, float32 | 46.8 | 46.8 |
| N300 | `div_bw`, bfloat16 | 781.6 | 781.7 |
| | `div_bw`, float32 | 1559.1 | **1557.8** |
| | `add_bw`, bfloat16 | 70.1 | **69.9** |
| | `add_bw`, float32 | 122.0 | 122.0 |

Dispatch counts are unchanged: 23 for `div_bw`, 2 for `add_bw`. `to_memory_config` short-circuits on a matching config (`to_memory_config_op.cpp:257-260`), so the three aliasing sites cost nothing unless a different placement was actually requested.

## Tests

`test_backward_memory_config.py`, 36 cases: 18 ops asserted to place every gradient in the requested L1, and the same 18 asserted to return identical values with and without the request. 18 of the 36 fail on `04cf22f7ee`, on both machines; all 36 pass here, on P300 and on N300.

## Not covered

- **Why the mismatch produced `-inf`.** Removing it removes the `-inf`, but the mechanism between them is not explained. Ruled out by measurement: L1 capacity (identical at 32x32 through 512x512), the program cache (a cold process and a warmed one agree), the predicates (`eqz`, `ltz`, `gtz`, `nez`, `sign` all correct under `memory_config=L1`), the arithmetic chain (`square → reciprocal → multiply → neg → multiply` by hand with L1 intermediates and a DRAM output gives `-15`), and the trailing `where` whose output aliases an operand.
- `unary_composite_op.cpp:42/:136/:151`, where the caller's config describes a full-shape output and the op reduces to `[N, C, 1, 1]`. Passing it down asserts for sharded configs.
- Sharded and ND-sharded configs. Only interleaved DRAM and L1 were measured.
