### PR TITLE
Fix program config prefetch command batching

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <numeric>
 #include "tt_metal/impl/dispatch/vector_aligned.hpp"
 #include <utility>
 #include <vector>
@@ -15,6 +17,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "tt_metal/impl/program/program_command_sequence.hpp"
 
 namespace tt::tt_metal {
 
@@ -24,6 +27,53 @@ class DeviceCommandTest : public ::testing::Test {
 protected:
     MetalContext& ctx_ = MetalContext::instance();
 };
+
+TEST_F(DeviceCommandTest, CPU_ProgramConfigBatchingSplitsAtPrefetchEntryLimit) {
+    constexpr uint32_t max_prefetch_command_size = 131072;
+    constexpr uint32_t pcie_alignment = 16;
+    constexpr uint32_t l1_alignment = 16;
+    constexpr std::array<uint32_t, 4> command_sizes = {70016, 60000, 60000, 29056};
+
+    EXPECT_TRUE(dispatch_write_packed_large_requires_new_command(
+        /*current_subcommand_count=*/2,
+        /*current_data_size_bytes=*/120000,
+        /*next_data_size_bytes=*/99072,
+        pcie_alignment,
+        l1_alignment,
+        max_prefetch_command_size));
+    EXPECT_FALSE(dispatch_write_packed_large_requires_new_command(
+        /*current_subcommand_count=*/1,
+        /*current_data_size_bytes=*/60000,
+        /*next_data_size_bytes=*/60000,
+        pcie_alignment,
+        l1_alignment,
+        max_prefetch_command_size));
+    EXPECT_TRUE(dispatch_write_packed_large_requires_new_command(
+        /*current_subcommand_count=*/CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS,
+        /*current_data_size_bytes=*/16,
+        /*next_data_size_bytes=*/16,
+        pcie_alignment,
+        l1_alignment,
+        max_prefetch_command_size));
+    EXPECT_LE(
+        dispatch_write_packed_large_size_bytes(1, 99072, pcie_alignment, l1_alignment), max_prefetch_command_size);
+
+    EXPECT_EQ(std::accumulate(command_sizes.begin(), command_sizes.end(), 0U), 219072);
+    EXPECT_TRUE(std::ranges::all_of(command_sizes, [](uint32_t size) { return size <= max_prefetch_command_size; }));
+}
+
+TEST_F(DeviceCommandTest, CPU_ProgramConfigCommandsRetainPrefetchEntryBoundaries) {
+    constexpr size_t command_count = 4;
+    ProgramCommandSequence program_commands(ctx_);
+    for (size_t command_index = 0; command_index < command_count; ++command_index) {
+        program_commands.program_config_buffer_command_sequences.emplace_back(ctx_);
+    }
+
+    size_t visited_command_count = 0;
+    program_commands.visit_program_config_buffer_commands(
+        [&visited_command_count](const HostMemDeviceCommand&) { ++visited_command_count; });
+    EXPECT_EQ(visited_command_count, command_count);
+}
 
 TEST_F(DeviceCommandTest, CPU_AddDispatchWait) {
     DeviceCommandCalculator calculator(ctx_);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -19,6 +19,7 @@
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/program/program_config_command_generator.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
+#include "tt_metal/impl/program/program_command_sequence_writer.hpp"
 
 namespace tt::tt_metal {
 
@@ -27,6 +28,39 @@ namespace tt::tt_metal {
 class DeviceCommandTest : public ::testing::Test {
 protected:
     MetalContext& ctx_ = MetalContext::instance();
+};
+
+class RecordingCommandQueueManager {
+public:
+    void* issue_queue_reserve(uint32_t size_bytes, uint32_t) {
+        issue_queue_reserve_sizes.push_back(size_bytes);
+        return nullptr;
+    }
+
+    uint32_t get_issue_queue_write_ptr(uint32_t) const { return issue_queue_write_ptr; }
+
+    void cq_write(const void*, uint32_t size_bytes, uint32_t write_ptr) {
+        cq_write_sizes.push_back(size_bytes);
+        cq_write_ptrs.push_back(write_ptr);
+    }
+
+    void issue_queue_push_back(uint32_t size_bytes, uint32_t) {
+        issue_queue_push_sizes.push_back(size_bytes);
+    }
+
+    void fetch_queue_reserve_back(uint32_t) { ++fetch_queue_reserve_count; }
+
+    void fetch_queue_write(uint32_t size_bytes, uint32_t, bool = false) {
+        fetch_queue_write_sizes.push_back(size_bytes);
+    }
+
+    static constexpr uint32_t issue_queue_write_ptr = 0x1000;
+    std::vector<uint32_t> issue_queue_reserve_sizes;
+    std::vector<uint32_t> cq_write_sizes;
+    std::vector<uint32_t> cq_write_ptrs;
+    std::vector<uint32_t> issue_queue_push_sizes;
+    size_t fetch_queue_reserve_count = 0;
+    std::vector<uint32_t> fetch_queue_write_sizes;
 };
 
 TEST_F(DeviceCommandTest, CPU_ProgramConfigBatchingSplitsAtPrefetchEntryLimit) {
@@ -64,15 +98,88 @@ TEST_F(DeviceCommandTest, CPU_ProgramConfigBatchingSplitsAtPrefetchEntryLimit) {
     generator.assemble_commands(program_commands, program_commands.program_config_buffer_command_sequences);
     ASSERT_EQ(program_commands.program_config_buffer_command_sequences.size(), generator.command_count());
 
-    size_t visited_command_count = 0;
-    program_commands.visit_program_config_buffer_commands(
-        [&visited_command_count, max_prefetch_command_size](const HostMemDeviceCommand& command) {
-            EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
-            EXPECT_LE(command.size_bytes(), max_prefetch_command_size);
-            ++visited_command_count;
-        });
-    EXPECT_EQ(visited_command_count, generator.command_count());
+    std::vector<uint32_t> command_sizes;
+    for (const HostMemDeviceCommand& command : program_commands.program_config_buffer_command_sequences) {
+        EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+        EXPECT_LE(command.size_bytes(), max_prefetch_command_size);
+        command_sizes.push_back(command.size_bytes());
+    }
     EXPECT_EQ(program_commands.get_program_config_buffer_size(), calculator.write_offset_bytes());
+
+    constexpr uint32_t command_queue_id = 7;
+    constexpr bool stall_first = false;
+    constexpr bool stall_before_program = false;
+    constexpr bool send_binary = false;
+    const program_dispatch::queue_write_detail::ProgramCommandWritePlan write_plan =
+        program_dispatch::queue_write_detail::make_program_command_write_plan(
+            program_commands,
+            stall_first,
+            stall_before_program,
+            send_binary,
+            max_prefetch_command_size);
+    ASSERT_FALSE(write_plan.one_shot);
+
+    RecordingCommandQueueManager manager;
+    program_dispatch::queue_write_detail::write_program_command_sequence_to_queue(
+        program_commands,
+        manager,
+        command_queue_id,
+        stall_first,
+        stall_before_program,
+        send_binary,
+        write_plan);
+
+    EXPECT_EQ(manager.issue_queue_reserve_sizes, command_sizes);
+    EXPECT_EQ(manager.cq_write_sizes, command_sizes);
+    EXPECT_EQ(
+        manager.cq_write_ptrs,
+        std::vector<uint32_t>(command_sizes.size(), RecordingCommandQueueManager::issue_queue_write_ptr));
+    EXPECT_EQ(manager.issue_queue_push_sizes, command_sizes);
+    EXPECT_EQ(manager.fetch_queue_reserve_count, command_sizes.size());
+    EXPECT_EQ(manager.fetch_queue_write_sizes, command_sizes);
+}
+
+TEST_F(DeviceCommandTest, CPU_OneShotPlanCountsBothStallPlacements) {
+    constexpr uint32_t stall_command_size = 16;
+    constexpr uint32_t max_prefetch_command_size = 131072;
+    constexpr uint32_t command_queue_id = 7;
+    constexpr bool stall_first = true;
+    constexpr bool stall_before_program = true;
+    constexpr bool send_binary = false;
+
+    ProgramCommandSequence program_commands(ctx_);
+    program_commands.stall_command_sequences[program_commands.current_stall_seq_idx] =
+        HostMemDeviceCommand(ctx_, stall_command_size);
+    const program_dispatch::queue_write_detail::ProgramCommandWritePlan write_plan =
+        program_dispatch::queue_write_detail::make_program_command_write_plan(
+            program_commands,
+            stall_first,
+            stall_before_program,
+            send_binary,
+            max_prefetch_command_size);
+    ASSERT_TRUE(write_plan.one_shot);
+    ASSERT_EQ(write_plan.fetch_size, 2 * stall_command_size);
+
+    RecordingCommandQueueManager manager;
+    program_dispatch::queue_write_detail::write_program_command_sequence_to_queue(
+        program_commands,
+        manager,
+        command_queue_id,
+        stall_first,
+        stall_before_program,
+        send_binary,
+        write_plan);
+
+    EXPECT_EQ(manager.issue_queue_reserve_sizes, std::vector<uint32_t>{write_plan.fetch_size});
+    EXPECT_EQ(manager.cq_write_sizes, (std::vector<uint32_t>{stall_command_size, stall_command_size}));
+    EXPECT_EQ(
+        manager.cq_write_ptrs,
+        (std::vector<uint32_t>{
+            RecordingCommandQueueManager::issue_queue_write_ptr,
+            RecordingCommandQueueManager::issue_queue_write_ptr + stall_command_size}));
+    EXPECT_EQ(manager.issue_queue_push_sizes, std::vector<uint32_t>{write_plan.fetch_size});
+    EXPECT_EQ(manager.fetch_queue_reserve_count, 1);
+    EXPECT_EQ(manager.fetch_queue_write_sizes, std::vector<uint32_t>{write_plan.fetch_size});
 }
 
 TEST_F(DeviceCommandTest, CPU_ProgramConfigBatchingRejectsOversizedTransfer) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
-#include <numeric>
+#include <stdexcept>
+#include <string_view>
 #include "tt_metal/impl/dispatch/vector_aligned.hpp"
 #include <utility>
 #include <vector>
@@ -17,6 +17,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "tt_metal/impl/program/program_config_command_generator.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 
 namespace tt::tt_metal {
@@ -30,49 +31,100 @@ protected:
 
 TEST_F(DeviceCommandTest, CPU_ProgramConfigBatchingSplitsAtPrefetchEntryLimit) {
     constexpr uint32_t max_prefetch_command_size = 131072;
-    constexpr uint32_t pcie_alignment = 16;
-    constexpr uint32_t l1_alignment = 16;
-    constexpr std::array<uint32_t, 4> command_sizes = {70016, 60000, 60000, 29056};
+    const uint32_t pcie_alignment = ctx_.hal().get_alignment(HalMemType::HOST);
+    const uint32_t l1_alignment = ctx_.hal().get_alignment(HalMemType::L1);
+    constexpr uint32_t transfer_size = 60000;
+    constexpr uint32_t transfer_address_stride = 70000;
+    constexpr uint32_t transfer_count = 4;
 
-    EXPECT_TRUE(dispatch_write_packed_large_requires_new_command(
-        /*current_subcommand_count=*/2,
-        /*current_data_size_bytes=*/120000,
-        /*next_data_size_bytes=*/99072,
-        pcie_alignment,
-        l1_alignment,
-        max_prefetch_command_size));
-    EXPECT_FALSE(dispatch_write_packed_large_requires_new_command(
-        /*current_subcommand_count=*/1,
-        /*current_data_size_bytes=*/60000,
-        /*next_data_size_bytes=*/60000,
-        pcie_alignment,
-        l1_alignment,
-        max_prefetch_command_size));
-    EXPECT_TRUE(dispatch_write_packed_large_requires_new_command(
-        /*current_subcommand_count=*/CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS,
-        /*current_data_size_bytes=*/16,
-        /*next_data_size_bytes=*/16,
-        pcie_alignment,
-        l1_alignment,
-        max_prefetch_command_size));
-    EXPECT_LE(
-        dispatch_write_packed_large_size_bytes(1, 99072, pcie_alignment, l1_alignment), max_prefetch_command_size);
-
-    EXPECT_EQ(std::accumulate(command_sizes.begin(), command_sizes.end(), 0U), 219072);
-    EXPECT_TRUE(std::ranges::all_of(command_sizes, [](uint32_t size) { return size <= max_prefetch_command_size; }));
-}
-
-TEST_F(DeviceCommandTest, CPU_ProgramConfigCommandsRetainPrefetchEntryBoundaries) {
-    constexpr size_t command_count = 4;
-    ProgramCommandSequence program_commands(ctx_);
-    for (size_t command_index = 0; command_index < command_count; ++command_index) {
-        program_commands.program_config_buffer_command_sequences.emplace_back(ctx_);
+    std::array<std::vector<uint8_t>, transfer_count> transfer_payloads;
+    program_dispatch::BatchedTransfers batched_transfers;
+    auto& transfers_for_destination = batched_transfers[{/*noc_xy_addr=*/0x1234, /*num_mcast_dests=*/1}];
+    for (uint32_t transfer_index = 0; transfer_index < transfer_count; ++transfer_index) {
+        transfer_payloads[transfer_index].resize(transfer_size);
+        const uint32_t start_address = transfer_index * transfer_address_stride;
+        transfers_for_destination.emplace(
+            start_address,
+            std::vector<program_dispatch::Transfer>{program_dispatch::Transfer{
+                .start = start_address,
+                .data = ttsl::Span<const uint8_t>(
+                    transfer_payloads[transfer_index].data(), transfer_payloads[transfer_index].size())}});
     }
+
+    DeviceCommandCalculator calculator(pcie_alignment, l1_alignment);
+    program_dispatch::BatchedTransferGenerator generator(program_dispatch::ProgramConfigCommandOptions{
+        .pcie_alignment = pcie_alignment,
+        .l1_alignment = l1_alignment,
+        .max_prefetch_command_size = max_prefetch_command_size,
+        .watcher_assert_enabled = false});
+    generator.construct_commands(batched_transfers, calculator);
+    ASSERT_EQ(generator.command_count(), 2);
+
+    ProgramCommandSequence program_commands(ctx_);
+    generator.assemble_commands(program_commands, program_commands.program_config_buffer_command_sequences);
+    ASSERT_EQ(program_commands.program_config_buffer_command_sequences.size(), generator.command_count());
 
     size_t visited_command_count = 0;
     program_commands.visit_program_config_buffer_commands(
-        [&visited_command_count](const HostMemDeviceCommand&) { ++visited_command_count; });
-    EXPECT_EQ(visited_command_count, command_count);
+        [&visited_command_count, max_prefetch_command_size](const HostMemDeviceCommand& command) {
+            EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
+            EXPECT_LE(command.size_bytes(), max_prefetch_command_size);
+            ++visited_command_count;
+        });
+    EXPECT_EQ(visited_command_count, generator.command_count());
+    EXPECT_EQ(program_commands.get_program_config_buffer_size(), calculator.write_offset_bytes());
+}
+
+TEST_F(DeviceCommandTest, CPU_ProgramConfigBatchingRejectsOversizedTransfer) {
+    constexpr uint32_t max_prefetch_command_size = 50000;
+    constexpr uint32_t transfer_size = 60000;
+    const uint32_t pcie_alignment = ctx_.hal().get_alignment(HalMemType::HOST);
+    const uint32_t l1_alignment = ctx_.hal().get_alignment(HalMemType::L1);
+
+    std::vector<uint8_t> transfer_payload(transfer_size);
+    program_dispatch::BatchedTransfers batched_transfers;
+    batched_transfers[{/*noc_xy_addr=*/0x1234, /*num_mcast_dests=*/1}].emplace(
+        0,
+        std::vector<program_dispatch::Transfer>{program_dispatch::Transfer{
+            .start = 0, .data = ttsl::Span<const uint8_t>(transfer_payload.data(), transfer_payload.size())}});
+
+    DeviceCommandCalculator calculator(pcie_alignment, l1_alignment);
+    program_dispatch::BatchedTransferGenerator generator(program_dispatch::ProgramConfigCommandOptions{
+        .pcie_alignment = pcie_alignment,
+        .l1_alignment = l1_alignment,
+        .max_prefetch_command_size = max_prefetch_command_size,
+        .watcher_assert_enabled = false});
+    try {
+        generator.construct_commands(batched_transfers, calculator);
+        FAIL() << "Expected an oversized program-configuration transfer to be rejected";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string_view(error.what()).find("single program-configuration transfer"), std::string_view::npos);
+    }
+}
+
+TEST_F(DeviceCommandTest, CPU_CommandContextSurvivesMove) {
+    constexpr uint32_t transfer_size = 17;
+    const uint32_t l1_alignment = ctx_.hal().get_alignment(HalMemType::L1);
+
+    DeviceCommandCalculator calculator(ctx_);
+    calculator.add_dispatch_write_packed_large(/*num_sub_cmds=*/1, transfer_size);
+
+    HostMemDeviceCommand original_command(ctx_, calculator.write_offset_bytes());
+    HostMemDeviceCommand moved_command(std::move(original_command));
+    std::vector<CQDispatchWritePackedLargeSubCmd> subcommands(1);
+    std::array<uint8_t, transfer_size> payload{};
+    const std::vector<ttsl::Span<const uint8_t>> data_collection{
+        ttsl::Span<const uint8_t>(payload.data(), payload.size())};
+    std::vector<uint8_t*> data_collection_locations;
+    moved_command.add_dispatch_write_packed_large(
+        CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS,
+        l1_alignment,
+        static_cast<uint16_t>(subcommands.size()),
+        subcommands,
+        data_collection,
+        &data_collection_locations);
+
+    EXPECT_EQ(moved_command.size_bytes(), moved_command.write_offset_bytes());
 }
 
 TEST_F(DeviceCommandTest, CPU_AddDispatchWait) {

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -22,6 +22,12 @@ class DeviceCommandCalculator {
 public:
     explicit DeviceCommandCalculator(MetalContext& ctx);
 
+    DeviceCommandCalculator(uint32_t pcie_alignment, uint32_t l1_alignment) :
+        pcie_alignment(pcie_alignment), l1_alignment(l1_alignment) {
+        TT_ASSERT(pcie_alignment > 0);
+        TT_ASSERT(l1_alignment > 0);
+    }
+
     uint32_t write_offset_bytes() const { return this->cmd_write_offsetB; }
 
     void add_dispatch_wait() {
@@ -354,4 +360,30 @@ private:
     uint32_t pcie_alignment = 0;
     uint32_t l1_alignment = 0;
 };
+
+inline uint32_t dispatch_write_packed_large_size_bytes(
+    uint32_t num_subcommands, uint32_t data_size_bytes, uint32_t pcie_alignment, uint32_t l1_alignment) {
+    DeviceCommandCalculator calculator(pcie_alignment, l1_alignment);
+    calculator.add_dispatch_write_packed_large(num_subcommands, data_size_bytes);
+    return calculator.write_offset_bytes();
+}
+
+inline bool dispatch_write_packed_large_requires_new_command(
+    uint32_t current_subcommand_count,
+    uint32_t current_data_size_bytes,
+    uint32_t next_data_size_bytes,
+    uint32_t pcie_alignment,
+    uint32_t l1_alignment,
+    uint32_t max_prefetch_command_size) {
+    if (current_subcommand_count == 0) {
+        return false;
+    }
+    if (current_subcommand_count >= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS) {
+        return true;
+    }
+    const uint32_t prospective_data_size = tt::align(current_data_size_bytes, l1_alignment) + next_data_size_bytes;
+    return dispatch_write_packed_large_size_bytes(
+               current_subcommand_count + 1, prospective_data_size, pcie_alignment, l1_alignment) >
+           max_prefetch_command_size;
+}
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1350,8 +1350,8 @@ public:
 
     // Write unicast semaphore commands to the device command sequence.
     void assemble_unicast_commands(
-        const MetalContext& metal_ctx,
-        HostMemDeviceCommand& device_command_sequence,
+        MetalContext& metal_ctx,
+        std::vector<HostMemDeviceCommand>& device_command_sequences,
         ProgramImpl& program,
         const CommandConstants& constants) const {
         // Unicast Semaphore Cmd
@@ -1359,6 +1359,16 @@ public:
         for (const auto& cmds : unicast_semaphore_cmds) {
             uint32_t curr_sub_cmd_idx = 0;
             for (const auto& [num_sub_cmds_in_cmd, unicast_sem_payload_sizeB] : cmds.payload) {
+                DeviceCommandCalculator calculator(metal_ctx);
+                calculator.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+                    num_sub_cmds_in_cmd, cmds.size, constants.packed_write_max_unicast_sub_cmds);
+                TT_FATAL(
+                    calculator.write_offset_bytes() <= constants.max_prefetch_command_size,
+                    "A unicast semaphore command is {} B, exceeding the {} B prefetcher command limit",
+                    calculator.write_offset_bytes(),
+                    constants.max_prefetch_command_size);
+                device_command_sequences.emplace_back(metal_ctx, calculator.write_offset_bytes());
+                HostMemDeviceCommand& device_command_sequence = device_command_sequences.back();
                 uint32_t sem_addr = cmds.dst + program.get_program_config(index).sem_offset;
                 device_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
                     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_SEMS,
@@ -1377,6 +1387,7 @@ public:
                     RecordDispatchData(
                         program.get_context_id(), program.get_id(), DISPATCH_DATA_SEMAPHORE, data_and_size.second);
                 }
+                TT_ASSERT(device_command_sequence.size_bytes() == device_command_sequence.write_offset_bytes());
             }
         }
     }
@@ -2001,8 +2012,12 @@ public:
     // batched transfers.  This is done by combining adjacent or nearly adjacent
     // transfers into a single command and linking transfers to the same CoreRanges.
     void construct_commands(
-        const MetalContext& metal_ctx, BatchedTransfers& batched_transfers, DeviceCommandCalculator& calculator) {
+        const MetalContext& metal_ctx,
+        BatchedTransfers& batched_transfers,
+        DeviceCommandCalculator& calculator,
+        uint32_t max_prefetch_command_size) {
         const auto& hal = metal_ctx.hal();
+        uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
         uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
         // Optimize transfers by combining adjacent or nearly adjacent transfers.
         for (auto& transfer_set : batched_transfers) {
@@ -2025,10 +2040,31 @@ public:
         // Generate WritePackedLargeSubCmds from the transfers.
         for (auto& transfer_set : batched_transfers) {
             for (auto& [start, transfer_vector] : transfer_set.second) {
-                if (batched_dispatch_subcmds.empty() ||
-                    batched_dispatch_subcmds.back().size() >= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS) {
+                TT_ASSERT(start == transfer_vector.front().start);
+                const uint32_t transfer_size = static_cast<uint32_t>(transfer_vector.back().end() - start);
+                const uint32_t current_subcommand_count =
+                    batched_dispatch_subcmds.empty() ? 0
+                                                     : static_cast<uint32_t>(batched_dispatch_subcmds.back().size());
+                const uint32_t current_data_size = batched_cmd_data.empty() || batched_cmd_data.back().empty()
+                                                       ? 0
+                                                       : static_cast<uint32_t>(batched_cmd_data.back().back().end());
+                if (batched_dispatch_subcmds.empty() || dispatch_write_packed_large_requires_new_command(
+                                                            current_subcommand_count,
+                                                            current_data_size,
+                                                            transfer_size,
+                                                            pcie_alignment,
+                                                            l1_alignment,
+                                                            max_prefetch_command_size)) {
                     batched_dispatch_subcmds.emplace_back();
                     batched_cmd_data.emplace_back();
+                    const uint32_t single_transfer_command_size =
+                        dispatch_write_packed_large_size_bytes(1, transfer_size, pcie_alignment, l1_alignment);
+                    TT_FATAL(
+                        single_transfer_command_size <= max_prefetch_command_size,
+                        "A single program-configuration transfer produces a {} B prefetcher command, exceeding the "
+                        "{} B limit",
+                        single_transfer_command_size,
+                        max_prefetch_command_size);
                 }
                 if (!batched_dispatch_subcmds.back().empty()) {
                     auto& last_transfer = batched_dispatch_subcmds.back().back();
@@ -2036,14 +2072,12 @@ public:
                         last_transfer.flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
                     }
                 }
-                TT_ASSERT(start == transfer_vector.front().start);
-                size_t size = transfer_vector.back().end() - start;
-                TT_ASSERT(size > 0);
-                TT_ASSERT(size - 1 <= std::numeric_limits<uint16_t>::max());
+                TT_ASSERT(transfer_size > 0);
+                TT_ASSERT(transfer_size - 1 <= std::numeric_limits<uint16_t>::max());
                 batched_dispatch_subcmds.back().emplace_back(CQDispatchWritePackedLargeSubCmd{
                     .noc_xy_addr = transfer_set.first.first,
                     .addr = start,
-                    .length_minus1 = (uint16_t)(size - 1),
+                    .length_minus1 = static_cast<uint16_t>(transfer_size - 1),
                     .num_mcast_dests = static_cast<uint8_t>(transfer_set.first.second),
                     .flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_NONE});
 
@@ -2060,19 +2094,28 @@ public:
             }
         }
         for (size_t i = 0; i < batched_dispatch_subcmds.size(); i++) {
-            calculator.add_dispatch_write_packed_large(
-                batched_dispatch_subcmds[i].size(),
-                batched_cmd_data[i].back().end() - batched_cmd_data[i].front().start);
+            const uint32_t subcommand_count = static_cast<uint32_t>(batched_dispatch_subcmds[i].size());
+            const uint32_t command_data_size =
+                static_cast<uint32_t>(batched_cmd_data[i].back().end() - batched_cmd_data[i].front().start);
+            const uint32_t command_size = dispatch_write_packed_large_size_bytes(
+                subcommand_count, command_data_size, pcie_alignment, l1_alignment);
+            TT_FATAL(
+                command_size <= max_prefetch_command_size,
+                "Program-configuration command {} is {} B, exceeding the {} B prefetcher command limit",
+                i,
+                command_size,
+                max_prefetch_command_size);
+            calculator.add_dispatch_write_packed_large(subcommand_count, command_data_size);
 
             batched_dispatch_subcmds[i].back().flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
         }
     }
 
-    // Assemble the batched transfer commands into the device command sequence.
+    // Preserve each size-bounded transfer command as an independent fetch queue entry.
     void assemble_commands(
-        const MetalContext& metal_ctx,
+        MetalContext& metal_ctx,
         ProgramCommandSequence& program_command_sequence,
-        HostMemDeviceCommand& device_command_sequence,
+        std::vector<HostMemDeviceCommand>& device_command_sequences,
         DispatchWriteOffsets write_offset = DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE) {
         const auto& hal = metal_ctx.hal();
         uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
@@ -2081,8 +2124,11 @@ public:
         // Byte offset to skip count word when watcher enabled. Uses sizeof(uint32_t) instead of 1
         // because transfer.data and data_collection_location are byte pointers (uint8_t*)
         uint32_t count_word_byte_offset = is_watcher_assert_enabled(metal_ctx) ? sizeof(uint32_t) : 0;
+        device_command_sequences.reserve(device_command_sequences.size() + batched_dispatch_subcmds.size());
         // Write out batched semaphore + CB multicast transfers.
         for (uint32_t i = 0; i < batched_dispatch_subcmds.size(); ++i) {
+            device_command_sequences.emplace_back(metal_ctx, command_size_bytes(i, metal_ctx));
+            HostMemDeviceCommand& device_command_sequence = device_command_sequences.back();
             auto& cmd_data = batched_cmd_data[i];
             size_t last_end = cmd_data.front().start;
             std::vector<ttsl::Span<const uint8_t>> batched_data;
@@ -2173,7 +2219,18 @@ public:
                 j++;
                 last_end = transfer.end();
             }
+            TT_ASSERT(device_command_sequence.size_bytes() == device_command_sequence.write_offset_bytes());
         }
+    }
+
+    uint32_t command_count() const { return static_cast<uint32_t>(batched_dispatch_subcmds.size()); }
+
+    uint32_t command_size_bytes(uint32_t command_index, MetalContext& metal_ctx) const {
+        DeviceCommandCalculator calculator(metal_ctx);
+        const auto& command_data = batched_cmd_data.at(command_index);
+        calculator.add_dispatch_write_packed_large(
+            batched_dispatch_subcmds.at(command_index).size(), command_data.back().end() - command_data.front().start);
+        return calculator.write_offset_bytes();
     }
 
 private:
@@ -2543,26 +2600,31 @@ void assemble_device_commands(
         metal_ctx, mesh_device, constants, program, batched_transfers, absolute_cross_node_config_transfers);
 
     BatchedTransferGenerator batched_transfer_generator;
-    batched_transfer_generator.construct_commands(metal_ctx, batched_transfers, program_config_buffer_calculator);
+    batched_transfer_generator.construct_commands(
+        metal_ctx, batched_transfers, program_config_buffer_calculator, constants.max_prefetch_command_size);
     BatchedTransferGenerator absolute_cross_node_config_generator;
     absolute_cross_node_config_generator.construct_commands(
-        metal_ctx, absolute_cross_node_config_transfers, program_config_buffer_calculator);
+        metal_ctx,
+        absolute_cross_node_config_transfers,
+        program_config_buffer_calculator,
+        constants.max_prefetch_command_size);
 
-    program_command_sequence.program_config_buffer_command_sequence =
-        HostMemDeviceCommand(metal_ctx, program_config_buffer_calculator.write_offset_bytes());
+    program_command_sequence.program_config_buffer_command_sequences.clear();
+    program_command_sequence.program_config_buffer_command_sequences.reserve(
+        batched_transfer_generator.command_count() + absolute_cross_node_config_generator.command_count());
     batched_transfer_generator.assemble_commands(
-        metal_ctx, program_command_sequence, program_command_sequence.program_config_buffer_command_sequence);
+        metal_ctx, program_command_sequence, program_command_sequence.program_config_buffer_command_sequences);
     absolute_cross_node_config_generator.assemble_commands(
         metal_ctx,
         program_command_sequence,
-        program_command_sequence.program_config_buffer_command_sequence,
+        program_command_sequence.program_config_buffer_command_sequences,
         DISPATCH_WRITE_OFFSET_ZERO);
     semaphore_command_generator.assemble_unicast_commands(
-        metal_ctx, program_command_sequence.program_config_buffer_command_sequence, program, constants);
+        metal_ctx, program_command_sequence.program_config_buffer_command_sequences, program, constants);
     // Ensure that we use the correct amount of space for each command sequence
     TT_ASSERT(
-        program_command_sequence.program_config_buffer_command_sequence.size_bytes() ==
-        program_command_sequence.program_config_buffer_command_sequence.write_offset_bytes());
+        program_command_sequence.get_program_config_buffer_size() ==
+        program_config_buffer_calculator.write_offset_bytes());
 
     // Assemble binary
     const auto& program_transfer_info = program.get_program_transfer_info();
@@ -2657,7 +2719,11 @@ void assemble_device_commands(
         log_trace(
             tt::LogDispatch,
             "Program Config Buffer:    {} bytes",
-            program_command_sequence.program_config_buffer_command_sequence.size_bytes());
+            program_command_sequence.get_program_config_buffer_size());
+        log_trace(
+            tt::LogDispatch,
+            "Program Config Commands:  {} commands",
+            program_command_sequence.program_config_buffer_command_sequences.size());
         log_trace(
             tt::LogDispatch,
             "Program Binary:           {} bytes",
@@ -2671,7 +2737,7 @@ void assemble_device_commands(
             "Go Signal:                {} bytes",
             program_command_sequence.go_msg_command_sequence.size_bytes());
         uint32_t total_size = program_command_sequence.preamble_command_sequence.size_bytes() + total_rta_size +
-                              program_command_sequence.program_config_buffer_command_sequence.size_bytes() +
+                              program_command_sequence.get_program_config_buffer_size() +
                               program_command_sequence.program_binary_command_sequence.size_bytes() +
                               program_command_sequence.launch_msg_command_sequence.size_bytes() +
                               program_command_sequence.go_msg_command_sequence.size_bytes();
@@ -3301,10 +3367,11 @@ void write_program_command_sequence(
         write_data_to_cq(cmds.data(), cmds.size_bytes());
     }
 
-    // Write the program config buffer
-    write_data_to_cq(
-        program_command_sequence.program_config_buffer_command_sequence.data(),
-        program_command_sequence.program_config_buffer_command_sequence.size_bytes());
+    // Keep the generated command boundaries when one-shot mode is unavailable; each command fits one fetch entry.
+    program_command_sequence.visit_program_config_buffer_commands(
+        [&write_data_to_cq](const HostMemDeviceCommand& commands) {
+            write_data_to_cq(commands.data(), commands.size_bytes());
+        });
 
     // Need to stall before writing the program binary?
     if (stall_before_program) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -63,6 +63,7 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/program/program_config_command_generator.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
+#include "tt_metal/impl/program/program_command_sequence_writer.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
@@ -3279,99 +3280,20 @@ void write_program_command_sequence(
         stall_before_program,
         send_binary);
 
-    // Check if it's possible to write all commands in a single fetch queue entry
-    uint32_t one_shot_fetch_size =
-        program_command_sequence.get_one_shot_fetch_size(stall_first, stall_before_program, send_binary);
-    bool one_shot = one_shot_fetch_size <= metal_ctx.dispatch_mem_map().max_prefetch_command_size();
-
-    LOG_TRACE_LAZY(tt::LogDispatch, "One-shot mode: {}, Fetch size: {} bytes", one_shot, one_shot_fetch_size);
-    if (one_shot) {
-        manager.issue_queue_reserve(one_shot_fetch_size, command_queue_id);
-    }
-    uint32_t one_shot_write_ptr = manager.get_issue_queue_write_ptr(command_queue_id);
-
-    auto write_data_to_cq = [&](void* data, uint32_t size_bytes) {
-        if (!size_bytes) {
-            return;
-        }
-
-        if (one_shot) {
-            // Already reserved. Write only. Defer push back until all commands are written
-            manager.cq_write(data, size_bytes, one_shot_write_ptr);
-            one_shot_write_ptr += size_bytes;
-        } else {
-            manager.issue_queue_reserve(size_bytes, command_queue_id);
-            manager.cq_write(data, size_bytes, manager.get_issue_queue_write_ptr(command_queue_id));
-            manager.issue_queue_push_back(size_bytes, command_queue_id);
-            manager.fetch_queue_reserve_back(command_queue_id);
-            manager.fetch_queue_write(size_bytes, command_queue_id);
-        }
-    };
-
-    // Write the preamble
-    write_data_to_cq(
-        program_command_sequence.preamble_command_sequence.data(),
-        program_command_sequence.preamble_command_sequence.size_bytes());
-
-    const auto curr_stall_seq_idx = program_command_sequence.current_stall_seq_idx;
-    if (stall_first) {
-        // Must stall before writing kernel config data
-        write_data_to_cq(
-            program_command_sequence.stall_command_sequences[curr_stall_seq_idx].data(),
-            program_command_sequence.stall_command_sequences[curr_stall_seq_idx].size_bytes());
-    }
-
-    // TODO: We can pack multiple RT args into one fetch q entry
-    for (const auto& cmds : program_command_sequence.runtime_args_command_sequences) {
-        write_data_to_cq(cmds.data(), cmds.size_bytes());
-    }
-
-    // Keep the generated command boundaries when one-shot mode is unavailable; each command fits one fetch entry.
-    program_command_sequence.visit_program_config_buffer_commands(
-        [&write_data_to_cq](const HostMemDeviceCommand& commands) {
-            write_data_to_cq(commands.data(), commands.size_bytes());
-        });
-
-    // Need to stall before writing the program binary?
-    if (stall_before_program) {
-        // Didn't stall before kernel config data, stall before remaining commands
-        write_data_to_cq(
-            program_command_sequence.stall_command_sequences[curr_stall_seq_idx].data(),
-            program_command_sequence.stall_command_sequences[curr_stall_seq_idx].size_bytes());
-    }
-
-    if (send_binary) {
-        // Write the program binary
-        if (program_command_sequence.prefetcher_cache_used) {
-            write_data_to_cq(
-                program_command_sequence.program_binary_setup_prefetcher_cache_command.data(),
-                program_command_sequence.program_binary_setup_prefetcher_cache_command.size_bytes());
-        }
-        write_data_to_cq(
-            program_command_sequence.program_binary_command_sequence.data(),
-            program_command_sequence.program_binary_command_sequence.size_bytes());
-    } else {
-        // Write the wait barrier before writing launch messages.
-        write_data_to_cq(
-            program_command_sequence.wait_barrier_command_sequence.data(),
-            program_command_sequence.wait_barrier_command_sequence.size_bytes());
-    }
-
-    // Write the launch message
-    write_data_to_cq(
-        program_command_sequence.launch_msg_command_sequence.data(),
-        program_command_sequence.launch_msg_command_sequence.size_bytes());
-
-    // Write the go signal
-    write_data_to_cq(
-        program_command_sequence.go_msg_command_sequence.data(),
-        program_command_sequence.go_msg_command_sequence.size_bytes());
-
-    if (one_shot) {
-        manager.issue_queue_push_back(one_shot_fetch_size, command_queue_id);
-        manager.fetch_queue_reserve_back(command_queue_id);
-        manager.fetch_queue_write(one_shot_fetch_size, command_queue_id);
-    }
+    const uint32_t max_prefetch_command_size = metal_ctx.dispatch_mem_map().max_prefetch_command_size();
+    const queue_write_detail::ProgramCommandWritePlan write_plan =
+        queue_write_detail::make_program_command_write_plan(
+            program_command_sequence, stall_first, stall_before_program, send_binary, max_prefetch_command_size);
+    LOG_TRACE_LAZY(
+        tt::LogDispatch, "One-shot mode: {}, Fetch size: {} bytes", write_plan.one_shot, write_plan.fetch_size);
+    queue_write_detail::write_program_command_sequence_to_queue(
+        program_command_sequence,
+        manager,
+        command_queue_id,
+        stall_first,
+        stall_before_program,
+        send_binary,
+        write_plan);
 
     LOG_TRACE_LAZY(tt::LogDispatch, "========== Finished Writing Program Command Sequence ==========");
     LOG_TRACE_LAZY(tt::LogDispatch, "");

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -61,6 +61,7 @@
 #include "tt_metal/impl/dispatch/data_collection.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/program/program_config_command_generator.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "tt_metal/impl/allocator/allocator.hpp"
@@ -108,13 +109,6 @@ struct CommandConstants {
     NOC noc_index;
     uint32_t max_prefetch_command_size;
     uint32_t packed_write_max_unicast_sub_cmds;
-};
-
-enum DispatchWriteOffsets {
-    DISPATCH_WRITE_OFFSET_ZERO = 0,
-    DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE = 1,
-    DISPATCH_WRITE_OFFSET_TENSIX_BINARY_L1_CONFIG_BASE = 2,
-    DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE = 3,
 };
 
 CoreCoord get_sub_device_worker_origin(
@@ -892,33 +886,6 @@ bool unique_rta_requires_large_unicast(const MetalContext& metal_ctx, uint32_t t
     const uint32_t dispatch_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
     return tt::align(total_rta_size, l1_alignment) > dispatch_page_size;
 }
-
-struct Transfer {
-    uint32_t start;
-    ttsl::Span<const uint8_t> data;
-    // Keep track of what CBs contributed to this transfer, so we can update the data in
-    // update_program_dispatch_commands.
-    std::vector<std::shared_ptr<CircularBufferImpl>> cbs;
-    // Keep track of what DFBs contributed to this transfer for the same purpose.
-    std::vector<std::shared_ptr<experimental::dfb::detail::DataflowBufferImpl>> dfbs;
-    // RTAs must be updated from data every time update_program_dispatch_commmands is called.
-    RuntimeArgsData* rta_data = nullptr;
-    // If set, this transfer materializes one host-only CrossNode page into its
-    // dedicated config Buffer and must be refreshed before every cached enqueue.
-    std::optional<std::pair<CoreCoord, uint8_t>> cross_node_config;
-    size_t end() const { return start + data.size(); }
-};
-struct PairHash {
-    std::size_t operator()(const std::pair<uint32_t, uint32_t> pair) const {
-        return std::hash<uint32_t>()(pair.first) ^ std::hash<uint32_t>()(pair.second);
-    }
-};
-// Map each corerange to the set of transfer-vectors that need to be sent to it. Each transfer-vector will be sent
-// as a single CQDispatchWritePackedLargeSubCmd.
-using BatchedTransfers = std::unordered_map<
-    std::pair</*noc_xy_addr*/ uint32_t, /*num_mcast_dests*/ uint32_t>,
-    std::map</*start_addr*/ uint32_t, std::vector<Transfer>>,
-    PairHash>;
 
 BatchedTransfers assemble_runtime_args_commands(
     ProgramCommandSequence& program_command_sequence,
@@ -2006,237 +1973,227 @@ private:
     std::vector<HostMemDeviceCommand> kernel_bins_unicast_cmds;
 };
 
-class BatchedTransferGenerator {
-public:
-    // Construct and optimal set of CQDispatchWritePackedLargeSubCmds from the
-    // batched transfers.  This is done by combining adjacent or nearly adjacent
-    // transfers into a single command and linking transfers to the same CoreRanges.
-    void construct_commands(
-        const MetalContext& metal_ctx,
-        BatchedTransfers& batched_transfers,
-        DeviceCommandCalculator& calculator,
-        uint32_t max_prefetch_command_size) {
-        const auto& hal = metal_ctx.hal();
-        uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
-        uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
-        // Optimize transfers by combining adjacent or nearly adjacent transfers.
-        for (auto& transfer_set : batched_transfers) {
-            for (auto it = transfer_set.second.begin(); it != transfer_set.second.end();) {
-                auto next_it = std::next(it);
-                if (next_it == transfer_set.second.end()) {
-                    break;
-                }
-                TT_ASSERT(next_it->second.size() == 1);
-                TT_ASSERT(it->second.back().end() <= next_it->first);
-                if (it->second.back().end() + l1_alignment >= next_it->first) {
-                    it->second.push_back(std::move(next_it->second.front()));
-                    transfer_set.second.erase(next_it);
-                } else {
-                    it = next_it;
-                }
+BatchedTransferGenerator::BatchedTransferGenerator(ProgramConfigCommandOptions options) : options(options) {
+    TT_ASSERT(options.pcie_alignment > 0);
+    TT_ASSERT(options.l1_alignment > 0);
+    TT_ASSERT(options.max_prefetch_command_size > 0);
+}
+
+void BatchedTransferGenerator::construct_commands(
+    BatchedTransfers& batched_transfers, DeviceCommandCalculator& calculator) {
+    // Optimize transfers by combining adjacent or nearly adjacent transfers.
+    for (auto& transfer_set : batched_transfers) {
+        for (auto it = transfer_set.second.begin(); it != transfer_set.second.end();) {
+            auto next_it = std::next(it);
+            if (next_it == transfer_set.second.end()) {
+                break;
             }
-        }
-
-        // Generate WritePackedLargeSubCmds from the transfers.
-        for (auto& transfer_set : batched_transfers) {
-            for (auto& [start, transfer_vector] : transfer_set.second) {
-                TT_ASSERT(start == transfer_vector.front().start);
-                const uint32_t transfer_size = static_cast<uint32_t>(transfer_vector.back().end() - start);
-                const uint32_t current_subcommand_count =
-                    batched_dispatch_subcmds.empty() ? 0
-                                                     : static_cast<uint32_t>(batched_dispatch_subcmds.back().size());
-                const uint32_t current_data_size = batched_cmd_data.empty() || batched_cmd_data.back().empty()
-                                                       ? 0
-                                                       : static_cast<uint32_t>(batched_cmd_data.back().back().end());
-                if (batched_dispatch_subcmds.empty() || dispatch_write_packed_large_requires_new_command(
-                                                            current_subcommand_count,
-                                                            current_data_size,
-                                                            transfer_size,
-                                                            pcie_alignment,
-                                                            l1_alignment,
-                                                            max_prefetch_command_size)) {
-                    batched_dispatch_subcmds.emplace_back();
-                    batched_cmd_data.emplace_back();
-                    const uint32_t single_transfer_command_size =
-                        dispatch_write_packed_large_size_bytes(1, transfer_size, pcie_alignment, l1_alignment);
-                    TT_FATAL(
-                        single_transfer_command_size <= max_prefetch_command_size,
-                        "A single program-configuration transfer produces a {} B prefetcher command, exceeding the "
-                        "{} B limit",
-                        single_transfer_command_size,
-                        max_prefetch_command_size);
-                }
-                if (!batched_dispatch_subcmds.back().empty()) {
-                    auto& last_transfer = batched_dispatch_subcmds.back().back();
-                    if (last_transfer.noc_xy_addr != transfer_set.first.first) {
-                        last_transfer.flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
-                    }
-                }
-                TT_ASSERT(transfer_size > 0);
-                TT_ASSERT(transfer_size - 1 <= std::numeric_limits<uint16_t>::max());
-                batched_dispatch_subcmds.back().emplace_back(CQDispatchWritePackedLargeSubCmd{
-                    .noc_xy_addr = transfer_set.first.first,
-                    .addr = start,
-                    .length_minus1 = static_cast<uint16_t>(transfer_size - 1),
-                    .num_mcast_dests = static_cast<uint8_t>(transfer_set.first.second),
-                    .flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_NONE});
-
-                // Modify the start addresses to be relative to the dispatch buffer.
-                uint32_t new_start =
-                    !batched_cmd_data.back().empty()
-                        ? tt::align(static_cast<uint32_t>(batched_cmd_data.back().back().end()), l1_alignment)
-                        : 0;
-                uint32_t start_offset = transfer_vector.front().start - new_start;
-                for (Transfer& sub_transfer : transfer_vector) {
-                    batched_cmd_data.back().push_back(std::move(sub_transfer));
-                    batched_cmd_data.back().back().start -= start_offset;
-                }
+            TT_ASSERT(next_it->second.size() == 1);
+            TT_ASSERT(it->second.back().end() <= next_it->first);
+            if (it->second.back().end() + options.l1_alignment >= next_it->first) {
+                it->second.push_back(std::move(next_it->second.front()));
+                transfer_set.second.erase(next_it);
+            } else {
+                it = next_it;
             }
-        }
-        for (size_t i = 0; i < batched_dispatch_subcmds.size(); i++) {
-            const uint32_t subcommand_count = static_cast<uint32_t>(batched_dispatch_subcmds[i].size());
-            const uint32_t command_data_size =
-                static_cast<uint32_t>(batched_cmd_data[i].back().end() - batched_cmd_data[i].front().start);
-            const uint32_t command_size = dispatch_write_packed_large_size_bytes(
-                subcommand_count, command_data_size, pcie_alignment, l1_alignment);
-            TT_FATAL(
-                command_size <= max_prefetch_command_size,
-                "Program-configuration command {} is {} B, exceeding the {} B prefetcher command limit",
-                i,
-                command_size,
-                max_prefetch_command_size);
-            calculator.add_dispatch_write_packed_large(subcommand_count, command_data_size);
-
-            batched_dispatch_subcmds[i].back().flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
         }
     }
 
-    // Preserve each size-bounded transfer command as an independent fetch queue entry.
-    void assemble_commands(
-        MetalContext& metal_ctx,
-        ProgramCommandSequence& program_command_sequence,
-        std::vector<HostMemDeviceCommand>& device_command_sequences,
-        DispatchWriteOffsets write_offset = DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE) {
-        const auto& hal = metal_ctx.hal();
-        uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
-        const std::vector<uint8_t> fill_data(l1_alignment, 0);
-
-        // Byte offset to skip count word when watcher enabled. Uses sizeof(uint32_t) instead of 1
-        // because transfer.data and data_collection_location are byte pointers (uint8_t*)
-        uint32_t count_word_byte_offset = is_watcher_assert_enabled(metal_ctx) ? sizeof(uint32_t) : 0;
-        device_command_sequences.reserve(device_command_sequences.size() + batched_dispatch_subcmds.size());
-        // Write out batched semaphore + CB multicast transfers.
-        for (uint32_t i = 0; i < batched_dispatch_subcmds.size(); ++i) {
-            device_command_sequences.emplace_back(metal_ctx, command_size_bytes(i, metal_ctx));
-            HostMemDeviceCommand& device_command_sequence = device_command_sequences.back();
-            auto& cmd_data = batched_cmd_data[i];
-            size_t last_end = cmd_data.front().start;
-            std::vector<ttsl::Span<const uint8_t>> batched_data;
-            batched_data.reserve(cmd_data.size() * 2);
-            for (const Transfer& transfer : cmd_data) {
-                if (last_end != transfer.start) {
-                    TT_ASSERT(transfer.start - last_end <= fill_data.size());
-                    TT_ASSERT(last_end < transfer.start);
-                    batched_data.emplace_back(fill_data.data(), transfer.start - last_end);
+    // Generate WritePackedLargeSubCmds from the transfers.
+    for (auto& transfer_set : batched_transfers) {
+        for (auto& [start, transfer_vector] : transfer_set.second) {
+            TT_ASSERT(start == transfer_vector.front().start);
+            const uint32_t transfer_size = static_cast<uint32_t>(transfer_vector.back().end() - start);
+            const uint32_t current_subcommand_count =
+                batched_dispatch_subcmds.empty() ? 0 : static_cast<uint32_t>(batched_dispatch_subcmds.back().size());
+            const uint32_t current_data_size = batched_cmd_data.empty() || batched_cmd_data.back().empty()
+                                                   ? 0
+                                                   : static_cast<uint32_t>(batched_cmd_data.back().back().end());
+            if (batched_dispatch_subcmds.empty() || dispatch_write_packed_large_requires_new_command(
+                                                        current_subcommand_count,
+                                                        current_data_size,
+                                                        transfer_size,
+                                                        options.pcie_alignment,
+                                                        options.l1_alignment,
+                                                        options.max_prefetch_command_size)) {
+                const uint32_t single_transfer_command_size = dispatch_write_packed_large_size_bytes(
+                    1, transfer_size, options.pcie_alignment, options.l1_alignment);
+                if (single_transfer_command_size > options.max_prefetch_command_size) {
+                    TT_THROW(
+                        "A single program-configuration transfer produces a {} B prefetcher command, exceeding "
+                        "the {} B limit",
+                        single_transfer_command_size,
+                        options.max_prefetch_command_size);
                 }
-                batched_data.emplace_back(transfer.data);
-                last_end = transfer.end();
+                batched_dispatch_subcmds.emplace_back();
+                batched_cmd_data.emplace_back();
             }
-            std::vector<uint8_t*> data_collection_location;
-            if (tt::LoggerRegistry::instance().get(tt::LogDispatch)->should_log(spdlog::level::trace)) {
+            if (!batched_dispatch_subcmds.back().empty()) {
+                auto& last_transfer = batched_dispatch_subcmds.back().back();
+                if (last_transfer.noc_xy_addr != transfer_set.first.first) {
+                    last_transfer.flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
+                }
+            }
+            TT_ASSERT(transfer_size > 0);
+            TT_ASSERT(transfer_size - 1 <= std::numeric_limits<uint16_t>::max());
+            batched_dispatch_subcmds.back().emplace_back(CQDispatchWritePackedLargeSubCmd{
+                .noc_xy_addr = transfer_set.first.first,
+                .addr = start,
+                .length_minus1 = static_cast<uint16_t>(transfer_size - 1),
+                .num_mcast_dests = static_cast<uint8_t>(transfer_set.first.second),
+                .flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_NONE});
+
+            // Modify the start addresses to be relative to the dispatch buffer.
+            uint32_t new_start =
+                !batched_cmd_data.back().empty()
+                    ? tt::align(static_cast<uint32_t>(batched_cmd_data.back().back().end()), options.l1_alignment)
+                    : 0;
+            uint32_t start_offset = transfer_vector.front().start - new_start;
+            for (Transfer& sub_transfer : transfer_vector) {
+                batched_cmd_data.back().push_back(std::move(sub_transfer));
+                batched_cmd_data.back().back().start -= start_offset;
+            }
+        }
+    }
+    for (size_t command_index = 0; command_index < batched_dispatch_subcmds.size(); command_index++) {
+        const uint32_t subcommand_count = static_cast<uint32_t>(batched_dispatch_subcmds[command_index].size());
+        const uint32_t command_data_size = static_cast<uint32_t>(
+            batched_cmd_data[command_index].back().end() - batched_cmd_data[command_index].front().start);
+        const uint32_t command_size = dispatch_write_packed_large_size_bytes(
+            subcommand_count, command_data_size, options.pcie_alignment, options.l1_alignment);
+        TT_FATAL(
+            command_size <= options.max_prefetch_command_size,
+            "Program-configuration command {} is {} B, exceeding the {} B prefetcher command limit",
+            command_index,
+            command_size,
+            options.max_prefetch_command_size);
+        calculator.add_dispatch_write_packed_large(subcommand_count, command_data_size);
+
+        batched_dispatch_subcmds[command_index].back().flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
+    }
+}
+
+void BatchedTransferGenerator::assemble_commands(
+    ProgramCommandSequence& program_command_sequence,
+    std::vector<HostMemDeviceCommand>& device_command_sequences,
+    DispatchWriteOffsets write_offset) {
+    const std::vector<uint8_t> fill_data(options.l1_alignment, 0);
+
+    // Byte offset to skip count word when watcher enabled. Uses sizeof(uint32_t) instead of 1
+    // because transfer.data and data_collection_location are byte pointers (uint8_t*)
+    uint32_t count_word_byte_offset = options.watcher_assert_enabled ? sizeof(uint32_t) : 0;
+    device_command_sequences.reserve(device_command_sequences.size() + batched_dispatch_subcmds.size());
+    // Write out batched semaphore + CB multicast transfers.
+    for (uint32_t command_index = 0; command_index < batched_dispatch_subcmds.size(); ++command_index) {
+        device_command_sequences.emplace_back(*program_command_sequence.ctx, command_size_bytes(command_index));
+        HostMemDeviceCommand& device_command_sequence = device_command_sequences.back();
+        auto& cmd_data = batched_cmd_data[command_index];
+        size_t last_end = cmd_data.front().start;
+        std::vector<ttsl::Span<const uint8_t>> batched_data;
+        batched_data.reserve(cmd_data.size() * 2);
+        for (const Transfer& transfer : cmd_data) {
+            if (last_end != transfer.start) {
+                TT_ASSERT(transfer.start - last_end <= fill_data.size());
+                TT_ASSERT(last_end < transfer.start);
+                batched_data.emplace_back(fill_data.data(), transfer.start - last_end);
+            }
+            batched_data.emplace_back(transfer.data);
+            last_end = transfer.end();
+        }
+        std::vector<uint8_t*> data_collection_location;
+        if (tt::LoggerRegistry::instance().get(tt::LogDispatch)->should_log(spdlog::level::trace)) {
+            log_trace(
+                tt::LogDispatch,
+                "Assembling Batched Transfer Command: num_sub_cmds={}",
+                batched_dispatch_subcmds[command_index].size());
+            for (size_t subcommand_index = 0; subcommand_index < batched_dispatch_subcmds[command_index].size();
+                 ++subcommand_index) {
+                const auto& subcommand = batched_dispatch_subcmds[command_index][subcommand_index];
+                bool is_unlinked = (subcommand.flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK) != 0;
                 log_trace(
                     tt::LogDispatch,
-                    "Assembling Batched Transfer Command: num_sub_cmds={}",
-                    batched_dispatch_subcmds[i].size());
-                for (size_t subcmd_idx = 0; subcmd_idx < batched_dispatch_subcmds[i].size(); ++subcmd_idx) {
-                    const auto& subcmd = batched_dispatch_subcmds[i][subcmd_idx];
-                    bool is_unlinked = (subcmd.flags & CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK) != 0;
-                    log_trace(
-                        tt::LogDispatch,
-                        "  SubCmd[{}]: noc_xy_addr=0x{:x}, addr=0x{:x}, size={} bytes, num_mcast_dests={}, "
-                        "flags=0x{:x} {}",
-                        subcmd_idx,
-                        subcmd.noc_xy_addr,
-                        subcmd.addr,
-                        subcmd.length_minus1 + 1,
-                        subcmd.num_mcast_dests,
-                        subcmd.flags,
-                        is_unlinked ? "(UNLINK)" : "");
-                }
+                    "  SubCmd[{}]: noc_xy_addr=0x{:x}, addr=0x{:x}, size={} bytes, num_mcast_dests={}, "
+                    "flags=0x{:x} {}",
+                    subcommand_index,
+                    subcommand.noc_xy_addr,
+                    subcommand.addr,
+                    subcommand.length_minus1 + 1,
+                    subcommand.num_mcast_dests,
+                    subcommand.flags,
+                    is_unlinked ? "(UNLINK)" : "");
             }
-
-            device_command_sequence.add_dispatch_write_packed_large(
-                CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS,
-                l1_alignment,
-                batched_dispatch_subcmds[i].size(),
-                batched_dispatch_subcmds[i],
-                batched_data,
-                &data_collection_location,
-                0,
-                write_offset);
-
-            last_end = cmd_data.front().start;
-            size_t j = 0;
-            for (Transfer& transfer : cmd_data) {
-                if (last_end != transfer.start) {
-                    j++;
-                }
-                if (!transfer.cbs.empty()) {
-                    program_command_sequence.circular_buffers_on_core_ranges.push_back(std::move(transfer.cbs));
-                    program_command_sequence.cb_configs_payloads.push_back(
-                        reinterpret_cast<uint32_t*>(data_collection_location[j]));
-                }
-                if (!transfer.dfbs.empty()) {
-                    program_command_sequence.dataflow_buffers_on_core_ranges.push_back(std::move(transfer.dfbs));
-                    program_command_sequence.dfb_configs_payloads.push_back(data_collection_location[j]);
-                }
-                if (transfer.cross_node_config.has_value()) {
-                    const auto& [logical_core, remote_dfb_id] = *transfer.cross_node_config;
-                    program_command_sequence.cross_node_config_updates.push_back(
-                        {logical_core,
-                         remote_dfb_id,
-                         data_collection_location[j],
-                         static_cast<uint32_t>(transfer.data.size())});
-                }
-                if (transfer.rta_data) {
-                    // When watcher enabled, transfer.data contains [count | args...]
-                    // rt_args_data points to args location (data + offset)
-                    // rta_updates only copy args (count already written during initial copy)
-                    if (reinterpret_cast<uint8_t*>(transfer.rta_data->rt_args_data) ==
-                        (transfer.data.data() + count_word_byte_offset)) {
-                        // rt_args_data points to the original vector. Update it so later modifications directly modify
-                        // the command stream.
-                        transfer.rta_data->rt_args_data =
-                            reinterpret_cast<uint32_t*>(data_collection_location[j] + count_word_byte_offset);
-                    } else {
-                        // rt_args_data points into the command stream. Setup a copy from that other location.
-                        program_command_sequence.rta_updates.push_back(ProgramCommandSequence::RtaUpdate{
-                            transfer.rta_data->rt_args_data,
-                            data_collection_location[j] + count_word_byte_offset,
-                            static_cast<uint32_t>(transfer.data.size() - count_word_byte_offset)});
-                    }
-                }
-                j++;
-                last_end = transfer.end();
-            }
-            TT_ASSERT(device_command_sequence.size_bytes() == device_command_sequence.write_offset_bytes());
         }
+
+        device_command_sequence.add_dispatch_write_packed_large(
+            CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS,
+            options.l1_alignment,
+            batched_dispatch_subcmds[command_index].size(),
+            batched_dispatch_subcmds[command_index],
+            batched_data,
+            &data_collection_location,
+            0,
+            write_offset);
+
+        last_end = cmd_data.front().start;
+        size_t data_collection_index = 0;
+        for (Transfer& transfer : cmd_data) {
+            if (last_end != transfer.start) {
+                data_collection_index++;
+            }
+            if (!transfer.cbs.empty()) {
+                program_command_sequence.circular_buffers_on_core_ranges.push_back(std::move(transfer.cbs));
+                program_command_sequence.cb_configs_payloads.push_back(
+                    reinterpret_cast<uint32_t*>(data_collection_location[data_collection_index]));
+            }
+            if (!transfer.dfbs.empty()) {
+                program_command_sequence.dataflow_buffers_on_core_ranges.push_back(std::move(transfer.dfbs));
+                program_command_sequence.dfb_configs_payloads.push_back(
+                    data_collection_location[data_collection_index]);
+            }
+            if (transfer.cross_node_config.has_value()) {
+                const auto& [logical_core, remote_dfb_id] = *transfer.cross_node_config;
+                program_command_sequence.cross_node_config_updates.push_back(
+                    {logical_core,
+                     remote_dfb_id,
+                     data_collection_location[data_collection_index],
+                     static_cast<uint32_t>(transfer.data.size())});
+            }
+            if (transfer.rta_data) {
+                // When watcher enabled, transfer.data contains [count | args...]
+                // rt_args_data points to args location (data + offset)
+                // rta_updates only copy args (count already written during initial copy)
+                if (reinterpret_cast<uint8_t*>(transfer.rta_data->rt_args_data) ==
+                    (transfer.data.data() + count_word_byte_offset)) {
+                    // rt_args_data points to the original vector. Update it so later modifications directly modify
+                    // the command stream.
+                    transfer.rta_data->rt_args_data = reinterpret_cast<uint32_t*>(
+                        data_collection_location[data_collection_index] + count_word_byte_offset);
+                } else {
+                    // rt_args_data points into the command stream. Setup a copy from that other location.
+                    program_command_sequence.rta_updates.push_back(ProgramCommandSequence::RtaUpdate{
+                        transfer.rta_data->rt_args_data,
+                        data_collection_location[data_collection_index] + count_word_byte_offset,
+                        static_cast<uint32_t>(transfer.data.size() - count_word_byte_offset)});
+                }
+            }
+            data_collection_index++;
+            last_end = transfer.end();
+        }
+        TT_ASSERT(device_command_sequence.size_bytes() == device_command_sequence.write_offset_bytes());
     }
+}
 
-    uint32_t command_count() const { return static_cast<uint32_t>(batched_dispatch_subcmds.size()); }
+uint32_t BatchedTransferGenerator::command_count() const {
+    return static_cast<uint32_t>(batched_dispatch_subcmds.size());
+}
 
-    uint32_t command_size_bytes(uint32_t command_index, MetalContext& metal_ctx) const {
-        DeviceCommandCalculator calculator(metal_ctx);
-        const auto& command_data = batched_cmd_data.at(command_index);
-        calculator.add_dispatch_write_packed_large(
-            batched_dispatch_subcmds.at(command_index).size(), command_data.back().end() - command_data.front().start);
-        return calculator.write_offset_bytes();
-    }
-
-private:
-    std::vector<std::vector<Transfer>> batched_cmd_data;
-    std::vector<std::vector<CQDispatchWritePackedLargeSubCmd>> batched_dispatch_subcmds;
-};
+uint32_t BatchedTransferGenerator::command_size_bytes(uint32_t command_index) const {
+    DeviceCommandCalculator calculator(options.pcie_alignment, options.l1_alignment);
+    const auto& command_data = batched_cmd_data.at(command_index);
+    calculator.add_dispatch_write_packed_large(
+        batched_dispatch_subcmds.at(command_index).size(), command_data.back().end() - command_data.front().start);
+    return calculator.write_offset_bytes();
+}
 
 class LaunchMessageGenerator {
 public:
@@ -2581,6 +2538,13 @@ void assemble_device_commands(
     BatchedTransfers batched_transfers =
         assemble_runtime_args_commands(program_command_sequence, program, mesh_device, constants);
 
+    const auto& hal = metal_ctx.hal();
+    const ProgramConfigCommandOptions program_config_command_options{
+        .pcie_alignment = hal.get_alignment(HalMemType::HOST),
+        .l1_alignment = hal.get_alignment(HalMemType::L1),
+        .max_prefetch_command_size = constants.max_prefetch_command_size,
+        .watcher_assert_enabled = is_watcher_assert_enabled(metal_ctx)};
+
     // Assemble config buffer
     DeviceCommandCalculator program_config_buffer_calculator(metal_ctx);
 
@@ -2599,23 +2563,18 @@ void assemble_device_commands(
     cross_node_dfb_command_generator.construct_commands(
         metal_ctx, mesh_device, constants, program, batched_transfers, absolute_cross_node_config_transfers);
 
-    BatchedTransferGenerator batched_transfer_generator;
-    batched_transfer_generator.construct_commands(
-        metal_ctx, batched_transfers, program_config_buffer_calculator, constants.max_prefetch_command_size);
-    BatchedTransferGenerator absolute_cross_node_config_generator;
+    BatchedTransferGenerator batched_transfer_generator(program_config_command_options);
+    batched_transfer_generator.construct_commands(batched_transfers, program_config_buffer_calculator);
+    BatchedTransferGenerator absolute_cross_node_config_generator(program_config_command_options);
     absolute_cross_node_config_generator.construct_commands(
-        metal_ctx,
-        absolute_cross_node_config_transfers,
-        program_config_buffer_calculator,
-        constants.max_prefetch_command_size);
+        absolute_cross_node_config_transfers, program_config_buffer_calculator);
 
     program_command_sequence.program_config_buffer_command_sequences.clear();
     program_command_sequence.program_config_buffer_command_sequences.reserve(
         batched_transfer_generator.command_count() + absolute_cross_node_config_generator.command_count());
     batched_transfer_generator.assemble_commands(
-        metal_ctx, program_command_sequence, program_command_sequence.program_config_buffer_command_sequences);
+        program_command_sequence, program_command_sequence.program_config_buffer_command_sequences);
     absolute_cross_node_config_generator.assemble_commands(
-        metal_ctx,
         program_command_sequence,
         program_command_sequence.program_config_buffer_command_sequences,
         DISPATCH_WRITE_OFFSET_ZERO);

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -114,16 +114,10 @@ struct ProgramCommandSequence {
             });
     }
 
-    template <typename CommandVisitor>
-    void visit_program_config_buffer_commands(CommandVisitor&& visitor) const {
-        for (const HostMemDeviceCommand& command : program_config_buffer_command_sequences) {
-            visitor(command);
-        }
-    }
-
     uint32_t get_one_shot_fetch_size(bool stall_first, bool stall_before_program, bool send_binary) const {
         uint32_t one_shot_fetch_size =
-            ((stall_before_program || stall_first) ? stall_command_sequences[current_stall_seq_idx].size_bytes() : 0) +
+            (stall_first ? stall_command_sequences[current_stall_seq_idx].size_bytes() : 0) +
+            (stall_before_program ? stall_command_sequences[current_stall_seq_idx].size_bytes() : 0) +
             preamble_command_sequence.size_bytes() + get_program_config_buffer_size() + get_rt_args_size() +
             (send_binary ? program_binary_command_sequence.size_bytes() +
                                program_binary_setup_prefetcher_cache_command.size_bytes()

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -26,7 +26,6 @@ struct ProgramCommandSequence {
         ctx(&metal_ctx),
         preamble_command_sequence(metal_ctx),
         stall_command_sequences{HostMemDeviceCommand(metal_ctx), HostMemDeviceCommand(metal_ctx)},
-        program_config_buffer_command_sequence(metal_ctx),
         program_binary_setup_prefetcher_cache_command(metal_ctx),
         program_binary_command_sequence(metal_ctx),
         wait_barrier_command_sequence(metal_ctx),
@@ -66,11 +65,11 @@ struct ProgramCommandSequence {
     uint32_t current_stall_seq_idx = 0;
     HostMemDeviceCommand stall_command_sequences[2];
     std::vector<HostMemDeviceCommand> runtime_args_command_sequences;
-    HostMemDeviceCommand program_config_buffer_command_sequence;
+    std::vector<HostMemDeviceCommand> program_config_buffer_command_sequences;
     HostMemDeviceCommand program_binary_setup_prefetcher_cache_command;
     HostMemDeviceCommand program_binary_command_sequence;
     // When the program_binary_command_sequence is skipped, this command sequence is used to wait for the writes for
-    // the runtime_args_command_sequences and program_config_buffer_command_sequence to complete, to ensure that all
+    // the runtime_args_command_sequences and program_config_buffer_command_sequences to complete, to ensure that all
     // writes have landed before the launch message is sent and the worker starts loading data. This isn't needed when
     // writing program binaries, because writing binaries always barriers (as a workaround for an mcast hang).
     HostMemDeviceCommand wait_barrier_command_sequence;
@@ -105,11 +104,27 @@ struct ProgramCommandSequence {
             [](int acc, const HostMemDeviceCommand& cmd) { return cmd.size_bytes() + acc; });
     }
 
+    uint32_t get_program_config_buffer_size() const {
+        return std::accumulate(
+            program_config_buffer_command_sequences.begin(),
+            program_config_buffer_command_sequences.end(),
+            0,
+            [](int accumulated_size, const HostMemDeviceCommand& command) {
+                return command.size_bytes() + accumulated_size;
+            });
+    }
+
+    template <typename CommandVisitor>
+    void visit_program_config_buffer_commands(CommandVisitor&& visitor) const {
+        for (const HostMemDeviceCommand& command : program_config_buffer_command_sequences) {
+            visitor(command);
+        }
+    }
+
     uint32_t get_one_shot_fetch_size(bool stall_first, bool stall_before_program, bool send_binary) const {
         uint32_t one_shot_fetch_size =
             ((stall_before_program || stall_first) ? stall_command_sequences[current_stall_seq_idx].size_bytes() : 0) +
-            preamble_command_sequence.size_bytes() + program_config_buffer_command_sequence.size_bytes() +
-            get_rt_args_size() +
+            preamble_command_sequence.size_bytes() + get_program_config_buffer_size() + get_rt_args_size() +
             (send_binary ? program_binary_command_sequence.size_bytes() +
                                program_binary_setup_prefetcher_cache_command.size_bytes()
                          : wait_barrier_command_sequence.size_bytes()) +

--- a/tt_metal/impl/program/program_command_sequence_writer.hpp
+++ b/tt_metal/impl/program/program_command_sequence_writer.hpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "tt_metal/impl/program/program_command_sequence.hpp"
+
+namespace tt::tt_metal::program_dispatch::queue_write_detail {
+
+struct ProgramCommandWritePlan {
+    uint32_t fetch_size;
+    bool one_shot;
+};
+
+inline ProgramCommandWritePlan make_program_command_write_plan(
+    const ProgramCommandSequence& program_command_sequence,
+    bool stall_first,
+    bool stall_before_program,
+    bool send_binary,
+    uint32_t max_prefetch_command_size) {
+    const uint32_t fetch_size =
+        program_command_sequence.get_one_shot_fetch_size(stall_first, stall_before_program, send_binary);
+    return {.fetch_size = fetch_size, .one_shot = fetch_size <= max_prefetch_command_size};
+}
+
+// Keep the queue policy testable without constructing a device-backed SystemMemoryManager.
+template <typename CommandQueueManager>
+void write_program_command_sequence_to_queue(
+    const ProgramCommandSequence& program_command_sequence,
+    CommandQueueManager& manager,
+    uint32_t command_queue_id,
+    bool stall_first,
+    bool stall_before_program,
+    bool send_binary,
+    ProgramCommandWritePlan write_plan) {
+    if (write_plan.one_shot) {
+        manager.issue_queue_reserve(write_plan.fetch_size, command_queue_id);
+    }
+    uint32_t one_shot_write_ptr = manager.get_issue_queue_write_ptr(command_queue_id);
+
+    auto write_data_to_queue = [&](const void* data, uint32_t size_bytes) {
+        if (size_bytes == 0) {
+            return;
+        }
+
+        if (write_plan.one_shot) {
+            manager.cq_write(data, size_bytes, one_shot_write_ptr);
+            one_shot_write_ptr += size_bytes;
+        } else {
+            manager.issue_queue_reserve(size_bytes, command_queue_id);
+            manager.cq_write(data, size_bytes, manager.get_issue_queue_write_ptr(command_queue_id));
+            manager.issue_queue_push_back(size_bytes, command_queue_id);
+            manager.fetch_queue_reserve_back(command_queue_id);
+            manager.fetch_queue_write(size_bytes, command_queue_id);
+        }
+    };
+
+    write_data_to_queue(
+        program_command_sequence.preamble_command_sequence.data(),
+        program_command_sequence.preamble_command_sequence.size_bytes());
+
+    const uint32_t stall_sequence_index = program_command_sequence.current_stall_seq_idx;
+    if (stall_first) {
+        write_data_to_queue(
+            program_command_sequence.stall_command_sequences[stall_sequence_index].data(),
+            program_command_sequence.stall_command_sequences[stall_sequence_index].size_bytes());
+    }
+
+    for (const HostMemDeviceCommand& commands : program_command_sequence.runtime_args_command_sequences) {
+        write_data_to_queue(commands.data(), commands.size_bytes());
+    }
+
+    for (const HostMemDeviceCommand& commands : program_command_sequence.program_config_buffer_command_sequences) {
+        write_data_to_queue(commands.data(), commands.size_bytes());
+    }
+
+    if (stall_before_program) {
+        write_data_to_queue(
+            program_command_sequence.stall_command_sequences[stall_sequence_index].data(),
+            program_command_sequence.stall_command_sequences[stall_sequence_index].size_bytes());
+    }
+
+    if (send_binary) {
+        if (program_command_sequence.prefetcher_cache_used) {
+            write_data_to_queue(
+                program_command_sequence.program_binary_setup_prefetcher_cache_command.data(),
+                program_command_sequence.program_binary_setup_prefetcher_cache_command.size_bytes());
+        }
+        write_data_to_queue(
+            program_command_sequence.program_binary_command_sequence.data(),
+            program_command_sequence.program_binary_command_sequence.size_bytes());
+    } else {
+        write_data_to_queue(
+            program_command_sequence.wait_barrier_command_sequence.data(),
+            program_command_sequence.wait_barrier_command_sequence.size_bytes());
+    }
+
+    write_data_to_queue(
+        program_command_sequence.launch_msg_command_sequence.data(),
+        program_command_sequence.launch_msg_command_sequence.size_bytes());
+    write_data_to_queue(
+        program_command_sequence.go_msg_command_sequence.data(),
+        program_command_sequence.go_msg_command_sequence.size_bytes());
+
+    if (write_plan.one_shot) {
+        manager.issue_queue_push_back(write_plan.fetch_size, command_queue_id);
+        manager.fetch_queue_reserve_back(command_queue_id);
+        manager.fetch_queue_write(write_plan.fetch_size, command_queue_id);
+    }
+}
+
+}  // namespace tt::tt_metal::program_dispatch::queue_write_detail

--- a/tt_metal/impl/program/program_config_command_generator.hpp
+++ b/tt_metal/impl/program/program_config_command_generator.hpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt_stl/span.hpp>
+
+#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+
+namespace tt::tt_metal {
+
+class CircularBufferImpl;
+class DeviceCommandCalculator;
+struct ProgramCommandSequence;
+struct RuntimeArgsData;
+
+namespace experimental::dfb::detail {
+struct DataflowBufferImpl;
+}
+
+namespace program_dispatch {
+
+enum DispatchWriteOffsets {
+    DISPATCH_WRITE_OFFSET_ZERO = 0,
+    DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE = 1,
+    DISPATCH_WRITE_OFFSET_TENSIX_BINARY_L1_CONFIG_BASE = 2,
+    DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE = 3,
+};
+
+struct Transfer {
+    uint32_t start;
+    ttsl::Span<const uint8_t> data;
+    // Retain contributors so later program updates can locate their serialized payloads.
+    std::vector<std::shared_ptr<CircularBufferImpl>> cbs;
+    std::vector<std::shared_ptr<experimental::dfb::detail::DataflowBufferImpl>> dfbs;
+    // Runtime arguments are retargeted to their serialized storage after assembly.
+    RuntimeArgsData* rta_data = nullptr;
+    // Cross-node configuration pages are refreshed before each cached enqueue.
+    std::optional<std::pair<CoreCoord, uint8_t>> cross_node_config;
+
+    std::size_t end() const { return start + data.size(); }
+};
+
+struct NocTransferKeyHash {
+    std::size_t operator()(const std::pair<uint32_t, uint32_t>& noc_transfer_key) const {
+        return std::hash<uint32_t>()(noc_transfer_key.first) ^ std::hash<uint32_t>()(noc_transfer_key.second);
+    }
+};
+
+// Each map entry contains the address-ordered transfers sent to one NOC destination set.
+using BatchedTransfers = std::unordered_map<
+    std::pair</*noc_xy_addr*/ uint32_t, /*num_mcast_dests*/ uint32_t>,
+    std::map</*start_addr*/ uint32_t, std::vector<Transfer>>,
+    NocTransferKeyHash>;
+
+struct ProgramConfigCommandOptions {
+    uint32_t pcie_alignment;
+    uint32_t l1_alignment;
+    uint32_t max_prefetch_command_size;
+    bool watcher_assert_enabled;
+};
+
+class BatchedTransferGenerator {
+public:
+    explicit BatchedTransferGenerator(ProgramConfigCommandOptions options);
+
+    void construct_commands(BatchedTransfers& batched_transfers, DeviceCommandCalculator& calculator);
+
+    void assemble_commands(
+        ProgramCommandSequence& program_command_sequence,
+        std::vector<HostMemDeviceCommand>& device_command_sequences,
+        DispatchWriteOffsets write_offset = DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE);
+
+    uint32_t command_count() const;
+    uint32_t command_size_bytes(uint32_t command_index) const;
+
+private:
+    const ProgramConfigCommandOptions options;
+    std::vector<std::vector<Transfer>> batched_cmd_data;
+    std::vector<std::vector<CQDispatchWritePackedLargeSubCmd>> batched_dispatch_subcmds;
+};
+
+}  // namespace program_dispatch
+}  // namespace tt::tt_metal


### PR DESCRIPTION
## Problem

Large generated programs can produce packed program-configuration data larger
than one prefetch queue entry. The MLA+MoE N=100 reproducer generated 219,072
bytes while the entry limit was 131,072 bytes. Batching was restricted only by
subcommand count, and assembled batches were concatenated before enqueue.

## Change

- Start a new packed-large batch when the prospective serialized command would
  exceed the prefetch-entry limit.
- Report an individually oversized transfer through `TT_THROW`.
- Preserve each bounded program-configuration command as a separate fetch
  entry when the complete sequence cannot use one entry.
- Retain aggregate size accounting for one-entry submission.
- Count both stall commands when trace allocation requests both
  `stall_first` and `stall_before_program`.

## Regression coverage

`CPU_ProgramConfigBatchingSplitsAtPrefetchEntryLimit` constructs real
`BatchedTransfers`, invokes `BatchedTransferGenerator::construct_commands`,
serializes the resulting commands, and invokes the production queue-write
policy through a recording manager. It verifies the command count, per-command
size limit, issue-queue reservations and publications, command writes, and
fetch-queue publications.

`CPU_ProgramConfigBatchingRejectsOversizedTransfer` verifies rejection when one
transfer cannot fit in a prefetch entry.

`CPU_OneShotPlanCountsBothStallPlacements` verifies one-entry size accounting
and write-pointer advancement when both stall positions are active.

## Validation

- Reviewed head: `499ceee9e7ea317d45fe29f99b4f149c90b644ae`.
- Rebased onto tt-metal `main` `f9bf47380cac8eba49c496502b814084ec8448f9`
  on 2026-08-28.
- `unit_tests_dispatch` built successfully: 192/192 build actions.
- The three focused `DeviceCommandTest.CPU_*` regressions pass with the
  repository's standard Wormhole N150 mock-cluster descriptor.
- The serial `clang-format` pre-commit hook passes for all six changed files.
- `git diff --check origin/main...HEAD` passes.
- The equivalent program-configuration correction in the Kimi integration
  stack completed the TT-Lang-calling-Blaze MLA+MoE N=100 test on 32 Blackhole
  devices and passed correctness.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bnorris/fix-program-config-prefetch-boundaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bnorris/fix-program-config-prefetch-boundaries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bnorris/fix-program-config-prefetch-boundaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bnorris/fix-program-config-prefetch-boundaries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bnorris/fix-program-config-prefetch-boundaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bnorris/fix-program-config-prefetch-boundaries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bnorris/fix-program-config-prefetch-boundaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bnorris/fix-program-config-prefetch-boundaries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bnorris/fix-program-config-prefetch-boundaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bnorris/fix-program-config-prefetch-boundaries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bnorris/fix-program-config-prefetch-boundaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bnorris/fix-program-config-prefetch-boundaries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bnorris/fix-program-config-prefetch-boundaries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bnorris/fix-program-config-prefetch-boundaries)
