### PR TITLE
Kimi-K3 prefill: MLA/KDA block dispatch [review only, do not merge]

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -12,7 +12,8 @@ Values from HuggingFace config.json for Kimi-K3 (``text_config``), whose ``model
 the TT stack reads lives under ``text_config``.
 
 K3 is a **hybrid**: of its 93 layers only 24 are full-attention (MLA) layers, the rest are KDA
-linear-attention layers. Only the MLA side is modelled here.
+linear-attention layers. The MLA dimensions are spelled out below; the KDA ones are handed to
+``KDAConfig`` through :func:`kimi_k3_kda_config`.
 
 MLA deltas vs Kimi-K2.6:
   * 96 attention heads (K2.6: 64)
@@ -30,6 +31,9 @@ included, is plain bf16. Only the MoE routed experts are quantized.
 """
 
 import types
+from typing import Any
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
 
 
 class KimiK3Config:
@@ -93,11 +97,21 @@ class KimiK3Config:
                                52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 93]
     # fmt: on
 
-    # KDA (linear attention) sizing, recorded for completeness; no TT implementation exists yet.
+    # KDA (linear attention) sizing. ``head_k_dim`` and ``head_v_dim`` are both KDA_HEAD_DIM.
     KDA_NUM_HEADS = 96
     KDA_HEAD_DIM = 128
     KDA_SHORT_CONV_KERNEL_SIZE = 4
     KDA_GATE_LOWER_BOUND = -5.0
+    KDA_USE_FULL_RANK_GATE = True
+
+    # Device-side KDA tuning, not checkpoint fields: chunks per distributed-affine summary group,
+    # and the output projection's per-core output block width.
+    KDA_SUMMARY_GROUP_CHUNKS = 20
+    KDA_OUTPUT_PROJECTION_OUT_BLOCK_W = 4
+
+    # 0-indexed layer index the single-layer KDA tests load weights for. Layer 0 is also KDA but
+    # pairs it with the dense MLP (``NUM_DENSE_LAYERS``); 1 is the first KDA layer in an MoE block.
+    FIRST_KDA_LAYER = 1
 
     # AttnRes (attention-side, out of scope here; recorded so the delta is not lost)
     ATTN_RES_BLOCK_SIZE = 12
@@ -133,6 +147,32 @@ class KimiK3Config:
         if layer_idx not in ids:
             raise ValueError(f"model layer {layer_idx} is a KDA layer, not an MLA layer; MLA layers are {ids}")
         return ids.index(layer_idx)
+
+
+def kimi_k3_model_config() -> dict[str, Any]:
+    """The HF-JSON-shaped subset of K3's ``text_config`` that ``KDAConfig`` reads.
+
+    ``KDAConfig.from_model_config`` parses the checkpoint's own nested JSON, so the KDA constants
+    are handed back in that shape rather than as keyword arguments.
+    """
+    return {
+        "hidden_size": KimiK3Config.EMB_SIZE,
+        "num_hidden_layers": KimiK3Config.NUM_LAYERS,
+        "num_attention_heads": KimiK3Config.NUM_ATTENTION_HEADS,
+        "rms_norm_eps": KimiK3Config.RMS_NORM_EPS,
+        "linear_attn_config": {
+            "num_heads": KimiK3Config.KDA_NUM_HEADS,
+            "head_dim": KimiK3Config.KDA_HEAD_DIM,
+            "short_conv_kernel_size": KimiK3Config.KDA_SHORT_CONV_KERNEL_SIZE,
+            "use_full_rank_gate": KimiK3Config.KDA_USE_FULL_RANK_GATE,
+            "gate_lower_bound": KimiK3Config.KDA_GATE_LOWER_BOUND,
+        },
+    }
+
+
+def kimi_k3_kda_config() -> KDAConfig:
+    """Reference KDA configuration for one Kimi-K3 KDA layer."""
+    return KDAConfig.from_model_config(kimi_k3_model_config())
 
 
 def kimi_k3_hf_config(max_seq: int = 8192):

--- a/models/demos/deepseek_v3_d_p/tests/kda/AGENTS.md
+++ b/models/demos/deepseek_v3_d_p/tests/kda/AGENTS.md
@@ -1,0 +1,115 @@
+# Kimi Delta Attention tests
+
+Run every device test through `scripts/run_safe_pytest.sh`. A passing hardware run must end with `SAFE_PYTEST_RESULT: PASS`; a skip is not a pass.
+
+## Policy
+
+- Hermetic tests use deterministic synthetic weights and never depend on local checkpoint discovery.
+- Real-weight tests require an explicit `KIMI_K3_CKPT` path, provided by `conftest.py`.
+- Numerical result assertions use only the three contracts in `utils.py`; do not add local wrappers
+  or direct Torch tensor comparisons.
+- `assert_accurate` compares an oracle with an implementation: both tensors must be finite and their
+  PCC must meet the test's threshold.
+- `assert_equal` checks finite oracle/implementation tensors for identical shape, dtype, and values.
+- `assert_bit_identical` compares implementation repetitions without computing a CPU oracle.
+- Dedicated determinism tests run the implementation three times from identical inputs and state.
+  They do not compute a CPU reference; every output and final-state tensor must be bit-identical.
+- CPU-reference determinism uses T=128 and three repetitions. It is marked `long_running` and skips
+  unless `KDA_RUN_LONG_TESTS=1`.
+- Required performance acceptance is real Kimi-K3, B=1, T=5120 on SP1xTP8, SP2xTP4, and SP4xTP2.
+- LoudBox references and regression limits live in `perf/perf_targets/bh_loudbox.json`.
+- Rebaseline only when the workload, hardware/runtime contract, or accepted baseline changes.
+- `model/test_real_weights.py` checks output and both states against the independent Torch reference
+  and requires usable realtime program records.
+- `perf/test_layer_perf.py` checks those endpoints on a synchronized eager forward, then measures
+  warm trace-replay wall time. Timing repetitions are not accuracy or determinism samples.
+- Use synchronized trace wall time for routine latency and Tracy only for targeted attribution.
+
+## Catalogue
+
+```text
+tests/
+├── conftest.py                         — Pinned checkpoint fixture plus perf and optional
+│                                         long-running marker registration.
+├── checkpoint_utils.py                 — Indexed Kimi-K3 layer loading for tests.
+├── test_cache_fingerprints.py           — Persistent tensor and CPU-oracle cache identities.
+├── test_numeric_validation.py          — Accuracy, equality, bit-identity, and finiteness contracts.
+├── utils.py                            — Three numeric contracts; case builders,
+│                                         reconstruction, and profiling support.
+├── checkpoint/
+│   └── test_checkpoint.py              — Indexed-shard loading, failures, and weight
+│                                         validation, and padded K3 A_log normalization.
+├── operations/
+│   ├── test_chunk.py                   — chunk recurrence accuracy, grouped invariance, and
+│   │                                     bit-identical implementation determinism.
+│   ├── test_distributed_affine.py      — Prefix accuracy, cache/trace replay, and
+│   │                                     bit-identical implementation determinism.
+│   └── test_halo.py                    — Halo accuracy on both TP axes and
+│                                         implementation determinism.
+├── model/
+│   ├── test_distributed_layer.py       — SP accuracy, segmented continuity, and
+│   │                                     bit-identical implementation determinism.
+│   ├── test_layer.py                   — Composed accuracy, state/cache contracts, immutable
+│   │                                     trace replay, and bit-identical determinism.
+│   ├── test_real_weights.py            — Kimi-K3 layer-1 accuracy on all layouts
+│   │                                     with required realtime program records.
+│   └── test_weights.py                 — TP placement and output-projection accuracy plus
+│                                         bit-identical projection determinism.
+└── perf/
+    ├── perf_targets/
+    │   ├── bh_loudbox.json             — T=5120 trace-wall references and provenance;
+    │   │                                 and one-sided regression limits.
+    └── test_layer_perf.py              — T=5120 accuracy and trace-wall acceptance on
+                                          SP1xTP8, SP2xTP4, and SP4xTP2.
+```
+
+Direct tests for the six split device operations live under
+`tests/ttnn/nightly/unit_tests/operations/experimental/kda/`; do not duplicate
+them in the model test tree.
+
+CPU-reference tests live beside the implementation:
+
+```text
+models/demos/deepseek_v3_d_p/reference/kda/tests/
+├── test_config.py                       — Config mapping and validation contracts.
+├── test_layer.py                        — Transition accuracy and optional bounded determinism.
+└── test_ops.py                          — Torch operation identities and accuracy checks.
+```
+
+## Commands
+
+Hermetic and real-weight correctness, excluding perf:
+
+```bash
+KIMI_K3_CKPT=/path/to/pinned/kimi-k3 \
+scripts/run_safe_pytest.sh --run-all \
+  models/demos/deepseek_v3_d_p/tests/kda \
+  models/demos/deepseek_v3_d_p/reference/kda/tests \
+  --ignore=models/demos/deepseek_v3_d_p/tests/kda/perf -q -s
+```
+
+Independent real-weight PCC:
+
+```bash
+KIMI_K3_CKPT=/path/to/pinned/kimi-k3 \
+scripts/run_safe_pytest.sh \
+  models/demos/deepseek_v3_d_p/tests/kda/model/test_real_weights.py -q -s
+```
+
+Required performance matrix:
+
+```bash
+KIMI_K3_CKPT=/path/to/pinned/kimi-k3 PERF_REPS=10 \
+scripts/run_safe_pytest.sh --run-all \
+  models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py -q -s
+```
+
+Optional bounded CPU-reference determinism:
+
+```bash
+KDA_RUN_LONG_TESTS=1 scripts/run_safe_pytest.sh \
+  models/demos/deepseek_v3_d_p/reference/kda/tests/test_layer.py \
+  -k reference_layer_determinism
+```
+
+Add `--profile` only for a specific Tracy investigation and use an exact node ID; `run_safe_pytest.sh --profile` does not preserve a spaced `-k` expression as one argument.

--- a/models/demos/deepseek_v3_d_p/tests/kda/checkpoint/test_checkpoint.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/checkpoint/test_checkpoint.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for indexed KDA checkpoint loading."""
+
+import json
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import (
+    kda_layer_prefix,
+    load_kda_layer_state_dict,
+    required_kda_weight_names,
+    resolve_kda_layer_shards,
+)
+from models.demos.deepseek_v3_d_p.tests.kda.utils import assert_equal, random_weights
+from models.demos.deepseek_v3_d_p.tt.kda.weight_schema import normalize_kda_state_dict, validate_kda_weights
+
+
+def _full_rank_config(*, num_heads: int = 2) -> KDAConfig:
+    return KDAConfig(
+        hidden_size=64,
+        num_heads=num_heads,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+        use_full_rank_gate=True,
+        gate_lower_bound=-5.0,
+    )
+
+
+def _write_indexed_layer(checkpoint_dir: Path, layer_idx: int, config: KDAConfig) -> Path:
+    shard_name = "model-00001-of-00001.safetensors"
+    prefix = kda_layer_prefix(layer_idx)
+    weights = {f"{prefix}{name}": tensor.contiguous() for name, tensor in random_weights(config).items()}
+    save_file(weights, checkpoint_dir / shard_name)
+    index = {"weight_map": {name: shard_name for name in weights}}
+    (checkpoint_dir / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+    return checkpoint_dir / shard_name
+
+
+def test_loads_one_indexed_full_rank_kda_layer(tmp_path: Path) -> None:
+    config = _full_rank_config()
+    shard = _write_indexed_layer(tmp_path, layer_idx=1, config=config)
+
+    assert resolve_kda_layer_shards(tmp_path, 1, config) == (shard,)
+    actual = load_kda_layer_state_dict(tmp_path, 1, config)
+
+    assert set(actual) == set(required_kda_weight_names(config))
+    assert "g_proj.weight" in actual
+    assert "g_a_proj.weight" not in actual
+    assert actual["A_log"].shape == (1, 1, config.num_heads, 1)
+
+
+def test_rejects_incomplete_checkpoint_shard_set(tmp_path: Path, expect_error) -> None:
+    config = _full_rank_config()
+    _write_indexed_layer(tmp_path, layer_idx=1, config=config).unlink()
+
+    with expect_error(FileNotFoundError, "missing complete KDA checkpoint shard"):
+        resolve_kda_layer_shards(tmp_path, 1, config)
+
+
+def test_rejects_index_missing_required_kda_weight(tmp_path: Path, expect_error) -> None:
+    config = _full_rank_config()
+    _write_indexed_layer(tmp_path, layer_idx=1, config=config)
+    index_path = tmp_path / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    del index["weight_map"][f"{kda_layer_prefix(1)}g_proj.weight"]
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    with expect_error(ValueError, "g_proj.weight"):
+        resolve_kda_layer_shards(tmp_path, 1, config)
+
+
+def test_weight_validation_reports_exact_name_and_shape(expect_error) -> None:
+    config = _full_rank_config()
+    weights = random_weights(config)
+    weights["q_proj.weight"] = torch.empty(config.q_dim, config.hidden_size + 1)
+
+    with expect_error(ValueError, r"q_proj\.weight shape .* !="):
+        validate_kda_weights(weights, config)
+
+
+def test_normalize_state_dict_trims_kimi_k3_padded_a_log() -> None:
+    config = _full_rank_config(num_heads=96)
+    state_dict = random_weights(config)
+    padded = torch.arange(128, dtype=torch.float32)
+    state_dict["A_log"] = padded
+
+    normalized = normalize_kda_state_dict(state_dict, config)
+
+    assert normalized["A_log"].shape == (1, 1, config.num_heads, 1)
+    assert_equal(padded[: config.num_heads], normalized["A_log"].reshape(-1), name="trimmed A_log")
+
+
+def test_normalize_state_dict_rejects_unsupported_a_log_padding(expect_error) -> None:
+    config = _full_rank_config(num_heads=96)
+    state_dict = random_weights(config)
+    state_dict["A_log"] = torch.arange(127, dtype=torch.float32)
+
+    with expect_error(ValueError, "A_log has 127 entries"):
+        normalize_kda_state_dict(state_dict, config)

--- a/models/demos/deepseek_v3_d_p/tests/kda/checkpoint_utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/checkpoint_utils.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Indexed safetensor loading for one Kimi Delta Attention layer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tt.kda.weight_schema import (
+    normalize_kda_a_log,
+    required_kda_weight_names,
+    validate_kda_weights,
+)
+
+
+def kda_layer_prefix(layer_idx: int) -> str:
+    """Return Kimi-K3's Hugging Face prefix for one KDA layer."""
+    if layer_idx < 0:
+        raise ValueError(f"layer_idx must be nonnegative, got {layer_idx}")
+    return f"language_model.model.layers.{layer_idx}.self_attn."
+
+
+def resolve_kda_layer_shards(checkpoint_dir: Path, layer_idx: int, config: KDAConfig) -> tuple[Path, ...]:
+    """Resolve and validate the complete local shards containing one KDA layer."""
+    checkpoint_dir = Path(checkpoint_dir)
+    index_path = checkpoint_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise FileNotFoundError(f"missing safetensor index: {index_path}")
+    with index_path.open(encoding="utf-8") as index_file:
+        weight_map = json.load(index_file).get("weight_map", {})
+
+    prefix = kda_layer_prefix(layer_idx)
+    full_names = {name: f"{prefix}{name}" for name in required_kda_weight_names(config)}
+    missing = [name for name, full_name in full_names.items() if full_name not in weight_map]
+    if missing:
+        raise ValueError(f"layer {layer_idx} checkpoint index is missing KDA weights: {missing}")
+
+    shards = tuple(sorted({checkpoint_dir / weight_map[full_name] for full_name in full_names.values()}))
+    missing_shards = [path for path in shards if not path.is_file()]
+    if missing_shards:
+        raise FileNotFoundError(f"missing complete KDA checkpoint shard(s): {missing_shards}")
+    return shards
+
+
+def load_kda_layer_state_dict(checkpoint_dir: Path, layer_idx: int, config: KDAConfig) -> dict[str, torch.Tensor]:
+    """Load and canonicalize one KDA layer from complete indexed safetensor shards."""
+    checkpoint_dir = Path(checkpoint_dir)
+    shards = resolve_kda_layer_shards(checkpoint_dir, layer_idx, config)
+    prefix = kda_layer_prefix(layer_idx)
+    required = required_kda_weight_names(config)
+    state_dict: dict[str, torch.Tensor] = {}
+    for shard in shards:
+        with safe_open(shard, framework="pt", device="cpu") as shard_file:
+            shard_keys = set(shard_file.keys())
+            for name in required:
+                full_name = f"{prefix}{name}"
+                if full_name in shard_keys:
+                    state_dict[name] = shard_file.get_tensor(full_name)
+
+    missing = [name for name in required if name not in state_dict]
+    if missing:
+        raise ValueError(f"layer {layer_idx} checkpoint shard(s) are missing KDA weights: {missing}")
+    state_dict["A_log"] = normalize_kda_a_log(state_dict["A_log"], config)
+    validate_kda_weights(state_dict, config)
+    return state_dict

--- a/models/demos/deepseek_v3_d_p/tests/kda/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared KDA test fixtures."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "perf: mark explicit KDA performance tests")
+    config.addinivalue_line("markers", "long_running: mark opt-in KDA tests excluded from routine runs")
+
+
+@pytest.fixture(scope="session")
+def kimi_k3_checkpoint_dir() -> Path:
+    """Return the explicitly selected pinned Kimi-K3 checkpoint subset."""
+    value = os.getenv("KIMI_K3_CKPT")
+    if value is None:
+        pytest.skip("set KIMI_K3_CKPT to the pinned Kimi-K3 checkpoint subset")
+    return Path(value)

--- a/models/demos/deepseek_v3_d_p/tests/kda/model/test_distributed_layer.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/model/test_distributed_layer.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end KDA sequence-parallel correctness tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    assert_accurate,
+    assert_bit_identical,
+    random_weights,
+    reconstruct_convolution_at_sp_rank,
+    reconstruct_sp_tp_tensor,
+    reconstruct_state_at_sp_rank,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, KDARecurrenceProgramConfig
+from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
+from models.tt_transformers.tt.ccl import TT_CCL
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+]
+
+
+def _to_sp_input(
+    hidden: torch.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+) -> ttnn.Tensor:
+    mesh_dims = [None, None]
+    mesh_dims[sp_axis] = 1
+    return ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=tuple(mesh_dims), mesh_shape=tuple(mesh_device.shape)),
+    )
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_sp_layer_matches_serial_reference(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    config = KDAConfig(
+        hidden_size=128,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    weights = random_weights(config)
+    sequence = 1024
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(937)).to(
+        torch.bfloat16
+    )
+    expected_output, expected_state = kda_forward_reference(hidden, weights, config)
+
+    sp_axis = 1 - tensor_parallel_axis
+    program_config = KDAProgramConfig(
+        recurrence=KDARecurrenceProgramConfig(summary_group_chunks=8),
+        gated_rms_output_dtype=ttnn.bfloat16,
+        output_projection_math_fidelity=ttnn.MathFidelity.HiFi2,
+    )
+    layer = ttKDA(
+        mesh_device,
+        config,
+        weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sp_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=program_config,
+    )
+    initial_state = layer.allocate_state(batch_size=1)
+    hidden_tt = _to_sp_input(hidden, mesh_device, sp_axis)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output_tt, state = layer.forward(hidden_tt, initial_state)
+
+    actual_output = reconstruct_sp_tp_tensor(
+        output_tt,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        tp_dim=2,
+        sp_dim=1,
+    )
+    expected_convolution = torch.cat(
+        (expected_state.q_convolution, expected_state.k_convolution, expected_state.v_convolution), dim=-1
+    )
+    local_heads = config.num_heads // tuple(mesh_device.shape)[tensor_parallel_axis]
+    local_width = local_heads * config.head_k_dim
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+
+    assert_accurate(
+        expected_output,
+        actual_output,
+        name=f"tp_axis={tensor_parallel_axis} output",
+        pcc_threshold=0.98,
+    )
+    for sp_rank in range(sp_size):
+        actual_recurrent = reconstruct_state_at_sp_rank(
+            state.recurrent, mesh_device, sp_axis, tensor_parallel_axis, sp_rank
+        )
+        actual_convolution = reconstruct_convolution_at_sp_rank(
+            state.convolution,
+            mesh_device,
+            sp_axis,
+            tensor_parallel_axis,
+            sp_rank,
+            local_width,
+        )
+        assert_accurate(
+            expected_state.recurrent,
+            actual_recurrent,
+            name=f"tp_axis={tensor_parallel_axis} sp_rank={sp_rank} recurrent",
+            pcc_threshold=0.98,
+        )
+        assert_accurate(
+            expected_convolution,
+            actual_convolution,
+            name=f"tp_axis={tensor_parallel_axis} sp_rank={sp_rank} convolution",
+            pcc_threshold=0.98,
+        )
+
+
+@pytest.mark.parametrize(
+    "tensor_parallel_axis,summary_group_chunks,splits",
+    [
+        (1, 8, (2048, 3072)),
+        (0, 8, (2048, 3072)),
+        (1, 10, (2560, 2560)),
+        (0, 10, (2560, 2560)),
+    ],
+)
+def test_sp_chunked_prefill_matches_one_shot(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    summary_group_chunks: int,
+    splits: tuple[int, int],
+) -> None:
+    config = KDAConfig(
+        hidden_size=128,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    weights = random_weights(config)
+    sequence = sum(splits)
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(421)).to(
+        torch.bfloat16
+    )
+    sp_axis = 1 - tensor_parallel_axis
+    layer = ttKDA(
+        mesh_device,
+        config,
+        weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sp_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=KDAProgramConfig(
+            recurrence=KDARecurrenceProgramConfig(summary_group_chunks=summary_group_chunks)
+        ),
+    )
+
+    one_shot_input_state = layer.allocate_state(batch_size=1)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        one_shot_tt, one_shot_state = layer.forward(_to_sp_input(hidden, mesh_device, sp_axis), one_shot_input_state)
+    one_shot = reconstruct_sp_tp_tensor(
+        one_shot_tt,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        tp_dim=2,
+        sp_dim=1,
+    )
+    one_shot_recurrent = reconstruct_state_at_sp_rank(
+        one_shot_state.recurrent, mesh_device, sp_axis, tensor_parallel_axis, sp_rank=0
+    )
+    local_heads = config.num_heads // tuple(mesh_device.shape)[tensor_parallel_axis]
+    one_shot_convolution = reconstruct_convolution_at_sp_rank(
+        one_shot_state.convolution,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        sp_rank=0,
+        local_width=local_heads * config.head_k_dim,
+    )
+
+    chunked_state = layer.allocate_state(batch_size=1)
+    outputs = []
+    start = 0
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        for split in splits:
+            stop = start + split
+            output_tt, chunked_state = layer.forward(
+                _to_sp_input(hidden[:, start:stop], mesh_device, sp_axis), chunked_state
+            )
+            outputs.append(
+                reconstruct_sp_tp_tensor(
+                    output_tt,
+                    mesh_device,
+                    sp_axis,
+                    tensor_parallel_axis,
+                    tp_dim=2,
+                    sp_dim=1,
+                )
+            )
+            start = stop
+
+    chunked = torch.cat(outputs, dim=1)
+    chunked_recurrent = reconstruct_state_at_sp_rank(
+        chunked_state.recurrent, mesh_device, sp_axis, tensor_parallel_axis, sp_rank=0
+    )
+    chunked_convolution = reconstruct_convolution_at_sp_rank(
+        chunked_state.convolution,
+        mesh_device,
+        sp_axis,
+        tensor_parallel_axis,
+        sp_rank=0,
+        local_width=local_heads * config.head_k_dim,
+    )
+    label = f"tp_axis={tensor_parallel_axis} group={summary_group_chunks}"
+    assert_accurate(one_shot, chunked, name=f"{label} chunked output", pcc_threshold=0.98)
+    assert_accurate(
+        one_shot_recurrent,
+        chunked_recurrent,
+        name=f"{label} chunked recurrent",
+        pcc_threshold=0.98,
+    )
+    assert_accurate(
+        one_shot_convolution,
+        chunked_convolution,
+        name=f"{label} chunked convolution",
+        pcc_threshold=0.98,
+    )
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_sp_layer_determinism(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    config = KDAConfig(
+        hidden_size=128,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    weights = random_weights(config)
+    sp_axis = 1 - tensor_parallel_axis
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+    sequence = sp_size * ttnn.TILE_SIZE
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(2421)).to(
+        torch.bfloat16
+    )
+    layer = ttKDA(
+        mesh_device,
+        config,
+        weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sp_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=KDAProgramConfig(recurrence=KDARecurrenceProgramConfig(summary_group_chunks=1)),
+    )
+    hidden_tt = _to_sp_input(hidden, mesh_device, sp_axis)
+    tp_size = tuple(mesh_device.shape)[tensor_parallel_axis]
+    local_width = config.num_heads // tp_size * config.head_k_dim
+    results = []
+
+    for _ in range(3):
+        state = layer.allocate_state(batch_size=1)
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            output_tt, state = layer.forward(hidden_tt, state)
+        ttnn.synchronize_device(mesh_device)
+        tensors = [reconstruct_sp_tp_tensor(output_tt, mesh_device, sp_axis, tensor_parallel_axis, tp_dim=2, sp_dim=1)]
+        for sp_rank in range(sp_size):
+            tensors.append(
+                reconstruct_state_at_sp_rank(state.recurrent, mesh_device, sp_axis, tensor_parallel_axis, sp_rank)
+            )
+            tensors.append(
+                reconstruct_convolution_at_sp_rank(
+                    state.convolution,
+                    mesh_device,
+                    sp_axis,
+                    tensor_parallel_axis,
+                    sp_rank,
+                    local_width,
+                )
+            )
+        results.append(tuple(tensors))
+
+    for iteration, result in enumerate(results[1:], start=1):
+        for tensor_index, (expected, actual) in enumerate(zip(results[0], result)):
+            assert_bit_identical(expected, actual, name=f"SP layer tensor {tensor_index} iteration {iteration}")

--- a/models/demos/deepseek_v3_d_p/tests/kda/model/test_layer.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/model/test_layer.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Blackhole PCC tests for the composed TTNN KDA layer."""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    assert_accurate,
+    assert_bit_identical,
+    make_config,
+    make_program_config,
+    random_weights,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "trace_region_size": 256 * 1024 * 1024}],
+        indirect=True,
+    ),
+]
+
+
+def _forward(
+    layer: ttKDA,
+    hidden: torch.Tensor,
+    state: KdaState,
+) -> tuple[torch.Tensor, KdaState]:
+    hidden_tt = ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=layer.device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, next_state = layer.forward(hidden_tt, state)
+    return ttnn.to_torch(output), next_state
+
+
+def test_composed_layer_pcc(device: ttnn.Device) -> None:
+    config = make_config()
+    weights = random_weights(config)
+    sequence = 32
+    hidden = torch.randn(
+        1,
+        sequence,
+        config.hidden_size,
+        generator=torch.Generator().manual_seed(41 + sequence),
+    ).to(torch.bfloat16)
+    golden_output, golden_state = kda_forward_reference(hidden, weights, config)
+
+    layer = ttKDA(device, config, weights)
+    actual_output, next_state = _forward(layer, hidden, layer.allocate_state())
+    actual_recurrent = ttnn.to_torch(next_state.recurrent)
+    actual_convolution = ttnn.to_torch(next_state.convolution)
+    golden_convolution = torch.cat(
+        (
+            golden_state.q_convolution,
+            golden_state.k_convolution,
+            golden_state.v_convolution,
+        ),
+        dim=-1,
+    )
+    assert_accurate(golden_output, actual_output, name=f"T={sequence} output", pcc_threshold=0.98)
+    assert_accurate(golden_state.recurrent, actual_recurrent, name=f"T={sequence} recurrent state", pcc_threshold=0.98)
+    assert_accurate(golden_convolution, actual_convolution, name=f"T={sequence} convolution state", pcc_threshold=0.98)
+
+
+def test_offline_cache_and_cache_only_layer_pcc(device: ttnn.Device, tmp_path: Path, expect_error) -> None:
+    config = make_config()
+    state_dict = random_weights(config)
+    hidden = torch.randn(1, 32, config.hidden_size, generator=torch.Generator().manual_seed(151), dtype=torch.bfloat16)
+    golden_output, _ = kda_forward_reference(hidden, state_dict, config)
+    cache_prefix = "layer_0.kda"
+
+    assert not KDAWeights.check_cache_complete(tmp_path, cache_prefix, config, device)
+    with expect_error(FileNotFoundError, "incomplete KDA TTNN cache"):
+        KDAWeights.from_cache(device, config, tmp_path, cache_prefix)
+
+    KDAWeights.build_ttnn_cache(state_dict, tmp_path, cache_prefix, device, config)
+    assert KDAWeights.check_cache_complete(tmp_path, cache_prefix, config, device)
+    cached_weights = KDAWeights.from_cache(device, config, tmp_path, cache_prefix)
+    layer = ttKDA(device, config, weights=cached_weights)
+    actual_output, _ = _forward(layer, hidden, layer.allocate_state())
+    assert_accurate(golden_output, actual_output, name="cache-only output", pcc_threshold=0.98)
+
+
+def test_cache_only_load_rejects_corrupt_tensorbin(device: ttnn.Device, tmp_path: Path, expect_error) -> None:
+    config = make_config()
+    cache_prefix = "layer_0.kda"
+    KDAWeights.build_ttnn_cache(random_weights(config), tmp_path, cache_prefix, device, config)
+    next(tmp_path.glob("*.tensorbin")).write_bytes(b"corrupt")
+
+    with expect_error(RuntimeError, "too small"):
+        KDAWeights.from_cache(device, config, tmp_path, cache_prefix)
+
+
+def test_non_tile_aligned_sequence_is_rejected(device: ttnn.Device, expect_error) -> None:
+    config = make_config()
+    hidden = torch.randn(
+        1,
+        4,
+        config.hidden_size,
+        generator=torch.Generator().manual_seed(45),
+    ).to(torch.bfloat16)
+    layer = ttKDA(device, config, random_weights(config))
+    with expect_error(ValueError, r"requires local T .* divisible by 32, got T=4"):
+        _forward(layer, hidden, layer.allocate_state())
+
+
+def test_batch_greater_than_one_is_rejected_at_state_setup(device: ttnn.Device, expect_error) -> None:
+    config = make_config()
+    layer = ttKDA(device, config, random_weights(config))
+
+    with expect_error(ValueError, "batch_size=1"):
+        layer.allocate_state(batch_size=2)
+
+
+def test_segmented_prefill_cache_continuity(device: ttnn.Device) -> None:
+    config = make_config()
+    weights = random_weights(config)
+    hidden = torch.randn(
+        1,
+        64,
+        config.hidden_size,
+        generator=torch.Generator().manual_seed(73),
+    ).to(torch.bfloat16)
+    golden_first, golden_state = kda_forward_reference(hidden[:, :32], weights, config)
+    golden_second, golden_state = kda_forward_reference(hidden[:, 32:], weights, config, golden_state)
+
+    layer = ttKDA(device, config, weights)
+    state = layer.allocate_state()
+    actual_first, state = _forward(layer, hidden[:, :32], state)
+    actual_second, state = _forward(layer, hidden[:, 32:], state)
+    actual_recurrent = ttnn.to_torch(state.recurrent)
+    actual_convolution = ttnn.to_torch(state.convolution)
+    golden_convolution = torch.cat(
+        (
+            golden_state.q_convolution,
+            golden_state.k_convolution,
+            golden_state.v_convolution,
+        ),
+        dim=-1,
+    )
+    assert_accurate(golden_first, actual_first, name="first prefill segment output", pcc_threshold=0.98)
+    assert_accurate(golden_second, actual_second, name="second prefill segment output", pcc_threshold=0.98)
+    assert_accurate(golden_state.recurrent, actual_recurrent, name="cache recurrent state", pcc_threshold=0.98)
+    assert_accurate(golden_convolution, actual_convolution, name="cache convolution state", pcc_threshold=0.98)
+
+
+def test_explicit_fp32_state_is_replaced_without_mutating_input(device: ttnn.Device) -> None:
+    config = make_config()
+    weights = random_weights(config)
+    hidden = torch.randn(
+        1,
+        64,
+        config.hidden_size,
+        generator=torch.Generator().manual_seed(109),
+    ).to(torch.bfloat16)
+    golden_output, golden_state = kda_forward_reference(hidden, weights, config)
+
+    layer = ttKDA(
+        device,
+        config,
+        weights,
+        program_config=make_program_config(),
+    )
+    input_state = layer.allocate_state()
+    external_recurrent = input_state.recurrent
+    external_convolution = input_state.convolution
+    recurrent_address = external_recurrent.buffer_address()
+    convolution_address = external_convolution.buffer_address()
+    first, next_state = _forward(layer, hidden[:, :32], input_state)
+    second, next_state = _forward(layer, hidden[:, 32:], next_state)
+    actual_output = torch.cat((first, second), dim=1)
+
+    assert input_state.recurrent is external_recurrent
+    assert input_state.convolution is external_convolution
+    assert input_state.recurrent.buffer_address() == recurrent_address
+    assert input_state.convolution.buffer_address() == convolution_address
+    assert next_state.recurrent.dtype == ttnn.float32
+    actual_recurrent = ttnn.to_torch(next_state.recurrent)
+    actual_convolution = ttnn.to_torch(next_state.convolution)
+    golden_convolution = torch.cat(
+        (
+            golden_state.q_convolution,
+            golden_state.k_convolution,
+            golden_state.v_convolution,
+        ),
+        dim=-1,
+    )
+    assert_accurate(golden_output, actual_output, name="external FP32 output", pcc_threshold=0.98)
+    assert_accurate(
+        golden_state.recurrent,
+        actual_recurrent,
+        name="external FP32 recurrent state",
+        pcc_threshold=0.98,
+    )
+    assert_accurate(
+        golden_convolution,
+        actual_convolution,
+        name="external BF16 convolution state",
+        pcc_threshold=0.98,
+    )
+
+
+def test_composed_layer_determinism(device: ttnn.Device) -> None:
+    config = make_config()
+    weights = random_weights(config)
+    hidden = torch.randn(1, 32, config.hidden_size, generator=torch.Generator().manual_seed(1741)).to(torch.bfloat16)
+    layer = ttKDA(device, config, weights)
+    results = []
+
+    for _ in range(3):
+        output, state = _forward(layer, hidden, layer.allocate_state())
+        results.append((output, ttnn.to_torch(state.recurrent), ttnn.to_torch(state.convolution)))
+
+    names = ("output", "recurrent state", "convolution state")
+    for iteration, result in enumerate(results[1:], start=1):
+        for name, expected, actual in zip(names, results[0], result):
+            assert_bit_identical(expected, actual, name=f"layer {name} iteration {iteration}")
+
+
+def test_composed_layer_immutable_state_trace_replay(device: ttnn.Device) -> None:
+    config = make_config()
+    hidden = torch.randn(1, 32, config.hidden_size, generator=torch.Generator().manual_seed(1917)).to(torch.bfloat16)
+    hidden_tt = ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    layer = ttKDA(device, config, random_weights(config))
+
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        layer.forward(hidden_tt, layer.allocate_state())
+    ttnn.synchronize_device(device)
+
+    input_state = layer.allocate_state()
+    input_state_before = (
+        ttnn.to_torch(input_state.recurrent),
+        ttnn.to_torch(input_state.convolution),
+    )
+    trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, next_state = layer.forward(hidden_tt, input_state)
+    ttnn.end_trace_capture(device, trace_id, cq_id=0)
+    captured_output = ttnn.to_torch(output)
+    assert next_state.recurrent is not input_state.recurrent
+    assert next_state.convolution is not input_state.convolution
+
+    ttnn.execute_trace(device, trace_id, cq_id=0, blocking=True)
+    replayed_output = ttnn.to_torch(output)
+    input_state_after = (
+        ttnn.to_torch(input_state.recurrent),
+        ttnn.to_torch(input_state.convolution),
+    )
+    ttnn.release_trace(device, trace_id)
+
+    assert_bit_identical(captured_output, replayed_output, name="traced layer output")
+    for name, expected, actual in zip(("recurrent", "convolution"), input_state_before, input_state_after):
+        assert_bit_identical(expected, actual, name=f"traced input {name} state")

--- a/models/demos/deepseek_v3_d_p/tests/kda/model/test_real_weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/model/test_real_weights.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Kimi-K3 layer-1 KDA PCC with the pinned Hugging Face weights."""
+
+from pathlib import Path
+
+import pytest
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    check_kimi_k3_accuracy,
+    kimi_k3_tensor_cache_path,
+    make_kimi_k3_device_case,
+    make_kimi_k3_test_case,
+    run_profiled_forward,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "mesh_device,tensor_parallel_axis",
+    [((1, 8), 1), ((2, 4), 1), ((2, 4), 0)],
+    indirect=["mesh_device"],
+    ids=["SP1xTP8", "SP2xTP4", "SP4xTP2"],
+)
+def test_kimi_k3_layer_1_real_weights_pcc(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    kimi_k3_checkpoint_dir: Path,
+) -> None:
+    case = make_kimi_k3_test_case(kimi_k3_checkpoint_dir, sequence=128)
+    golden_output, golden_state = kda_forward_reference(case.hidden, case.state_dict, case.config)
+    cache_path = kimi_k3_tensor_cache_path(case.checkpoint_dir, mesh_device, tensor_parallel_axis)
+    cache_prefix = f"layer_{KimiK3Config.FIRST_KDA_LAYER}.kda"
+    if not KDAWeights.check_cache_complete(
+        cache_path,
+        cache_prefix,
+        case.config,
+        mesh_device,
+        tensor_parallel_axis=tensor_parallel_axis,
+    ):
+        KDAWeights.build_ttnn_cache(
+            case.state_dict,
+            cache_path,
+            cache_prefix,
+            mesh_device,
+            case.config,
+            tensor_parallel_axis=tensor_parallel_axis,
+        )
+    assert KDAWeights.check_cache_complete(
+        cache_path,
+        cache_prefix,
+        case.config,
+        mesh_device,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )
+    cached_weights = KDAWeights.from_cache(
+        mesh_device,
+        case.config,
+        cache_path,
+        cache_prefix,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    local_chunks = case.hidden.shape[1] // tuple(mesh_device.shape)[sequence_parallel_axis] // ttnn.TILE_SIZE
+    # Accuracy uses the shortest tile-aligned global sequence shared by all three mesh geometries.
+    # Keep the production K3 tuning except for this local grouping constraint.
+    layer, hidden_tt = make_kimi_k3_device_case(
+        mesh_device,
+        case,
+        tensor_parallel_axis=tensor_parallel_axis,
+        summary_group_chunks=local_chunks,
+        weights=cached_weights,
+    )
+    state = layer.allocate_state(batch_size=1)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        (output, state), records = run_profiled_forward(mesh_device, lambda: layer.forward(hidden_tt, state))
+    print(f"Kimi-K3 layer 1 realtime program records: {len(records)}")
+
+    mesh_shape = tuple(mesh_device.shape)
+    layout = f"SP{mesh_shape[sequence_parallel_axis]}xTP{mesh_shape[tensor_parallel_axis]}"
+    check_kimi_k3_accuracy(
+        f"Kimi-K3 layer 1 {layout}",
+        case,
+        golden_output,
+        golden_state,
+        state,
+        output,
+        mesh_device,
+        tensor_parallel_axis,
+        pcc_threshold=0.98,
+    )

--- a/models/demos/deepseek_v3_d_p/tests/kda/model/test_weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/model/test_weights.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Eight-device whole-head KDA weight-layout tests."""
+
+import os
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    assert_accurate,
+    assert_bit_identical,
+    assert_equal,
+    random_weights,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.kda import _output_projection_program_config, ttKDA
+from models.demos.deepseek_v3_d_p.tt.kda.weights import load_kda_weights
+from models.tt_transformers.tt.ccl import TT_CCL
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("mesh_device", [(1, 8), (2, 4)], indirect=True),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+]
+
+
+def _host_shards(tensor: ttnn.Tensor) -> list[torch.Tensor]:
+    return [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+
+
+def test_cache_build_requires_state_dict(mesh_device: ttnn.MeshDevice, tmp_path, expect_error) -> None:
+    config = KDAConfig(
+        hidden_size=64,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    with expect_error(ValueError, "requires a state_dict"):
+        load_kda_weights(mesh_device, config, None, tmp_path, _load_to_device=False)
+
+
+def test_tp_weight_layout(mesh_device: ttnn.MeshDevice) -> None:
+    if tuple(mesh_device.shape) != (1, 8):
+        pytest.skip("TP=8 layout case requires a 1x8 mesh")
+    config = KDAConfig(
+        hidden_size=64,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    state_dict = random_weights(config)
+    weights = load_kda_weights(mesh_device, config, state_dict)
+
+    assert weights.tensor_parallel_size == 8
+    input_shards = _host_shards(weights.input_projection)
+    output_shards = _host_shards(weights.output_projection)
+    tap_shards = _host_shards(weights.convolution_taps[0])
+
+    for device_index in range(8):
+        head_start = device_index * config.head_k_dim
+        head_end = head_start + config.head_k_dim
+        expected_qkv = torch.cat(
+            (
+                state_dict["q_proj.weight"][head_start:head_end],
+                state_dict["k_proj.weight"][head_start:head_end],
+                state_dict["v_proj.weight"][head_start:head_end],
+            ),
+            dim=0,
+        ).T
+        output_gate_projection = state_dict["g_b_proj.weight"].reshape(
+            config.num_heads, config.head_v_dim, config.head_v_dim
+        )
+        output_gate_direct = torch.matmul(output_gate_projection, state_dict["g_a_proj.weight"]).reshape(
+            config.v_dim, config.hidden_size
+        )
+        value_start = device_index * config.head_v_dim
+        value_end = value_start + config.head_v_dim
+        expected_auxiliary = torch.cat(
+            (
+                state_dict["f_a_proj.weight"],
+                output_gate_direct[value_start:value_end],
+                state_dict["b_proj.weight"][device_index : device_index + 1],
+            ),
+            dim=0,
+        ).T
+        expected_output = state_dict["o_proj.weight"][:, head_start:head_end].T
+        expected_tap = torch.cat(
+            (
+                state_dict["q_conv1d.weight"][head_start:head_end, 0, 0],
+                state_dict["k_conv1d.weight"][head_start:head_end, 0, 0],
+                state_dict["v_conv1d.weight"][head_start:head_end, 0, 0],
+            )
+        ).reshape(1, 1, -1)
+
+        expected_input = torch.cat((expected_qkv, expected_auxiliary), dim=-1)
+        assert_equal(
+            expected_input.to(torch.bfloat16),
+            input_shards[device_index],
+            name=f"input weight device {device_index}",
+        )
+        assert_equal(
+            expected_output.to(torch.bfloat16),
+            output_shards[device_index],
+            name=f"output weight device {device_index}",
+        )
+        assert_equal(
+            expected_tap.to(torch.bfloat16),
+            tap_shards[device_index],
+            name=f"convolution tap device {device_index}",
+        )
+
+
+def test_tp_layer_pcc(mesh_device: ttnn.MeshDevice) -> None:
+    if tuple(mesh_device.shape) != (1, 8):
+        pytest.skip("TP=8 layer case requires a 1x8 mesh")
+    config = KDAConfig(
+        hidden_size=256,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=256,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    state_dict = random_weights(config)
+    sequence = int(os.getenv("KDA_TP_TEST_SEQ", "32"))
+    hidden = torch.randn(1, sequence, config.hidden_size, generator=torch.Generator().manual_seed(911)).to(
+        torch.bfloat16
+    )
+    golden_output, golden_state = kda_forward_reference(hidden, state_dict, config)
+
+    layer = ttKDA(mesh_device, config, state_dict, tt_ccl=TT_CCL(mesh_device))
+    initial_state = layer.allocate_state(batch_size=1)
+    hidden_tt = ttnn.from_torch(
+        hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, state = layer.forward(hidden_tt, initial_state)
+
+    actual_output = ttnn.to_torch(output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=-1))
+    recurrent_shards = _host_shards(state.recurrent)
+    convolution_shards = _host_shards(state.convolution)
+    actual_recurrent = torch.cat(recurrent_shards, dim=1)
+    local_key_width = config.head_k_dim
+    local_value_width = config.head_v_dim
+    actual_convolution = torch.cat(
+        (
+            torch.cat([shard[..., :local_key_width] for shard in convolution_shards], dim=-1),
+            torch.cat([shard[..., local_key_width : 2 * local_key_width] for shard in convolution_shards], dim=-1),
+            torch.cat(
+                [
+                    shard[..., 2 * local_key_width : 2 * local_key_width + local_value_width]
+                    for shard in convolution_shards
+                ],
+                dim=-1,
+            ),
+        ),
+        dim=-1,
+    )
+    golden_convolution = torch.cat(
+        (golden_state.q_convolution, golden_state.k_convolution, golden_state.v_convolution), dim=-1
+    )
+
+    for name, golden, actual in (
+        ("output", golden_output, actual_output),
+        ("recurrent state", golden_state.recurrent, actual_recurrent),
+        ("convolution state", golden_convolution, actual_convolution),
+    ):
+        assert_accurate(golden, actual, name=f"TP=8 {name}", pcc_threshold=0.98)
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_2d_tp_weight_and_output_placement(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    if tuple(mesh_device.shape) != (2, 4):
+        pytest.skip("2D placement case requires a 2x4 mesh")
+    config = KDAConfig(
+        hidden_size=256,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=256,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    state_dict = random_weights(config)
+    tensor_parallel_size = tuple(mesh_device.shape)[tensor_parallel_axis]
+    weights = load_kda_weights(
+        mesh_device,
+        config,
+        state_dict,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )
+    assert weights.tensor_parallel_size == tensor_parallel_size
+
+    output_weight_shards = _host_shards(weights.output_projection)
+    for physical_index, actual_weight in enumerate(output_weight_shards):
+        row, column = divmod(physical_index, 4)
+        tp_rank = (row, column)[tensor_parallel_axis]
+        head_start = tp_rank * (config.num_heads // tensor_parallel_size) * config.head_v_dim
+        head_end = head_start + (config.num_heads // tensor_parallel_size) * config.head_v_dim
+        expected_weight = state_dict["o_proj.weight"][:, head_start:head_end].T.to(torch.bfloat16)
+        assert_equal(expected_weight, actual_weight, name=f"output weight device {physical_index}")
+
+    sequence = 64
+    value = torch.randn(1, sequence, config.v_dim, generator=torch.Generator().manual_seed(817), dtype=torch.bfloat16)
+    golden_output = value @ state_dict["o_proj.weight"].T.to(torch.bfloat16)
+    mesh_dims = [None, None]
+    mesh_dims[tensor_parallel_axis] = 2
+    value_tt = ttnn.from_torch(
+        value,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=tuple(mesh_dims), mesh_shape=tuple(mesh_device.shape)),
+    )
+    compute_config = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    output_grid = mesh_device.compute_with_storage_grid_size()
+    value_tt = ttnn.reshape(value_tt, (1, 1, sequence, value_tt.shape[-1]))
+    output = ttnn.linear(
+        value_tt,
+        weights.output_projection,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        program_config=_output_projection_program_config(
+            sequence,
+            value_tt.shape[-1],
+            weights.output_projection.shape[-1],
+            None,
+            (output_grid.x, output_grid.y),
+        ),
+        compute_kernel_config=compute_config,
+    )
+    tt_ccl = TT_CCL(mesh_device)
+    output = ttnn.experimental.reduce_scatter_minimal_async(
+        output,
+        dim=3,
+        multi_device_global_semaphore=tt_ccl.get_and_cycle_rs_semaphore_handles(tensor_parallel_axis),
+        barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(tensor_parallel_axis),
+        num_links=tt_ccl.get_num_links(tensor_parallel_axis),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        topology=ttnn.Topology.Linear,
+        cluster_axis=tensor_parallel_axis,
+    )
+
+    output_shards = _host_shards(output)
+    hidden_per_rank = config.hidden_size // tensor_parallel_size
+    for physical_index, actual_output in enumerate(output_shards):
+        row, column = divmod(physical_index, 4)
+        tp_rank = (row, column)[tensor_parallel_axis]
+        expected_output = golden_output[..., tp_rank * hidden_per_rank : (tp_rank + 1) * hidden_per_rank]
+        actual_output = actual_output.reshape_as(expected_output)
+        assert_accurate(
+            expected_output,
+            actual_output,
+            name=f"tp_axis={tensor_parallel_axis} device={physical_index} output",
+            pcc_threshold=0.98,
+        )
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_output_projection_determinism(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    if tuple(mesh_device.shape) != (2, 4):
+        pytest.skip("2D projection determinism requires a 2x4 mesh")
+    config = KDAConfig(
+        hidden_size=256,
+        num_heads=8,
+        head_k_dim=32,
+        head_v_dim=256,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+    weights = load_kda_weights(
+        mesh_device,
+        config,
+        random_weights(config),
+        tensor_parallel_axis=tensor_parallel_axis,
+    )
+    sequence = 32
+    value = torch.randn(1, sequence, config.v_dim, generator=torch.Generator().manual_seed(2817), dtype=torch.bfloat16)
+    mesh_dims = [None, None]
+    mesh_dims[tensor_parallel_axis] = 2
+    value_tt = ttnn.from_torch(
+        value,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=tuple(mesh_dims), mesh_shape=tuple(mesh_device.shape)),
+    )
+    value_tt = ttnn.reshape(value_tt, (1, 1, sequence, value_tt.shape[-1]))
+    compute_config = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(), math_fidelity=ttnn.MathFidelity.HiFi4, fp32_dest_acc_en=True
+    )
+    output_grid = mesh_device.compute_with_storage_grid_size()
+    tt_ccl = TT_CCL(mesh_device)
+    results = []
+
+    for _ in range(3):
+        output = ttnn.linear(
+            value_tt,
+            weights.output_projection,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=_output_projection_program_config(
+                sequence,
+                value_tt.shape[-1],
+                weights.output_projection.shape[-1],
+                None,
+                (output_grid.x, output_grid.y),
+            ),
+            compute_kernel_config=compute_config,
+        )
+        output = ttnn.experimental.reduce_scatter_minimal_async(
+            output,
+            dim=3,
+            multi_device_global_semaphore=tt_ccl.get_and_cycle_rs_semaphore_handles(tensor_parallel_axis),
+            barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(tensor_parallel_axis),
+            num_links=tt_ccl.get_num_links(tensor_parallel_axis),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Linear,
+            cluster_axis=tensor_parallel_axis,
+        )
+        ttnn.synchronize_device(mesh_device)
+        results.append(tuple(_host_shards(output)))
+
+    for iteration, shards in enumerate(results[1:], start=1):
+        for device_index, (expected, actual) in enumerate(zip(results[0], shards)):
+            assert_bit_identical(
+                expected, actual, name=f"output projection device {device_index} iteration {iteration}"
+            )

--- a/models/demos/deepseek_v3_d_p/tests/kda/operations/test_chunk.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/operations/test_chunk.py
@@ -136,8 +136,7 @@ def test_chunk_recurrence_rejects_nonproduction_contract(device: ttnn.Device, ex
     invalid_constants = ops._ChunkConstants(
         constants.eye,
         constants.tril,
-        constants.ones,
-        _to_device(torch.zeros(1, 1, dim, 3 * dim), device, ttnn.bfloat16),
+        _to_device(torch.ones(1, 1, 32, 32), device, ttnn.bfloat16),
     )
     with expect_error(AssertionError, "^$"):
         run(valid_inputs, chunk_constants=invalid_constants)

--- a/models/demos/deepseek_v3_d_p/tests/kda/operations/test_chunk.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/operations/test_chunk.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Blackhole PCC tests for the chunk-parallel KDA operation."""
+
+import time
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda.ops import kda_recurrent_reference
+from models.demos.deepseek_v3_d_p.tests.kda.utils import assert_accurate, assert_bit_identical, compare_cpu_device
+from models.demos.deepseek_v3_d_p.tt.kda import ops
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDARecurrenceProgramConfig
+from models.demos.deepseek_v3_d_p.tt.kda.const_tiles import build_kda_const_tiles
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True),
+]
+
+
+def test_chunk_scan_strategy_policy(device: ttnn.Device) -> None:
+    compute_config = ops._RecurrenceComputeConfig(None, None, None)
+    cases = (
+        (159, None, ops._DirectScan),
+        (160, None, ops._LocalGroupedScan),
+        (161, None, ops._DirectScan),
+        (8, 0, ops._DistributedGroupedScan),
+        (9, 0, ops._DistributedGroupedScan),
+    )
+    for num_chunks, sp_axis, expected in cases:
+        actual = ops._select_scan(
+            num_chunks=num_chunks,
+            program_config=KDARecurrenceProgramConfig(summary_group_chunks=8),
+            compute_config=compute_config,
+            sequence_parallel_axis=sp_axis,
+        )
+        assert isinstance(actual, expected)
+
+
+def _to_device(tensor: torch.Tensor, device: ttnn.Device, dtype: ttnn.DataType) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        tensor,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _run_recurrence(
+    device: ttnn.Device,
+    q: ttnn.Tensor,
+    k: ttnn.Tensor,
+    v: ttnn.Tensor,
+    gate: ttnn.Tensor,
+    beta: ttnn.Tensor,
+    state: ttnn.Tensor,
+    *,
+    summary_group_chunks: int = 8,
+) -> ops._ScanResult:
+    prefix_compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        fp32_dest_acc_en=True,
+    )
+    return ops._chunk_recurrence(
+        ops._FlatRecurrenceInputs(q=q, k=k, v=v, gate=gate, beta=beta),
+        state,
+        ops._ChunkConstants(*build_kda_const_tiles(device)),
+        program_config=KDARecurrenceProgramConfig(summary_group_chunks=summary_group_chunks),
+        compute_config=ops._RecurrenceComputeConfig(
+            preparation=None,
+            affine_prefix=prefix_compute_config,
+            grouped_scan=prefix_compute_config,
+        ),
+        sequence_parallel_axis=None,
+    )
+
+
+def test_chunk_recurrence_rejects_nonproduction_contract(device: ttnn.Device, expect_error) -> None:
+    sequence, heads, dim = 32, 2, 32
+    flat_shape = (1, sequence, heads * dim)
+    beta_shape = (1, sequence, heads)
+    state_shape = (1, heads, dim, dim)
+    valid_inputs = {
+        "q": _to_device(torch.randn(flat_shape), device, ttnn.bfloat16),
+        "k": _to_device(torch.randn(flat_shape), device, ttnn.bfloat16),
+        "v": _to_device(torch.randn(flat_shape), device, ttnn.bfloat16),
+        "gate": _to_device(torch.randn(flat_shape), device, ttnn.bfloat16),
+        "beta": _to_device(torch.randn(beta_shape), device, ttnn.float32),
+    }
+    valid_state = _to_device(torch.randn(state_shape), device, ttnn.float32)
+    constants = ops._ChunkConstants(*build_kda_const_tiles(device))
+    program_config = KDARecurrenceProgramConfig()
+    compute_config = ops._RecurrenceComputeConfig(None, None, None)
+
+    def run(
+        inputs: dict[str, ttnn.Tensor],
+        state: ttnn.Tensor = valid_state,
+        chunk_constants: ops._ChunkConstants = constants,
+    ) -> None:
+        ops._chunk_recurrence(
+            ops._FlatRecurrenceInputs(**inputs),
+            state,
+            chunk_constants,
+            program_config=program_config,
+            compute_config=compute_config,
+            sequence_parallel_axis=None,
+        )
+
+    wrong_dtype_inputs = {
+        "q": _to_device(torch.randn(flat_shape), device, ttnn.float32),
+        "k": _to_device(torch.randn(flat_shape), device, ttnn.float32),
+        "v": _to_device(torch.randn(flat_shape), device, ttnn.float32),
+        "gate": _to_device(torch.randn(flat_shape), device, ttnn.float32),
+        "beta": _to_device(torch.randn(beta_shape), device, ttnn.bfloat16),
+    }
+    for name, tensor in wrong_dtype_inputs.items():
+        with expect_error(AssertionError, "^$"):
+            run({**valid_inputs, name: tensor})
+
+    with expect_error(AssertionError, "^$"):
+        run(valid_inputs, _to_device(torch.randn(state_shape), device, ttnn.bfloat16))
+
+    l1_state = ttnn.to_memory_config(valid_state, ttnn.L1_MEMORY_CONFIG)
+    with expect_error(AssertionError, "^$"):
+        run(valid_inputs, l1_state)
+
+    rank_four_q = _to_device(torch.randn(1, 1, sequence, heads * dim), device, ttnn.bfloat16)
+    with expect_error(ValueError, "flat rank-3"):
+        run({**valid_inputs, "q": rank_four_q})
+
+    invalid_constants = ops._ChunkConstants(
+        constants.eye,
+        constants.tril,
+        constants.ones,
+        _to_device(torch.zeros(1, 1, dim, 3 * dim), device, ttnn.bfloat16),
+    )
+    with expect_error(AssertionError, "^$"):
+        run(valid_inputs, chunk_constants=invalid_constants)
+
+
+@pytest.mark.parametrize(
+    "sequence,heads,key_dim,value_dim,summary_group_chunks",
+    [
+        (32, 2, 32, 32, 8),
+        (64, 32, 128, 128, 8),
+        (256, 4, 128, 128, 8),
+        (512, 4, 128, 128, 8),
+        (2816, 12, 128, 128, 21),
+        (5120, 2, 32, 32, 8),
+        (5120, 1, 128, 128, 8),
+        (5152, 2, 32, 32, 8),
+    ],
+)
+def test_chunk_recurrence_pcc(
+    device: ttnn.Device,
+    sequence: int,
+    heads: int,
+    key_dim: int,
+    value_dim: int,
+    summary_group_chunks: int,
+) -> None:
+    generator = torch.Generator().manual_seed(401 + sequence + heads)
+    shape = (1, sequence, heads)
+    q = torch.randn(*shape, key_dim, generator=generator)
+    k = torch.randn(*shape, key_dim, generator=generator)
+    v = torch.randn(*shape, value_dim, generator=generator)
+    gate = -0.02 * torch.rand(*shape, key_dim, generator=generator)
+    beta = torch.sigmoid(torch.randn(*shape, generator=generator))
+    state = 0.02 * torch.randn(1, heads, key_dim, value_dim, generator=generator)
+    print("KDA_CPU_REFERENCE_CACHE=disabled; computing deterministic operation oracle", flush=True)
+    reference_start = time.perf_counter()
+    golden_output, golden_state = kda_recurrent_reference(q, k, v, gate, beta, state)
+    print(f"KDA_CPU_REFERENCE_SECONDS={time.perf_counter() - reference_start:.3f}", flush=True)
+
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        result = _run_recurrence(
+            device,
+            _to_device(q.reshape(1, sequence, heads * key_dim), device, ttnn.bfloat16),
+            _to_device(k.reshape(1, sequence, heads * key_dim), device, ttnn.bfloat16),
+            _to_device(v.reshape(1, sequence, heads * value_dim), device, ttnn.bfloat16),
+            _to_device(gate.reshape(1, sequence, heads * key_dim), device, ttnn.bfloat16),
+            _to_device(beta, device, ttnn.float32),
+            _to_device(state, device, ttnn.float32),
+            summary_group_chunks=summary_group_chunks,
+        )
+
+    assert result.final_state.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    actual_output = ttnn.to_torch(result.output)
+    actual_output = actual_output.reshape(1, heads, sequence, value_dim).permute(0, 2, 1, 3)
+    actual_state = ttnn.to_torch(result.final_state)
+    label = f"H={heads},K={key_dim},V={value_dim},T={sequence},group={summary_group_chunks}"
+    _, output_failures = compare_cpu_device(
+        f"{label} output",
+        golden_output,
+        actual_output,
+        pcc_threshold=0.999,
+    )
+    _, state_failures = compare_cpu_device(
+        f"{label} state",
+        golden_state,
+        actual_state,
+        pcc_threshold=0.999,
+    )
+    failures = output_failures + state_failures
+    assert not failures, "\n".join(failures)
+
+
+def test_grouped_summary_preserves_weak_decay(device: ttnn.Device) -> None:
+    sequence, heads, dim = 5120, 1, 32
+    generator = torch.Generator().manual_seed(9401)
+    shape = (1, sequence, heads, dim)
+    q = torch.randn(*shape, generator=generator)
+    k = torch.randn(*shape, generator=generator)
+    v = torch.randn(*shape, generator=generator)
+    gate = torch.full(shape, -1e-5)
+    beta = torch.sigmoid(torch.randn(1, sequence, heads, generator=generator))
+    state = 0.02 * torch.randn(1, heads, dim, dim, generator=generator)
+    golden_output, golden_state = kda_recurrent_reference(q, k, v, gate, beta, state)
+
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        result_eight = _run_recurrence(
+            device,
+            _to_device(q.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(k.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(v.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(gate.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(beta, device, ttnn.float32),
+            _to_device(state, device, ttnn.float32),
+            summary_group_chunks=8,
+        )
+
+    ttnn.synchronize_device(device)
+
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        result_two = _run_recurrence(
+            device,
+            _to_device(q.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(k.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(v.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(gate.reshape(1, sequence, heads * dim), device, ttnn.bfloat16),
+            _to_device(beta, device, ttnn.float32),
+            _to_device(state, device, ttnn.float32),
+            summary_group_chunks=2,
+        )
+
+    output_eight = ttnn.to_torch(result_eight.output).reshape(1, sequence, heads, dim)
+    output_two = ttnn.to_torch(result_two.output).reshape(1, sequence, heads, dim)
+    label = "weak-decay production contract"
+    assert_accurate(golden_output, output_eight, name=f"{label} grouped output")
+    assert_accurate(
+        output_two,
+        output_eight,
+        name=f"{label} group-size output invariance",
+        pcc_threshold=0.9999,
+    )
+    assert_accurate(
+        ttnn.to_torch(result_two.final_state),
+        ttnn.to_torch(result_eight.final_state),
+        name=f"{label} group-size state invariance",
+        pcc_threshold=0.9999,
+    )
+    assert_accurate(golden_state, ttnn.to_torch(result_eight.final_state), name=f"{label} grouped state")
+
+
+def test_chunk_recurrence_determinism(device: ttnn.Device) -> None:
+    sequence, heads, dim = 64, 2, 32
+    generator = torch.Generator().manual_seed(1401)
+    shape = (1, sequence, heads)
+    flat_shape = (1, sequence, heads * dim)
+    q_tt = _to_device(torch.randn(*shape, dim, generator=generator).reshape(flat_shape), device, ttnn.bfloat16)
+    k_tt = _to_device(torch.randn(*shape, dim, generator=generator).reshape(flat_shape), device, ttnn.bfloat16)
+    v_tt = _to_device(torch.randn(*shape, dim, generator=generator).reshape(flat_shape), device, ttnn.bfloat16)
+    gate_tt = _to_device(
+        (-0.02 * torch.rand(*shape, dim, generator=generator)).reshape(flat_shape), device, ttnn.bfloat16
+    )
+    beta_tt = _to_device(torch.sigmoid(torch.randn(*shape, generator=generator)), device, ttnn.float32)
+    state_tt = _to_device(0.02 * torch.randn(1, heads, dim, dim, generator=generator), device, ttnn.float32)
+
+    results = []
+    for _ in range(3):
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            result = _run_recurrence(device, q_tt, k_tt, v_tt, gate_tt, beta_tt, state_tt, summary_group_chunks=2)
+        ttnn.synchronize_device(device)
+        results.append((ttnn.to_torch(result.output), ttnn.to_torch(result.final_state)))
+
+    first_output, first_state = results[0]
+    for iteration, (output, final_state) in enumerate(results[1:], start=1):
+        assert_bit_identical(first_output, output, name=f"chunk recurrence output iteration {iteration}")
+        assert_bit_identical(first_state, final_state, name=f"chunk recurrence state iteration {iteration}")

--- a/models/demos/deepseek_v3_d_p/tests/kda/operations/test_distributed_affine.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/operations/test_distributed_affine.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Blackhole correctness tests for the 2D-mesh KDA affine prefix."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.tests.kda.utils import assert_accurate, assert_bit_identical
+from models.demos.deepseek_v3_d_p.tt.kda import ops
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDARecurrenceProgramConfig
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 4_000_000}],
+        indirect=True,
+    ),
+]
+
+
+AffineTransform = tuple[torch.Tensor, torch.Tensor]
+
+
+def _compose(
+    after_a: torch.Tensor,
+    after_b: torch.Tensor,
+    before_a: torch.Tensor,
+    before_b: torch.Tensor,
+) -> AffineTransform:
+    return after_a @ before_a, after_a @ before_b + after_b
+
+
+def _serial_prefix(
+    transform_a: torch.Tensor,
+    transform_b: torch.Tensor,
+    initial_state: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    transform_a = transform_a.to(torch.float32)
+    transform_b = transform_b.to(torch.float32)
+    initial_state = initial_state.to(torch.float32)
+    entries = [initial_state]
+    prefix_a, prefix_b = transform_a[0], transform_b[0]
+    for rank in range(1, transform_a.shape[0]):
+        entries.append(prefix_a @ initial_state + prefix_b)
+        prefix_a, prefix_b = _compose(transform_a[rank], transform_b[rank], prefix_a, prefix_b)
+    return torch.stack(entries), (prefix_a @ initial_state + prefix_b).unsqueeze(0)
+
+
+def _to_device(
+    tensor: torch.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    mesh_dims: tuple[int | None, int | None],
+    dtype: ttnn.DataType = ttnn.float32,
+) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        tensor,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=mesh_dims, mesh_shape=tuple(mesh_device.shape)),
+    )
+
+
+def _host_shards(tensor: ttnn.Tensor) -> list[torch.Tensor]:
+    return [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+
+
+def _coordinate(sp_rank: int, tp_rank: int, sp_axis: int) -> tuple[int, int]:
+    return (sp_rank, tp_rank) if sp_axis == 0 else (tp_rank, sp_rank)
+
+
+def _partitioned_to_torch(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+) -> torch.Tensor:
+    shards = _host_shards(tensor)
+    rows, columns = tuple(mesh_device.shape)
+    sp_size = (rows, columns)[sp_axis]
+    tp_size = (rows, columns)[tp_axis]
+    partitions = []
+    for sp_rank in range(sp_size):
+        head_shards = []
+        for tp_rank in range(tp_size):
+            row, column = _coordinate(sp_rank, tp_rank, sp_axis)
+            head_shards.append(shards[row * columns + column])
+        partitions.append(torch.cat(head_shards, dim=0))
+    return torch.stack(partitions, dim=0)
+
+
+def _replicated_sp_to_torch(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+) -> torch.Tensor:
+    shards = _host_shards(tensor)
+    _, columns = tuple(mesh_device.shape)
+    tp_size = tuple(mesh_device.shape)[tp_axis]
+    head_shards = []
+    for tp_rank in range(tp_size):
+        row, column = _coordinate(0, tp_rank, sp_axis)
+        head_shards.append(shards[row * columns + column])
+    return torch.cat(head_shards, dim=0)
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_distributed_affine_prefix_matches_serial(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    sp_axis = 1 - tensor_parallel_axis
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+    heads = 8
+    local_heads = heads // tuple(mesh_device.shape)[tensor_parallel_axis]
+    dim = 32
+    generator = torch.Generator().manual_seed(621 + tensor_parallel_axis)
+    eye = torch.eye(dim, dtype=torch.float32).reshape(1, 1, dim, dim)
+    transform_a = (0.91 * eye).expand(sp_size, heads, -1, -1).clone()
+    transform_a += 0.001 * torch.randn(sp_size, heads, dim, dim, generator=generator)
+    transform_b = 0.01 * torch.randn(sp_size, heads, dim, dim, generator=generator)
+    initial_state = 0.01 * torch.randn(heads, dim, dim, generator=generator)
+
+    summary_dims = [None, None]
+    summary_dims[tensor_parallel_axis] = 1
+    state_dims = [None, None]
+    state_dims[tensor_parallel_axis] = 0
+    replicated_a = _to_device(transform_a, mesh_device, tuple(summary_dims))
+    replicated_b = _to_device(transform_b, mesh_device, tuple(summary_dims))
+    a_tt = ttnn.reshape(ttnn.mesh_partition(replicated_a, dim=0, cluster_axis=sp_axis), (local_heads, dim, dim))
+    b_tt = ttnn.reshape(ttnn.mesh_partition(replicated_b, dim=0, cluster_axis=sp_axis), (local_heads, dim, dim))
+    state_tt = _to_device(initial_state, mesh_device, tuple(state_dims))
+
+    expected_entries, expected_final = _serial_prefix(transform_a, transform_b, initial_state)
+    program_config = KDARecurrenceProgramConfig()
+    compute_config = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(),
+        math_fidelity=program_config.affine_prefix_math_fidelity,
+        fp32_dest_acc_en=True,
+    )
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        entry_tt, final_tt = ops._distributed_affine_prefix(
+            a_tt,
+            b_tt,
+            state_tt,
+            sequence_parallel_axis=sp_axis,
+            program_config=program_config,
+            compute_config=compute_config,
+        )
+    cache_entries = mesh_device.num_program_cache_entries()
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        repeated_entry_tt, repeated_final_tt = ops._distributed_affine_prefix(
+            a_tt,
+            b_tt,
+            state_tt,
+            sequence_parallel_axis=sp_axis,
+            program_config=program_config,
+            compute_config=compute_config,
+        )
+    ttnn.synchronize_device(mesh_device)
+    assert mesh_device.num_program_cache_entries() == cache_entries
+
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        traced_entry_tt, traced_final_tt = ops._distributed_affine_prefix(
+            a_tt,
+            b_tt,
+            state_tt,
+            sequence_parallel_axis=sp_axis,
+            program_config=program_config,
+            compute_config=compute_config,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    # Exercise the cached trace enough times to expose cross-rank CB reuse races.
+    for _ in range(100):
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+
+    actual_entries = _partitioned_to_torch(entry_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    actual_final = _replicated_sp_to_torch(final_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    repeated_entries = _partitioned_to_torch(repeated_entry_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    repeated_final = _replicated_sp_to_torch(repeated_final_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    traced_entries = _partitioned_to_torch(traced_entry_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    traced_final = _replicated_sp_to_torch(traced_final_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    ttnn.release_trace(mesh_device, trace_id)
+
+    assert entry_tt.dtype == program_config.recurrent_state_dtype
+    assert final_tt.dtype == program_config.recurrent_state_dtype
+
+    assert_accurate(expected_entries, actual_entries, name=f"tp_axis={tensor_parallel_axis} production entries")
+    assert_accurate(expected_final.squeeze(0), actual_final, name=f"tp_axis={tensor_parallel_axis} production final")
+    assert_accurate(expected_entries, repeated_entries, name=f"tp_axis={tensor_parallel_axis} repeated entries")
+    assert_accurate(expected_final.squeeze(0), repeated_final, name=f"tp_axis={tensor_parallel_axis} repeated final")
+    assert_accurate(expected_entries, traced_entries, name=f"tp_axis={tensor_parallel_axis} traced entries")
+    assert_accurate(expected_final.squeeze(0), traced_final, name=f"tp_axis={tensor_parallel_axis} traced final")
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_distributed_affine_prefix_determinism(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    sp_axis = 1 - tensor_parallel_axis
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+    heads, dim = 8, 32
+    local_heads = heads // tuple(mesh_device.shape)[tensor_parallel_axis]
+    generator = torch.Generator().manual_seed(1621 + tensor_parallel_axis)
+    eye = torch.eye(dim, dtype=torch.float32).reshape(1, 1, dim, dim)
+    transform_a = (0.91 * eye).expand(sp_size, heads, -1, -1).clone()
+    transform_a += 0.001 * torch.randn(sp_size, heads, dim, dim, generator=generator)
+    transform_b = 0.01 * torch.randn(sp_size, heads, dim, dim, generator=generator)
+    initial_state = 0.01 * torch.randn(heads, dim, dim, generator=generator)
+    summary_dims = [None, None]
+    summary_dims[tensor_parallel_axis] = 1
+    state_dims = [None, None]
+    state_dims[tensor_parallel_axis] = 0
+    replicated_a = _to_device(transform_a, mesh_device, tuple(summary_dims))
+    replicated_b = _to_device(transform_b, mesh_device, tuple(summary_dims))
+    a_tt = ttnn.reshape(ttnn.mesh_partition(replicated_a, dim=0, cluster_axis=sp_axis), (local_heads, dim, dim))
+    b_tt = ttnn.reshape(ttnn.mesh_partition(replicated_b, dim=0, cluster_axis=sp_axis), (local_heads, dim, dim))
+    state_tt = _to_device(initial_state, mesh_device, tuple(state_dims))
+    program_config = KDARecurrenceProgramConfig()
+    compute_config = ttnn.init_device_compute_kernel_config(
+        mesh_device.arch(),
+        math_fidelity=program_config.affine_prefix_math_fidelity,
+        fp32_dest_acc_en=True,
+    )
+
+    results = []
+    for _ in range(3):
+        entry_tt, final_tt = ops._distributed_affine_prefix(
+            a_tt,
+            b_tt,
+            state_tt,
+            sequence_parallel_axis=sp_axis,
+            program_config=program_config,
+            compute_config=compute_config,
+        )
+        ttnn.synchronize_device(mesh_device)
+        results.append(
+            (
+                _partitioned_to_torch(entry_tt, mesh_device, sp_axis, tensor_parallel_axis),
+                _replicated_sp_to_torch(final_tt, mesh_device, sp_axis, tensor_parallel_axis),
+            )
+        )
+
+    for iteration, (entries, final) in enumerate(results[1:], start=1):
+        assert_bit_identical(results[0][0], entries, name=f"affine entries iteration {iteration}")
+        assert_bit_identical(results[0][1], final, name=f"affine final iteration {iteration}")

--- a/models/demos/deepseek_v3_d_p/tests/kda/operations/test_halo.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/operations/test_halo.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Blackhole correctness tests for the 2D-mesh KDA convolution halo."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.tests.kda.utils import assert_bit_identical, assert_equal
+from models.demos.deepseek_v3_d_p.tt.kda import ops
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+]
+
+
+def _coordinate(sp_rank: int, tp_rank: int, sp_axis: int) -> tuple[int, int]:
+    return (sp_rank, tp_rank) if sp_axis == 0 else (tp_rank, sp_rank)
+
+
+def _to_device(tensor: torch.Tensor, device: ttnn.MeshDevice, dims: tuple[int | None, int | None]) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(device, dims=dims, mesh_shape=tuple(device.shape)),
+    )
+
+
+def _sp_carries(tensor: ttnn.Tensor, device: ttnn.MeshDevice, sp_axis: int, tp_axis: int) -> torch.Tensor:
+    shards = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+    rows, columns = tuple(device.shape)
+    sp_size, tp_size = (rows, columns)[sp_axis], (rows, columns)[tp_axis]
+    partitions = []
+    for sp_rank in range(sp_size):
+        channel_shards = []
+        for tp_rank in range(tp_size):
+            row, column = _coordinate(sp_rank, tp_rank, sp_axis)
+            channel_shards.append(shards[row * columns + column])
+        partitions.append(torch.cat(channel_shards, dim=2))
+    return torch.stack(partitions)
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_convolution_halo_preserves_causal_carries(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    sp_axis = 1 - tensor_parallel_axis
+    sp_size = tuple(mesh_device.shape)[sp_axis]
+    tp_size = tuple(mesh_device.shape)[tensor_parallel_axis]
+    batch, local_sequence, history = 1, 8, 3
+    channels = tp_size * 32
+    sequence = sp_size * local_sequence
+
+    qkv = torch.arange(batch * sequence * channels, dtype=torch.float32).reshape(batch, sequence, channels)
+    qkv = ((qkv.remainder(97) - 48) / 8).to(torch.bfloat16)
+    external = torch.arange(batch * history * channels, dtype=torch.float32).reshape(batch, history, channels)
+    external = (-(external.remainder(31) + 1) / 8).to(torch.bfloat16)
+
+    qkv_dims = [None, None]
+    qkv_dims[sp_axis], qkv_dims[tensor_parallel_axis] = 1, 2
+    state_dims = [None, None]
+    state_dims[tensor_parallel_axis] = 2
+    qkv_tt = _to_device(qkv, mesh_device, tuple(qkv_dims))
+    state_tt = _to_device(external, mesh_device, tuple(state_dims))
+
+    entry_tt, final_tt = ops.convolution_halo(
+        qkv_tt,
+        state_tt,
+        sequence_parallel_axis=sp_axis,
+    )
+    actual_entries = _sp_carries(entry_tt, mesh_device, sp_axis, tensor_parallel_axis)
+    actual_finals = _sp_carries(final_tt, mesh_device, sp_axis, tensor_parallel_axis)
+
+    expected_entries = [external]
+    for sp_rank in range(1, sp_size):
+        predecessor_end = sp_rank * local_sequence
+        expected_entries.append(qkv[:, predecessor_end - history : predecessor_end])
+    expected_entries_tensor = torch.stack(expected_entries)
+    expected_final = qkv[:, -history:]
+
+    assert_equal(expected_entries_tensor, actual_entries, name="halo entries")
+    for sp_rank in range(sp_size):
+        assert_equal(expected_final, actual_finals[sp_rank], name=f"halo final rank {sp_rank}")
+    print(
+        f"tp_axis={tensor_parallel_axis}: rank0 external carry, {sp_size - 1} neighbor carries, "
+        "and all replicated final carries are exact"
+    )
+
+
+@pytest.mark.parametrize("tensor_parallel_axis", [0, 1])
+def test_convolution_halo_determinism(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> None:
+    sp_axis = 1 - tensor_parallel_axis
+    tp_size = tuple(mesh_device.shape)[tensor_parallel_axis]
+    batch, local_sequence, history = 1, 8, 3
+    sequence = tuple(mesh_device.shape)[sp_axis] * local_sequence
+    channels = tp_size * 32
+    qkv = torch.arange(batch * sequence * channels, dtype=torch.float32).reshape(batch, sequence, channels)
+    external = -torch.arange(1, batch * history * channels + 1, dtype=torch.float32).reshape(batch, history, channels)
+    qkv_dims = [None, None]
+    qkv_dims[sp_axis], qkv_dims[tensor_parallel_axis] = 1, 2
+    state_dims = [None, None]
+    state_dims[tensor_parallel_axis] = 2
+    qkv_tt = _to_device(qkv.to(torch.bfloat16), mesh_device, tuple(qkv_dims))
+    state_tt = _to_device(external.to(torch.bfloat16), mesh_device, tuple(state_dims))
+
+    results = []
+    for _ in range(3):
+        entry_tt, final_tt = ops.convolution_halo(qkv_tt, state_tt, sequence_parallel_axis=sp_axis)
+        ttnn.synchronize_device(mesh_device)
+        results.append(
+            (
+                _sp_carries(entry_tt, mesh_device, sp_axis, tensor_parallel_axis),
+                _sp_carries(final_tt, mesh_device, sp_axis, tensor_parallel_axis),
+            )
+        )
+
+    for iteration, (entries, final) in enumerate(results[1:], start=1):
+        assert_bit_identical(results[0][0], entries, name=f"halo entries iteration {iteration}")
+        assert_bit_identical(results[0][1], final, name=f"halo final iteration {iteration}")

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/perf_targets/bh_loudbox.json
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/perf_targets/bh_loudbox.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "sku": "bh_loudbox",
+  "metric": "synchronized_trace_wall_ms",
+  "workload": {
+    "model": "Kimi-K3",
+    "layer": 1,
+    "weights_revision": "9f62e4e9fffbd0a83ddd60e1c209d828994b3569",
+    "batch": 1,
+    "sequence": 5120,
+    "dtype": "bfloat16",
+    "repetitions": 10
+  },
+  "provenance": {
+    "measured_at_commit": "09419e3dd635028a2ab7ad3319216f61fe223d63",
+    "measured_at_utc": "2026-08-06",
+    "method": "first of five warm synchronized trace replay averages, 10 replays per sample"
+  },
+  "targets": {
+    "SP1xTP8": {
+      "reference_ms": 9.784,
+      "max_regression_pct": 1.0
+    },
+    "SP2xTP4": {
+      "reference_ms": 9.732,
+      "max_regression_pct": 1.0
+    },
+    "SP4xTP2": {
+      "reference_ms": 10.190,
+      "max_regression_pct": 1.0
+    }
+  }
+}

--- a/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/perf/test_layer_perf.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Real-weight correctness and performance acceptance for Kimi-K3 KDA."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import statistics
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import KDAReferenceState, kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    KimiK3TestCase,
+    check_kimi_k3_accuracy,
+    make_kimi_k3_device_case,
+    make_kimi_k3_test_case,
+)
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.perf,
+    pytest.mark.parametrize(
+        "device_params",
+        [
+            # FABRIC_2D follow-up: SP1xTP8 hangs with a device timeout and failed
+            # Ethernet-core recovery. SP2xTP4/SP4xTP2 were correct but 0.05%/0.10%
+            # slower than FABRIC_1D; do not enable 2D until the SP1 failure is fixed.
+            pytest.param(
+                {
+                    "l1_small_size": 24576,
+                    "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                    "trace_region_size": 256 * 1024 * 1024,
+                },
+                id="fabric_1d",
+            ),
+        ],
+        indirect=True,
+    ),
+]
+
+_SEQUENCE = 5120
+_REPETITIONS = 10
+_TIMING_SAMPLES = int(os.getenv("KDA_TIMING_SAMPLES", "5"))
+_PCC_THRESHOLD = 0.98
+_PERF_TARGETS_PATH = Path(__file__).parent / "perf_targets" / "bh_loudbox.json"
+_CPU_REFERENCE_CACHE_VERSION = 2
+
+
+def _tensor_sha256(tensor: torch.Tensor) -> str:
+    storage = tensor.detach().cpu().contiguous().view(torch.uint8).numpy()
+    return hashlib.sha256(memoryview(storage)).hexdigest()
+
+
+def _update_state_dict_fingerprint(fingerprint: Any, state_dict: Mapping[str, torch.Tensor]) -> None:
+    for name in sorted(state_dict):
+        tensor = state_dict[name]
+        metadata = json.dumps(
+            [name, str(tensor.dtype), list(tensor.shape)],
+            separators=(",", ":"),
+        )
+        fingerprint.update(metadata.encode())
+        fingerprint.update(_tensor_sha256(tensor).encode())
+
+
+def _cpu_reference_cache_path(case: KimiK3TestCase) -> Path:
+    reference_dir = Path(inspect.getfile(kda_forward_reference)).parent
+    fingerprint = hashlib.sha256()
+    fingerprint.update(f"v{_CPU_REFERENCE_CACHE_VERSION}".encode())
+    fingerprint.update(str(KimiK3Config.FIRST_KDA_LAYER).encode())
+    fingerprint.update(str(case.hidden.shape[1]).encode())
+    fingerprint.update(case.checkpoint_dir.name.encode())
+    fingerprint.update((case.checkpoint_dir / "config.json").read_bytes())
+    fingerprint.update(_tensor_sha256(case.hidden).encode())
+    _update_state_dict_fingerprint(fingerprint, case.state_dict)
+    for source_path in (reference_dir / "layer.py", reference_dir / "ops.py"):
+        fingerprint.update(source_path.read_bytes())
+    return (
+        case.checkpoint_dir
+        / "ttnn_cache"
+        / "cpu_reference"
+        / f"layer_{KimiK3Config.FIRST_KDA_LAYER}_t{case.hidden.shape[1]}_{fingerprint.hexdigest()[:20]}.pt"
+    )
+
+
+def _reference_tensors(output: torch.Tensor, state: KDAReferenceState) -> dict[str, torch.Tensor]:
+    return {
+        "output": output.detach().clone(),
+        "recurrent": state.recurrent.detach().clone(),
+        "q_convolution": state.q_convolution.detach().clone(),
+        "k_convolution": state.k_convolution.detach().clone(),
+        "v_convolution": state.v_convolution.detach().clone(),
+    }
+
+
+def _validate_cached_reference(case: KimiK3TestCase, payload: dict[str, Any]) -> tuple[torch.Tensor, KDAReferenceState]:
+    tensors = {name: payload[name] for name in payload["digests"]}
+    expected_shapes = {
+        "output": (1, case.hidden.shape[1], case.config.hidden_size),
+        "recurrent": (1, case.config.num_heads, case.config.head_k_dim, case.config.head_v_dim),
+        "q_convolution": (1, case.config.conv_kernel_size - 1, case.config.q_dim),
+        "k_convolution": (1, case.config.conv_kernel_size - 1, case.config.k_dim),
+        "v_convolution": (1, case.config.conv_kernel_size - 1, case.config.v_dim),
+    }
+    assert set(tensors) == set(expected_shapes), f"unexpected CPU-reference cache tensors: {set(tensors)}"
+    for name, tensor in tensors.items():
+        assert isinstance(tensor, torch.Tensor), f"cached {name} is not a tensor"
+        assert (
+            tuple(tensor.shape) == expected_shapes[name]
+        ), f"cached {name} shape {tuple(tensor.shape)} != {expected_shapes[name]}"
+        assert _tensor_sha256(tensor) == payload["digests"][name], f"cached {name} checksum mismatch"
+    return tensors["output"], KDAReferenceState(
+        recurrent=tensors["recurrent"],
+        q_convolution=tensors["q_convolution"],
+        k_convolution=tensors["k_convolution"],
+        v_convolution=tensors["v_convolution"],
+    )
+
+
+def _load_or_compute_cpu_reference(case: KimiK3TestCase) -> tuple[torch.Tensor, KDAReferenceState, float]:
+    cache_path = _cpu_reference_cache_path(case)
+    start = time.perf_counter()
+    if cache_path.exists():
+        payload = torch.load(cache_path, map_location="cpu", weights_only=True)
+        output, state = _validate_cached_reference(case, payload)
+        elapsed = time.perf_counter() - start
+        logger.info(f"KDA T=5120 CPU reference cache hit: {cache_path}")
+        logger.info(f"KDA T=5120 CPU reference load completed in {elapsed:.3f} seconds")
+        return output, state, elapsed
+
+    output, state = kda_forward_reference(case.hidden, case.state_dict, case.config)
+    tensors = _reference_tensors(output, state)
+    payload = {**tensors, "digests": {name: _tensor_sha256(tensor) for name, tensor in tensors.items()}}
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = cache_path.with_suffix(f".{os.getpid()}.tmp")
+    try:
+        torch.save(payload, temporary_path)
+        temporary_path.replace(cache_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    elapsed = time.perf_counter() - start
+    logger.info(f"KDA T=5120 CPU reference cache miss: {cache_path}")
+    logger.info(f"KDA T=5120 CPU reference computation completed in {elapsed:.3f} seconds")
+    return output, state, elapsed
+
+
+@pytest.fixture(scope="session")
+def kimi_k3_production_reference(
+    kimi_k3_checkpoint_dir: Path,
+) -> tuple[KimiK3TestCase, torch.Tensor, KDAReferenceState, float]:
+    """Compute the independent production-length CPU oracle once per test session."""
+    case = make_kimi_k3_test_case(kimi_k3_checkpoint_dir, sequence=_SEQUENCE)
+    golden_output, golden_state, elapsed = _load_or_compute_cpu_reference(case)
+    return case, golden_output, golden_state, elapsed
+
+
+def _load_perf_target(layout: str, *, sequence: int, repetitions: int) -> tuple[float, float]:
+    targets = json.loads(_PERF_TARGETS_PATH.read_text(encoding="utf-8"))
+    workload = targets["workload"]
+    assert sequence == int(workload["sequence"]), "LoudBox targets only apply to the required sequence length"
+    assert repetitions == int(workload["repetitions"]), "LoudBox targets require the calibrated replay count"
+    target = targets["targets"][layout]
+    return float(target["reference_ms"]), float(target["max_regression_pct"])
+
+
+def _allocate_state(layer: ttKDA) -> KdaState:
+    return layer.allocate_state(batch_size=1)
+
+
+def _deallocate_state(state: KdaState) -> None:
+    ttnn.deallocate(state.recurrent)
+    ttnn.deallocate(state.convolution)
+
+
+def _trace_wall_samples_ms(
+    mesh_device: ttnn.MeshDevice,
+    layer: ttKDA,
+    hidden: ttnn.Tensor,
+    repetitions: int,
+) -> list[float]:
+    state = _allocate_state(layer)
+    warm_output, warm_state = layer.forward(hidden, state)
+    ttnn.synchronize_device(mesh_device)
+    ttnn.deallocate(warm_output)
+    _deallocate_state(warm_state)
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    output, next_state = layer.forward(hidden, state)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    samples_ms = []
+    for _ in range(_TIMING_SAMPLES):
+        start = time.perf_counter()
+        for _ in range(repetitions):
+            ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+        ttnn.synchronize_device(mesh_device)
+        samples_ms.append((time.perf_counter() - start) * 1e3 / repetitions)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.deallocate(output)
+    _deallocate_state(state)
+    _deallocate_state(next_state)
+    return samples_ms
+
+
+@pytest.mark.parametrize(
+    "mesh_device,tensor_parallel_axis",
+    [((1, 8), 1), ((2, 4), 1), ((2, 4), 0)],
+    indirect=["mesh_device"],
+    ids=["SP1xTP8", "SP2xTP4", "SP4xTP2"],
+)
+def test_kimi_k3_layer_1_perf(
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    kimi_k3_production_reference: tuple[KimiK3TestCase, torch.Tensor, KDAReferenceState, float],
+) -> None:
+    """Compare production geometry with an independent CPU oracle before timing it."""
+    sequence = int(os.getenv("KIMI_K3_PERF_SEQ", str(_SEQUENCE)))
+    assert sequence == _SEQUENCE, "the cached CPU oracle covers only the production sequence"
+    case, golden_output, golden_state, cpu_reference_seconds = kimi_k3_production_reference
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    layer, hidden_tt = make_kimi_k3_device_case(
+        mesh_device,
+        case,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )
+
+    state = _allocate_state(layer)
+    start = time.perf_counter()
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        output, state = layer.forward(hidden_tt, state)
+    ttnn.synchronize_device(mesh_device)
+    device_forward_ms = (time.perf_counter() - start) * 1e3
+    mesh_shape = tuple(mesh_device.shape)
+    layout = f"SP{mesh_shape[sequence_parallel_axis]}xTP{mesh_shape[tensor_parallel_axis]}"
+    try:
+        pcc = check_kimi_k3_accuracy(
+            f"Kimi-K3 layer 1 T={sequence} {layout}",
+            case,
+            golden_output,
+            golden_state,
+            state,
+            output,
+            mesh_device,
+            tensor_parallel_axis,
+            pcc_threshold=_PCC_THRESHOLD,
+        )
+    finally:
+        ttnn.deallocate(output)
+    _deallocate_state(state)
+
+    repetitions = int(os.getenv("PERF_REPS", str(_REPETITIONS)))
+    samples_ms = _trace_wall_samples_ms(mesh_device, layer, hidden_tt, repetitions)
+    wall_ms = samples_ms[0]
+    median_wall_ms = statistics.median(samples_ms)
+    tail_wall_ms = max(samples_ms)
+    reference_ms, max_regression_pct = _load_perf_target(layout, sequence=sequence, repetitions=repetitions)
+    max_wall_ms = reference_ms * (1.0 + max_regression_pct / 100.0)
+    result = {
+        "fabric_config": ttnn.get_fabric_config().name,
+        "layout": layout,
+        "sequence": sequence,
+        "repetitions": repetitions,
+        "pcc": pcc,
+        "pcc_reference": "independent pure-Torch FP32 CPU reference",
+        "trace_wall_ms": wall_ms,
+        "trace_wall_samples_ms": samples_ms,
+        "median_trace_wall_ms": median_wall_ms,
+        "tail_trace_wall_ms": tail_wall_ms,
+        "timing_sample_count": _TIMING_SAMPLES,
+        "reference_trace_wall_ms": reference_ms,
+        "max_regression_pct": max_regression_pct,
+        "max_trace_wall_ms": max_wall_ms,
+        "cpu_reference_seconds": cpu_reference_seconds,
+        "device_forward_ms": device_forward_ms,
+    }
+    print("KDA_LAYER_PERF=" + json.dumps(result, sort_keys=True))
+    assert wall_ms <= max_wall_ms, (
+        f"{layout} trace wall {wall_ms:.3f} ms exceeds LoudBox limit {max_wall_ms:.3f} ms "
+        f"(reference {reference_ms:.3f} ms + {max_regression_pct:.1f}%)"
+    )

--- a/models/demos/deepseek_v3_d_p/tests/kda/test_cache_fingerprints.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/test_cache_fingerprints.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for persistent KDA cache identities."""
+
+from dataclasses import replace
+
+from models.demos.deepseek_v3_d_p.tests.kda.utils import make_config
+from models.demos.deepseek_v3_d_p.tt.kda.weights import _cache_stem
+
+
+def test_tensor_cache_stem_uses_only_parent_owned_layer_namespace() -> None:
+    unbounded = make_config()
+    bounded = replace(unbounded, gate_lower_bound=-5.0)
+
+    assert _cache_stem("layer_0.kda", "decay_scale_flat", unbounded, (1, 1), 1) == "layer_0.kda.decay_scale_flat"
+    assert _cache_stem("layer_0.kda", "decay_scale_flat", bounded, (2, 4), 0) == "layer_0.kda.decay_scale_flat"

--- a/models/demos/deepseek_v3_d_p/tests/kda/test_numeric_validation.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/test_numeric_validation.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for shared KDA numeric-result validation."""
+
+import pytest
+import torch
+
+from models.demos.deepseek_v3_d_p.tests.kda.utils import assert_accurate, assert_bit_identical, assert_equal
+
+
+def test_assert_accurate_accepts_finite_high_pcc_tensors() -> None:
+    golden = torch.tensor([0.0, 1.0, 2.0, 4.0])
+    actual = torch.tensor([0.0, 1.0, 2.0, 4.0])
+
+    assert_accurate(golden, actual)
+
+
+@pytest.mark.parametrize(
+    "side,value,expected_field",
+    [
+        (side, value, expected_field)
+        for side in ("golden", "actual")
+        for value, expected_field in (
+            (float("nan"), "nan=1/4"),
+            (float("inf"), r"\+inf=1/4"),
+            (-float("inf"), "-inf=1/4"),
+        )
+    ],
+)
+def test_assert_accurate_rejects_non_finite_tensor(side: str, value: float, expected_field: str, expect_error) -> None:
+    golden = torch.tensor([0.0, 1.0, 2.0, 4.0])
+    actual = golden.clone()
+    target = golden if side == "golden" else actual
+    target[-1] = value
+
+    with expect_error(AssertionError, expected_field):
+        assert_accurate(golden, actual)
+
+
+def test_assert_accurate_rejects_low_pcc(expect_error) -> None:
+    golden = torch.tensor([0.0, 1.0, 2.0, 4.0])
+    actual = torch.tensor([4.0, 2.0, 1.0, 0.0])
+
+    with expect_error(AssertionError, "PCC"):
+        assert_accurate(golden, actual, pcc_threshold=0.999)
+
+
+def test_assert_equal_accepts_finite_equal_tensors() -> None:
+    expected = torch.tensor([1.0, 2.0])
+    assert_equal(expected, expected.clone())
+
+
+@pytest.mark.parametrize(
+    "side,value,expected_field",
+    [
+        (side, value, expected_field)
+        for side in ("expected", "actual")
+        for value, expected_field in (
+            (float("nan"), "nan=1/2"),
+            (float("inf"), r"\+inf=1/2"),
+            (-float("inf"), "-inf=1/2"),
+        )
+    ],
+)
+def test_assert_equal_rejects_non_finite_tensor(side: str, value: float, expected_field: str, expect_error) -> None:
+    expected = torch.tensor([1.0, 2.0])
+    actual = expected.clone()
+    target = expected if side == "expected" else actual
+    target[-1] = value
+
+    with expect_error(AssertionError, expected_field):
+        assert_equal(expected, actual)
+
+
+def test_assert_equal_rejects_changed_value(expect_error) -> None:
+    with expect_error(AssertionError, "values differ"):
+        assert_equal(torch.tensor([1.0, 2.0]), torch.tensor([1.0, 3.0]))
+
+
+def test_assert_bit_identical_rejects_changed_value(expect_error) -> None:
+    expected = torch.tensor([1.0, 2.0])
+    actual = torch.tensor([1.0, 3.0])
+
+    with expect_error(AssertionError, "not bit-identical"):
+        assert_bit_identical(expected, actual)

--- a/models/demos/deepseek_v3_d_p/tests/kda/utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/kda/utils.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared deterministic KDA test cases and runners."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.reference.kda import KDAReferenceState
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config, kimi_k3_kda_config
+from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import load_kda_layer_state_dict
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig, kimi_k3_program_config
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights
+from models.tt_transformers.tt.ccl import TT_CCL
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
+
+
+@dataclass(frozen=True)
+class KimiK3TestCase:
+    config: KDAConfig
+    state_dict: dict[str, torch.Tensor]
+    hidden: torch.Tensor
+    checkpoint_dir: Path
+
+
+def report_finiteness(name: str, tensor: torch.Tensor) -> tuple[bool, str]:
+    """Report absolute/relative non-finite counts and return the verdict."""
+    element_count = tensor.numel()
+    nan_count = int(torch.isnan(tensor).sum().item())
+    positive_inf_count = int(torch.isposinf(tensor).sum().item())
+    negative_inf_count = int(torch.isneginf(tensor).sum().item())
+    non_finite_count = nan_count + positive_inf_count + negative_inf_count
+
+    def fraction(count: int) -> float:
+        return count / element_count if element_count else 0.0
+
+    summary = (
+        f"{name} finiteness: "
+        f"non_finite={non_finite_count}/{element_count} ({fraction(non_finite_count):.6e}), "
+        f"nan={nan_count}/{element_count} ({fraction(nan_count):.6e}), "
+        f"+inf={positive_inf_count}/{element_count} ({fraction(positive_inf_count):.6e}), "
+        f"-inf={negative_inf_count}/{element_count} ({fraction(negative_inf_count):.6e})"
+    )
+    print(summary)
+    return non_finite_count == 0, summary
+
+
+def assert_accurate(
+    golden: torch.Tensor,
+    actual: torch.Tensor,
+    *,
+    name: str = "accuracy",
+    pcc_threshold: float = 0.999,
+) -> float:
+    """Require finite tensors and a passing PCC, and return the measured PCC."""
+    golden_finite, golden_summary = report_finiteness(f"{name} golden", golden)
+    actual_finite, actual_summary = report_finiteness(f"{name} actual", actual)
+    passed, pcc = comp_pcc(golden, actual, pcc=pcc_threshold)
+    max_abs = (golden.float() - actual.float()).abs().max().item()
+    print(f"{name}: PCC={pcc:.6f}, max_abs={max_abs:.6e}")
+    failures = []
+    if not golden_finite:
+        failures.append(golden_summary)
+    if not actual_finite:
+        failures.append(actual_summary)
+    if not passed:
+        failures.append(f"{name} PCC {pcc:.6f} < {pcc_threshold}")
+    assert not failures, "\n".join(failures)
+    return pcc
+
+
+def assert_equal(
+    expected: torch.Tensor,
+    actual: torch.Tensor,
+    *,
+    name: str = "equality",
+) -> None:
+    """Require finite tensors with identical metadata and values."""
+    expected_finite, expected_summary = report_finiteness(f"{name} expected", expected)
+    actual_finite, actual_summary = report_finiteness(f"{name} actual", actual)
+    failures = []
+    if not expected_finite:
+        failures.append(expected_summary)
+    if not actual_finite:
+        failures.append(actual_summary)
+    if expected.shape != actual.shape:
+        failures.append(f"{name} shape {tuple(actual.shape)} != {tuple(expected.shape)}")
+    if expected.dtype != actual.dtype:
+        failures.append(f"{name} dtype {actual.dtype} != {expected.dtype}")
+    if expected.shape == actual.shape and expected.dtype == actual.dtype and not torch.equal(expected, actual):
+        failures.append(f"{name} values differ")
+    assert not failures, "\n".join(failures)
+
+
+def assert_bit_identical(
+    expected: torch.Tensor,
+    actual: torch.Tensor,
+    *,
+    name: str = "determinism",
+) -> None:
+    """Require two implementation results to have identical metadata and values."""
+    assert expected.shape == actual.shape, f"{name} shape {tuple(actual.shape)} != {tuple(expected.shape)}"
+    assert expected.dtype == actual.dtype, f"{name} dtype {actual.dtype} != {expected.dtype}"
+    assert torch.equal(expected, actual), f"{name} is not bit-identical"
+
+
+def _mesh_coordinate(sp_rank: int, tp_rank: int, sp_axis: int) -> tuple[int, int]:
+    return (sp_rank, tp_rank) if sp_axis == 0 else (tp_rank, sp_rank)
+
+
+def _device_shards(tensor: ttnn.Tensor) -> list[torch.Tensor]:
+    return [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(tensor)]
+
+
+def reconstruct_sp_tp_tensor(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    tp_dim: int,
+    sp_dim: int,
+) -> torch.Tensor:
+    """Reconstruct a logical tensor from sequence- and tensor-parallel device shards."""
+    shards = _device_shards(tensor)
+    rows, columns = tuple(mesh_device.shape)
+    sp_size, tp_size = (rows, columns)[sp_axis], (rows, columns)[tp_axis]
+    partitions = []
+    for sp_rank in range(sp_size):
+        tp_shards = []
+        for tp_rank in range(tp_size):
+            row, column = _mesh_coordinate(sp_rank, tp_rank, sp_axis)
+            shard = shards[row * columns + column]
+            if shard.ndim == 4:
+                shard = shard.reshape(shard.shape[0], shard.shape[-2], shard.shape[-1])
+            tp_shards.append(shard)
+        partitions.append(torch.cat(tp_shards, dim=tp_dim))
+    return torch.cat(partitions, dim=sp_dim)
+
+
+def reconstruct_state_at_sp_rank(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    sp_rank: int,
+) -> torch.Tensor:
+    """Reconstruct a tensor-parallel recurrent state at one sequence rank."""
+    shards = _device_shards(tensor)
+    columns = tuple(mesh_device.shape)[1]
+    tp_size = tuple(mesh_device.shape)[tp_axis]
+    tp_shards = []
+    for tp_rank in range(tp_size):
+        row, column = _mesh_coordinate(sp_rank, tp_rank, sp_axis)
+        tp_shards.append(shards[row * columns + column])
+    return torch.cat(tp_shards, dim=1)
+
+
+def reconstruct_convolution_at_sp_rank(
+    tensor: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    sp_rank: int,
+    local_width: int,
+) -> torch.Tensor:
+    """Reconstruct grouped Q/K/V convolution state at one sequence rank."""
+    shards = _device_shards(tensor)
+    columns = tuple(mesh_device.shape)[1]
+    tp_size = tuple(mesh_device.shape)[tp_axis]
+    physical = []
+    for tp_rank in range(tp_size):
+        row, column = _mesh_coordinate(sp_rank, tp_rank, sp_axis)
+        physical.append(shards[row * columns + column])
+    return torch.cat(
+        tuple(
+            torch.cat([shard[..., index * local_width : (index + 1) * local_width] for shard in physical], dim=-1)
+            for index in range(3)
+        ),
+        dim=-1,
+    )
+
+
+def compare_cpu_device(
+    name: str,
+    expected: torch.Tensor,
+    actual: torch.Tensor,
+    *,
+    pcc_threshold: float,
+) -> tuple[float, list[str]]:
+    """Run the shared accuracy contract without hiding later tensor results."""
+    try:
+        pcc = assert_accurate(expected, actual, name=name, pcc_threshold=pcc_threshold)
+    except AssertionError as error:
+        return float("nan"), [str(error)]
+    return pcc, []
+
+
+def check_kimi_k3_accuracy(
+    name: str,
+    case: KimiK3TestCase,
+    golden_output: torch.Tensor,
+    golden_state: KDAReferenceState,
+    state: KdaState,
+    output: ttnn.Tensor,
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+    *,
+    pcc_threshold: float,
+) -> dict[str, float]:
+    """Reconstruct an SP/TP K3 result and run the shared accuracy contract on every endpoint."""
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    mesh_shape = tuple(mesh_device.shape)
+    sp_size = mesh_shape[sequence_parallel_axis]
+    tp_size = mesh_shape[tensor_parallel_axis]
+    actual_output = reconstruct_sp_tp_tensor(
+        output,
+        mesh_device,
+        sequence_parallel_axis,
+        tensor_parallel_axis,
+        tp_dim=2,
+        sp_dim=1,
+    )
+    golden_convolution = torch.cat(
+        (golden_state.q_convolution, golden_state.k_convolution, golden_state.v_convolution), dim=-1
+    )
+    local_width = case.config.num_heads // tp_size * case.config.head_k_dim
+    output_pcc, failures = compare_cpu_device(
+        f"{name} output", golden_output, actual_output, pcc_threshold=pcc_threshold
+    )
+    pcc = {"output": output_pcc}
+    for sp_rank in range(sp_size):
+        actual_recurrent = reconstruct_state_at_sp_rank(
+            state.recurrent, mesh_device, sequence_parallel_axis, tensor_parallel_axis, sp_rank
+        )
+        actual_convolution = reconstruct_convolution_at_sp_rank(
+            state.convolution,
+            mesh_device,
+            sequence_parallel_axis,
+            tensor_parallel_axis,
+            sp_rank,
+            local_width,
+        )
+        recurrent_pcc, recurrent_failures = compare_cpu_device(
+            f"{name} sp_rank={sp_rank} recurrent state",
+            golden_state.recurrent,
+            actual_recurrent,
+            pcc_threshold=pcc_threshold,
+        )
+        pcc[f"sp_rank_{sp_rank}_recurrent"] = recurrent_pcc
+        failures.extend(recurrent_failures)
+        convolution_pcc, convolution_failures = compare_cpu_device(
+            f"{name} sp_rank={sp_rank} convolution state",
+            golden_convolution,
+            actual_convolution,
+            pcc_threshold=pcc_threshold,
+        )
+        pcc[f"sp_rank_{sp_rank}_convolution"] = convolution_pcc
+        failures.extend(convolution_failures)
+    assert not failures, "\n".join(failures)
+    return pcc
+
+
+def make_kimi_k3_test_case(checkpoint_dir: Path, *, sequence: int) -> KimiK3TestCase:
+    """Load the pinned Kimi-K3 layer and deterministic input used by correctness and perf."""
+    config = kimi_k3_kda_config()
+    downloaded_config = json.loads((checkpoint_dir / "config.json").read_text(encoding="utf-8"))
+    assert KDAConfig.from_model_config(downloaded_config) == config
+    state_dict = load_kda_layer_state_dict(checkpoint_dir, KimiK3Config.FIRST_KDA_LAYER, config)
+    hidden = torch.randn(
+        1,
+        sequence,
+        config.hidden_size,
+        generator=torch.Generator().manual_seed(1607),
+        dtype=torch.bfloat16,
+    )
+    return KimiK3TestCase(config=config, state_dict=state_dict, hidden=hidden, checkpoint_dir=checkpoint_dir)
+
+
+def make_kimi_k3_device_case(
+    mesh_device: ttnn.MeshDevice,
+    case: KimiK3TestCase,
+    *,
+    tensor_parallel_axis: int = 1,
+    summary_group_chunks: int | None = None,
+    program_config: KDAProgramConfig | None = None,
+    weights: KDAWeights | None = None,
+) -> tuple[ttKDA, ttnn.Tensor]:
+    """Construct the real-weight layer and sequence-parallel device input."""
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    tensor_cache_path = kimi_k3_tensor_cache_path(
+        case.checkpoint_dir,
+        mesh_device,
+        tensor_parallel_axis,
+    )
+    mesh_dims: list[int | None] = [None, None]
+    mesh_dims[sequence_parallel_axis] = 1
+    hidden = ttnn.from_torch(
+        case.hidden,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=tuple(mesh_dims),
+            mesh_shape=tuple(mesh_device.shape),
+        ),
+    )
+    default_program_config = kimi_k3_program_config(
+        tp_ccl_topology=(
+            ttnn.Topology.Ring if tuple(mesh_device.shape)[sequence_parallel_axis] == 1 else ttnn.Topology.Linear
+        )
+    )
+    selected_program_config = program_config or default_program_config
+    if summary_group_chunks is not None:
+        selected_program_config = replace(
+            selected_program_config,
+            recurrence=replace(selected_program_config.recurrence, summary_group_chunks=summary_group_chunks),
+        )
+    layer = ttKDA(
+        mesh_device,
+        case.config,
+        case.state_dict if weights is None else None,
+        weight_cache_path=tensor_cache_path,
+        layer_idx=KimiK3Config.FIRST_KDA_LAYER,
+        weights=weights,
+        tt_ccl=TT_CCL(mesh_device),
+        sp_axis=sequence_parallel_axis,
+        tp_axis=tensor_parallel_axis,
+        program_config=selected_program_config,
+    )
+    return layer, hidden
+
+
+def kimi_k3_tensor_cache_path(
+    checkpoint_dir: Path,
+    mesh_device: ttnn.MeshDevice,
+    tensor_parallel_axis: int,
+) -> Path:
+    """Select the parent-owned cache root for one mesh placement."""
+    mesh_shape = tuple(mesh_device.shape)
+    sequence_parallel_axis = 1 - tensor_parallel_axis
+    layout = f"sp{mesh_shape[sequence_parallel_axis]}_tp{mesh_shape[tensor_parallel_axis]}"
+    return checkpoint_dir / "ttnn_cache" / layout
+
+
+def run_profiled_forward(
+    mesh_device: ttnn.MeshDevice,
+    forward: Callable[[], ttnn.Tensor],
+) -> tuple[ttnn.Tensor, list[dict[str, object]]]:
+    """Run one correctness forward and require usable realtime-profiler records."""
+    assert ttnn.device.IsProgramRealtimeProfilerActive(), "realtime profiler must be active for KDA correctness"
+    output, records = profile_realtime_program(
+        mesh_device,
+        forward,
+        collect_all=True,
+        record_timeout_seconds=10.0,
+    )
+    non_sentinel_records = [record for record in records if int(record["runtime_id"]) != 0]
+    assert non_sentinel_records, "realtime profiler returned no program records"
+    return output, non_sentinel_records
+
+
+def make_config() -> KDAConfig:
+    return KDAConfig(
+        hidden_size=64,
+        num_heads=2,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+    )
+
+
+def make_program_config() -> KDAProgramConfig:
+    return KDAProgramConfig()
+
+
+def random_weights(config: KDAConfig) -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(20260723)
+
+    def normal(*shape: int, scale: float = 0.05) -> torch.Tensor:
+        return scale * torch.randn(*shape, generator=generator)
+
+    hidden = config.hidden_size
+    key_rank, value_rank = config.head_k_dim, config.head_v_dim
+    weights = {
+        "q_proj.weight": normal(config.q_dim, hidden),
+        "k_proj.weight": normal(config.k_dim, hidden),
+        "v_proj.weight": normal(config.v_dim, hidden),
+        "q_conv1d.weight": normal(config.q_dim, 1, config.conv_kernel_size, scale=0.2),
+        "k_conv1d.weight": normal(config.k_dim, 1, config.conv_kernel_size, scale=0.2),
+        "v_conv1d.weight": normal(config.v_dim, 1, config.conv_kernel_size, scale=0.2),
+        "A_log": torch.log(torch.linspace(1.0, 4.0, config.num_heads)).reshape(1, 1, config.num_heads, 1),
+        "f_a_proj.weight": normal(key_rank, hidden),
+        "f_b_proj.weight": normal(config.num_heads * key_rank, key_rank),
+        "dt_bias": normal(config.num_heads * key_rank),
+        "b_proj.weight": normal(config.num_heads, hidden),
+        "o_norm.weight": 1.0 + normal(value_rank),
+        "o_proj.weight": normal(hidden, config.num_heads * value_rank),
+    }
+    if config.use_full_rank_gate:
+        weights["g_proj.weight"] = normal(config.v_dim, hidden)
+    else:
+        weights["g_a_proj.weight"] = normal(value_rank, hidden)
+        weights["g_b_proj.weight"] = normal(config.num_heads * value_rank, value_rank)
+    return weights

--- a/models/demos/deepseek_v3_d_p/tests/kimi_k3/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/kimi_k3/conftest.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Fixtures for Kimi-K3 tests gated against the captured vLLM trace."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from models.demos.deepseek_v3_d_p.tests.kimi_k3.trace import KimiK3Trace
+
+KIMI_K3_MODEL_ID = "moonshotai/Kimi-K3"
+
+
+@pytest.fixture(scope="session")
+def kimi_k3_checkpoint_dir() -> Path:
+    """The Hugging Face checkpoint the trace was captured from."""
+    value = os.getenv("KIMI_K3_CKPT")
+    if value is None:
+        pytest.skip("set KIMI_K3_CKPT to the pinned Kimi-K3 checkpoint")
+    return Path(value)
+
+
+@pytest.fixture(scope="session")
+def kimi_k3_trace() -> KimiK3Trace:
+    """The captured trace, or a skip when it is absent or unreadable.
+
+    Payload readability is worth probing up front: the trace directories are only group-readable
+    if whoever published them made them so, and safetensors surfaces EACCES as a missing file,
+    which reads as a corrupt trace rather than as a permission problem.
+    """
+    value = os.getenv("KIMI_K3_TRACE")
+    if value is None:
+        pytest.skip("set KIMI_K3_TRACE to the Kimi-K3 vLLM trace directory")
+    root = Path(value)
+    if not (root / "tensor_mapping.json").is_file():
+        raise FileNotFoundError(f"{root} is not a trace directory: no tensor_mapping.json")
+    trace = KimiK3Trace(root)
+    unreadable = sorted(stream.name for stream in trace.streams.values() if not os.access(stream.path, os.R_OK))
+    if unreadable:
+        pytest.skip(f"{root} holds unreadable streams: {unreadable}")
+    return trace
+
+
+@pytest.fixture(scope="session")
+def kimi_k3_tt_cache_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Where the ttnn weight cache goes.
+
+    Layer 0 alone caches ~1.4 GB of dense-FFN weights, so point ``KIMI_K3_TT_CACHE`` at a
+    persistent directory to pay that once; the tmp fallback rebuilds it every run.
+    """
+    value = os.getenv("KIMI_K3_TT_CACHE")
+    return Path(value) if value else tmp_path_factory.mktemp("kimi_k3_tt_cache")

--- a/models/demos/deepseek_v3_d_p/tests/kimi_k3/harness.py
+++ b/models/demos/deepseek_v3_d_p/tests/kimi_k3/harness.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared device setup for the Kimi-K3 prefill-block tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config, kimi_k3_hf_config
+from models.demos.deepseek_v3_d_p.tests.kimi_k3.weights import load_dense_block_state_dict
+from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
+from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
+
+SP_AXIS = 0
+TP_AXIS = 1
+
+
+def kda_sequence_length(mesh_device: ttnn.MeshDevice) -> int:
+    """The shortest sequence the KDA recurrence accepts on this mesh.
+
+    ttKDA groups its chunked recurrence in ``KDA_SUMMARY_GROUP_CHUNKS`` chunks of one tile, and the
+    block hands it the production program config, so the per-device sequence must be a whole number
+    of groups. Sequence-parallel splitting makes that a constraint on the global length.
+    """
+    return ttnn.TILE_SIZE * KimiK3Config.KDA_SUMMARY_GROUP_CHUNKS * mesh_device.shape[SP_AXIS]
+
+
+def shard_activation(mesh_device: ttnn.MeshDevice, activation: torch.Tensor) -> ttnn.Tensor:
+    """Place ``[1, 1, T, emb]`` as the block wants it: sequence on SP, embedding on TP."""
+    dims: list[int | None] = [None, None]
+    dims[SP_AXIS] = 2
+    dims[TP_AXIS] = 3
+    return ttnn.from_torch(
+        activation,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=tuple(dims), mesh_shape=tuple(mesh_device.shape)),
+    )
+
+
+def layer_cache_path(mesh_device: ttnn.MeshDevice, cache_root: Path) -> Path:
+    """The weight-cache directory for one mesh placement."""
+    mesh_shape = tuple(mesh_device.shape)
+    path = cache_root / f"sp{mesh_shape[SP_AXIS]}_tp{mesh_shape[TP_AXIS]}"
+    path.mkdir(parents=True, exist_ok=True)
+    init_checker(path)
+    return path
+
+
+def build_layer_0(
+    mesh_device: ttnn.MeshDevice,
+    checkpoint_dir: Path,
+    cache_root: Path,
+    seq_len: int,
+) -> tuple[TtPrefillBlock, dict]:
+    """Cache and construct the real-weight layer-0 block, returning it and its torch weights."""
+    config = kimi_k3_hf_config(max_seq=seq_len)
+    state_dict = load_dense_block_state_dict(checkpoint_dir, layer_idx=0)
+    cache_path = layer_cache_path(mesh_device, cache_root)
+    if not TtPrefillBlock.check_cache_complete(cache_path, 0, is_dense=True, model_cfg=KimiK3Config):
+        TtPrefillBlock.build_ttnn_cache(
+            state_dict=state_dict,
+            layer_idx=0,
+            cache_path=cache_path,
+            mesh_device=mesh_device,
+            config=config,
+            model_cfg=KimiK3Config,
+            seq_len=seq_len,
+            sp_axis=SP_AXIS,
+            tp_axis=TP_AXIS,
+        )
+    block = TtPrefillBlock(
+        mesh_device=mesh_device,
+        config=config,
+        model_cfg=KimiK3Config,
+        state_dict=state_dict,
+        layer_idx=0,
+        seq_len=seq_len,
+        sp_axis=SP_AXIS,
+        tp_axis=TP_AXIS,
+        weight_cache_path=cache_path,
+    )
+    return block, state_dict

--- a/models/demos/deepseek_v3_d_p/tests/kimi_k3/test_block_golden.py
+++ b/models/demos/deepseek_v3_d_p/tests/kimi_k3/test_block_golden.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Kimi-K3 layer 0 on device against the captured vLLM trace.
+
+Layer 0 is where the trace and the block can be compared without any of the model that is not
+built yet. It is dense (``first_k_dense_replace=1``) and KDA, so no MXFP4 dequantizer is needed,
+and its attention input is a plain RMSNorm of the residual stream: the attn-res read that
+replaces the residual add elsewhere in K3 sees an empty snapshot history at layer 0.
+
+The comparison stops at the KDA output. Layer 0's *pre-MLP* attn-res read is not empty, so the
+residual stream diverges from the trace from the FFN input onward until the walk lands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.kda.utils import (
+    compare_cpu_device,
+    reconstruct_sp_tp_tensor,
+    reconstruct_state_at_sp_rank,
+)
+from models.demos.deepseek_v3_d_p.tests.kimi_k3.harness import (
+    SP_AXIS,
+    TP_AXIS,
+    build_layer_0,
+    kda_sequence_length,
+    shard_activation,
+)
+from models.demos.deepseek_v3_d_p.tests.kimi_k3.trace import KimiK3Trace
+from models.demos.deepseek_v3_d_p.tt.kda.state_store import KdaStateStore
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+    pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True),
+]
+
+# The RMSNorm is elementwise on a BF16 residual, so it is held to the tighter bound; the
+# recurrence and its carry get the threshold the rest of the KDA device tests use.
+NORM_PCC = 0.999
+KDA_PCC = 0.98
+
+
+def test_kimi_k3_layer_0_kda_matches_vllm_trace(
+    mesh_device: ttnn.MeshDevice,
+    kimi_k3_checkpoint_dir: Path,
+    kimi_k3_trace: KimiK3Trace,
+    kimi_k3_tt_cache_root: Path,
+) -> None:
+    """PCC the block's KDA path against the trace, from residual stream to recurrent carry.
+
+    Drives ``attn_norm`` and ``_kda_path`` rather than ``forward`` so the comparison ends where
+    the trace stops being comparable, but that is still the whole integration under test: the
+    tensor-parallel gather into KDA's full-width input projection, the carry the store hands over
+    and takes back, and the reduce-scattered residual-shaped result.
+    """
+    trace = kimi_k3_trace
+    assert trace.metadata["kda_layer"] == 0, "the trace captures KDA on a layer this test does not build"
+
+    seq_len = kda_sequence_length(mesh_device)
+    state_every = int(trace.metadata["kda_state_every"])
+    assert (
+        seq_len % state_every == 0
+    ), f"the trace snapshots the carry every {state_every} tokens, which does not line up with T={seq_len}"
+
+    hidden = trace.rows("decoder_input_layer_0", seq_len).reshape(1, 1, seq_len, KimiK3Config.EMB_SIZE)
+    block, _ = build_layer_0(mesh_device, kimi_k3_checkpoint_dir, kimi_k3_tt_cache_root, seq_len)
+    assert block.is_kda, "layer 0 must be a KDA layer"
+
+    kda_states = KdaStateStore({0: block.kda})
+    attn_norm_out = block.attn_norm(shard_activation(mesh_device, hidden))
+    actual_norm = reconstruct_sp_tp_tensor(attn_norm_out, mesh_device, SP_AXIS, TP_AXIS, tp_dim=2, sp_dim=1)
+    attn_out = block._kda_path(attn_norm_out, kda_states)
+    actual_attn = reconstruct_sp_tp_tensor(attn_out, mesh_device, SP_AXIS, TP_AXIS, tp_dim=2, sp_dim=1)
+    actual_recurrent = {
+        sp_rank: reconstruct_state_at_sp_rank(kda_states.get(0).recurrent, mesh_device, SP_AXIS, TP_AXIS, sp_rank)
+        for sp_rank in range(tuple(mesh_device.shape)[SP_AXIS])
+    }
+
+    failures: list[str] = []
+    for name, golden, actual, threshold in (
+        ("attn_norm output", trace.rows("kda_input_layer_0", seq_len), actual_norm, NORM_PCC),
+        ("KDA output", trace.rows("kda_output_layer_0", seq_len), actual_attn, KDA_PCC),
+    ):
+        _, stream_failures = compare_cpu_device(
+            f"layer 0 {name}",
+            golden.reshape(1, seq_len, KimiK3Config.EMB_SIZE),
+            actual.to(golden.dtype),
+            pcc_threshold=threshold,
+        )
+        failures.extend(stream_failures)
+
+    # The recurrence chains across the sequence-parallel ranks, so every rank ends up holding the
+    # same carry: the one the trace snapshots after the last token of the window.
+    # The trace stores the carry as [heads, value, key]; ttKDA carries [heads, key, value]. The
+    # trace metadata names neither axis, so the orientation is established empirically: an
+    # unweighted k^T v proxy correlates with the transposed snapshot and not with the snapshot.
+    golden_recurrent = trace.rows("kda_recurrent_state_layer_0", 1, start=seq_len // state_every - 1)
+    golden_recurrent = golden_recurrent.transpose(-2, -1)
+    for sp_rank, actual in actual_recurrent.items():
+        _, state_failures = compare_cpu_device(
+            f"layer 0 recurrent carry sp_rank={sp_rank}",
+            golden_recurrent,
+            actual.to(golden_recurrent.dtype),
+            pcc_threshold=KDA_PCC,
+        )
+        failures.extend(state_failures)
+
+    assert not failures, "\n".join(failures)

--- a/models/demos/deepseek_v3_d_p/tests/kimi_k3/test_block_layer0.py
+++ b/models/demos/deepseek_v3_d_p/tests/kimi_k3/test_block_layer0.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Kimi-K3 layer 0 on device against the torch reference, on real checkpoint weights.
+
+Layer 0 is the cheapest real-weight gate in the model: it is dense (``first_k_dense_replace=1``)
+and KDA, so every weight it touches is stored unquantized and no MXFP4 dequantizer is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kimi_k3.modeling_kimi_k3_mla import KimiRMSNorm
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config, kimi_k3_hf_config, kimi_k3_kda_config
+from models.demos.deepseek_v3_d_p.tests.kda.utils import assert_accurate, reconstruct_sp_tp_tensor
+from models.demos.deepseek_v3_d_p.tests.kimi_k3.harness import (
+    SP_AXIS,
+    TP_AXIS,
+    build_layer_0,
+    kda_sequence_length,
+    layer_cache_path,
+    shard_activation,
+)
+from models.demos.deepseek_v3_d_p.tests.kimi_k3.weights import load_dense_block_state_dict
+from models.demos.deepseek_v3_d_p.tt.kda.state_store import KdaStateStore
+from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_mla_kv_cache
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize(
+        "device_params",
+        [{"l1_small_size": 24576, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    ),
+    pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True),
+]
+
+
+def residual_stream(seq_len: int) -> torch.Tensor:
+    """A deterministic stand-in for the embedding output entering layer 0."""
+    return torch.randn(
+        1,
+        1,
+        seq_len,
+        KimiK3Config.EMB_SIZE,
+        generator=torch.Generator().manual_seed(20260821),
+        dtype=torch.bfloat16,
+    )
+
+
+def test_kimi_k3_layer_0_kda_matches_torch_reference(
+    mesh_device: ttnn.MeshDevice,
+    kimi_k3_checkpoint_dir: Path,
+    kimi_k3_tt_cache_root: Path,
+) -> None:
+    """PCC the block's KDA attention output against ``norm -> kda_forward_reference`` in torch.
+
+    This drives ``attn_norm`` and ``_kda_path`` rather than ``forward``, because ``forward`` folds
+    the attention output into the residual and on through the FFN. It is still the whole
+    integration under test: the tensor-parallel gather into KDA's full-width input projection, the
+    recurrent carry the store hands over, and the reduce-scattered residual-shaped result.
+    """
+    seq_len = kda_sequence_length(mesh_device)
+    hidden = residual_stream(seq_len)
+
+    block, state_dict = build_layer_0(mesh_device, kimi_k3_checkpoint_dir, kimi_k3_tt_cache_root, seq_len)
+    assert block.is_kda, "layer 0 must be a KDA layer"
+
+    norm = KimiRMSNorm(KimiK3Config.EMB_SIZE, eps=KimiK3Config.RMS_NORM_EPS)
+    with torch.no_grad():
+        norm.weight.copy_(state_dict["attn_norm_weight"])
+        normed = norm(hidden.reshape(1, seq_len, KimiK3Config.EMB_SIZE))
+    golden, _ = kda_forward_reference(normed, state_dict["kda_weights"], kimi_k3_kda_config())
+
+    kda_states = KdaStateStore({0: block.kda})
+    attn_norm_out = block.attn_norm(shard_activation(mesh_device, hidden))
+    attn_out = block._kda_path(attn_norm_out, kda_states)
+
+    actual = reconstruct_sp_tp_tensor(attn_out, mesh_device, SP_AXIS, TP_AXIS, tp_dim=2, sp_dim=1)
+    assert_accurate(golden, actual.to(golden.dtype), name="Kimi-K3 layer 0 attn output", pcc_threshold=0.98)
+
+
+def test_kimi_k3_single_layer_transformer_forward(
+    mesh_device: ttnn.MeshDevice,
+    kimi_k3_checkpoint_dir: Path,
+    kimi_k3_tt_cache_root: Path,
+) -> None:
+    """Run a one-layer ``TtPrefillTransformer`` over layer 0 and check what only it owns.
+
+    Not an accuracy gate: the block's dense FFN applies SiLU where Kimi-K3 applies ``situ``, so the
+    layer output is not comparable to anything yet. What this does exercise is the wiring the
+    transformer adds around a KDA layer — the MLA-relative KV-slot map, and the state store that
+    makes the recurrence something the caller carries across chunks.
+
+    Built as a middle pipeline rank so the tail is skipped: the embedding and LM head are 2.4 GB of
+    vocab weights each and neither is on the path being checked.
+    """
+    seq_len = kda_sequence_length(mesh_device)
+    config = kimi_k3_hf_config(max_seq=seq_len)
+    state_dict = {"layers": [load_dense_block_state_dict(kimi_k3_checkpoint_dir, layer_idx=0)]}
+    mesh_shape = tuple(mesh_device.shape)
+
+    transformer = TtPrefillTransformer(
+        mesh_device=mesh_device,
+        config=config,
+        model_cfg=KimiK3Config,
+        state_dict=state_dict,
+        num_layers=1,
+        seq_len=seq_len,
+        sp_axis=SP_AXIS,
+        tp_axis=TP_AXIS,
+        weight_cache_path=layer_cache_path(mesh_device, kimi_k3_tt_cache_root),
+        first_layer_idx=0,
+        is_first_rank=False,
+        is_last_rank=False,
+    )
+    assert transformer.kv_slot_of_layer == [None], "layer 0 is KDA and owns no KV slot"
+    assert transformer.num_mla_layers == 0
+    assert transformer.kda_states is not None
+
+    # Layer 0 writes no KV, but forward() takes a cache unconditionally; one slot is the smallest
+    # allocation that is still a cache.
+    kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=SP_AXIS,
+        num_kvpe_cache_layers=1,
+    )
+
+    x = shard_activation(mesh_device, residual_stream(seq_len))
+    output = transformer.forward(x, kvpe_cache, actual_isl=seq_len)
+    assert tuple(output.shape) == (
+        1,
+        1,
+        seq_len // mesh_shape[SP_AXIS],
+        KimiK3Config.EMB_SIZE // mesh_shape[TP_AXIS],
+    )
+    host_output = reconstruct_sp_tp_tensor(output, mesh_device, SP_AXIS, TP_AXIS, tp_dim=2, sp_dim=1)
+    assert torch.isfinite(host_output.float()).all(), "layer output is not finite"
+
+    # The recurrence has to have advanced: a store that was never written back still holds the
+    # zeros ttKDA allocated, and every later chunk would restart the layer's history.
+    recurrent = ttnn.to_torch(ttnn.get_device_tensors(transformer.kda_states.get(0).recurrent)[0])
+    assert recurrent.float().abs().sum() > 0, "KDA recurrent carry was not written back to the store"

--- a/models/demos/deepseek_v3_d_p/tests/kimi_k3/trace.py
+++ b/models/demos/deepseek_v3_d_p/tests/kimi_k3/trace.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Reader for the ``per_stream_safetensors_v1`` Kimi-K3 vLLM trace."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+LAYOUT = "per_stream_safetensors_v1"
+
+
+@dataclass(frozen=True)
+class TraceStream:
+    name: str
+    path: Path
+    shape: tuple[int, ...]
+    dtype: str
+
+
+class KimiK3Trace:
+    """One trace directory, addressed by stream name.
+
+    Every stream is a whole tensor in its own file, so a stream is read by slicing rows off it
+    rather than by stitching chunks together. ``tensor_mapping.json`` is the only source of the
+    stream-to-file mapping: the file stem usually equals the stream name but not always.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.metadata = json.loads((root / "tensor_mapping.json").read_text())
+        layout = self.metadata.get("layout")
+        if layout != LAYOUT:
+            raise ValueError(f"{root} has layout {layout!r}, expected {LAYOUT!r}")
+        self.streams = _expand_streams(root, self.metadata["tensor_streams"])
+
+    @property
+    def row_count(self) -> int:
+        return int(self.metadata["n_rows"])
+
+    def stream(self, name: str) -> TraceStream:
+        stream = self.streams.get(name)
+        if stream is None:
+            raise KeyError(f"{self.root} has no stream {name!r}; known: {sorted(self.streams)}")
+        return stream
+
+    def rows(self, name: str, count: int, start: int = 0) -> torch.Tensor:
+        """The first ``count`` rows of a stream from row ``start``, along the token axis."""
+        stream = self.stream(name)
+        if start < 0 or count <= 0 or start + count > stream.shape[0]:
+            raise ValueError(f"rows [{start}, {start + count}) fall outside {name} {stream.shape}")
+        with safe_open(str(stream.path), framework="pt", device="cpu") as handle:
+            return handle.get_slice(name)[start : start + count]
+
+
+def _expand_streams(root: Path, entries: list[dict]) -> dict[str, TraceStream]:
+    streams: dict[str, TraceStream] = {}
+    for entry in entries:
+        template = entry["stream"]
+        layer_range = entry.get("layer_range")
+        layers = range(layer_range[0], layer_range[1] + 1) if layer_range else [None]
+        for layer in layers:
+            name = template if layer is None else template.format(i=layer)
+            path = entry["path"] if layer is None else entry["path"].format(i=layer)
+            streams[name] = TraceStream(
+                name=name,
+                path=root / path,
+                shape=tuple(entry["shape"]),
+                dtype=entry["dtype"],
+            )
+    return streams

--- a/models/demos/deepseek_v3_d_p/tests/kimi_k3/weights.py
+++ b/models/demos/deepseek_v3_d_p/tests/kimi_k3/weights.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Real Kimi-K3 layer weights in the layout ``TtPrefillBlock`` reads."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config, kimi_k3_kda_config
+from models.demos.deepseek_v3_d_p.tests.kda.checkpoint_utils import load_kda_layer_state_dict
+
+LAYER_PREFIX = "language_model.model.layers"
+
+
+def load_hf_tensors(checkpoint_dir: Path, full_names: dict[str, str]) -> dict[str, torch.Tensor]:
+    """Read ``{alias: checkpoint key}`` from the shards the index puts each key in."""
+    index_path = Path(checkpoint_dir) / "model.safetensors.index.json"
+    with index_path.open(encoding="utf-8") as index_file:
+        weight_map = json.load(index_file)["weight_map"]
+
+    missing = sorted(name for name in full_names.values() if name not in weight_map)
+    if missing:
+        raise ValueError(f"{checkpoint_dir} index is missing: {missing}")
+
+    by_shard: dict[str, list[tuple[str, str]]] = {}
+    for alias, name in full_names.items():
+        by_shard.setdefault(weight_map[name], []).append((alias, name))
+
+    tensors: dict[str, torch.Tensor] = {}
+    for shard, entries in by_shard.items():
+        with safe_open(Path(checkpoint_dir) / shard, framework="pt", device="cpu") as shard_file:
+            for alias, name in entries:
+                tensors[alias] = shard_file.get_tensor(name)
+    return tensors
+
+
+def load_dense_block_state_dict(checkpoint_dir: Path, layer_idx: int) -> dict:
+    """Assemble one DENSE Kimi-K3 layer for ``TtPrefillBlock``.
+
+    Dense only (layer 0 under ``first_k_dense_replace=1``): every tensor a dense layer touches is
+    stored unquantized, so this needs no MXFP4 dequantizer. A MoE layer's 896 routed experts ship
+    as packed FP4 nibbles plus per-32 e8m0 scales and cannot be read this way.
+    """
+    if layer_idx >= KimiK3Config.NUM_DENSE_LAYERS:
+        raise ValueError(f"layer {layer_idx} is a MoE layer; only layers < {KimiK3Config.NUM_DENSE_LAYERS} are dense")
+
+    prefix = f"{LAYER_PREFIX}.{layer_idx}"
+    tensors = load_hf_tensors(
+        checkpoint_dir,
+        {
+            "attn_norm_weight": f"{prefix}.input_layernorm.weight",
+            "ffn_norm_weight": f"{prefix}.post_attention_layernorm.weight",
+            "gate_proj": f"{prefix}.mlp.gate_proj.weight",
+            "up_proj": f"{prefix}.mlp.up_proj.weight",
+            "down_proj": f"{prefix}.mlp.down_proj.weight",
+        },
+    )
+    return {
+        "attn_norm_weight": tensors["attn_norm_weight"],
+        "ffn_norm_weight": tensors["ffn_norm_weight"],
+        "kda_weights": load_kda_layer_state_dict(checkpoint_dir, layer_idx, kimi_k3_kda_config()),
+        "ffn_weights": {name: tensors[name] for name in ("gate_proj", "up_proj", "down_proj")},
+    }

--- a/models/demos/deepseek_v3_d_p/tt/kda/__init__.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Public Kimi Delta Attention layer API."""
+
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+
+__all__ = ["ttKDA", "KdaState"]

--- a/models/demos/deepseek_v3_d_p/tt/kda/config.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/config.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Device-program configuration for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+
+
+@dataclass(frozen=True)
+class KDARecurrenceProgramConfig:
+    """Complete tensor and program contract for KDA recurrence."""
+
+    chunk_size: int = ttnn.TILE_SIZE
+    grouped_scan_min_chunks: int = 160
+    summary_group_chunks: int = 20
+
+    qkv_dtype: ttnn.DataType = ttnn.bfloat16
+    gate_dtype: ttnn.DataType = ttnn.bfloat16
+    beta_dtype: ttnn.DataType = ttnn.float32
+    recurrent_state_dtype: ttnn.DataType = ttnn.float32
+    affine_summary_dtype: ttnn.DataType = ttnn.bfloat16
+    scan_output_dtype: ttnn.DataType = ttnn.bfloat16
+    prep_output_bf16_mask: int = (1 << 1) | (1 << 2) | (1 << 5)
+
+    preparation_memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG
+    prefix_memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG
+    distributed_working_memory_config: ttnn.MemoryConfig = ttnn.L1_MEMORY_CONFIG
+    output_memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG
+
+    affine_prefix_math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.HiFi2
+    grouped_scan_math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.HiFi2
+
+    def __post_init__(self) -> None:
+        if self.chunk_size != ttnn.TILE_SIZE:
+            raise ValueError(f"KDA recurrence requires chunk_size={ttnn.TILE_SIZE}, got {self.chunk_size}")
+        if self.grouped_scan_min_chunks <= 0:
+            raise ValueError("grouped_scan_min_chunks must be positive")
+        if self.summary_group_chunks <= 0:
+            raise ValueError("summary_group_chunks must be positive")
+        fixed_dtypes = {
+            "qkv_dtype": (self.qkv_dtype, ttnn.bfloat16),
+            "gate_dtype": (self.gate_dtype, ttnn.bfloat16),
+            "beta_dtype": (self.beta_dtype, ttnn.float32),
+            "recurrent_state_dtype": (self.recurrent_state_dtype, ttnn.float32),
+            "affine_summary_dtype": (self.affine_summary_dtype, ttnn.bfloat16),
+            "scan_output_dtype": (self.scan_output_dtype, ttnn.bfloat16),
+        }
+        for name, (actual, expected) in fixed_dtypes.items():
+            if actual != expected:
+                raise ValueError(f"{name} is fixed to {expected}, got {actual}")
+        fixed_memory_configs = {
+            "preparation_memory_config": (self.preparation_memory_config, ttnn.DRAM_MEMORY_CONFIG),
+            "prefix_memory_config": (self.prefix_memory_config, ttnn.DRAM_MEMORY_CONFIG),
+            "distributed_working_memory_config": (
+                self.distributed_working_memory_config,
+                ttnn.L1_MEMORY_CONFIG,
+            ),
+            "output_memory_config": (self.output_memory_config, ttnn.DRAM_MEMORY_CONFIG),
+        }
+        for name, (actual, expected) in fixed_memory_configs.items():
+            if actual != expected:
+                raise ValueError(f"{name} is fixed to {expected}, got {actual}")
+        expected_mask = (1 << 1) | (1 << 2) | (1 << 5)
+        if self.prep_output_bf16_mask != expected_mask:
+            raise ValueError(f"prep_output_bf16_mask is fixed to {expected_mask}, got {self.prep_output_bf16_mask}")
+
+
+@dataclass(frozen=True)
+class KDAProgramConfig:
+    """Device-program tuning kept separate from checkpoint model dimensions."""
+
+    recurrence: KDARecurrenceProgramConfig = field(default_factory=KDARecurrenceProgramConfig)
+    output_projection_out_block_w: int | None = None
+    tp_ccl_topology: ttnn.Topology = ttnn.Topology.Linear
+    gated_rms_output_dtype: ttnn.DataType = ttnn.float32
+    output_projection_math_fidelity: ttnn.MathFidelity = ttnn.MathFidelity.HiFi4
+
+    def __post_init__(self) -> None:
+        if self.output_projection_out_block_w is not None and self.output_projection_out_block_w <= 0:
+            raise ValueError(
+                "output_projection_out_block_w must be positive, " f"got {self.output_projection_out_block_w}"
+            )
+        if self.gated_rms_output_dtype not in (ttnn.float32, ttnn.bfloat16):
+            raise ValueError("gated_rms_output_dtype must be ttnn.float32 or ttnn.bfloat16")
+
+
+def kimi_k3_program_config(*, tp_ccl_topology: ttnn.Topology) -> KDAProgramConfig:
+    """Return measured K3 tuning with caller-owned per-axis CCL topology."""
+    return KDAProgramConfig(
+        recurrence=KDARecurrenceProgramConfig(summary_group_chunks=KimiK3Config.KDA_SUMMARY_GROUP_CHUNKS),
+        output_projection_out_block_w=KimiK3Config.KDA_OUTPUT_PROJECTION_OUT_BLOCK_W,
+        tp_ccl_topology=tp_ccl_topology,
+        gated_rms_output_dtype=ttnn.bfloat16,
+        output_projection_math_fidelity=ttnn.MathFidelity.HiFi2,
+    )

--- a/models/demos/deepseek_v3_d_p/tt/kda/const_tiles.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/const_tiles.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Host construction of KDA's fixed chunk-operation tensors."""
+
+from __future__ import annotations
+
+import torch
+
+import ttnn
+
+_CHUNK_SIZE = 32
+
+
+def build_kda_const_tiles(
+    device: ttnn.Device | ttnn.MeshDevice,
+) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    """Build replicated eye, triangular, ones, and quadrant-mask tiles."""
+    eye = torch.eye(_CHUNK_SIZE, dtype=torch.float32)
+    tril = torch.tril(torch.ones(_CHUNK_SIZE, _CHUNK_SIZE, dtype=torch.float32))
+    ones = torch.ones(_CHUNK_SIZE, _CHUNK_SIZE, dtype=torch.float32)
+
+    # Packing must match make_quadrant_masks in chunk_gated_delta_rule.cpp.
+    indices = torch.arange(_CHUNK_SIZE)
+    rows = indices.unsqueeze(1)
+    columns = indices.unsqueeze(0)
+    lower_rows = rows < _CHUNK_SIZE / 2
+    lower_columns = columns < _CHUNK_SIZE / 2
+    masks = torch.cat(
+        [
+            (lower_rows & lower_columns).float(),
+            (~lower_rows & ~lower_columns).float(),
+            (~lower_rows & lower_columns).float(),
+        ],
+        dim=1,
+    )
+
+    def upload(tensor: torch.Tensor) -> ttnn.Tensor:
+        return ttnn.from_torch(
+            tensor.reshape(1, 1, *tensor.shape),
+            dtype=ttnn.float32,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+        )
+
+    return upload(eye), upload(tril), upload(ones), upload(masks)

--- a/models/demos/deepseek_v3_d_p/tt/kda/const_tiles.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/const_tiles.py
@@ -13,26 +13,11 @@ _CHUNK_SIZE = 32
 
 def build_kda_const_tiles(
     device: ttnn.Device | ttnn.MeshDevice,
-) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
-    """Build replicated eye, triangular, ones, and quadrant-mask tiles."""
+) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    """Build the replicated eye, triangular, and ones tiles."""
     eye = torch.eye(_CHUNK_SIZE, dtype=torch.float32)
     tril = torch.tril(torch.ones(_CHUNK_SIZE, _CHUNK_SIZE, dtype=torch.float32))
     ones = torch.ones(_CHUNK_SIZE, _CHUNK_SIZE, dtype=torch.float32)
-
-    # Packing must match make_quadrant_masks in chunk_gated_delta_rule.cpp.
-    indices = torch.arange(_CHUNK_SIZE)
-    rows = indices.unsqueeze(1)
-    columns = indices.unsqueeze(0)
-    lower_rows = rows < _CHUNK_SIZE / 2
-    lower_columns = columns < _CHUNK_SIZE / 2
-    masks = torch.cat(
-        [
-            (lower_rows & lower_columns).float(),
-            (~lower_rows & ~lower_columns).float(),
-            (~lower_rows & lower_columns).float(),
-        ],
-        dim=1,
-    )
 
     def upload(tensor: torch.Tensor) -> ttnn.Tensor:
         return ttnn.from_torch(
@@ -43,4 +28,4 @@ def build_kda_const_tiles(
             mesh_mapper=ttnn.ReplicateTensorToMesh(device),
         )
 
-    return upload(eye), upload(tril), upload(ones), upload(masks)
+    return upload(eye), upload(tril), upload(ones)

--- a/models/demos/deepseek_v3_d_p/tt/kda/kda.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/kda.py
@@ -194,20 +194,29 @@ class ttKDA:
             fp32_dest_acc_en=True,
             packer_l1_acc=True,
         )
+        # Every ttnn.experimental.kda op rejects packer_l1_acc outright: their compute kernels do not
+        # accumulate through L1, so the flag was never doing anything for them. self.compute_config
+        # is therefore only safe on the generic ttnn ops.
+        self.kda_op_compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
         self.affine_prefix_compute_config = ttnn.init_device_compute_kernel_config(
             mesh_device.arch(),
             math_fidelity=self.recurrence_config.affine_prefix_math_fidelity,
             fp32_dest_acc_en=True,
-            packer_l1_acc=True,
+            packer_l1_acc=False,
         )
         self.grouped_scan_compute_config = ttnn.init_device_compute_kernel_config(
             mesh_device.arch(),
             math_fidelity=self.recurrence_config.grouped_scan_math_fidelity,
             fp32_dest_acc_en=True,
-            packer_l1_acc=True,
+            packer_l1_acc=False,
         )
         self.recurrence_compute_config = ops._RecurrenceComputeConfig(
-            preparation=self.compute_config,
+            preparation=self.kda_op_compute_config,
             affine_prefix=self.affine_prefix_compute_config,
             grouped_scan=self.grouped_scan_compute_config,
         )
@@ -325,7 +334,7 @@ class ttKDA:
             config.k_dim,
             config.v_dim,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            compute_kernel_config=self.compute_config,
+            compute_kernel_config=self.kda_op_compute_config,
         )
         return q, k, v, new_state
 
@@ -479,7 +488,7 @@ class ttKDA:
             config.num_heads,
             epsilon=config.norm_eps,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            compute_kernel_config=self.compute_config,
+            compute_kernel_config=self.kda_op_compute_config,
             # Real-K3 component A/B: direct BF16 output retained PCC 1.0 for every LoudBox layout
             # and improved median component latency by 0.655%-1.339%.
             output_dtype=self.gated_rms_output_dtype,

--- a/models/demos/deepseek_v3_d_p/tt/kda/kda.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/kda.py
@@ -1,0 +1,559 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Composed TTNN Kimi Delta Attention layer."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tt.kda import ops
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDAProgramConfig
+from models.demos.deepseek_v3_d_p.tt.kda.const_tiles import build_kda_const_tiles
+from models.demos.deepseek_v3_d_p.tt.kda.weights import KDAWeights, load_kda_weights
+from models.tt_transformers.tt.ccl import TT_CCL
+
+
+def _slice_width(tensor: ttnn.Tensor, start: int, end: int) -> ttnn.Tensor:
+    stop = list(tensor.shape)
+    begin = [0] * len(stop)
+    begin[-1] = start
+    stop[-1] = end
+    return ttnn.slice(tensor, tuple(begin), tuple(stop), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+
+def _largest_divisor_at_most(value: int, limit: int) -> int:
+    for divisor in range(limit, 0, -1):
+        if value % divisor == 0:
+            return divisor
+    return 1
+
+
+def _output_projection_program_config(
+    sequence: int,
+    input_width: int,
+    output_width: int,
+    out_block_w_cap: int | None,
+    grid: tuple[int, int],
+) -> ttnn.MatmulMultiCoreReuseMultiCastProgramConfig:
+    per_core_n = max(1, math.ceil(output_width / ttnn.TILE_SIZE / grid[0]))
+    out_block_w_limit = max(1, per_core_n // 2)
+    if out_block_w_cap is not None:
+        out_block_w_limit = min(out_block_w_limit, out_block_w_cap)
+    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=grid,
+        in0_block_w=_largest_divisor_at_most(
+            input_width // ttnn.TILE_SIZE,
+            min(4, max(1, input_width // ttnn.TILE_SIZE // grid[0])),
+        ),
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=max(1, math.ceil(sequence / ttnn.TILE_SIZE / grid[1])),
+        per_core_N=per_core_n,
+        out_block_w=_largest_divisor_at_most(per_core_n, out_block_w_limit),
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=False,
+        allowed_worker_cores=ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid[0] - 1, grid[1] - 1))}
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class _ProjectedInputs:
+    qkv: ttnn.Tensor
+    decay_rank: ttnn.Tensor
+    output_gate: ttnn.Tensor
+    beta: ttnn.Tensor
+
+
+@dataclass(frozen=True)
+class _KDAInputs:
+    q: ttnn.Tensor
+    k: ttnn.Tensor
+    v: ttnn.Tensor
+    decay: ttnn.Tensor
+    beta: ttnn.Tensor
+    output_gate: ttnn.Tensor
+
+
+@dataclass(frozen=True)
+class KdaState:
+    """Logical KDA carries owned by the caller, never by :class:`ttKDA`."""
+
+    recurrent: ttnn.Tensor
+    convolution: ttnn.Tensor
+
+
+class ttKDA:
+    """Prefill-only KDA layer with immutable, caller-owned logical state."""
+
+    @staticmethod
+    def check_cache_complete(
+        cache_path: Path | None,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        config: KDAConfig,
+        layer_idx: int,
+        *,
+        tp_axis: int = 1,
+    ) -> bool:
+        return KDAWeights.check_cache_complete(
+            cache_path, f"layer_{layer_idx}.kda", config, mesh_device, tensor_parallel_axis=tp_axis
+        )
+
+    @staticmethod
+    def build_ttnn_cache(
+        state_dict: Mapping[str, torch.Tensor],
+        cache_path: Path,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        config: KDAConfig,
+        layer_idx: int,
+        *,
+        tp_axis: int = 1,
+    ) -> None:
+        KDAWeights.build_ttnn_cache(
+            state_dict, cache_path, f"layer_{layer_idx}.kda", mesh_device, config, tensor_parallel_axis=tp_axis
+        )
+
+    def __init__(
+        self,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        config: KDAConfig,
+        state_dict: Mapping[str, torch.Tensor] | None = None,
+        layer_idx: int = 0,
+        weight_cache_path: Path | None = None,
+        tt_ccl: TT_CCL | None = None,
+        sp_axis: int = 0,
+        tp_axis: int = 1,
+        topology: ttnn.Topology | None = None,
+        program_config: KDAProgramConfig | None = None,
+        weights: KDAWeights | None = None,
+    ) -> None:
+        if tp_axis not in (0, 1) or sp_axis not in (0, 1) or sp_axis == tp_axis:
+            raise ValueError(f"KDA requires distinct 2D SP/TP axes, got SP={sp_axis}, TP={tp_axis}")
+        program_config = program_config or KDAProgramConfig()
+        self.device = mesh_device
+        self.layer_idx = layer_idx
+        self.tensor_parallel_axis = tp_axis
+        self.sequence_parallel_axis = sp_axis
+        self.sequence_parallel_size = (
+            tuple(mesh_device.shape)[self.sequence_parallel_axis] if isinstance(mesh_device, ttnn.MeshDevice) else 1
+        )
+        self.recurrence_config = program_config.recurrence
+        self.output_projection_out_block_w = program_config.output_projection_out_block_w
+        output_grid = mesh_device.compute_with_storage_grid_size()
+        self.output_projection_grid = (output_grid.x, output_grid.y)
+        self.tp_ccl_topology = (
+            topology
+            if topology is not None
+            else (ttnn.Topology.Ring if self.sequence_parallel_size == 1 else ttnn.Topology.Linear)
+        )
+        self.gated_rms_output_dtype = program_config.gated_rms_output_dtype
+        if weights is not None and state_dict:
+            raise ValueError("pass either constructed KDAWeights or host state_dict, not both")
+        if weights is None:
+            loaded = load_kda_weights(
+                mesh_device,
+                config,
+                state_dict,
+                weight_cache_path,
+                cache_name_prefix=f"layer_{layer_idx}.kda",
+                tensor_parallel_axis=tp_axis,
+            )
+            assert loaded is not None
+            weights = loaded
+        expected_tp_size = tuple(mesh_device.shape)[tp_axis] if isinstance(mesh_device, ttnn.MeshDevice) else 1
+        if weights.tensor_parallel_size != expected_tp_size or weights.tensor_parallel_axis != tp_axis:
+            raise ValueError(
+                "KDAWeights placement does not match the layer mesh: "
+                f"weights TP={weights.tensor_parallel_size} axis={weights.tensor_parallel_axis}, "
+                f"layer TP={expected_tp_size} axis={tp_axis}"
+            )
+        self.weights = weights
+        self.tensor_parallel_size = self.weights.tensor_parallel_size
+        self.global_config = config
+        if self.sequence_parallel_size > 1 and config.head_k_dim != config.head_v_dim:
+            raise ValueError(
+                f"sequence-parallel KDA currently requires K == V, got {config.head_k_dim} and {config.head_v_dim}"
+            )
+        self.config = replace(config, num_heads=config.num_heads // self.tensor_parallel_size)
+        if self.tensor_parallel_size > 1 and tt_ccl is None:
+            raise ValueError("tt_ccl is required for tensor-parallel KDA")
+        self.tt_ccl = tt_ccl
+        self.chunk_constants = ops._ChunkConstants(*build_kda_const_tiles(mesh_device))
+        self.compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        self.affine_prefix_compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=self.recurrence_config.affine_prefix_math_fidelity,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        self.grouped_scan_compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=self.recurrence_config.grouped_scan_math_fidelity,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        self.recurrence_compute_config = ops._RecurrenceComputeConfig(
+            preparation=self.compute_config,
+            affine_prefix=self.affine_prefix_compute_config,
+            grouped_scan=self.grouped_scan_compute_config,
+        )
+        # Real-K3 component A/B: output-projection HiFi2 retained PCC >=0.999987 for every LoudBox
+        # layout and improved median component latency by 3.580%-5.165%.
+        self.output_projection_compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=program_config.output_projection_math_fidelity,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+    @property
+    def _convolution_width(self) -> int:
+        return self.config.q_dim + self.config.k_dim + self.config.v_dim
+
+    def allocate_state(self, batch_size: int = 1) -> KdaState:
+        """Allocate the canonical device-resident KDA carries for one prefill stream."""
+        if batch_size != 1:
+            raise ValueError(f"KDA prefill currently requires batch_size=1, got {batch_size}")
+        return KdaState(
+            recurrent=ttnn.zeros(
+                (batch_size, self.config.num_heads, self.config.head_k_dim, self.config.head_v_dim),
+                dtype=self.recurrence_config.recurrent_state_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.device,
+                memory_config=self.recurrence_config.output_memory_config,
+            ),
+            convolution=ttnn.zeros(
+                (batch_size, self.config.conv_kernel_size - 1, self._convolution_width),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self.device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            ),
+        )
+
+    def _validate_forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        state: KdaState,
+    ) -> tuple[int, int]:
+        if len(hidden_states.shape) != 3 or hidden_states.shape[-1] != self.config.hidden_size:
+            raise ValueError(
+                f"hidden_states shape {tuple(hidden_states.shape)} must be [B,T,{self.config.hidden_size}]"
+            )
+        batch = hidden_states.shape[0]
+        sequence = hidden_states.shape[1]
+        if batch != 1:
+            raise ValueError(f"KDA prefill currently requires batch size 1, got B={batch}")
+        chunk_size = self.recurrence_config.chunk_size
+        if sequence <= 0 or sequence % chunk_size != 0:
+            raise ValueError(
+                f"KDA prefill requires local T to be positive and divisible by {chunk_size}, got T={sequence}"
+            )
+        if self.sequence_parallel_size > 1:
+            local_chunks = sequence // chunk_size
+            if local_chunks % self.recurrence_config.summary_group_chunks != 0:
+                raise ValueError(
+                    f"local chunk count {local_chunks} must be divisible by "
+                    f"summary_group_chunks {self.recurrence_config.summary_group_chunks}"
+                )
+        expected_recurrent = (batch, self.config.num_heads, self.config.head_k_dim, self.config.head_v_dim)
+        expected_convolution = (batch, self.config.conv_kernel_size - 1, self._convolution_width)
+        if tuple(state.recurrent.shape) != expected_recurrent:
+            raise ValueError(f"recurrent state shape {tuple(state.recurrent.shape)} != {expected_recurrent}")
+        if tuple(state.convolution.shape) != expected_convolution:
+            raise ValueError(f"convolution state shape {tuple(state.convolution.shape)} != {expected_convolution}")
+        if state.recurrent.dtype != self.recurrence_config.recurrent_state_dtype:
+            raise ValueError(
+                f"recurrent state dtype {state.recurrent.dtype} != {self.recurrence_config.recurrent_state_dtype}"
+            )
+        if state.convolution.dtype != ttnn.bfloat16 or state.convolution.layout != ttnn.ROW_MAJOR_LAYOUT:
+            raise ValueError("convolution state must be BF16 row-major")
+        return batch, sequence
+
+    def _convolve_qkv(
+        self,
+        qkv: ttnn.Tensor,
+        convolution_state: ttnn.Tensor,
+        sequence: int,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        """Run depthwise convolution and emit Q/K/V without post-convolution slices."""
+        config = self.config
+        channels = self._convolution_width
+        qkv_row_major = ttnn.to_layout(
+            qkv,
+            ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        state_row_major = ttnn.to_layout(
+            convolution_state,
+            ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        if self.sequence_parallel_size > 1:
+            state_row_major, new_state = ops.convolution_halo(
+                qkv_row_major,
+                state_row_major,
+                sequence_parallel_axis=self.sequence_parallel_axis,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        else:
+            new_state = ttnn.slice(
+                qkv_row_major,
+                (0, sequence - (config.conv_kernel_size - 1), 0),
+                (qkv_row_major.shape[0], sequence, channels),
+            )
+            # Retained by real-K3 T=5120 component A/B: 74.36-75.76% faster at direct Q/K/V PCC >=0.999989.
+        q, k, v = ttnn.experimental.kda.qkv_causal_conv1d_silu(
+            qkv_row_major,
+            state_row_major,
+            *self.weights.convolution_taps,
+            config.q_dim,
+            config.k_dim,
+            config.v_dim,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_config,
+        )
+        return q, k, v, new_state
+
+    def _project_inputs(
+        self,
+        hidden_states: ttnn.Tensor,
+    ) -> _ProjectedInputs:
+        """Run the fused input projection and split its semantic outputs."""
+        config = self.config
+        weights = self.weights
+        projected = ttnn.linear(
+            hidden_states,
+            weights.input_projection,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_config,
+        )
+        auxiliary_start = self._convolution_width
+        return _ProjectedInputs(
+            qkv=_slice_width(projected, 0, auxiliary_start),
+            decay_rank=_slice_width(projected, auxiliary_start, auxiliary_start + config.head_k_dim),
+            output_gate=_slice_width(
+                projected,
+                auxiliary_start + config.head_k_dim,
+                auxiliary_start + config.head_k_dim + config.v_dim,
+            ),
+            beta=_slice_width(
+                projected,
+                auxiliary_start + config.head_k_dim + config.v_dim,
+                auxiliary_start + config.head_k_dim + config.v_dim + config.num_heads,
+            ),
+        )
+
+    def _compute_gates(
+        self,
+        q: ttnn.Tensor,
+        k: ttnn.Tensor,
+        v: ttnn.Tensor,
+        *,
+        beta: ttnn.Tensor,
+        decay_rank: ttnn.Tensor,
+        output_gate: ttnn.Tensor,
+    ) -> _KDAInputs:
+        """Evaluate decay and write gates while preserving the output gate for the epilogue."""
+        config, weights = self.config, self.weights
+        beta = ttnn.sigmoid(beta, memory_config=self.recurrence_config.output_memory_config)
+        # Precision boundary: the preparation leaf requires FP32 beta.
+        beta_for_recurrence = ttnn.typecast(
+            beta,
+            self.recurrence_config.beta_dtype,
+            memory_config=self.recurrence_config.output_memory_config,
+        )
+        gate = ttnn.linear(
+            decay_rank,
+            weights.decay_output_projection,
+            bias=weights.decay_bias_flat,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_config,
+        )
+        if config.gate_lower_bound is None:
+            gate = ttnn.multiply(
+                weights.decay_scale_flat,
+                gate,
+                input_tensor_b_activations=[ttnn.UnaryWithParam(ttnn.UnaryOpType.SOFTPLUS, 1.0, 20.0)],
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        else:
+            gate = ttnn.multiply(
+                weights.decay_scale_flat,
+                gate,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            gate = ttnn.sigmoid(gate, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            gate = ttnn.multiply(gate, config.gate_lower_bound, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return _KDAInputs(
+            q=q,
+            k=k,
+            v=v,
+            decay=gate,
+            beta=beta_for_recurrence,
+            output_gate=output_gate,
+        )
+
+    def _assert_flat_recurrence_contract(
+        self,
+        inputs: _KDAInputs,
+        recurrent_state: ttnn.Tensor,
+    ) -> None:
+        """Assert postconditions of the internal recurrence producers."""
+        batch, sequence, heads = inputs.beta.shape
+        key_width = heads * self.config.head_k_dim
+        value_width = heads * self.config.head_v_dim
+        assert tuple(inputs.q.shape) == (batch, sequence, key_width)
+        assert tuple(inputs.k.shape) == (batch, sequence, key_width)
+        assert tuple(inputs.v.shape) == (batch, sequence, value_width)
+        assert tuple(inputs.decay.shape) == (batch, sequence, key_width)
+        assert tuple(recurrent_state.shape) == (
+            batch,
+            heads,
+            self.config.head_k_dim,
+            self.config.head_v_dim,
+        )
+        for tensor in (inputs.q, inputs.k, inputs.v):
+            assert tensor.dtype == self.recurrence_config.qkv_dtype
+            assert tensor.layout == ttnn.TILE_LAYOUT
+        assert inputs.decay.dtype == self.recurrence_config.gate_dtype
+        assert inputs.decay.layout == ttnn.TILE_LAYOUT
+        assert inputs.beta.dtype == self.recurrence_config.beta_dtype
+        assert inputs.beta.layout == ttnn.TILE_LAYOUT
+        assert recurrent_state.dtype == self.recurrence_config.recurrent_state_dtype
+        assert recurrent_state.layout == ttnn.TILE_LAYOUT
+        assert recurrent_state.memory_config() == self.recurrence_config.output_memory_config
+
+    def _kda_prefill(
+        self,
+        inputs: _KDAInputs,
+        recurrent_state: ttnn.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Run the KDA recurrence and return its raw output and updated state."""
+        self._assert_flat_recurrence_contract(inputs, recurrent_state)
+        recurrence_inputs = ops._FlatRecurrenceInputs(
+            q=inputs.q,
+            k=inputs.k,
+            v=inputs.v,
+            gate=inputs.decay,
+            beta=inputs.beta,
+        )
+        result = ops._chunk_recurrence(
+            recurrence_inputs,
+            recurrent_state,
+            self.chunk_constants,
+            program_config=self.recurrence_config,
+            compute_config=self.recurrence_compute_config,
+            sequence_parallel_axis=(self.sequence_parallel_axis if self.sequence_parallel_size > 1 else None),
+        )
+        return result.output, result.final_state
+
+    def _kda_rms_norm(
+        self,
+        output: ttnn.Tensor,
+        output_gate: ttnn.Tensor,
+    ) -> ttnn.Tensor:
+        """Apply the KDA gated RMSNorm epilogue."""
+        config, weights = self.config, self.weights
+        # Retained by real-K3 T=5120 component A/B: 92.72-93.92% faster at output PCC >=0.999990.
+        return ttnn.experimental.kda.sigmoid_gated_rms_norm(
+            output,
+            output_gate,
+            weights.norm,
+            config.num_heads,
+            epsilon=config.norm_eps,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=self.compute_config,
+            # Real-K3 component A/B: direct BF16 output retained PCC 1.0 for every LoudBox layout
+            # and improved median component latency by 0.655%-1.339%.
+            output_dtype=self.gated_rms_output_dtype,
+        )
+
+    def _project_output(
+        self,
+        output: ttnn.Tensor,
+        *,
+        batch: int,
+        sequence: int,
+    ) -> ttnn.Tensor:
+        """Project normalized heads and perform the required TP reduction."""
+        config, weights = self.config, self.weights
+        output = ttnn.reshape(output, (batch, sequence, config.v_dim))
+        if self.tensor_parallel_size > 1:
+            assert self.tt_ccl is not None
+            assert output.dtype == self.gated_rms_output_dtype
+            output = ttnn.reshape(output, (1, batch, sequence, config.v_dim))
+            output = ttnn.linear(
+                output,
+                weights.output_projection,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                program_config=_output_projection_program_config(
+                    sequence,
+                    config.v_dim,
+                    weights.output_projection.shape[-1],
+                    self.output_projection_out_block_w,
+                    self.output_projection_grid,
+                ),
+                compute_kernel_config=self.output_projection_compute_config,
+            )
+            cluster_axis = None if self.sequence_parallel_size == 1 else self.tensor_parallel_axis
+            output = ttnn.experimental.reduce_scatter_minimal_async(
+                output,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                num_links=self.tt_ccl.get_num_links(cluster_axis),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=self.tp_ccl_topology,
+                cluster_axis=cluster_axis,
+            )
+        else:
+            output = ttnn.linear(
+                output,
+                weights.output_projection,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=self.output_projection_compute_config,
+            )
+        return output
+
+    def forward(
+        self,
+        hidden_states: ttnn.Tensor,
+        state: KdaState,
+    ) -> tuple[ttnn.Tensor, KdaState]:
+        """Run prefill KDA and return replacement logical carries.
+
+        The input state is only read. No tensor reachable from it is used as a
+        ``ttnn.copy`` destination or retained on this layer.
+        """
+        batch, sequence = self._validate_forward(hidden_states, state)
+        projected = self._project_inputs(hidden_states)
+        q, k, v, new_convolution = self._convolve_qkv(projected.qkv, state.convolution, sequence=sequence)
+        inputs = self._compute_gates(
+            q,
+            k,
+            v,
+            beta=projected.beta,
+            decay_rank=projected.decay_rank,
+            output_gate=projected.output_gate,
+        )
+        output, new_recurrent = self._kda_prefill(inputs, state.recurrent)
+        output = self._kda_rms_norm(output, inputs.output_gate)
+        output = self._project_output(output, batch=batch, sequence=sequence)
+        return output, KdaState(recurrent=new_recurrent, convolution=new_convolution)

--- a/models/demos/deepseek_v3_d_p/tt/kda/ops.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/ops.py
@@ -144,10 +144,9 @@ class _ChunkConstants:
     eye: ttnn.Tensor
     tril: ttnn.Tensor
     ones: ttnn.Tensor
-    masks: ttnn.Tensor
 
     def as_kernel_args(self) -> tuple[ttnn.Tensor, ...]:
-        return self.eye, self.tril, self.ones, self.masks
+        return self.eye, self.tril, self.ones
 
 
 @dataclass(frozen=True)
@@ -249,7 +248,7 @@ def _prepare_chunk_terms(
     program_config: KDARecurrenceProgramConfig,
     compute_config: _RecurrenceComputeConfig,
 ) -> _PreparedChunks:
-    eye_tile, tril_tile, ones_tile, mask_tiles = constants.as_kernel_args()
+    eye_tile, tril_tile, ones_tile = constants.as_kernel_args()
     outputs = ttnn.experimental.kda.prepare_chunk_recurrence(
         inputs.q,
         inputs.k,
@@ -259,7 +258,6 @@ def _prepare_chunk_terms(
         eye_tile,
         tril_tile,
         ones_tile,
-        mask_tiles,
         geometry.heads,
         memory_config=program_config.preparation_memory_config,
         compute_kernel_config=compute_config.preparation,
@@ -571,7 +569,6 @@ def _assert_chunk_constants(constants: _ChunkConstants, chunk_size: int) -> None
         (constants.eye, (1, 1, chunk_size, chunk_size)),
         (constants.tril, (1, 1, chunk_size, chunk_size)),
         (constants.ones, (1, 1, chunk_size, chunk_size)),
-        (constants.masks, (1, 1, chunk_size, 3 * chunk_size)),
     )
     for tensor, expected_shape in expected_shapes:
         assert tuple(tensor.shape) == expected_shape

--- a/models/demos/deepseek_v3_d_p/tt/kda/ops.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/ops.py
@@ -1,0 +1,734 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Python-owned KDA graph orchestration.
+
+The KDA layer keeps collective and state-flow decisions here; device leaves only
+perform the bespoke kernels exposed by ``ttnn.experimental.kda``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.kda.config import KDARecurrenceProgramConfig
+
+
+def _output_memory_config(memory_config: ttnn.MemoryConfig | None) -> ttnn.MemoryConfig:
+    return ttnn.DRAM_MEMORY_CONFIG if memory_config is None else memory_config
+
+
+def _group_summary_memory_config(device: ttnn.Device, group_heads: int, key_dim: int) -> ttnn.MemoryConfig:
+    worker_cores = ttnn.num_cores_to_corerangeset(
+        group_heads,
+        device.compute_with_storage_grid_size(),
+        row_wise=True,
+    )
+    return ttnn.create_sharded_memory_config(
+        (group_heads, key_dim, key_dim),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+def convolution_halo(
+    projected_qkv: ttnn.Tensor,
+    initial_carry: ttnn.Tensor,
+    *,
+    sequence_parallel_axis: int,
+    memory_config: ttnn.MemoryConfig | None = None,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """Exchange causal-convolution carries along the configured SP axis."""
+    qkv_shape = tuple(projected_qkv.shape)
+    carry_shape = tuple(initial_carry.shape)
+    if sequence_parallel_axis not in (0, 1):
+        raise ValueError(f"sequence_parallel_axis must be 0 or 1, got {sequence_parallel_axis}")
+    if len(qkv_shape) != 3 or len(carry_shape) != 3:
+        raise ValueError("KDA convolution halo expects rank-3 tensors")
+    if qkv_shape[0] != carry_shape[0] or qkv_shape[2] != carry_shape[2]:
+        raise ValueError("KDA convolution halo requires matching batch and channel dimensions")
+    history = carry_shape[1]
+    if history <= 0 or qkv_shape[1] < history:
+        raise ValueError("KDA convolution halo requires 0 < history <= local T")
+    if projected_qkv.dtype != initial_carry.dtype or projected_qkv.layout != initial_carry.layout:
+        raise ValueError("KDA convolution halo requires matching dtypes and layouts")
+    if history > ttnn.TILE_SIZE:
+        raise ValueError("KDA convolution history must fit in one tile")
+
+    mesh_device = projected_qkv.device()
+    mesh_shape = tuple(mesh_device.shape)
+    if len(mesh_shape) != 2 or mesh_shape[sequence_parallel_axis] <= 1:
+        raise ValueError("KDA convolution halo requires a 2D mesh with SP > 1")
+    sp_size = mesh_shape[sequence_parallel_axis]
+    batch, local_sequence, channels = qkv_shape
+    out_mem = _output_memory_config(memory_config)
+
+    local_tail = ttnn.slice(
+        projected_qkv,
+        (0, local_sequence - history, 0),
+        (batch, local_sequence, channels),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    padded_tail = ttnn.pad(
+        local_tail,
+        ((0, 0), (0, ttnn.TILE_SIZE - history), (0, 0)),
+        value=0.0,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tiled_tail = ttnn.to_layout(padded_tail, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    gathered_tails = ttnn.all_gather(
+        tiled_tail,
+        dim=1,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    entry_carries = [initial_carry]
+    for rank in range(sp_size - 1):
+        tiled_rank_tail = ttnn.slice(
+            gathered_tails,
+            (0, rank * ttnn.TILE_SIZE, 0),
+            (batch, (rank + 1) * ttnn.TILE_SIZE, channels),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        rank_tail = ttnn.to_layout(tiled_rank_tail, ttnn.ROW_MAJOR_LAYOUT)
+        entry_carries.append(ttnn.slice(rank_tail, (0, 0, 0), (batch, history, channels), memory_config=out_mem))
+    replicated_entries = ttnn.concat(entry_carries, dim=1, memory_config=out_mem)
+    partition_carry = ttnn.mesh_partition(
+        replicated_entries,
+        dim=1,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=out_mem,
+    )
+
+    tiled_final_carry = ttnn.slice(
+        gathered_tails,
+        (0, (sp_size - 1) * ttnn.TILE_SIZE, 0),
+        (batch, sp_size * ttnn.TILE_SIZE, channels),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    final_row_major = ttnn.to_layout(tiled_final_carry, ttnn.ROW_MAJOR_LAYOUT)
+    final_carry = ttnn.slice(final_row_major, (0, 0, 0), (batch, history, channels), memory_config=out_mem)
+    return partition_carry, final_carry
+
+
+@dataclass(frozen=True)
+class _RecurrenceGeometry:
+    batch: int
+    sequence: int
+    heads: int
+    key_dim: int
+    value_dim: int
+    chunk_size: int
+    num_chunks: int
+
+    @property
+    def batch_heads(self) -> int:
+        return self.batch * self.heads
+
+
+@dataclass(frozen=True)
+class _FlatRecurrenceInputs:
+    q: ttnn.Tensor
+    k: ttnn.Tensor
+    v: ttnn.Tensor
+    gate: ttnn.Tensor
+    beta: ttnn.Tensor
+
+
+@dataclass(frozen=True)
+class _ChunkConstants:
+    eye: ttnn.Tensor
+    tril: ttnn.Tensor
+    ones: ttnn.Tensor
+    masks: ttnn.Tensor
+
+    def as_kernel_args(self) -> tuple[ttnn.Tensor, ...]:
+        return self.eye, self.tril, self.ones, self.masks
+
+
+@dataclass(frozen=True)
+class _PreparedChunks:
+    v_beta: ttnn.Tensor
+    kd: ttnn.Tensor
+    q_decay: ttnn.Tensor
+    intra: ttnn.Tensor
+    k_dec_t: ttnn.Tensor
+    final_decay: ttnn.Tensor
+    t_inv: ttnn.Tensor
+
+    @classmethod
+    def from_kernel_outputs(cls, outputs: list[ttnn.Tensor]) -> _PreparedChunks:
+        if len(outputs) != 7:
+            raise RuntimeError(f"KDA chunk preparation returned {len(outputs)} tensors, expected 7")
+        return cls(*outputs)
+
+    def as_kernel_args(self) -> tuple[ttnn.Tensor, ...]:
+        return (
+            self.v_beta,
+            self.kd,
+            self.q_decay,
+            self.intra,
+            self.k_dec_t,
+            self.final_decay,
+            self.t_inv,
+        )
+
+
+@dataclass(frozen=True)
+class _ScanResult:
+    output: ttnn.Tensor
+    final_state: ttnn.Tensor
+
+
+@dataclass(frozen=True)
+class _RecurrenceComputeConfig:
+    preparation: ttnn.DeviceComputeKernelConfig | None
+    affine_prefix: ttnn.DeviceComputeKernelConfig | None
+    grouped_scan: ttnn.DeviceComputeKernelConfig | None
+
+
+def _validate_recurrence_geometry(
+    inputs: _FlatRecurrenceInputs,
+    *,
+    program_config: KDARecurrenceProgramConfig,
+    sequence_parallel_axis: int | None,
+) -> _RecurrenceGeometry:
+    """Validate the flat production contract and derive host-only execution metadata."""
+    q_shape = tuple(inputs.q.shape)
+    k_shape = tuple(inputs.k.shape)
+    v_shape = tuple(inputs.v.shape)
+    gate_shape = tuple(inputs.gate.shape)
+    beta_shape = tuple(inputs.beta.shape)
+    if len(beta_shape) != 3:
+        raise ValueError("KDA recurrence beta must be [B,T,H]")
+    batch, sequence, heads = beta_shape
+    if any(len(shape) != 3 for shape in (q_shape, k_shape, v_shape, gate_shape)):
+        raise ValueError("KDA recurrence q/k/v/g must be flat rank-3 tensors")
+    if k_shape != q_shape or q_shape[:2] != (batch, sequence) or v_shape[:2] != (batch, sequence):
+        raise ValueError("KDA recurrence q/k/v shapes are inconsistent")
+    if gate_shape[:2] != (batch, sequence) or q_shape[2] != gate_shape[2]:
+        raise ValueError("flat q/k/gate shapes are inconsistent")
+    if q_shape[2] % heads or v_shape[2] % heads:
+        raise ValueError("flat q/k/v widths must be divisible by the number of heads")
+    key_dim = q_shape[2] // heads
+    value_dim = v_shape[2] // heads
+    if sequence_parallel_axis not in (None, 0, 1):
+        raise ValueError("sequence_parallel_axis must be 0 or 1")
+    if sequence <= 0 or sequence % program_config.chunk_size:
+        raise ValueError(f"flat KDA recurrence requires T divisible by {program_config.chunk_size}")
+
+    return _RecurrenceGeometry(
+        batch=batch,
+        sequence=sequence,
+        heads=heads,
+        key_dim=key_dim,
+        value_dim=value_dim,
+        chunk_size=program_config.chunk_size,
+        num_chunks=sequence // program_config.chunk_size,
+    )
+
+
+def _prepare_chunk_inputs(
+    inputs: _FlatRecurrenceInputs,
+    geometry: _RecurrenceGeometry,
+) -> _FlatRecurrenceInputs:
+    beta_by_head = ttnn.permute(inputs.beta, (0, 2, 1))
+    beta = ttnn.reshape(beta_by_head, (geometry.batch_heads, geometry.num_chunks, geometry.chunk_size, 1))
+    return _FlatRecurrenceInputs(q=inputs.q, k=inputs.k, v=inputs.v, gate=inputs.gate, beta=beta)
+
+
+def _prepare_chunk_terms(
+    inputs: _FlatRecurrenceInputs,
+    constants: _ChunkConstants,
+    geometry: _RecurrenceGeometry,
+    *,
+    program_config: KDARecurrenceProgramConfig,
+    compute_config: _RecurrenceComputeConfig,
+) -> _PreparedChunks:
+    eye_tile, tril_tile, ones_tile, mask_tiles = constants.as_kernel_args()
+    outputs = ttnn.experimental.kda.prepare_chunk_recurrence(
+        inputs.q,
+        inputs.k,
+        inputs.v,
+        inputs.gate,
+        inputs.beta,
+        eye_tile,
+        tril_tile,
+        ones_tile,
+        mask_tiles,
+        geometry.heads,
+        memory_config=program_config.preparation_memory_config,
+        compute_kernel_config=compute_config.preparation,
+        output_bf16_mask=program_config.prep_output_bf16_mask,
+    )
+    prepared = _PreparedChunks.from_kernel_outputs(outputs)
+    for index, tensor in enumerate(outputs):
+        expected_dtype = (
+            program_config.qkv_dtype
+            if program_config.prep_output_bf16_mask & (1 << index)
+            else program_config.recurrent_state_dtype
+        )
+        assert tensor.dtype == expected_dtype
+        assert tensor.memory_config() == program_config.preparation_memory_config
+    return prepared
+
+
+def _reshape_chunks_for_groups(
+    prepared: _PreparedChunks,
+    geometry: _RecurrenceGeometry,
+    *,
+    group_heads: int,
+    summary_group_chunks: int,
+) -> _PreparedChunks:
+    return _PreparedChunks(
+        v_beta=ttnn.reshape(
+            prepared.v_beta, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.value_dim)
+        ),
+        kd=ttnn.reshape(prepared.kd, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.key_dim)),
+        q_decay=ttnn.reshape(
+            prepared.q_decay, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.key_dim)
+        ),
+        intra=ttnn.reshape(
+            prepared.intra, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.chunk_size)
+        ),
+        k_dec_t=ttnn.reshape(
+            prepared.k_dec_t, (group_heads, summary_group_chunks, geometry.key_dim, geometry.chunk_size)
+        ),
+        final_decay=ttnn.reshape(prepared.final_decay, (group_heads, summary_group_chunks, geometry.key_dim, 1)),
+        t_inv=ttnn.reshape(
+            prepared.t_inv, (group_heads, summary_group_chunks, geometry.chunk_size, geometry.chunk_size)
+        ),
+    )
+
+
+def _summarize_chunk_groups(
+    grouped: _PreparedChunks,
+    geometry: _RecurrenceGeometry,
+    *,
+    program_config: KDARecurrenceProgramConfig,
+    compute_config: _RecurrenceComputeConfig,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    summary_memory_config = _group_summary_memory_config(
+        grouped.v_beta.device(), grouped.v_beta.shape[0], geometry.key_dim
+    )
+    affine_a, affine_b = ttnn.experimental.kda.summarize_chunk_recurrence(
+        *grouped.as_kernel_args(),
+        memory_config=summary_memory_config,
+        compute_kernel_config=compute_config.preparation,
+    )
+    assert affine_a.dtype == ttnn.float32
+    assert affine_b.dtype == ttnn.float32
+    # Precision boundary: summary-pair math is FP32; storage and transport are measured BF16.
+    summary_a = ttnn.typecast(affine_a, program_config.affine_summary_dtype, memory_config=summary_memory_config)
+    summary_b = ttnn.typecast(affine_b, program_config.affine_summary_dtype, memory_config=summary_memory_config)
+    return summary_a, summary_b
+
+
+class _RecurrenceScan(ABC):
+    def __init__(
+        self,
+        program_config: KDARecurrenceProgramConfig,
+        compute_config: _RecurrenceComputeConfig,
+    ) -> None:
+        self._program_config = program_config
+        self._compute_config = compute_config
+
+    @abstractmethod
+    def run(
+        self,
+        prepared: _PreparedChunks,
+        initial_state: ttnn.Tensor,
+        identity_tile: ttnn.Tensor,
+        geometry: _RecurrenceGeometry,
+    ) -> _ScanResult:
+        """Run the selected recurrence scan without changing the device operation order."""
+
+
+class _DirectScan(_RecurrenceScan):
+    def run(
+        self,
+        prepared: _PreparedChunks,
+        initial_state: ttnn.Tensor,
+        identity_tile: ttnn.Tensor,
+        geometry: _RecurrenceGeometry,
+    ) -> _ScanResult:
+        del identity_tile
+        output, final_state = ttnn.experimental.kda.recurrent_chunk_scan(
+            *prepared.as_kernel_args(),
+            initial_state,
+            memory_config=self._program_config.output_memory_config,
+            compute_kernel_config=self._compute_config.preparation,
+        )
+        assert output.dtype == self._program_config.scan_output_dtype
+        assert final_state.dtype == self._program_config.recurrent_state_dtype
+        return _ScanResult(output=output, final_state=final_state)
+
+
+class _GroupedScan(_RecurrenceScan):
+    def run(
+        self,
+        prepared: _PreparedChunks,
+        initial_state: ttnn.Tensor,
+        identity_tile: ttnn.Tensor,
+        geometry: _RecurrenceGeometry,
+    ) -> _ScanResult:
+        group_chunks = self._program_config.summary_group_chunks
+        if geometry.num_chunks % group_chunks:
+            raise ValueError(
+                f"local chunk count {geometry.num_chunks} must be divisible by " f"summary_group_chunks {group_chunks}"
+            )
+        if geometry.key_dim != geometry.value_dim:
+            raise ValueError("grouped KDA affine prefix currently requires K == V")
+        groups_per_head = geometry.num_chunks // group_chunks
+        group_heads = geometry.batch_heads * groups_per_head
+        grid = prepared.v_beta.device().compute_with_storage_grid_size()
+        if group_heads > min(grid.x * grid.y, 128):
+            raise ValueError(f"grouped KDA needs {group_heads} summary owners, but only 128 are supported")
+
+        grouped = _reshape_chunks_for_groups(
+            prepared,
+            geometry,
+            group_heads=group_heads,
+            summary_group_chunks=group_chunks,
+        )
+        summary_a, summary_b = _summarize_chunk_groups(
+            grouped,
+            geometry,
+            program_config=self._program_config,
+            compute_config=self._compute_config,
+        )
+        group_initial_states, strategy_final_state = self._compute_group_entry_states(
+            summary_a,
+            summary_b,
+            initial_state,
+            groups_per_head,
+        )
+        grouped_output, grouped_final_states = ttnn.experimental.kda.recurrent_chunk_scan(
+            *grouped.as_kernel_args(),
+            group_initial_states,
+            memory_config=self._program_config.output_memory_config,
+            compute_kernel_config=self._compute_config.grouped_scan,
+        )
+        assert grouped_output.dtype == self._program_config.scan_output_dtype
+        output = ttnn.reshape(
+            grouped_output,
+            (geometry.batch_heads, geometry.num_chunks, geometry.chunk_size, geometry.value_dim),
+        )
+        final_state = self._resolve_final_state(grouped_final_states, strategy_final_state, geometry, groups_per_head)
+        return _ScanResult(output=output, final_state=final_state)
+
+    @abstractmethod
+    def _compute_group_entry_states(
+        self,
+        summary_a: ttnn.Tensor,
+        summary_b: ttnn.Tensor,
+        initial_state: ttnn.Tensor,
+        groups_per_head: int,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor | None]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _resolve_final_state(
+        self,
+        grouped_final_states: ttnn.Tensor,
+        strategy_final_state: ttnn.Tensor | None,
+        geometry: _RecurrenceGeometry,
+        groups_per_head: int,
+    ) -> ttnn.Tensor:
+        raise NotImplementedError
+
+
+class _LocalGroupedScan(_GroupedScan):
+    def _compute_group_entry_states(
+        self,
+        summary_a: ttnn.Tensor,
+        summary_b: ttnn.Tensor,
+        initial_state: ttnn.Tensor,
+        groups_per_head: int,
+    ) -> tuple[ttnn.Tensor, None]:
+        group_initial_states = ttnn.experimental.kda.affine_exclusive_scan(
+            summary_a,
+            summary_b,
+            initial_state,
+            groups_per_head,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+            compute_kernel_config=self._compute_config.affine_prefix,
+        )
+        return group_initial_states, None
+
+    def _resolve_final_state(
+        self,
+        grouped_final_states: ttnn.Tensor,
+        strategy_final_state: ttnn.Tensor | None,
+        geometry: _RecurrenceGeometry,
+        groups_per_head: int,
+    ) -> ttnn.Tensor:
+        if strategy_final_state is not None:
+            raise RuntimeError("local grouped KDA scan unexpectedly produced a distributed final state")
+        all_final_states = ttnn.reshape(
+            grouped_final_states,
+            (geometry.batch_heads, groups_per_head, geometry.key_dim, geometry.value_dim),
+        )
+        last_final_state = ttnn.slice(
+            all_final_states,
+            (0, groups_per_head - 1, 0, 0),
+            (geometry.batch_heads, groups_per_head, geometry.key_dim, geometry.value_dim),
+            memory_config=self._program_config.output_memory_config,
+        )
+        return ttnn.reshape(last_final_state, (geometry.batch_heads, geometry.key_dim, geometry.value_dim))
+
+
+class _DistributedGroupedScan(_GroupedScan):
+    def __init__(
+        self,
+        sequence_parallel_axis: int,
+        program_config: KDARecurrenceProgramConfig,
+        compute_config: _RecurrenceComputeConfig,
+    ) -> None:
+        super().__init__(program_config, compute_config)
+        self._sequence_parallel_axis = sequence_parallel_axis
+
+    def _compute_group_entry_states(
+        self,
+        summary_a: ttnn.Tensor,
+        summary_b: ttnn.Tensor,
+        initial_state: ttnn.Tensor,
+        groups_per_head: int,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        partition_a, partition_b = ttnn.experimental.kda.reduce_affine_transforms(
+            summary_a,
+            summary_b,
+            groups_per_head,
+            memory_config=self._program_config.output_memory_config,
+            compute_kernel_config=self._compute_config.affine_prefix,
+        )
+        assert partition_a.dtype == ttnn.float32
+        assert partition_b.dtype == ttnn.float32
+        partition_entry_state, distributed_final_state = _distributed_affine_prefix(
+            partition_a,
+            partition_b,
+            initial_state,
+            sequence_parallel_axis=self._sequence_parallel_axis,
+            program_config=self._program_config,
+            compute_config=self._compute_config.affine_prefix,
+        )
+        assert partition_entry_state.dtype == self._program_config.recurrent_state_dtype
+        group_initial_states = ttnn.experimental.kda.affine_exclusive_scan(
+            summary_a,
+            summary_b,
+            partition_entry_state,
+            groups_per_head,
+            memory_config=self._program_config.prefix_memory_config,
+            compute_kernel_config=self._compute_config.affine_prefix,
+        )
+        return group_initial_states, distributed_final_state
+
+    def _resolve_final_state(
+        self,
+        grouped_final_states: ttnn.Tensor,
+        strategy_final_state: ttnn.Tensor | None,
+        geometry: _RecurrenceGeometry,
+        groups_per_head: int,
+    ) -> ttnn.Tensor:
+        del grouped_final_states, geometry, groups_per_head
+        if strategy_final_state is None:
+            raise RuntimeError("distributed grouped KDA scan did not produce a final state")
+        return strategy_final_state
+
+
+def _select_scan(
+    *,
+    num_chunks: int,
+    program_config: KDARecurrenceProgramConfig,
+    compute_config: _RecurrenceComputeConfig,
+    sequence_parallel_axis: int | None,
+) -> _RecurrenceScan:
+    if sequence_parallel_axis is not None:
+        return _DistributedGroupedScan(sequence_parallel_axis, program_config, compute_config)
+    if num_chunks >= program_config.grouped_scan_min_chunks and num_chunks % program_config.summary_group_chunks == 0:
+        return _LocalGroupedScan(program_config, compute_config)
+    return _DirectScan(program_config, compute_config)
+
+
+def _restore_recurrence_output(scan: _ScanResult, geometry: _RecurrenceGeometry) -> _ScanResult:
+    output = ttnn.reshape(
+        scan.output,
+        (geometry.batch_heads, geometry.sequence, geometry.value_dim),
+    )
+    final_state = ttnn.reshape(
+        scan.final_state,
+        (geometry.batch, geometry.heads, geometry.key_dim, geometry.value_dim),
+    )
+    return _ScanResult(output=output, final_state=final_state)
+
+
+def _assert_chunk_constants(constants: _ChunkConstants, chunk_size: int) -> None:
+    expected_shapes = (
+        (constants.eye, (1, 1, chunk_size, chunk_size)),
+        (constants.tril, (1, 1, chunk_size, chunk_size)),
+        (constants.ones, (1, 1, chunk_size, chunk_size)),
+        (constants.masks, (1, 1, chunk_size, 3 * chunk_size)),
+    )
+    for tensor, expected_shape in expected_shapes:
+        assert tuple(tensor.shape) == expected_shape
+        assert tensor.dtype == ttnn.float32
+        assert tensor.layout == ttnn.TILE_LAYOUT
+
+
+def _chunk_recurrence(
+    inputs: _FlatRecurrenceInputs,
+    initial_state: ttnn.Tensor,
+    constants: _ChunkConstants,
+    *,
+    program_config: KDARecurrenceProgramConfig,
+    compute_config: _RecurrenceComputeConfig,
+    sequence_parallel_axis: int | None,
+) -> _ScanResult:
+    """Run the fixed Kimi-K3 recurrence contract through the selected scan strategy."""
+    geometry = _validate_recurrence_geometry(
+        inputs,
+        program_config=program_config,
+        sequence_parallel_axis=sequence_parallel_axis,
+    )
+    for tensor in (inputs.q, inputs.k, inputs.v, inputs.gate, inputs.beta, initial_state):
+        assert tensor.layout == ttnn.TILE_LAYOUT
+    assert inputs.q.dtype == program_config.qkv_dtype
+    assert inputs.k.dtype == program_config.qkv_dtype
+    assert inputs.v.dtype == program_config.qkv_dtype
+    assert inputs.gate.dtype == program_config.gate_dtype
+    assert inputs.beta.dtype == program_config.beta_dtype
+    assert initial_state.dtype == program_config.recurrent_state_dtype
+    assert tuple(initial_state.shape) == (
+        geometry.batch,
+        geometry.heads,
+        geometry.key_dim,
+        geometry.value_dim,
+    )
+    assert initial_state.memory_config() == program_config.output_memory_config
+    _assert_chunk_constants(constants, program_config.chunk_size)
+
+    state = ttnn.reshape(
+        initial_state,
+        (geometry.batch_heads, geometry.key_dim, geometry.value_dim),
+    )
+    scan_strategy = _select_scan(
+        num_chunks=geometry.num_chunks,
+        program_config=program_config,
+        compute_config=compute_config,
+        sequence_parallel_axis=sequence_parallel_axis,
+    )
+    chunk_inputs = _prepare_chunk_inputs(inputs, geometry)
+    prepared = _prepare_chunk_terms(
+        chunk_inputs,
+        constants,
+        geometry,
+        program_config=program_config,
+        compute_config=compute_config,
+    )
+    scan = scan_strategy.run(prepared, state, constants.eye, geometry)
+    result = _restore_recurrence_output(scan, geometry)
+    assert result.output.dtype == program_config.scan_output_dtype
+    assert result.final_state.dtype == program_config.recurrent_state_dtype
+    return result
+
+
+def _distributed_affine_prefix(
+    transform_a: ttnn.Tensor,
+    transform_b: ttnn.Tensor,
+    initial_state: ttnn.Tensor,
+    *,
+    sequence_parallel_axis: int,
+    program_config: KDARecurrenceProgramConfig,
+    compute_config: ttnn.DeviceComputeKernelConfig | None,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """Compose SP partition affine summaries and return entry/final carries."""
+    if sequence_parallel_axis not in (0, 1):
+        raise ValueError(f"sequence_parallel_axis must be 0 or 1, got {sequence_parallel_axis}")
+    shape = tuple(transform_a.shape)
+    if tuple(transform_b.shape) != shape or tuple(initial_state.shape) != shape:
+        raise ValueError("distributed KDA affine prefix requires equal batched [K,K] tensor shapes")
+    if len(shape) != 3:
+        raise ValueError("distributed KDA affine prefix requires rank-3 production transforms")
+    if shape[-2] != shape[-1]:
+        raise ValueError("distributed KDA affine prefix currently requires K == V")
+    assert transform_a.dtype == ttnn.float32
+    assert transform_b.dtype == ttnn.float32
+    assert initial_state.dtype == program_config.recurrent_state_dtype
+
+    mesh_device = transform_a.device()
+    mesh_shape = tuple(mesh_device.shape)
+    if len(mesh_shape) != 2 or mesh_shape[sequence_parallel_axis] <= 1:
+        raise ValueError("distributed KDA affine prefix requires a 2D mesh with SP > 1")
+    sp_size = mesh_shape[sequence_parallel_axis]
+    batch_heads, key_dim = shape[0], shape[1]
+    value_dim = transform_b.shape[-1]
+    output_memory = program_config.output_memory_config
+    working_memory = program_config.distributed_working_memory_config
+
+    # Precision boundary: FP32 composition is transported as measured BF16.
+    transport_a = ttnn.typecast(transform_a, program_config.affine_summary_dtype, memory_config=output_memory)
+    transport_b = ttnn.typecast(transform_b, program_config.affine_summary_dtype, memory_config=output_memory)
+    transport_a = ttnn.reshape(transport_a, (1, batch_heads, key_dim, key_dim))
+    transport_b = ttnn.reshape(transport_b, (1, batch_heads, key_dim, value_dim))
+    packed = ttnn.concat([transport_a, transport_b], dim=3, memory_config=output_memory)
+    gathered = ttnn.all_gather(
+        packed,
+        dim=0,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=output_memory,
+    )
+
+    carry = ttnn.to_memory_config(initial_state, working_memory)
+    assert carry.dtype == program_config.recurrent_state_dtype
+    carry = ttnn.reshape(carry, (1, batch_heads, key_dim, value_dim))
+    entry_states = []
+    for rank in range(sp_size):
+        entry_states.append(carry)
+        transported_rank_a = ttnn.slice(
+            gathered,
+            (rank, 0, 0, 0),
+            (rank + 1, batch_heads, key_dim, key_dim),
+            memory_config=working_memory,
+        )
+        transported_rank_b = ttnn.slice(
+            gathered,
+            (rank, 0, 0, key_dim),
+            (rank + 1, batch_heads, key_dim, key_dim + value_dim),
+            memory_config=working_memory,
+        )
+        # Precision boundary: BF16 collective payload is restored for FP32 carry math.
+        rank_a_for_carry = ttnn.typecast(
+            transported_rank_a,
+            program_config.recurrent_state_dtype,
+            memory_config=working_memory,
+        )
+        rank_b_for_carry = ttnn.typecast(
+            transported_rank_b,
+            program_config.recurrent_state_dtype,
+            memory_config=working_memory,
+        )
+        carry = ttnn.matmul(
+            rank_a_for_carry,
+            carry,
+            memory_config=working_memory,
+            dtype=program_config.recurrent_state_dtype,
+            compute_kernel_config=compute_config,
+        )
+        carry = ttnn.add(carry, rank_b_for_carry, memory_config=working_memory)
+
+    replicated_entries = ttnn.concat(entry_states, dim=0, memory_config=output_memory)
+    entry_state = ttnn.mesh_partition(
+        replicated_entries,
+        dim=0,
+        cluster_axis=sequence_parallel_axis,
+        memory_config=output_memory,
+    )
+    final_state = ttnn.to_memory_config(carry, output_memory)
+    assert final_state.dtype == program_config.recurrent_state_dtype
+    entry_state = ttnn.reshape(entry_state, (batch_heads, key_dim, value_dim))
+    final_state = ttnn.reshape(final_state, (batch_heads, key_dim, value_dim))
+    return entry_state, final_state

--- a/models/demos/deepseek_v3_d_p/tt/kda/state_store.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/state_store.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-layer ownership of the carries a KDA prefill stream walks forward.
+
+``ttKDA.forward`` reads a state and hands back its replacement, retaining nothing, so
+something outside the layer has to hold them. That something is this: the KDA counterpart
+of ``MlaKvCache``. A KDA layer writes no KV slab, and these carries are what a later chunk
+continues the recurrence from and what a chunked prefill eventually hands to decode.
+
+Keyed by GLOBAL layer index, matching the block's own ``layer_idx``, so a pipeline rank
+holding a layer slice needs no second numbering.
+"""
+
+from __future__ import annotations
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.kda.kda import KdaState, ttKDA
+
+
+class KdaStateStore:
+    """The live KDA carries for one prefill stream, one entry per KDA layer."""
+
+    def __init__(self, layers: dict[int, ttKDA], batch_size: int = 1) -> None:
+        self._layers = dict(layers)
+        self._batch_size = batch_size
+        self._states: dict[int, KdaState] = {}
+        self.reset()
+
+    def reset(self) -> None:
+        """Zero every carry, ending whatever stream was in flight.
+
+        A carry summarizes the whole prefix behind it, so a new request must not start from
+        the previous one's. ``allocate_state`` zeros, which is where a stream begins.
+        """
+        self.deallocate()
+        self._states = {idx: layer.allocate_state(self._batch_size) for idx, layer in self._layers.items()}
+
+    def get(self, layer_idx: int) -> KdaState:
+        return self._states[layer_idx]
+
+    def replace(self, layer_idx: int, state: KdaState) -> None:
+        """Install a layer's returned carry and free the one it supersedes.
+
+        Freeing is safe because ``ttKDA.forward`` only reads the state it was given: nothing
+        reachable from the superseded carry is aliased into its replacement.
+        """
+        previous = self._states.get(layer_idx)
+        self._states[layer_idx] = state
+        if previous is not None:
+            ttnn.deallocate(previous.recurrent)
+            ttnn.deallocate(previous.convolution)
+
+    def deallocate(self) -> None:
+        for state in self._states.values():
+            ttnn.deallocate(state.recurrent)
+            ttnn.deallocate(state.convolution)
+        self._states = {}

--- a/models/demos/deepseek_v3_d_p/tt/kda/weight_schema.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/weight_schema.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical host-weight schema for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+
+KDA_COMMON_WEIGHT_NAMES = (
+    "q_proj.weight",
+    "k_proj.weight",
+    "v_proj.weight",
+    "q_conv1d.weight",
+    "k_conv1d.weight",
+    "v_conv1d.weight",
+    "A_log",
+    "f_a_proj.weight",
+    "f_b_proj.weight",
+    "dt_bias",
+    "b_proj.weight",
+    "o_norm.weight",
+    "o_proj.weight",
+)
+KDA_LOW_RANK_GATE_WEIGHT_NAMES = ("g_a_proj.weight", "g_b_proj.weight")
+KDA_FULL_RANK_GATE_WEIGHT_NAMES = ("g_proj.weight",)
+
+
+def required_kda_weight_names(config: KDAConfig) -> tuple[str, ...]:
+    """Return the canonical layer-local checkpoint keys for ``config``."""
+    gate_names = KDA_FULL_RANK_GATE_WEIGHT_NAMES if config.use_full_rank_gate else KDA_LOW_RANK_GATE_WEIGHT_NAMES
+    return KDA_COMMON_WEIGHT_NAMES + gate_names
+
+
+def expected_kda_weight_shapes(config: KDAConfig) -> dict[str, tuple[int, ...]]:
+    """Return the canonical shape of every host weight for ``config``."""
+    hidden = config.hidden_size
+    key_rank = config.head_k_dim
+    value_rank = config.head_v_dim
+    heads = config.num_heads
+    shapes = {
+        "q_proj.weight": (config.q_dim, hidden),
+        "k_proj.weight": (config.k_dim, hidden),
+        "v_proj.weight": (config.v_dim, hidden),
+        "q_conv1d.weight": (config.q_dim, 1, config.conv_kernel_size),
+        "k_conv1d.weight": (config.k_dim, 1, config.conv_kernel_size),
+        "v_conv1d.weight": (config.v_dim, 1, config.conv_kernel_size),
+        "A_log": (1, 1, heads, 1),
+        "f_a_proj.weight": (key_rank, hidden),
+        "f_b_proj.weight": (heads * key_rank, key_rank),
+        "dt_bias": (heads * key_rank,),
+        "b_proj.weight": (heads, hidden),
+        "o_norm.weight": (value_rank,),
+        "o_proj.weight": (hidden, heads * value_rank),
+    }
+    if config.use_full_rank_gate:
+        shapes["g_proj.weight"] = (heads * value_rank, hidden)
+    else:
+        shapes["g_a_proj.weight"] = (value_rank, hidden)
+        shapes["g_b_proj.weight"] = (heads * value_rank, value_rank)
+    return shapes
+
+
+def normalize_kda_a_log(a_log: torch.Tensor, config: KDAConfig) -> torch.Tensor:
+    """Normalize checkpoint head padding into canonical ``[1,1,H,1]`` form."""
+    if a_log.numel() == config.num_heads:
+        return a_log.reshape(1, 1, config.num_heads, 1)
+    if config.num_heads == 96 and a_log.numel() == 128:
+        return a_log.reshape(-1)[: config.num_heads].reshape(1, 1, config.num_heads, 1)
+    raise ValueError(f"A_log has {a_log.numel()} entries; expected {config.num_heads} logical heads")
+
+
+def validate_kda_weights(weights: Mapping[str, torch.Tensor], config: KDAConfig) -> None:
+    """Validate the presence and shape of every canonical host weight."""
+    for name, expected_shape in expected_kda_weight_shapes(config).items():
+        try:
+            weight = weights[name]
+        except KeyError as error:
+            raise ValueError(f"missing KDA weight: {name}") from error
+        if tuple(weight.shape) != expected_shape:
+            raise ValueError(f"{name} shape {tuple(weight.shape)} != {expected_shape}")
+
+
+def normalize_kda_state_dict(state_dict: Mapping[str, torch.Tensor], config: KDAConfig) -> dict[str, torch.Tensor]:
+    """Copy, canonicalize, and validate a layer-local host-weight mapping."""
+    normalized = dict(state_dict)
+    try:
+        normalized["A_log"] = normalize_kda_a_log(normalized["A_log"], config)
+    except KeyError as error:
+        raise ValueError("missing KDA weight: A_log") from error
+    validate_kda_weights(normalized, config)
+    return normalized

--- a/models/demos/deepseek_v3_d_p/tt/kda/weights.py
+++ b/models/demos/deepseek_v3_d_p/tt/kda/weights.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Device weight loading for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.tt.kda.weight_schema import normalize_kda_state_dict
+
+
+def _parallel_geometry(device: ttnn.Device | ttnn.MeshDevice, tensor_parallel_axis: int) -> tuple[tuple[int, int], int]:
+    if tensor_parallel_axis not in (0, 1):
+        raise ValueError(f"tensor_parallel_axis must be 0 or 1, got {tensor_parallel_axis}")
+    if isinstance(device, ttnn.MeshDevice):
+        mesh_shape = tuple(device.shape)
+        return mesh_shape, mesh_shape[tensor_parallel_axis]
+    return (1, 1), 1
+
+
+def _cache_artifact_names(config: KDAConfig) -> tuple[str, ...]:
+    fixed = (
+        "input_projection_head_major",
+        "decay_output_projection",
+        "output_projection",
+        "decay_scale_flat",
+        "decay_bias_flat",
+        "norm",
+    )
+    return fixed + tuple(f"conv_tap_{tap}" for tap in range(config.conv_kernel_size))
+
+
+def _cache_stem(
+    cache_name_prefix: str,
+    name: str,
+    config: KDAConfig,
+    mesh_shape: tuple[int, int],
+    tensor_parallel_axis: int,
+) -> str:
+    del config, mesh_shape, tensor_parallel_axis
+    return f"{cache_name_prefix}.{name}"
+
+
+@dataclass(frozen=True)
+class KDAWeights:
+    input_projection: ttnn.Tensor
+    decay_output_projection: ttnn.Tensor
+    output_projection: ttnn.Tensor
+    decay_scale_flat: ttnn.Tensor
+    decay_bias_flat: ttnn.Tensor
+    norm: ttnn.Tensor
+    convolution_taps: tuple[ttnn.Tensor, ...]
+    tensor_parallel_size: int
+    tensor_parallel_axis: int
+
+    @classmethod
+    def check_cache_complete(
+        cls,
+        cache_path: Path | None,
+        cache_name_prefix: str,
+        config: KDAConfig,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        *,
+        tensor_parallel_axis: int = 1,
+    ) -> bool:
+        """Return whether every dtype/layout/placement-specific KDA tensorbin exists."""
+        if cache_path is None:
+            return False
+        cache_path = Path(cache_path)
+        mesh_shape, _ = _parallel_geometry(mesh_device, tensor_parallel_axis)
+        for name in _cache_artifact_names(config):
+            stem = _cache_stem(cache_name_prefix, name, config, mesh_shape, tensor_parallel_axis)
+            pattern = f"{stem}_dtype_{ttnn.bfloat16.name}_layout_{ttnn.TILE_LAYOUT.name}.tensorbin"
+            if not any(cache_path.glob(pattern)):
+                return False
+        return True
+
+    @classmethod
+    def build_ttnn_cache(
+        cls,
+        state_dict: Mapping[str, torch.Tensor],
+        cache_path: Path,
+        cache_name_prefix: str,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        config: KDAConfig,
+        *,
+        tensor_parallel_axis: int = 1,
+    ) -> None:
+        """Build all KDA tensorbins without copying weights to device memory."""
+        result = load_kda_weights(
+            mesh_device,
+            config,
+            state_dict,
+            cache_path,
+            cache_name_prefix=cache_name_prefix,
+            tensor_parallel_axis=tensor_parallel_axis,
+            _load_to_device=False,
+        )
+        assert result is None
+
+    @classmethod
+    def from_cache(
+        cls,
+        mesh_device: ttnn.Device | ttnn.MeshDevice,
+        config: KDAConfig,
+        cache_path: Path,
+        cache_name_prefix: str,
+        *,
+        tensor_parallel_axis: int = 1,
+    ) -> "KDAWeights":
+        """Construct device weights exclusively from a complete TTNN cache."""
+        result = load_kda_weights(
+            mesh_device,
+            config,
+            None,
+            cache_path,
+            cache_name_prefix=cache_name_prefix,
+            tensor_parallel_axis=tensor_parallel_axis,
+        )
+        assert result is not None
+        return result
+
+
+def load_kda_weights(
+    device: ttnn.Device | ttnn.MeshDevice,
+    config: KDAConfig,
+    state_dict: Mapping[str, torch.Tensor] | None,
+    tensor_cache_path: Path | None = None,
+    *,
+    cache_name_prefix: str = "kda",
+    tensor_parallel_axis: int = 1,
+    _load_to_device: bool = True,
+) -> KDAWeights | None:
+    """Fuse compatible projections and place whole-head shards on device."""
+    mesh_shape, tensor_parallel_size = _parallel_geometry(device, tensor_parallel_axis)
+    if config.num_heads % tensor_parallel_size != 0:
+        raise ValueError(
+            f"num_heads {config.num_heads} must be divisible by tensor parallel size {tensor_parallel_size}"
+        )
+    if not state_dict and not _load_to_device:
+        raise ValueError("building the KDA TTNN cache requires a state_dict")
+    if state_dict:
+        state_dict = normalize_kda_state_dict(state_dict, config)
+    elif _load_to_device and not KDAWeights.check_cache_complete(
+        tensor_cache_path,
+        cache_name_prefix,
+        config,
+        device,
+        tensor_parallel_axis=tensor_parallel_axis,
+    ):
+        raise FileNotFoundError(f"incomplete KDA TTNN cache for {cache_name_prefix!r} at {tensor_cache_path!r}")
+    if tensor_cache_path is not None:
+        tensor_cache_path = Path(tensor_cache_path)
+        tensor_cache_path.mkdir(parents=True, exist_ok=True)
+
+    def device_tensor(
+        tensor: torch.Tensor,
+        name: str,
+        *,
+        dtype: ttnn.DataType = ttnn.bfloat16,
+        shard_dim: int | None = None,
+    ) -> ttnn.Tensor:
+        cache_name = _cache_stem(cache_name_prefix, name, config, mesh_shape, tensor_parallel_axis)
+        cache_file = tensor_cache_path / cache_name if tensor_cache_path is not None else None
+        mesh_mapper = None
+        if tensor_parallel_size > 1:
+            mesh_dims = [None, None]
+            mesh_dims[tensor_parallel_axis] = shard_dim
+            mesh_mapper = ttnn.ShardTensor2dMesh(device, dims=tuple(mesh_dims), mesh_shape=mesh_shape)
+        if state_dict is None:
+            assert cache_file is not None
+            serialized_cache_file = Path(f"{cache_file}_dtype_{dtype.name}_layout_{ttnn.TILE_LAYOUT.name}.tensorbin")
+            return ttnn.load_tensor(serialized_cache_file, device=device)
+        converted = ttnn.as_tensor(
+            tensor.contiguous(),
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=device if _load_to_device else None,
+            mesh_mapper=mesh_mapper,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG if _load_to_device else None,
+            cache_file_name=cache_file,
+        )
+        return converted
+
+    def group_output_shards(*weights: torch.Tensor) -> torch.Tensor:
+        """Group every projection tensor corresponding head slice on the same device."""
+        grouped = []
+        for device_index in range(tensor_parallel_size):
+            device_weights = []
+            for weight in weights:
+                shard_width = weight.shape[0] // tensor_parallel_size
+                start = device_index * shard_width
+                device_weights.append(weight[start : start + shard_width])
+            grouped.append(torch.cat(device_weights, dim=0))
+        return torch.cat(grouped, dim=0)
+
+    if state_dict:
+        common_input_weights = (
+            state_dict["q_proj.weight"],
+            state_dict["k_proj.weight"],
+            state_dict["v_proj.weight"],
+            state_dict["f_a_proj.weight"].repeat(tensor_parallel_size, 1),
+        )
+        if config.use_full_rank_gate:
+            input_projection = group_output_shards(
+                *common_input_weights,
+                state_dict["g_proj.weight"],
+                state_dict["b_proj.weight"],
+            ).T
+        else:
+            output_gate_projection = state_dict["g_b_proj.weight"].reshape(
+                config.num_heads, config.head_v_dim, config.head_v_dim
+            )
+            output_gate_direct = torch.matmul(
+                output_gate_projection,
+                state_dict["g_a_proj.weight"],
+            ).reshape(config.v_dim, config.hidden_size)
+            input_projection = group_output_shards(
+                *common_input_weights,
+                output_gate_direct,
+                state_dict["b_proj.weight"],
+            ).T
+
+        decay_scale = state_dict["A_log"].float().exp()
+        if config.gate_lower_bound is None:
+            decay_scale = -decay_scale
+        decay_bias = state_dict["dt_bias"].reshape(1, 1, config.num_heads, config.head_k_dim)
+        decay_scale_flat = decay_scale.expand(-1, -1, -1, config.head_k_dim).reshape(1, 1, config.q_dim)
+        decay_bias_flat = decay_bias.reshape(1, 1, config.q_dim)
+        decay_output_projection = state_dict["f_b_proj.weight"].T
+        output_projection = state_dict["o_proj.weight"].T
+        norm = state_dict["o_norm.weight"]
+        convolution_host_taps = []
+        for tap in range(config.conv_kernel_size):
+            tap_weights = (
+                state_dict["q_conv1d.weight"][:, 0, tap],
+                state_dict["k_conv1d.weight"][:, 0, tap],
+                state_dict["v_conv1d.weight"][:, 0, tap],
+            )
+            fused_tap = group_output_shards(*tap_weights).reshape(1, 1, -1)
+            convolution_host_taps.append(fused_tap)
+    else:
+        input_width = (
+            config.q_dim
+            + config.k_dim
+            + config.v_dim
+            + config.head_k_dim * tensor_parallel_size
+            + config.v_dim
+            + config.num_heads
+        )
+        input_projection = torch.empty(config.hidden_size, input_width)
+        decay_output_projection = torch.empty(config.head_k_dim, config.q_dim)
+        output_projection = torch.empty(config.v_dim, config.hidden_size)
+        decay_scale_flat = torch.empty(1, 1, config.q_dim)
+        decay_bias_flat = torch.empty(1, 1, config.q_dim)
+        norm = torch.empty(config.head_v_dim)
+        convolution_host_taps = [
+            torch.empty(1, 1, config.q_dim + config.k_dim + config.v_dim) for _ in range(config.conv_kernel_size)
+        ]
+
+    converted = {
+        "input_projection": device_tensor(input_projection, "input_projection_head_major", shard_dim=-1),
+        "decay_output_projection": device_tensor(decay_output_projection, "decay_output_projection", shard_dim=-1),
+        "output_projection": device_tensor(output_projection, "output_projection", shard_dim=-2),
+        "decay_scale_flat": device_tensor(decay_scale_flat, "decay_scale_flat", shard_dim=-1),
+        "decay_bias_flat": device_tensor(decay_bias_flat, "decay_bias_flat", shard_dim=-1),
+        "norm": device_tensor(norm, "norm"),
+    }
+    convolution_taps = tuple(
+        device_tensor(tensor, f"conv_tap_{tap}", shard_dim=-1) for tap, tensor in enumerate(convolution_host_taps)
+    )
+    if not _load_to_device:
+        return None
+    return KDAWeights(
+        **converted,
+        convolution_taps=convolution_taps,
+        tensor_parallel_size=tensor_parallel_size,
+        tensor_parallel_axis=tensor_parallel_axis,
+    )

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -12,11 +12,16 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import kimi_k3_kda_config
+from models.demos.deepseek_v3_d_p.tt.kda.config import kimi_k3_program_config
+from models.demos.deepseek_v3_d_p.tt.kda.kda import ttKDA
+from models.demos.deepseek_v3_d_p.tt.kda.state_store import KdaStateStore
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import compute_constants, extract_mesh_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
@@ -45,6 +50,16 @@ def get_block_timings() -> dict[int, dict[str, list[float]]]:
 # FABRIC_2D_TORUS_Y, where only the SP axis is wrapped into a ring.
 PerAxisTopology = Tuple[ttnn.Topology, ttnn.Topology]
 TopologyArg = Union[ttnn.Topology, PerAxisTopology]
+
+
+def is_kda_layer(model_cfg: type, layer_idx: int) -> bool:
+    """Whether this layer runs KDA linear attention instead of full attention.
+
+    Only a hybrid variant publishes ``mla_layer_ids``; every other model is full-attention
+    throughout, so the absence of that classmethod is the answer rather than a missing case.
+    """
+    mla_layer_ids = getattr(model_cfg, "mla_layer_ids", None)
+    return mla_layer_ids is not None and layer_idx not in mla_layer_ids()
 
 
 class TtPrefillBlock(LightweightModule):
@@ -86,7 +101,10 @@ class TtPrefillBlock(LightweightModule):
 
         if not TtDistributedRmsNorm.check_cache_complete(cache_path, f"{prefix}.attn_norm"):
             return False
-        if not ttMLA.check_cache_complete(cache_path, f"{prefix}.mla"):
+        # A KDA layer's attention weights are not checked here: ttKDA.check_cache_complete needs the
+        # mesh device to know the per-device shard shapes, and this check has none. An incomplete KDA
+        # cache is still caught, just later — load_kda_weights raises at block construction.
+        if not is_kda_layer(model_cfg, layer_idx) and not ttMLA.check_cache_complete(cache_path, f"{prefix}.mla"):
             return False
         if not TtDistributedRmsNorm.check_cache_complete(cache_path, f"{prefix}.ffn_norm"):
             return False
@@ -154,18 +172,28 @@ class TtPrefillBlock(LightweightModule):
             cache_name_prefix=f"layer_{layer_idx}.attn_norm",
         )
 
-        # Build MLA cache
-        ttMLA.build_ttnn_cache(
-            state_dict=state_dict.get("mla_weights", {}),
-            cache_path=cache_path,
-            mesh_device=mesh_device,
-            config=config,
-            layer_idx=layer_idx,
-            seq_len=seq_len,
-            sp_axis=sp_axis,
-            tp_axis=tp_axis,
-            kv_only=kv_only,
-        )
+        # Build attention cache
+        if is_kda_layer(model_cfg, layer_idx):
+            ttKDA.build_ttnn_cache(
+                state_dict.get("kda_weights", {}),
+                cache_path,
+                mesh_device,
+                kimi_k3_kda_config(),
+                layer_idx,
+                tp_axis=tp_axis,
+            )
+        else:
+            ttMLA.build_ttnn_cache(
+                state_dict=state_dict.get("mla_weights", {}),
+                cache_path=cache_path,
+                mesh_device=mesh_device,
+                config=config,
+                layer_idx=layer_idx,
+                seq_len=seq_len,
+                sp_axis=sp_axis,
+                tp_axis=tp_axis,
+                kv_only=kv_only,
+            )
 
         if kv_only:
             # The kv-only last layer has no ffn_norm / FFN / MoE.
@@ -280,6 +308,7 @@ class TtPrefillBlock(LightweightModule):
         self.topology = tp_topology  # forward()'s dense-FFN all-gather is on the TP axis (cluster_axis=1)
         self.kv_only = kv_only
         self.is_moe = layer_idx >= model_cfg.NUM_DENSE_LAYERS
+        self.is_kda = is_kda_layer(model_cfg, layer_idx)
         # The KV pad-zero and layer-ack path in forward() is the block's own: it addresses the
         # cache by global layer index and by the SP geometry of the activation slab, neither of
         # which belongs to whichever attention module a layer happens to build.
@@ -287,12 +316,13 @@ class TtPrefillBlock(LightweightModule):
         self.layer_num = layer_num
         self.sp_axis = sp_axis
         self.sp_factor = mesh_device.shape[sp_axis]
+        self.tp_axis = tp_axis
 
         emb_dim = config.hidden_size
 
         logger.info(
             f"Building TtPrefillBlock layer_idx={layer_idx} "
-            f"({'MoE' if self.is_moe else 'dense'}, kv_only={kv_only})"
+            f"({'MoE' if self.is_moe else 'dense'}, {'KDA' if self.is_kda else 'MLA'}, kv_only={kv_only})"
         )
 
         # --- Attention norm ---
@@ -308,30 +338,55 @@ class TtPrefillBlock(LightweightModule):
             cache_name_prefix=f"layer_{layer_idx}.attn_norm",
         )
 
-        # --- MLA ---
-        # In chunked prefill the MLA's seq_len sizes the gathered-KV ring buffer (= full per-user
-        # cache length), while the block's seq_len is the per-chunk size used by the MoE/FFN dispatch
-        # buffers. They are equal in the single-shot path (max_seq_len is None).
-        self.mla = ttMLA(
-            config,
-            state_dict.get("mla_weights", {}),  # Empty dict if cache exists
-            mesh_device,
-            layer_idx=layer_idx,
-            seq_len=max_seq_len if max_seq_len is not None else seq_len,
-            sp_axis=sp_axis,
-            tp_axis=tp_axis,
-            # Pass the full per-axis topology: MLA's q/kv/wo CCLs use the TP element (cluster_axis=
-            # tp_axis), but its ring-attention SDPA runs on the SP axis and needs the SP element.
-            topology=topology,
-            is_balanced=is_balanced,
-            weight_cache_path=weight_cache_path,
-            is_chunked=is_chunked,
-            active_seq_len=seq_len,
-            slot_num=slot_num,
-            layer_num=layer_num,
-            kv_only=kv_only,
-            sparse_kv_cache_format=sparse_kv_cache_format,
-        )
+        # --- Attention: KDA on a hybrid variant's linear-attention layers, MLA otherwise ---
+        if self.is_kda:
+            assert not kv_only, (
+                f"layer {layer_idx} is a KDA layer and writes no KV slab, so it cannot be the "
+                "kv_only migration layer"
+            )
+            self.mla = None
+            self.kda = ttKDA(
+                mesh_device,
+                kimi_k3_kda_config(),
+                state_dict.get("kda_weights", {}),  # empty dict if cache exists
+                layer_idx=layer_idx,
+                weight_cache_path=weight_cache_path,
+                # One TT_CCL per mesh: its semaphores are hardware resources, so a second instance
+                # alongside the model's own would claim a second set of them.
+                tt_ccl=get_tt_ccl(mesh_device) if mesh_device.shape[tp_axis] > 1 else None,
+                sp_axis=sp_axis,
+                tp_axis=tp_axis,
+                # Scalar TP element: KDA's only collective is the output projection's reduce-scatter
+                # on cluster_axis=tp_axis. Passed explicitly because ttKDA reads its topology from
+                # here and NOT from program_config.tp_ccl_topology.
+                topology=tp_topology,
+                program_config=kimi_k3_program_config(tp_ccl_topology=tp_topology),
+            )
+        else:
+            self.kda = None
+            # In chunked prefill the MLA's seq_len sizes the gathered-KV ring buffer (= full per-user
+            # cache length), while the block's seq_len is the per-chunk size used by the MoE/FFN
+            # dispatch buffers. They are equal in the single-shot path (max_seq_len is None).
+            self.mla = ttMLA(
+                config,
+                state_dict.get("mla_weights", {}),  # Empty dict if cache exists
+                mesh_device,
+                layer_idx=layer_idx,
+                seq_len=max_seq_len if max_seq_len is not None else seq_len,
+                sp_axis=sp_axis,
+                tp_axis=tp_axis,
+                # Pass the full per-axis topology: MLA's q/kv/wo CCLs use the TP element (cluster_axis=
+                # tp_axis), but its ring-attention SDPA runs on the SP axis and needs the SP element.
+                topology=topology,
+                is_balanced=is_balanced,
+                weight_cache_path=weight_cache_path,
+                is_chunked=is_chunked,
+                active_seq_len=seq_len,
+                slot_num=slot_num,
+                layer_num=layer_num,
+                kv_only=kv_only,
+                sparse_kv_cache_format=sparse_kv_cache_format,
+            )
 
         if kv_only:
             # Last layer: no FFN norm, no FFN/MoE. Forward returns after MLA.
@@ -534,6 +589,7 @@ class TtPrefillBlock(LightweightModule):
         return_indexer_indices: bool = False,
         index_kv_cache: Optional[ttnn.Tensor] = None,
         metadata: Optional[ttnn.Tensor] = None,
+        kda_states: Optional[KdaStateStore] = None,
     ):
         """
         Args:
@@ -572,6 +628,9 @@ class TtPrefillBlock(LightweightModule):
                 sees the ROTATED block-cyclic layout, so the per-chip real-token split depends on
                 BOTH values (see MoeGate.build_padding_config).
             padding_side: "right" or "left"; threaded to the MoE FFN for padding-aware routing.
+            kda_states: the caller's live KDA carries, required on a KDA layer and unused otherwise.
+                This layer reads its own entry and writes back the replacement ttKDA returns, so the
+                store is what makes a second chunk continue the recurrence rather than restart it.
 
         Returns:
             (output_tensor, kv_cache) where kv_cache is a host tensor or None, or
@@ -588,30 +647,42 @@ class TtPrefillBlock(LightweightModule):
         # --- Attention ---
         attn_norm_out = self.attn_norm(x)
         seq_len_local = attn_norm_out.shape[2]
-        mla_out = self.mla.forward(
-            attn_norm_out,
-            rope_tensors,
-            kvpe_cache,
-            cache_layer_idx=cache_layer_idx,
-            actual_start=actual_start,
-            cache_user_id=cache_user_id,
-            return_kv_intermediates=return_kv_intermediates,
-            indexer_indices=indexer_indices,
-            return_indexer_indices=return_indexer_indices,
-            index_kv_cache=index_kv_cache,
-            metadata=metadata,
-        )
         kv_intermediates = None
         mla_indices = None  # GLM-5.2 reuse: this layer's top-k indices (full layer) for downstream shared layers
-        # A kv_only layer's MLA returns None (it fills the cache and stops before attention/output), so it
-        # has nothing to unpack; the kv_only short-circuit below returns the matching (None, ...) arity.
-        if not self.kv_only:
-            if return_kv_intermediates and return_indexer_indices:
-                mla_out, kv_intermediates, mla_indices = mla_out
-            elif return_kv_intermediates:
-                mla_out, kv_intermediates = mla_out
-            elif return_indexer_indices:
-                mla_out, mla_indices = mla_out
+        if self.is_kda:
+            assert kda_states is not None, f"layer {self.layer_idx} is a KDA layer and needs kda_states"
+            # A KDA layer's history lives in its recurrent carry, not in a KV slab, so nothing here feeds
+            # the KV-shaped protocols: no cache to ack, no KV stages to surface, no indexer top-k.
+            assert d2h_service is None and on_layer_complete is None, (
+                f"layer {self.layer_idx} is a KDA layer and writes no KV slab; the per-layer KV ack has "
+                "nothing to signal here and the migration path does not cover the recurrent carry"
+            )
+            assert not return_kv_intermediates, f"layer {self.layer_idx} is a KDA layer and has no KV stages"
+            assert not return_indexer_indices, f"layer {self.layer_idx} is a KDA layer and has no indexer"
+            attn_out = self._kda_path(attn_norm_out, kda_states)
+        else:
+            attn_out = self.mla.forward(
+                attn_norm_out,
+                rope_tensors,
+                kvpe_cache,
+                cache_layer_idx=cache_layer_idx,
+                actual_start=actual_start,
+                cache_user_id=cache_user_id,
+                return_kv_intermediates=return_kv_intermediates,
+                indexer_indices=indexer_indices,
+                return_indexer_indices=return_indexer_indices,
+                index_kv_cache=index_kv_cache,
+                metadata=metadata,
+            )
+            # A kv_only layer's MLA returns None (it fills the cache and stops before attention/output), so
+            # it has nothing to unpack; the kv_only short-circuit below returns the matching (None, ...) arity.
+            if not self.kv_only:
+                if return_kv_intermediates and return_indexer_indices:
+                    attn_out, kv_intermediates, mla_indices = attn_out
+                elif return_kv_intermediates:
+                    attn_out, kv_intermediates = attn_out
+                elif return_indexer_indices:
+                    attn_out, mla_indices = attn_out
         ttnn.deallocate(attn_norm_out)
 
         # Chunked-prefill migration handoff. MLA's update_padded_kv_cache wrote this chunk as full
@@ -687,13 +758,13 @@ class TtPrefillBlock(LightweightModule):
                 return None, None, None
             return None, None
 
-        x = ttnn.add(x, mla_out)
-        ttnn.deallocate(mla_out)
+        x = ttnn.add(x, attn_out)
+        ttnn.deallocate(attn_out)
         if _timing:
             ttnn.synchronize_device(self.mesh_device)
             _t_mla = time.perf_counter()
         if return_kv_intermediates:
-            # post-MLA residual (x + mla_out), TP-sharded on hidden.
+            # post-MLA residual (x + attn_out), TP-sharded on hidden.
             kv_intermediates["post_mla_residual"] = ttnn.clone(x)
 
         # --- FFN ---
@@ -739,6 +810,39 @@ class TtPrefillBlock(LightweightModule):
         if return_indexer_indices:
             return x, kv_cache, mla_indices
         return x, kv_cache
+
+    def _kda_path(self, attn_norm_out: ttnn.Tensor, kda_states: KdaStateStore) -> ttnn.Tensor:
+        """KDA linear attention: 4D TP-sharded in, 4D TP-sharded residual-shaped out.
+
+        KDA's input projection is sharded on its INPUT dim, so it needs the whole emb_dim row that a
+        TP-sharded activation only holds a slice of — hence the all_gather, as in the dense FFN path.
+        Its output projection reduce-scatters back onto the block's own sharding, so only the
+        single-TP-device case (no reduce-scatter, no leading unit batch) needs reshaping by hand.
+        """
+        if self.mesh_device.shape[self.tp_axis] > 1:
+            gathered = ttnn.all_gather(
+                attn_norm_out,
+                dim=-1,
+                cluster_axis=self.tp_axis,
+                num_links=self.num_links,
+                topology=self.topology,
+            )
+        else:
+            gathered = attn_norm_out
+        # ttKDA takes [B, T, emb_dim]; the block carries B in a leading 4th dim.
+        hidden = ttnn.squeeze(gathered, dim=0)
+
+        attn_out, new_state = self.kda.forward(hidden, kda_states.get(self.layer_idx))
+        kda_states.replace(self.layer_idx, new_state)
+
+        # `hidden` shares its buffer with `gathered`, so freeing the gather frees both. attn_norm_out is
+        # the caller's and is freed there, so the single-TP-device aliasing is left alone.
+        if gathered is not attn_norm_out:
+            ttnn.deallocate(gathered)
+
+        if len(attn_out.shape) == 3:
+            attn_out = ttnn.unsqueeze(attn_out, dim=0)
+        return attn_out
 
     def _moe_path(
         self,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -280,6 +280,13 @@ class TtPrefillBlock(LightweightModule):
         self.topology = tp_topology  # forward()'s dense-FFN all-gather is on the TP axis (cluster_axis=1)
         self.kv_only = kv_only
         self.is_moe = layer_idx >= model_cfg.NUM_DENSE_LAYERS
+        # The KV pad-zero and layer-ack path in forward() is the block's own: it addresses the
+        # cache by global layer index and by the SP geometry of the activation slab, neither of
+        # which belongs to whichever attention module a layer happens to build.
+        self.layer_idx = layer_idx
+        self.layer_num = layer_num
+        self.sp_axis = sp_axis
+        self.sp_factor = mesh_device.shape[sp_axis]
 
         emb_dim = config.hidden_size
 
@@ -636,19 +643,19 @@ class TtPrefillBlock(LightweightModule):
                         metadata[0],  # slot_idx tensor
                         metadata[2],  # valid_global (= actual_end) tensor
                         cache_layer_idx,
-                        self.mla.layer_num,
-                        seq_len_local * self.mla.sp_factor,
-                        self.mla.sp_axis,
+                        self.layer_num,
+                        seq_len_local * self.sp_factor,
+                        self.sp_axis,
                     )
                 else:
                     ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
                         cache_tensor,
                         cache_user_id,
                         cache_layer_idx,
-                        self.mla.layer_num,
+                        self.layer_num,
                         actual_end,
-                        seq_len_local * self.mla.sp_factor,
-                        self.mla.sp_axis,
+                        seq_len_local * self.sp_factor,
+                        self.sp_axis,
                     )
             if d2h_service is not None:
                 # Device-op ack, enqueued on the same CQ right after the zero: the record cannot reach the
@@ -667,10 +674,10 @@ class TtPrefillBlock(LightweightModule):
                 # is False (and on_layer_complete is None there, so neither fires).
                 tc = getattr(self, "_trace_controller", None)
                 if tc is not None and tc.has_layer_ack():
-                    tc.layer_ack(self.mla.layer_idx)
+                    tc.layer_ack(self.layer_idx)
                 else:
                     ttnn.synchronize_device(self.mesh_device)
-                    on_layer_complete(self.mla.layer_idx)
+                    on_layer_complete(self.layer_idx)
 
         if self.kv_only:
             # KV cache filled (by MLA), migration callback fired. The block
@@ -713,15 +720,15 @@ class TtPrefillBlock(LightweightModule):
         if _timing:
             ttnn.synchronize_device(self.mesh_device)
             _t_ffn = time.perf_counter()
-            rec = _BLOCK_TIMINGS.setdefault(self.mla.layer_idx, {"mla": [], "ffn": []})
+            rec = _BLOCK_TIMINGS.setdefault(self.layer_idx, {"mla": [], "ffn": []})
             rec["mla"].append(_t_mla - _t_start)  # attn_norm + MLA + residual
             rec["ffn"].append(_t_ffn - _t_mla)  # ffn_norm + (MoE|dense FFN) + residual
 
         # Post-FFN output-residual tap (e.g. the DFlash drafter): fire with this block's GLOBAL layer
-        # index (self.mla.layer_idx) and its final output residual. Not reached for kv_only blocks (they
+        # index (self.layer_idx) and its final output residual. Not reached for kv_only blocks (they
         # returned above with no output). The callback must NOT free/mutate x — it flows to the next layer.
         if on_layer_hidden is not None:
-            on_layer_hidden(self.mla.layer_idx, x)
+            on_layer_hidden(self.layer_idx, x)
 
         if return_kv_intermediates:
             if return_indexer_indices:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -21,6 +21,7 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.demos.deepseek_v3_d_p.tt.kda.state_store import KdaStateStore
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import create_balanced_chunk_order, reverse_reorder_tensor_chunks
@@ -28,7 +29,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
-from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TopologyArg, TtPrefillBlock
+from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TopologyArg, TtPrefillBlock, is_kda_layer
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
 
@@ -200,6 +201,21 @@ class TtPrefillTransformer(LightweightModule):
         # length so the block's flat KV slot (cache_user_id * layer_num + cache_layer_idx)
         # matches the per-rank cache sized to num_layers. With kv_only_last_layer, the last block is
         # built kv_only=True (only attn_norm + the KV branch of MLA).
+        # Hybrid variants (Kimi-K3) run KDA on most layers, and a KDA layer writes no KV slab. The kvpe
+        # cache therefore holds one slot per MLA layer of this rank's slice, not one per layer, so both
+        # the block's flat slot arithmetic (cache_user_id * layer_num + cache_layer_idx) and the slot
+        # forward() hands each layer count MLA layers only. On a full-attention model every layer is an
+        # MLA layer and this collapses to the identity.
+        self.kv_slot_of_layer = []
+        next_kv_slot = 0
+        for local_idx in range(num_layers):
+            if is_kda_layer(model_cfg, first_layer_idx + local_idx):
+                self.kv_slot_of_layer.append(None)
+            else:
+                self.kv_slot_of_layer.append(next_kv_slot)
+                next_kv_slot += 1
+        self.num_mla_layers = next_kv_slot
+
         self.layers = []
         for local_idx in range(num_layers):
             layer_idx = first_layer_idx + local_idx
@@ -229,7 +245,7 @@ class TtPrefillTransformer(LightweightModule):
                 weight_cache_path=weight_cache_path,
                 is_chunked=is_chunked,
                 slot_num=slot_num,
-                layer_num=num_layers,
+                layer_num=self.num_mla_layers,
                 max_seq_len=max_seq_len,
                 kv_only=kv_only_last_layer and is_last,
                 routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
@@ -237,6 +253,12 @@ class TtPrefillTransformer(LightweightModule):
                 overlap_shared_expert_with_dispatch=overlap_shared_expert_with_dispatch,
             )
             self.layers.append(layer)
+
+        # --- KDA carries (hybrid variants only) ---
+        # ttKDA retains nothing across calls, so the recurrent + convolution carries need an owner
+        # outside the layer; this instance is it, the KDA counterpart of the caller-owned kvpe cache.
+        kda_layers = {layer.layer_idx: layer.kda for layer in self.layers if layer.is_kda}
+        self.kda_states = KdaStateStore(kda_layers) if kda_layers else None
 
         # --- Final norm (last token-emitting rank only) ---
         # Built iff is_last_rank and not kv_only_last_layer: a kv_only last layer (chunked prefill)
@@ -460,7 +482,8 @@ class TtPrefillTransformer(LightweightModule):
                 h,
                 rope_tensors,
                 kvpe_cache,
-                cache_layer_idx=i,
+                # A KDA layer writes no KV slab, so it has no slot; pass 0, which it never reads.
+                cache_layer_idx=self.kv_slot_of_layer[i] if self.kv_slot_of_layer[i] is not None else 0,
                 return_intermediates=return_intermediates,
                 d2h_service=d2h_service,
                 record_dev=record_dev,
@@ -475,6 +498,7 @@ class TtPrefillTransformer(LightweightModule):
                 return_indexer_indices=reuse,
                 index_kv_cache=index_kv_cache,
                 metadata=metadata,
+                kda_states=self.kda_states,
             )
             if reuse:
                 h, _, new_idx = ret


### PR DESCRIPTION
**Review-only PR. Do not merge.** The base branch `jjovicic/kimi-k3-base` is a
frozen snapshot of the prerequisite Kimi-K3 branch stack, pushed purely so the
diff on this PR is *our* work and nothing else. A real PR against `main` will be
opened once the prerequisite branches land.

## What this is

Kimi-K3 prefill model support on the 8x4 Blackhole galaxy, plus the unit tests
that PCC it against a vLLM golden trace. Runner/adapter integration is out of
scope (#52693). Tracking: #53508.

K3 is a hybrid: 93 layers, 24 MLA and 69 KDA, `first_k_dense_replace=1`. The
work so far takes the block from MLA-only to dispatching either attention path,
with the transformer owning the KDA recurrent carry.

## Commits, oldest first

| commit | what |
|---|---|
| `kimi-k3: vendor the ttKDA layer and its tests` | copies `tt/kda/` and `tests/kda/` from `kda-split/05-kimi-k3-model` |
| `prefill/block: own the layer identity the KV-ack path reads` | pure refactor, `self.mla.*` -> `self.*` |
| `kda: match the vendored layer to the merged KDA op ABI` | forward-adapts the vendored Python to the newer merged C++ ops |
| `prefill: dispatch MLA and KDA from one block` | the feature |

## The ABI commit, and why it exists

The vendored Python targets an older `ttnn.experimental.kda` ABI than the KDA
C++ ops merged into this stack. Two divergences, both adapted forward:

- `prepare_chunk_recurrence` dropped its quadrant-mask input in
  `cc2664f7cf6`, when the masked 16x16 Horner inverse was replaced by the
  doubling inverse. The constant is removed end-to-end here, not just at the
  call site: nothing reads it, so uploading it was dead weight.
- Every `ttnn.experimental.kda` op now rejects `packer_l1_acc` outright. The
  vendored layer hardcoded it on one shared config feeding both generic `ttnn`
  ops and KDA ops. Split into `self.compute_config` (generic ops, flag kept)
  and `self.kda_op_compute_config` (KDA ops, flag off). No math change - those
  kernels never accumulated through L1.

Note for whoever lands `kda-split/05`: it needs this same adaptation, or it
breaks on the first device test.

## Validation

`bh-glx-b06u08`, mesh (8,4), single rank, 5120 tokens, real K3 weights against
`kimi_k3_100k_vllm`:

| gate | PCC | max abs | threshold |
|---|---|---|---|
| `attn_norm` out vs `kda_input_layer_0` | 0.999985 | 4.69e-02 | 0.999 |
| KDA out vs `kda_output_layer_0` | 0.999900 | 1.37e-02 | 0.98 |
| recurrent carry vs `kda_recurrent_state_layer_0`, all 8 SP ranks | 0.999709 | 2.34e-01 | 0.98 |
| layer 0 vs torch reference | 0.999788 | 1.28e-03 | - |

Plus a `TtPrefillTransformer(num_layers=1)` build+forward smoke, and
`tests/kda/operations/test_chunk.py` 12/12 in 41.61s to cover the mask removal.

The KDA output PCC spans the whole 5120-token window, so it exercises the
sequence-parallel carry chaining: `convolution_halo` passes conv carries along
the SP axis and `_distributed_affine_prefix` composes the per-partition affine
summaries, leaving a globally correct final state replicated across SP ranks.

Two constraints worth knowing. KDA fixes chunk = `TILE_SIZE` = 32 and
`KDA_SUMMARY_GROUP_CHUNKS` = 20, so the per-rank sequence must be a multiple of
640; on (8,4) with `sp_axis=0` that makes 5120 the smallest valid window. And
the trace stores the recurrent carry value-major while ttKDA carries it
key-major - the trace metadata names neither axis, so the tests transpose based
on a measured `k^T v` correlation, not on documentation.

## Not here yet

Steps 3-5 of the plan: the AttnRes walk in the block, then 13 layers to cross an
AttnRes block boundary, then all 93. Layers 1+ additionally need an MXFP4
dequantizer.

Single-galaxy only by design for now; multi-rank comes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/kimi-k3-model)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/kimi-k3-model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/kimi-k3-model)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/kimi-k3-model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/kimi-k3-model)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/kimi-k3-model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/kimi-k3-model)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/kimi-k3-model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/kimi-k3-model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/kimi-k3-model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/kimi-k3-model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/kimi-k3-model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/kimi-k3-model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/kimi-k3-model)