### PR TITLE
[Perf] complex div_bw: one reciprocal of the divisor instead of three

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_complex_div_bw_shared_reciprocal.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_complex_div_bw_shared_reciprocal.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""div_bw on ComplexTensors builds one reciprocal of the divisor, not three.
+
+Complex divide is multiply-by-reciprocal, and all three divisions in this op divide
+by the same tensor. The reciprocal of a conjugate is the conjugate of the reciprocal,
+so the conjugated division shares it too.
+"""
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 32, 32)
+DTYPES = [(ttnn.bfloat16, torch.bfloat16), (ttnn.float32, torch.float32)]
+
+
+def _c(re, im, dtype, torch_dtype, device):
+    def t(v):
+        return ttnn.from_torch(
+            torch.full(SHAPE, v, dtype=torch_dtype), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device
+        )
+
+    return ttnn.complex_tensor(t(re), t(im))
+
+
+@pytest.mark.parametrize("dtype, torch_dtype", DTYPES)
+def test_complex_div_bw_matches_the_closed_form(device, dtype, torch_dtype):
+    grad, a, b = (2.0, 1.0), (3.0, -4.0), (1.0, 2.0)
+    out = ttnn.div_bw(
+        _c(*grad, dtype, torch_dtype, device),
+        _c(*a, dtype, torch_dtype, device),
+        _c(*b, dtype, torch_dtype, device),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    g, ta, tb = complex(*grad), complex(*a), complex(*b)
+    want = [g / tb.conjugate(), -g * (ta / tb / tb).conjugate()]
+    tol = 0.05 if dtype == ttnn.bfloat16 else 1e-4
+    for got, w in zip(out, want):
+        r = ttnn.to_torch(got.real).float().flatten()[0].item()
+        i = ttnn.to_torch(got.imag).float().flatten()[0].item()
+        assert abs(r - w.real) <= tol * max(1.0, abs(w.real)), f"real {r} vs {w.real}"
+        assert abs(i - w.imag) <= tol * max(1.0, abs(w.imag)), f"imag {i} vs {w.imag}"
+
+
+@pytest.mark.parametrize("dtype, torch_dtype", DTYPES)
+def test_complex_div_bw_still_writes_nan_when_the_divisor_is_zero(device, dtype, torch_dtype):
+    out = ttnn.div_bw(
+        _c(2.0, 1.0, dtype, torch_dtype, device),
+        _c(3.0, -4.0, dtype, torch_dtype, device),
+        _c(0.0, 0.0, dtype, torch_dtype, device),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    for got in out:
+        for half in (got.real, got.imag):
+            v = ttnn.to_torch(half).float().flatten()[0].item()
+            # bfloat16 Dest cannot carry NaN and returns an infinity instead.
+            assert v != v or v in (float("inf"), float("-inf")), f"expected NaN or inf, got {v}"
+
+
+def test_complex_div_bw_dispatch_count(device):
+    grad = _c(2.0, 1.0, ttnn.bfloat16, torch.bfloat16, device)
+    a = _c(3.0, -4.0, ttnn.bfloat16, torch.bfloat16, device)
+    b = _c(1.0, 2.0, ttnn.bfloat16, torch.bfloat16, device)
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NO_DISPATCH)
+    try:
+        ttnn.div_bw(grad, a, b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    finally:
+        captured = ttnn.graph.end_graph_capture()
+    n = sum(
+        1
+        for x in captured
+        if x.get("node_type") == "function_start" and str(x.get("params", {}).get("name", "")).endswith("DeviceOperation")
+    )
+    assert n == 44, f"expected 44 device operations, got {n}"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -766,8 +766,12 @@ std::vector<ComplexTensor> div_bw(
         ttnn::eqz(other.imag(), output_mem_config),
         std::nullopt,
         output_mem_config);
-    ComplexTensor grad_a =
-        ttnn::operations::complex_binary::divide(grad_tensor, ttnn::conj(other, output_mem_config), output_mem_config);
+    // Complex divide is multiply-by-reciprocal, and all three divisions below divide by
+    // `other`. The reciprocal of a conjugate is the conjugate of the reciprocal -- the
+    // denominator a*a + b*b is the same either way -- so one reciprocal serves all three.
+    const ComplexTensor recip_other = ttnn::reciprocal(other, output_mem_config);
+    ComplexTensor grad_a = ttnn::operations::complex_binary::multiply(
+        grad_tensor, ttnn::conj(recip_other, output_mem_config), output_mem_config);
     Tensor grad_a_r = where(condition_nan, std::nanf(""), ttnn::real(grad_a, output_mem_config), output_mem_config);
     Tensor grad_a_i = where(condition_nan, std::nanf(""), ttnn::imag(grad_a, output_mem_config), output_mem_config);
     grad_a = ComplexTensor({grad_a_r, grad_a_i});
@@ -779,8 +783,10 @@ std::vector<ComplexTensor> div_bw(
     ComplexTensor grad_b = ttnn::operations::complex_binary::multiply(
         neg_grad,
         ttnn::conj(
-            ttnn::operations::complex_binary::divide(
-                ttnn::operations::complex_binary::divide(input_a, other, output_mem_config), other, output_mem_config),
+            ttnn::operations::complex_binary::multiply(
+                ttnn::operations::complex_binary::multiply(input_a, recip_other, output_mem_config),
+                recip_other,
+                output_mem_config),
             output_mem_config),
         output_mem_config);
     neg_grad.deallocate();


### PR DESCRIPTION
## PR Category

Performance.

## Summary

Closes #53981.

`div_bw` on ComplexTensors divided by `other` three times, and complex divide is multiply-by-reciprocal, so it built the same complex reciprocal three times. One is built and shared. The conjugated division shares it too: `reciprocal(conj(z))` is `conj(reciprocal(z))`, because the denominator `a*a + b*b` is unchanged by the sign flip and `(-b)*(-b)` is `b*b` exactly.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device, output bits compared as integers.

Every one of the 65536 bfloat16 bit patterns in each of the six operand halves — grad.real, grad.imag, a.real, a.imag, b.real, b.imag — against four counterparts, 2^20 float32 patterns the same way, all four returned halves compared:

| halves compared | values | P300 | N300 |
|---|---|---|---|
| 192 | 106954752 | **0 differ** | **0 differ** |

Including NaN payloads: the count above is a raw bit comparison, not a NaN-tolerant one.

## Cost

Wall clock, 3 warm-up then 20 timed calls with one `synchronize_device` at the end, median of five runs, profiler off, µs per call.

| | | main | this branch |
|---|---|---|---|
| both | dispatches | 62 | **44** |
| P300 | 1 tile, bfloat16 | 1168.6 | **867.9** |
| | 1 tile, float32 | 1195.3 | **864.1** |
| | 256 tiles, bfloat16 | 1293.8 | **952.6** |
| | 1024 tiles, bfloat16 | 1313.6 | **981.9** |
| | 1024 tiles, float32 | 1740.4 | **1262.7** |
| N300 | 1 tile, bfloat16 | 2271.8 | **1682.1** |
| | 1 tile, float32 | 2292.9 | **1692.5** |
| | 256 tiles, bfloat16 | 2474.1 | **1799.8** |
| | 1024 tiles, bfloat16 | 2462.4 | **1808.1** |
| | 1024 tiles, float32 | 4545.9 | **3302.0** |

## Tests

`test_complex_div_bw_shared_reciprocal.py`, 5 cases, all passing on P300 and on N300: both gradients against the closed form in both dtypes, the zero-divisor path still returning a non-number, and the dispatch count pinned at 44.

## Not covered

- Folding `logical_and(eqz(a), eqz(b))` into operand activations, which the issue originally proposed as part of this. It is **not** equivalent: over all 65536 bfloat16 patterns a folded EQZ reports true for the 254 subnormals, where a separate `ttnn.eqz` reports false. Those two dispatches stay.
- The complex reciprocal's own 9 dispatches, filed separately.
