### PR TITLE
[Bug fix] multiply: honour an explicit fast_and_approximate_mode on block-float

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_multiply_block_float_fast_approx.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_multiply_block_float_fast_approx.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""multiply honours an explicit fast_and_approximate_mode on block-float operands.
+
+Block-float still defaults to the FPU path. What changed is that a caller who passes
+False now gets the SFPU path, where before the argument was discarded — while divide,
+bound by the same helper, honoured it for the same dtypes.
+"""
+
+import pytest
+import torch
+import ttnn
+
+SHAPE = (1, 1, 256, 256)
+ALL_BF16 = torch.arange(0, 65536, dtype=torch.int64).to(torch.int32).to(torch.int16).view(torch.bfloat16)
+
+
+def _t(x, dtype, device):
+    torch_dtype = torch.float32 if dtype == ttnn.float32 else torch.bfloat16
+    return ttnn.from_torch(x.to(torch_dtype), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+
+def _differ(a, b):
+    x, y = ttnn.to_torch(a).float(), ttnn.to_torch(b).float()
+    return ((x != y) & ~(torch.isnan(x) & torch.isnan(y))).sum().item()
+
+
+def test_block_float_multiply_still_defaults_to_the_fast_path(device):
+    a = _t(ALL_BF16.reshape(SHAPE), ttnn.bfloat8_b, device)
+    b = _t(torch.full(SHAPE, 1.5), ttnn.bfloat8_b, device)
+    assert _differ(ttnn.multiply(a, b), ttnn.multiply(a, b, fast_and_approximate_mode=True)) == 0
+
+
+def test_block_float_multiply_honours_an_explicit_false(device):
+    a = _t(ALL_BF16.reshape(SHAPE), ttnn.bfloat8_b, device)
+    b = _t(torch.full(SHAPE, 1.5), ttnn.bfloat8_b, device)
+    moved = _differ(ttnn.multiply(a, b, fast_and_approximate_mode=False), ttnn.multiply(a, b))
+    assert moved > 0, "an explicit False is still being discarded for block-float operands"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_non_block_float_defaults_are_unchanged(device, dtype):
+    a = _t(ALL_BF16.reshape(SHAPE), dtype, device)
+    b = _t(torch.full(SHAPE, 1.5), dtype, device)
+    assert _differ(ttnn.multiply(a, b), ttnn.multiply(a, b, fast_and_approximate_mode=False)) == 0
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.float32])
+def test_divide_default_is_unchanged(device, dtype):
+    a = _t(ALL_BF16.reshape(SHAPE), dtype, device)
+    b = _t(torch.full(SHAPE, 1.5), dtype, device)
+    assert _differ(ttnn.divide(a, b), ttnn.divide(a, b, fast_and_approximate_mode=False)) == 0
+
+
+def test_block_float_scalar_overload_honours_an_explicit_false(device):
+    a = _t(ALL_BF16.reshape(SHAPE), ttnn.bfloat8_b, device)
+    moved = _differ(ttnn.multiply(a, 2.0, fast_and_approximate_mode=False), ttnn.multiply(a, 2.0))
+    assert moved > 0, "an explicit False is still being discarded for the scalar overload"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -858,8 +858,10 @@ Tensor inplace_mul_operation_with_fast_approx(
     std::optional<bool> fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    bool is_block_fmt_inp = (is_block_float(lhs.dtype()) || is_block_float(rhs.dtype()));
-    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    // Block-float still defaults to the FPU path, but an explicit argument is an argument:
+    // the caller's False was discarded here, while divide honours it for the same dtypes.
+    bool fast_and_approx =
+        fast_and_approximate_mode.value_or(is_block_float(lhs.dtype()) || is_block_float(rhs.dtype()));
     return ttnn::detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -885,8 +887,9 @@ Tensor inplace_mul_operation_with_fast_approx(
     std::optional<bool> fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    bool is_block_fmt_inp = (is_block_float(lhs.dtype()));
-    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    // Block-float still defaults to the FPU path, but an explicit argument is an argument:
+    // the caller's False was discarded here, while divide honours it for the same dtypes.
+    bool fast_and_approx = fast_and_approximate_mode.value_or(is_block_float(lhs.dtype()));
     return ttnn::detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -1162,8 +1165,10 @@ Tensor multiply(
     const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    bool is_block_fmt_inp = (is_block_float(lhs.dtype()) || is_block_float(rhs.dtype()));
-    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    // Block-float still defaults to the FPU path, but an explicit argument is an argument:
+    // the caller's False was discarded here, while divide honours it for the same dtypes.
+    bool fast_and_approx =
+        fast_and_approximate_mode.value_or(is_block_float(lhs.dtype()) || is_block_float(rhs.dtype()));
     return ttnn::detail::invoke_binary_ng(
         lhs,
         rhs,
@@ -1190,8 +1195,9 @@ Tensor multiply(
     const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    bool is_block_fmt_inp = (is_block_float(lhs.dtype()));
-    bool fast_and_approx = is_block_fmt_inp ? true : fast_and_approximate_mode.value_or(false);
+    // Block-float still defaults to the FPU path, but an explicit argument is an argument:
+    // the caller's False was discarded here, while divide honours it for the same dtypes.
+    bool fast_and_approx = fast_and_approximate_mode.value_or(is_block_float(lhs.dtype()));
     return ttnn::detail::invoke_binary_ng(
         lhs,
         rhs,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -1194,7 +1194,7 @@ void bind_div(
 Tensor multiply_fast_approx_tensor_scalar(
     const Tensor& input_tensor_a,
     unary::ScalarVariant value,
-    bool fast_and_approximate_mode,
+    const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<ttnn::Tensor>& output_tensor,
@@ -1222,7 +1222,7 @@ Tensor multiply_fast_approx_tensor_scalar(
 Tensor multiply_fast_approx_tensor_tensor(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
-    bool fast_and_approximate_mode,
+    const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<ttnn::Tensor>& output_tensor,
@@ -1250,7 +1250,7 @@ Tensor multiply_fast_approx_tensor_tensor(
 Tensor divide_fast_approx_tensor_scalar(
     const Tensor& input_tensor_a,
     unary::ScalarVariant value,
-    bool fast_and_approximate_mode,
+    const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<ttnn::Tensor>& output_tensor,
@@ -1278,7 +1278,7 @@ Tensor divide_fast_approx_tensor_scalar(
 Tensor divide_fast_approx_tensor_tensor(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
-    bool fast_and_approximate_mode,
+    const std::optional<bool>& fast_and_approximate_mode,
     const std::optional<const DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<ttnn::Tensor>& output_tensor,
@@ -1368,7 +1368,7 @@ void bind_binary_operation_with_fast_approx(
             nb::arg("input_tensor_a"),
             nb::arg("input_tensor_b"),
             nb::kw_only(),
-            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("fast_and_approximate_mode") = nb::none(),
             nb::arg("dtype") = nb::none(),
             nb::arg("memory_config") = nb::none(),
             nb::arg("output_tensor") = nb::none(),
@@ -1382,7 +1382,7 @@ void bind_binary_operation_with_fast_approx(
             nb::arg("input_tensor_a"),
             nb::arg("input_tensor_b"),
             nb::kw_only(),
-            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("fast_and_approximate_mode") = nb::none(),
             nb::arg("dtype") = nb::none(),
             nb::arg("memory_config") = nb::none(),
             nb::arg("output_tensor") = nb::none(),
@@ -1672,7 +1672,7 @@ void bind_inplace_operation_with_fast_approx(
             nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
             nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
             nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
-            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("fast_and_approximate_mode") = nb::none(),
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("sub_device_id") = nb::none()),
         ttnn::overload_t(
@@ -1683,7 +1683,7 @@ void bind_inplace_operation_with_fast_approx(
             nb::arg("activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
             nb::arg("input_tensor_a_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
             nb::arg("input_tensor_b_activations") = nb::cast(ttsl::Span<const unary::EltwiseUnaryWithParam>{}),
-            nb::arg("fast_and_approximate_mode") = false,
+            nb::arg("fast_and_approximate_mode") = nb::none(),
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("sub_device_id") = nb::none()));
 }


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #53984.

`multiply` forced `fast_and_approximate_mode` to true for block-float operands, discarding whatever the caller passed. `divide`, bound by the same helper and taking the same flag, honours it for the same dtypes.

The default does not move: block-float still takes the FPU path when the caller says nothing. To make "says nothing" expressible from Python at all, the binding default becomes `None` and the four trampolines take `std::optional<bool>` instead of `bool` — before this, the binding always passed an explicit `false`, so the C++ `std::nullopt` branch was unreachable and the override was the only thing keeping block-float on the fast path.

## Accuracy

Every number is this branch against `04cf22f7ee`, built and run on the same device, output bits compared as integers.

`multiply` in both overloads, every one of the 65536 bfloat16 bit patterns in each operand position against three counterparts, 2^22 float32 patterns, and the same source patterns as bfloat8_b, with the flag unset, False and True:

| dtype | flag unset | explicit True | explicit False, P300 | explicit False, N300 |
|---|---|---|---|---|
| bfloat16 | **0** | **0** | **0** | **0** |
| float32 | **0** | **0** | **0** | **0** |
| bfloat8_b | **0** | **0** | **25986** tensor, **2322** scalar | **25482** tensor, **1944** scalar |

108 sweeps, 77070336 values, on each machine. The only thing that moves is the case where the caller passed the argument that was being thrown away.

`divide`'s default is unchanged in all three dtypes — its default and an explicit `False` are bit-identical on both branches, which is what the binding change had to preserve.

What the newly reachable path gives, against a float64 golden of the values the device holds:

| bfloat8_b multiply | mean relative error | max |
|---|---|---|
| SFPU (`fast_and_approximate_mode=False`) | **2.821e-03** | 1.205e-02 |
| FPU (the default) | 3.406e-03 | 1.205e-02 |

Identical to four figures on both machines.

## Cost

None for any existing caller — the default path is the same kernel it was.

| bfloat8_b multiply | FPU (default) | SFPU (`False`) |
|---|---|---|
| P300, 1 tile | 23.28 | 25.56 |
| P300, 1024x1024 | 25.10 | 25.12 |
| P300, 2048x2048 | 35.30 | 36.23 |
| N300, 1 tile | 47.53 | **46.75** |
| N300, 1024x1024 | 47.80 | 48.55 |
| N300, 2048x2048 | 81.67 | 83.10 |

The path a caller opts into is within a couple of percent either way and about 21% more accurate. That trade is now theirs to make.

## Tests

`test_multiply_block_float_fast_approx.py`, 8 cases: block-float multiply asserted to still default to the fast path, an explicit `False` asserted to change something, bfloat16 and float32 defaults asserted unchanged, `divide`'s default asserted unchanged in three dtypes, and the scalar overload. 2 of the 8 fail on `04cf22f7ee`, on both machines; all 8 pass here, on P300 and on N300.

## Not covered

- Whether the FPU path should stay the block-float default. This branch does not change it.
- `inplace_mul_operation_with_fast_approx` carries the same override and gets the same treatment, but the in-place op has no Python binding for the flag, so it is not swept here.
