### PR TITLE
[Bug fix] rsqrt_bw: at zero the gradient's sign is the derivative's, not +inf

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_rsqrt_bw_zero_sign.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_rsqrt_bw_zero_sign.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""rsqrt_bw at zero carries the sign the derivative has.
+
+d/dx rsqrt(x) is -0.5 * x^-3/2, so at zero the gradient is -inf for a positive
+incoming gradient and +inf for a negative one. The composite wrote +inf for both.
+"""
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 32, 32)
+
+
+def _t(v, dtype, device):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    return ttnn.from_torch(
+        torch.full(SHAPE, v, dtype=torch_dtype), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("grad, want", [(2.0, float("-inf")), (-2.0, float("inf")), (0.5, float("-inf"))])
+def test_rsqrt_bw_at_zero_follows_the_gradient_sign(device, dtype, grad, want):
+    got = ttnn.to_torch(ttnn.rsqrt_bw(_t(grad, dtype, device), _t(0.0, dtype, device))[0])
+    assert got.float().flatten()[0].item() == want
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("x, grad", [(4.0, 2.0), (0.25, -1.0), (1.0, 3.0)])
+def test_rsqrt_bw_in_the_domain_matches_torch(device, dtype, x, grad):
+    got = ttnn.to_torch(ttnn.rsqrt_bw(_t(grad, dtype, device), _t(x, dtype, device))[0]).float().flatten()[0].item()
+    t = torch.tensor([x], requires_grad=True)
+    torch.rsqrt(t).backward(torch.tensor([grad]))
+    assert got == pytest.approx(t.grad.item(), rel=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_rsqrt_bw_out_of_domain_is_unchanged(device, dtype):
+    got = ttnn.to_torch(ttnn.rsqrt_bw(_t(2.0, dtype, device), _t(-4.0, dtype, device))[0]).float().flatten()[0].item()
+    # bfloat16 Dest cannot carry NaN and returns an infinity instead.
+    assert got != got or got in (float("inf"), float("-inf"))
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("x, grad", [(4.0, 2.0), (0.0, 2.0), (0.0, -2.0)])
+def test_sqrt_bw_is_unchanged(device, dtype, x, grad):
+    got = ttnn.to_torch(ttnn.sqrt_bw(_t(grad, dtype, device), _t(x, dtype, device))[0]).float().flatten()[0].item()
+    t = torch.tensor([x], requires_grad=True)
+    torch.sqrt(t).backward(torch.tensor([grad]))
+    want = t.grad.item()
+    assert got == pytest.approx(want, rel=2e-2) if abs(want) != float("inf") else got == want

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -479,7 +479,6 @@ std::vector<std::optional<ttnn::Tensor>> rsqrt_bw(
     if (!input_grad.has_value()) {
         input_grad = ttnn::empty_like(grad);
     }
-    float t_inf = std::numeric_limits<float>::infinity();
     float t_nan = std::nanf("");
 
     ttnn::rsqrt(input, false, output_mem_config, input_grad);
@@ -490,7 +489,10 @@ std::vector<std::optional<ttnn::Tensor>> rsqrt_bw(
         std::nullopt,
         output_mem_config,
         input_grad);
-    where(ttnn::eqz(input, output_mem_config), t_inf, input_grad.value(), output_mem_config, input_grad);
+    // d/dx rsqrt(x) is -0.5 * x^-3/2, so at zero the answer is -inf for a positive gradient
+    // and +inf for a negative one -- which is what the arithmetic above already produces,
+    // since rsqrt(0) is inf and the -0.5f carries the sign. Writing +inf unconditionally
+    // inverted it for every positive gradient.
     where(ttnn::ltz(input, output_mem_config), t_nan, input_grad.value(), output_mem_config, input_grad);
     where(
         ttnn::logical_and(


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53973.

`rsqrt_bw` wrote `+inf` at zero unconditionally. `d/dx rsqrt(x)` is `-0.5 * x^-3/2`, so the answer there is `-inf` for a positive incoming gradient and `+inf` for a negative one — which the arithmetic three lines above already produces, since `rsqrt(0)` is inf and the `-0.5f` carries the sign. The line is deleted; the out-of-domain guard stays.

`sqrt_bw` is deliberately left alone. The issue's original premise was that its host-side guards duplicate the in-kernel domain check; measured, they do not — with them removed the arithmetic returns **0** for a negative input rather than NaN, because `reciprocal(2 * NaN)` is 0, and 16358 of 4194304 float32 values regress.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device, output bits compared as integers.

`sqrt_bw` and `rsqrt_bw`, every one of the 65536 bfloat16 bit patterns in each operand position against three counterparts, 2^22 float32 patterns the same way — 24 sweeps, 51118080 values:

| | P300 | N300 |
|---|---|---|
| `sqrt_bw`, values moved | **0** | **0** |
| `rsqrt_bw` with a non-zero input, values moved | 2 | 2 |
| `rsqrt_bw` with input zero, values moved | 2145453 | 2145199 |

Every moved value is a zero-input case, and they move toward torch. Gradient swept, input 0:

| wrong vs torch | P300 before | P300 after | N300 before | N300 after |
|---|---|---|---|---|
| `rsqrt_bw`, bfloat16 | 32896 / 65536 | **383** | 32896 / 65536 | **256** |
| `rsqrt_bw`, float32 | 2104251 / 4194304 | **16358** | 2104251 / 4194304 | **16358** |
| `sqrt_bw`, bfloat16 | 256 / 65536 | 256 | 256 / 65536 | 256 |
| `sqrt_bw`, float32 | 0 | 0 | 0 | 0 |

## Cost

One dispatch fewer: the `eqz` and its `where` are gone.

## Tests

`test_rsqrt_bw_zero_sign.py`, 20 cases: `rsqrt_bw` at zero for three gradient signs in both dtypes, three in-domain points against torch, the out-of-domain case, and `sqrt_bw` asserted unchanged at the same points. 4 of the 20 fail on `04cf22f7ee`, on both machines; all 20 pass here, on P300 and on N300.

## Not covered

- The residual after the fix — 383 of 65536 bfloat16 values on P300, 256 on N300 — which is entirely subnormal gradients, NaN gradients and the two zeros, classes where the bfloat16 Dest and the subnormal flush already misbehave.
- `sqrt_bw` at `-0.0`, which returns `+inf` where torch says `-inf`. That traces through `sqrt(-0.0)` returning NaN and `multiply(-0.0, 2.0f)` returning `+0.0`, both filed separately.
