### PR TITLE
[Bug Fix] Fix Common Program Cache Hash Bugs

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -46,6 +46,15 @@ void ReshapeDeviceOperation::validate_on_program_cache_miss(
         "Reshape does not currently support sharding. Use ttnn::reshape for reshaping sharded inputs");
 
     if (input_tensor_a.layout() == Layout::TILE) {
+        // ReshapeTileProgramFactory sizes its CBs and tile counts from the architectural 32x32
+        // constants, and the tile is absent from compute_program_hash, so a non-standard tile would
+        // both compile a mis-sized program and alias onto a cached 32x32 one.
+        const auto tile = input_tensor_a.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "reshape_on_device requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
         TT_FATAL(
             input_tensor_a.physical_volume() % TILE_HW == 0,
             "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
@@ -49,7 +49,7 @@ void bind_reshape(nb::module_& mod) {
 
 
         Args:
-            * :attr:`input_tensor`: Input Tensor.
+            * :attr:`input_tensor`: Input Tensor. A TILE layout tensor must use the standard 32x32 tile.
             * :attr:`W`: W dim of tensor.
             * :attr:`Z`: Z dim of tensor.
             * :attr:`Y`: Y dim of tensor.

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
@@ -4,6 +4,8 @@
 
 #include "roll_device_operation.hpp"
 
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
@@ -27,6 +29,17 @@ void validate_roll(const RollParams& operation_attributes, const RollInputs& ten
     TT_FATAL(
         input.shard_spec().value().grid.ranges().size() == 1,
         "Native sharded roll requires a single contiguous rectangular CoreRange");
+    if (input.layout() == Layout::TILE) {
+        // The factory derives cell_h/cell_w/cell_size from the architectural 32x32 constants, and the
+        // tile is absent from compute_program_hash, so a non-standard tile would both compile a
+        // mis-sized program and alias onto a cached 32x32 one.
+        const auto tile = input.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+            "roll requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
+    }
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
@@ -19,7 +19,7 @@ void bind_roll(nb::module_& mod) {
         Performs circular shifting of elements along the specified dimension(s).
 
         Args:
-            input_tensor: A tensor whose elements will be rolled.
+            input_tensor: A tensor whose elements will be rolled. A TILE layout tensor must use the standard 32x32 tile.
             shifts: The number of places by which elements are shifted. Can be an integer or a list of integers (one per dimension).
             dim: The dimension(s) along which to roll. If shifts is a list, then dim must be a list of the same length as shifts.
         )doc";

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -24,6 +24,17 @@ void InterleavedToShardedPartialDeviceOperation::validate_on_program_cache_miss(
         slice_index,
         num_slices);
     TT_FATAL(input_tensor.layout() == Layout::TILE, "Currently, only tile layout is supported for partial I->S");
+    // The factory sizes its units and tile counts from the architectural 32x32 constants, and the tile
+    // is absent from compute_program_hash, so a non-standard tile would both compile a mis-sized
+    // program and alias onto a cached 32x32 one.
+    {
+        const auto tile = input_tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+            "interleaved_to_sharded_partial requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
+    }
     TT_FATAL(
         (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) % num_slices == 0,
         "Total height of a tensor must be divisible by num_slices!");

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_nanobind.cpp
@@ -21,7 +21,7 @@ void bind_interleaved_to_sharded_partial(nb::module_& mod) {
         Converts a partial tensor from interleaved to sharded memory layout
 
         Args:
-            * :attr:`input_tensor` (ttnn.Tensor): input tensor
+            * :attr:`input_tensor` (ttnn.Tensor): input tensor. Must be TILE layout with the standard 32x32 tile.
             * :attr:`grid` (ttnn.CoreGrid): Grid of sharded tensor
             * :attr:`num_slices` (int): Number of slices.
             * :attr:`slice_index` (int): Slice index.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -335,7 +335,9 @@ ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
         operation_attributes.output_mem_config,
         operation_attributes.sub_core_grids,
         factory.index(),
-        tensor_args.start_tensor.has_value());
+        tensor_args.start_tensor.has_value(),
+        tensor_args.end_tensor.has_value(),
+        tensor_args.preallocated_output.has_value());
 
     const auto& input = tensor_args.input;
     hash = ttsl::hash::hash_objects(
@@ -359,6 +361,20 @@ ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
             st.memory_config());
     }
 
+    // SliceTileTensorArgsProgramFactory gives the end tensor its own TensorAccessorArgs in the reader's
+    // compile-time args, so its memory config picks the bank table and cannot be refreshed on a hit.
+    if (tensor_args.end_tensor.has_value()) {
+        const auto& et = tensor_args.end_tensor.value();
+        hash = ttsl::hash::hash_objects(
+            hash,
+            et.logical_shape().rank(),
+            et.logical_shape(),
+            et.padded_shape(),
+            et.layout(),
+            et.dtype(),
+            et.memory_config());
+    }
+
     const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
     hash = ttsl::hash::hash_objects(
         hash,
@@ -368,6 +384,22 @@ ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
         output_spec.layout(),
         output_spec.data_type(),
         output_spec.memory_config());
+
+    // compute_output_specs derives the spec above from operation_attributes.output_mem_config, but
+    // create_output_tensors hands the program the caller's tensor verbatim when one is supplied, and
+    // every factory bakes a TensorAccessorArgs for that destination buffer into its writer's
+    // compile-time args. Key on the real destination so it cannot alias a differently-placed one.
+    if (tensor_args.preallocated_output.has_value()) {
+        const auto& po = tensor_args.preallocated_output.value();
+        hash = ttsl::hash::hash_objects(
+            hash,
+            po.logical_shape().rank(),
+            po.logical_shape(),
+            po.padded_shape(),
+            po.layout(),
+            po.dtype(),
+            po.memory_config());
+    }
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -155,6 +155,25 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
             args.slice_end.rank());
     }
     if (tensor_args.input.layout() == Layout::TILE) {
+        // Both tile factories derive their page sizes and tile counts from the architectural 32x32
+        // constants, and the tile is absent from compute_program_hash, so a non-standard tile would
+        // both compile a mis-sized program and alias onto a cached 32x32 one.
+        const auto tile = tensor_args.input.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "slice requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
+        if (tensor_args.preallocated_output.has_value()) {
+            const auto out_tile = tensor_args.preallocated_output.value().tensor_spec().tile();
+            TT_FATAL(
+                out_tile == tile,
+                "The preallocated output tensor tile ({}x{}) must match the input tensor tile ({}x{})",
+                out_tile.get_height(),
+                out_tile.get_width(),
+                tile.get_height(),
+                tile.get_width());
+        }
         TT_FATAL(
             tensor_args.input.physical_volume() % TILE_HW == 0,
             "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -65,6 +65,9 @@ void bind_slice(nb::module_& mod) {
         Note:
             Strided slicing (``slice_step != 1``) is not supported for ``bfloat8_b`` tensors.
 
+            TILE layout tensors must use the standard 32x32 tile, and a pre-allocated ``output_tensor`` must
+            carry the same tile as the input.
+
         Returns:
             ttnn.Tensor: the output tensor.
     )doc";

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tanh_bw_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "tanh_bw_program_factory.hpp"
 
@@ -61,7 +64,26 @@ void TanhBwDeviceOperation::validate_on_program_cache_miss(
         "memory layout: `{}`",
         static_cast<int>(input_tensor.memory_config().memory_layout()));
 
+    // The factory sizes its circular buffers with tt::tile_size and splits work by
+    // physical_volume() / TILE_HW, and the tile is absent from compute_program_hash, so a
+    // non-standard tile would both compile a mis-sized program and alias onto a cached 32x32 one.
+    const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
+        if (tensor.layout() != Layout::TILE) {
+            return;
+        }
+        const auto tile = tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+            "TANH_BW operation requires standard 32x32 tiles, but {} has a {}x{} tile.",
+            name,
+            tile.get_height(),
+            tile.get_width());
+    };
+    require_standard_tile(input_tensor, "the input tensor");
+    require_standard_tile(tensor_args.grad_output, "the grad_output tensor");
+
     if (preallocated_input_grad.has_value()) {
+        require_standard_tile(preallocated_input_grad.value(), "the preallocated output tensor");
         const auto computed_output_shape = compute_output_specs(args, tensor_args).logical_shape();
         const auto preallocated_output_shape = preallocated_input_grad.value().logical_shape();
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
@@ -136,6 +136,16 @@ ttsl::hash::hash_t TanhBwDeviceOperation::compute_program_hash(
         grad_output.memory_config(),
         input_shape.volume());
 
+    // args only carries the requested output_dtype/output_memory_config; when the caller supplies its
+    // own output tensor that is what the factory actually binds, sizing the destination CB from its
+    // dtype and baking a TensorAccessorArgs for its buffer into the writer's compile-time args. Neither
+    // can be refreshed on a cache hit, so key on the tensor that is really used.
+    if (tensor_args.preallocated_input_grad.has_value()) {
+        const auto& preallocated = tensor_args.preallocated_input_grad.value();
+        hash =
+            ttsl::hash::hash_objects(hash, preallocated.dtype(), preallocated.layout(), preallocated.memory_config());
+    }
+
     return hash;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_nanobind.cpp
@@ -1145,7 +1145,10 @@ void py_module(nb::module_& mod) {
     bind_unary_backward_optional<"tanh_bw">(
         mod,
         &ttnn::tanh_bw,
-        R"doc(Performs backward operations for hyperbolic tangent (tanh) function on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for hyperbolic tangent (tanh) function on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc",
+        R"doc(BFLOAT16)doc",
+        R"doc(TILE)doc",
+        R"doc(All operands must use the standard 32x32 tile.)doc");
 
     bind_unary_backward_optional<"sqrt_bw">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -92,21 +92,27 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input0 = tensor_args.input0;
     const auto& input1 = tensor_args.input1;
+    const auto& intermediate = tensor_args.intermediate;
 
     auto input0_shape = input0.padded_shape();
     auto input0_memory_layout = input0.layout();
     auto input0_dtype = input0.dtype();
     auto input0_memory_config = input0.memory_config();
+    // The matmul half reads in0/in1 tiles off its operands to size every block and circular buffer,
+    // and the aggregated matmul input inherits input0's page config, so tile geometry must be keyed.
+    auto input0_page_config = input0.tensor_spec().page_config();
 
     auto input1_shape = input1.padded_shape();
     auto input1_memory_layout = input1.layout();
     auto input1_dtype = input1.dtype();
     auto input1_memory_config = input1.memory_config();
+    auto input1_page_config = input1.tensor_spec().page_config();
 
-    auto intermediate_shape = input1.padded_shape();
-    auto intermediate_memory_layout = input1.layout();
-    auto intermediate_dtype = input1.dtype();
-    auto intermediate_memory_config = input1.memory_config();
+    auto intermediate_shape = intermediate.padded_shape();
+    auto intermediate_memory_layout = intermediate.layout();
+    auto intermediate_dtype = intermediate.dtype();
+    auto intermediate_memory_config = intermediate.memory_config();
+    auto intermediate_page_config = intermediate.tensor_spec().page_config();
 
     return tt::tt_metal::operation::hash_operation<LlamaAllGatherMatmulAsyncDeviceOperation>(
         args.dim,
@@ -119,14 +125,17 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
         input0_memory_layout,
         input0_dtype,
         input0_memory_config,
+        input0_page_config,
         input1_shape,
         input1_memory_layout,
         input1_dtype,
         input1_memory_config,
+        input1_page_config,
         intermediate_shape,
         intermediate_memory_layout,
         intermediate_dtype,
-        intermediate_memory_config);
+        intermediate_memory_config,
+        intermediate_page_config);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -85,6 +85,10 @@ Matmul_RS::tensor_return_value_t Matmul_RS::create_output_tensors(
 
 ttsl::hash::hash_t Matmul_RS::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // Both halves are tile-aware: the shared reduce-scatter factory derives
+    // input_tiles_per_core_width from the input's real tile, and the matmul helper reads in0/in1
+    // tiles off its operands to size every block and circular buffer. Keying on each page config
+    // keeps tensors that differ only in tile geometry on separate programs.
     return tt::tt_metal::operation::hash_operation<Matmul_RS>(
         operation_attributes.rs_op.dim,
         operation_attributes.rs_op.cluster_axis,
@@ -94,7 +98,11 @@ ttsl::hash::hash_t Matmul_RS::compute_program_hash(
         operation_attributes.rs_op.use_noc1_only,
         tensor_args.rs.input_tensor.dtype(),
         tensor_args.rs.input_tensor.memory_config(),
-        tensor_args.rs.input_tensor.device()->id());
+        tensor_args.rs.input_tensor.device()->id(),
+        tensor_args.rs.input_tensor.tensor_spec().page_config(),
+        tensor_args.rs.intermediate_packet_buffer.tensor_spec().page_config(),
+        tensor_args.matmul.input_tensor.tensor_spec().page_config(),
+        tensor_args.matmul.weight_tensor.tensor_spec().page_config());
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
@@ -80,6 +80,15 @@ void validate_runtime_args(
     };
     validate_meta(tensor_args.actual_start, "actual_start");
     validate_meta(tensor_args.actual_end, "actual_end");
+    // create_descriptor emits a single TensorAccessorArgs built from actual_start and the kernel uses it
+    // for both metadata reads, so a differing memory config on actual_end would resolve its address
+    // through the wrong bank table.
+    TT_FATAL(
+        tensor_args.actual_start.memory_config() == tensor_args.actual_end.memory_config(),
+        "metadata tensors actual_start and actual_end must share a memory config because one "
+        "TensorAccessor serves both reads (got buffer types {} and {})",
+        tensor_args.actual_start.memory_config().buffer_type(),
+        tensor_args.actual_end.memory_config().buffer_type());
 }
 
 }  // namespace
@@ -124,7 +133,10 @@ ttsl::hash::hash_t MoePaddingConfigDeviceOperation::compute_program_hash(
         config.dtype(),
         config.layout(),
         config.memory_config(),
-        config.padded_shape());
+        config.padded_shape(),
+        // The metadata accessor is baked into the writer's compile-time args, so the bank table it
+        // selects cannot be refreshed on a cache hit; validate_runtime_args pins actual_end to match.
+        tensor_args.actual_start.memory_config());
 }
 
 tt::tt_metal::ProgramDescriptor MoePaddingConfigDeviceOperation::ProgramFactory::create_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -73,6 +73,27 @@ void validate_runtime_args(
     // divisor/modulus to derive the boundary chip; a zero-height input chunk would divide by zero.
     TT_FATAL(chunk_local_t > 0, "input chunk seq dim ({}) must be at least one tile", input.padded_shape()[-2]);
 
+    // create_at sizes every DFB entry with tt::tile_size, derives its tile counts from the
+    // architectural 32x32 constants and passes TILE_HEIGHT as the tile_height compile arg, and the tile
+    // is absent from compute_program_hash. Runs on both paths so a non-standard tile is reported here
+    // rather than as a mis-sized program on a miss or a TensorSpec mismatch on a hit.
+    const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
+        if (tensor.layout() != Layout::TILE) {
+            return;
+        }
+        const auto tile = tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "rotary_embedding_indexed requires standard 32x32 tiles, but {} has a {}x{} tile",
+            name,
+            tile.get_height(),
+            tile.get_width());
+    };
+    require_standard_tile(input, "input");
+    require_standard_tile(cos, "cos");
+    require_standard_tile(tensor_args.sin, "sin");
+    require_standard_tile(tensor_args.trans_mat, "trans_mat");
+
     if (tensor_args.metadata.has_value()) {
         // Metadata path: kv_actual_global is read on-device from element [0] of the metadata tensor, so
         // its VALUE is the caller's responsibility. But the tensor is bound as tensor::metadata and read

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed_nanobind.cpp
@@ -43,7 +43,8 @@ void bind_rotary_embedding_indexed(nb::module_& mod) {
 
             Args:
                 input (ttnn.Tensor): 4D per-chip input chunk on device, TILE layout
-                    [1, n_heads, chunk_local, head_dim].
+                    [1, n_heads, chunk_local, head_dim]. All four tensor operands must use the
+                    standard 32x32 tile.
                 cos (ttnn.Tensor): 4D cos cache on device, TILE layout, SP-sharded over
                     `cluster_axis` in block-cyclic order keyed by `chunk_local`.
                 sin (ttnn.Tensor): 4D sin cache, same layout/shape as `cos`.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -68,6 +68,25 @@ void validate_runtime_args(
     const auto& mesh_view = cache.device()->get_view();
     TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
 
+    // create_descriptor's TILE branch derives its page size, Wt/input_Ht/cache_HtWt and the
+    // writer_tile_height compile arg from the architectural 32x32 constants, and the tile is absent
+    // from compute_program_hash. Checked here rather than in the miss validator so it also runs on the
+    // cache-hit path, where a non-standard tile would otherwise alias onto a cached 32x32 program.
+    const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
+        if (tensor.layout() != Layout::TILE) {
+            return;
+        }
+        const auto tile = tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "update_padded_kv_cache requires standard 32x32 tiles, but {} has a {}x{} tile",
+            name,
+            tile.get_height(),
+            tile.get_width());
+    };
+    require_standard_tile(cache, "cache");
+    require_standard_tile(tensor_args.input, "input");
+
     // Metadata-path invariant: the two per-request tensors are supplied together or not at all.
     // The path is selected on `slot_idx.has_value()`, but create_descriptor / override_runtime_arguments
     // dereference `kv_actual_global` unconditionally whenever slot_idx is set — a mismatched optional

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -117,6 +117,15 @@ void validate_runtime_args(
         };
         validate_meta(tensor_args.slot_idx.value(), "slot_idx");
         validate_meta(tensor_args.kv_actual_global.value(), "kv_actual_global");
+        // create_descriptor emits a single TensorAccessorArgs built from slot_idx and the writer uses it
+        // for both metadata reads, so a differing memory config on kv_actual_global would resolve its
+        // address through the wrong bank table.
+        TT_FATAL(
+            tensor_args.slot_idx->memory_config() == tensor_args.kv_actual_global->memory_config(),
+            "metadata tensors slot_idx and kv_actual_global must share a memory config because one "
+            "TensorAccessor serves both reads (got buffer types {} and {})",
+            tensor_args.slot_idx->memory_config().buffer_type(),
+            tensor_args.kv_actual_global->memory_config().buffer_type());
     }
 
     if (!tensor_args.slot_idx.has_value()) {
@@ -249,7 +258,11 @@ ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
         input.memory_config(),
         input.padded_shape(),
         cache.memory_config(),
-        cache.padded_shape());
+        cache.padded_shape(),
+        // On the metadata path the writer bakes a TensorAccessorArgs built from slot_idx into its
+        // compile-time args, so the bank table it selects cannot be refreshed on a cache hit. Only the
+        // config is keyed, never the value; kv_actual_global is pinned to match by validate_runtime_args.
+        tensor_args.slot_idx.has_value() ? tensor_args.slot_idx->memory_config() : MemoryConfig{});
 }
 
 tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -49,7 +49,8 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                     across `cluster_axis` with `sp_factor` slots per chip. Outermost dim equals
                     ``num_slots * num_layers``. Layout/dtype must match ``input``: block-float
                     (bfloat8_b/bfloat4_b) requires TILE; FP8_E4M3 requires ROW_MAJOR (Blackhole).
-                    Seq dims stay 32-aligned in both layouts.
+                    Seq dims stay 32-aligned in both layouts, and TILE layout requires the standard
+                    32x32 tile.
                 input (ttnn.Tensor): 4D input slab on device, same layout, dtype and head dim as
                     cache. Per-chip seq length = chunk_local.
                 slot_idx (int | ttnn.Tensor): scalar form: user slot in the batched prefill cache.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -107,6 +107,15 @@ void validate_runtime_args(
         };
         validate_meta(tensor_args.slot_idx.value(), "slot_idx");
         validate_meta(tensor_args.valid_global.value(), "valid_global");
+        // The reader and writer each emit a single TensorAccessorArgs built from slot_idx and use it for
+        // both metadata reads, so a differing memory config on valid_global would resolve its address
+        // through the wrong bank table.
+        TT_FATAL(
+            tensor_args.slot_idx->memory_config() == tensor_args.valid_global->memory_config(),
+            "metadata tensors slot_idx and valid_global must share a memory config because one "
+            "TensorAccessor serves both reads (got buffer types {} and {})",
+            tensor_args.slot_idx->memory_config().buffer_type(),
+            tensor_args.valid_global->memory_config().buffer_type());
     }
 
     // slot_idx is a host value only on the scalar path; on the tensor path it lives in the device
@@ -241,7 +250,11 @@ ttsl::hash::hash_t ZeroPaddedKvCacheDeviceOperation::compute_program_hash(
         cache.dtype(),
         cache.layout(),
         cache.memory_config(),
-        cache.padded_shape());
+        cache.padded_shape(),
+        // On the metadata path the reader and writer bake a TensorAccessorArgs built from slot_idx into
+        // their compile-time args, so the bank table it selects cannot be refreshed on a cache hit. Only
+        // the config is keyed, never the value; valid_global is pinned to match by validate_runtime_args.
+        tensor_args.slot_idx.has_value() ? tensor_args.slot_idx->memory_config() : MemoryConfig{});
 }
 
 tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -69,6 +69,20 @@ void validate_runtime_args(
     TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
     const auto& cache = tensor_args.cache;
 
+    // The TILE branch of the factory derives Wt/cache_H_pages and the cache_tile_size compile arg from
+    // the architectural 32x32 constants, and the reader's face loop hardcodes the 32x32 four-face
+    // layout; the tile is absent from compute_program_hash. Checked here rather than in the miss
+    // validator so it also runs on the cache-hit path, where a non-standard tile would otherwise alias
+    // onto a cached 32x32 program and zero the wrong region of the cache.
+    if (cache.layout() == Layout::TILE) {
+        const auto tile = cache.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "zero_padded_kv_cache requires standard 32x32 tiles, but cache has a {}x{} tile",
+            tile.get_height(),
+            tile.get_width());
+    }
+
     // Metadata-path invariant + tensor validation. The path is selected on slot_idx.has_value(), but the
     // factory dereferences valid_global->buffer() whenever slot_idx is set, so a mismatched optional would
     // null-deref -- reject it up front. Then validate each metadata tensor's structural properties (device,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
@@ -47,8 +47,9 @@ void bind_zero_padded_kv_cache(nb::module_& mod) {
 
             Args:
                 cache (ttnn.Tensor): 4D, DRAM-backed KV cache tensor with head dim 1. Supports
-                    TILE layout, or ROW_MAJOR layout with BF16 or FP8_E4M3 dtype. The per-element-tensor
-                    (metadata) form of slot_idx/valid_global below is TILE-only; ROW_MAJOR uses scalars.
+                    TILE layout with the standard 32x32 tile, or ROW_MAJOR layout with BF16 or FP8_E4M3
+                    dtype. The per-element-tensor (metadata) form of slot_idx/valid_global below is
+                    TILE-only; ROW_MAJOR uses scalars.
                 slot_idx (int, scalar form / ttnn.Tensor, tensor form): user slot in the batched prefill
                     cache. As a tensor: a 1-element uint32 DRAM tensor (replicated across the mesh, the
                     runner's h2d_socket_sync payload element 0 [slot_id]); read on-device from element 0.

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -58,7 +58,10 @@ ttsl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     // GlobalCircularBuffer / Tensor aren't reflection-hashable here; pick the bits that
     // determine Program shape: scalar attrs, GCB identity, the source tensor's DRAM
-    // address (compile-time arg via TensorAccessorArgs), and its dataformat.
+    // address (compile-time arg via TensorAccessorArgs), its dataformat, and its page config.
+    // create_at reads the real tile off the source tensor to derive k_tiles, total_n_tiles,
+    // tile_bytes and the CB page sizes, so two tensors differing only in tile geometry compile
+    // different programs and must not share a key.
     const auto* tensor_buffer = tensor_args.source_tensor.buffer();
     const tt::DataFormat dataformat = tt::tt_metal::datatype_to_dataformat_converter(tensor_args.source_tensor.dtype());
     return ttsl::hash::hash_objects_with_default_seed(
@@ -69,7 +72,8 @@ ttsl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
         attrs.rotation,
         static_cast<uint64_t>(attrs.global_cb->config_address()),
         static_cast<uint64_t>(tensor_buffer != nullptr ? tensor_buffer->address() : 0),
-        static_cast<uint32_t>(dataformat));
+        static_cast<uint32_t>(dataformat),
+        tensor_args.source_tensor.tensor_spec().page_config());
 }
 
 ttnn::device_operation::CachedProgram<DramPrefetcherValidatorDeviceOperation::ProgramFactory::shared_variables_t>


### PR DESCRIPTION
### Summary
This PR addresses three common program cache bugs, to enable the upcoming Metal 2.0 ports of the impacted ops. The three issues are combined into one PR because the impacted ops between the three overlap heavily.

I'm not aware of any of these causing issues right now, but that's probably because the problematic situations haven't been exercised yet. 

The three issues are as follows:

### 1. Silently Assuming 32×32 Tiles
For eight ops, the program factories size their CBs and calculate tile counts from 32x32 constants but don't check the tensor's tile shape. 

This PR makes these explicit by adding a `TT_FATAL` check and putting a note in the docs.

### 2. Tile-Aware Factories Don't Hash the Tile Shape
Three factories calculate page sizes and block shapes using the tile shape, but don't hash the tile. This means that if somehow you called the op twice with only the tile shape changing between calls, the hash will yield a fake cache hit. 

Added `page_config` to each hash. Alongside this, also fixed a copy-paste bug in `llama_all_gather_matmul_async`, where the intermediate tensor's hash is just a copy of `input1`.

### 3. Compile-time `TensorAccessorArgs`Missing from Hash

`TensorAccessorArgs::append_to` puts the `IsDram` flag and the aligned page size
into the compile-time args. These compile time args can't be updated and since they're missing from the hash, an otherwise-identical tensor in
the other memory space results in a fake cache hit. 

Added the relevant tensor's memory config to the hash in 5 ops, also adding optional operands that had been overlooked (`slot_idx`,`end_tensor`, and preallocated output tensors).

While fixing these, three ops also generate a single `TensorAccessor` and
use it to read two different metadata tensors. This assumes they share a
layout. Added an assertion that the configs match.

## Notes for reviewers
The PR shouldn't change results but could cause extra program compiles or crashes, in cases where previously a mis-compilation would have been silently accepted.
