### PR TITLE
topk_large_indices: multi-core engines on the fused-body base (stacked on #53953)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/_topk_li_width_sweep.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/_topk_li_width_sweep.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Per-cell bench for topk_large_indices width scaling (Pavle's prefill sweep).
-Usage: _topk_li_width_sweep.py <rows> <W> <k> [iters]
+Usage: _topk_li_width_sweep.py <rows> <W> <k> [iters] [valid_length]
 Run under `python -m tracy -r -v`; parse ops_perf_results CSV afterward.
 """
 import sys

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/_topk_li_width_sweep.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/_topk_li_width_sweep.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-cell bench for topk_large_indices width scaling (Pavle's prefill sweep).
+Usage: _topk_li_width_sweep.py <rows> <W> <k> [iters]
+Run under `python -m tracy -r -v`; parse ops_perf_results CSV afterward.
+"""
+import sys
+import torch
+import ttnn
+from loguru import logger
+
+ROWS, W, K = int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
+ITERS = int(sys.argv[4]) if len(sys.argv) > 4 else 20
+# Optional: search only the first VALID columns of a wider preallocated
+# buffer (the DSA indexer's growing-prefill calling shape).
+VALID = int(sys.argv[5]) if len(sys.argv) > 5 else None
+WARMUP = 3
+
+device = ttnn.open_device(device_id=0)
+device.enable_program_cache()
+
+torch.manual_seed(2005)
+# Chunked generation to keep host memory sane at 1M width.
+torch_input = torch.randn(ROWS, W, dtype=torch.bfloat16) * 0.9
+tt_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.ROW_MAJOR, device=device)
+
+for _ in range(WARMUP + ITERS):
+    indices = ttnn.experimental.topk_large_indices(tt_input, k=K, valid_length=VALID)
+    ttnn.synchronize_device(device)
+
+logger.info(f"BENCH_DONE rows={ROWS} W={W} k={K} iters={WARMUP + ITERS}")
+ttnn.close_device(device)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -403,6 +403,35 @@ def test_topk_large_indices_program_cache_per_engine_regime(device):
         device.disable_and_clear_program_cache()
 
 
+def test_topk_large_indices_hybrid_row_window_cache_reuse(device):
+    # A P150 worker grid has 13x10=130 cores. With 160 rows, the first 130
+    # rows take one full row-parallel wave and the remaining 30 rows take the
+    # multi-rectangle engine (P=4 at this width). This exercises row-window
+    # input addressing, output-relative writes, concat ordering, and cached
+    # runtime-argument patching on both launches. Growing valid_length must
+    # reuse that same physical-width hybrid structure and cached programs.
+    k, num_rows, n = 2048, 160, 65536
+    torch_input = torch.zeros((num_rows, n), dtype=torch.bfloat16)
+    hi16 = (0x3F80 + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+    high_values = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+    torch_input[:, 8192 - k : 8192] = high_values
+    tt_input = _to_device(torch_input, device)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        cache_entries = []
+        for valid_length in (n, 8192, 32768):
+            tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+            _assert_topk_matches_torch(torch_input[:, :valid_length], tt_indices, k)
+            cache_entries.append(device.num_program_cache_entries())
+
+        assert cache_entries[0] > 0
+        assert max(cache_entries) == min(cache_entries)
+    finally:
+        device.disable_and_clear_program_cache()
+
+
 @pytest.mark.parametrize(
     "k,num_chunks",
     [
@@ -525,11 +554,13 @@ def test_topk_large_indices_segmented_valid_length_collapses_to_one_segment(devi
     tt_input = _to_device(torch_input, device)
     device.enable_program_cache()
     device.clear_program_cache()
-    for valid_length in (n, 40960, 98304):  # 256 chunks, 20 chunks (1 seg), 48 chunks (2 segs)
-        tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
-        _assert_topk_matches_torch(torch_input[:, :valid_length], tt_indices, k)
-    assert device.num_program_cache_entries() == 1  # one program serves every runtime length
-    device.disable_and_clear_program_cache()
+    try:
+        for valid_length in (n, 40960, 98304):  # 256 chunks, 20 chunks (1 seg), 48 chunks (2 segs)
+            tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+            _assert_topk_matches_torch(torch_input[:, :valid_length], tt_indices, k)
+        assert device.num_program_cache_entries() == 1  # one program serves every runtime length
+    finally:
+        device.disable_and_clear_program_cache()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -99,6 +99,31 @@ def test_topk_large_indices_row_major_bfloat16_uint32_indices(device, k, num_row
     _assert_topk_matches_torch(torch_input, tt_indices, k)
 
 
+def test_topk_large_indices_random_k2048_multichunk_multirow(device):
+    # Minimal repro shape for a class of silicon failures seen during bring-up
+    # (then the row-parallel factory; since the auto-rects flip this shape
+    # auto-selects the multi-row rectangle engine — llk_k=2048, num_chunks=4,
+    # P=4, one rect per row). If this passes while the routed
+    # composite fails, the composite's post-op chain (gather at index width
+    # 2048 -> gather's untested RM multi-core variant) is the culprit, not
+    # this op. Tie-safe value-multiset assertions (random bf16 has duplicates).
+    torch.manual_seed(0)
+    rows, n, k = 2, 8192, 2048
+    torch_input = torch.randn(rows, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    for row_indices in indices:
+        assert row_indices.unique().numel() == k
+
+    actual_values = torch.gather(torch_input.float(), dim=-1, index=indices)
+    ref_values, _ = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+    assert_equal(actual_values.sort(dim=-1).values, ref_values.sort(dim=-1).values)
+
+
 def test_topk_large_indices_random_bfloat16_ties_return_distinct_indices(device):
     torch.manual_seed(0)
     rows = 8
@@ -267,6 +292,10 @@ TOPK_LARGE_INDICES_PRODUCTION_PERF_CONFIGS = [
 ]
 
 
+@pytest.mark.skip(
+    reason="expected_duration_ns pins predate the multi-core landings and must be re-baselined "
+    "on the IOMMU perf-runner class: https://github.com/tenstorrent/tt-metal/issues/53459"
+)
 @pytest.mark.parametrize(
     "case_id,num_rows,n,valid_length,k,expected_duration_ns",
     TOPK_LARGE_INDICES_PRODUCTION_PERF_CONFIGS,
@@ -316,25 +345,60 @@ def test_topk_large_indices_production_perf_check(
     )
 
 
-def test_topk_large_indices_program_cache_ignores_row_count_and_array_size(device):
+def test_topk_large_indices_program_cache_per_engine_regime(device):
+    # Engine selection is automatic: the cost model picks the multi-row
+    # rectangle engine when 2*ceil(chunks/P) + ceil(log2 P) beats the
+    # row-parallel 2*chunks by the multi-row margin, and the program hash
+    # carries the derived split-config fields. The caching invariant is
+    # therefore PER ENGINE REGIME (P150 13x10 worker grid assumed, as in the
+    # merge-tree tests below):
+    #   - shapes that stay row-parallel share ONE shape-free cached program
+    #     across any row count and width: (2, 3000) declines rects on the
+    #     margin (best rect cost 3 vs row cost 4, short of the required
+    #     margin), while (128, 51200) and (640, 51200) exceed every
+    #     rectangle's row capacity (25 chunks, max capacity 65 rows at P=2).
+    #     At k >= 1024 the compute-body mode is width-independent, so no
+    #     width term enters the hash within the regime;
+    #   - valid_length is runtime-only and the split is modeled on the
+    #     PHYSICAL width, so growing prefixes on one shape NEVER recompile;
+    #   - an engine-crossing shape compiles exactly ONE extra program:
+    #     (2, 131072) is 64 chunks, so the model auto-selects rects
+    #     (P=32: 2*2 + 5 = 9, far under the row-parallel 2*64 = 128) and the
+    #     changed split-config fields hash to a new entry. Repeats of it hit
+    #     the cache; regime growth is bounded because the model quantizes P
+    #     to a handful of choices and fixed-shape callers compile once.
     k = 1536
-    cases = [(2, 3000), (640, 51200), (5, 4097)]
-    tt_inputs = []
-    for num_rows, n in cases:
-        torch_input = _make_large_index_input(num_rows=num_rows, n=n, k=k)
-        tt_inputs.append(_to_device(torch_input, device))
+    row_parallel_cases = [(2, 3000), (128, 51200), (640, 51200)]
+    tt_inputs = [
+        _to_device(_make_large_index_input(num_rows=num_rows, n=n, k=k), device) for num_rows, n in row_parallel_cases
+    ]
+    tt_crossing = _to_device(_make_large_index_input(num_rows=2, n=131072, k=k), device)
 
     device.enable_program_cache()
     device.clear_program_cache()
     try:
         cache_entries = []
-        for tt_input, (num_rows, _) in zip(tt_inputs, cases):
+        for tt_input, (num_rows, _) in zip(tt_inputs, row_parallel_cases):
             tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k)
             cache_entries.append(device.num_program_cache_entries())
             _assert_index_metadata(tt_indices, [num_rows, k])
+        for valid_length in (4097, 26000):  # runtime-only: same (128, 51200) program
+            tt_indices = ttnn.experimental.topk_large_indices(tt_inputs[1], k=k, valid_length=valid_length)
+            cache_entries.append(device.num_program_cache_entries())
+            _assert_index_metadata(tt_indices, [128, k])
 
         assert cache_entries[0] > 0
-        assert max(cache_entries) == min(cache_entries)
+        assert max(cache_entries) == min(cache_entries)  # one program serves the whole regime
+        row_parallel_entries = cache_entries[-1]
+
+        tt_indices = ttnn.experimental.topk_large_indices(tt_crossing, k=k)
+        _assert_index_metadata(tt_indices, [2, k])
+        # Crossing into the rect engine compiles exactly one new program ...
+        assert device.num_program_cache_entries() == row_parallel_entries + 1
+        tt_indices = ttnn.experimental.topk_large_indices(tt_crossing, k=k)
+        _assert_index_metadata(tt_indices, [2, k])
+        # ... and repeat calls of the same shape stay cached.
+        assert device.num_program_cache_entries() == row_parallel_entries + 1
     finally:
         device.disable_and_clear_program_cache()
 
@@ -415,6 +479,60 @@ def test_topk_large_indices_row_major_mixed_negative_infinity_indices_are_sentin
 
 
 # ---------------------------------------------------------------------------
+# Segmented fusion: rows wider than the 32-chunk fused ceiling run <=32-chunk
+# fused segments (segment-local chunk-id stamp, one split per segment) folded
+# by unfused cross-segment merges. Cells pin the risky boundaries: first
+# unfused-era width (33 chunks), a single-chunk tail segment, deep segment
+# counts, and valid_length collapsing a wide program back to one segment.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "k,num_rows,n",
+    [
+        (2048, 2, 67584),  # 33 chunks: segment 1 holds exactly ONE chunk (rebuild-asc after bare sort)
+        (2048, 2, 131072),  # 64 chunks: 2 full segments
+        (1536, 2, 131072),  # k=1536 runs the 2048 window; USER_K slice of a segmented row
+        (2048, 1, 524288),  # 256 chunks: 8 segments (Pavle's scaled shape class)
+        (1536, 2, 524288),
+        (2048, 1, 1048576),  # 512 chunks: 16 segments, index magnitudes to 2^20
+        (1024, 2, 66560),  # K=1024 window: 65 chunks, seg1 = 33... spans capacity at a different K
+        (2048, 2, 100000),  # non-chunk-multiple width: -inf padded tail inside the last segment
+        (2048, 66, 131072),  # rows above rect capacity: the ROW-PARALLEL segmented body (>32 chunks)
+        #                      stays covered by a bare call now that 2-row shapes auto-select rects
+    ],
+)
+def test_topk_large_indices_segmented_widths(device, k, num_rows, n):
+    torch_input = _make_large_index_input(num_rows=num_rows, n=n, k=k)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+def test_topk_large_indices_segmented_valid_length_collapses_to_one_segment(device):
+    # A wide program whose runtime valid_length shrinks the row to <= 32
+    # chunks must keep running inside the SAME cached binary -- and again at
+    # a segment-boundary-crossing length. Since the auto-rects flip this
+    # (2, 524288) shape (256 chunks) runs the multi-row rectangle engine, so
+    # the collapse is exercised through the rect slices' runtime prefix
+    # rebalancing rather than the row-parallel segmented body; either way
+    # valid_length stays runtime-only and no recompile is allowed.
+    k, n = 2048, 524288
+    # Distinct top-k block INSIDE the smallest tested valid_length so every
+    # tested prefix has a tie-free torch reference (zeros elsewhere).
+    torch_input = torch.zeros((2, n), dtype=torch.bfloat16)
+    hi16 = (0x3F80 + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+    torch_input[:, 40960 - k : 40960] = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+    tt_input = _to_device(torch_input, device)
+    device.enable_program_cache()
+    device.clear_program_cache()
+    for valid_length in (n, 40960, 98304):  # 256 chunks, 20 chunks (1 seg), 48 chunks (2 segs)
+        tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+        _assert_topk_matches_torch(torch_input[:, :valid_length], tt_indices, k)
+    assert device.num_program_cache_entries() == 1  # one program serves every runtime length
+    device.disable_and_clear_program_cache()
+
+
+# ---------------------------------------------------------------------------
 # valid_length: bound the search to the first N columns of each (wider) row.
 # ---------------------------------------------------------------------------
 
@@ -456,8 +574,13 @@ def test_topk_large_indices_valid_length_ignores_stale_tail(device, k, n, valid_
     ],
 )
 def test_topk_large_indices_valid_length_matches_sliced_input(device, k, num_rows, n, valid_length):
-    # valid_length=L must be numerically identical to physically slicing the row to [0, L) and running the
-    # full-width op. Both compute top-k over the exact same prefix, so the indices are bit-identical.
+    # valid_length=L must select the exact same top-k VALUE multiset as physically slicing the row to
+    # [0, L) and running the full-width op. Indices may legitimately differ ONLY on exact-bf16 ties: the
+    # two calls have different physical widths, and the engine (and with it the unspecified non-stable
+    # tie order) is chosen per physical width — e.g. the FUSED_E2E gate flips at 32 chunks, and fused
+    # cross-chunk compares break ties by stamped chunk id while unfused merges break them by network
+    # position. Every index mismatch is therefore asserted to be a bitwise value tie, and the sorted
+    # value sequences must match bit-for-bit.
     torch.manual_seed(0)
     torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
 
@@ -467,7 +590,18 @@ def test_topk_large_indices_valid_length_matches_sliced_input(device, k, num_row
     bounded_t = ttnn.to_torch(bounded, dtype=torch.uint32).to(torch.int64)
     sliced_t = ttnn.to_torch(sliced, dtype=torch.uint32).to(torch.int64)
     _assert_index_metadata(bounded, [num_rows, k])
-    assert_equal(bounded_t, sliced_t)
+    source = torch_input.to(torch.float32)
+    for r in range(num_rows):
+        gathered_bounded = source[r, bounded_t[r]]
+        gathered_sliced = source[r, sliced_t[r]]
+        diff = (bounded_t[r] != sliced_t[r]).nonzero().flatten()
+        assert torch.equal(
+            gathered_bounded[diff], gathered_sliced[diff]
+        ), f"row {r}: {len(diff)} index diffs include a non-tie (values differ)"
+        assert torch.equal(
+            torch.sort(gathered_bounded, descending=True).values,
+            torch.sort(gathered_sliced, descending=True).values,
+        ), f"row {r}: top-k value multisets differ"
 
 
 def test_topk_large_indices_valid_length_full_width_is_noop(device):
@@ -576,3 +710,307 @@ def test_topk_large_indices_valid_length_out_of_range_raises(device, expect_erro
     torch_input = _make_bf16_exact_input(num_rows=1, n=n)
     with expect_error(RuntimeError, "valid_length"):
         ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+
+# ---------------------------------------------------------------------------
+# Column-parallel (intra-row multi-core) path: single row, many chunks per row.
+# The op splits the row's chunks over a rectangle of local cores and merges the
+# per-slice survivors on one final core. Selected automatically when num_rows
+# is 1 and the row is wide enough that the split beats a single core.
+# ---------------------------------------------------------------------------
+
+
+def _make_distinct_block_input(n: int, k: int, block_start: int, background: float = 0.0) -> torch.Tensor:
+    """One row of `background` with k strictly-increasing bf16-exact values at [block_start, block_start+k)."""
+    values = torch.full((1, n), background, dtype=torch.bfloat16)
+    hi16 = (0x3F80 + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+    block = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+    values[:, block_start : block_start + k] = block
+    return values
+
+
+@pytest.mark.parametrize(
+    "k,n",
+    [
+        (512, 32768),  # 64 chunks
+        (512, 65536),  # 128 chunks
+        (1024, 32768),  # 32 chunks
+        (1024, 65536),  # 64 chunks
+        (2048, 65536),  # 32 chunks over ~8 slices -> >=4 chained chunk merges per local core
+        (2048, 102400),  # 50 chunks: uneven chunk split across slices
+        (1536, 65536),  # k below the LLK window (2048): output narrower than the merge sequence
+        (2048, 65537),  # 33 chunks with a 1-element tail chunk on the last slice
+    ],
+)
+def test_topk_large_indices_column_parallel_single_row(device, k, n):
+    torch_input = _make_large_index_input(num_rows=1, n=n, k=k)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+def test_topk_large_indices_column_parallel_top_values_straddle_slice_boundary(device):
+    # W=65536 with k=2048 splits into 8 slices of 8192 columns. Center the
+    # winning block on a slice boundary so both neighbors contribute half of
+    # the final top-k and the cross-slice merge ordering is exercised.
+    n, k = 65536, 2048
+    boundary = 4 * 8192
+    torch_input = _make_distinct_block_input(n, k, block_start=boundary - k // 2)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+def test_topk_large_indices_column_parallel_random_ties_return_distinct_indices(device):
+    # Random bf16 over 64K columns is guaranteed to contain duplicate values,
+    # including ties that straddle slice boundaries. Tie order between slices
+    # is unspecified, so check the selected value multiset and index validity
+    # instead of exact index equality.
+    torch.manual_seed(0)
+    n, k = 65536, 2048
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    assert indices.unique().numel() == k
+
+    actual_values = torch_input.float()[0][indices]
+    ref_values, _ = torch.topk(torch_input.float()[0], k, largest=True, sorted=True)
+    assert_equal(actual_values.sort().values, ref_values.sort().values)
+
+
+def test_topk_large_indices_column_parallel_all_equal_row(device):
+    # Every element ties. Any k distinct indices are a correct answer; the
+    # merge tree must not lose or duplicate lanes across slices.
+    n, k = 65536, 2048
+    torch_input = torch.ones(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    assert indices.unique().numel() == k
+
+
+@pytest.mark.parametrize("k", [512, 1024, 2048])
+def test_topk_large_indices_column_parallel_all_neginf_is_sentinel(device, k):
+    # All lanes are -inf in every slice, so every gathered sequence is the
+    # degenerate all--inf run and the final core must emit only sentinels.
+    sentinel = 0xFFFFFFFF
+    n = 32 * k
+    torch_input = torch.full((1, n), -float("inf"), dtype=torch.bfloat16)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_indices(tt_indices, torch.full((1, k), sentinel, dtype=torch.int64), [1, k])
+
+
+@pytest.mark.parametrize(
+    "valid_length,block_start",
+    [
+        (2048, 0),  # only slice 0 active (single chunk); slices 1..P-1 empty -> writer -inf fill
+        (8192, 8192 - 2048),  # slice 0 fully active, the rest empty
+        (20000, 17952),  # partial tail chunk mid-slice; trailing slices empty
+        (65536, 65536 - 2048),  # full width: no empty slices
+    ],
+)
+def test_topk_large_indices_column_parallel_valid_length(device, valid_length, block_start):
+    # The winning block sits inside the valid prefix; the stale tail holds
+    # LARGER finite decoys that must never be selected. Empty slices (fully
+    # beyond valid_length) contribute writer-fabricated -inf sequences.
+    n, k = 65536, 2048
+    torch_input = _make_distinct_block_input(n, k, block_start=block_start)
+    if valid_length < n:
+        torch_input[:, valid_length:] = 100.0
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+    _, ref_indices = torch.topk(torch_input[:, :valid_length].float(), k, dim=-1, largest=True, sorted=True)
+    assert int(ref_indices.max()) < valid_length
+    _assert_indices(tt_indices, ref_indices, [1, k])
+
+
+def test_topk_large_indices_column_parallel_short_valid_length_emits_sentinels(device):
+    # valid_length < k: the real indices come from the short prefix and the
+    # remaining output lanes must be sentinels, with every slice past the
+    # prefix contributing an empty (writer-filled) sequence.
+    n, k = 65536, 2048
+    valid_length = 496
+    torch_input = _make_bf16_exact_input(num_rows=1, n=2048)
+    torch_input = torch.nn.functional.pad(torch_input.float(), (0, n - 2048), value=100.0).to(torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+    _, valid_indices = torch.topk(
+        torch_input[:, :valid_length].float(), valid_length, dim=-1, largest=True, sorted=True
+    )
+    expected = torch.cat(
+        [valid_indices, torch.full((1, k - valid_length), 0xFFFFFFFF, dtype=torch.int64)],
+        dim=-1,
+    )
+    _assert_indices(tt_indices, expected, [1, k])
+
+
+def test_topk_large_indices_column_parallel_valid_length_cache_reuse(device):
+    # The column split is derived from the PHYSICAL width only, so a serving
+    # loop growing valid_length must reuse one cached column-parallel program
+    # (empty slices shrink to active ones purely through runtime args).
+    #
+    # Every 8192-wide region carries its own strictly-increasing distinct
+    # k-block at its start, with each block's values above the previous
+    # block's. There are no ties anywhere (tie order vs torch is unspecified,
+    # so an all-zeros prefix cannot be exact-asserted), and each growth step
+    # has a DIFFERENT exact answer — the newest fully-visible block — so a
+    # stale valid_length-derived runtime arg on a cache hit cannot pass.
+    n, k = 65536, 2048
+    num_blocks = 8
+    region_width = n // num_blocks
+    torch_input = torch.zeros(1, n, dtype=torch.bfloat16)
+    for i in range(num_blocks):
+        hi16 = (0x3F80 + i * k + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+        block = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+        torch_input[:, i * region_width : i * region_width + k] = block
+    tt_input = _to_device(torch_input, device)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        entries = []
+        # valid_length -> index of the largest fully-visible block:
+        # 2048 sees only block 0; 20480 reaches block 2 ([16384, 18432));
+        # 40960 reaches block 4 ([32768, 34816)); full width reaches block 7.
+        for valid_length, top_block in ((2048, 0), (20480, 2), (40960, 4), (n, 7)):
+            tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+            entries.append(device.num_program_cache_entries())
+            block_start = top_block * region_width
+            expected = torch.arange(block_start + k - 1, block_start - 1, -1, dtype=torch.int64).unsqueeze(0)
+            _assert_indices(tt_indices, expected, [1, k])
+        assert entries[0] > 0
+        assert max(entries) == min(entries)  # no recompile as valid_length grew
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+def test_topk_large_indices_column_and_row_parallel_programs_coexist_in_cache(device):
+    # A single-row wide input takes the column-parallel factory while a
+    # multi-row input of the same width keeps the row-parallel one; the two
+    # must hash to distinct cache entries and both must stay correct. 128
+    # rows exceed every rectangle's row capacity at 32 chunks (max 65 at
+    # P=2 on the 13x10 grid), so the auto-rects cost model declines and the
+    # multi-row call genuinely stays row-parallel; a low row count (e.g. 2)
+    # would itself auto-select the rect engine since the flip.
+    n, k = 65536, 2048
+    single_row = _make_large_index_input(num_rows=1, n=n, k=k)
+    multi_row = _make_large_index_input(num_rows=128, n=n, k=k)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        tt_single = ttnn.experimental.topk_large_indices(_to_device(single_row, device), k=k)
+        entries_after_single = device.num_program_cache_entries()
+        tt_multi = ttnn.experimental.topk_large_indices(_to_device(multi_row, device), k=k)
+        entries_after_multi = device.num_program_cache_entries()
+
+        assert entries_after_single > 0
+        assert entries_after_multi == entries_after_single + 1
+
+        _assert_topk_matches_torch(single_row, tt_single, k)
+        _assert_topk_matches_torch(multi_row, tt_multi, k)
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+def test_topk_large_indices_returns_single_indices_tensor(device):
+    # Contract: the result is a single indices tensor (not a tuple/list).
+    torch_input = _make_bf16_exact_input(num_rows=2, n=1024)
+    result = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=512)
+    assert isinstance(result, ttnn.Tensor)
+    _assert_topk_matches_torch(torch_input, result, 512)
+
+
+# ---------------------------------------------------------------------------
+# Column-parallel MERGE TREE (in-place log2(P) reduction on the slice
+# rectangle; slice 0 is the root). Single-row shapes auto-select the tree via
+# the cost model (cost(P) = 2*ceil(chunks/P) + ceil(log2 P)); the widths below
+# are chosen so the model picks a KNOWN P, so each test still pins a specific
+# tree depth without any public slice-count knob.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_chunks", [4, 8, 16, 32, 64])
+@pytest.mark.parametrize("k", [512, 2048])
+def test_topk_large_indices_tree_random_ties(device, num_chunks, k):
+    # Random bf16 has duplicate values, including ties that straddle slice and
+    # tree-level boundaries; tie order is unspecified, so assert the selected
+    # value multiset + index validity. n spans chunk counts from 4 to 64 for
+    # both LLK windows; the model-picked P grows with the chunk count (P ==
+    # chunks up to the grid's rectangle capacity), covering 2- to 6-level trees.
+    torch.manual_seed(0)
+    llk_k = 512 if k == 512 else 2048
+    n = num_chunks * llk_k
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    assert indices.unique().numel() == k
+
+    actual_values = torch_input.float()[0][indices]
+    ref_values, _ = torch.topk(torch_input.float()[0], k, largest=True, sorted=True)
+    assert_equal(actual_values.sort().values, ref_values.sort().values)
+
+
+def test_topk_large_indices_tree_multilevel_adversarial_placement(device):
+    # 3-level tree: 8 chunks of the 2048 window (n=16384) make the cost model
+    # pick P=8 (cost 2*1+3=5, strictly under every smaller P), slice width
+    # 2048. The winning block is split across slices that meet only AT THE
+    # ROOT and traverse different tree depths:
+    #   slice 5 (upper half of the top-k): 5 -> 4 (level 0), 4 -> 0 (level 2)
+    #   slice 3 (lower half):              3 -> 2 (level 0), 2 -> 0 (level 1)
+    # A mis-ordered intermediate survivor (the num_chunks=4 lesson, applied at
+    # tree levels) only shows when its consumer merges it — the root sees both
+    # halves through 2-deep chains. Values are globally distinct, so the final
+    # rank order is asserted EXACTLY against torch.
+    n, k = 16384, 2048
+    region = 2048  # one chunk per slice
+    half = k // 2
+    torch_input = torch.zeros(1, n, dtype=torch.bfloat16)
+
+    def block(count, base):
+        hi16 = (0x3F80 + base + np.arange(count, dtype=np.uint32)).astype(np.uint32)
+        return torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+
+    # Lower half of the winners in slice 3, upper half in slice 5 (all values
+    # distinct and above the zero background).
+    torch_input[0, 3 * region : 3 * region + half] = block(half, 0)
+    torch_input[0, 5 * region : 5 * region + half] = block(half, half)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _, ref_indices = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+    _assert_indices(tt_indices, ref_indices, [1, k])
+
+
+def test_topk_large_indices_tree_valid_length_empty_winners(device):
+    # 16 chunks of the 2048 window (n=32768) make the cost model pick P=16
+    # (4-level tree). valid_length=5000 is 3 valid chunks, rebalanced over the
+    # slices: slices 0..1 full, slice 2 a 904-element tail, slices 3..15
+    # EMPTY. Empty WINNERS (4, 6, 8, ...) must adopt their first incoming
+    # survivor instead of merging into an empty DST; empty pure losers ship
+    # the writer's -inf scratch. Winning block sits inside the prefix, decoys
+    # beyond it.
+    n, k = 32768, 2048
+    valid_length = 5000
+    torch_input = _make_distinct_block_input(n, k, block_start=valid_length - k)
+    torch_input[:, valid_length:] = 100.0  # stale decoys, must never be selected
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+    _, ref_indices = torch.topk(torch_input[:, :valid_length].float(), k, dim=-1, largest=True, sorted=True)
+    assert int(ref_indices.max()) < valid_length
+    _assert_indices(tt_indices, ref_indices, [1, k])

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
@@ -2,6 +2,46 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Unified topk_large_indices compute kernel. The factory selects the role per
+// CreateKernel site via compile-time defines:
+//
+//   (no role define) -- ROW-PARALLEL: each core reduces full rows and
+//   materializes the index output itself. The row-reduction body is selected
+//   host-side (compute_body_mode) and passed as a compile-time arg:
+//   Classic (unfused per-chunk split), FusedEndToEnd (stay fused through
+//   every merge/rebuild, one global split per row; <= 32 chunks), or
+//   FusedSegmented (per-<=32-chunk-segment fusion folded into an unfused
+//   cross-segment survivor).
+//
+//   TOPK_TREE -- COLUMN-PARALLEL tree node (every rectangle core except the
+//   root). Phase 1 (leaf): reduce this core's chunk slice to one K survivor in
+//   DST. Phase 2 (tree): for each of this core's num_merges winning levels,
+//   consume one partner sequence from the recv CB (delivered by this core's
+//   writer via the pairwise handshake), copy it to DST operand-1, and
+//   merge+rebuild IN PLACE -- the survivor never leaves DST between levels.
+//   Phase 3 (ship): pack the survivor raw (FP32 values + UINT32 indices) for
+//   the writer to send to this core's winner.
+//
+//   TOPK_TREE + TOPK_TREE_ROOT -- COLUMN-PARALLEL tree root (rectangle core
+//   (0,0), slice 0). Same leaf reduction and in-DST tree merges, but the root
+//   never ships: every rebuild stays DESCENDING (it is always the next merge's
+//   operand 0), and after the last level it materializes the indices exactly
+//   like the row-parallel epilogue.
+//
+// Tree directions: the bitonic halver needs operand0 descending and operand1
+// ascending, so every DST-mutating action rebuilds DESCENDING except a node's
+// LAST one before shipping, which rebuilds ASCENDING (validated upstream by
+// test_topk_xl_rebuild_ascending: rebuild(asc) after a merge is the exact
+// rank-mirror of rebuild(desc)).
+//
+// Tree empty slice (valid_length cut, nodes only -- slice 0 always holds at
+// least one element):
+//   * num_merges == 0 -> nothing to compute; the writer ships the prefilled
+//     all--inf scratch sequence instead.
+//   * num_merges > 0 -> the FIRST partner is ADOPTED (copied to operand-0 and
+//     rebuilt) instead of merged; an ascending monotonic run is bitonic, so
+//     the rebuild is valid in either direction.
+
 #include <cstdint>
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/compute_kernel_hw_startup.h"
@@ -10,6 +50,13 @@
 #include "api/compute/transpose_dest.h"
 #include "api/dataflow/circular_buffer.h"
 #include "topk_large_indices_compute_body_mode.hpp"
+
+#ifdef TOPK_TREE
+#include "api/compute/tile_move_copy.h"  // copy_tile of received sequences
+#ifndef TOPK_TREE_ROOT
+#include "api/compute/pack.h"  // pack_block of the shipped survivor
+#endif
+#endif
 
 #ifdef TRISC_MATH
 namespace ckernel::sfpu {
@@ -243,19 +290,169 @@ void kernel_main() {
     const uint32_t num_chunks = get_arg_val<uint32_t>(1);
     const uint32_t tail_elements = get_arg_val<uint32_t>(2);
 
+#if defined(TOPK_TREE_ROOT)
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t indices_out_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t recv_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t K = get_compile_time_arg_val(3);
+#elif defined(TOPK_TREE)
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t ship_values_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t ship_indices_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t recv_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t K = get_compile_time_arg_val(4);
+#else
     constexpr uint32_t input_cb = get_compile_time_arg_val(0);
     constexpr uint32_t indices_cb = get_compile_time_arg_val(1);
     constexpr uint32_t K = get_compile_time_arg_val(2);
     constexpr auto body_mode = static_cast<ComputeBodyMode>(get_compile_time_arg_val(3));
-    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
     static_assert(
         body_mode == ComputeBodyMode::Classic || body_mode == ComputeBodyMode::FusedEndToEnd ||
             body_mode == ComputeBodyMode::FusedSegmented,
         "invalid TopK compute body mode");
+#endif
 
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
     constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
-    constexpr uint32_t final_survivor = 0;
+    constexpr uint32_t slot0 = 0;
 
+#ifdef TOPK_TREE
+    constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
+    // ------------------------------------------------------------------
+    // COLUMN-PARALLEL tree body (node and root)
+    // ------------------------------------------------------------------
+    const uint32_t start_chunk = get_arg_val<uint32_t>(3);  // always 0 for slice 0; kept for arg-layout parity
+    const uint32_t num_merges = get_arg_val<uint32_t>(4);
+
+#ifdef TOPK_TREE_ROOT
+    constexpr bool is_tree_root = true;
+#else
+    constexpr bool is_tree_root = false;
+#endif
+    constexpr uint32_t slot1 = sequence_tiles;
+
+    // An empty slice (valid_length cut) with no partners contributes nothing;
+    // the writer ships the -inf scratch sequence. The root's slice 0 always
+    // contains at least one element (valid_length >= 1), so it never takes
+    // the empty/adopt paths and they fold away.
+    const bool own_empty = !is_tree_root && (num_chunks == 0);
+    if (own_empty && num_merges == 0) {
+        return;
+    }
+
+#ifdef TOPK_TREE_ROOT
+    compute_kernel_hw_startup(input_cb, indices_out_cb);
+#else
+    compute_kernel_hw_startup(input_cb, ship_values_cb);
+#endif
+
+    CircularBuffer input_cb_obj(input_cb);
+    CircularBuffer recv_obj(recv_cb);
+#ifdef TOPK_TREE_ROOT
+    CircularBuffer indices_out_obj(indices_out_cb);
+#else
+    CircularBuffer ship_values_obj(ship_values_cb);
+    CircularBuffer ship_indices_obj(ship_indices_cb);
+#endif
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        tile_regs_acquire();
+
+        if (!own_empty) {
+            // Leaf reduction of this core's chunk slice. The chunk base is
+            // latched at 0 and stepped with the all-constant advance
+            // primitive: a runtime chunk_base cannot reach the
+            // TTI-immediate config write inside the init.
+            topk_xl_separate_indices_row_major_init_static<0, 0>();
+            for (uint32_t c = 0; c < start_chunk; ++c) {
+                topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+            }
+
+            // A node whose leaf survivor ships directly (no tree merges)
+            // rebuilds ASCENDING on its last DST action; the root (and any
+            // survivor with merges still ahead) rebuilds DESCENDING.
+            const bool ship_after_leaf = !is_tree_root && (num_merges == 0);
+
+            const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
+            sort_classic_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
+
+            if (num_chunks == 1) {
+                topk_xl_init<K, false>();
+                topk_xl_rebuild<K, false>(slot0, ship_after_leaf);
+            }
+
+            for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
+                const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
+                sort_classic_chunk<K>(input_cb_obj, slot1, active_elements, true);
+
+                topk_xl_init<K, false>();
+                topk_xl_merge<K, false>(slot0);
+                const bool last_chunk = (chunk + 1 == num_chunks);
+                topk_xl_rebuild<K, false>(slot0, last_chunk && ship_after_leaf);
+            }
+        }
+
+        // Tree merges: one partner sequence per winning level, in level order.
+        for (uint32_t m = 0; m < num_merges; ++m) {
+            const bool ship_next = !is_tree_root && (m + 1 == num_merges);
+            const bool adopt = own_empty && (m == 0);
+            const uint32_t dst_base = adopt ? slot0 : slot1;
+
+            recv_obj.wait_front(sequence_tiles);
+            // EXPLICIT format reconfig (bf16 -> UInt32): the preceding chunk phase
+            // (topk_xl_copy_tile_init) hw-configures the unpacker for the BF16
+            // input CB, and the plain _short init's state_configure is a no-op
+            // in production JIT builds (the compute-kernel sentinel is compiled
+            // out), so the _with_dt variant's llk reconfig is required here.
+            // The reverse transition is explicit inside topk_xl_copy_tile_init.
+            copy_tile_to_dst_init_short_with_dt(input_cb, recv_cb);
+            for (uint32_t t = 0; t < sequence_tiles; ++t) {
+                copy_tile(recv_cb, t, dst_base + t);
+            }
+            recv_obj.pop_front(sequence_tiles);
+
+            topk_xl_init<K, false>();
+            if (!adopt) {
+                topk_xl_merge<K, false>(slot0);
+            }
+            topk_xl_rebuild<K, false>(slot0, ship_next /* ascending for the winner's halver */);
+        }
+
+#ifdef TOPK_TREE_ROOT
+        // Root epilogue: materialize the indices exactly like the row-parallel
+        // kernel (mark_neginf + rank-order transpose + pack_untilize).
+        mark_neginf_indices<K>(slot0);
+        materialize_index_rank_order<K>(slot0, indices_out_cb);
+#endif
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+#ifdef TOPK_TREE_ROOT
+        indices_out_obj.reserve_back(1);
+        pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(indices_out_cb);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(indices_out_cb, 1, 0, slot0 + tiles_per_sequence);
+        indices_out_obj.push_back(1);
+#else
+        // Ship the survivor raw: bit-exact FP32 value tiles then UINT32 index
+        // tiles; the winner's copy_tile round-trips the DST image unchanged.
+        ship_values_obj.reserve_back(tiles_per_sequence);
+        pack_block(slot0, ship_values_cb, tiles_per_sequence);
+        ship_values_obj.push_back(tiles_per_sequence);
+
+        ship_indices_obj.reserve_back(tiles_per_sequence);
+        pack_block(slot0 + tiles_per_sequence, ship_indices_cb, tiles_per_sequence);
+        ship_indices_obj.push_back(tiles_per_sequence);
+#endif
+
+        tile_regs_release();
+    }
+
+#else  // !TOPK_TREE
+
+    // ------------------------------------------------------------------
+    // ROW-PARALLEL body (Classic / FusedEndToEnd / FusedSegmented)
+    // ------------------------------------------------------------------
     compute_kernel_hw_startup(input_cb, indices_cb);
     pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(indices_cb);
 
@@ -273,17 +470,18 @@ void kernel_main() {
             reduce_classic_row<K>(input, num_chunks, tail_elements);
         }
 
-        mark_neginf_indices<K>(final_survivor);
-        materialize_index_rank_order<K>(final_survivor, indices_cb);
+        mark_neginf_indices<K>(slot0);
+        materialize_index_rank_order<K>(slot0, indices_cb);
 
         tile_regs_commit();
         tile_regs_wait();
 
         indices.reserve_back(1);
-        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(
-            indices_cb, 1, 0, final_survivor + tiles_per_sequence);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(indices_cb, 1, 0, slot0 + tiles_per_sequence);
         indices.push_back(1);
 
         tile_regs_release();
     }
+
+#endif  // TOPK_TREE
 }

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Chunked row reader, both parallelization modes (role picked by the factory):
+//   * default (row-parallel): each core reads full rows.
+//   * TOPK_TREE (column-parallel): each core reads only its contiguous slice
+//     of every row, offset by the extra slice_offset_bytes runtime arg. An
+//     empty slice (num_chunks == 0, valid_length cut) reads nothing.
+
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -14,6 +20,12 @@ void kernel_main() {
     const uint32_t num_chunks = get_arg_val<uint32_t>(3);
     const uint32_t tail_chunk_bytes = get_arg_val<uint32_t>(4);
     const uint32_t input_page_bytes = get_arg_val<uint32_t>(5);
+#ifdef TOPK_TREE
+    // Byte offset of this core's slice within each row.
+    const uint32_t slice_offset_bytes = get_arg_val<uint32_t>(6);
+#else
+    constexpr uint32_t slice_offset_bytes = 0;
+#endif
 
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
     constexpr uint32_t chunk_bytes = get_compile_time_arg_val(1);
@@ -42,7 +54,7 @@ void kernel_main() {
                         input,
                         input_cb,
                         read_bytes,
-                        {.page_id = row, .offset_bytes = chunk * chunk_bytes + tile_offset},
+                        {.page_id = row, .offset_bytes = slice_offset_bytes + chunk * chunk_bytes + tile_offset},
                         {.offset_bytes = tile_offset});
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer.cpp
@@ -2,12 +2,44 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Unified topk_large_indices writer. The factory selects the role per
+// CreateKernel site via a compile-time define:
+//
+//   (no role define) -- ROW-PARALLEL output writer: stream each core's
+//   materialized index rows to DRAM (contiguous for the 512 LLK window,
+//   face-pair -> row-major reorder otherwise).
+//
+//   TOPK_TREE -- COLUMN-PARALLEL tree writer: runs on every rectangle core;
+//   runtime args select this core's roles per row:
+//
+//   RECEIVER (num_recv > 0): for each winning level with a real partner, in
+//   level order: reserve the recv CB (backpressure: capacity is exactly one
+//   sequence, so this blocks until compute consumed the previous level), zero
+//   the local data semaphore, bump that partner's ready semaphore, wait for
+//   the data semaphore, publish the sequence to compute. Pairwise version of
+//   the old 2-semaphore gather protocol; reset-before-signal ordering is kept
+//   on both sides so a next-row signal can never be clobbered.
+//
+//   SHIPPER (do_ship): wait for compute's packed survivor (or use the
+//   prefilled all--inf scratch when this slice is empty with no partners),
+//   wait for the winner's ready signal, reset it, NoC-write both regions into
+//   the winner's recv CB (same L1 address everywhere: the recv CB spans the
+//   whole rectangle, and its pointers wrap to base every full cycle), barrier,
+//   then bump the winner's data semaphore.
+//
+//   ROOT (!do_ship): after the receive events, stream the materialized index
+//   row to DRAM exactly like the row-parallel writer.
+
 #include "api/core_local_mem.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc.h"
 #include "api/tensor/noc_traits.h"
+
+#ifdef TOPK_TREE
+#include "api/dataflow/noc_semaphore.h"
+#endif
 
 namespace {
 
@@ -31,7 +63,7 @@ FORCE_INLINE void copy_row_to_scratch(CircularBuffer& src_cb, CircularBuffer& sc
 
     for (uint32_t dst_slice = 0; dst_slice < output_slices_per_row; ++dst_slice) {
         // pack_untilize emits 16-element slices in face-pair order:
-        // [top-left, bottom-left, top-right, bottom-right] for each tile column.
+        // [top-left, bottom-left, top-right, bottom-right] per tile column.
         const uint32_t tile_col = dst_slice >> 2;
         const uint32_t face_col = dst_slice & 0x1;
         const uint32_t face_row_offset = (dst_slice & 0x2) ? source_slices_per_row / 2 : 0;
@@ -79,6 +111,155 @@ FORCE_INLINE void issue_contiguous_row_write(
 
 }  // namespace
 
+#ifdef TOPK_TREE
+
+// ----------------------------------------------------------------------
+// COLUMN-PARALLEL tree writer body
+// ----------------------------------------------------------------------
+void kernel_main() {
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_recv = get_arg_val<uint32_t>(1);
+    // Up to 7 (x, y) physical-coordinate pairs of the partners this core
+    // receives from, in level order (P <= 128 -> <= 7 levels). Offsets must
+    // match the factory's partner_coords(14) writer-args block.
+    uint32_t partner_x[7];
+    uint32_t partner_y[7];
+    for (uint32_t m = 0; m < 7; ++m) {
+        partner_x[m] = get_arg_val<uint32_t>(2 + 2 * m);
+        partner_y[m] = get_arg_val<uint32_t>(3 + 2 * m);
+    }
+    const uint32_t do_ship = get_arg_val<uint32_t>(16);
+    const uint32_t winner_x = get_arg_val<uint32_t>(17);
+    const uint32_t winner_y = get_arg_val<uint32_t>(18);
+    const uint32_t is_empty_ship = get_arg_val<uint32_t>(19);
+    const uint32_t indices_addr = get_arg_val<uint32_t>(20);
+    // Multi-rectangle: this rectangle's first output row (0 on a single-rect program).
+    const uint32_t start_row = get_arg_val<uint32_t>(21);
+
+    constexpr uint32_t cb_ship_values = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_ship_indices = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_neginf_scratch = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_recv = get_compile_time_arg_val(3);
+    constexpr uint32_t ready_sem_id = get_compile_time_arg_val(4);
+    constexpr uint32_t data_sem_id = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_sequence = get_compile_time_arg_val(6);
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_indices_out = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_indices_scratch = get_compile_time_arg_val(9);
+    constexpr uint32_t indices_page_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t source_slices_per_row = get_compile_time_arg_val(11);
+    constexpr uint32_t output_slices_per_row = get_compile_time_arg_val(12);
+    constexpr uint32_t indices_slice_bytes = get_compile_time_arg_val(13);
+    constexpr auto indices_args = TensorAccessorArgs<14>();
+
+    constexpr uint32_t sequence_tiles = 2 * tiles_per_sequence;
+    constexpr uint32_t sequence_bytes = tiles_per_sequence * tile_bytes;
+
+    Noc noc;
+    Semaphore<> ready_sem(ready_sem_id);
+    Semaphore<> data_sem(data_sem_id);
+    UnicastEndpoint remote;
+    CircularBuffer ship_values_cb(cb_ship_values);
+    CircularBuffer ship_indices_cb(cb_ship_indices);
+    CircularBuffer recv_cb(cb_recv);
+
+    // Address symmetry: the recv CB spans the whole rectangle at one address,
+    // and its pointers wrap to base after every full receive cycle, so this
+    // core's own write pointer doubles as the winner's destination base.
+    const uint32_t recv_values_base = recv_cb.get_write_ptr();
+    const uint32_t recv_indices_base = recv_values_base + sequence_bytes;
+
+    if (do_ship != 0 && is_empty_ship != 0) {
+        CircularBuffer scratch_cb(cb_neginf_scratch);
+        scratch_cb.reserve_back(sequence_tiles);
+        const uint32_t scratch_base = scratch_cb.get_write_ptr();
+        constexpr uint32_t sequence_words = sequence_bytes / sizeof(uint32_t);
+        volatile tt_l1_ptr uint32_t* scratch = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_base);
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[i] = 0xFF800000u;  // exact BF16 -inf in the FP32 DST container
+        }
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[sequence_words + i] = 0xFFFFFFFFu;  // sentinel index
+        }
+    }
+
+    const auto indices = TensorAccessor(indices_args, indices_addr, indices_page_bytes);
+    CircularBuffer indices_cb(cb_indices_out);
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        // Receive events, in level order.
+        for (uint32_t m = 0; m < num_recv; ++m) {
+            recv_cb.reserve_back(sequence_tiles);
+            data_sem.set(0);
+            ready_sem.up(noc, partner_x[m], partner_y[m], 1);
+            data_sem.wait(1);
+            recv_cb.push_back(sequence_tiles);
+        }
+
+        if (do_ship != 0) {
+            uint32_t src_values;
+            uint32_t src_indices;
+            if (is_empty_ship != 0) {
+                CircularBuffer scratch_cb(cb_neginf_scratch);
+                src_values = scratch_cb.get_write_ptr();
+                src_indices = src_values + sequence_bytes;
+            } else {
+                ship_values_cb.wait_front(tiles_per_sequence);
+                ship_indices_cb.wait_front(tiles_per_sequence);
+                src_values = ship_values_cb.get_read_ptr();
+                src_indices = ship_indices_cb.get_read_ptr();
+            }
+
+            ready_sem.wait(1);
+            ready_sem.set(0);
+
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_values),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_values_base});
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_indices),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_indices_base});
+            // Drain both source reads (WAR against the compute producer) and
+            // guarantee data-before-signal at the winner.
+            noc.async_write_barrier();
+
+            data_sem.up(noc, winner_x, winner_y, 1);
+            noc.async_atomic_barrier();
+
+            if (is_empty_ship == 0) {
+                ship_values_cb.pop_front(tiles_per_sequence);
+                ship_indices_cb.pop_front(tiles_per_sequence);
+            }
+        } else {
+            // Root: stream the materialized index row to DRAM.
+            if constexpr (source_slices_per_row == 32) {
+                issue_contiguous_row_write(indices_cb, noc, indices, start_row + row, indices_page_bytes);
+                noc.async_writes_flushed();
+                indices_cb.pop_front(1);
+            } else {
+                CircularBuffer indices_scratch_cb(cb_indices_scratch);
+                issue_reordered_row_write<source_slices_per_row, output_slices_per_row, indices_slice_bytes>(
+                    indices_cb, indices_scratch_cb, noc, indices, start_row + row, indices_page_bytes);
+                noc.async_writes_flushed();
+                indices_scratch_cb.pop_front(1);
+            }
+        }
+    }
+
+    noc.async_write_barrier();
+}
+
+#else  // !TOPK_TREE
+
+// ----------------------------------------------------------------------
+// ROW-PARALLEL output writer body
+// ----------------------------------------------------------------------
 void kernel_main() {
     const uint32_t indices_addr = get_arg_val<uint32_t>(0);
     const uint32_t start_row = get_arg_val<uint32_t>(1);
@@ -117,3 +298,5 @@ void kernel_main() {
 
     noc.async_write_barrier();
 }
+
+#endif  // TOPK_TREE

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -4,6 +4,10 @@
 
 #include "topk_large_indices_device_operation.hpp"
 
+#include <algorithm>
+
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/math.hpp>
 
@@ -66,11 +70,32 @@ void validate_runtime_args(const operation_attributes_t& attrs, const tensor_arg
     if (attrs.valid_length.has_value()) {
         const uint32_t valid_length = attrs.valid_length.value();
         TT_FATAL(valid_length > 0, "topk_large_indices valid_length must be > 0");
+        // valid_length < k is supported by design — lanes beyond the prefix's
+        // capacity emit the 0xFFFFFFFF sentinel index; the documented and
+        // tested domain is (0, last dimension].
         TT_FATAL(
             valid_length <= n,
             "topk_large_indices valid_length {} must be <= the input last dimension {}",
             valid_length,
             n);
+    }
+
+    // Composite-internal row window: must map onto the canonical rows dimension (all leading dims 1)
+    // and stay in bounds. Both fields travel together.
+    TT_FATAL(
+        attrs.row_start.has_value() == attrs.row_count.has_value(),
+        "topk_large_indices row_start and row_count must be set together");
+    if (attrs.row_count.has_value()) {
+        TT_FATAL(
+            shape.rank() >= 2 && num_rows == shape[shape.rank() - 2],
+            "topk_large_indices row windows require the canonical [1.., R, W] shape (leading dims 1)");
+        const uint64_t row_end = static_cast<uint64_t>(*attrs.row_start) + *attrs.row_count;
+        TT_FATAL(
+            *attrs.row_count > 0 && row_end <= num_rows,
+            "topk_large_indices row window [{}, {}) out of bounds for {} rows",
+            *attrs.row_start,
+            row_end,
+            num_rows);
     }
 }
 
@@ -87,19 +112,75 @@ void TopkLargeIndicesDeviceOperation::validate_on_program_cache_miss(
     validate_runtime_args(attrs, tensor_args);
 }
 
+namespace {
+
+program::ColumnSplitConfig column_split_config_for(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    const auto& shape = input.logical_shape();
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t num_rows = attrs.row_count.value_or(flattened_rows_excluding_last_dim(shape));
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    // The cost model may auto-select the multi-row rectangle engine when it
+    // models a win: 2*ceil(chunks/P) + ceil(log2 P) beating the row-parallel
+    // 2*chunks by the extra multi-row margin (measured routed 477 -> 330 us
+    // at 32x65536 k=2048). Engine selection changes only WHICH of the tied
+    // bf16 values win — tie identity is the documented non-stable contract;
+    // the selected value multiset is engine-invariant. The program hash
+    // carries the derived split-config fields, so an engine change
+    // recompiles — bounded, because the model quantizes P to a handful of
+    // choices per (k, width, rows, grid) and fixed-shape callers compile
+    // once. Explicit (internal) num_slices still bypasses the model and pins
+    // P directly (the hybrid wrapper's remainder window).
+    return program::compute_column_split_config(attrs.k, n, num_rows, grid, attrs.num_slices, /*allow_multi_row=*/true);
+}
+
+}  // namespace
+
+TopkLargeIndicesDeviceOperation::program_factory_t TopkLargeIndicesDeviceOperation::select_program_factory(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    if (column_split_config_for(attrs, tensor_args).enabled) {
+        return program::TopkLargeIndicesMultiCoreProgramFactory{};
+    }
+    return program::TopkLargeIndicesProgramFactory{};
+}
+
 ttsl::hash::hash_t TopkLargeIndicesDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input_tensor;
     const auto grid = input.device()->compute_with_storage_grid_size();
 
+    // Factory selection (and, on the column-parallel path, the program
+    // structure) depends on the derived split config, so its fields must be
+    // hashed. On the row-parallel path the config is all zeros, preserving the
+    // original shape-free hash: row counts and row widths keep patching
+    // through runtime args without recompiles.
+    const auto split_config = column_split_config_for(attrs, tensor_args);
+
     return tt::tt_metal::operation::hash_operation<TopkLargeIndicesDeviceOperation>(
         attrs.k,
+        // Internal P override: also reflected in the derived split_config fields
+        // below, but hashed directly so intent and derivation can never skew.
+        attrs.num_slices,
         input.dtype(),
         input.layout(),
         input.memory_config().memory_layout(),
         input.memory_config().buffer_type(),
         grid.x,
         grid.y,
+        split_config.enabled,
+        split_config.num_slices,
+        split_config.local_grid_x,
+        split_config.local_grid_y,
+        // Rectangle count is program structure (kernel core placement); row
+        // distribution within a fixed rectangle layout stays runtime-only.
+        split_config.num_rects,
+        // Compute-body mode, single-sourced with the factory's kernel-define
+        // selection (see compute_body_mode). For k >= 1024 the mode is
+        // width-independent (one segmented codepath at every width), so the
+        // hash carries NO width term there -- growing-prefill callers never
+        // recompile crossing the old 65536 fused boundary. For smaller k the
+        // mode still folds in the <= 32-chunk fused bit, the only width term.
         static_cast<uint32_t>(program::compute_body_mode(attrs.k, input.logical_shape()[-1])));
 }
 
@@ -112,10 +193,15 @@ spec_return_value_t TopkLargeIndicesDeviceOperation::compute_output_specs(
         output_shape_vec.push_back(input_shape[i]);
     }
     output_shape_vec.back() = attrs.k;
+    if (attrs.row_count.has_value()) {
+        // Row-window launch: the output carries only the window's rows.
+        output_shape_vec[output_shape_vec.size() - 2] = *attrs.row_count;
+    }
+    const ttnn::Shape output_shape(std::move(output_shape_vec));
 
     const auto memory_config = tensor_args.input_tensor.memory_config();
     return tt::tt_metal::TensorSpec(
-        ttnn::Shape(std::move(output_shape_vec)),
+        output_shape,
         tt::tt_metal::TensorLayout(DataType::UINT32, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), memory_config));
 }
 
@@ -125,21 +211,116 @@ tensor_return_value_t TopkLargeIndicesDeviceOperation::create_output_tensors(
 }
 
 std::tuple<TopkLargeIndicesDeviceOperation::operation_attributes_t, TopkLargeIndicesDeviceOperation::tensor_args_t>
-TopkLargeIndicesDeviceOperation::invoke(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length) {
-    return {operation_attributes_t{.k = k, .valid_length = valid_length}, tensor_args_t{.input_tensor = input_tensor}};
+TopkLargeIndicesDeviceOperation::invoke(
+    const Tensor& input_tensor,
+    uint32_t k,
+    std::optional<uint32_t> valid_length,
+    std::optional<uint32_t> num_slices,
+    std::optional<uint32_t> row_start,
+    std::optional<uint32_t> row_count) {
+    return {
+        operation_attributes_t{
+            .k = k,
+            .valid_length = valid_length,
+            .num_slices = num_slices,
+            .row_start = row_start,
+            .row_count = row_count},
+        tensor_args_t{.input_tensor = input_tensor}};
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices
 
 namespace ttnn::experimental {
 
+namespace {
+
+// Hybrid row split: for canonical multi-row calls whose rows exceed the worker
+// grid (>= 2 row-parallel waves), peel the partially-filled last wave off into
+// a concurrent multi-rectangle launch — the row-parallel full waves keep every
+// core busy, and the remainder rows run column-parallel trees on the cores the
+// last wave would have left idle. Two launches over one un-sliced input (the
+// device op's internal row window), then a cheap [rows, k] concat. Returns
+// (full-wave rows, remainder rows, remainder P), or nullopt when the plain
+// single launch is already the right program.
+struct HybridSplit {
+    uint32_t full_wave_rows;
+    uint32_t remainder_rows;
+    uint32_t remainder_slices;
+};
+std::optional<HybridSplit> hybrid_row_split(
+    const Tensor& input, uint32_t k, std::optional<uint32_t> num_slices, std::optional<uint32_t> valid_length) {
+    if (num_slices.has_value()) {
+        // An internal caller already chose an explicit P: keep its single launch.
+        return std::nullopt;
+    }
+    if (input.storage_type() != StorageType::DEVICE || input.device() == nullptr) {
+        return std::nullopt;
+    }
+    const auto& shape = input.logical_shape();
+    if (shape.rank() < 2) {
+        return std::nullopt;
+    }
+    const uint32_t rows = operations::experimental::topk_large_indices::flattened_rows_excluding_last_dim(shape);
+    if (rows == 0 || rows != shape[shape.rank() - 2]) {
+        return std::nullopt;  // the row window needs the canonical [1.., R, W] shape
+    }
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const uint32_t cores = static_cast<uint32_t>(grid.x) * static_cast<uint32_t>(grid.y);
+    if (cores == 0 || rows <= cores) {
+        return std::nullopt;  // single row-parallel wave (or the model's own rect pick) already optimal
+    }
+    const uint32_t waves = tt::div_up(rows, cores);
+    const uint32_t r1 = cores * (waves - 1);
+    const uint32_t r2 = rows - r1;
+    // Split only when the remainder genuinely takes (and wins on) the
+    // multi-rectangle path; otherwise the extra launch + concat is pure cost.
+    // Model on the SEARCHED width (valid_length when set), not the buffer's
+    // logical width: preallocated-buffer callers (the DSA indexer grows
+    // valid_length across prefill inside a fixed 1M buffer) otherwise get a
+    // rect window sized for chunks that never run -- measured 2204us for a
+    // 30-row remainder vs 1424us for a FULL 130-row wave at buf=1M/valid=512k,
+    // turning the hybrid into a net loss. The chosen num_slices is an op attr
+    // (hashed), so distinct valid regimes compile distinct remainder programs;
+    // the cost model quantizes P to a handful of values, so cache growth is
+    // bounded.
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t searched = std::min(valid_length.value_or(n), n);
+    // Model on the searched width. Note the rect window's slice boundaries
+    // are position-based over the LOGICAL row, so a short valid prefix
+    // empties trailing slices and the busy ones keep near-full per-slice
+    // work (measured at buf=1M/valid=512k k=2048: remainder 1424us vs 720us
+    // when the trees are sized to the valid width) -- degraded, but still
+    // well ahead of the row-parallel wave (2204us/row-set at that shape), so
+    // the split stays profitable at any valid_length. Runtime slice
+    // rebalancing from valid_length is the follow-up that recovers the gap.
+    const auto cfg = operations::experimental::topk_large_indices::program::compute_column_split_config(
+        k, searched, r2, grid, std::nullopt, /*allow_multi_row=*/true);
+    if (!cfg.enabled || cfg.num_rects < 2) {
+        return std::nullopt;
+    }
+    // The remainder launch passes cfg.num_slices explicitly to pin the P
+    // modeled on the SEARCHED width above: the device op's own auto model
+    // (column_split_config_for) runs on the physical width and could pick a
+    // different split (or none) for the remainder window.
+    return HybridSplit{r1, r2, cfg.num_slices};
+}
+
+}  // namespace
+
 Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length) {
-    auto [operation_attributes, tensor_args] =
-        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation::invoke(
-            input_tensor, k, valid_length);
-    return ttnn::device_operation::launch<
-        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation>(
-        operation_attributes, tensor_args);
+    using Op = operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation;
+    if (const auto split = hybrid_row_split(input_tensor, k, std::nullopt, valid_length)) {
+        auto run = [&](uint32_t start, uint32_t count, std::optional<uint32_t> window_slices) {
+            auto [attrs, args] = Op::invoke(input_tensor, k, valid_length, window_slices, start, count);
+            return ttnn::device_operation::launch<Op>(attrs, args);
+        };
+        Tensor full_waves = run(0, split->full_wave_rows, std::nullopt);
+        Tensor remainder = run(split->full_wave_rows, split->remainder_rows, split->remainder_slices);
+        const int rows_dim = static_cast<int>(input_tensor.logical_shape().rank()) - 2;
+        return ttnn::concat(std::vector<Tensor>{full_waves, remainder}, rows_dim);
+    }
+    auto [operation_attributes, tensor_args] = Op::invoke(input_tensor, k, valid_length);
+    return ttnn::device_operation::launch<Op>(operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -4,8 +4,6 @@
 
 #include "topk_large_indices_device_operation.hpp"
 
-#include <algorithm>
-
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 
 #include <tt-metalium/hal.hpp>
@@ -248,7 +246,7 @@ struct HybridSplit {
     uint32_t remainder_slices;
 };
 std::optional<HybridSplit> hybrid_row_split(
-    const Tensor& input, uint32_t k, std::optional<uint32_t> num_slices, std::optional<uint32_t> valid_length) {
+    const Tensor& input, uint32_t k, std::optional<uint32_t> num_slices) {
     if (num_slices.has_value()) {
         // An internal caller already chose an explicit P: keep its single launch.
         return std::nullopt;
@@ -274,34 +272,18 @@ std::optional<HybridSplit> hybrid_row_split(
     const uint32_t r2 = rows - r1;
     // Split only when the remainder genuinely takes (and wins on) the
     // multi-rectangle path; otherwise the extra launch + concat is pure cost.
-    // Model on the SEARCHED width (valid_length when set), not the buffer's
-    // logical width: preallocated-buffer callers (the DSA indexer grows
-    // valid_length across prefill inside a fixed 1M buffer) otherwise get a
-    // rect window sized for chunks that never run -- measured 2204us for a
-    // 30-row remainder vs 1424us for a FULL 130-row wave at buf=1M/valid=512k,
-    // turning the hybrid into a net loss. The chosen num_slices is an op attr
-    // (hashed), so distinct valid regimes compile distinct remainder programs;
-    // the cost model quantizes P to a handful of values, so cache growth is
-    // bounded.
+    // Model the hybrid structure on the PHYSICAL width, matching the regular
+    // column-parallel path. valid_length is a runtime-only search bound: it
+    // rebalances active chunks inside the already-selected slices and must not
+    // select a different factory, P, or program hash as a prefix grows.
     const uint32_t n = shape[shape.rank() - 1];
-    const uint32_t searched = std::min(valid_length.value_or(n), n);
-    // Model on the searched width. Note the rect window's slice boundaries
-    // are position-based over the LOGICAL row, so a short valid prefix
-    // empties trailing slices and the busy ones keep near-full per-slice
-    // work (measured at buf=1M/valid=512k k=2048: remainder 1424us vs 720us
-    // when the trees are sized to the valid width) -- degraded, but still
-    // well ahead of the row-parallel wave (2204us/row-set at that shape), so
-    // the split stays profitable at any valid_length. Runtime slice
-    // rebalancing from valid_length is the follow-up that recovers the gap.
     const auto cfg = operations::experimental::topk_large_indices::program::compute_column_split_config(
-        k, searched, r2, grid, std::nullopt, /*allow_multi_row=*/true);
+        k, n, r2, grid, std::nullopt, /*allow_multi_row=*/true);
     if (!cfg.enabled || cfg.num_rects < 2) {
         return std::nullopt;
     }
-    // The remainder launch passes cfg.num_slices explicitly to pin the P
-    // modeled on the SEARCHED width above: the device op's own auto model
-    // (column_split_config_for) runs on the physical width and could pick a
-    // different split (or none) for the remainder window.
+    // Pin the remainder P explicitly so its row-window launch uses exactly the
+    // physical-width split selected here.
     return HybridSplit{r1, r2, cfg.num_slices};
 }
 
@@ -309,7 +291,7 @@ std::optional<HybridSplit> hybrid_row_split(
 
 Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length) {
     using Op = operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation;
-    if (const auto split = hybrid_row_split(input_tensor, k, std::nullopt, valid_length)) {
+    if (const auto split = hybrid_row_split(input_tensor, k, std::nullopt)) {
         auto run = [&](uint32_t start, uint32_t count, std::optional<uint32_t> window_slices) {
             auto [attrs, args] = Op::invoke(input_tensor, k, valid_length, window_slices, start, count);
             return ttnn::device_operation::launch<Op>(attrs, args);
@@ -317,7 +299,8 @@ Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k, std::optional<
         Tensor full_waves = run(0, split->full_wave_rows, std::nullopt);
         Tensor remainder = run(split->full_wave_rows, split->remainder_rows, split->remainder_slices);
         const int rows_dim = static_cast<int>(input_tensor.logical_shape().rank()) - 2;
-        return ttnn::concat(std::vector<Tensor>{full_waves, remainder}, rows_dim);
+        return ttnn::concat(
+            std::vector<Tensor>{full_waves, remainder}, rows_dim, input_tensor.memory_config());
     }
     auto [operation_attributes, tensor_args] = Op::invoke(input_tensor, k, valid_length);
     return ttnn::device_operation::launch<Op>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
@@ -20,7 +20,11 @@ struct TopkLargeIndicesDeviceOperation {
     using tensor_return_value_t = topk_large_indices::tensor_return_value_t;
     using spec_return_value_t = topk_large_indices::spec_return_value_t;
 
-    using program_factory_t = std::variant<program::TopkLargeIndicesProgramFactory>;
+    using program_factory_t =
+        std::variant<program::TopkLargeIndicesProgramFactory, program::TopkLargeIndicesMultiCoreProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
 
     static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
@@ -33,8 +37,15 @@ struct TopkLargeIndicesDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
 
+    // num_slices, row_start, and row_count are composite-internal (the hybrid row split and the
+    // remainder window's tree launch); the public API passes only (input, k, valid_length).
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length);
+        const Tensor& input_tensor,
+        uint32_t k,
+        std::optional<uint32_t> valid_length,
+        std::optional<uint32_t> num_slices = std::nullopt,
+        std::optional<uint32_t> row_start = std::nullopt,
+        std::optional<uint32_t> row_count = std::nullopt);
 };
 
 }  // namespace ttnn::operations::experimental::topk_large_indices

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
@@ -33,6 +33,25 @@ struct operation_attributes_t {
     // without physically slicing the input. nullopt = search the full width. Runtime-only (hash-excluded,
     // validated on cache hit) so a serving loop growing valid_length reuses one program.
     std::optional<uint32_t> valid_length{};
+    // INTERNAL (not exposed through the public API): override the column-parallel slice count P
+    // (tree cores splitting each row). Single row: the classic column-parallel tree. Multiple
+    // rows: the multi-rectangle variant — one P-core tree per rectangle, rows split contiguously
+    // over as many rectangles as tile the worker grid, all concurrent (the cost model can also
+    // auto-select this form when it models a win; the override bypasses the model and pins an
+    // exact P — the hybrid wrapper's remainder window sets it to a searched-width-modeled P).
+    // Values outside [2, 128] or above the row's chunk count are loud errors; P is clamped only
+    // against the physical core grid (with a warning). Changes the program structure, so it is
+    // part of the program hash. nullopt = the built-in cost model.
+    std::optional<uint32_t> num_slices{};
+    // Composite-internal row window [row_start, row_start + row_count): the op reads only these
+    // input rows and emits a row_count-row output. Set by the hybrid wrapper (ttnn::experimental::
+    // topk_large_indices) to run row-parallel full waves and a multi-rectangle remainder wave as
+    // two launches over one un-sliced input; not exposed through the public bindings. Requires the
+    // canonical [1.., R, W] shape (leading dims 1). Runtime-only for the program itself (rows are
+    // runtime args); the effective row count feeds the derived split config, whose hashed fields
+    // already capture any structural difference.
+    std::optional<uint32_t> row_start{};
+    std::optional<uint32_t> row_count{};
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
@@ -4,12 +4,16 @@
 
 #include "topk_large_indices_program_factory.hpp"
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
+#include <algorithm>
+#include <map>
 #include <optional>
+#include <string>
 #include <tuple>
 
 namespace ttnn::operations::experimental::topk_large_indices::program {
@@ -66,6 +70,69 @@ tt::tt_metal::TensorAccessorArgs interleaved_accessor_args(const Tensor& tensor)
                                       : tt::tt_metal::TensorAccessorArgs::create_l1_interleaved();
 }
 
+// Double-buffered input chunk-staging CB, identical in both factories.
+void create_input_cb(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& cores,
+    uint32_t cb_depth,
+    uint32_t tiles_per_sequence,
+    uint32_t input_tile_bytes,
+    uint32_t cb_in) {
+    const auto input_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_depth * tiles_per_sequence * input_tile_bytes, {{cb_in, tt::DataFormat::Float16_b}})
+            .set_page_size(cb_in, input_tile_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, cores, input_cb_config);
+}
+
+// Output-side CBs (materialized index row + face-reorder scratch), identical
+// in both factories; the tree factory creates them on the root cores only.
+// The indices CB carries the raw 32-bit index words the packer produces.
+void create_indices_output_cbs(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& cores,
+    LlkTargetK llk_target_k,
+    uint32_t cb_depth,
+    uint32_t indices_cb_row_bytes,
+    uint32_t indices_row_bytes,
+    uint32_t cb_indices,
+    uint32_t cb_indices_scratch) {
+    auto indices_cb_config =
+        tt::tt_metal::CircularBufferConfig(cb_depth * indices_cb_row_bytes, {{cb_indices, tt::DataFormat::Float32}})
+            .set_page_size(cb_indices, indices_cb_row_bytes);
+    if (llk_target_k == LlkTargetK::K512) {
+        indices_cb_config.set_unpack_face_geometry(cb_indices, tt::constants::FACE_HEIGHT, 2);
+    }
+    tt::tt_metal::CreateCircularBuffer(program, cores, indices_cb_config);
+
+    if (llk_target_k != LlkTargetK::K512) {
+        const auto indices_scratch_cb_config =
+            tt::tt_metal::CircularBufferConfig(indices_row_bytes, {{cb_indices_scratch, tt::DataFormat::Float32}})
+                .set_page_size(cb_indices_scratch, indices_row_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, cores, indices_scratch_cb_config);
+    }
+}
+
+// Chunked row reader (kernels/reader.cpp), shared source for both factories;
+// the tree factory passes TOPK_TREE to enable the per-core slice offset.
+tt::tt_metal::KernelHandle create_reader_kernel(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& cores,
+    const Tensor& input,
+    uint32_t cb_in,
+    uint32_t input_chunk_bytes,
+    uint32_t input_tile_bytes,
+    uint32_t tiles_per_sequence,
+    std::map<std::string, std::string> defines) {
+    std::vector<uint32_t> reader_compile_args = {cb_in, input_chunk_bytes, input_tile_bytes, tiles_per_sequence};
+    interleaved_accessor_args(input).append_to(reader_compile_args);
+    return tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader.cpp",
+        cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args, std::move(defines)));
+}
+
 uint32_t rows_for_core(
     const CoreCoord& core,
     const CoreRangeSet& core_group_1,
@@ -86,11 +153,16 @@ void set_runtime_args(
     const TopkLargeIndicesSharedVariables& shared,
     const Tensor& input,
     const Tensor& indices,
-    LlkTargetK llk_target_k,
-    std::optional<uint32_t> valid_length) {
+    const operation_attributes_t& attrs) {
+    const LlkTargetK llk_target_k = snap_to_llk_target_k(attrs.k);
+    const std::optional<uint32_t> valid_length = attrs.valid_length;
     const auto runtime_args = get_runtime_shape_args(input, llk_target_k, valid_length);
-    const auto work_split = tt::tt_metal::split_work_to_cores(
-        input.device()->compute_with_storage_grid_size(), runtime_args.num_rows, true);
+    // Row window (hybrid wrapper): readers index global input rows from row_base;
+    // writers stay output-relative (the window's output has its own row 0).
+    const uint32_t row_base = attrs.row_start.value_or(0);
+    const uint32_t effective_rows = attrs.row_count.value_or(runtime_args.num_rows);
+    const auto work_split =
+        tt::tt_metal::split_work_to_cores(input.device()->compute_with_storage_grid_size(), effective_rows, true);
     const auto num_active_cores = std::get<0>(work_split);
     const auto& core_group_1 = std::get<2>(work_split);
     const auto& core_group_2 = std::get<3>(work_split);
@@ -108,12 +180,13 @@ void set_runtime_args(
             rows,
             num_rows_per_core_group_1);
 
+        const uint32_t input_row = row_base + start_row;
         tt::tt_metal::SetRuntimeArgs(
             program,
             shared.reader_kernel_id,
             core,
             {input.buffer()->address(),
-             start_row,
+             input_row,
              rows,
              runtime_args.num_chunks,
              runtime_args.input_tail_chunk_bytes,
@@ -126,28 +199,10 @@ void set_runtime_args(
         start_row += rows;
     }
     TT_FATAL(
-        start_row == runtime_args.num_rows,
-        "topk_large_indices assigned {} rows, expected {}",
-        start_row,
-        runtime_args.num_rows);
+        start_row == effective_rows, "topk_large_indices assigned {} rows, expected {}", start_row, effective_rows);
 }
 
 }  // namespace
-
-ComputeBodyMode compute_body_mode(uint32_t k, uint32_t input_last_dim) {
-    const uint32_t llk_k = to_uint32(snap_to_llk_target_k(k));
-
-    // For an internal K >= 1024, segmented fusion handles every width with
-    // one binary; rows of at most 32 chunks naturally execute as one segment.
-    // Gate on the snapped LLK K so public k values in [528, 1008] get the same
-    // fused body as k=1024 instead of silently falling back to classic.
-    if (llk_k >= to_uint32(LlkTargetK::K1024)) {
-        return ComputeBodyMode::FusedSegmented;
-    }
-
-    const uint32_t physical_chunks = tt::div_up(input_last_dim, llk_k);
-    return physical_chunks <= 32 ? ComputeBodyMode::FusedEndToEnd : ComputeBodyMode::Classic;
-}
 
 TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory::create(
     const operation_attributes_t& operation_attributes,
@@ -180,39 +235,28 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
     const uint32_t output_slices_per_row = k / row_slice_elements;
     const uint32_t indices_slice_bytes = row_slice_elements * indices.element_size();
     const uint32_t indices_row_bytes = k * indices.element_size();
-    const uint32_t indices_cb_row_bytes = llk_k * indices.element_size();
+    // The indices CB carries the raw 32-bit index words the packer produces.
+    const uint32_t indices_cb_row_bytes = llk_k * static_cast<uint32_t>(sizeof(uint32_t));
 
     const uint32_t cb_depth = 2;
-    const auto input_cb_config =
-        tt::tt_metal::CircularBufferConfig(
-            cb_depth * tiles_per_sequence * input_tile_bytes, {{cb_in, tt::DataFormat::Float16_b}})
-            .set_page_size(cb_in, input_tile_bytes);
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, input_cb_config);
-
-    auto indices_cb_config =
-        tt::tt_metal::CircularBufferConfig(cb_depth * indices_cb_row_bytes, {{cb_indices, tt::DataFormat::Float32}})
-            .set_page_size(cb_indices, indices_cb_row_bytes);
-    if (llk_target_k == LlkTargetK::K512) {
-        indices_cb_config.set_unpack_face_geometry(cb_indices, tt::constants::FACE_HEIGHT, 2);
-    }
-    tt::tt_metal::CreateCircularBuffer(program, all_cores, indices_cb_config);
-
-    if (llk_target_k != LlkTargetK::K512) {
-        const auto indices_scratch_cb_config =
-            tt::tt_metal::CircularBufferConfig(indices_row_bytes, {{cb_indices_scratch, tt::DataFormat::Float32}})
-                .set_page_size(cb_indices_scratch, indices_row_bytes);
-        tt::tt_metal::CreateCircularBuffer(program, all_cores, indices_scratch_cb_config);
-    }
-
-    std::vector<uint32_t> reader_compile_args = {cb_in, input_chunk_bytes, input_tile_bytes, tiles_per_sequence};
-    interleaved_accessor_args(input).append_to(reader_compile_args);
-
-    auto reader_kernel = tt::tt_metal::CreateKernel(
+    create_input_cb(program, all_cores, cb_depth, tiles_per_sequence, input_tile_bytes, cb_in);
+    create_indices_output_cbs(
         program,
-        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader.cpp",
         all_cores,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
+        llk_target_k,
+        cb_depth,
+        indices_cb_row_bytes,
+        indices_row_bytes,
+        cb_indices,
+        cb_indices_scratch);
 
+    auto reader_kernel = create_reader_kernel(
+        program, all_cores, input, cb_in, input_chunk_bytes, input_tile_bytes, tiles_per_sequence, /*defines=*/{});
+
+    // Row-reduction body (classic / fused end-to-end / fused segmented),
+    // selected host-side from (k, physical last dim) and passed as a
+    // compile-time arg the kernel dispatches on with if constexpr. Derived
+    // from shape, so it is mirrored into compute_program_hash.
     const auto body_mode = compute_body_mode(k, input.logical_shape()[-1]);
     std::vector<uint32_t> compute_compile_args = {cb_in, cb_indices, llk_k, static_cast<uint32_t>(body_mode)};
     auto compute_kernel = tt::tt_metal::CreateKernel(
@@ -246,7 +290,7 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
         .compute_kernel_id = compute_kernel,
         .writer_kernel_id = writer_kernel,
         .cores = cores};
-    set_runtime_args(program, shared, input, indices, llk_target_k, operation_attributes.valid_length);
+    set_runtime_args(program, shared, input, tensor_return_value, operation_attributes);
 
     return cached_program_t{std::move(program), std::move(shared)};
 }
@@ -261,8 +305,634 @@ void TopkLargeIndicesProgramFactory::override_runtime_arguments(
         cached_program.shared_variables,
         tensor_args.input_tensor,
         tensor_return_value,
-        snap_to_llk_target_k(operation_attributes.k),
-        operation_attributes.valid_length);
+        operation_attributes);
+}
+
+// ---------------------------------------------------------------------------
+// Column-parallel (intra-row multi-core) path
+// ---------------------------------------------------------------------------
+
+// Slice-count cap: the in-place merge tree needs only one 2-sequence recv CB
+// per core (16 KB at K=2048), so L1 does not bind P; the envelope is 7 tree
+// levels (128 slices). In practice P is bound first by the worker-grid
+// rectangle capacity (e.g. 13x10 = 130 on P150) and the chunk count.
+constexpr uint32_t max_column_slices = 128;
+
+namespace {
+
+// ceil(log2(p)) for p >= 1: number of pairwise merge-tree levels.
+uint32_t tree_levels(uint32_t p) {
+    uint32_t levels = 0;
+    while ((1u << levels) < p) {
+        ++levels;
+    }
+    return levels;
+}
+
+// The built-in cost-model pick (no user override).
+ColumnSplitConfig compute_model_column_split_config(
+    uint32_t k, uint32_t n, uint32_t num_rows, const CoreCoord& grid, bool allow_multi_row) {
+    constexpr uint32_t max_slices = max_column_slices;
+
+    ColumnSplitConfig config{};
+    // Intra-row parallelism only pays off when rows cannot saturate the grid.
+    // Single row: the classic tree. Multiple rows (allow_multi_row): the
+    // multi-rectangle form, considered only when EVERY row gets its own
+    // concurrent rectangle (one rect-wave) — then the per-row cost comparison
+    // below is exact and, at any runtime valid_length, the rect's saturating
+    // makespan bounds the loss to one merge term while row-parallel would run
+    // the same single wave. Rows beyond every rectangle capacity keep the
+    // row-parallel factory (and its shape-free program hash) unchanged; the
+    // hybrid wrapper handles those by splitting off a remainder window.
+    if (num_rows != 1 && !allow_multi_row) {
+        return config;
+    }
+    if (static_cast<uint32_t>(grid.x * grid.y) < 2) {
+        return config;
+    }
+    if (num_rows == 0) {
+        return config;
+    }
+
+    const uint32_t llk_k = to_uint32(snap_to_llk_target_k(k));
+    // Physical width only: valid_length must stay runtime-only, so the split
+    // never depends on it (short valid prefixes empty out trailing slices at
+    // runtime instead of changing the program).
+    const uint32_t num_chunks = tt::div_up(n, llk_k);
+    if (num_chunks < 2) {
+        return config;
+    }
+
+    // Cost model in merge units: processing one chunk locally
+    // (copy + lsb + fused sort + index split + merge + rebuild) ~ 2 units,
+    // one tree merge+rebuild ~ 1 unit. With the log-tree the serial term is
+    // ceil(log2 P), so cost(P) = 2*ceil(chunks/P) + ceil(log2 P). Tree cores
+    // must form a rectangle, so search every a x b rectangle that fits the
+    // grid (a <= grid.x, b <= grid.y, a*b <= min(chunks, max_slices)) and
+    // take the cheapest P; ties prefer fewer cores. This beats the previous
+    // full-rows-only fit (e.g. 32 chunks on a 13x10 grid: 8x4 = 32 slices vs
+    // 13x2 = 26; 128+ chunks: 8x8 = 64 vs 13x4 = 52).
+    const uint32_t slice_ceiling = std::min(num_chunks, max_slices);
+    uint32_t num_slices = 0;
+    uint32_t local_grid_x = 0;
+    uint32_t local_grid_y = 0;
+    uint32_t best_cost = std::numeric_limits<uint32_t>::max();
+    for (uint32_t a = 1; a <= static_cast<uint32_t>(grid.x); ++a) {
+        for (uint32_t b = 1; b <= static_cast<uint32_t>(grid.y); ++b) {
+            const uint32_t p = a * b;
+            if (p < 2 || p > slice_ceiling) {
+                continue;
+            }
+            // Multi-row: every row must own a concurrent rectangle, so the
+            // candidate's grid-tiling capacity must cover the row count.
+            const uint32_t capacity = (static_cast<uint32_t>(grid.x) / a) * (static_cast<uint32_t>(grid.y) / b);
+            if (num_rows > capacity) {
+                continue;
+            }
+            const uint32_t cost = 2 * tt::div_up(num_chunks, p) + tree_levels(p);
+            if (cost < best_cost || (cost == best_cost && p < num_slices)) {
+                best_cost = cost;
+                num_slices = p;
+                local_grid_x = a;
+                local_grid_y = b;
+            }
+        }
+    }
+    if (num_slices < 2) {
+        return config;
+    }
+
+    const uint32_t cost_row = 2 * num_chunks;  // one row per core on the row-parallel path (single wave)
+    if (best_cost >= cost_row) {
+        return config;
+    }
+    // Multi-row acceptance needs a margin over row-parallel: the hybrid
+    // wrapper's remainder window adds a concat + a second dispatch, and bare
+    // multi-row calls (the device op auto-routes them here too — see
+    // column_split_config_for) shouldn't flip engines on a marginal modeled
+    // win the merge-unit model can't guarantee on silicon. Demand a >= 12.5%
+    // modeled win to keep marginal picks from netting negative.
+    if (num_rows > 1 && best_cost + std::max(2u, cost_row / 8) > cost_row) {
+        return config;
+    }
+
+    config.enabled = true;
+    config.num_slices = num_slices;
+    config.local_grid_x = local_grid_x;
+    config.local_grid_y = local_grid_y;
+    // Single row keeps the classic one-rectangle program (byte-identical to
+    // before multi-rect existed). Multi-row tiles at full capacity: rectangles
+    // beyond the runtime row count run zero rows, so the program (and its
+    // hash) is row-count-free within this mode — one cached program serves
+    // any rows in [1, capacity].
+    config.num_rects = (num_rows == 1) ? 1
+                                       : (static_cast<uint32_t>(grid.x) / local_grid_x) *
+                                             (static_cast<uint32_t>(grid.y) / local_grid_y);
+    return config;
+}
+
+}  // namespace
+
+ComputeBodyMode compute_body_mode(uint32_t k, uint32_t input_last_dim) {
+    const uint32_t llk_k = to_uint32(snap_to_llk_target_k(k));
+
+    // For an internal K >= 1024, segmented fusion handles every width with
+    // one binary; rows of at most 32 chunks naturally execute as one segment.
+    // Gate on the snapped LLK K so public k values in [528, 1008] get the same
+    // fused body as k=1024 instead of silently falling back to classic.
+    if (llk_k >= to_uint32(LlkTargetK::K1024)) {
+        return ComputeBodyMode::FusedSegmented;
+    }
+
+    const uint32_t physical_chunks = tt::div_up(input_last_dim, llk_k);
+    return physical_chunks <= 32 ? ComputeBodyMode::FusedEndToEnd : ComputeBodyMode::Classic;
+}
+
+ColumnSplitConfig compute_column_split_config(
+    uint32_t k,
+    uint32_t n,
+    uint32_t num_rows,
+    const CoreCoord& grid,
+    std::optional<uint32_t> num_slices_override,
+    bool allow_multi_row) {
+    ColumnSplitConfig config = compute_model_column_split_config(k, n, num_rows, grid, allow_multi_row);
+    if (!num_slices_override.has_value()) {
+        return config;
+    }
+
+    // Explicit num_slices selects the tree path directly. Single row: the
+    // classic column-parallel tree. Multiple rows: the multi-rectangle
+    // variant — one P-core tree per rectangle, rows split contiguously across
+    // as many rectangles as tile the grid, all running concurrently. (The
+    // built-in cost model can also auto-select the multi-row form when it
+    // models a win; the override bypasses the model and pins an exact P —
+    // the hybrid wrapper uses it to carry a P modeled on the searched width.)
+    TT_FATAL(
+        static_cast<uint32_t>(grid.x * grid.y) >= 2,
+        "topk_large_indices num_slices={} needs a worker grid of at least 2 cores",
+        *num_slices_override);
+
+    const uint32_t requested = *num_slices_override;
+    TT_FATAL(
+        requested >= 2 && requested <= max_column_slices,
+        "topk_large_indices num_slices must be in [2, {}], got {}",
+        max_column_slices,
+        requested);
+    const uint32_t llk_k = to_uint32(snap_to_llk_target_k(k));
+    const uint32_t num_chunks = tt::div_up(n, llk_k);
+    TT_FATAL(
+        requested <= num_chunks,
+        "topk_large_indices num_slices={} exceeds the row's chunk count {} (last dim {} / LLK window {}); every "
+        "slice must own at least one chunk",
+        requested,
+        num_chunks,
+        n,
+        llk_k);
+
+    // Clamp only against the physical grid (rectangle capacity), with a warning.
+    // Honor the requested count with an exact a x b rectangle when one fits
+    // the grid (e.g. 32 = 8x4 on 13x10); otherwise fall back to the largest
+    // achievable product <= requested, with a warning. The old full-rows-only
+    // fit silently clamped 16->13, 24->13, 32->26, mislabeling P-sweeps.
+    uint32_t num_slices = 0;
+    uint32_t local_grid_x = 0;
+    uint32_t local_grid_y = 0;
+    // Among rectangles of equal core count, prefer the shape that tiles the
+    // grid the most times: with rows > 1 the tiling capacity IS the rectangle
+    // concurrency (a 2x2 fit tiles a 13x10 grid 30 times; a 1x4 fit only 26,
+    // silently doubling some rectangles' row load).
+    uint32_t best_capacity = 0;
+    for (uint32_t a = 1; a <= static_cast<uint32_t>(grid.x); ++a) {
+        for (uint32_t b = 1; b <= static_cast<uint32_t>(grid.y); ++b) {
+            const uint32_t p = a * b;
+            if (p > requested) {
+                continue;
+            }
+            const uint32_t capacity = (static_cast<uint32_t>(grid.x) / a) * (static_cast<uint32_t>(grid.y) / b);
+            if (p > num_slices || (p == num_slices && capacity > best_capacity)) {
+                num_slices = p;
+                local_grid_x = a;
+                local_grid_y = b;
+                best_capacity = capacity;
+            }
+        }
+    }
+    if (num_slices != requested) {
+        log_warning(
+            tt::LogOp,
+            "topk_large_indices num_slices={} does not fit the {}x{} worker grid's local-core rectangle; "
+            "clamped to {} ({}x{} tree cores, in-place root)",
+            requested,
+            grid.x,
+            grid.y,
+            num_slices,
+            local_grid_x,
+            local_grid_y);
+    }
+
+    config.enabled = true;
+    config.num_slices = num_slices;
+    config.local_grid_x = local_grid_x;
+    config.local_grid_y = local_grid_y;
+    // Single row keeps the classic one-rectangle program; multi-row tiles at
+    // full capacity (rectangles beyond the runtime row count run zero rows):
+    // row distribution is pure runtime args, so one cached program serves any
+    // row count with this layout.
+    config.num_rects =
+        (num_rows == 1)
+            ? 1
+            : std::max(
+                  1u, (static_cast<uint32_t>(grid.x) / local_grid_x) * (static_cast<uint32_t>(grid.y) / local_grid_y));
+    return config;
+}
+
+namespace {
+
+struct SliceRuntime {
+    uint32_t start_chunk = 0;    // index of the slice's first chunk within the row
+    uint32_t start_element = 0;  // start_chunk * llk_k
+    uint32_t num_chunks = 0;     // active chunks after the valid_length cut (0 = empty slice)
+    uint32_t tail_elements = 0;  // active elements in the slice's last chunk
+};
+
+// Splits the VALID chunk range (bounded by the runtime search width) evenly
+// over the slices. Balancing on valid rather than physical chunks keeps every
+// tree working when a preallocated buffer carries a short valid prefix (the
+// DSA indexer grows valid_length inside a fixed 1M buffer): position-based
+// physical splitting emptied the trailing slices while the busy ones kept
+// near-full per-slice work — measured 1424us vs 720us for a 30-row remainder
+// window at buf=1M/valid=512k k=2048. Slices beyond the valid chunk count
+// come back empty and are serviced by the writer's -inf fill; everything here
+// is runtime-only, so one cached program serves any valid_length with
+// freshly balanced slices.
+std::vector<SliceRuntime> compute_slice_runtime(
+    uint32_t n, uint32_t llk_k, uint32_t num_slices, std::optional<uint32_t> valid_length) {
+    const uint32_t search_len = std::min(valid_length.value_or(n), n);
+    const uint32_t num_chunks_valid = tt::div_up(search_len, llk_k);
+    const uint32_t base_chunks = num_chunks_valid / num_slices;
+    const uint32_t extra_chunks = num_chunks_valid % num_slices;
+
+    std::vector<SliceRuntime> slices(num_slices);
+    uint32_t start_chunk = 0;
+    for (uint32_t s = 0; s < num_slices; ++s) {
+        const uint32_t chunk_count = base_chunks + (s < extra_chunks ? 1 : 0);
+        const uint32_t start_element = start_chunk * llk_k;
+        const uint32_t active_end = std::min((start_chunk + chunk_count) * llk_k, search_len);
+
+        SliceRuntime& slice = slices[s];
+        slice.start_chunk = start_chunk;
+        slice.start_element = start_element;
+        if (chunk_count > 0 && active_end > start_element) {
+            const uint32_t active_len = active_end - start_element;
+            slice.num_chunks = tt::div_up(active_len, llk_k);
+            slice.tail_elements = active_len - ((slice.num_chunks - 1) * llk_k);
+        }
+        start_chunk += chunk_count;
+    }
+    TT_FATAL(
+        start_chunk == num_chunks_valid,
+        "topk_large_indices column split assigned {} chunks, expected {}",
+        start_chunk,
+        num_chunks_valid);
+    return slices;
+}
+
+void set_runtime_args_multi_core(
+    tt::tt_metal::Program& program,
+    const TopkLargeIndicesMultiCoreSharedVariables& shared,
+    const Tensor& input,
+    const Tensor& indices,
+    const operation_attributes_t& attrs) {
+    const LlkTargetK llk_target_k = snap_to_llk_target_k(attrs.k);
+    const std::optional<uint32_t> valid_length = attrs.valid_length;
+    const uint32_t llk_k = to_uint32(llk_target_k);
+    const auto& shape = input.logical_shape();
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t num_rows = flattened_rows_excluding_last_dim(shape);
+    const uint32_t input_row_bytes = n * input.element_size();
+    const uint32_t num_rects = static_cast<uint32_t>(shared.rect_cores.size());
+    TT_FATAL(num_rects >= 1, "topk_large_indices multi-core program has no rectangles");
+    const uint32_t num_slices = static_cast<uint32_t>(shared.rect_cores[0].size());
+    const uint32_t num_levels = tree_levels(num_slices);
+    TT_FATAL(
+        num_levels <= 7, "topk_large_indices merge tree supports at most 7 levels (128 slices), got {}", num_levels);
+
+    const auto slices = compute_slice_runtime(n, llk_k, num_slices, valid_length);
+    auto* device = input.device();
+
+    // Rows split contiguously across the leading rectangles (runtime-only,
+    // like valid_length: a different row count reuses this cached program;
+    // rectangles beyond the row count run zero rows and exit immediately).
+    // Row window (hybrid wrapper): readers index global input rows from
+    // row_base; writers stay output-relative.
+    const uint32_t row_base = attrs.row_start.value_or(0);
+    const uint32_t effective_rows = attrs.row_count.value_or(num_rows);
+    const uint32_t rects_used = std::max(1u, std::min(effective_rows, num_rects));
+    const uint32_t base_rows = effective_rows / rects_used;
+    const uint32_t extra_rows = effective_rows % rects_used;
+
+    uint32_t rect_start_row = 0;
+    for (uint32_t r = 0; r < num_rects; ++r) {
+        const auto& rect = shared.rect_cores[r];
+        const uint32_t rect_rows = (r < rects_used) ? base_rows + (r < extra_rows ? 1 : 0) : 0;
+        const uint32_t start_row = rect_start_row;
+        rect_start_row += rect_rows;
+
+        for (uint32_t i = 0; i < num_slices; ++i) {
+            const auto& core = rect[i];
+            const auto& slice = slices[i];
+            const uint32_t input_row = row_base + start_row;
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                shared.reader_kernel_id,
+                core,
+                {input.buffer()->address(),
+                 input_row,
+                 rect_rows,
+                 slice.num_chunks,
+                 slice.tail_elements * input.element_size(),
+                 input_row_bytes,
+                 slice.start_element * input.element_size()});
+
+            // Tree schedule for slice i: it wins levels [0, t) where t is the
+            // index of i's lowest set bit (root i=0 wins every level), merging
+            // partner i + 2^level whenever that slice exists (byes otherwise),
+            // then ships its survivor to i with the lowest set bit cleared.
+            const bool is_root = (i == 0);
+            uint32_t winning_levels = num_levels;
+            if (!is_root) {
+                winning_levels = 0;
+                while (((i >> winning_levels) & 1u) == 0) {
+                    ++winning_levels;
+                }
+            }
+            uint32_t num_merges = 0;
+            // 7 (x, y) pairs — must match the tree writer's partner_x/y[7] and
+            // the positional offsets of the args that follow (do_ship at 16).
+            std::vector<uint32_t> partner_coords(14, 0);
+            for (uint32_t level = 0; level < winning_levels; ++level) {
+                const uint32_t partner = i + (1u << level);
+                if (partner < num_slices) {
+                    const CoreCoord partner_physical = device->worker_core_from_logical_core(rect[partner]);
+                    partner_coords[2 * num_merges] = static_cast<uint32_t>(partner_physical.x);
+                    partner_coords[2 * num_merges + 1] = static_cast<uint32_t>(partner_physical.y);
+                    ++num_merges;
+                }
+            }
+
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                is_root ? shared.compute_root_kernel_id : shared.compute_node_kernel_id,
+                core,
+                {rect_rows, slice.num_chunks, slice.tail_elements, slice.start_chunk, num_merges});
+
+            uint32_t winner_x = 0;
+            uint32_t winner_y = 0;
+            if (!is_root) {
+                const uint32_t winner = i & (i - 1);  // clear the lowest set bit
+                const CoreCoord winner_physical = device->worker_core_from_logical_core(rect[winner]);
+                winner_x = static_cast<uint32_t>(winner_physical.x);
+                winner_y = static_cast<uint32_t>(winner_physical.y);
+            }
+            // A shipping core with an empty slice AND no adopted partners has no
+            // survivor in DST; its writer sends the prefilled -inf sequence.
+            const uint32_t is_empty_ship = (!is_root && slice.num_chunks == 0 && num_merges == 0) ? 1u : 0u;
+
+            std::vector<uint32_t> writer_args;
+            writer_args.reserve(22);
+            writer_args.push_back(rect_rows);
+            writer_args.push_back(num_merges);
+            for (uint32_t v : partner_coords) {
+                writer_args.push_back(v);
+            }
+            writer_args.push_back(is_root ? 0u : 1u);  // do_ship
+            writer_args.push_back(winner_x);
+            writer_args.push_back(winner_y);
+            writer_args.push_back(is_empty_ship);
+            writer_args.push_back(indices.buffer()->address());
+            // The tree writer reads start_row at arg 21, directly after the indices address.
+            writer_args.push_back(start_row);
+            tt::tt_metal::SetRuntimeArgs(program, shared.writer_kernel_id, core, writer_args);
+        }
+    }
+    TT_FATAL(
+        rect_start_row == effective_rows,
+        "topk_large_indices multi-rect assigned {} rows, expected {}",
+        rect_start_row,
+        effective_rows);
+}
+
+}  // namespace
+
+TopkLargeIndicesMultiCoreProgramFactory::cached_program_t TopkLargeIndicesMultiCoreProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto program = tt::tt_metal::CreateProgram();
+
+    const auto& input = tensor_args.input_tensor;
+    auto& indices = tensor_return_value;
+
+    const uint32_t k = operation_attributes.k;
+    const auto llk_target_k = snap_to_llk_target_k(k);
+    const uint32_t llk_k = to_uint32(llk_target_k);
+    const uint32_t tiles_per_sequence = (llk_k + tt::constants::TILE_HW - 1) / tt::constants::TILE_HW;
+
+    const auto& shape = input.logical_shape();
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t num_rows = operation_attributes.row_count.value_or(flattened_rows_excluding_last_dim(shape));
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const auto config =
+        compute_column_split_config(k, n, num_rows, grid, operation_attributes.num_slices, /*allow_multi_row=*/true);
+    TT_FATAL(config.enabled, "topk_large_indices multi-core factory selected for a shape it does not support");
+    const uint32_t num_slices = config.num_slices;
+
+    // The merge tree lives IN PLACE on each slice rectangle: slice i is
+    // rectangle-local core (i % sx, i / sx) in row-major order; slice 0 (the
+    // rectangle origin) is that tree's root and produces its rows' output.
+    // Winners keep their survivor in DST across levels — only the shipped
+    // operand crosses the NoC, once, per losing core. Multi-rectangle
+    // (num_rects > 1): disjoint rectangles tile the grid and run their trees
+    // concurrently on contiguous row ranges.
+    const uint32_t num_rects = config.num_rects;
+    TT_FATAL(num_rects >= 1, "topk_large_indices multi-core factory needs at least one rectangle");
+    const uint32_t rects_x = static_cast<uint32_t>(grid.x) / config.local_grid_x;
+    std::vector<CoreRange> all_ranges;
+    std::vector<CoreRange> root_ranges;
+    std::vector<CoreRange> node_ranges;
+    std::vector<std::vector<CoreCoord>> rect_cores(num_rects);
+    for (uint32_t r = 0; r < num_rects; ++r) {
+        const uint32_t ox = (r % rects_x) * config.local_grid_x;
+        const uint32_t oy = (r / rects_x) * config.local_grid_y;
+        const CoreRange rect(CoreCoord(ox, oy), CoreCoord(ox + config.local_grid_x - 1, oy + config.local_grid_y - 1));
+        all_ranges.push_back(rect);
+        rect_cores[r] = corerange_to_cores(CoreRangeSet(rect), std::nullopt, true);
+        TT_FATAL(
+            rect_cores[r].size() == num_slices,
+            "topk_large_indices column split expected {} tree cores per rectangle, got {}",
+            num_slices,
+            rect_cores[r].size());
+        root_ranges.emplace_back(rect_cores[r].front(), rect_cores[r].front());
+        // All rectangle cores except the root run the node compute kernel.
+        if (config.local_grid_x > 1) {
+            node_ranges.emplace_back(CoreCoord(ox + 1, oy), CoreCoord(ox + config.local_grid_x - 1, oy));
+        }
+        if (config.local_grid_y > 1) {
+            node_ranges.emplace_back(
+                CoreCoord(ox, oy + 1), CoreCoord(ox + config.local_grid_x - 1, oy + config.local_grid_y - 1));
+        }
+    }
+    TT_FATAL(!node_ranges.empty(), "topk_large_indices merge tree needs at least 2 slices");
+    const CoreRangeSet all_cores(all_ranges);
+    const CoreRangeSet root_core_set(root_ranges);
+    const CoreRangeSet node_cores_set(node_ranges);
+
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_indices_out = tt::CBIndex::c_1;
+    constexpr uint32_t cb_indices_scratch = tt::CBIndex::c_2;
+    constexpr uint32_t cb_recv = tt::CBIndex::c_3;
+    constexpr uint32_t cb_ship_values = tt::CBIndex::c_5;
+    constexpr uint32_t cb_ship_indices = tt::CBIndex::c_6;
+    constexpr uint32_t cb_neginf_scratch = tt::CBIndex::c_7;
+
+    const uint32_t input_chunk_bytes = llk_k * input.element_size();
+    const uint32_t input_tile_bytes = tt::constants::TILE_HW * input.element_size();
+    // The unfused sequences travel as opaque 32-bit words (FP32 values /
+    // UINT32 indices packed raw from DST); one 32x32 tile is 4 KB.
+    const uint32_t tile32_bytes = tt::constants::TILE_HW * sizeof(uint32_t);
+    const uint32_t sequence_bytes = tiles_per_sequence * tile32_bytes;
+    constexpr uint32_t row_slice_elements = tt::constants::FACE_WIDTH;
+    const uint32_t source_slices_per_row = llk_k / row_slice_elements;
+    const uint32_t output_slices_per_row = k / row_slice_elements;
+    const uint32_t indices_slice_bytes = row_slice_elements * indices.element_size();
+    const uint32_t indices_row_bytes = k * indices.element_size();
+    // The indices CB carries the raw 32-bit index words the packer produces.
+    const uint32_t indices_cb_row_bytes = llk_k * static_cast<uint32_t>(sizeof(uint32_t));
+    constexpr uint32_t cb_depth = 2;
+
+    // The recv CB spans the whole rectangle so every core sees the same L1
+    // address (a shipping core derives its winner's destination from its own
+    // copy). Sized to exactly one sequence: capacity IS the level-to-level
+    // backpressure. Created FIRST so the multi-range address has no gaps.
+    const auto recv_cb_config =
+        tt::tt_metal::CircularBufferConfig(2 * sequence_bytes, {{cb_recv, tt::DataFormat::UInt32}})
+            .set_page_size(cb_recv, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, recv_cb_config);
+
+    create_input_cb(program, all_cores, cb_depth, tiles_per_sequence, input_tile_bytes, cb_in);
+
+    const auto ship_values_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_depth * tiles_per_sequence * tile32_bytes, {{cb_ship_values, tt::DataFormat::UInt32}})
+            .set_page_size(cb_ship_values, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, ship_values_cb_config);
+
+    const auto ship_indices_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_depth * tiles_per_sequence * tile32_bytes, {{cb_ship_indices, tt::DataFormat::UInt32}})
+            .set_page_size(cb_ship_indices, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, ship_indices_cb_config);
+
+    // Writer-owned scratch for the empty-slice -inf sequence (values + indices).
+    const auto neginf_scratch_cb_config =
+        tt::tt_metal::CircularBufferConfig(2 * sequence_bytes, {{cb_neginf_scratch, tt::DataFormat::UInt32}})
+            .set_page_size(cb_neginf_scratch, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, neginf_scratch_cb_config);
+
+    // Root-only output CBs: identical shape to the row-parallel factory's.
+    create_indices_output_cbs(
+        program,
+        root_core_set,
+        llk_target_k,
+        cb_depth,
+        indices_cb_row_bytes,
+        indices_row_bytes,
+        cb_indices_out,
+        cb_indices_scratch);
+
+    // Pairwise tree flow control (see the TOPK_TREE writer role in kernels/writer.cpp):
+    // ready = "my winner's recv slot is free", data = "my current partner's sequence landed".
+    const uint32_t ready_sem_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    const uint32_t data_sem_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    // Role selection for the unified kernel sources: TOPK_TREE marks a tree
+    // member (leaf slice reduction + in-DST pairwise merges); TOPK_TREE_ROOT
+    // additionally selects the root's materializing epilogue.
+    const std::map<std::string, std::string> tree_defines = {{"TOPK_TREE", "1"}};
+    const std::map<std::string, std::string> tree_root_defines = {{"TOPK_TREE", "1"}, {"TOPK_TREE_ROOT", "1"}};
+
+    // Leaf reader: the row-parallel reader plus a per-core slice offset
+    // (TOPK_TREE enables the extra slice_offset_bytes runtime arg).
+    auto reader_kernel = create_reader_kernel(
+        program, all_cores, input, cb_in, input_chunk_bytes, input_tile_bytes, tiles_per_sequence, tree_defines);
+
+    const std::vector<uint32_t> compute_node_compile_args = {cb_in, cb_ship_values, cb_ship_indices, cb_recv, llk_k};
+    auto compute_node_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp",
+        node_cores_set,
+        tt::tt_metal::ComputeConfig{// Same DST configuration as the row-parallel compute role: the
+                                    // unfused K=2048 merge occupies DEST slots 0..7 (FP32, full sync).
+                                    .fp32_dest_acc_en = true,
+                                    .dst_full_sync_en = true,
+                                    .compile_args = compute_node_compile_args,
+                                    .defines = tree_defines});
+
+    const std::vector<uint32_t> compute_root_compile_args = {cb_in, cb_indices_out, cb_recv, llk_k};
+    auto compute_root_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp",
+        root_core_set,
+        tt::tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = true,
+            .dst_full_sync_en = true,
+            .compile_args = compute_root_compile_args,
+            .defines = tree_root_defines});
+
+    std::vector<uint32_t> writer_compile_args = {
+        cb_ship_values,
+        cb_ship_indices,
+        cb_neginf_scratch,
+        cb_recv,
+        ready_sem_id,
+        data_sem_id,
+        tiles_per_sequence,
+        tile32_bytes,
+        cb_indices_out,
+        cb_indices_scratch,
+        indices_row_bytes,
+        source_slices_per_row,
+        output_slices_per_row,
+        indices_slice_bytes};
+    interleaved_accessor_args(indices).append_to(writer_compile_args);
+    auto writer_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_args, tree_defines));
+
+    TopkLargeIndicesMultiCoreSharedVariables shared{
+        .reader_kernel_id = reader_kernel,
+        .compute_node_kernel_id = compute_node_kernel,
+        .compute_root_kernel_id = compute_root_kernel,
+        .writer_kernel_id = writer_kernel,
+        .rect_cores = std::move(rect_cores)};
+    set_runtime_args_multi_core(program, shared, input, tensor_return_value, operation_attributes);
+
+    return cached_program_t{std::move(program), std::move(shared)};
+}
+
+void TopkLargeIndicesMultiCoreProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    set_runtime_args_multi_core(
+        cached_program.program,
+        cached_program.shared_variables,
+        tensor_args.input_tensor,
+        tensor_return_value,
+        operation_attributes);
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::program

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
@@ -35,6 +35,76 @@ struct TopkLargeIndicesProgramFactory {
         tensor_return_value_t& tensor_return_value);
 };
 
+// Row-parallel compute-body selection (ComputeBodyMode lives in
+// kernels/topk_large_indices_compute_body_mode.hpp so the kernel decodes the
+// same encoding), single-sourced into the compute kernel's compile-time arg
+// AND compute_program_hash so they can never skew. For k >= 1024 the mode is
+// width-independent (one segmented codepath at every width), so the hash
+// carries no width term there; for smaller k the mode folds in the
+// <= 32-chunk fused bit, the only width term.
 ComputeBodyMode compute_body_mode(uint32_t k, uint32_t input_last_dim);
+
+// Column-parallel (intra-row multi-core) configuration. Derived purely from
+// (k, physical last dim, num_rows, worker grid) so that:
+//   - select_program_factory / compute_program_hash / create all agree, and
+//   - valid_length stays runtime-only: it shrinks per-core active chunk
+//     counts (down to empty slices) without changing the program structure,
+//     so a serving loop growing valid_length reuses one cached program.
+struct ColumnSplitConfig {
+    bool enabled = false;
+    // Number of row slices == number of tree cores PER RECTANGLE (each reduces >= 1 chunk).
+    uint32_t num_slices = 0;
+    // Each tree is a local_grid_x x local_grid_y rectangle with
+    // num_slices == local_grid_x * local_grid_y. Within a rectangle, slice i
+    // lives at rectangle-local (i % local_grid_x, i / local_grid_x); slice 0
+    // is that rectangle's merge-tree root (the reduction is in place: at tree
+    // level L, core i with i % 2^(L+1) == 0 merges core i + 2^L's survivor).
+    uint32_t local_grid_x = 0;
+    uint32_t local_grid_y = 0;
+    // Multi-rectangle (rows > 1 with an explicit num_slices): the grid is
+    // tiled with num_rects disjoint rectangles running concurrently, rows
+    // split contiguously across them (runtime args — one cached program
+    // serves any row count with the same rectangle layout). 1 on the
+    // single-row model-selected path; 0 when disabled.
+    uint32_t num_rects = 0;
+};
+
+// num_slices_override: internal explicit P (operation_attributes_t::num_slices). Validated loudly
+// against [2, 128] and the row's chunk count, clamped only against the physical grid; setting it
+// when the column-parallel path is not selected is an error.
+ColumnSplitConfig compute_column_split_config(
+    uint32_t k,
+    uint32_t n,
+    uint32_t num_rows,
+    const CoreCoord& grid,
+    std::optional<uint32_t> num_slices_override = std::nullopt,
+    bool allow_multi_row = true);
+
+struct TopkLargeIndicesMultiCoreSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id{};
+    tt::tt_metal::KernelHandle compute_node_kernel_id{};
+    tt::tt_metal::KernelHandle compute_root_kernel_id{};
+    tt::tt_metal::KernelHandle writer_kernel_id{};
+    // Per-rectangle slice-major (row-major within the rectangle) core lists;
+    // rect_cores[r][0] is rectangle r's tree root. Single-rect programs have
+    // exactly one entry.
+    std::vector<std::vector<CoreCoord>> rect_cores{};
+};
+
+struct TopkLargeIndicesMultiCoreProgramFactory {
+    using shared_variables_t = TopkLargeIndicesMultiCoreSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::program

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
@@ -44,7 +44,9 @@ void bind_topk_large_indices(nb::module_& mod) {
             * restricts the search to the first ``valid_length`` columns of each row;
             * the remaining columns are ignored -- neither read nor ranked -- so an
               over-allocated row whose tail is stale can be searched without slicing it;
-            * must be in [k, last dimension]; defaults to the full last dimension;
+            * must be in (0, last dimension]; defaults to the full last dimension. A
+              prefix shorter than k is allowed: the lanes past its capacity emit the
+              sentinel index 0xFFFFFFFF;
             * applied at runtime (no recompile), so a loop growing valid_length reuses one program.
 
         Args:


### PR DESCRIPTION
## Summary

Stacked on #53953. Grafts the #53457 multi-core engine layer (column-parallel merge tree, hybrid row-split, multi-rect scheduling, cost model, survivor transport, writer concat) onto the fused-body base, so the fused row reduction and the inter-core engines ship as one composed op.

- The #53953 compute bodies are kept byte-identical as the single row-parallel leaf (`ComputeBodyMode` CT-arg unchanged; the merge-tree leaf reuses `sort_classic_chunk`); only a `final_survivor`→`slot0` rename and a moved `static_assert`.
- Zero LLK diff. Engine selection stays cost-model driven; on grids or shapes where the engines don't engage (e.g. rows ≥ cores at one wave), the op falls through to exactly the #53953 single-launch path.
- Scope exclusions preserved from the base PR: no stable ties, no chunk skipping, no public API change (both remain in the #53457 line as follow-ups).

## Measured (p150a, k=2048 bf16, Tracy device totals, 13 iters after 3 warmups, 3 trials, spread ≤0.3 µs)

| Cell | #53953 base | composed (this PR) | composed, 80-core fence |
| --- | ---: | ---: | ---: |
| 160 × 51,200 | 432.4 µs | **316.3** | 434.5 |
| 160 × 512,000 | 4295.6 | **2866.4** | 4295.8 |
| 160 × 1M (valid 512K) | 4400.6 | **2931.3** | 4398.9 |
| 32 × 65,536 | 277.3 | **131.0** | 183.2 |
| 80 × 1M (valid 512K) | 2202.0 | 2201.0 | 2201.2 |

The fenced column was measured with a local env-gated grid clamp (bench scaffolding, deliberately not part of this PR; verified via Tracy core counts = 80). Two properties worth noting for the 80/40 overlap plan: under an 80-core fence at 160 rows the hybrid self-disables and the op reproduces the base PR's numbers exactly (the composition costs nothing inside the fence), and on short-wide shapes the column engines win under the fence as well (183.2 vs 277.3 µs). Full grid, the engines are 1.37–2.12× over the base at every cell where they engage.

## Validation

- `tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py` — union of the base PR's 121-case suite and the engine tests: **167 passed, 2 skipped** (the two `production_perf_check` pins stay skipped pending the #53459 multi-core re-baseline; base-PR pin values retained).
- Program-cache invariance tests green (fresh cache, cache-hit idempotence per shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/compose-53953-tree)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/compose-53953-tree)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/compose-53953-tree)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/compose-53953-tree)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/compose-53953-tree)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/compose-53953-tree)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/compose-53953-tree)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/compose-53953-tree)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/compose-53953-tree)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/compose-53953-tree)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/compose-53953-tree)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/compose-53953-tree)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/compose-53953-tree)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/compose-53953-tree)