### PR TITLE
buffers: don't deallocate through a dangling allocator pointer

### DIFF
--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -567,7 +567,26 @@ void Buffer::deallocate_impl() {
                     tt::tt_metal::emule::LiveDramRanges::remove(device_->id(), static_cast<uint32_t>(address_));
                 }
             }
-            allocator_->deallocate_buffer(this);
+            // `allocator_` is a raw AllocatorImpl*, but IDevice owns its AllocatorImpl
+            // through a unique_ptr. A buffer that outlives an allocator swap on a device
+            // that is still initialized therefore holds a dangling pointer, and
+            // deallocate_buffer() then blocks forever inside the destroyed mutex. The
+            // device_->is_initialized() check above guards the DEVICE, not the ALLOCATOR,
+            // so it does not catch this case. Recompute the owning allocator the same way
+            // the constructor did (see Buffer::Buffer) and skip the free when it is gone:
+            // the ranges it tracked died with it.
+            const AllocatorImpl* live_allocator = sub_device_id_.has_value()
+                                                      ? device_->allocator_impl(*sub_device_id_).get()
+                                                      : device_->allocator_impl().get();
+            if (allocator_ != live_allocator) {
+                log_warning(
+                    tt::LogMetal,
+                    "Buffer {} (type {}) outlived the allocator it was created from; skipping deallocation.",
+                    unique_id_,
+                    enchantum::to_string(buffer_type_));
+            } else {
+                allocator_->deallocate_buffer(this);
+            }
         }
 
         // Capture deallocates here instead of higher levels.


### PR DESCRIPTION
`Buffer::allocator_` is a raw `AllocatorImpl*`, but `IDevice` owns its `AllocatorImpl` through a `unique_ptr`. A buffer that outlives an allocator swap on a device that is still initialized keeps a pointer to the destroyed allocator; `Buffer::deallocate_impl()` then calls `deallocate_buffer()` on freed memory and blocks forever inside the destroyed `std::mutex`. The existing `device_->is_initialized()` guard checks the DEVICE, not the ALLOCATOR, so it does not catch this.

Recompute the owning allocator the same way `Buffer::Buffer` does (the sub-device allocator when `sub_device_id_` is set, the default one otherwise) and skip the free when it no longer matches: the ranges that allocator tracked died with it.

Found as a permanent hang in blaze's CI, bisected over 194 commits to a36575e99a0 ("[Performance] Per-core H2D socket FIFO in hybrid mode"). That change routes the H2D socket FIFO through the per-core branch of `MeshBuffer::deallocate()`, which drops the per-device `Buffer`s late enough that a socket kept alive across a mesh-device teardown reaches an allocator that is already gone. Reverting a36575e99a0 also makes the hang go away, but the dangling pointer is the real defect: `TT_METAL_ALLOCATOR_MODE_HYBRID=1` is merely what arms the per-core path, and any buffer outliving an allocator swap hits the same wedge with no diagnostics.

Evidence: instrumenting the deallocation path showed exactly one allocator-pointer mismatch across ~840k deallocations in a single run, on the very buffer that then hung. The allocator's own mutex was idle and unowned at that moment (acquire/release counts balanced, no recorded holder), consistent with the object backing it having been destroyed rather than with any lock contention.

With this change the same command passes (4 passed, 142s) without any blaze side change.

Based on d103fddd8fc; may need a rebase onto current main.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yuqiaoli/fix-buffer-dangling-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yuqiaoli/fix-buffer-dangling-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yuqiaoli/fix-buffer-dangling-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yuqiaoli/fix-buffer-dangling-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yuqiaoli/fix-buffer-dangling-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yuqiaoli/fix-buffer-dangling-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yuqiaoli/fix-buffer-dangling-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yuqiaoli/fix-buffer-dangling-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yuqiaoli/fix-buffer-dangling-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yuqiaoli/fix-buffer-dangling-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yuqiaoli/fix-buffer-dangling-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yuqiaoli/fix-buffer-dangling-allocator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yuqiaoli/fix-buffer-dangling-allocator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yuqiaoli/fix-buffer-dangling-allocator)