### PR TITLE
[Bug fix] sqrt / rsqrt: -0.0 is in the domain

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_sqrt_negative_zero.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_sqrt_negative_zero.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""sqrt(-0.0) is -0.0 and rsqrt(-0.0) is -inf.
+
+The domain guard compares with a sign-bit test, so negative zero landed with the
+genuinely negative values and came back as NaN. IEEE-754 and torch both put -0.0
+in the domain.
+"""
+
+import math
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 32, 32)
+
+
+def _t(v, dtype, device):
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    return ttnn.from_torch(
+        torch.full(SHAPE, v, dtype=torch_dtype), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+
+def test_sqrt_of_negative_zero_is_negative_zero(device):
+    got = ttnn.to_torch(ttnn.sqrt(_t(-0.0, ttnn.float32, device))).flatten()[0].item()
+    assert got == 0.0 and math.copysign(1.0, got) < 0, f"expected -0.0, got {got}"
+
+
+def test_rsqrt_of_negative_zero_is_negative_infinity(device):
+    for dtype in (ttnn.float32, ttnn.bfloat16):
+        got = ttnn.to_torch(ttnn.rsqrt(_t(-0.0, dtype, device))).float().flatten()[0].item()
+        assert got == float("-inf"), f"{dtype}: expected -inf, got {got}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize("value, sqrt_want, rsqrt_want", [(4.0, 2.0, 0.5), (0.0, 0.0, float("inf"))])
+def test_the_domain_is_unchanged(device, dtype, value, sqrt_want, rsqrt_want):
+    assert ttnn.to_torch(ttnn.sqrt(_t(value, dtype, device))).float().flatten()[0].item() == sqrt_want
+    assert ttnn.to_torch(ttnn.rsqrt(_t(value, dtype, device))).float().flatten()[0].item() == rsqrt_want
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_genuinely_negative_input_still_leaves_the_domain(device, dtype):
+    got = ttnn.to_torch(ttnn.sqrt(_t(-4.0, dtype, device))).float().flatten()[0].item()
+    # bfloat16 Dest cannot carry NaN and returns an infinity instead.
+    assert got != got or math.isinf(got), f"expected NaN or inf, got {got}"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -77,7 +77,20 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
     }
 
     if constexpr (!FAST_APPROX) {
-        v_if(x < 0.0f) { y = std::numeric_limits<float>::quiet_NaN(); }
+        v_if(x < 0.0f) {
+            y = std::numeric_limits<float>::quiet_NaN();
+            // -0.0 is in the domain. The comparison above is a sign-bit test, so it lands
+            // here with the genuinely negative values; IEEE-754 says sqrt(-0) is -0 and
+            // rsqrt(-0) is -inf, which is also what torch returns.
+            v_if(sfpi::as<sfpi::vInt>(x) == static_cast<int>(0x80000000)) {
+                if constexpr (RECIPROCAL) {
+                    y = -std::numeric_limits<float>::infinity();
+                } else {
+                    y = x;
+                }
+            }
+            v_endif;
+        }
         v_endif;
     }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -76,8 +76,19 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
         }
     }
     if constexpr (!FAST_APPROX) {
-        v_if(x < 0.0F) {
-            y = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
+        v_if(x < 0.0f) {
+            y = std::numeric_limits<float>::quiet_NaN();
+            // -0.0 is in the domain. The comparison above is a sign-bit test, so it lands
+            // here with the genuinely negative values; IEEE-754 says sqrt(-0) is -0 and
+            // rsqrt(-0) is -inf, which is also what torch returns.
+            v_if(sfpi::as<sfpi::vInt>(x) == static_cast<int>(0x80000000)) {
+                if constexpr (RECIPROCAL) {
+                    y = -std::numeric_limits<float>::infinity();
+                } else {
+                    y = x;
+                }
+            }
+            v_endif;
         }
         v_endif;
     }


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53975.

The domain guard in `_calculate_sqrt_body_` compares with a sign-bit test, so `-0.0` landed with the genuinely negative values and came back as NaN. IEEE-754 and torch both put it in the domain: `sqrt(-0)` is `-0` and `rsqrt(-0)` is `-inf`. The guard now separates the one bit pattern that belongs in the domain from the ones that do not.

Applied identically to Blackhole and Wormhole B0, which carry the same guard.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device with the JIT cache cleared on both sides, output bits compared as integers.

`sqrt` and `rsqrt` in both modes, every one of the 65536 bfloat16 bit patterns and 2^22 float32 patterns:

| sweep | values | P300 moved | N300 moved |
|---|---|---|---|
| sqrt, bfloat16, exact | 65536 | **1** — the -0.0 pattern | **1** |
| rsqrt, bfloat16, exact | 65536 | **1** — the -0.0 pattern | **1** |
| sqrt / rsqrt, bfloat16, fast | 131072 | 0 | 0 |
| sqrt / rsqrt, float32, both modes | 16777216 | 0 | 0 |
| **total** | **17039360** | **2** | **2** |

The float32 sample does not happen to contain the `-0.0` bit pattern; it is covered by the targeted case below.

| x = -0.0 | main | this branch | torch |
|---|---|---|---|
| `sqrt`, float32 | NaN | **-0.0** | -0.0 |
| `rsqrt`, float32 | NaN | **-inf** | -inf |
| `rsqrt`, bfloat16 | inf | **-inf** | -inf |

The rest of the domain is untouched: `sqrt(4)` is 2, `sqrt(0)` is 0, `rsqrt(0)` is inf, and `sqrt(-4)` still leaves the domain — NaN in float32, inf in bfloat16 because Dest cannot carry NaN.

## Cost

None. One `v_if` inside a branch that already only runs for negative inputs, in the non-fast path only.

## Tests

`test_sqrt_negative_zero.py`, 8 cases: `sqrt(-0.0)` asserted to be negative zero including its sign, `rsqrt(-0.0)` asserted to be -inf in both dtypes, the ordinary domain asserted unchanged, and a genuinely negative input asserted to still leave the domain. 2 of the 8 fail on `04cf22f7ee`, on both machines; all 8 pass here, on P300 and on N300.

## Not covered

- The `FAST_APPROX` path, which has no guard by design and still returns 7.0116e-20 for this input. Guarding it costs the ~4% that flag buys.
- bfloat16 `sqrt(-0.0)`, which comes back as `+0.0` even here — the sign of zero does not survive the bfloat16 Dest, and that is not specific to this op: `ttnn.identity(-0.0)` returns `+0.0` in bfloat16 too, while the same input through a float32 tensor keeps its sign. `rsqrt` is right in bfloat16 because -inf does survive.

