### PR TITLE
[Performance]:  Use aligned loads for FD command field reads

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -470,8 +470,12 @@ struct CQDispatchCmdLarge {
 
 //////////////////////////////////////////////////////////////////////////////
 
-static_assert(sizeof(CQPrefetchBaseCmd) == sizeof(uint8_t));  // if this fails, padding above needs to be adjusted
-static_assert(sizeof(CQDispatchBaseCmd) == sizeof(uint8_t));  // if this fails, padding above needs to be adjusted
-static_assert((sizeof(CQPrefetchCmd) & (CQ_DISPATCH_CMD_SIZE - 1)) == 0);
-static_assert((sizeof(CQPrefetchCmdLarge) & (CQ_DISPATCH_CMD_SIZE - 1)) == 0);
-static_assert((sizeof(CQDispatchCmd) & (CQ_DISPATCH_CMD_SIZE - 1)) == 0);
+// Base cmd size sets where every payload field lands: if this fails, adjust the padding above and
+// every load_aligned() field offset shifts with it.
+static_assert(sizeof(CQPrefetchBaseCmd) == sizeof(uint8_t));
+static_assert(sizeof(CQDispatchBaseCmd) == sizeof(uint8_t));
+// Exact, not a multiple: a union member growing past the largest would silently double every stride.
+static_assert(sizeof(CQPrefetchCmd) == CQ_DISPATCH_CMD_SIZE);
+static_assert(sizeof(CQPrefetchCmdLarge) == 2 * CQ_DISPATCH_CMD_SIZE);
+static_assert(sizeof(CQDispatchCmd) == CQ_DISPATCH_CMD_SIZE);
+static_assert(sizeof(CQDispatchCmdLarge) == 2 * CQ_DISPATCH_CMD_SIZE);

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -168,10 +168,9 @@ struct CQPrefetchPagedToRingbufferCmd {
 } __attribute__((packed));
 
 struct CQPrefetchSetRingbufferOffsetCmd {
-    uint32_t offset;
-    uint16_t pad1;
-    uint8_t pad2;
     uint8_t update_wp;  // if set, the ringbuffer write pointer will be updated to the offset
+    uint16_t pad1;
+    uint32_t offset;
 } __attribute__((packed));
 
 // Current implementation limit is based on size of the l1_cache which stores the sub_cmds
@@ -396,11 +395,11 @@ struct CQDispatchSetUnicastOnlyCoresCmd {
 constexpr uint8_t CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET = 0xff;
 
 struct CQDispatchGoSignalMcastCmd {
-    uint32_t go_signal;
     uint8_t multicast_go_offset;  // Index of the multicast go to write to. CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET - no
                                   // multicast gos.
     uint8_t num_unicast_txns;
     uint8_t noc_data_start_index;
+    uint32_t go_signal;
     uint32_t wait_count;
     uint32_t wait_stream;  // Index of the stream to wait on
 } __attribute__((packed));
@@ -413,6 +412,8 @@ struct CQDispatchNotifySubordinateGoSignalCmd {
 } __attribute__((packed));
 
 struct CQDispatchRtProfilerFlushCmd {
+    uint8_t pad1;
+    uint16_t pad2;
     uint32_t wait_count;   // worker completion count to wait on
     uint32_t wait_stream;  // stream index to wait on
 } __attribute__((packed));

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -780,3 +780,16 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
     uint32_t command_size = sizeof(CQDispatchCmd) + num_sub_devices * sizeof(uint32_t);
     return round_up_pow2(command_size, L1_ALIGNMENT);
 }
+
+// Single wide load of a field in a `packed` struct, which the compiler would otherwise reassemble from
+// byte loads (packed sets struct alignment to 1).
+//
+// Do not change the `void*` parameter to `const volatile T*`: taking the address of a packed member as
+// `T*` fails the build under -Werror=address-of-packed-member.
+//
+// T must match the field's width -- a narrower T silently truncates. The field must also be naturally
+// aligned, which for the command structs is what their pad members exist to guarantee
+template <typename T>
+FORCE_INLINE T load_aligned(const volatile void* ptr) {
+    return *reinterpret_cast<const volatile T*>(ptr);
+}

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -784,11 +784,11 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
 // Single wide load of a field in a `packed` struct, which the compiler would otherwise reassemble from
 // byte loads (packed sets struct alignment to 1).
 //
-// Do not change the `void*` parameter to `const volatile T*`: taking the address of a packed member as
-// `T*` fails the build under -Werror=address-of-packed-member.
+// The `void*` parameter is required: taking the address of a packed member as `T*` trips
+// -Waddress-of-packed-member, which this build promotes to an error.
 //
-// T must match the field's width -- a narrower T silently truncates. The field must also be naturally
-// aligned, which for the command structs is what their pad members exist to guarantee
+// Unchecked caller obligations: T must match the field's width (a narrower T silently truncates), and
+// the field must be naturally aligned.
 template <typename T>
 FORCE_INLINE T load_aligned(const volatile void* ptr) {
     return *reinterpret_cast<const volatile T*>(ptr);

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -791,5 +791,6 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
 // the field must be naturally aligned.
 template <typename T>
 FORCE_INLINE T load_aligned(const volatile void* ptr) {
+    ASSERT((reinterpret_cast<uintptr_t>(ptr) & (alignof(T) - 1)) == 0);
     return *reinterpret_cast<const volatile T*>(ptr);
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -339,7 +339,7 @@ void process_write_host_h() {
 
     // We will send the cmd back in the first X bytes, this makes the logic of reserving/pushing completion queue
     // pages much simpler since we are always sending writing full pages (except for last page)
-    uint64_t wlength = cmd->write_linear_host.length;
+    uint64_t wlength = load_aligned<uint64_t>(&cmd->write_linear_host.length);
     bool is_event = cmd->write_linear_host.is_event;
     // DPRINT("process_write_host_h: length {}\n", length);
     uintptr_t data_ptr = cmd_ptr;
@@ -513,7 +513,7 @@ void process_write_host_d() {
     volatile tt_l1_ptr CQDispatchCmd* cmd =
         reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(l1_uncached_addr(cmd_ptr));
     // Remember: host transfer command includes the command in the payload, don't add it here
-    uint64_t length = cmd->write_linear_host.length;
+    uint64_t length = load_aligned<uint64_t>(&cmd->write_linear_host.length);
     uintptr_t data_ptr = cmd_ptr;
 
     relay_to_next_cb(data_ptr, length);
@@ -522,7 +522,7 @@ void process_write_host_d() {
 void relay_write_h() {
     volatile tt_l1_ptr CQDispatchCmdLarge* cmd =
         reinterpret_cast<volatile tt_l1_ptr CQDispatchCmdLarge*>(l1_uncached_addr(cmd_ptr));
-    uint64_t length = sizeof(CQDispatchCmdLarge) + cmd->write_linear.length;
+    uint64_t length = sizeof(CQDispatchCmdLarge) + load_aligned<uint64_t>(&cmd->write_linear.length);
     uintptr_t data_ptr = cmd_ptr;
 
     relay_to_next_cb(data_ptr, length);
@@ -540,10 +540,10 @@ void process_write_linear(uint32_t num_mcast_dests) {
         num_mcast_dests = 1;
     }
 
-    uint32_t dst_noc = cmd->write_linear.noc_xy_addr;
+    uint32_t dst_noc = load_aligned<uint32_t>(&cmd->write_linear.noc_xy_addr);
     uint32_t write_offset_index = cmd->write_linear.write_offset_index;
-    uint64_t dst_addr = cmd->write_linear.addr + write_offset[write_offset_index];
-    uint64_t length = cmd->write_linear.length;
+    uint64_t dst_addr = load_aligned<uint64_t>(&cmd->write_linear.addr) + write_offset[write_offset_index];
+    uint64_t length = load_aligned<uint64_t>(&cmd->write_linear.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmdLarge);
     // DPRINT("process_write_linear noc_xy:0x{:x} write_offset:{} dst_addr:0x{08x} length:{} data_ptr:0x{08x}\n",
     // dst_noc, write_offset_index, dst_addr, length, data_ptr);
@@ -604,10 +604,10 @@ __attribute__((noinline)) void process_write_paged() {
     volatile tt_l1_ptr CQDispatchCmd* cmd =
         reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(l1_uncached_addr(cmd_ptr));
 
-    uint32_t page_id = cmd->write_paged.start_page;
-    uint32_t base_addr = cmd->write_paged.base_addr;
-    uint32_t page_size = cmd->write_paged.page_size;
-    uint32_t pages = cmd->write_paged.pages;
+    uint32_t page_id = load_aligned<uint16_t>(&cmd->write_paged.start_page);
+    uint32_t base_addr = load_aligned<uint32_t>(&cmd->write_paged.base_addr);
+    uint32_t page_size = load_aligned<uint32_t>(&cmd->write_paged.page_size);
+    uint32_t pages = load_aligned<uint32_t>(&cmd->write_paged.pages);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd);
     uint32_t write_length = pages * page_size;
     [[maybe_unused]] auto addr_gen =
@@ -718,7 +718,7 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
 
-    uint32_t count = cmd->write_packed.count;
+    uint32_t count = load_aligned<uint16_t>(&cmd->write_packed.count);
     ASSERT(count <= (mcast ? packed_write_max_multicast_sub_cmds : packed_write_max_unicast_sub_cmds));
     constexpr uint32_t sub_cmd_size = sizeof(WritePackedSubCmd);
     // Copying in a burst is about a 30% net gain vs reading one value per loop below
@@ -727,9 +727,9 @@ void process_write_packed(uint32_t flags, uint32_t* l1_cache) {
         count * sub_cmd_size / sizeof(uint32_t),
         l1_cache);
 
-    uint32_t xfer_size = cmd->write_packed.size;
-    uint32_t write_offset_index = cmd->write_packed.write_offset_index;
-    uint32_t dst_addr = cmd->write_packed.addr + write_offset[write_offset_index];
+    uint32_t xfer_size = load_aligned<uint16_t>(&cmd->write_packed.size);
+    uint32_t write_offset_index = load_aligned<uint16_t>(&cmd->write_packed.write_offset_index);
+    uint32_t dst_addr = load_aligned<uint32_t>(&cmd->write_packed.addr) + write_offset[write_offset_index];
 
     ASSERT(xfer_size <= dispatch_cb_page_size);
 
@@ -845,10 +845,10 @@ void process_write_packed_large(uint32_t* l1_cache) {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
 
-    uint32_t count = cmd->write_packed_large.count;
+    uint32_t count = load_aligned<uint16_t>(&cmd->write_packed_large.count);
     ASSERT(count <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS);
-    uint32_t alignment = cmd->write_packed_large.alignment;
-    uint32_t write_offset_index = cmd->write_packed_large.write_offset_index;
+    uint32_t alignment = load_aligned<uint16_t>(&cmd->write_packed_large.alignment);
+    uint32_t write_offset_index = load_aligned<uint16_t>(&cmd->write_packed_large.write_offset_index);
     uint32_t local_write_offset = write_offset[write_offset_index];
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
@@ -978,10 +978,10 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
 
-    uint32_t count = cmd->write_packed_large_unicast.count;
+    uint32_t count = load_aligned<uint16_t>(&cmd->write_packed_large_unicast.count);
     ASSERT(count <= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_UNICAST_MAX_SUB_CMDS);
-    uint32_t alignment = cmd->write_packed_large_unicast.alignment;
-    uint32_t write_offset_index = cmd->write_packed_large_unicast.write_offset_index;
+    uint32_t alignment = load_aligned<uint16_t>(&cmd->write_packed_large_unicast.alignment);
+    uint32_t write_offset_index = load_aligned<uint16_t>(&cmd->write_packed_large_unicast.write_offset_index);
     uint32_t local_write_offset = write_offset[write_offset_index];
     uintptr_t data_ptr = cmd_ptr + sizeof(CQDispatchCmd) + count * sizeof(CQDispatchWritePackedLargeUnicastSubCmd);
     data_ptr = round_up_pow2(data_ptr, L1_ALIGNMENT);
@@ -1054,7 +1054,7 @@ void process_write_packed_large_unicast(uint32_t* l1_cache) {
 static uintptr_t process_debug_cmd(uintptr_t cmd_ptr) {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
-    return cmd_ptr + cmd->debug.stride;
+    return cmd_ptr + load_aligned<uint32_t>(&cmd->debug.stride);
 }
 
 FORCE_INLINE
@@ -1088,8 +1088,8 @@ static void process_wait() {
     uint32_t clear_memory = flags & CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_MEMORY;
     uint32_t wait_memory = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_MEMORY;
     uint32_t wait_stream = flags & CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM;
-    uint32_t count = cmd->wait.count;
-    uint32_t stream = cmd->wait.stream;
+    uint32_t count = load_aligned<uint32_t>(&cmd->wait.count);
+    uint32_t stream = load_aligned<uint16_t>(&cmd->wait.stream);
 
     if (barrier) {
         // DPRINT("dispatch barrier\n");
@@ -1102,7 +1102,7 @@ static void process_wait() {
     WAYPOINT("PWW");
     uint32_t heartbeat = 0;
     if (wait_memory) {
-        uintptr_t addr = cmd->wait.addr;
+        uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
         volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr));
         // DPRINT("DISPATCH WAIT 0x{:08x} count {}\n", addr, count);
         do {
@@ -1136,7 +1136,7 @@ static void process_wait() {
         }
     }
     if (clear_memory) {
-        uintptr_t addr = cmd->wait.addr;
+        uintptr_t addr = load_aligned<uint32_t>(&cmd->wait.addr);
         *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(addr)) = 0;
     }
     if (notify_prefetch) {
@@ -1156,7 +1156,7 @@ static void process_wait() {
 static void process_delay_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
-    uint32_t count = cmd->delay.delay;
+    uint32_t count = load_aligned<uint32_t>(&cmd->delay.delay);
     for (volatile uint32_t i = 0; i < count; i++);
     cmd_ptr += sizeof(CQDispatchCmd);
 }
@@ -1165,24 +1165,23 @@ FORCE_INLINE
 void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
-    uint32_t stream = cmd->mcast.wait_stream;
+    uint32_t stream = load_aligned<uint32_t>(&cmd->mcast.wait_stream);
     // The location of the go signal embedded in the command does not meet NOC alignment requirements.
     // cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher over NOC.
-    // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This is safe as long as we
-    // can guarantee that copying the go signal does not corrupt any other command fields, which is true (see
-    // CQDispatchGoSignalMcastCmd).
-    // NOC source addresses must be raw L1 byte offsets (cached-alias form), so keep
-    // aligned_go_signal_storage at the cached alias for the NOC sources at lines 1065 and 1108.
-    // CPU writes go through a separate uncached pointer so the value lands in L1 SRAM directly;
-    // the NOC then reads the same physical location via the cached-form source address.
+    // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This overwrites command
+    // fields, so every field must be read into a local below before the first store; do not read cmd ptr cmd-> after
+    // it. NOC source addresses must be raw L1 byte offsets (cached-alias form), so keep aligned_go_signal_storage at
+    // the cached alias for the NOC sources at lines 1065 and 1108. CPU writes go through a separate uncached pointer so
+    // the value lands in L1 SRAM directly; the NOC then reads the same physical location via the cached-form source
+    // address.
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr);
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached =
         reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
-    uint32_t go_signal_value = cmd->mcast.go_signal;
+    uint32_t go_signal_value = load_aligned<uint32_t>(&cmd->mcast.go_signal);
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
     uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
-    uint32_t wait_count = cmd->mcast.wait_count;
+    uint32_t wait_count = load_aligned<uint32_t>(&cmd->mcast.wait_count);
     if (multicast_go_offset != CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET) {
         // Setup registers before waiting for workers so only the NOC_CMD_CTRL register needs to be touched after.
         uint64_t dst_noc_addr_multicast =
@@ -1217,11 +1216,11 @@ void process_go_signal_mcast_cmd() {
         // This chip is virtualizing cores the go signal is unicasted to
         // In this case, the number of unicasts specified in the command can exceed
         // the number of actual cores on this chip.
-        if (cmd->mcast.num_unicast_txns > num_physical_unicast_cores) {
+        if (num_unicasts > num_physical_unicast_cores) {
             // If this is the case, cap the number of unicasts to avoid invalid NOC txns
             num_unicasts = num_physical_unicast_cores;
             // Fake updates from non-existent workers here. The dispatcher expects an ack from
-            // the number of cores specified inside cmd->mcast.num_unicast_txns. If this is
+            // the number of cores specified inside num_unicasts. If this is
             // greater than the number of cores actually on the chip, we must account for acks
             // from non-existent cores here.
 #ifdef ARCH_QUASAR
@@ -1259,7 +1258,7 @@ void process_notify_dispatch_s_go_signal_cmd() {
 #endif
         noc_async_write_barrier();
     }
-    uint16_t index_bitmask = cmd->notify_dispatch_s_go_signal.index_bitmask;
+    uint16_t index_bitmask = load_aligned<uint16_t>(&cmd->notify_dispatch_s_go_signal.index_bitmask);
 
     while (index_bitmask != 0) {
         uint32_t set_index = __builtin_ctz(index_bitmask);
@@ -1285,7 +1284,7 @@ FORCE_INLINE
 void set_go_signal_noc_data() {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
-    uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
+    uint32_t num_words = load_aligned<uint32_t>(&cmd->set_go_signal_noc_data.num_words);
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
     volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
     for (uint32_t i = 0; i < num_words; ++i) {
@@ -1423,15 +1422,18 @@ re_run_command:
             // DPRINT("write offset: {} {} {} host id {}\n", cmd->set_write_offset.offset0,
             // cmd->set_write_offset.offset1,
             //              cmd->set_write_offset.offset2, cmd->set_write_offset.program_host_id);
-            DeviceTimestampedData("runtime_host_id_dispatch", cmd->set_write_offset.program_host_id);
+            DeviceTimestampedData(
+                "runtime_host_id_dispatch", load_aligned<uint16_t>(&cmd->set_write_offset.program_host_id));
             if constexpr (telemetry_enabled) {
                 reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
                     dispatch_telemetry_base)
                     ->program_count = ++program_counter;
             }
             if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0 &&
-                cmd->set_write_offset.program_host_id != REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
-                while (!program_id_fifo_append(rt_profiler_msg, cmd->set_write_offset.program_host_id)) {
+                load_aligned<uint16_t>(&cmd->set_write_offset.program_host_id) !=
+                    REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
+                while (!program_id_fifo_append(
+                    rt_profiler_msg, load_aligned<uint16_t>(&cmd->set_write_offset.program_host_id))) {
                     invalidate_l1_cache();
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1166,14 +1166,13 @@ void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd =
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
     uint32_t stream = load_aligned<uint32_t>(&cmd->mcast.wait_stream);
-    // The location of the go signal embedded in the command does not meet NOC alignment requirements.
-    // cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher over NOC.
-    // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This overwrites command
-    // fields, so every field must be read into a local below before the first store; do not read cmd ptr cmd-> after
-    // it. NOC source addresses must be raw L1 byte offsets (cached-alias form), so keep aligned_go_signal_storage at
-    // the cached alias for the NOC sources at lines 1065 and 1108. CPU writes go through a separate uncached pointer so
-    // the value lands in L1 SRAM directly; the NOC then reads the same physical location via the cached-form source
-    // address.
+    // The go signal embedded in the command does not meet NOC alignment requirements, but cmd_ptr does
+    // (the prefetcher writes it over the NOC), so the go signal is copied there. storage_offset lands that
+    // copy anywhere in the 16-byte command, so every field must be read into a local before the first
+    // store below, and none may be read from cmd after it.
+    // NOC source addresses must be raw L1 byte offsets, so aligned_go_signal_storage stays at the cached
+    // alias; CPU writes go through the uncached alias so the value lands in L1 SRAM directly, and the NOC
+    // then reads the same physical location via the cached-form source address.
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(cmd_ptr);
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached =
         reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
@@ -1219,10 +1218,10 @@ void process_go_signal_mcast_cmd() {
         if (num_unicasts > num_physical_unicast_cores) {
             // If this is the case, cap the number of unicasts to avoid invalid NOC txns
             num_unicasts = num_physical_unicast_cores;
-            // Fake updates from non-existent workers here. The dispatcher expects an ack from
-            // the number of cores specified inside num_unicasts. If this is
-            // greater than the number of cores actually on the chip, we must account for acks
-            // from non-existent cores here.
+            // Fake updates from non-existent workers here. The dispatcher expects an ack from the
+            // number of cores specified in the command's num_unicast_txns. If that is greater than
+            // the number of cores actually on the chip, we must account for acks from non-existent
+            // cores here.
 #ifdef ARCH_QUASAR
             *worker_completion_sem_addr(stream, first_stream_used, completion_counter_offset) +=
                 (num_virtual_unicast_cores - num_physical_unicast_cores);
@@ -1422,18 +1421,16 @@ re_run_command:
             // DPRINT("write offset: {} {} {} host id {}\n", cmd->set_write_offset.offset0,
             // cmd->set_write_offset.offset1,
             //              cmd->set_write_offset.offset2, cmd->set_write_offset.program_host_id);
-            DeviceTimestampedData(
-                "runtime_host_id_dispatch", load_aligned<uint16_t>(&cmd->set_write_offset.program_host_id));
+            uint16_t program_host_id = load_aligned<uint16_t>(&cmd->set_write_offset.program_host_id);
+            DeviceTimestampedData("runtime_host_id_dispatch", program_host_id);
             if constexpr (telemetry_enabled) {
                 reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
                     dispatch_telemetry_base)
                     ->program_count = ++program_counter;
             }
             if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0 &&
-                load_aligned<uint16_t>(&cmd->set_write_offset.program_host_id) !=
-                    REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
-                while (!program_id_fifo_append(
-                    rt_profiler_msg, load_aligned<uint16_t>(&cmd->set_write_offset.program_host_id))) {
+                program_host_id != REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
+                while (!program_id_fifo_append(rt_profiler_msg, program_host_id)) {
                     invalidate_l1_cache();
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -345,7 +345,7 @@ FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
-    uint32_t sync_index = cmd->mcast.wait_stream - first_stream_used;
+    uint32_t sync_index = load_aligned<uint32_t>(&cmd->mcast.wait_stream) - first_stream_used;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
 
     volatile tt_l1_ptr uint32_t* sync_sem_addr =
@@ -375,12 +375,12 @@ void process_go_signal_mcast_cmd() {
     // the NOC then reads the same physical location via the cached-form source address.
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
     volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached = uncached_l1_ptr<uint32_t>(cmd_ptr);
-    uint32_t go_signal_value = cmd->mcast.go_signal;
+    uint32_t go_signal_value = load_aligned<uint32_t>(&cmd->mcast.go_signal);
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
     uint32_t num_unicasts = cmd->mcast.num_unicast_txns;
-    uint32_t wait_count = cmd->mcast.wait_count;
-    uint32_t wait_stream = cmd->mcast.wait_stream;
+    uint32_t wait_count = load_aligned<uint32_t>(&cmd->mcast.wait_count);
+    uint32_t wait_stream = load_aligned<uint32_t>(&cmd->mcast.wait_stream);
 
     if (multicast_go_offset != CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET) {
         // Setup registers before waiting for workers so only the NOC_CMD_CTRL register needs to be touched after.
@@ -485,13 +485,13 @@ void process_dispatch_s_wait_cmd() {
     ASSERT(
         (cmd->wait.flags == (CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM)) &&
         distributed_dispatcher);
-    uint32_t stream = cmd->wait.stream;
+    uint32_t stream = load_aligned<uint16_t>(&cmd->wait.stream);
     uint32_t index = stream - first_stream_used;
     volatile uint32_t* worker_sem = reinterpret_cast<volatile uint32_t*>(
         static_cast<uintptr_t>(STREAM_REG_ADDR(stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
 
     // Wait for workers to complete
-    while (stream_wrap_gt(cmd->wait.count, *worker_sem)) {
+    while (stream_wrap_gt(load_aligned<uint32_t>(&cmd->wait.count), *worker_sem)) {
 #if DEVICE_PRINT_DISPATCH_ENABLED
         device_print_dispatcher.execute();
 #endif
@@ -510,7 +510,7 @@ void process_dispatch_s_wait_cmd() {
 FORCE_INLINE
 void set_num_worker_sems() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
-    num_worker_sems = cmd->set_num_worker_sems.num_worker_sems;
+    num_worker_sems = load_aligned<uint32_t>(&cmd->set_num_worker_sems.num_worker_sems);
     ASSERT(num_worker_sems <= max_num_worker_sems);
     cmd_ptr += sizeof(CQDispatchCmd);
 }
@@ -518,7 +518,7 @@ void set_num_worker_sems() {
 FORCE_INLINE
 void set_go_signal_noc_data() {
     volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
-    uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
+    uint32_t num_words = load_aligned<uint32_t>(&cmd->set_go_signal_noc_data.num_words);
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
     volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
     for (uint32_t i = 0; i < num_words; ++i) {
@@ -662,7 +662,9 @@ void kernel_main() {
                 break;
             case CQ_DISPATCH_CMD_RT_PROFILER_FLUSH:
                 DPRINT("CQ_DISPATCH_CMD_RT_PROFILER_FLUSH\n");
-                wait_for_workers(cmd->rt_profiler_flush.wait_count, cmd->rt_profiler_flush.wait_stream);
+                wait_for_workers(
+                    load_aligned<uint32_t>(&cmd->rt_profiler_flush.wait_count),
+                    load_aligned<uint32_t>(&cmd->rt_profiler_flush.wait_stream));
                 cmd_ptr += sizeof(CQDispatchCmd);
                 break;
             case CQ_DISPATCH_CMD_TERMINATE:

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -364,11 +364,10 @@ void process_go_signal_mcast_cmd() {
     }
     mcasts_sent++;  // Go signal sent -> update counter
 
-    // The location of the go signal embedded in the command does not meet NOC alignment requirements.
-    // cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher over NOC.
-    // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This is safe as long as we
-    // can guarantee that copying the go signal does not corrupt any other command fields, which is true (see
-    // CQDispatchGoSignalMcastCmd).
+    // The go signal embedded in the command does not meet NOC alignment requirements, but cmd_ptr does
+    // (the prefetcher writes it over the NOC), so the go signal is copied there. storage_offset lands that
+    // copy anywhere in the 16-byte command, so every field must be read into a local before the first
+    // store below, and none may be read from cmd after it.
     // NOC source addresses must be raw L1 byte offsets (cached-alias form), so keep
     // aligned_go_signal_storage at the cached alias for the NOC sources below.
     // CPU writes go through a separate uncached pointer so the value lands in L1 SRAM directly;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -858,13 +858,13 @@ void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_
 
 uint32_t process_debug_cmd(uintptr_t cmd_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    return cmd->debug.stride;
+    return load_aligned<uint32_t>(&cmd->debug.stride);
 }
 
 template <bool cmddat_wrap_enable, typename RelayInlineState>
 static uint32_t process_relay_inline_cmd(uintptr_t cmd_ptr, uint32_t& local_downstream_data_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t length = cmd->relay_inline.length;
+    uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
     uint32_t npages =
@@ -897,7 +897,7 @@ static uint32_t process_relay_inline_cmd(uintptr_t cmd_ptr, uint32_t& local_down
     local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
     noc_async_writes_flushed();
     RelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr);
-    return cmd->relay_inline.stride;
+    return load_aligned<uint32_t>(&cmd->relay_inline.stride);
 }
 
 // This version of inline sends inline data to the dispatcher but doesn't flush the page to the dispatcher
@@ -908,7 +908,7 @@ template <bool cmddat_wrap_enable>
 static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& dispatch_data_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
 
-    uint32_t length = cmd->relay_inline.length;
+    uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
     DispatchRelayInlineState::cb_writer.acquire_pages(1);
@@ -930,7 +930,7 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
     dispatch_data_ptr += length;
 
-    return cmd->relay_inline.stride;
+    return load_aligned<uint32_t>(&cmd->relay_inline.stride);
 }
 
 // The hard problem here is: when an xfer lands exactly at a page boundary, who is responsible for getting the next
@@ -1382,10 +1382,11 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     noc_async_writes_flushed();
 
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t base_addr = cmd->relay_paged.base_addr;
-    uint32_t page_size = cmd->relay_paged.page_size;
-    uint32_t pages = cmd->relay_paged.pages;
-    uint16_t length_adjust = cmd->relay_paged.is_dram_and_length_adjust & CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK;
+    uint32_t base_addr = load_aligned<uint32_t>(&cmd->relay_paged.base_addr);
+    uint32_t page_size = load_aligned<uint32_t>(&cmd->relay_paged.page_size);
+    uint32_t pages = load_aligned<uint32_t>(&cmd->relay_paged.pages);
+    uint16_t length_adjust = load_aligned<uint16_t>(&cmd->relay_paged.is_dram_and_length_adjust) &
+                             CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK;
 
     if (page_size > scratch_db_half_size) {
         return process_relay_paged_cmd_large<is_dram>(
@@ -1638,9 +1639,10 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cac
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t total_length = cmd->relay_paged_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
-    uint32_t stride = cmd->relay_paged_packed.stride;
+    uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_paged_packed.total_length);
+    uint32_t sub_cmds_length =
+        load_aligned<uint16_t>(&cmd->relay_paged_packed.count) * sizeof(CQPrefetchRelayPagedPackedSubCmd);
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_paged_packed.stride);
     ASSERT(total_length > 0);
     // DPRINT("paged_packed: total_length={} stride={}\n", total_length, cmd->relay_paged_packed.stride);
 
@@ -1709,9 +1711,9 @@ uint32_t process_relay_linear_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_p
     noc_async_writes_flushed();
 
     volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmdLarge>(cmd_ptr);
-    uint32_t noc_xy_addr = cmd->relay_linear.noc_xy_addr;
-    uint64_t read_addr = cmd->relay_linear.addr;
-    uint64_t wlength = cmd->relay_linear.length;
+    uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear.noc_xy_addr);
+    uint64_t read_addr = load_aligned<uint64_t>(&cmd->relay_linear.addr);
+    uint64_t wlength = load_aligned<uint64_t>(&cmd->relay_linear.length);
     // DPRINT("relay_linear: cmd_ptr={} length={} read_addr={} noc_xy_addr={}\n", cmd_ptr, wlength, read_addr,
     // noc_xy_addr);
 
@@ -1913,7 +1915,7 @@ template <typename RelayInlineState>
 FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     uintptr_t& cmd_ptr, uint32_t& local_downstream_data_ptr, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t length = cmd->relay_inline.length;
+    uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
     // DPRINT("relay_inline_exec_buf_cmd: length={}\n", length);
@@ -1926,7 +1928,7 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     // Assume the downstream buffer is big relative to cmddat command size that we can
     // grab what we need in one chunk
     RelayInlineState::cb_writer.acquire_pages(npages);
-    uint32_t stride = cmd->relay_inline.stride;
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_inline.stride);
     uint32_t remaining_stride = exec_buf_state.length;
     uint32_t remaining = exec_buf_state.length - sizeof(CQPrefetchCmd);
     while (length > remaining) {
@@ -1971,10 +1973,10 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     uintptr_t& cmd_ptr, uint32_t& dispatch_data_ptr, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
 
-    uint32_t length = cmd->relay_inline.length;
+    uint32_t length = load_aligned<uint32_t>(&cmd->relay_inline.length);
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
-    uint32_t stride = cmd->relay_inline.stride;
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_inline.stride);
 
     DispatchRelayInlineState::cb_writer.acquire_pages(1);
     if (dispatch_data_ptr == downstream_cb_end) {
@@ -2069,9 +2071,10 @@ void* copy_into_l1_cache(
 static uint32_t process_exec_buf_relay_paged_packed_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t total_length = cmd->relay_paged_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
-    uint32_t stride = cmd->relay_paged_packed.stride;
+    uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_paged_packed.total_length);
+    uint32_t sub_cmds_length =
+        load_aligned<uint16_t>(&cmd->relay_paged_packed.count) * sizeof(CQPrefetchRelayPagedPackedSubCmd);
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_paged_packed.stride);
     ASSERT(total_length > 0);
     // DPRINT("paged_packed: total_length={} stride={}\n", total_length, cmd->relay_paged_packed.stride);
 
@@ -2093,9 +2096,9 @@ uint32_t process_exec_buf_cmd(
 
     // setup exec_buf_state the first time
     exec_buf_state.page_id = 0;
-    exec_buf_state.base_addr = cmd->exec_buf.base_addr;
-    exec_buf_state.log_page_size = cmd->exec_buf.log_page_size;
-    exec_buf_state.pages = cmd->exec_buf.pages;
+    exec_buf_state.base_addr = load_aligned<uint32_t>(&cmd->exec_buf.base_addr);
+    exec_buf_state.log_page_size = load_aligned<uint32_t>(&cmd->exec_buf.log_page_size);
+    exec_buf_state.pages = load_aligned<uint32_t>(&cmd->exec_buf.pages);
     exec_buf_state.length = 0;
     exec_buf_state.read_ptr = cmddat_q_base;
     exec_buf_state.prefetch_length = 0;
@@ -2127,12 +2130,12 @@ uint32_t process_paged_to_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream
 
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t start_page = cmd->paged_to_ringbuffer.start_page;
-    uint32_t base_addr = cmd->paged_to_ringbuffer.base_addr;
+    uint32_t base_addr = load_aligned<uint32_t>(&cmd->paged_to_ringbuffer.base_addr);
     uint8_t log2_page_size = cmd->paged_to_ringbuffer.log2_page_size;
     uint32_t page_size = 1 << log2_page_size;
-    uint32_t length = cmd->paged_to_ringbuffer.length;
+    uint32_t length = load_aligned<uint32_t>(&cmd->paged_to_ringbuffer.length);
     uint8_t flags = cmd->paged_to_ringbuffer.flags;
-    uint32_t wp_update_offset = cmd->paged_to_ringbuffer.wp_offset_update;
+    uint32_t wp_update_offset = load_aligned<uint32_t>(&cmd->paged_to_ringbuffer.wp_offset_update);
 
     ASSERT(length <= wp_update_offset);
 
@@ -2172,7 +2175,7 @@ uint32_t process_paged_to_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream
 
 uint32_t process_set_ringbuffer_offset(uintptr_t cmd_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t offset = cmd->set_ringbuffer_offset.offset;
+    uint32_t offset = load_aligned<uint32_t>(&cmd->set_ringbuffer_offset.offset);
 
     if (cmd->set_ringbuffer_offset.update_wp) {
         ringbuffer_wp = scratch_db_base + offset;
@@ -2212,9 +2215,9 @@ void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t count = cmd->relay_ringbuffer.count;
+    uint32_t count = load_aligned<uint16_t>(&cmd->relay_ringbuffer.count);
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
-    uint32_t stride = cmd->relay_ringbuffer.stride;
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_ringbuffer.stride);
     // DPRINT("relay_ringbuffer: count={} stride={}\n", count, cmd->relay_ringbuffer.stride);
 
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
@@ -2249,9 +2252,9 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
 static uint32_t process_exec_buf_relay_ringbuffer_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t count = cmd->relay_ringbuffer.count;
+    uint32_t count = load_aligned<uint16_t>(&cmd->relay_ringbuffer.count);
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
-    uint32_t stride = cmd->relay_ringbuffer.stride;
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_ringbuffer.stride);
 
     copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
 
@@ -2265,6 +2268,8 @@ void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_l
 
     // First step - read multiple sub_cmds worth into DB0
     CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr*)(l1_cache);
+    // addr is not load_aligned-able: this sub-cmd is 12 bytes, so in an array every odd element's
+    // 8-byte addr lands 4-mod-8, and l1_cache only guarantees 4-byte alignment anyway.
     uint64_t current_addr = sub_cmd->addr;
     uint32_t current_length = sub_cmd->length;
     uint32_t scratch_read_addr = scratch_db_top[0];
@@ -2344,10 +2349,11 @@ void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_l
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
-    uint32_t total_length = cmd->relay_linear_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
-    uint32_t stride = cmd->relay_linear_packed.stride;
+    uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear_packed.noc_xy_addr);
+    uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_linear_packed.total_length);
+    uint32_t sub_cmds_length =
+        load_aligned<uint16_t>(&cmd->relay_linear_packed.count) * sizeof(CQPrefetchRelayLinearPackedSubCmd);
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_linear_packed.stride);
     ASSERT(total_length > 0);
     // DPRINT("linear_packed: {} {}\n", total_length, cmd->relay_linear_packed.stride);
 
@@ -2383,10 +2389,11 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
 static uint32_t process_exec_buf_relay_linear_packed_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
-    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
-    uint32_t total_length = cmd->relay_linear_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
-    uint32_t stride = cmd->relay_linear_packed.stride;
+    uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear_packed.noc_xy_addr);
+    uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_linear_packed.total_length);
+    uint32_t sub_cmds_length =
+        load_aligned<uint16_t>(&cmd->relay_linear_packed.count) * sizeof(CQPrefetchRelayLinearPackedSubCmd);
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_linear_packed.stride);
 
     copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
     process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
@@ -2412,7 +2419,8 @@ bool process_cmd(
         case CQ_PREFETCH_CMD_RELAY_PAGED:
             // DPRINT("relay_paged: {}\n", cmd_ptr);
             {
-                uint32_t is_dram_and_length_adjust = cmd->relay_paged.is_dram_and_length_adjust;
+                uint32_t is_dram_and_length_adjust =
+                    load_aligned<uint16_t>(&cmd->relay_paged.is_dram_and_length_adjust);
                 uint32_t is_dram = is_dram_and_length_adjust & (1 << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT);
                 uint32_t start_page = cmd->relay_paged.start_page;
                 if (is_dram) {
@@ -2598,7 +2606,7 @@ static void relay_linear_to_downstream(
 uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr) {
     volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
     cmd = uncached_l1_ptr<CQPrefetchCmdLarge>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
-    uint64_t wlength = cmd->relay_linear_h.length;
+    uint64_t wlength = load_aligned<uint64_t>(&cmd->relay_linear_h.length);
     uint32_t scratch_read_addr = scratch_db_top[0];
     constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
     // kernel_h must relay user data from pinned buffer to downstream (kernel_d's cmddatq)
@@ -2608,8 +2616,8 @@ uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data
     dptr->header.raw_copy = true;
     scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
 
-    uint32_t noc_xy_addr = cmd->relay_linear_h.noc_xy_addr;
-    uint64_t read_addr = cmd->relay_linear_h.addr;
+    uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear_h.noc_xy_addr);
+    uint64_t read_addr = load_aligned<uint64_t>(&cmd->relay_linear_h.addr);
 
     // DPRINT("relay_linear_h: cmd_ptr:0x{:08x}, length:0x{:08x}, addr:0x{:08x}, nocxy:0x{:08x},
     // downstream_data_ptr:0x{:08x}\n",
@@ -2680,10 +2688,11 @@ uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data
 uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd =
         uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
-    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
-    uint32_t total_length = cmd->relay_linear_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
-    uint32_t stride = cmd->relay_linear_packed.stride;
+    uint32_t noc_xy_addr = load_aligned<uint32_t>(&cmd->relay_linear_packed.noc_xy_addr);
+    uint32_t total_length = load_aligned<uint32_t>(&cmd->relay_linear_packed.total_length);
+    uint32_t sub_cmds_length =
+        load_aligned<uint16_t>(&cmd->relay_linear_packed.count) * sizeof(CQPrefetchRelayLinearPackedSubCmd);
+    uint32_t stride = load_aligned<uint32_t>(&cmd->relay_linear_packed.stride);
     ASSERT(total_length > 0);
 
     // Copy sub-commands into L1 cache (same pattern as process_relay_linear_packed_cmd)


### PR DESCRIPTION
### PR Category
Performance

### Summary
FD command struct uses  `__attribute__((packed))` which sets their alignment requirement to 1. The compiler then loaded `uint32_t` / `uint64_t` words as bytes using `lbu` (+ `slli`/`or` for reassembly of the bytes into word) instead of `lw` or `ld`, even though the structs use `pad1`/`pad2` (every field aligns to a natural boundary).  Disassembly of the dispatch kernels showed ~450 `lbu` across the prefetcher, dispatcher, and dispatch_s. This was disproportionately costly on Quasar, where accesses went through uncached L1. 

Fix is to supply the alignment information via `load_aligned<T>()` in `cq_common.hpp`, at ~90 read sites. 

Three structs are also modified so previously misaligned fields become naturally aligned:
- `CQDispatchGoSignalMcastCmd` - `go_signal` moved after the three `uint8_t` fields, to offset 4
- `CQDispatchRtProfilerFlushCmd` - leading `uint8_t`/`uint16_t` pads added, landing `wait_count`  --> offset 4, `wait_stream` --> offset 8
- `CQPrefetchSetRingbufferOffsetCmd` - offset reordered to command offset 4

Results: `lbu` shrinks from ~450 --> ~110 (about 75% fewer), total instructions  lower by ~6.3%, and savings of ~300 cyc/command on Quasar (~10-15% of the `RELAY_LINEAR` period) and ~65 cyc/command on Blackhole, flat across payload size.

Also tightens `static_asserts` from "multiple of CQ_DISPATCH_CMD_SIZE" to exact sizes, and adds the missing one for `CQDispatchCmdLarge`.

### Notes for reviewers
- `cq_dispatch.cpp::process_go_signal_mcast_cmd` contains a correctness fix. The `go_signal` copy writes into `cmd_ptr` twice - always at word 0, plus at word `multicast_go_offset % 4` on the multicast path - so it can clobber any word of the 16-byte command. On the old layout, the `storage_offset` store could hit `num_unicast_txns` at offset 6 before it was read, yielding byte 2 of `go_signal_value` instead. After reorder `num_unicast_txns` sits in word 0, so the same read would break on every call. Hence `cmd->mcast.num_unicast_txns` stored in local var `num_unicasts`.  Shouldn't be reverted to the direct field read.
- Both copies of that function claimed the copy "does not corrupt any other command fields" -- wrong on main too. They now state the real invariant: read every field into a local before the first store. Enforced by convention only -- no scoping block was added in `cq_dispatch.cpp` / `cq_dispatch_subordinate.cpp`, to keep the change small.
- Not converted on purpose: all `uint8_t` fields, `CQPrefetchRelayLinearPackedSubCmd::addr` (12-byte stride puts odd elements 4-mod-8), sub-cmds read off `l1_cache`, which already get wide loads.


Runtime performance tests: https://github.com/tenstorrent/tt-metal/actions/runs/32461664739
Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/32461562425

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fd_opt_aligned_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fd_opt_aligned_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fd_opt_aligned_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fd_opt_aligned_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fd_opt_aligned_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fd_opt_aligned_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fd_opt_aligned_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fd_opt_aligned_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fd_opt_aligned_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fd_opt_aligned_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fd_opt_aligned_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fd_opt_aligned_access)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fd_opt_aligned_access)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fd_opt_aligned_access)