### PR TITLE
[Cleanup] Buffer replaced with MeshBuffer in tests

### DIFF
--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -207,7 +207,10 @@ TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
     Program program = CreateProgram();
     uint32_t sem_id = CreateSemaphore(program, logical_core, /*initial_value=*/0);
     // Allocate a buffer so the live-tensor range set is armed (non-null).
-    auto buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        this->devices_.at(0).get());
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -195,8 +195,8 @@ void EnqueueAndCheckScratchpad(
 
 void SetLoopbackArgs(
     distributed::MeshWorkload& workload,
-    const std::shared_ptr<Buffer>& input_buffer,
-    const std::shared_ptr<Buffer>& output_buffer,
+    const std::shared_ptr<distributed::MeshBuffer>& input_buffer,
+    const std::shared_ptr<distributed::MeshBuffer>& output_buffer,
     uint32_t dfb_num_entries) {
     const NodeCoord node{0, 0};
     Program& program = workload.get_programs().begin()->second;
@@ -265,15 +265,20 @@ TEST_F(MeshWorkloadFactorySlowDispatchHWTest, FactoryMethodsSupportSlowDispatch)
 
 TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecSupportsDfbResizeBetweenEnqueues) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     // Build a workload with a producer-consumer DFB loopback.
     distributed::MeshWorkload workload = MakeMeshWorkloadFromSpec(*mesh_device, MakeLoopbackSpec());
 
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = kBufferBytes, .page_size = kBufferBytes, .buffer_type = BufferType::DRAM};
-    auto input_buffer = CreateBuffer(dram_config);
-    auto output_buffer = CreateBuffer(dram_config);
+    auto input_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = kBufferBytes},
+        {.page_size = kBufferBytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto output_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = kBufferBytes},
+        {.page_size = kBufferBytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+
+    auto& cq = mesh_device->mesh_command_queue();
 
     // Resize the DFB between enqueues and verify each loopback result.
     for (uint32_t dfb_num_entries : {2u, 4u, 6u}) {
@@ -283,15 +288,14 @@ TEST_F(MeshWorkloadFactoryHWTest, MakeMeshWorkloadFromSpecSupportsDfbResizeBetwe
         }
         std::vector<uint32_t> output_data(input_data.size());
 
-        detail::WriteToBuffer(input_buffer, input_data);
-        detail::WriteToBuffer(output_buffer, output_data);
+        distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/true);
+        distributed::EnqueueWriteMeshBuffer(cq, output_buffer, output_data, /*blocking=*/true);
         SetLoopbackArgs(workload, input_buffer, output_buffer, dfb_num_entries);
 
-        distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
         distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
         output_data.clear();
-        detail::ReadFromBuffer(output_buffer, output_data);
+        distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
         EXPECT_EQ(output_data, input_data);
     }
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -77,7 +77,6 @@ protected:
 
 TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     // Test parameters
     constexpr uint32_t entry_size = 1024;  // bytes per DFB entry
@@ -91,10 +90,15 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // -------------------------------------------------------
     // Create DRAM buffers (single-page so all data is on one bank)
     // -------------------------------------------------------
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
-    auto input_buffer = CreateBuffer(dram_config);
-    auto output_buffer = CreateBuffer(dram_config);
+    auto input_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_bytes},
+        {.page_size = total_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto output_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_bytes},
+        {.page_size = total_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto& cq = mesh_device->mesh_command_queue();
 
     // -------------------------------------------------------
     // Build ProgramSpec
@@ -168,7 +172,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     for (size_t i = 0; i < input_data.size(); i++) {
         input_data[i] = static_cast<uint32_t>(i);
     }
-    detail::WriteToBuffer(input_buffer, input_data);
+    distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/true);
 
     // -------------------------------------------------------
     // Dispatch
@@ -179,7 +183,7 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
     // Verify
     // -------------------------------------------------------
     std::vector<uint32_t> output_data;
-    detail::ReadFromBuffer(output_buffer, output_data);
+    distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
 
     ASSERT_EQ(output_data.size(), input_data.size());
     EXPECT_EQ(output_data, input_data);
@@ -219,7 +223,6 @@ TEST_F(ProgramSpecHWTest, DFBAccessorNameLoopback) {
 
 TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries_in_dfb = 4;
@@ -228,10 +231,15 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 
     const NodeCoord node{0, 0};
 
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
-    auto input_buffer = CreateBuffer(dram_config);
-    auto output_buffer = CreateBuffer(dram_config);
+    auto input_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_bytes},
+        {.page_size = total_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto output_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_bytes},
+        {.page_size = total_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto& cq = mesh_device->mesh_command_queue();
 
     ProgramSpec spec;
     spec.name = "named_args_loopback";
@@ -309,12 +317,12 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
     for (size_t i = 0; i < input_data.size(); i++) {
         input_data[i] = static_cast<uint32_t>(i);
     }
-    detail::WriteToBuffer(input_buffer, input_data);
+    distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/true);
 
     LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output_data;
-    detail::ReadFromBuffer(output_buffer, output_data);
+    distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
 
     ASSERT_EQ(output_data.size(), input_data.size());
     EXPECT_EQ(output_data, input_data);
@@ -413,7 +421,6 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
 
 TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries_in_dfb = 4;
@@ -422,10 +429,15 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
 
     const NodeCoord node{0, 0};
 
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
-    auto input_buffer = CreateBuffer(dram_config);
-    auto output_buffer = CreateBuffer(dram_config);
+    auto input_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_bytes},
+        {.page_size = total_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto output_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = total_bytes},
+        {.page_size = total_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto& cq = mesh_device->mesh_command_queue();
 
     ProgramSpec spec;
     spec.name = "tt_kernel_named_args_loopback";
@@ -475,12 +487,12 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
     for (size_t i = 0; i < input_data.size(); i++) {
         input_data[i] = static_cast<uint32_t>(i);
     }
-    detail::WriteToBuffer(input_buffer, input_data);
+    distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/true);
 
     LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output_data;
-    detail::ReadFromBuffer(output_buffer, output_data);
+    distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
 
     ASSERT_EQ(output_data.size(), input_data.size());
     EXPECT_EQ(output_data, input_data);
@@ -994,7 +1006,6 @@ TEST_F(ProgramSpecHWTest, ScratchpadWriteReadback) {
 //            MULTI-WORD binding in the middle (River's original had named=0, binding=0).
 TEST_F(ProgramSpecHWTest, CrtaAllFourSectionsSetAndPartialUpdate) {
     auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;  // bytes per DFB entry
     constexpr uint32_t num_entries = 4;    // DFB depth
@@ -1016,9 +1027,11 @@ TEST_F(ProgramSpecHWTest, CrtaAllFourSectionsSetAndPartialUpdate) {
     constexpr uint32_t kVararg1Upd = 0xD4D4FFFFu;
 
     // Output buffer holds one DFB entry (single page → single bank).
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = entry_size, .page_size = entry_size, .buffer_type = BufferType::DRAM};
-    auto output_buffer = CreateBuffer(dram_config);
+    auto output_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = entry_size},
+        {.page_size = entry_size, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto& cq = mesh_device->mesh_command_queue();
 
     // Input tensor for the tensor-binding section (interleaved DRAM; only its base address is read here).
     auto tensor_layout = TensorLayout(
@@ -1121,7 +1134,7 @@ void kernel_main() {
     auto launch_and_read = [&]() {
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
         std::vector<uint32_t> out;
-        detail::ReadFromBuffer(output_buffer, out);
+        distributed::EnqueueReadMeshBuffer(cq, out, output_buffer, /*blocking=*/true);
         EXPECT_GE(out.size(), 7u);
         out.resize(7);
         return out;
@@ -1228,9 +1241,11 @@ TEST_F(ProgramSpecHWTest, ScratchpadBaseReDeliveredAfterDfbResize) {
     const NodeCoord node{0, 0};
 
     // Output buffer holds one DFB entry (single page → single bank).
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = entry_size, .page_size = entry_size, .buffer_type = BufferType::DRAM};
-    auto output_buffer = CreateBuffer(dram_config);
+    auto output_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = entry_size},
+        {.page_size = entry_size, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto& cq = mesh_device->mesh_command_queue();
 
     ProgramSpec spec;
     spec.name = "scratchpad_base_redelivered_after_dfb_resize";
@@ -1314,7 +1329,7 @@ void kernel_main() {
         distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
 
         std::vector<uint32_t> out;
-        detail::ReadFromBuffer(output_buffer, out);
+        distributed::EnqueueReadMeshBuffer(cq, out, output_buffer, /*blocking=*/true);
         EXPECT_FALSE(out.empty());
         const uint32_t base = out.empty() ? 0u : out[0];
         EXPECT_NE(base, 0u) << "Kernel reported a 0 scratchpad base address (token not delivered?)";

--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -46,16 +46,15 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
 
     const size_t total_size_bytes = test_config.num_pages * test_config.page_size_bytes;
 
-    InterleavedBufferConfig interleaved_buffer_config{
-        .device = device,
-        .size = total_size_bytes,
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::ReplicatedBufferConfig global_config{.size = total_size_bytes};
+    distributed::DeviceLocalBufferConfig local_config{
         .page_size = test_config.page_size_bytes,
         .buffer_type = test_config.is_dram ? BufferType::DRAM : BufferType::L1};
-    std::shared_ptr<Buffer> input_buffer;
-    input_buffer = CreateBuffer(interleaved_buffer_config);
+    auto input_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
     uint32_t input_buffer_address = input_buffer->address();
 
-    auto output_buffer = CreateBuffer(interleaved_buffer_config);
+    auto output_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
     uint32_t output_buffer_address = output_buffer->address();
 
     TT_FATAL(input_buffer_address != output_buffer_address, "Input and output buffer addresses must be different");
@@ -155,7 +154,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
     vector<uint32_t> packed_output;
 
     if (test_config.read_kernel) {
-        detail::WriteToBuffer(input_buffer, packed_input);
+        distributed::EnqueueWriteMeshBuffer(cq, input_buffer, packed_input, /*blocking=*/true);
         if (test_config.is_dram) {
             MetalContext::instance().get_cluster().dram_barrier(device->id());
         } else {
@@ -172,12 +171,11 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
     if (test_config.write_kernel) {
-        detail::ReadFromBuffer(output_buffer, packed_output);
+        distributed::EnqueueReadMeshBuffer(cq, packed_output, output_buffer, /*blocking=*/true);
     } else {
         detail::ReadFromDeviceL1(
             device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -54,16 +54,14 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     const size_t per_core_size_bytes = test_config.num_pages * test_config.page_size_bytes;
     const size_t total_buffer_size_bytes = num_cores * per_core_size_bytes;
 
-    InterleavedBufferConfig interleaved_buffer_config{
-        .device = device,
-        .size = total_buffer_size_bytes,
-        .page_size = test_config.page_size_bytes,
-        .buffer_type = BufferType::DRAM};
-    std::shared_ptr<Buffer> input_buffer;
-    input_buffer = CreateBuffer(interleaved_buffer_config);
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::ReplicatedBufferConfig global_config{.size = total_buffer_size_bytes};
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = test_config.page_size_bytes, .buffer_type = BufferType::DRAM};
+    auto input_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
     uint32_t input_buffer_address = input_buffer->address();
 
-    auto output_buffer = CreateBuffer(interleaved_buffer_config);
+    auto output_buffer = distributed::MeshBuffer::create(global_config, local_config, mesh_device.get());
     uint32_t output_buffer_address = output_buffer->address();
 
     TT_FATAL(input_buffer_address != output_buffer_address, "Input and output buffer addresses must be different");
@@ -214,7 +212,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     // Launch program and record outputs
 
     if (test_config.read_kernel) {
-        detail::WriteToBuffer(input_buffer, packed_input);
+        distributed::EnqueueWriteMeshBuffer(cq, input_buffer, packed_input, /*blocking=*/true);
         MetalContext::instance().get_cluster().dram_barrier(device->id());
     } else {
         // If not reading, write each core's slice to L1 directly
@@ -233,7 +231,6 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
         distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));  // Single device at (0,0)
     mesh_workload.add_program(target_devices, std::move(program));
 
-    auto& cq = mesh_device->mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     Finish(cq);
 
@@ -241,7 +238,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     bool is_equal = false;
 
     if (test_config.write_kernel) {
-        detail::ReadFromBuffer(output_buffer, packed_output);
+        distributed::EnqueueReadMeshBuffer(cq, packed_output, output_buffer, /*blocking=*/true);
         is_equal = (packed_output == packed_golden);
         if (!is_equal) {
             log_error(tt::LogTest, "Equality Check failed");

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -633,12 +633,11 @@ static bool run_dram_accessor(
 
     uint32_t num_pages = num_dram_banks;
 
-    InterleavedBufferConfig buf_config{
-        .device = device,
-        .size = (size_t)num_pages * bytes_per_txn,
-        .page_size = (uint32_t)bytes_per_txn,
-        .buffer_type = BufferType::DRAM};
-    auto dram_buffer = CreateBuffer(buf_config);
+    auto& cq = mesh_device->mesh_command_queue();
+    auto dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = (size_t)num_pages * bytes_per_txn},
+        {.page_size = (uint32_t)bytes_per_txn, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
 
     std::set<CoreRange> core_ranges;
     for (const auto& c : cores) {
@@ -671,7 +670,7 @@ static bool run_dram_accessor(
         (uint32_t)cfg.pattern,    // 6
         num_pages,                // 7
     };
-    TensorAccessorArgs(*dram_buffer).append_to(compile_args);
+    TensorAccessorArgs(dram_buffer).append_to(compile_args);
 
     auto kernel = CreateKernel(
         program,
@@ -704,7 +703,7 @@ static bool run_dram_accessor(
     for (uint32_t p = 0; p < num_pages; p++) {
         full_input.insert(full_input.end(), page_data.begin(), page_data.end());
     }
-    detail::WriteToBuffer(dram_buffer, full_input);
+    distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, full_input, /*blocking=*/true);
     MetalContext::instance().get_cluster().dram_barrier(device->id());
 
     execute_program(mesh_device, std::move(program));

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_tile_counters_log.cpp
@@ -49,12 +49,10 @@ void RunTest(
     const experimental::NodeCoord node{static_cast<uint32_t>(logical_core.x), static_cast<uint32_t>(logical_core.y)};
 
     // Allocate L1 buffer for sync flag
-    tt_metal::InterleavedBufferConfig sync_buffer_config{
-        .device = device,
-        .size = sizeof(uint32_t),
-        .page_size = sizeof(uint32_t),
-        .buffer_type = tt_metal::BufferType::L1};
-    auto sync_buffer = CreateBuffer(sync_buffer_config);
+    auto sync_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = sizeof(uint32_t)},
+        {.page_size = sizeof(uint32_t), .buffer_type = tt_metal::BufferType::L1},
+        mesh_device.get());
     uint32_t tensix_sync_addr = sync_buffer->address();
     std::vector<uint32_t> zero_data = {0};
     tt::tt_metal::detail::WriteToDeviceL1(device, logical_core, tensix_sync_addr, zero_data);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/distributed.hpp>
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
 
 using namespace tt;
@@ -51,12 +52,13 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     const uint32_t num_tiles = tiles_to_transfer_per_cb * total_cbs;
     const uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig global_config{.size = dram_buffer_size};
 
-    auto src_dram_buffer = CreateBuffer(dram_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     auto create_cb = [&](uint32_t cb_index) {
@@ -98,7 +100,7 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
 
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_cb});
     SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_cb});
@@ -111,7 +113,7 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     this->RunProgram(mesh_device, workload);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);
@@ -119,7 +121,6 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
 
 TEST_F(MeshDispatchFixture, DataflowDfb) {
     auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -140,12 +141,13 @@ TEST_F(MeshDispatchFixture, DataflowDfb) {
     const uint32_t num_tiles = tiles_to_transfer_per_dfb * total_dfbs;
     const uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig global_config{.size = dram_buffer_size};
 
-    auto src_dram_buffer = CreateBuffer(dram_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     tt_metal::experimental::dfb::DataflowBufferConfig dfb_config = {
@@ -194,7 +196,7 @@ TEST_F(MeshDispatchFixture, DataflowDfb) {
 
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, /*blocking=*/true);
 
     SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_dfb});
     SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_dfb});
@@ -207,7 +209,7 @@ TEST_F(MeshDispatchFixture, DataflowDfb) {
     this->RunProgram(mesh_device, workload);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -87,7 +87,6 @@ void run_single_core_cumsum(
     Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
     CoreCoord core = {0, 0};
 
@@ -100,19 +99,17 @@ void run_single_core_cumsum(
     uint32_t H = test_config.Ht * tile_height;
     uint32_t dram_buffer_size = single_tile_size * test_config.N * test_config.Wt * test_config.Ht;
 
-    tt_metal::InterleavedBufferConfig dram_config{
-        .device = device,
-        .size = dram_buffer_size,
-        .page_size = dram_buffer_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
+    distributed::ReplicatedBufferConfig global_config{.size = dram_buffer_size};
+    distributed::DeviceLocalBufferConfig dram_config{
+        .page_size = dram_buffer_size, .buffer_type = tt_metal::BufferType::DRAM};
 
-    auto src_dram_buffer = CreateBuffer(dram_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
     tt_metal::CircularBufferConfig l1_src_cb_config = tt_metal::CircularBufferConfig(dram_buffer_size, {{0, tt::DataFormat::Float16_b}})
         .set_page_size(0, single_tile_size);
     tt_metal::CreateCircularBuffer(program_, core, l1_src_cb_config);
 
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
     tt_metal::CircularBufferConfig l1_dst_cb_config = tt_metal::CircularBufferConfig(dram_buffer_size, {{16, tt::DataFormat::Float16_b}})
         .set_page_size(16, single_tile_size);
@@ -193,13 +190,13 @@ void run_single_core_cumsum(
     auto input_packed_tilized =
         ::unit_tests::compute::gold_standard_tilize(input_packed, {test_config.N * test_config.Ht, test_config.Wt});
 
-    tt_metal::detail::WriteToBuffer(src_dram_buffer, input_packed_tilized);
+    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, input_packed_tilized, /*blocking=*/true);
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> output_packed_tilized;
-    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, output_packed_tilized);
+    distributed::EnqueueReadMeshBuffer(cq, output_packed_tilized, dst_dram_buffer, /*blocking=*/true);
     auto output_packed = ::unit_tests::compute::gold_standard_untilize(
         output_packed_tilized, {test_config.N * test_config.Ht, test_config.Wt});
 

--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -115,22 +115,17 @@ bool test_dropout_standalone(
         Program program = CreateProgram();
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
-        auto* const device = mesh_device->get_devices()[0];
 
         constexpr CoreCoord core = {0, 0};
         constexpr uint32_t single_tile_size = 2 * 1024;
         constexpr uint32_t num_tiles = 128;
         constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-        tt_metal::InterleavedBufferConfig dram_config{
-            .device = device,
-            .size = dram_buffer_size,
-            .page_size = dram_buffer_size,
-            .buffer_type = tt_metal::BufferType::DRAM};
-
-        std::shared_ptr<tt::tt_metal::Buffer> src0_dram_buffer = CreateBuffer(dram_config);
-
-        std::shared_ptr<tt::tt_metal::Buffer> dst_dram_buffer = CreateBuffer(dram_config);
+        distributed::ReplicatedBufferConfig global_config{.size = dram_buffer_size};
+        distributed::DeviceLocalBufferConfig dram_config{
+            .page_size = dram_buffer_size, .buffer_type = tt_metal::BufferType::DRAM};
+        auto src0_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
+        auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
 
         /*
          * Use circular buffers to set input and output buffers that the
@@ -191,7 +186,7 @@ bool test_dropout_standalone(
          */
         std::vector<uint32_t> src0_vec = create_constant_vector_of_bfloat16(dram_buffer_size, const_bias);
 
-        tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/true);
 
         /*
          * Configure program and runtime kernel arguments, then execute.
@@ -222,7 +217,7 @@ bool test_dropout_standalone(
          * and teardown.
          */
         std::vector<uint32_t> result_vec;
-        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
         auto transform_identity = [](const bfloat16& a) { return a; };
 

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -39,26 +39,21 @@ static vector<uint32_t> run_fp8_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = num_tiles * input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
+    auto src_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
+        {.page_size = num_tiles * input_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = num_tiles * output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+    auto dst_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * output_tile_size},
+        {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     CircularBufferConfig cb_src_config = CircularBufferConfig(input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
                                              .set_page_size(tt::CBIndex::c_0, input_tile_size);
@@ -86,7 +81,8 @@ static vector<uint32_t> run_fp8_typecast(
         core,
         ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}});
 
-    detail::WriteToBuffer(src_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, /*blocking=*/true);
     SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
 
@@ -96,12 +92,11 @@ static vector<uint32_t> run_fp8_typecast(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -50,7 +50,6 @@ struct MulReduceScalarConfig {
 };
 
 bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulReduceScalarConfig& config) {
-    IDevice* device = mesh_device.get_devices()[0];
     tt_metal::Program program = tt_metal::CreateProgram();
     CoreCoord core = {0, 0};
 
@@ -60,16 +59,16 @@ bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulR
     const bool tiny_tile = (config.tile_height != tt::constants::TILE_HEIGHT);
 
     uint32_t input_buffer_size = config.num_tiles * tile_byte_size;
-    tt_metal::InterleavedBufferConfig dram_config = {
-        .device = device,
-        .size = input_buffer_size,
-        .page_size = tile_byte_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
-    auto src0_dram_buffer = CreateBuffer(dram_config);
-    auto src1_dram_buffer = CreateBuffer(dram_config);
+    distributed::ReplicatedBufferConfig input_global_config{.size = input_buffer_size};
+    distributed::DeviceLocalBufferConfig input_local_config{
+        .page_size = tile_byte_size, .buffer_type = tt_metal::BufferType::DRAM};
+    auto src0_dram_buffer = distributed::MeshBuffer::create(input_global_config, input_local_config, &mesh_device);
+    auto src1_dram_buffer = distributed::MeshBuffer::create(input_global_config, input_local_config, &mesh_device);
 
-    dram_config.size = tile_byte_size;
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = tile_byte_size},
+        {.page_size = tile_byte_size, .buffer_type = tt_metal::BufferType::DRAM},
+        &mesh_device);
 
     uint32_t cb_tiles = std::max(8u, config.num_tiles);
     uint32_t cb_size = cb_tiles * tile_byte_size;
@@ -141,8 +140,9 @@ bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulR
         val = (static_cast<uint32_t>(one_u16) << 16) | one_u16;
     }
 
-    tt_metal::detail::WriteToBuffer(*src0_dram_buffer, packed_input0);
-    tt_metal::detail::WriteToBuffer(*src1_dram_buffer, packed_input1);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, packed_input0, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, packed_input1, /*blocking=*/true);
 
     // Wrap the program into a MeshWorkload and dispatch via the mesh command queue.
     // This path works under both fast dispatch and slow dispatch, unlike detail::LaunchProgram.
@@ -150,12 +150,11 @@ bool run_mul_reduce_scalar_test(distributed::MeshDevice& mesh_device, const MulR
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     auto u16_src0_vec = u16_from_u32_vector(packed_input0);
     auto u16_src1_vec = u16_from_u32_vector(packed_input1);

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -56,7 +56,6 @@ void run_single_core_pack_rows_program(
     Program program = tt::tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
     CoreCoord core = {0, 0};
 
@@ -65,19 +64,16 @@ void run_single_core_pack_rows_program(
     // Output: num_rows * 16 datums * 2 bytes each
     uint32_t output_size = test_config.num_rows * 16 * 2;
 
-    tt_metal::InterleavedBufferConfig input_dram_config{
-        .device = device,
-        .size = input_single_tile_size,
-        .page_size = input_single_tile_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
-
-    tt_metal::InterleavedBufferConfig output_dram_config{
-        .device = device, .size = output_size, .page_size = output_size, .buffer_type = tt_metal::BufferType::DRAM};
-
-    std::shared_ptr<tt_metal::Buffer> src0_dram_buffer = CreateBuffer(input_dram_config);
+    auto src0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = input_single_tile_size},
+        {.page_size = input_single_tile_size, .buffer_type = tt_metal::BufferType::DRAM},
+        mesh_device.get());
     uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
 
-    std::shared_ptr<tt_metal::Buffer> dst_dram_buffer = CreateBuffer(output_dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = output_size},
+        {.page_size = output_size, .buffer_type = tt_metal::BufferType::DRAM},
+        mesh_device.get());
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
@@ -126,7 +122,7 @@ void run_single_core_pack_rows_program(
         bfloat16 val2(static_cast<float>((i * 2) + 1));
         src0_vec.push_back(pack_two_bfloat16_into_uint32({val1, val2}));
     }
-    tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -145,7 +141,7 @@ void run_single_core_pack_rows_program(
     distributed::Finish(cq);
 
     std::vector<uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     ::unit_tests::compute::PackRowsConfig golden_config = {
         .num_rows = static_cast<int>(test_config.num_rows),

--- a/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_bfd_datacopy.cpp
@@ -47,26 +47,22 @@ constexpr std::uint32_t TOTAL_TILES = NUM_CYCLES * NUM_LOOPS;
 
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
     const std::shared_ptr<distributed::MeshDevice>& mesh_device = this->devices_.at(0);
-    IDevice* dev = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
     const std::uint32_t single_tile_size = 2 * 1024;  // Float16_b 32x32 tile
 
-    InterleavedBufferConfig src0_config{
-        .device = dev,
-        .size = single_tile_size * TILES_STREAMED_PER_INPUT,
-        .page_size = single_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src0_dram_buffer = CreateBuffer(src0_config);
-    auto src1_dram_buffer = CreateBuffer(src0_config);
-    auto src2_dram_buffer = CreateBuffer(src0_config);
+    distributed::ReplicatedBufferConfig src_global_config{.size = single_tile_size * TILES_STREAMED_PER_INPUT};
+    distributed::DeviceLocalBufferConfig src_local_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
+    auto src0_dram_buffer = distributed::MeshBuffer::create(src_global_config, src_local_config, mesh_device.get());
+    auto src1_dram_buffer = distributed::MeshBuffer::create(src_global_config, src_local_config, mesh_device.get());
+    auto src2_dram_buffer = distributed::MeshBuffer::create(src_global_config, src_local_config, mesh_device.get());
 
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = single_tile_size * TOTAL_TILES,
-        .page_size = single_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_dram_buffer = CreateBuffer(dst_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = single_tile_size * TOTAL_TILES},
+        {.page_size = single_tile_size, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
 
     const experimental::DFBSpecName IN0_DFB{"in0_dfb"};
     const experimental::DFBSpecName IN1_DFB{"in1_dfb"};
@@ -192,14 +188,16 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
     std::vector<std::uint32_t> src0_vec = make_streamed(0xC0FFEE);
     std::vector<std::uint32_t> src1_vec = make_streamed(0xDEAD01);
     std::vector<std::uint32_t> src2_vec = make_streamed(0xBEEF02);
-    tt::tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
-    tt::tt_metal::detail::WriteToBuffer(src1_dram_buffer, src1_vec);
-    tt::tt_metal::detail::WriteToBuffer(src2_dram_buffer, src2_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, src2_dram_buffer, src2_vec, /*blocking=*/true);
 
-    const std::uint32_t src_aligned_page_size = static_cast<std::uint32_t>(src0_dram_buffer->aligned_page_size());
-    const std::uint32_t dst_aligned_page_size = static_cast<std::uint32_t>(dst_dram_buffer->aligned_page_size());
+    const std::uint32_t src_aligned_page_size =
+        static_cast<std::uint32_t>(src0_dram_buffer->get_reference_buffer()->aligned_page_size());
+    const std::uint32_t dst_aligned_page_size =
+        static_cast<std::uint32_t>(dst_dram_buffer->get_reference_buffer()->aligned_page_size());
 
-    auto reader_run_args = [&](const std::shared_ptr<Buffer>& buf) {
+    auto reader_run_args = [&](const std::shared_ptr<distributed::MeshBuffer>& buf) {
         return experimental::MakeRuntimeArgsForSingleNode(
             node,
             {{"src_addr", buf->address()},
@@ -231,7 +229,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarBfdDatacopy) {
     LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<std::uint32_t> result_vec;
-    tt::tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     // Output order = pack order: per outer loop, in0's whole block, then in1's, then in2's (blocked).
     // Within a loop, cycle i copies tile (i % TILES_PER_INPUT) of input (i / TILES_PER_INPUT), taken from

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -117,44 +117,37 @@ bool single_core_reconfig(
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
-    tt::tt_metal::InterleavedBufferConfig dram_config_bfp16b{
-        .device = device,
-        .size = dram_buffer_size_bfp16b,
-        .page_size = dram_buffer_size_bfp16b,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-
-    tt::tt_metal::InterleavedBufferConfig dram_config_bfp8b{
-        .device = device,
-        .size = dram_buffer_size_bfp8b,
-        .page_size = dram_buffer_size_bfp8b,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-
-    tt::tt_metal::InterleavedBufferConfig dram_config_out0{
-        .device = device,
-        .size = dram_buffer_size_out0,
-        .page_size = dram_buffer_size_out0,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config_bfp16b{
+        .page_size = dram_buffer_size_bfp16b, .buffer_type = tt::tt_metal::BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config_bfp8b{
+        .page_size = dram_buffer_size_bfp8b, .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     // This will be srcB in Bfp8_b
-    auto input0_dram_buffer = CreateBuffer(dram_config_bfp8b);
+    auto input0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp8b}, dram_config_bfp8b, mesh_device.get());
     uint32_t input0_dram_byte_address = input0_dram_buffer->address();
 
     // This will be srcA in Float16_b
-    auto input1_dram_buffer = CreateBuffer(dram_config_bfp16b);
+    auto input1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp16b}, dram_config_bfp16b, mesh_device.get());
     uint32_t input1_dram_byte_address = input1_dram_buffer->address();
 
     // This will be DEST in Float16_b
-    auto input2_dram_buffer = CreateBuffer(dram_config_bfp16b);
+    auto input2_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp16b}, dram_config_bfp16b, mesh_device.get());
     uint32_t input2_dram_byte_address = input2_dram_buffer->address();
 
     // This will be Output0 in Float32 or Float16_b depending on fp32_dest_acc_en
-    auto output0_dram_buffer = CreateBuffer(dram_config_out0);
+    auto output0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_buffer_size_out0},
+        {.page_size = dram_buffer_size_out0, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
     uint32_t output0_dram_byte_address = output0_dram_buffer->address();
 
     // This will be Output1 in Bfp8_b
-    auto output1_dram_buffer = CreateBuffer(dram_config_bfp8b);
+    auto output1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp8b}, dram_config_bfp8b, mesh_device.get());
     uint32_t output1_dram_byte_address = output1_dram_buffer->address();
 
     tt_metal::CircularBufferConfig l1_input0_cb_config =
@@ -294,9 +287,9 @@ bool single_core_reconfig(
     // ////////////////////////////////////////////////////////////////////////////
     // //                      Compile and Execute Application
     // ////////////////////////////////////////////////////////////////////////////
-    tt_metal::detail::WriteToBuffer(input0_dram_buffer, src0_vec);
-    tt_metal::detail::WriteToBuffer(input1_dram_buffer, src1_vec);
-    tt_metal::detail::WriteToBuffer(input2_dram_buffer, src2_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, input0_dram_buffer, src0_vec, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, src1_vec, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, input2_dram_buffer, src2_vec, /*blocking=*/true);
 
     static constexpr uint32_t k_input0_dram_bank_id = 0;
     static constexpr uint32_t k_input1_dram_bank_id = 0;
@@ -340,8 +333,8 @@ bool single_core_reconfig(
     // ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest0_buffer_data(src1_vec.size());
     std::vector<uint32_t> dest1_buffer_data(src0_vec.size());
-    tt_metal::detail::ReadFromBuffer(output0_dram_buffer, dest0_buffer_data);
-    tt_metal::detail::ReadFromBuffer(output1_dram_buffer, dest1_buffer_data);
+    distributed::EnqueueReadMeshBuffer(cq, dest0_buffer_data, output0_dram_buffer, /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, dest1_buffer_data, output1_dram_buffer, /*blocking=*/true);
 
     pass &= is_close_packed_vectors<bfloat16, uint32_t>(
         dest0_buffer_data, packed_golden0, [&](const bfloat16& a, const bfloat16& b) {

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -47,6 +47,7 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/int8.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -976,16 +977,16 @@ std::vector<uint32_t> sfpu_quasar_run(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const experimental::ProgramSpec& spec,
     const experimental::ProgramRunArgs& params,
-    const std::vector<std::pair<std::shared_ptr<tt::tt_metal::Buffer>, const std::vector<uint32_t>*>>& inputs,
-    const std::shared_ptr<tt::tt_metal::Buffer>& out_buf) {
+    const std::vector<std::pair<std::shared_ptr<distributed::MeshBuffer>, const std::vector<uint32_t>*>>& inputs,
+    const std::shared_ptr<distributed::MeshBuffer>& out_buf) {
     auto program = experimental::MakeProgramFromSpec(*mesh_device, spec);
     experimental::SetProgramRunArgs(program, params);
     for (const auto& [buf, data] : inputs) {
-        tt_metal::detail::WriteToBuffer(buf, *data);
+        slow_dispatch::WriteToBuffer(*buf, *data);
     }
     LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
     std::vector<uint32_t> dest;
-    tt_metal::detail::ReadFromBuffer(out_buf, dest);
+    slow_dispatch::ReadFromBuffer(*out_buf, dest);
     return dest;
 }
 
@@ -1003,24 +1004,21 @@ std::vector<uint32_t> sfpu_quasar_run(
 /// @return
 bool run_sfpu_binary_two_input_buffer(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SfpuConfig& test_config) {
-    auto* device = mesh_device->get_devices()[0];
     const size_t per_buffer_byte_size_input = test_config.num_tiles * tt::tile_size(test_config.l1_input_data_format);
     const size_t per_buffer_byte_size_output = test_config.num_tiles * tt::tile_size(test_config.l1_output_data_format);
 
-    tt::tt_metal::InterleavedBufferConfig dram_config_input{
-        .device = device,
-        .size = per_buffer_byte_size_input,
-        .page_size = per_buffer_byte_size_input,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-    tt::tt_metal::InterleavedBufferConfig dram_config_output{
-        .device = device,
-        .size = per_buffer_byte_size_output,
-        .page_size = per_buffer_byte_size_output,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-
-    auto input0_dram_buffer = CreateBuffer(dram_config_input);
-    auto input1_dram_buffer = CreateBuffer(dram_config_input);
-    auto output_dram_buffer = CreateBuffer(dram_config_output);
+    auto input0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size_input},
+        {.page_size = per_buffer_byte_size_input, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto input1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size_input},
+        {.page_size = per_buffer_byte_size_input, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto output_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size_output},
+        {.page_size = per_buffer_byte_size_output, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
 
     const bool is_int8_op = sfpu_util::is_int8_binary_sfpu_op(test_config.sfpu_op);
     const size_t element_size = is_int8_op ? sizeof(int8_t) : sizeof(bfloat16);
@@ -1191,16 +1189,22 @@ bool run_sfpu_ternary_three_input_buffer(
     const size_t per_buffer_byte_size = test_config.num_tiles * test_config.tile_byte_size;
     auto* device = mesh_device->get_devices()[0];
 
-    tt::tt_metal::InterleavedBufferConfig dram_config{
-        .device = device,
-        .size = per_buffer_byte_size,
-        .page_size = per_buffer_byte_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-
-    auto input0_dram_buffer = CreateBuffer(dram_config);
-    auto input1_dram_buffer = CreateBuffer(dram_config);
-    auto input2_dram_buffer = CreateBuffer(dram_config);
-    auto output_dram_buffer = CreateBuffer(dram_config);
+    auto input0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
+        {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto input1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
+        {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto input2_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
+        {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto output_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = per_buffer_byte_size},
+        {.page_size = per_buffer_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
 
     const size_t numel = per_buffer_byte_size / sizeof(bfloat16);
     const int seed = std::chrono::system_clock::now().time_since_epoch().count();
@@ -1425,12 +1429,12 @@ bool run_sfpu_ternary_three_input_buffer(
             }
         }
 
-        tt_metal::detail::WriteToBuffer(input0_dram_buffer, packed_in0);
-        tt_metal::detail::WriteToBuffer(input1_dram_buffer, packed_in1);
-        tt_metal::detail::WriteToBuffer(input2_dram_buffer, packed_in2);
+        distributed::EnqueueWriteMeshBuffer(cq, input0_dram_buffer, packed_in0, /*blocking=*/true);
+        distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, packed_in1, /*blocking=*/true);
+        distributed::EnqueueWriteMeshBuffer(cq, input2_dram_buffer, packed_in2, /*blocking=*/true);
         distributed::EnqueueMeshWorkload(cq, workload, false);
         distributed::Finish(cq);
-        tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+        distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     }
 
     return sfpu_util::is_close_packed_sfpu_output(dest_buffer_data, packed_golden, test_config.sfpu_op);

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -365,7 +365,6 @@ bool single_tile_matmul(
     const uint32_t in1_tile_size = tt::tile_size(in1_fmt);
     const uint32_t out_tile_size = tt::tile_size(out_fmt);
 
-    auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -373,29 +372,22 @@ bool single_tile_matmul(
     ////////////////////////////////////////////////////////////////////////////
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
-    tt::tt_metal::InterleavedBufferConfig dram_in0_config{
-        .device = device,
-        .size = in0_tile_size,
-        .page_size = in0_tile_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-    tt::tt_metal::InterleavedBufferConfig dram_in1_config{
-        .device = device,
-        .size = in1_tile_size,
-        .page_size = in1_tile_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-    tt::tt_metal::InterleavedBufferConfig dram_out_config{
-        .device = device,
-        .size = out_tile_size,
-        .page_size = out_tile_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
-    auto input0_dram_buffer = CreateBuffer(dram_in0_config);
-    auto input1_dram_buffer = CreateBuffer(dram_in1_config);
-    auto output_dram_buffer = CreateBuffer(dram_out_config);
+    auto input0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in0_tile_size},
+        {.page_size = in0_tile_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto input1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in1_tile_size},
+        {.page_size = in1_tile_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto output_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out_tile_size},
+        {.page_size = out_tile_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
 
     tt_metal::CreateCircularBuffer(
         program_,
@@ -448,8 +440,8 @@ bool single_tile_matmul(
     ////////////////////////////////////////////////////////////////////////////
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::detail::WriteToBuffer(input0_dram_buffer, stimulus.packed_input0);
-    tt_metal::detail::WriteToBuffer(input1_dram_buffer, stimulus.packed_input1);
+    distributed::EnqueueWriteMeshBuffer(cq, input0_dram_buffer, stimulus.packed_input0, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, stimulus.packed_input1, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -470,7 +462,7 @@ bool single_tile_matmul(
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     std::vector<float> dest_floats;
     if (out_fmt == tt::DataFormat::Fp8_e4m3) {
         dest_floats = fp8_to_floats(dest_buffer_data);
@@ -526,31 +518,22 @@ bool single_block_matmul(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
-    auto* device = mesh_device->get_devices()[0];
-
-    tt::tt_metal::InterleavedBufferConfig dram_config_0{
-        .device = device,
-        .size = in0_byte_size,
-        .page_size = in0_byte_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-    tt::tt_metal::InterleavedBufferConfig dram_config_1{
-        .device = device,
-        .size = in1_byte_size,
-        .page_size = in1_byte_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-    tt::tt_metal::InterleavedBufferConfig dram_config_out{
-        .device = device,
-        .size = out_byte_size,
-        .page_size = out_byte_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-
-    auto input0_dram_buffer = CreateBuffer(dram_config_0);
-    auto input1_dram_buffer = CreateBuffer(dram_config_1);
-    auto output_dram_buffer = CreateBuffer(dram_config_out);
+    auto input0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in0_byte_size},
+        {.page_size = in0_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto input1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in1_byte_size},
+        {.page_size = in1_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
+    auto output_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out_byte_size},
+        {.page_size = out_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
 
     tt_metal::CreateCircularBuffer(
         program_,
@@ -603,8 +586,8 @@ bool single_block_matmul(
     ////////////////////////////////////////////////////////////////////////////
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
-    tt_metal::detail::WriteToBuffer(input0_dram_buffer, stimulus.packed_input0);
-    tt_metal::detail::WriteToBuffer(input1_dram_buffer, stimulus.packed_input1);
+    distributed::EnqueueWriteMeshBuffer(cq, input0_dram_buffer, stimulus.packed_input0, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, stimulus.packed_input1, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -629,7 +612,7 @@ bool single_block_matmul(
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     std::vector<float> dest_floats;
     // Tolerances under random U(-1, +1) stimulus. FP8 output: ~1/8
     // quantization plus deeper accumulation rounding for K>1. BF16 output
@@ -692,35 +675,25 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
-    auto* device = mesh_device->get_devices()[0];
-
-    tt::tt_metal::InterleavedBufferConfig dram_config_0{
-        .device = device,
-        .size = in0_total_size_bytes,
-        .page_size = in0_total_size_bytes,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-
-    tt::tt_metal::InterleavedBufferConfig dram_config_1{
-        .device = device,
-        .size = in1_total_size_bytes,
-        .page_size = in1_total_size_bytes,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-
-    tt::tt_metal::InterleavedBufferConfig dram_config_out{
-        .device = device,
-        .size = out_byte_size,
-        .page_size = out_byte_size,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
 
     tt_metal::Program program = tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
 
-    auto input0_dram_buffer = CreateBuffer(dram_config_0);
+    auto input0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in0_total_size_bytes},
+        {.page_size = in0_total_size_bytes, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
     const uint32_t in0_dram_addr = input0_dram_buffer->address();
-    auto input1_dram_buffer = CreateBuffer(dram_config_1);
+    auto input1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in1_total_size_bytes},
+        {.page_size = in1_total_size_bytes, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
     const uint32_t in1_dram_addr = input1_dram_buffer->address();
-    auto output_dram_buffer = CreateBuffer(dram_config_out);
+    auto output_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out_byte_size},
+        {.page_size = out_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
+        mesh_device.get());
     const uint32_t out_dram_addr = output_dram_buffer->address();
 
     uint32_t in0_id = 0;
@@ -916,8 +889,8 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
 
-    tt_metal::detail::WriteToBuffer(input0_dram_buffer, in0_stim.packed);
-    tt_metal::detail::WriteToBuffer(input1_dram_buffer, in1_stim.packed);
+    distributed::EnqueueWriteMeshBuffer(cq, input0_dram_buffer, in0_stim.packed, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, in1_stim.packed, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -953,7 +926,7 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     std::vector<float> dest_floats;
     if (out_fmt == tt::DataFormat::Fp8_e4m3) {
         dest_floats = fp8_to_floats(dest_buffer_data);

--- a/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
@@ -78,22 +78,14 @@ StochasticRoundingResult run_stochastic_rounding(
     tt_metal::Program program = tt_metal::CreateProgram();
     auto mesh_workload = distributed::MeshWorkload();
 
-    const distributed::DeviceLocalBufferConfig input_device_local_config{
-        .page_size = input_byte_size,
-        .buffer_type = tt_metal::BufferType::DRAM,
-    };
-    const distributed::DeviceLocalBufferConfig output_device_local_config{
-        .page_size = output_byte_size,
-        .buffer_type = tt_metal::BufferType::DRAM,
-    };
-
-    const distributed::ReplicatedBufferConfig input_replicated_config{.size = input_byte_size};
-    const distributed::ReplicatedBufferConfig output_replicated_config{.size = output_byte_size};
-
-    auto input_dram_buffer =
-        distributed::MeshBuffer::create(input_replicated_config, input_device_local_config, cq.device());
-    auto output_dram_buffer =
-        distributed::MeshBuffer::create(output_replicated_config, output_device_local_config, cq.device());
+    auto input_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = input_byte_size},
+        {.page_size = input_byte_size, .buffer_type = tt_metal::BufferType::DRAM},
+        cq.device());
+    auto output_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = output_byte_size},
+        {.page_size = output_byte_size, .buffer_type = tt_metal::BufferType::DRAM},
+        cq.device());
 
     uint32_t input_dram_byte_address = input_dram_buffer->address();
     uint32_t output_dram_byte_address = output_dram_buffer->address();

--- a/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sum_reduce_scalar.cpp
@@ -53,7 +53,6 @@ struct SumReduceScalarConfig {
 };
 
 bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumReduceScalarConfig& config) {
-    IDevice* device = mesh_device.get_devices()[0];
     tt_metal::Program program = tt_metal::CreateProgram();
     CoreCoord core = {0, 0};
 
@@ -68,16 +67,15 @@ bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumR
     // reader_unary_push_n walks a bank linearly, which would otherwise stride across
     // interleaved banks and hand the compute kernel the wrong tiles.
     const uint32_t input_byte_size = config.num_tiles * tile_byte_size;
-    tt_metal::InterleavedBufferConfig dram_config = {
-        .device = device,
-        .size = input_byte_size,
-        .page_size = input_byte_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
-    auto src_dram_buffer = CreateBuffer(dram_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = input_byte_size},
+        {.page_size = input_byte_size, .buffer_type = tt_metal::BufferType::DRAM},
+        &mesh_device);
 
-    dram_config.size = out_tile_byte_size;
-    dram_config.page_size = out_tile_byte_size;
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out_tile_byte_size},
+        {.page_size = out_tile_byte_size, .buffer_type = tt_metal::BufferType::DRAM},
+        &mesh_device);
 
     uint32_t cb_tiles = std::max(8u, config.num_tiles);
     tt_metal::CircularBufferConfig cb_src_config =
@@ -137,7 +135,8 @@ bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumR
     auto packed_input = test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(
         0, 1.0f, byte_size / sizeof(bfloat16), config.seed);
 
-    tt_metal::detail::WriteToBuffer(*src_dram_buffer, packed_input);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, packed_input, /*blocking=*/true);
 
     // Wrap the program into a MeshWorkload and dispatch via the mesh command queue.
     // This path works under both fast dispatch and slow dispatch, unlike detail::LaunchProgram.
@@ -145,12 +144,11 @@ bool run_sum_reduce_scalar_test(distributed::MeshDevice& mesh_device, const SumR
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(*dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     auto u16_src_vec = u16_from_u32_vector(packed_input);
 

--- a/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_top32_rm_dev.cpp
@@ -164,7 +164,6 @@ bool verify_top32_outputs(
 
 bool run_top32_rm_dev(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t row_elements, uint32_t seed) {
-    auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -182,19 +181,22 @@ bool run_top32_rm_dev(
     const uint32_t out0_bytes = kOutputTiles * tile_bf16;
     const uint32_t out1_bytes = kOutputTiles * tile_u32;
 
-    InterleavedBufferConfig dram_in0{
-        .device = device, .size = in0_bytes, .page_size = in0_bytes, .buffer_type = BufferType::DRAM};
-    InterleavedBufferConfig dram_in1{
-        .device = device, .size = in1_bytes, .page_size = in1_bytes, .buffer_type = BufferType::DRAM};
-    InterleavedBufferConfig dram_out0{
-        .device = device, .size = out0_bytes, .page_size = out0_bytes, .buffer_type = BufferType::DRAM};
-    InterleavedBufferConfig dram_out1{
-        .device = device, .size = out1_bytes, .page_size = out1_bytes, .buffer_type = BufferType::DRAM};
-
-    auto buf_in0 = CreateBuffer(dram_in0);
-    auto buf_in1 = CreateBuffer(dram_in1);
-    auto buf_out0 = CreateBuffer(dram_out0);
-    auto buf_out1 = CreateBuffer(dram_out1);
+    auto buf_in0 = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in0_bytes},
+        {.page_size = in0_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto buf_in1 = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in1_bytes},
+        {.page_size = in1_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto buf_out0 = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out0_bytes},
+        {.page_size = out0_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
+    auto buf_out1 = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out1_bytes},
+        {.page_size = out1_bytes, .buffer_type = BufferType::DRAM},
+        mesh_device.get());
 
     CoreCoord core{0, 0};
     CoreRangeSet crs({CoreRange(core)});
@@ -247,16 +249,16 @@ bool run_top32_rm_dev(
 
     ShuffledInputs in = make_shuffled_inputs_row_major(row_elements, seed);
 
-    detail::WriteToBuffer(buf_in0, in.packed_scores);
-    detail::WriteToBuffer(buf_in1, in.indices_u32);
+    distributed::EnqueueWriteMeshBuffer(cq, buf_in0, in.packed_scores, /*blocking=*/true);
+    distributed::EnqueueWriteMeshBuffer(cq, buf_in1, in.indices_u32, /*blocking=*/true);
 
     EnqueueMeshWorkload(cq, workload, false);
     Finish(cq);
 
     std::vector<uint32_t> out0;
     std::vector<uint32_t> out1;
-    detail::ReadFromBuffer(buf_out0, out0);
-    detail::ReadFromBuffer(buf_out1, out1);
+    distributed::EnqueueReadMeshBuffer(cq, out0, buf_out0, /*blocking=*/true);
+    distributed::EnqueueReadMeshBuffer(cq, out1, buf_out1, /*blocking=*/true);
     return verify_top32_outputs(in.packed_scores, in.indices_u32, out0, out1, row_elements);
 }
 


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

Public runtime APIs are all supposed to be natively distributed/multi-device by now.
However, we still expose single-device methods like `Buffer::create` and `CreateBuffer`.

As a preparation to their removal, we replace their usage with mesh API (where it's straightforward to do) following the migration guide
https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/TT-Distributed/TTMeshMigrationGuide.md

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-create-buffer-replace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-create-buffer-replace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-create-buffer-replace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-create-buffer-replace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-create-buffer-replace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-create-buffer-replace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-create-buffer-replace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-create-buffer-replace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-create-buffer-replace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-create-buffer-replace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-create-buffer-replace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-create-buffer-replace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-create-buffer-replace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-create-buffer-replace)