### PR TITLE
[Bug fix] tril / triu: build the mask in the input's own dtype

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_tril_triu_integer_dtype.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tril_triu_integer_dtype.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""tril and triu build their 0/1 mask in the input's own dtype.
+
+A bfloat16 mask against an integer input promoted the multiply to bfloat16, so the
+kept elements came back rounded to 8 mantissa bits and the returned dtype was
+BFLOAT16 rather than the input's.
+"""
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 64, 64)
+N = SHAPE[2] * SHAPE[3]
+
+
+def _t(x, dtype, device):
+    return ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.int32, ttnn.uint32])
+@pytest.mark.parametrize("start", [1, 100000, 2**30])
+@pytest.mark.parametrize("diagonal", [0, 1, -1, 5, -7])
+@pytest.mark.parametrize("op, golden", [("tril", torch.tril), ("triu", torch.triu)])
+def test_integer_inputs_keep_their_dtype_and_their_value(device, dtype, start, diagonal, op, golden):
+    x = torch.arange(start, start + N, dtype=torch.int32).reshape(SHAPE)
+    got = getattr(ttnn, op)(_t(x, dtype, device), diagonal=diagonal)
+    assert got.dtype == dtype, f"{op} on {dtype} returned {got.dtype}"
+    assert torch.equal(ttnn.to_torch(got).to(torch.int64), golden(x, diagonal=diagonal).to(torch.int64))
+
+
+@pytest.mark.parametrize("dtype, torch_dtype", [(ttnn.bfloat16, torch.bfloat16), (ttnn.float32, torch.float32)])
+@pytest.mark.parametrize("diagonal", [0, 1, -1])
+@pytest.mark.parametrize("op, golden", [("tril", torch.tril), ("triu", torch.triu)])
+def test_float_inputs_are_unchanged(device, dtype, torch_dtype, diagonal, op, golden):
+    torch.manual_seed(0)
+    x = (torch.rand(SHAPE) * 8 - 4).to(torch_dtype)
+    got = ttnn.to_torch(getattr(ttnn, op)(_t(x, dtype, device), diagonal=diagonal))
+    assert got.dtype == torch_dtype
+    assert torch.equal(got.float(), golden(x.float(), diagonal=diagonal))

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -304,29 +304,52 @@ Tensor swiglu(const Tensor& input_a, std::int32_t dim, const std::optional<Memor
     return swiglu_result;
 }
 
+// The 0/1 mask has to be built in the input's own dtype. A bfloat16 mask against an
+// integer input promotes the multiply to bfloat16, and the result comes back rounded
+// to 8 mantissa bits -- tril(int32 around 2^30) was off by up to 1023.
+static Tensor trilu_mask(
+    const Tensor& input_a, std::int32_t diag, bool upper, const std::optional<MemoryConfig>& output_mem_config) {
+    const auto mem = output_mem_config.value_or(input_a.memory_config());
+    const DataType dt = input_a.dtype();
+    if (dt == DataType::INT32) {
+        return upper ? ttnn::index_triu<std::int32_t>(
+                           input_a.logical_shape(), input_a.padded_shape(), diag, dt, Layout::TILE, input_a.device(), mem)
+                     : ttnn::index_tril<std::int32_t>(
+                           input_a.logical_shape(), input_a.padded_shape(), diag, dt, Layout::TILE, input_a.device(), mem);
+    }
+    if (dt == DataType::UINT32) {
+        return upper ? ttnn::index_triu<std::uint32_t>(
+                           input_a.logical_shape(), input_a.padded_shape(), diag, dt, Layout::TILE, input_a.device(), mem)
+                     : ttnn::index_tril<std::uint32_t>(
+                           input_a.logical_shape(), input_a.padded_shape(), diag, dt, Layout::TILE, input_a.device(), mem);
+    }
+    return upper ? ttnn::index_triu<::bfloat16>(
+                       input_a.logical_shape(),
+                       input_a.padded_shape(),
+                       diag,
+                       DataType::BFLOAT16,
+                       Layout::TILE,
+                       input_a.device(),
+                       mem)
+                 : ttnn::index_tril<::bfloat16>(
+                       input_a.logical_shape(),
+                       input_a.padded_shape(),
+                       diag,
+                       DataType::BFLOAT16,
+                       Layout::TILE,
+                       input_a.device(),
+                       mem);
+}
+
 // tril : select lower triangular region of input matrix
 Tensor tril(const Tensor& input_a, std::int32_t diag, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor index_l = ttnn::index_tril<::bfloat16>(
-        input_a.logical_shape(),
-        input_a.padded_shape(),
-        diag,
-        DataType::BFLOAT16,
-        Layout::TILE,
-        input_a.device(),
-        output_mem_config.value_or(input_a.memory_config()));
+    Tensor index_l = trilu_mask(input_a, diag, /*upper=*/false, output_mem_config);
     return ttnn::multiply(input_a, index_l, std::nullopt, output_mem_config);
 }
 
 // triu : select upper triangular region of input matrix
 Tensor triu(const Tensor& input_a, std::int32_t diag, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor index_u = ttnn::index_triu<::bfloat16>(
-        input_a.logical_shape(),
-        input_a.padded_shape(),
-        diag,
-        DataType::BFLOAT16,
-        Layout::TILE,
-        input_a.device(),
-        output_mem_config.value_or(input_a.memory_config()));
+    Tensor index_u = trilu_mask(input_a, diag, /*upper=*/true, output_mem_config);
     return ttnn::multiply(input_a, index_u, std::nullopt, output_mem_config);
 }
 


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53971.

The triangular mask was `index_tril<::bfloat16>` regardless of the input dtype, so an integer input promoted the multiply to bfloat16: the kept elements came back rounded to 8 mantissa bits, and the returned dtype was BFLOAT16. The mask now follows the input — `int32_t` for INT32, `uint32_t` for UINT32, bfloat16 for everything else, which is what those dtypes get today.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device, output bits compared as integers.

Float inputs must not move — for them a 0/1 bfloat16 mask is exact and the multiply already produced the input's dtype. bfloat16, float32 and bfloat8_b, all 65536 bfloat16 bit patterns as the input, five diagonals, both ops:

| | outputs | values compared | P300 | N300 |
|---|---|---|---|---|
| float dtypes | 30 | 1966080 | **0 differ** | **0 differ** |

Integer inputs move from wrong to right. `[1, 1, 32, 32]`, three value ranges, both ops, against torch:

| | main | this branch |
|---|---|---|
| int32 1..1024, wrong of 1024 | 352 / 176 | **0** |
| int32 from 100000 | 526 / 528 | **0** |
| int32 from 2^30 | 527 / 527 | **0** |
| max absolute error, 2^30 range | **1023** | **0** |
| returned dtype | BFLOAT16 | **INT32** |

Identical on both machines. `uint32` the same, returning UINT32. At `[1, 1, 256, 256]` over five diagonals main's maximum absolute error is 65535 and its mean over the wrong elements is 43606; this branch is exact.

## Cost

None. The same one multiply, against a mask of the same shape built on the host either way.

## Tests

`test_tril_triu_integer_dtype.py`, 72 cases: int32 and uint32 at three magnitudes, five diagonals, both ops, each asserted to return the input's dtype and to equal torch exactly; plus bfloat16 and float32 asserted unchanged. 60 of the 72 fail on `04cf22f7ee`, on both machines; all 72 pass here, on P300 and on N300.

## Not covered

- bfloat16 subnormals in the kept region, which come back as zero on both branches. The value is flushed when it is unpacked into Dest, not by the mask — a `where` formulation gives the same zero.
- `uint16`, which raises on both branches from the multiply's dtype check.
