### PR TITLE
[cleanup] Migrate ttnn device operation infra to use `MakeMeshWorkloadFromSpec`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -12,6 +12,7 @@
 #include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operations/examples/example/device/example_device_operation.hpp"
+#include "ttnn/operations/reduction/prod/device/prod_all_device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
@@ -109,18 +110,17 @@ static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFacto
 // ---------------------------------------------------------------------------
 // ProgramSpecFactoryConcept (Metal 2.0 op-porting stepping stone)
 //
-// No real op uses create_program_artifacts yet, so the adapter's templated
-// method bodies — including the op-owned tensor enumeration and parking added
-// for this concept — are never instantiated by a normal build. The checks below
-// (a) pin the concept's classification (it recognizes a create_program_artifacts
-// factory and is mutually exclusive with the other factory concepts, per
-// all_factories_valid), and (b) force-instantiate the adapter so its bodies are
-// actually compiled.
+// Real ops already use create_program_artifacts (typecast, prod_all, …). The
+// checks below still (a) pin the concept's classification (it recognizes a
+// create_program_artifacts factory and is mutually exclusive with the other
+// factory concepts, per all_factories_valid), and (b) force-instantiate the
+// adapter so its bodies are compiled even when a particular TU does not
+// instantiate them through a real op.
 //
-// NOTE: runtime behavior (cache miss -> hit TensorArg patching, op-owned device
-// allocation liveness across dispatches) is NOT exercised here — that requires a
-// real op dispatched through the launch path, i.e. the first op port. Until then
-// this is compile-coverage only.
+// NOTE: runtime occupancy mapping (programs only on tensor_coords) is covered
+// by ProgramSpecAdapterProgramsOnUniformTensorCoords and
+// ProgramSpecAdapterProgramsOnlyOnUnevenTensorCoords below. Hit-path TensorArg
+// patching / op-owned liveness remain covered by op-level program-cache tests.
 // ---------------------------------------------------------------------------
 struct ProgramSpecFactory {
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
@@ -347,6 +347,79 @@ TEST_F(LaunchOperation2x4Test, CachingHeterogeneousDispatch) {
 
     auto sum3 = ttnn::add(uneven_tensor, uneven_tensor);
     EXPECT_EQ(mesh_device_->get_program_cache().num_entries(), 2);
+}
+
+TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterProgramsOnUniformTensorCoords) {
+    using Op = ttnn::prim::ProdAllDeviceOperation;
+    using Adapter = device_operation::MeshDeviceOperationAdapter<Op>::ProgramSpecMeshWorkloadFactoryAdapter<
+        Op::ProdAllProgramFactory>;
+
+    auto input = make_tensor_with_num_shards(8, mesh_device_.get());
+    EXPECT_TRUE(all_tensors_have_uniform_storage(input));
+
+    Op::operation_attributes_t attrs{.output_mem_config = MemoryConfig{}};
+    Op::tensor_args_t tensor_args{.input = input};
+    auto output = Op::create_output_tensors(attrs, tensor_args);
+
+    // Fast path in launch: one range covering the entire mesh.
+    ttnn::MeshCoordinateRangeSet tensor_coords;
+    tensor_coords.merge(ttnn::MeshCoordinateRange(mesh_device_->shape()));
+
+    auto cached = Adapter::create_mesh_workload(attrs, tensor_coords, tensor_args, output);
+
+    const ttnn::MeshCoordinateRange full_mesh(mesh_device_->shape());
+    EXPECT_EQ(cached.workload.get_programs().size(), 1u);
+    EXPECT_EQ(cached.shared_variables.size(), 1u);
+    EXPECT_TRUE(cached.workload.get_programs().contains(full_mesh));
+    EXPECT_TRUE(cached.shared_variables.contains(full_mesh));
+}
+
+TEST_F(LaunchOperation2x4Test, ProgramSpecAdapterProgramsOnlyOnUnevenTensorCoords) {
+    using Op = ttnn::prim::ProdAllDeviceOperation;
+    using Adapter = device_operation::MeshDeviceOperationAdapter<Op>::ProgramSpecMeshWorkloadFactoryAdapter<
+        Op::ProdAllProgramFactory>;
+
+    auto input = make_tensor_with_num_shards(2, mesh_device_.get());
+    EXPECT_FALSE(all_tensors_have_uniform_storage(input));
+    EXPECT_THAT(
+        extract_tensor_coordinates(input),
+        ElementsAre(
+            ttnn::MeshCoordinate{0, 0},  //
+            ttnn::MeshCoordinate{0, 1}));
+
+    Op::operation_attributes_t attrs{.output_mem_config = MemoryConfig{}};
+    Op::tensor_args_t tensor_args{.input = input};
+    auto output = Op::create_output_tensors(attrs, tensor_args);
+
+    // Slow path in launch: merge occupied coordinates one by one.
+    ttnn::MeshCoordinateRangeSet tensor_coords;
+    for (const auto& coord : extract_tensor_coordinates(input, mesh_device_.get())) {
+        tensor_coords.merge(ttnn::MeshCoordinateRange(coord, coord));
+    }
+
+    auto cached = Adapter::create_mesh_workload(attrs, tensor_coords, tensor_args, output);
+
+    EXPECT_EQ(cached.workload.get_programs().size(), tensor_coords.ranges().size());
+    EXPECT_EQ(cached.shared_variables.size(), tensor_coords.ranges().size());
+    for (const auto& range : tensor_coords.ranges()) {
+        EXPECT_TRUE(cached.workload.get_programs().contains(range));
+        EXPECT_TRUE(cached.shared_variables.contains(range));
+    }
+
+    // Unpopulated mesh coordinates must not have a program associated with them.
+    for (const auto& coord : {
+             ttnn::MeshCoordinate{0, 2},
+             ttnn::MeshCoordinate{0, 3},
+             ttnn::MeshCoordinate{1, 0},
+             ttnn::MeshCoordinate{1, 1},
+             ttnn::MeshCoordinate{1, 2},
+             ttnn::MeshCoordinate{1, 3},
+         }) {
+        for (const auto& [program_range, _] : cached.workload.get_programs()) {
+            EXPECT_FALSE(program_range.contains(coord))
+                << "unexpected program covering unpopulated mesh coordinate " << coord;
+        }
+    }
 }
 
 TEST_F(LaunchOperation2x4Test, OutputTensorTopology) {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -905,16 +905,25 @@ public:
             auto op_owned_tensors =
                 std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
 
-            // Cache miss is the cold path: always validate here, so every cached program was
-            // built from a checked spec. validate_program_args only gates the hit-path re-checks.
+            // Map the factory's ProgramSpec onto every occupied range and materialize
+            // the MeshWorkload. Cache miss is the cold path: always validate here, so
+            // every cached program was built from a checked spec. validate_program_args
+            // only gates the hit-path re-checks.
             std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramSpec> program_specs;
             for (const auto& range : tensor_coords.ranges()) {
                 program_specs.emplace(range, artifacts.spec);
             }
             auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
-            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+            // Apply the factory's initial ProgramRunArgs to each MeshWorkload program.
             for (auto& [range, program] : mesh_workload.get_programs()) {
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+            }
+
+            // shared_variables is TTNN cache state, independent of the MeshWorkload:
+            // per-range bindings and parked op-owned tensors for the cache-hit path.
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+            for (const auto& range : tensor_coords.ranges()) {
                 shared_variables.emplace(
                     range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
             }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -763,18 +763,14 @@ public:
     // Adapts a ProgramSpecFactoryConcept factory (Metal 2.0,
     // single-program / SPMD-flavored) for mesh dispatch. The op author writes
     // ONLY create_program_artifacts, returning a single ProgramArtifacts (one
-    // ProgramSpec + ProgramRunArgs + any op-owned tensors). The adapter stamps a
-    // Program from that spec onto each mesh coordinate range covered by the
-    // workload — mirroring the descriptor adapter's per-range build pattern.
+    // ProgramSpec + ProgramRunArgs + any op-owned tensors). The adapter calls `MakeMeshWorkloadFromSpec` to create a
+    // mesh-wide MeshWorkload.
     //
-    // On cache miss: the adapter calls create_program_artifacts, builds one
-    // Program per coordinate range via experimental::MakeProgramFromSpec, applies
-    // the initial ProgramRunArgs via SetProgramRunArgs, then resolves each
-    // TensorArgument against the combined enumeration of io tensors (from
+    // On cache miss: the adapter calls create_program_artifacts, builds a mesh-wide MeshWorkload via
+    // `MakeMeshWorkloadFromSpec`, resolves each TensorArgument against the combined enumeration of io tensors (from
     // tensor_args / tensor_return_value) followed by the factory's op-owned
-    // tensors (pointer-identity match within the call). Op-owned tensors are
-    // parked in shared_variables so their device allocation outlives the miss and
-    // stays at a stable address across dispatches.
+    // tensors (pointer-identity match within the call), parks op-owned tensors in shared_variables so their device
+    // allocation outlives the miss, then applies the initial ProgramRunArgs via SetProgramRunArgs.
     //
     // On cache hit: the adapter enumerates fresh io tensors, appends the parked
     // op-owned tensors, rebuilds a TensorArgument for every binding using the
@@ -807,10 +803,9 @@ public:
         struct shared_variables_t {
             std::vector<ResolvedTensorBinding> bindings;
             // Op-owned tensors produced by the factory, parked here so the
-            // (move-only) MeshTensors outlive the cache miss and every stamped
-            // program can reference the same workload-wide set. Shared ownership
-            // (not a per-range copy) keeps the device allocation alive for the
-            // life of the cache entry.
+            // (move-only) MeshTensors outlive the cache miss and the mesh-wide
+            // program can reference them. Shared ownership keeps the device
+            // allocation alive for the life of the cache entry.
             std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
@@ -865,12 +860,16 @@ public:
 
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            [[maybe_unused]] const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull from the first device tensor
-            // reachable from tensor_args, falling back to tensor_return_value for output-only ops
-            // (e.g. rand) whose tensor_args carry no input tensor.
+            // Occupancy in tensor_coords is used by other factory kinds and by launch()
+            // (filter_tensor_shards). This path is mesh-wide SPMD: MakeMeshWorkloadFromSpec
+            // maps the spec onto the entire MeshDevice.
+
+            // Metal 2.0's MakeMeshWorkloadFromSpec needs a MeshDevice; pull from the first
+            // device tensor reachable from tensor_args, falling back to tensor_return_value
+            // for output-only ops (e.g. rand) whose tensor_args carry no input tensor.
             auto first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_args);
             if (!first_tensor.has_value()) {
                 first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_return_value);
@@ -884,7 +883,7 @@ public:
                 mesh_device != nullptr,
                 "The sourced tensor (from tensor_args or tensor_return_value) must be allocated on a MeshDevice");
 
-            // The factory produces a single ProgramArtifacts; the adapter stamps it
+            // The factory produces a single ProgramArtifacts; then calls `MakeMeshWorkloadFromSpec` that stamps it
             // across all coordinate ranges. Bindings derive from the (single) set of
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
@@ -900,7 +899,7 @@ public:
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors);
 
             // Park op-owned tensors in a shared vector so the move-only MeshTensors
-            // outlive this call and every stamped program references the same set.
+            // outlive this call and the mesh-wide program can reference them.
             // (A vector move preserves element addresses, so the references held by
             // artifacts.run_params stay valid for the SetProgramRunArgs calls below.)
             auto op_owned_tensors =
@@ -908,14 +907,12 @@ public:
 
             // Cache miss is the cold path: always validate here, so every cached program was
             // built from a checked spec. validate_program_args only gates the hit-path re-checks.
-            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpec(*mesh_device, artifacts.spec);
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-            for (const auto& range : tensor_coords.ranges()) {
-                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+            for (auto& [range, program] : mesh_workload.get_programs()) {
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
                 shared_variables.emplace(
                     range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
-                mesh_workload.add_program(range, std::move(program));
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
         }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -763,14 +763,18 @@ public:
     // Adapts a ProgramSpecFactoryConcept factory (Metal 2.0,
     // single-program / SPMD-flavored) for mesh dispatch. The op author writes
     // ONLY create_program_artifacts, returning a single ProgramArtifacts (one
-    // ProgramSpec + ProgramRunArgs + any op-owned tensors). The adapter calls `MakeMeshWorkloadFromSpec` to create a
-    // mesh-wide MeshWorkload.
+    // ProgramSpec + ProgramRunArgs + any op-owned tensors). The adapter maps
+    // that same ProgramSpec onto every range in tensor_coords via
+    // experimental::MakeMeshWorkloadFromSpecs (occupancy = mesh devices that
+    // hold a tensor shard).
     //
-    // On cache miss: the adapter calls create_program_artifacts, builds a mesh-wide MeshWorkload via
-    // `MakeMeshWorkloadFromSpec`, resolves each TensorArgument against the combined enumeration of io tensors (from
-    // tensor_args / tensor_return_value) followed by the factory's op-owned
-    // tensors (pointer-identity match within the call), parks op-owned tensors in shared_variables so their device
-    // allocation outlives the miss, then applies the initial ProgramRunArgs via SetProgramRunArgs.
+    // On cache miss: the adapter calls create_program_artifacts once, builds a
+    // MeshWorkload via MakeMeshWorkloadFromSpecs, resolves each TensorArgument
+    // against the combined enumeration of io tensors (from tensor_args /
+    // tensor_return_value) followed by the factory's op-owned tensors
+    // (pointer-identity match within the call), parks op-owned tensors in
+    // shared_variables so their device allocation outlives the miss, then
+    // applies the initial ProgramRunArgs via SetProgramRunArgs.
     //
     // On cache hit: the adapter enumerates fresh io tensors, appends the parked
     // op-owned tensors, rebuilds a TensorArgument for every binding using the
@@ -803,9 +807,9 @@ public:
         struct shared_variables_t {
             std::vector<ResolvedTensorBinding> bindings;
             // Op-owned tensors produced by the factory, parked here so the
-            // (move-only) MeshTensors outlive the cache miss and the mesh-wide
-            // program can reference them. Shared ownership keeps the device
-            // allocation alive for the life of the cache entry.
+            // (move-only) MeshTensors outlive the cache miss and every program
+            // on the occupied ranges can reference them. Shared ownership keeps
+            // the device allocation alive for the life of the cache entry.
             std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
@@ -860,14 +864,10 @@ public:
 
         static auto create_mesh_workload(
             const operation_attributes_t& attrs,
-            [[maybe_unused]] const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            // Occupancy in tensor_coords is used by other factory kinds and by launch()
-            // (filter_tensor_shards). This path is mesh-wide SPMD: MakeMeshWorkloadFromSpec
-            // maps the spec onto the entire MeshDevice.
-
-            // Metal 2.0's MakeMeshWorkloadFromSpec needs a MeshDevice; pull from the first
+            // Metal 2.0's MakeMeshWorkloadFromSpecs needs a MeshDevice; pull from the first
             // device tensor reachable from tensor_args, falling back to tensor_return_value
             // for output-only ops (e.g. rand) whose tensor_args carry no input tensor.
             auto first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_args);
@@ -883,10 +883,10 @@ public:
                 mesh_device != nullptr,
                 "The sourced tensor (from tensor_args or tensor_return_value) must be allocated on a MeshDevice");
 
-            // The factory produces a single ProgramArtifacts; then calls `MakeMeshWorkloadFromSpec` that stamps it
-            // across all coordinate ranges. Bindings derive from the (single) set of
-            // factory tensor_args and are identical for every stamped program; copy
-            // per range into the cached shared state.
+            // The factory produces a single ProgramArtifacts; the adapter maps that same
+            // ProgramSpec onto every range in tensor_coords (occupancy). Bindings derive
+            // from the (single) set of factory tensor_args and are identical for every
+            // stamped program; copy per range into the cached shared state.
             auto artifacts = SpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
 
             // Enumerate io tensors (inputs + outputs), then append the factory's
@@ -899,7 +899,7 @@ public:
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, mesh_tensors);
 
             // Park op-owned tensors in a shared vector so the move-only MeshTensors
-            // outlive this call and the mesh-wide program can reference them.
+            // outlive this call and every program on the occupied ranges can reference them.
             // (A vector move preserves element addresses, so the references held by
             // artifacts.run_params stay valid for the SetProgramRunArgs calls below.)
             auto op_owned_tensors =
@@ -907,7 +907,11 @@ public:
 
             // Cache miss is the cold path: always validate here, so every cached program was
             // built from a checked spec. validate_program_args only gates the hit-path re-checks.
-            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpec(*mesh_device, artifacts.spec);
+            std::unordered_map<ttnn::MeshCoordinateRange, tt::tt_metal::experimental::ProgramSpec> program_specs;
+            for (const auto& range : tensor_coords.ranges()) {
+                program_specs.emplace(range, artifacts.spec);
+            }
+            auto mesh_workload = tt::tt_metal::experimental::MakeMeshWorkloadFromSpecs(*mesh_device, program_specs);
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (auto& [range, program] : mesh_workload.get_programs()) {
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);

--- a/ttnn/api/ttnn/metal_v2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal_v2_artifacts.hpp
@@ -16,8 +16,8 @@ namespace ttnn::device_operation {
 // ProgramSpec, the mutable ProgramRunArgs, and any op-owned tensors the factory
 // allocates for itself. Returned by a ProgramSpecFactoryConcept or
 // CustomProgramSpecFactoryConcept factory's
-// create_program_artifacts method; the framework adapter builds a mesh-wide
-// MeshWorkload from the spec via experimental::MakeMeshWorkloadFromSpec.
+// create_program_artifacts method; the framework adapter maps that same spec
+// onto tensor_coords via experimental::MakeMeshWorkloadFromSpecs.
 //
 // A future MeshWorkloadSpecFactoryConcept will return a different (multi-program)
 // artifact type for ops whose programs vary across the mesh.

--- a/ttnn/api/ttnn/metal_v2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal_v2_artifacts.hpp
@@ -16,8 +16,8 @@ namespace ttnn::device_operation {
 // ProgramSpec, the mutable ProgramRunArgs, and any op-owned tensors the factory
 // allocates for itself. Returned by a ProgramSpecFactoryConcept or
 // CustomProgramSpecFactoryConcept factory's
-// create_program_artifacts method; the framework adapter stamps a Program out of
-// this artifact onto each mesh coordinate range of the workload.
+// create_program_artifacts method; the framework adapter builds a mesh-wide
+// MeshWorkload from the spec via experimental::MakeMeshWorkloadFromSpec.
 //
 // A future MeshWorkloadSpecFactoryConcept will return a different (multi-program)
 // artifact type for ops whose programs vary across the mesh.

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -75,8 +75,8 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 
 // Metal 2.0 op-porting stepping-stone factory concept: factories that return
 // ProgramArtifacts (a ProgramSpec + ProgramRunArgs + any op-owned tensors) from
-// create_program_artifacts. The framework adapter builds a mesh-wide MeshWorkload
-// from the spec via experimental::MakeMeshWorkloadFromSpec on cache miss, and
+// create_program_artifacts. The framework adapter maps that same ProgramSpec onto
+// tensor_coords via experimental::MakeMeshWorkloadFromSpecs on cache miss, and
 // patches every TensorArg (io and op-owned alike) via experimental::UpdateTensorArgs
 // on cache hit.
 //

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -75,9 +75,10 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 
 // Metal 2.0 op-porting stepping-stone factory concept: factories that return
 // ProgramArtifacts (a ProgramSpec + ProgramRunArgs + any op-owned tensors) from
-// create_program_artifacts. The framework adapter stamps a Program from the spec onto
-// each mesh coordinate range on cache miss, and patches every TensorArg (io and
-// op-owned alike) via experimental::UpdateTensorArgs on cache hit.
+// create_program_artifacts. The framework adapter builds a mesh-wide MeshWorkload
+// from the spec via experimental::MakeMeshWorkloadFromSpec on cache miss, and
+// patches every TensorArg (io and op-owned alike) via experimental::UpdateTensorArgs
+// on cache hit.
 //
 // NOTE: Each TensorArgument in ProgramRunArgs MUST reference a MeshTensor reachable from
 // the factory's `tensor_args` / `tensor_return_value` parameters, OR one of the


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Metal 2.0 provides native functionality to construct a multi-device `MeshWorkload` from a `ProgramSpec` (`MakeMeshWorkloadFromSpec`), alongside the single-device Program constructor (`MakeProgramFromSpec`).

TTNN spec-factory dispatch currently invokes the single-device constructor and assembles a `MeshWorkload` itself (`MakeProgramFromSpec` + `MeshWorkload::add_program`).

This PR swaps that path to the MeshWorkload constructor Metal 2.0 already provides. 

### Notes for reviewers
This is a pure ttnn infrastructure update; there is no impact on any use sites (ops).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/m2-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/m2-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/m2-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/m2-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/m2-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/m2-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/m2-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/m2-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/m2-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/m2-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/m2-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/m2-small)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/m2-small)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/m2-small)