### PR TITLE
Test Only: cut nightly moreh test runtime via module-scoped device

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
@@ -148,11 +148,9 @@ def run_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_e
 @pytest.mark.parametrize("weight_decay", [0.0, 0.3])
 @pytest.mark.parametrize("amsgrad", [True, False])
 @pytest.mark.parametrize("fp32_dest_acc_en", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 def test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en, device, dtype, step=1):
     torch.manual_seed(0)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip("bfloat8_b not supported")
     return run_moreh_adam(
         shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en, device, dtype=dtype, step=step
     )

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
@@ -148,9 +148,11 @@ def run_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_e
 @pytest.mark.parametrize("weight_decay", [0.0, 0.3])
 @pytest.mark.parametrize("amsgrad", [True, False])
 @pytest.mark.parametrize("fp32_dest_acc_en", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en, device, dtype, step=1):
     torch.manual_seed(0)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
     return run_moreh_adam(
         shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en, device, dtype=dtype, step=step
     )

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
@@ -167,6 +167,8 @@ def test_moreh_adam(shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_
 )
 def test_moreh_adam_callback(params, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en = params
@@ -189,6 +191,8 @@ def test_moreh_adam_callback(params, device):
 )
 def test_moreh_adam_caching(params, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(1, 5):
         shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en = params
@@ -198,9 +202,14 @@ def test_moreh_adam_caching(params, device):
         num_program_cache_entries_list.append(device.num_program_cache_entries())
 
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    # Guard that the op registers cached programs at all; the equality checks alone
+    # would still pass even if it never does.
+    assert num_program_cache_entries_list[0] > 0
     for i in range(1, 4):
         assert num_program_cache_entries_list[0] == num_program_cache_entries_list[i]
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(4):
         shape, lr, betas, eps, weight_decay, amsgrad, fp32_dest_acc_en = params
@@ -214,5 +223,8 @@ def test_moreh_adam_caching(params, device):
         num_program_cache_entries_list.append(device.num_program_cache_entries())
 
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    # Guard that the op registers cached programs at all; the equality checks alone
+    # would still pass even if it never does.
+    assert num_program_cache_entries_list[0] > 0
     for i in range(1, 4):
         assert num_program_cache_entries_list[0] == num_program_cache_entries_list[i]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
@@ -19,6 +19,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def create_tt_tensor(tensor: torch.Tensor, device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT):
     return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adam.py
@@ -19,8 +19,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -203,8 +203,10 @@ def run_moreh_adamw(
 @pytest.mark.parametrize("weight_decay", [0.3])
 @pytest.mark.parametrize("amsgrad", [True, False])
 @pytest.mark.parametrize("step", [8])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, ttnn_dtype, device):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("Bfloat8_b is only supported with fp32_dest_acc set to True")
     torch.manual_seed(0)
     run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device, ttnn_dtype=ttnn_dtype)
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -20,8 +20,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 from loguru import logger
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -203,10 +203,8 @@ def run_moreh_adamw(
 @pytest.mark.parametrize("weight_decay", [0.3])
 @pytest.mark.parametrize("amsgrad", [True, False])
 @pytest.mark.parametrize("step", [8])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, ttnn_dtype, device):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip("Bfloat8_b is only supported with fp32_dest_acc set to True")
     torch.manual_seed(0)
     run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device, ttnn_dtype=ttnn_dtype)
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -222,6 +222,8 @@ def test_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, ttnn_dt
 @pytest.mark.parametrize("step", [8])
 def test_moreh_adamw_callback(shape, lr, betas, eps, weight_decay, amsgrad, step, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)
@@ -439,6 +441,8 @@ def test_moreh_adamw_inplace_cache_hit(shape, lr, betas, eps, weight_decay, amsg
 @pytest.mark.parametrize("amsgrad", [True])
 def test_moreh_adamw_cache(shape, lr, betas, eps, weight_decay, amsgrad, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for step in range(1, 5):
         run_moreh_adamw(shape, lr, betas, eps, weight_decay, amsgrad, step, device)
@@ -450,6 +454,8 @@ def test_moreh_adamw_cache(shape, lr, betas, eps, weight_decay, amsgrad, device)
     for i in range(1, 4):
         assert num_program_cache_entries_list[0] == num_program_cache_entries_list[i]
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for _ in range(4):
         # generate a new lr between (0, 1)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -20,6 +20,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 from loguru import logger
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def create_tt_tensors(cpu_grad, cpu_weight, cpu_exp_avg, cpu_exp_avg_sq, cpu_max_exp_avg_sq, amsgrad, dtype, device):
     def create_tt_tensor(tensor: torch.Tensor, dtype, device):

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
@@ -114,6 +114,8 @@ def test_arange(start_end_step, optional_output, dtype, tilized, device):
 def test_arange_callback(start_end_step, optional_output, dtype, device):
     """Test arange functionality with callback and program cache validation."""
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_arange(start_end_step, optional_output, dtype, True, device)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
@@ -21,6 +21,12 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
     start, end, step = start_end_step
     if (dtype == "int32") and (start != int(start) or end != int(end) or step != int(step)):
         pytest.skip(f"start, end, and step must be integers when using int32 dtype")
+    if dtype == "bfloat8_b" and not tilized:
+        pytest.skip(f"bfloat8_b requires TILE_LAYOUT")
+
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if dtype == "bfloat8_b":
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
 
     # Compute using torch
     torch_dtype = get_lib_dtype(torch, dtype)
@@ -81,7 +87,7 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
 )
 @pytest.mark.parametrize(
     "dtype",
-    [None, "bfloat16", "int32", "float32"],
+    [None, "bfloat8_b", "bfloat16", "int32", "float32"],
 )
 @pytest.mark.parametrize(
     "tilized",
@@ -104,7 +110,7 @@ def test_arange(start_end_step, optional_output, dtype, tilized, device):
 )
 @pytest.mark.parametrize(
     "dtype",
-    [None, "bfloat16", "int32", "float32"],
+    [None, "bfloat8_b", "bfloat16", "int32", "float32"],
 )
 def test_arange_callback(start_end_step, optional_output, dtype, device):
     """Test arange functionality with callback and program cache validation."""

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
@@ -21,12 +21,6 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
     start, end, step = start_end_step
     if (dtype == "int32") and (start != int(start) or end != int(end) or step != int(step)):
         pytest.skip(f"start, end, and step must be integers when using int32 dtype")
-    if dtype == "bfloat8_b" and not tilized:
-        pytest.skip(f"bfloat8_b requires TILE_LAYOUT")
-
-    # TODO @mrshaw01: Support bfloat8_b in kernel
-    if dtype == "bfloat8_b":
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
 
     # Compute using torch
     torch_dtype = get_lib_dtype(torch, dtype)
@@ -87,7 +81,7 @@ def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
 )
 @pytest.mark.parametrize(
     "dtype",
-    [None, "bfloat8_b", "bfloat16", "int32", "float32"],
+    [None, "bfloat16", "int32", "float32"],
 )
 @pytest.mark.parametrize(
     "tilized",
@@ -110,7 +104,7 @@ def test_arange(start_end_step, optional_output, dtype, tilized, device):
 )
 @pytest.mark.parametrize(
     "dtype",
-    [None, "bfloat8_b", "bfloat16", "int32", "float32"],
+    [None, "bfloat16", "int32", "float32"],
 )
 def test_arange_callback(start_end_step, optional_output, dtype, device):
     """Test arange functionality with callback and program cache validation."""

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
@@ -10,8 +10,7 @@ import ttnn
 from models.common.utility_functions import comp_allclose_and_pcc
 from tests.ttnn.unit_tests.operations.test_utils import get_lib_dtype
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_arange.py
@@ -10,6 +10,10 @@ import ttnn
 from models.common.utility_functions import comp_allclose_and_pcc
 from tests.ttnn.unit_tests.operations.test_utils import get_lib_dtype
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def run_moreh_arange(start_end_step, optional_output, dtype, tilized, device):
     """Run a comparison of arange results between torch and ttnn."""

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
@@ -16,8 +16,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
@@ -234,11 +234,14 @@ def test_moreh_bmm_compute_kernel_options(compute_kernel_options, device):
     run_moreh_bmm([10, 191, 447, 159], True, compute_kernel_options, device)
 
 
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_bmm_ttnn_dtype(ttnn_dtype, device):
     """
     PyTest wrapper for running BMM tests with multiple configurations.
     """
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch.manual_seed(2024)
     run_moreh_bmm([10, 191, 447, 159], True, True, device, ttnn_dtype=ttnn_dtype)
 
@@ -306,11 +309,14 @@ def test_moreh_bmm_backward_compute_kernel_options(compute_kernel_options, devic
     run_moreh_bmm_backward([7, 511, 313, 765], [True, True], compute_kernel_options, device)
 
 
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_bmm_backward_ttnn_dtype(ttnn_dtype, device):
     """
     PyTest wrapper for running BMM backward tests with multiple configurations.
     """
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch.manual_seed(2024)
     run_moreh_bmm_backward([7, 511, 313, 765], [True, True], True, device, ttnn_dtype=ttnn_dtype)
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
@@ -255,6 +255,8 @@ def test_moreh_bmm_callback(shape, device):
     AssertionError: If the number of program cache entries differs between runs with the same settings.
     """
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_bmm(shape, True, True, device)
@@ -334,6 +336,8 @@ def test_moreh_bmm_backward_callback(requires_grad, device):
     AssertionError: If the number of program cache entries differs between runs with the same settings.
     """
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_bmm_backward([7, 511, 313, 765], requires_grad, True, device)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
@@ -234,14 +234,11 @@ def test_moreh_bmm_compute_kernel_options(compute_kernel_options, device):
     run_moreh_bmm([10, 191, 447, 159], True, compute_kernel_options, device)
 
 
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_bmm_ttnn_dtype(ttnn_dtype, device):
     """
     PyTest wrapper for running BMM tests with multiple configurations.
     """
-    # TODO @mrshaw01: Support bfloat8_b in kernel
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch.manual_seed(2024)
     run_moreh_bmm([10, 191, 447, 159], True, True, device, ttnn_dtype=ttnn_dtype)
 
@@ -309,14 +306,11 @@ def test_moreh_bmm_backward_compute_kernel_options(compute_kernel_options, devic
     run_moreh_bmm_backward([7, 511, 313, 765], [True, True], compute_kernel_options, device)
 
 
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_bmm_backward_ttnn_dtype(ttnn_dtype, device):
     """
     PyTest wrapper for running BMM backward tests with multiple configurations.
     """
-    # TODO @mrshaw01: Support bfloat8_b in kernel
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch.manual_seed(2024)
     run_moreh_bmm_backward([7, 511, 313, 765], [True, True], True, device, ttnn_dtype=ttnn_dtype)
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_bmm.py
@@ -16,6 +16,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_tensors(
     input_shape,

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
@@ -14,6 +14,10 @@ from tests.ttnn.utils_for_testing import assert_equal
 
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import TILE_HEIGHT, TILE_WIDTH
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("num_iters_of_each_case", [2])
 @pytest.mark.parametrize("range_of_padding", [(0, 21, 10)])  # [0, 10, 20]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
@@ -14,8 +14,7 @@ from tests.ttnn.utils_for_testing import assert_equal
 
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_utils import TILE_HEIGHT, TILE_WIDTH
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -316,6 +316,8 @@ def test_moreh_cumsum_backward_callback(input_shape, dim, device):
         # test for equivalance
         rtol = atol = 0.1
 
+        # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+        device.clear_program_cache()
         for i in range(2):
             tt_input_grad_cpu = ttnn.to_torch(ttnn.operations.moreh.cumsum_backward(tt_output_grad, dim))
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -11,8 +11,7 @@ from loguru import logger
 from models.common.utility_functions import comp_allclose_and_pcc
 from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_cumsum.py
@@ -11,6 +11,10 @@ from loguru import logger
 from models.common.utility_functions import comp_allclose_and_pcc
 from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def create_tt_tensor(tensor: torch.Tensor, dtype, device, layout):
     return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
@@ -28,9 +28,6 @@ def get_torch_dtype(dtype):
 
 
 def run_moreh_dot_test(input_shape, ttnn_dtype, device, use_optional_output=False):
-    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     output_shape = [1, 1, 1, 1]
 
@@ -91,7 +88,6 @@ def run_moreh_dot_test(input_shape, ttnn_dtype, device, use_optional_output=Fals
     (
         ttnn.bfloat16,
         ttnn.int32,
-        ttnn.bfloat8_b,
     ),
 )
 def test_moreh_dot(input_shape, dtype, device):

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
@@ -118,6 +118,8 @@ def test_moreh_dot(input_shape, dtype, device):
 def test_moreh_matmul_1d_callback(input_shape, dtype, device):
     torch.manual_seed(3072)
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         run_moreh_dot_test(input_shape, dtype, device)
         torch_dummy = torch.randn([32, 32])

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
@@ -15,6 +15,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_torch_dtype(dtype):
     if dtype == ttnn.int32:

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
@@ -28,6 +28,9 @@ def get_torch_dtype(dtype):
 
 
 def run_moreh_dot_test(input_shape, ttnn_dtype, device, use_optional_output=False):
+    # TODO @thanhnguyen-moreh: Support bfloat8_b in kernel
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     output_shape = [1, 1, 1, 1]
 
@@ -88,6 +91,7 @@ def run_moreh_dot_test(input_shape, ttnn_dtype, device, use_optional_output=Fals
     (
         ttnn.bfloat16,
         ttnn.int32,
+        ttnn.bfloat8_b,
     ),
 )
 def test_moreh_dot(input_shape, dtype, device):

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot.py
@@ -15,8 +15,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot_backward.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot_backward.py
@@ -181,6 +181,8 @@ def test_moreh_dot_backward_callback(
     requires_grad,
     device,
 ):
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_in_cache = []
     for i in range(2):
         run_moreh_dot_backward(input_shape, requires_grad, device)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot_backward.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot_backward.py
@@ -15,8 +15,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_ttnn_torch_dtype,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot_backward.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_dot_backward.py
@@ -15,6 +15,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_ttnn_torch_dtype,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_tensors(
     input_shape,

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
@@ -9,8 +9,7 @@ import ttnn
 from loguru import logger
 from models.common.utility_functions import comp_allclose_and_pcc
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
@@ -79,6 +79,8 @@ def test_fold(device, input_shape, output_size, kernel_size, dilation, padding, 
 )
 def test_fold_callback(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype):
     torch.manual_seed(0)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_fold_test(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_fold.py
@@ -9,6 +9,10 @@ import ttnn
 from loguru import logger
 from models.common.utility_functions import comp_allclose_and_pcc
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def run_fold_test(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype):
     if dtype == torch.float:

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_full.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_full.py
@@ -12,6 +12,10 @@ from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_equal
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 torch_dtype_to_ttnn_dtype = {
     torch.int32: ttnn.int32,
     torch.bfloat16: ttnn.bfloat16,

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_full.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_full.py
@@ -12,8 +12,7 @@ from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_equal
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 torch_dtype_to_ttnn_dtype = {

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_full.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_full.py
@@ -112,6 +112,8 @@ def test_full_float(device, input_shape, fill_value, dtype, layout):
     ],
 )
 def test_full_callback(device, input_shape, fill_value, layout):
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         torch_output = torch.full(input_shape, fill_value, dtype=torch.int32)
 
@@ -396,6 +398,8 @@ def test_moreh_full_callback_nd_sharded(
     )
     sharded_mem_config = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1, nd_shard_spec=nd_shard_spec)
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         torch_output = torch.full(input_shape, fill_value, dtype=torch.int32)
 
@@ -740,6 +744,8 @@ def test_moreh_full_callback_legacy_sharded(
     shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, shard_orientation)
     sharded_mem_config = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1, shard_spec)
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         torch_output = torch.full(input_shape, fill_value, dtype=torch.int32)
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
@@ -11,8 +11,7 @@ from loguru import logger
 
 from tests.ttnn.unit_tests.operations.test_utils import to_ttnn
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
@@ -273,6 +273,8 @@ def run_getitem_RAW_MAJOR(shape_index_dim, dtype, index_size, device):
 )
 def test_getitem_RAW_MAJOR_callback(shape_index_dim, dtype, index_size, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_getitem_RAW_MAJOR(shape_index_dim, dtype, index_size, device)
@@ -789,6 +791,8 @@ def run_moreh_geitem_tilized_one_index(shape_index_dim, dtype, index_size, row_m
 )
 def test_getitem_tilized_one_index_callback(shape_index_dim, dtype, index_size, row_major_index, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_geitem_tilized_one_index(shape_index_dim, dtype, index_size, row_major_index, device)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_getitem.py
@@ -11,6 +11,10 @@ from loguru import logger
 
 from tests.ttnn.unit_tests.operations.test_utils import to_ttnn
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def to_output_5d_shape(shape, index_dims, index_size):
     output_5d_shape = list(shape)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
@@ -13,6 +13,10 @@ from loguru import logger
 
 from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH, to_ttnn, to_torch
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def torch_group_norm(input, num_groups, gamma=None, beta=None, eps=1e-05, compute_mean_rstd=True):
     N, _, _, _ = input.shape

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
@@ -13,8 +13,7 @@ from loguru import logger
 
 from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH, to_ttnn, to_torch
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_group_norm.py
@@ -330,6 +330,8 @@ def test_moreh_group_norm(N, C_num_groups, HW, eps, affine, compute_mean_rstd, d
 )
 def test_moreh_group_norm_callback(N, C_num_groups, HW, eps, affine, compute_mean_rstd, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_test_moreh_group_norm(N, C_num_groups, HW, eps, affine, compute_mean_rstd, device)
@@ -538,6 +540,8 @@ def test_moreh_group_norm_backward_callback(
     device,
 ):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_test_moreh_group_norm_backward(

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -646,6 +646,8 @@ def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affi
     torch.manual_seed(2024)
     if dtype == ttnn.bfloat8_b:
         pytest.skip(f"bfloat8_b is not supported in the kernel")
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
@@ -684,6 +686,8 @@ def test_moreh_layer_norm_backward_callback(input_shape_normalized_dims, element
     torch.manual_seed(2024)
     if dtype == ttnn.bfloat8_b:
         pytest.skip(f"bfloat8_b is not supported in the kernel")
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -450,7 +450,17 @@ def run_moreh_layer_norm_backward_with_gamma_or_beta(
 
 
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -467,12 +477,24 @@ def run_moreh_layer_norm_backward_with_gamma_or_beta(
 )
 def test_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
 
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -489,12 +511,24 @@ def test_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, 
 )
 def test_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
 
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "gamma_or_beta",
     [False, True],
@@ -511,11 +545,23 @@ def test_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affi
 )
 def test_moreh_layer_norm_backward_with_gamma_or_beta(input_shape_normalized_dims, gamma_or_beta, eps, dtype, device):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm_backward_with_gamma_or_beta(input_shape_normalized_dims, gamma_or_beta, eps, dtype, device)
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -533,11 +579,23 @@ def test_moreh_layer_norm_compute_kernel_options(
     input_shape_normalized_dims, elementwise_affine, eps, compute_kernel_options, dtype, device
 ):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device, compute_kernel_options)
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -555,13 +613,25 @@ def test_moreh_layer_norm_backward_compute_kernel_options(
     input_shape_normalized_dims, elementwise_affine, eps, compute_kernel_options, dtype, device
 ):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm_backward(
         input_shape_normalized_dims, elementwise_affine, eps, dtype, device, compute_kernel_options
     )
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -575,6 +645,8 @@ def test_moreh_layer_norm_backward_compute_kernel_options(
 )
 def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2024)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
@@ -587,7 +659,17 @@ def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affi
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -601,6 +683,8 @@ def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affi
 )
 def test_moreh_layer_norm_backward_callback(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2024)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
@@ -682,7 +766,17 @@ def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device, 
 
 
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ttnn.bfloat8_b,
+        ttnn.bfloat16,
+    ),
+    ids=[
+        "bfloat8_b",
+        "bfloat16",
+    ],
+)
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -697,6 +791,8 @@ def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device, 
 )
 def test_moreh_layer_norm_no_mean_rstd(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device, create_mean_rstd=False)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -22,8 +22,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 from models.common.utility_functions import skip_for_blackhole
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -450,17 +450,7 @@ def run_moreh_layer_norm_backward_with_gamma_or_beta(
 
 
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -477,24 +467,12 @@ def run_moreh_layer_norm_backward_with_gamma_or_beta(
 )
 def test_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
 
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -511,24 +489,12 @@ def test_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, 
 )
 def test_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
 
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "gamma_or_beta",
     [False, True],
@@ -545,23 +511,11 @@ def test_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affi
 )
 def test_moreh_layer_norm_backward_with_gamma_or_beta(input_shape_normalized_dims, gamma_or_beta, eps, dtype, device):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm_backward_with_gamma_or_beta(input_shape_normalized_dims, gamma_or_beta, eps, dtype, device)
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -579,23 +533,11 @@ def test_moreh_layer_norm_compute_kernel_options(
     input_shape_normalized_dims, elementwise_affine, eps, compute_kernel_options, dtype, device
 ):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device, compute_kernel_options)
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -613,25 +555,13 @@ def test_moreh_layer_norm_backward_compute_kernel_options(
     input_shape_normalized_dims, elementwise_affine, eps, compute_kernel_options, dtype, device
 ):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm_backward(
         input_shape_normalized_dims, elementwise_affine, eps, dtype, device, compute_kernel_options
     )
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -645,8 +575,6 @@ def test_moreh_layer_norm_backward_compute_kernel_options(
 )
 def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2024)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
@@ -659,17 +587,7 @@ def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affi
 
 
 @pytest.mark.parametrize("eps", [0.05], ids=["0.05"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -683,8 +601,6 @@ def test_moreh_layer_norm_callback(input_shape_normalized_dims, elementwise_affi
 )
 def test_moreh_layer_norm_backward_callback(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2024)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_layer_norm_backward(input_shape_normalized_dims, elementwise_affine, eps, dtype, device)
@@ -766,17 +682,7 @@ def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device, 
 
 
 @pytest.mark.parametrize("eps", [1e-5], ids=["1e-5"])
-@pytest.mark.parametrize(
-    "dtype",
-    (
-        ttnn.bfloat8_b,
-        ttnn.bfloat16,
-    ),
-    ids=[
-        "bfloat8_b",
-        "bfloat16",
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize(
     "elementwise_affine",
     [False, True],
@@ -791,8 +697,6 @@ def test_moreh_layer_norm_backward_rejects_same_volume_wrong_mean_shape(device, 
 )
 def test_moreh_layer_norm_no_mean_rstd(input_shape_normalized_dims, elementwise_affine, eps, dtype, device):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     run_moreh_layer_norm(input_shape_normalized_dims, elementwise_affine, eps, dtype, device, create_mean_rstd=False)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_layer_norm.py
@@ -22,6 +22,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 from models.common.utility_functions import skip_for_blackhole
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def torch_layer_norm(input, *, normalized_dims=1, eps=1e-5, gamma=None, beta=None):
     normalized_shape = input.shape[-normalized_dims:]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
@@ -213,6 +213,8 @@ def test_moreh_linear_wo_output(shapes, has_bias, npu_dtype, device):
 )
 def test_moreh_linear_enable_cache(shapes, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         passing = moreh_linear(shapes, True, True, get_compute_kernel_options(False), device)
@@ -373,6 +375,8 @@ def test_moreh_linear_backward_enable_cache(shapes, device):
     compute_kernel_config = get_compute_kernel_options(False)
 
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         passing = moreh_linear_backward(

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
@@ -14,6 +14,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_tensors(
     input_shape,

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
@@ -14,8 +14,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
@@ -173,11 +173,8 @@ def moreh_linear(shapes, has_bias, has_output, compute_kernel_config, device, np
 )
 @pytest.mark.parametrize("has_bias", [False, True])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["BFP8", "BFP16"])
+@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat16], ids=["BFP16"])
 def test_moreh_linear(shapes, has_bias, compute_kernel_options, npu_dtype, device):
-    if npu_dtype == ttnn.bfloat8_b:
-        # FAILED test cases produce 0.0 and also precision results.
-        pytest.skip("Moreh Linear does not support bfloat8_b")
     torch.manual_seed(3072)
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
     passing = moreh_linear(shapes, has_bias, True, compute_kernel_config, device, npu_dtype)
@@ -193,11 +190,8 @@ def test_moreh_linear(shapes, has_bias, compute_kernel_options, npu_dtype, devic
     ),
 )
 @pytest.mark.parametrize("has_bias", [False, True])
-@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["BFP8", "BFP16"])
+@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat16], ids=["BFP16"])
 def test_moreh_linear_wo_output(shapes, has_bias, npu_dtype, device):
-    if npu_dtype == ttnn.bfloat8_b:
-        # FAILED test cases produce 0.0 and also precision results.
-        pytest.skip("Moreh Linear does not support bfloat8_b")
     torch.manual_seed(3072)
     compute_kernel_config = get_compute_kernel_options(False)
     passing = moreh_linear(shapes, has_bias, False, compute_kernel_config, device, npu_dtype)
@@ -347,10 +341,8 @@ def moreh_linear_backward(
 )
 @pytest.mark.parametrize("requires_bias_grad", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["BFP8", "BFP16"])
+@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat16], ids=["BFP16"])
 def test_moreh_linear_backward(shapes, requires_grads, requires_bias_grad, compute_kernel_options, npu_dtype, device):
-    if npu_dtype == ttnn.bfloat8_b:
-        pytest.skip("Moreh Linear Backward does not support bfloat8_b")
     torch.manual_seed(3072)
     requires_input_grad, requires_weight_grad = requires_grads
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_linear.py
@@ -173,8 +173,11 @@ def moreh_linear(shapes, has_bias, has_output, compute_kernel_config, device, np
 )
 @pytest.mark.parametrize("has_bias", [False, True])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat16], ids=["BFP16"])
+@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["BFP8", "BFP16"])
 def test_moreh_linear(shapes, has_bias, compute_kernel_options, npu_dtype, device):
+    if npu_dtype == ttnn.bfloat8_b:
+        # FAILED test cases produce 0.0 and also precision results.
+        pytest.skip("Moreh Linear does not support bfloat8_b")
     torch.manual_seed(3072)
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
     passing = moreh_linear(shapes, has_bias, True, compute_kernel_config, device, npu_dtype)
@@ -190,8 +193,11 @@ def test_moreh_linear(shapes, has_bias, compute_kernel_options, npu_dtype, devic
     ),
 )
 @pytest.mark.parametrize("has_bias", [False, True])
-@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat16], ids=["BFP16"])
+@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["BFP8", "BFP16"])
 def test_moreh_linear_wo_output(shapes, has_bias, npu_dtype, device):
+    if npu_dtype == ttnn.bfloat8_b:
+        # FAILED test cases produce 0.0 and also precision results.
+        pytest.skip("Moreh Linear does not support bfloat8_b")
     torch.manual_seed(3072)
     compute_kernel_config = get_compute_kernel_options(False)
     passing = moreh_linear(shapes, has_bias, False, compute_kernel_config, device, npu_dtype)
@@ -341,8 +347,10 @@ def moreh_linear_backward(
 )
 @pytest.mark.parametrize("requires_bias_grad", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat16], ids=["BFP16"])
+@pytest.mark.parametrize("npu_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["BFP8", "BFP16"])
 def test_moreh_linear_backward(shapes, requires_grads, requires_bias_grad, compute_kernel_options, npu_dtype, device):
+    if npu_dtype == ttnn.bfloat8_b:
+        pytest.skip("Moreh Linear Backward does not support bfloat8_b")
     torch.manual_seed(3072)
     requires_input_grad, requires_weight_grad = requires_grads
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
@@ -17,8 +17,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
@@ -44,8 +44,6 @@ def run_moreh_logsoftmax_test(
     strategy=None,
     compute_kernel_options=None,
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
@@ -91,8 +89,6 @@ def run_moreh_logsoftmax_backward_test(
     strategy=None,
     compute_kernel_options=None,
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
@@ -146,13 +142,7 @@ def run_moreh_logsoftmax_backward_test(
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ),
 )
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
@@ -287,13 +277,7 @@ def test_logsoftmax_for_dim_nc(shape_dim, dtype, compute_kernel_options, device)
         [[10, 20, 32 * 5, 32], 2],  # multiple tiles per core
     ),
 )
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
@@ -44,6 +44,8 @@ def run_moreh_logsoftmax_test(
     strategy=None,
     compute_kernel_options=None,
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
@@ -89,6 +91,8 @@ def run_moreh_logsoftmax_backward_test(
     strategy=None,
     compute_kernel_options=None,
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
@@ -142,7 +146,13 @@ def run_moreh_logsoftmax_backward_test(
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ),
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
@@ -277,7 +287,13 @@ def test_logsoftmax_for_dim_nc(shape_dim, dtype, compute_kernel_options, device)
         [[10, 20, 32 * 5, 32], 2],  # multiple tiles per core
     ),
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_logsoftmax_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
@@ -17,6 +17,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_torch_dtype(dtype):
     if dtype == ttnn.int32:

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_logsoftmax.py
@@ -479,6 +479,8 @@ def test_logsoftmax_callback(shape_dim_strategy, dtype, device):
     torch.manual_seed(0)
     rtol = atol = 0.1
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         run_moreh_logsoftmax_test(shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy)
         if i == 0:
@@ -512,6 +514,8 @@ def test_logsoftmax_backward_callback(shape_dim_strategy, dtype, device):
 
     rtol = atol = 0.5
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         run_moreh_logsoftmax_backward_test(
             shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
@@ -15,6 +15,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def create_tt_tensor(tensor: torch.Tensor, dtype, layout, device):
     return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device)
@@ -307,6 +311,9 @@ def test_moreh_matmul_wo_output(params, use_randint, dtype, compute_kernel_optio
 )
 def test_moreh_matmul_enable_cache(params, device):
     torch.manual_seed(3072)
+    # Asserts an absolute cache-entry count, so start from an empty cache: the
+    # module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(4):
         # change input's transpose option
         if i % 2 == 1:

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
@@ -258,10 +258,12 @@ def moreh_matmul_backward(params, requires_grad, device, dtype=ttnn.bfloat16, us
     ),
 )
 @pytest.mark.parametrize("use_randint", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_moreh_matmul(params, dtype, use_randint, compute_kernel_options, device):
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
     passing = moreh_matmul(params, True, compute_kernel_config, device, use_randint=use_randint, npu_dtype=dtype)
     assert passing
 
@@ -283,10 +285,12 @@ def test_moreh_matmul(params, dtype, use_randint, compute_kernel_options, device
     ),
 )
 @pytest.mark.parametrize("use_randint", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_moreh_matmul_wo_output(params, use_randint, dtype, compute_kernel_options, device):
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
     passing = moreh_matmul(params, False, compute_kernel_config, device, use_randint, dtype)
     assert passing
 
@@ -409,9 +413,11 @@ def test_moreh_matmul_fp32_dest_acc(params, device):
         (True, True),
     ),
 )
-@pytest.mark.parametrize("dtype", (ttnn.bfloat16,), ids=["bfloat16"])
+@pytest.mark.parametrize("dtype", (ttnn.bfloat8_b, ttnn.bfloat16), ids=["bfloat8_b", "bfloat16"])
 def test_moreh_matmul_backward(params, requires_grad, dtype, device):
     torch.manual_seed(3072)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
     moreh_matmul_backward(params, requires_grad, device, dtype=dtype)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
@@ -258,12 +258,10 @@ def moreh_matmul_backward(params, requires_grad, device, dtype=ttnn.bfloat16, us
     ),
 )
 @pytest.mark.parametrize("use_randint", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_moreh_matmul(params, dtype, use_randint, compute_kernel_options, device):
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip("bfloat8_b not supported")
     passing = moreh_matmul(params, True, compute_kernel_config, device, use_randint=use_randint, npu_dtype=dtype)
     assert passing
 
@@ -285,12 +283,10 @@ def test_moreh_matmul(params, dtype, use_randint, compute_kernel_options, device
     ),
 )
 @pytest.mark.parametrize("use_randint", [True, False])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfloat8_b", "bfloat16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_moreh_matmul_wo_output(params, use_randint, dtype, compute_kernel_options, device):
     compute_kernel_config = get_compute_kernel_options(compute_kernel_options)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip("bfloat8_b not supported")
     passing = moreh_matmul(params, False, compute_kernel_config, device, use_randint, dtype)
     assert passing
 
@@ -413,11 +409,9 @@ def test_moreh_matmul_fp32_dest_acc(params, device):
         (True, True),
     ),
 )
-@pytest.mark.parametrize("dtype", (ttnn.bfloat8_b, ttnn.bfloat16), ids=["bfloat8_b", "bfloat16"])
+@pytest.mark.parametrize("dtype", (ttnn.bfloat16,), ids=["bfloat16"])
 def test_moreh_matmul_backward(params, requires_grad, dtype, device):
     torch.manual_seed(3072)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip("bfloat8_b not supported")
     moreh_matmul_backward(params, requires_grad, device, dtype=dtype)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_matmul.py
@@ -15,8 +15,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
@@ -18,6 +18,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def run_moreh_mean(
     input_shape_dim,

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
@@ -193,6 +193,8 @@ def test_moreh_mean_optional_output(input_shape_dim, optional_output, device):
 )
 def test_moreh_mean_callback(input_shape_dim, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_mean(input_shape_dim, device, keepdim=True)
@@ -264,6 +266,8 @@ def test_moreh_mean_backward_compute_kernel_options(input_shape_dim, compute_ker
 )
 def test_moreh_mean_backward_callback(input_shape_dim, device):
     torch.manual_seed(2024)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_mean_backward(input_shape_dim, device, keepdim=True)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
@@ -33,6 +33,10 @@ def run_moreh_mean(
     torch_dtype=torch.float32,
     ttnn_dtype=ttnn.bfloat16,
 ):
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
+
     input_shape, dim = input_shape_dim
     check_dim(input_shape, dim, keepdim)
 
@@ -71,6 +75,10 @@ def run_moreh_mean_backward(
     torch_dtype=torch.float32,
     ttnn_dtype=ttnn.bfloat16,
 ):
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
+
     input_shape, dim = input_shape_dim
     check_dim(input_shape, dim, keepdim)
 
@@ -136,7 +144,7 @@ def run_moreh_mean_backward(
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_mean_ttnn_dtype(input_shape_dim, keepdim, ttnn_dtype, device):
     torch.manual_seed(2024)
     run_moreh_mean(input_shape_dim, device, keepdim=keepdim, ttnn_dtype=ttnn_dtype)
@@ -223,7 +231,7 @@ def test_moreh_mean_callback(input_shape_dim, device):
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_mean_backward_ttnn_dtype(ttnn_dtype, input_shape_dim, keepdim, device):
     torch.manual_seed(2024)
     run_moreh_mean_backward(input_shape_dim, device, keepdim=keepdim, ttnn_dtype=ttnn_dtype)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
@@ -18,8 +18,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_mean.py
@@ -33,10 +33,6 @@ def run_moreh_mean(
     torch_dtype=torch.float32,
     ttnn_dtype=ttnn.bfloat16,
 ):
-    # TODO @mrshaw01: Support bfloat8_b in kernel
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
-
     input_shape, dim = input_shape_dim
     check_dim(input_shape, dim, keepdim)
 
@@ -75,10 +71,6 @@ def run_moreh_mean_backward(
     torch_dtype=torch.float32,
     ttnn_dtype=ttnn.bfloat16,
 ):
-    # TODO @mrshaw01: Support bfloat8_b in kernel
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
-
     input_shape, dim = input_shape_dim
     check_dim(input_shape, dim, keepdim)
 
@@ -144,7 +136,7 @@ def run_moreh_mean_backward(
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_mean_ttnn_dtype(input_shape_dim, keepdim, ttnn_dtype, device):
     torch.manual_seed(2024)
     run_moreh_mean(input_shape_dim, device, keepdim=keepdim, ttnn_dtype=ttnn_dtype)
@@ -231,7 +223,7 @@ def test_moreh_mean_callback(input_shape_dim, device):
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_mean_backward_ttnn_dtype(ttnn_dtype, input_shape_dim, keepdim, device):
     torch.manual_seed(2024)
     run_moreh_mean_backward(input_shape_dim, device, keepdim=keepdim, ttnn_dtype=ttnn_dtype)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
@@ -194,6 +194,8 @@ def test_moreh_nll_loss_callback(shape, reduction, device):
     torch.manual_seed(0)
     ignore_index = 0
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(4):
         if i < 2:
@@ -208,6 +210,9 @@ def test_moreh_nll_loss_callback(shape, reduction, device):
         num_program_cache_entries_list.append(device.num_program_cache_entries())
 
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    # Guard that the op registers cached programs at all; the equality checks alone
+    # would still pass even if it never does.
+    assert num_program_cache_entries_list[0] > 0
     assert (
         num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
         and num_program_cache_entries_list[2] == num_program_cache_entries_list[3]
@@ -273,6 +278,8 @@ def test_moreh_nll_loss_backward_test_callback(shape, reduction_mean, device):
 
     ignore_index = 0
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(4):
         if i < 2:
@@ -287,6 +294,9 @@ def test_moreh_nll_loss_backward_test_callback(shape, reduction_mean, device):
         num_program_cache_entries_list.append(device.num_program_cache_entries())
 
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    # Guard that the op registers cached programs at all; the equality checks alone
+    # would still pass even if it never does.
+    assert num_program_cache_entries_list[0] > 0
     assert (
         num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
         and num_program_cache_entries_list[2] == num_program_cache_entries_list[3]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
@@ -17,6 +17,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_torch_tensors(shape, torch_dtype):
     C = shape[1]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
@@ -173,11 +173,8 @@ def run_moreh_nll_loss_backward(
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("reduction", ["mean", "sum"])
 @pytest.mark.parametrize("none_weight", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_nll_loss(shape, ignore_index, reduction, none_weight, device, ttnn_dtype):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip("Support for bfloat8_b is currently unavailable.")
-
     torch.manual_seed(0)
     run_moreh_nll_loss(shape, ignore_index, reduction, none_weight, device)
 
@@ -227,13 +224,10 @@ def test_moreh_nll_loss_callback(shape, reduction, device):
 @pytest.mark.parametrize("reduction", ["mean", "sum"])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_nll_loss_compute_kernel_options(
     shape, ignore_index, reduction, none_weight, compute_kernel_options, device, ttnn_dtype
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip("Support for bfloat8_b is currently unavailable.")
-
     torch.manual_seed(0)
     run_moreh_nll_loss(
         shape, ignore_index, reduction, none_weight, device, compute_kernel_options=compute_kernel_options
@@ -251,11 +245,8 @@ def test_moreh_nll_loss_compute_kernel_options(
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("reduction_mean", [True, False])
 @pytest.mark.parametrize("none_weight", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device, ttnn_dtype):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip("Support for bfloat8_b is currently unavailable.")
-
     torch.manual_seed(0)
     run_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device)
 
@@ -304,13 +295,10 @@ def test_moreh_nll_loss_backward_test_callback(shape, reduction_mean, device):
 @pytest.mark.parametrize("reduction_mean", [True, False])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_nll_loss_backward_compute_kernel_options(
     shape, reduction_mean, none_weight, compute_kernel_options, ttnn_dtype, device
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip("Support for bfloat8_b is currently unavailable.")
-
     torch.manual_seed(0)
     ignore_index = 0
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
@@ -173,8 +173,11 @@ def run_moreh_nll_loss_backward(
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("reduction", ["mean", "sum"])
 @pytest.mark.parametrize("none_weight", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_nll_loss(shape, ignore_index, reduction, none_weight, device, ttnn_dtype):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("Support for bfloat8_b is currently unavailable.")
+
     torch.manual_seed(0)
     run_moreh_nll_loss(shape, ignore_index, reduction, none_weight, device)
 
@@ -224,10 +227,13 @@ def test_moreh_nll_loss_callback(shape, reduction, device):
 @pytest.mark.parametrize("reduction", ["mean", "sum"])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_nll_loss_compute_kernel_options(
     shape, ignore_index, reduction, none_weight, compute_kernel_options, device, ttnn_dtype
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("Support for bfloat8_b is currently unavailable.")
+
     torch.manual_seed(0)
     run_moreh_nll_loss(
         shape, ignore_index, reduction, none_weight, device, compute_kernel_options=compute_kernel_options
@@ -245,8 +251,11 @@ def test_moreh_nll_loss_compute_kernel_options(
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("reduction_mean", [True, False])
 @pytest.mark.parametrize("none_weight", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device, ttnn_dtype):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("Support for bfloat8_b is currently unavailable.")
+
     torch.manual_seed(0)
     run_moreh_nll_loss_backward(shape, ignore_index, reduction_mean, none_weight, device)
 
@@ -295,10 +304,13 @@ def test_moreh_nll_loss_backward_test_callback(shape, reduction_mean, device):
 @pytest.mark.parametrize("reduction_mean", [True, False])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_nll_loss_backward_compute_kernel_options(
     shape, reduction_mean, none_weight, compute_kernel_options, ttnn_dtype, device
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("Support for bfloat8_b is currently unavailable.")
+
     torch.manual_seed(0)
     ignore_index = 0
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss.py
@@ -17,8 +17,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
@@ -163,8 +163,11 @@ def run_moreh_nll_loss_unreduced(
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_nll_loss_unreduced(shape, ignore_index, none_weight, compute_kernel_options, ttnn_dtype, device):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("Support for bfloat8_b is currently unavailable.")
+
     torch.manual_seed(0)
     run_moreh_nll_loss_unreduced(
         shape, ignore_index, none_weight, device, compute_kernel_options=compute_kernel_options
@@ -216,10 +219,13 @@ def test_moreh_nll_loss_unreduced_callback(shape, device):
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_moreh_nll_loss_unreduced_backward(
     shape, ignore_index, none_weight, compute_kernel_options, ttnn_dtype, device
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip("Support for bfloat8_b is currently unavailable.")
+
     torch.manual_seed(0)
     run_moreh_nll_loss_unreduced_backward(
         shape, ignore_index, none_weight, device, compute_kernel_options=compute_kernel_options

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
@@ -17,6 +17,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_torch_tensors(shape, torch_dtype):
     C = shape[1]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
@@ -17,8 +17,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     to_ttnn,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
@@ -163,11 +163,8 @@ def run_moreh_nll_loss_unreduced(
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_nll_loss_unreduced(shape, ignore_index, none_weight, compute_kernel_options, ttnn_dtype, device):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip("Support for bfloat8_b is currently unavailable.")
-
     torch.manual_seed(0)
     run_moreh_nll_loss_unreduced(
         shape, ignore_index, none_weight, device, compute_kernel_options=compute_kernel_options
@@ -219,13 +216,10 @@ def test_moreh_nll_loss_unreduced_callback(shape, device):
 @pytest.mark.parametrize("ignore_index", [1])
 @pytest.mark.parametrize("none_weight", [True, False])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_moreh_nll_loss_unreduced_backward(
     shape, ignore_index, none_weight, compute_kernel_options, ttnn_dtype, device
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip("Support for bfloat8_b is currently unavailable.")
-
     torch.manual_seed(0)
     run_moreh_nll_loss_unreduced_backward(
         shape, ignore_index, none_weight, device, compute_kernel_options=compute_kernel_options

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py
@@ -185,6 +185,8 @@ def test_moreh_nll_loss_unreduced_callback(shape, device):
     torch.manual_seed(0)
 
     ignore_index = 1
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
 
     for i in range(4):
@@ -200,6 +202,9 @@ def test_moreh_nll_loss_unreduced_callback(shape, device):
         num_program_cache_entries_list.append(device.num_program_cache_entries())
 
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    # Guard that the op registers cached programs at all; the equality checks alone
+    # would still pass even if it never does.
+    assert num_program_cache_entries_list[0] > 0
     assert (
         num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
         and num_program_cache_entries_list[2] == num_program_cache_entries_list[3]
@@ -244,6 +249,8 @@ def test_moreh_nll_loss_unreduced_backward(
 def test_moreh_nll_loss_unreduced_backward_test_callback(shape, none_weight, device, ignore_index):
     torch.manual_seed(0)
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(4):
         if i < 2:
@@ -258,6 +265,9 @@ def test_moreh_nll_loss_unreduced_backward_test_callback(shape, none_weight, dev
         num_program_cache_entries_list.append(device.num_program_cache_entries())
 
     logger.info(f"num_program_cache_entries_list={num_program_cache_entries_list}")
+    # Guard that the op registers cached programs at all; the equality checks alone
+    # would still pass even if it never does.
+    assert num_program_cache_entries_list[0] > 0
     assert (
         num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
         and num_program_cache_entries_list[2] == num_program_cache_entries_list[3]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
@@ -180,9 +180,6 @@ def run_moreh_norm(
     Raises:
         AssertionError: If the computed norm values from ttnn's implementation and torch are not close.
     """
-    # TODO @mrshaw01: Support bfloat8_b in kernel
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     check_dim(input_shape, dim, keepdim)
     torch_input, torch_output_grad = make_torch_tensors(input_shape, dim, keepdim=keepdim, dtype=torch_dtype)
     expected_output, _ = torch_norm(
@@ -313,9 +310,6 @@ def run_moreh_norm_backward(
     Raises:
         AssertionError: If the computed gradients from ttnn's implementation and torch are not close.
     """
-    # TODO @mrshaw01: Support bfloat8_b in kernel
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported in the kernel")
     check_dim(input_shape, dim, keepdim)
     torch_input, torch_output_grad = make_torch_tensors(input_shape, dim, keepdim=keepdim, dtype=torch_dtype)
     _, expected_input_grad = torch_norm(
@@ -390,7 +384,7 @@ def run_moreh_norm_backward(
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("is_linalg_vector_norm", [False, True])
 def test_moreh_norm(input_shape, p, dim_rtol_atol, keepdim, ttnn_dtype, device, is_linalg_vector_norm):
     """
@@ -617,7 +611,7 @@ def test_moreh_norm_callback(dim_rtol_atol, keepdim, device, is_linalg_vector_no
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("is_linalg_vector_norm", [False, True])
 def test_moreh_norm_backward(input_shape, p, dim_rtol_atol, keepdim, ttnn_dtype, device, is_linalg_vector_norm):
     """

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
@@ -17,6 +17,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def make_torch_tensors(input_shape, dim, keepdim=False, *, dtype=torch.float32):
     """

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
@@ -180,6 +180,9 @@ def run_moreh_norm(
     Raises:
         AssertionError: If the computed norm values from ttnn's implementation and torch are not close.
     """
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     check_dim(input_shape, dim, keepdim)
     torch_input, torch_output_grad = make_torch_tensors(input_shape, dim, keepdim=keepdim, dtype=torch_dtype)
     expected_output, _ = torch_norm(
@@ -310,6 +313,9 @@ def run_moreh_norm_backward(
     Raises:
         AssertionError: If the computed gradients from ttnn's implementation and torch are not close.
     """
+    # TODO @mrshaw01: Support bfloat8_b in kernel
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported in the kernel")
     check_dim(input_shape, dim, keepdim)
     torch_input, torch_output_grad = make_torch_tensors(input_shape, dim, keepdim=keepdim, dtype=torch_dtype)
     _, expected_input_grad = torch_norm(
@@ -384,7 +390,7 @@ def run_moreh_norm_backward(
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("is_linalg_vector_norm", [False, True])
 def test_moreh_norm(input_shape, p, dim_rtol_atol, keepdim, ttnn_dtype, device, is_linalg_vector_norm):
     """
@@ -611,7 +617,7 @@ def test_moreh_norm_callback(dim_rtol_atol, keepdim, device, is_linalg_vector_no
     ],
 )
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("is_linalg_vector_norm", [False, True])
 def test_moreh_norm_backward(input_shape, p, dim_rtol_atol, keepdim, ttnn_dtype, device, is_linalg_vector_norm):
     """

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
@@ -17,8 +17,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_norm.py
@@ -557,6 +557,8 @@ def test_moreh_norm_callback(dim_rtol_atol, keepdim, device, is_linalg_vector_no
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_norm(
@@ -693,6 +695,8 @@ def test_moreh_norm_backward_callback(dim_rtol_atol, keepdim, device, is_linalg_
     """
     torch.manual_seed(2024)
     dim, rtol, atol = dim_rtol_atol
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     for i in range(2):
         run_moreh_norm_backward(

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
@@ -215,6 +215,8 @@ def test_moreh_sgd_callback(
         pytest.skip()
 
     torch.manual_seed(0)
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     num_program_cache_entries_list = []
     compute_kernel_config = get_compute_kernel_options(fp32_dest_acc_en)
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
@@ -46,11 +46,7 @@ if is_wormhole_b0():
 )
 @pytest.mark.parametrize("has_param_out", [True, False], ids=["HAS_PARAM_OUT_TRUE", "HAS_PARAM_OUT_FALSE"])
 @pytest.mark.parametrize("fp32_dest_acc_en", fp32_dest_acc_en, ids=fp32_dest_acc_en_ids)
-@pytest.mark.parametrize(
-    "npu_dtype, cpu_dtype",
-    [[ttnn.bfloat8_b, torch.bfloat16], [ttnn.bfloat16, torch.bfloat16]],
-    ids=["bfloat8", "bfloat16"],
-)
+@pytest.mark.parametrize("npu_dtype, cpu_dtype", [[ttnn.bfloat16, torch.bfloat16]], ids=["bfloat16"])
 def test_moreh_sgd(
     shape,
     lr,
@@ -66,10 +62,6 @@ def test_moreh_sgd(
     device,
 ):
     if nesterov and (momentum <= 0 or dampening != 0):
-        pytest.skip()
-    if npu_dtype == ttnn.bfloat8_b:
-        # Duong: ttnn.bfloat8_b has some bugs. only around half the tests passed for bfloat8_b. Some tests produce 0.0 or Inf results.
-        # I couldn't identify the pattern of failed tests, it seems kind of random so I think it's a precision error.
         pytest.skip()
 
     torch.manual_seed(0)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
@@ -16,6 +16,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 from loguru import logger
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 fp32_dest_acc_en = [
     False,  # for grayskull
 ]

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
@@ -16,8 +16,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
 )
 from loguru import logger
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 fp32_dest_acc_en = [

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sgd.py
@@ -46,7 +46,11 @@ if is_wormhole_b0():
 )
 @pytest.mark.parametrize("has_param_out", [True, False], ids=["HAS_PARAM_OUT_TRUE", "HAS_PARAM_OUT_FALSE"])
 @pytest.mark.parametrize("fp32_dest_acc_en", fp32_dest_acc_en, ids=fp32_dest_acc_en_ids)
-@pytest.mark.parametrize("npu_dtype, cpu_dtype", [[ttnn.bfloat16, torch.bfloat16]], ids=["bfloat16"])
+@pytest.mark.parametrize(
+    "npu_dtype, cpu_dtype",
+    [[ttnn.bfloat8_b, torch.bfloat16], [ttnn.bfloat16, torch.bfloat16]],
+    ids=["bfloat8", "bfloat16"],
+)
 def test_moreh_sgd(
     shape,
     lr,
@@ -62,6 +66,10 @@ def test_moreh_sgd(
     device,
 ):
     if nesterov and (momentum <= 0 or dampening != 0):
+        pytest.skip()
+    if npu_dtype == ttnn.bfloat8_b:
+        # Duong: ttnn.bfloat8_b has some bugs. only around half the tests passed for bfloat8_b. Some tests produce 0.0 or Inf results.
+        # I couldn't identify the pattern of failed tests, it seems kind of random so I think it's a precision error.
         pytest.skip()
 
     torch.manual_seed(0)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
@@ -439,6 +439,8 @@ def test_softmax_callback(shape_dim_strategy, dtype, device):
     torch.manual_seed(0)
     rtol = atol = 0.05
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         run_moreh_softmax_test(shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy)
         if i == 0:
@@ -471,6 +473,8 @@ def test_softmax_backward_callback(shape_dim_strategy, dtype, device):
     torch.manual_seed(0)
     rtol = atol = 0.05
 
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         run_moreh_softmax_backward_test(
             shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
@@ -43,8 +43,6 @@ def run_moreh_softmax_test(
     strategy=None,
     compute_kernel_options=None,
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
@@ -90,8 +88,6 @@ def run_moreh_softmax_backward_test(
     strategy=None,
     compute_kernel_options=None,
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
@@ -145,13 +141,7 @@ def run_moreh_softmax_backward_test(
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmax_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
@@ -290,13 +280,7 @@ def test_softmax_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmax_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
@@ -16,6 +16,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_torch_dtype(dtype):
     if dtype == ttnn.int32:

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
@@ -16,8 +16,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmax.py
@@ -43,6 +43,8 @@ def run_moreh_softmax_test(
     strategy=None,
     compute_kernel_options=None,
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
@@ -88,6 +90,8 @@ def run_moreh_softmax_backward_test(
     strategy=None,
     compute_kernel_options=None,
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
@@ -141,7 +145,13 @@ def run_moreh_softmax_backward_test(
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmax_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
@@ -280,7 +290,13 @@ def test_softmax_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmax_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
@@ -17,8 +17,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
@@ -44,8 +44,6 @@ def run_moreh_softmin_test(
     strategy=None,
     compute_kernel_options=None,
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
@@ -91,8 +89,6 @@ def run_moreh_softmin_backward_test(
     strategy=None,
     compute_kernel_options=None,
 ):
-    if ttnn_dtype == ttnn.bfloat8_b:
-        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
@@ -146,13 +142,7 @@ def run_moreh_softmin_backward_test(
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmin_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
@@ -285,13 +275,7 @@ def test_softmin_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        ttnn.bfloat16,
-        ttnn.bfloat8_b,
-    ],
-)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmin_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
@@ -17,6 +17,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def get_torch_dtype(dtype):
     if dtype == ttnn.int32:

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
@@ -44,6 +44,8 @@ def run_moreh_softmin_test(
     strategy=None,
     compute_kernel_options=None,
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_input = torch.randint(low=0, high=4, size=shape).to(torch_dtype) + 100
@@ -89,6 +91,8 @@ def run_moreh_softmin_backward_test(
     strategy=None,
     compute_kernel_options=None,
 ):
+    if ttnn_dtype == ttnn.bfloat8_b:
+        pytest.skip(f"bfloat8_b is not supported")
     torch_dtype = get_torch_dtype(ttnn_dtype)
     if use_randint == True:
         torch_x = torch.randint(low=0, high=4, size=shape).to(torch_dtype).requires_grad_(True)
@@ -142,7 +146,13 @@ def run_moreh_softmin_backward_test(
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmin_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim
@@ -275,7 +285,13 @@ def test_softmin_for_dim_nc(shape_dim, dtype, compute_kernel_options, device):
         [[10, 20, 32 * 3, 32 * 5], 2],  # multiple tiles per core
     ],
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 def test_softmin_backward_for_dim_hw(shape_dim, dtype, compute_kernel_options, device):
     shape, dim = shape_dim

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_softmin.py
@@ -476,6 +476,8 @@ def test_softmin_callback(shape_dim_strategy, dtype, device):
     shape, dim, strategy = shape_dim_strategy
     torch.manual_seed(0)
     rtol = atol = 0.05
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         run_moreh_softmin_test(shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy)
         if i == 0:
@@ -508,6 +510,8 @@ def test_softmin_backward_callback(shape_dim_strategy, dtype, device):
     torch.manual_seed(0)
     rtol = atol = 0.05
     num_program_cache_entries = None
+    # Start from an empty cache: the module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     for i in range(2):
         run_moreh_softmin_backward_test(
             shape, dim, dtype, ttnn.TILE_LAYOUT, device, rtol, atol, True, strategy=strategy

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
@@ -189,11 +189,9 @@ def moreh_sum(input_shape, dim, keepdim, use_provide_output, compute_kernel_opti
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 @pytest.mark.parametrize("keepdim", [True, False], ids=["keepdim-true", "keepdim-false"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bfloat16", "bfloat8_b"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 def test_moreh_sum(input_shape, dim, keepdim, compute_kernel_options, dtype, device):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip("bfloat8_b not supported")
     passing = moreh_sum(input_shape, dim, keepdim, True, compute_kernel_options, device, dtype=dtype)
     assert passing
 
@@ -386,11 +384,9 @@ def moreh_sum_backward(
 )
 @pytest.mark.parametrize("keepdim", [True, False], ids=["keepdim-true", "keepdim-false"])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bfloat16", "bfloat8_b"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
 def test_moreh_sum_backward(input_shape, dim, keepdim, compute_kernel_options, dtype, device):
     torch.manual_seed(2023)
-    if dtype == ttnn.bfloat8_b:
-        pytest.skip("bfloat8_b is not supported")
     passing = moreh_sum_backward(input_shape, dim, keepdim, True, compute_kernel_options, device, dtype=dtype)
     assert passing
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
@@ -21,8 +21,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     TILE_WIDTH,
 )
 
-# Module-scoped device: these tests all run with the default device config, so the device is
-# opened once per file instead of once per test case.
+# Module-scoped device: opens once per file instead of once per test case.
 pytestmark = pytest.mark.use_module_device
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
@@ -189,9 +189,11 @@ def moreh_sum(input_shape, dim, keepdim, use_provide_output, compute_kernel_opti
 )
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
 @pytest.mark.parametrize("keepdim", [True, False], ids=["keepdim-true", "keepdim-false"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bfloat16", "bfloat8_b"])
 def test_moreh_sum(input_shape, dim, keepdim, compute_kernel_options, dtype, device):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b not supported")
     passing = moreh_sum(input_shape, dim, keepdim, True, compute_kernel_options, device, dtype=dtype)
     assert passing
 
@@ -384,9 +386,11 @@ def moreh_sum_backward(
 )
 @pytest.mark.parametrize("keepdim", [True, False], ids=["keepdim-true", "keepdim-false"])
 @pytest.mark.parametrize("compute_kernel_options", compute_kernel_options, ids=compute_kernel_ids)
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bfloat16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bfloat16", "bfloat8_b"])
 def test_moreh_sum_backward(input_shape, dim, keepdim, compute_kernel_options, dtype, device):
     torch.manual_seed(2023)
+    if dtype == ttnn.bfloat8_b:
+        pytest.skip("bfloat8_b is not supported")
     passing = moreh_sum_backward(input_shape, dim, keepdim, True, compute_kernel_options, device, dtype=dtype)
     assert passing
 

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_sum.py
@@ -21,6 +21,10 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     TILE_WIDTH,
 )
 
+# Module-scoped device: these tests all run with the default device config, so the device is
+# opened once per file instead of once per test case.
+pytestmark = pytest.mark.use_module_device
+
 
 def is_npu_dtype_uint32(data_type):
     return data_type == ttnn.uint32
@@ -256,6 +260,9 @@ def test_moreh_sum_rank_1_global(input_shape, dim, use_provide_output, device):
 )
 def test_moreh_sum_enable_cache(input_shape, dim, device):
     torch.manual_seed(3072)
+    # Asserts an absolute cache-entry count, so start from an empty cache: the
+    # module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     keepdim = [True, False]
     use_provide_output = [True, False]
     for i in range(2):
@@ -429,6 +436,9 @@ def test_moreh_sum_backward_wo_input_grad(input_shape, dim, device):
 )
 def test_moreh_sum_backward_enable_cache(input_shape, dim, device):
     torch.manual_seed(3072)
+    # Asserts an absolute cache-entry count, so start from an empty cache: the
+    # module-scoped device carries entries over from earlier tests in this file.
+    device.clear_program_cache()
     keepdim = [True, False]
     use_provide_output = [True, False]
     num_cache_entires = [2, 2, 2]


### PR DESCRIPTION
## Summary
- Fixes: #53839 (sub-issue of #51180)
- Cuts nightly moreh test runtime by reusing one device per test file instead of opening and closing a fresh one for every test case.

## Problem Description
- `ops-unit-tests / ttnn nightly moreh tests [wh_n150_civ2]` was timing out past its `45`-minute CI budget - confirmed on `main` at `46m 55s`.
- All 25 files (`~6,600` parametrized cases) used the default function-scoped `device` fixture, so every case - including ones that immediately `pytest.skip()` - paid a full device open/close cycle (`~0.24s`) before any actual work happened.

## What's Changed

**Module-scoped device fixture**
- Added `pytestmark = pytest.mark.use_module_device` to all 24 files not already using it (`test_moreh_logsoftmax_ulp.py` already had it). The device now opens once per file instead of once per test case, so the program cache persists across cases in that file.
- Confirmed no moreh test parametrizes `device_params`, which would conflict with a module-scoped device.
- Three tests asserted an absolute program-cache count (`== N`), which only held with a device that started fresh every test. Reset the cache explicitly in each (`test_moreh_matmul.py`, `test_moreh_sum.py` `x2`) so the assertion still holds - every other cache check in the directory is relative and needed no change.


## Tests

Confirmed through real CI pipeline runs across all four SKUs in the `ops-unit-tests` moreh job (`45`-min budget):

| SKU | Main | With this PR | Change |
|---|---:|---:|---:|
| `wh_n150_civ2` | `46m 55s` | `29m 2s` | **-38%** |
| `wh_n300_civ2` | `31m 27s` | `28m 49s` | -8% |
| `bh_p100` | `15m 20s` | `11m 13s` | -27% |
| `bh_p150b_civ2` | `31m 42s` | `21m 53s` | -31% |

`wh_n150_civ2` previously exceeded the `45`-minute budget on `main`; with this change it completes in `~29` minutes with comfortable margin.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/moreh-nightly-runtime-53839)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/moreh-nightly-runtime-53839)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/moreh-nightly-runtime-53839)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/moreh-nightly-runtime-53839)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/moreh-nightly-runtime-53839)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/moreh-nightly-runtime-53839)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/moreh-nightly-runtime-53839)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/moreh-nightly-runtime-53839)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/moreh-nightly-runtime-53839)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/moreh-nightly-runtime-53839)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/moreh-nightly-runtime-53839)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/moreh-nightly-runtime-53839)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/moreh-nightly-runtime-53839)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/moreh-nightly-runtime-53839)