### PR TITLE
[Bug Fix] Fix Common Program Cache Bugs

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -46,6 +46,15 @@ void ReshapeDeviceOperation::validate_on_program_cache_miss(
         "Reshape does not currently support sharding. Use ttnn::reshape for reshaping sharded inputs");
 
     if (input_tensor_a.layout() == Layout::TILE) {
+        // ReshapeTileProgramFactory sizes its CBs and tile counts from the architectural 32x32
+        // constants, and the tile is absent from compute_program_hash, so a non-standard tile would
+        // both compile a mis-sized program and alias onto a cached 32x32 one.
+        const auto tile = input_tensor_a.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "reshape_on_device requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
         TT_FATAL(
             input_tensor_a.physical_volume() % TILE_HW == 0,
             "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -52,7 +52,7 @@ void ReshapeDeviceOperation::validate_on_program_cache_miss(
         const auto tile = input_tensor_a.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
-            "reshape_on_device requires standard 32x32 tiles, got {}x{}",
+            "reshape_on_device does not currently support tiles other than 32x32, got {}x{}",
             tile.get_height(),
             tile.get_width());
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_nanobind.cpp
@@ -49,7 +49,7 @@ void bind_reshape(nb::module_& mod) {
 
 
         Args:
-            * :attr:`input_tensor`: Input Tensor.
+            * :attr:`input_tensor`: Input Tensor. A TILE layout tensor must use the standard 32x32 tile.
             * :attr:`W`: W dim of tensor.
             * :attr:`Z`: Z dim of tensor.
             * :attr:`Y`: Y dim of tensor.

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
@@ -56,8 +56,18 @@ void RollDeviceOperation::validate_on_program_cache_hit(
 
 ttsl::hash::hash_t RollDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& args) {
+    // padded_shape drives the N-D decomposition the factory writes into per-core runtime args, and it
+    // changes their count, which override_runtime_arguments cannot resize. output_mem_config supplies
+    // the output shard grid and orientation, which become the kernels' core ranges and select the
+    // shard-linear mapping; only the shard shape is re-checked on a hit.
     return tt::tt_metal::operation::hash_operation<RollDeviceOperation>(
-        attrs.shift, attrs.dim, args.input.memory_config(), args.input.dtype(), args.input.layout());
+        attrs.shift,
+        attrs.dim,
+        attrs.output_mem_config,
+        args.input.memory_config(),
+        args.input.dtype(),
+        args.input.layout(),
+        args.input.padded_shape());
 }
 
 RollDeviceOperation::spec_return_value_t RollDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
@@ -36,7 +36,7 @@ void validate_roll(const RollParams& operation_attributes, const RollInputs& ten
         const auto tile = input.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
-            "roll requires standard 32x32 tiles, got {}x{}",
+            "roll does not currently support tiles other than 32x32, got {}x{}",
             tile.get_height(),
             tile.get_width());
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
@@ -4,6 +4,8 @@
 
 #include "roll_device_operation.hpp"
 
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
@@ -27,6 +29,17 @@ void validate_roll(const RollParams& operation_attributes, const RollInputs& ten
     TT_FATAL(
         input.shard_spec().value().grid.ranges().size() == 1,
         "Native sharded roll requires a single contiguous rectangular CoreRange");
+    if (input.layout() == Layout::TILE) {
+        // The factory derives cell_h/cell_w/cell_size from the architectural 32x32 constants, and the
+        // tile is absent from compute_program_hash, so a non-standard tile would both compile a
+        // mis-sized program and alias onto a cached 32x32 one.
+        const auto tile = input.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+            "roll requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
+    }
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/roll_nanobind.cpp
@@ -19,7 +19,7 @@ void bind_roll(nb::module_& mod) {
         Performs circular shifting of elements along the specified dimension(s).
 
         Args:
-            input_tensor: A tensor whose elements will be rolled.
+            input_tensor: A tensor whose elements will be rolled. A TILE layout tensor must use the standard 32x32 tile.
             shifts: The number of places by which elements are shifted. Can be an integer or a list of integers (one per dimension).
             dim: The dimension(s) along which to roll. If shifts is a list, then dim must be a list of the same length as shifts.
         )doc";

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -89,9 +89,15 @@ ttsl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_h
     const operation_attributes_t& operation_attributes, const Tensor& input_tensor) {
     // slice_index is deliberately excluded from the key: it only feeds the runtime read-offset
     // starting_idx_h (same program structure for every slice of a given num_slices), and it is
-    // re-applied on every cache hit via get_dynamic_runtime_args. Keying on it would rebuild the
+    // re-applied on every cache hit by InterleavedToShardedPartialProgramFactory::
+    // override_runtime_arguments. Keying on it would rebuild the
     // program for each slice of a partial-slicing loop. num_slices -- which drives the work split --
     // stays keyed.
+    // padded_shape and the input's memory config both reach the compiled program and neither is
+    // refreshed on a hit: the factory bakes shape-derived reader/writer args at first miss while
+    // override_runtime_arguments patches only the address and starting offset, and the input buffer
+    // type selects the TensorAccessorArgs compile-time words, the scratch CB's existence and the input
+    // CB page size. The non-partial sibling already keys both.
     return tt::tt_metal::operation::hash_operation<InterleavedToShardedPartialDeviceOperation>(
         operation_attributes.grid_size,
         operation_attributes.shard_spec,
@@ -99,7 +105,9 @@ ttsl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_h
         operation_attributes.output_mem_config,
         operation_attributes.output_dtype,
         input_tensor.dtype(),
-        input_tensor.layout());
+        input_tensor.layout(),
+        input_tensor.padded_shape(),
+        input_tensor.memory_config());
 }
 
 Tensor interleaved_to_sharded_partial(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -24,6 +24,17 @@ void InterleavedToShardedPartialDeviceOperation::validate_on_program_cache_miss(
         slice_index,
         num_slices);
     TT_FATAL(input_tensor.layout() == Layout::TILE, "Currently, only tile layout is supported for partial I->S");
+    // The factory sizes its units and tile counts from the architectural 32x32 constants, and the tile
+    // is absent from compute_program_hash, so a non-standard tile would both compile a mis-sized
+    // program and alias onto a cached 32x32 one.
+    {
+        const auto tile = input_tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+            "interleaved_to_sharded_partial requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
+    }
     TT_FATAL(
         (input_tensor.physical_volume() / input_tensor.padded_shape()[-1]) % num_slices == 0,
         "Total height of a tensor must be divisible by num_slices!");

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -31,7 +31,7 @@ void InterleavedToShardedPartialDeviceOperation::validate_on_program_cache_miss(
         const auto tile = input_tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
-            "interleaved_to_sharded_partial requires standard 32x32 tiles, got {}x{}",
+            "interleaved_to_sharded_partial does not currently support tiles other than 32x32, got {}x{}",
             tile.get_height(),
             tile.get_width());
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -442,7 +442,7 @@ void InterleavedToShardedPartialProgramFactory::override_runtime_arguments(
     // work-split (shard extents, curr_idx, num_units) is pinned by the hashed shape/shard-spec. The only
     // per-dispatch values are the source/output buffer addresses and the slice_index-dependent
     // starting_idx_h. Patch just those slots in place instead of rebuilding the whole descriptor (O(1)
-    // per core rather than O(num_cores) descriptor work). Replaces get_dynamic_runtime_args.
+    // per core rather than O(num_cores) descriptor work).
     const uint32_t starting_idx_h = operations::data_movement::detail::calculate_starting_idx_h(
         input_tensor, operation_attributes.num_slices, operation_attributes.slice_index);
     const uint32_t src_addr = input_tensor.buffer()->address();

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_nanobind.cpp
@@ -21,7 +21,7 @@ void bind_interleaved_to_sharded_partial(nb::module_& mod) {
         Converts a partial tensor from interleaved to sharded memory layout
 
         Args:
-            * :attr:`input_tensor` (ttnn.Tensor): input tensor
+            * :attr:`input_tensor` (ttnn.Tensor): input tensor. Must be TILE layout with the standard 32x32 tile.
             * :attr:`grid` (ttnn.CoreGrid): Grid of sharded tensor
             * :attr:`num_slices` (int): Number of slices.
             * :attr:`slice_index` (int): Slice index.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -335,7 +335,9 @@ ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
         operation_attributes.output_mem_config,
         operation_attributes.sub_core_grids,
         factory.index(),
-        tensor_args.start_tensor.has_value());
+        tensor_args.start_tensor.has_value(),
+        tensor_args.end_tensor.has_value(),
+        tensor_args.preallocated_output.has_value());
 
     const auto& input = tensor_args.input;
     hash = ttsl::hash::hash_objects(
@@ -359,6 +361,20 @@ ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
             st.memory_config());
     }
 
+    // SliceTileTensorArgsProgramFactory gives the end tensor its own TensorAccessorArgs in the reader's
+    // compile-time args, so its memory config picks the bank table and cannot be refreshed on a hit.
+    if (tensor_args.end_tensor.has_value()) {
+        const auto& et = tensor_args.end_tensor.value();
+        hash = ttsl::hash::hash_objects(
+            hash,
+            et.logical_shape().rank(),
+            et.logical_shape(),
+            et.padded_shape(),
+            et.layout(),
+            et.dtype(),
+            et.memory_config());
+    }
+
     const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
     hash = ttsl::hash::hash_objects(
         hash,
@@ -368,6 +384,22 @@ ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
         output_spec.layout(),
         output_spec.data_type(),
         output_spec.memory_config());
+
+    // compute_output_specs derives the spec above from operation_attributes.output_mem_config, but
+    // create_output_tensors hands the program the caller's tensor verbatim when one is supplied, and
+    // every factory bakes a TensorAccessorArgs for that destination buffer into its writer's
+    // compile-time args. Key on the real destination so it cannot alias a differently-placed one.
+    if (tensor_args.preallocated_output.has_value()) {
+        const auto& po = tensor_args.preallocated_output.value();
+        hash = ttsl::hash::hash_objects(
+            hash,
+            po.logical_shape().rank(),
+            po.logical_shape(),
+            po.padded_shape(),
+            po.layout(),
+            po.dtype(),
+            po.memory_config());
+    }
 
     return hash;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -110,7 +110,7 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
     // directly, so re-check it here where the factory is actually chosen.
     TT_FATAL(
         !args.use_tensor_args || tensor_args.input.layout() == Layout::TILE,
-        "Tensor-args slice requires a TILE layout input, but got {}",
+        "Tensor-args slice does not currently support non-TILE inputs, but got {} layout",
         tensor_args.input.layout());
     TT_FATAL(
         tensor_args.input.padded_shape().rank() == args.slice_start.rank() &&
@@ -169,7 +169,7 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
         const auto tile = tensor_args.input.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
-            "slice requires standard 32x32 tiles, got {}x{}",
+            "slice does not currently support tiles other than 32x32, got {}x{}",
             tile.get_height(),
             tile.get_width());
         if (tensor_args.preallocated_output.has_value()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -155,6 +155,25 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
             args.slice_end.rank());
     }
     if (tensor_args.input.layout() == Layout::TILE) {
+        // Both tile factories derive their page sizes and tile counts from the architectural 32x32
+        // constants, and the tile is absent from compute_program_hash, so a non-standard tile would
+        // both compile a mis-sized program and alias onto a cached 32x32 one.
+        const auto tile = tensor_args.input.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "slice requires standard 32x32 tiles, got {}x{}",
+            tile.get_height(),
+            tile.get_width());
+        if (tensor_args.preallocated_output.has_value()) {
+            const auto out_tile = tensor_args.preallocated_output.value().tensor_spec().tile();
+            TT_FATAL(
+                out_tile == tile,
+                "The preallocated output tensor tile ({}x{}) must match the input tensor tile ({}x{})",
+                out_tile.get_height(),
+                out_tile.get_width(),
+                tile.get_height(),
+                tile.get_width());
+        }
         TT_FATAL(
             tensor_args.input.physical_volume() % TILE_HW == 0,
             "Input tensor physical volume ({}) must be divisible by TILE_HW ({})",

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -104,6 +104,14 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
         tensor_args.input.layout() == Layout::TILE || tensor_args.input.layout() == Layout::ROW_MAJOR,
         "Input tensor layout must be TILE or ROW_MAJOR but got {}",
         tensor_args.input.layout());
+    // use_tensor_args unconditionally selects SliceTileTensorArgsProgramFactory, which counts work as
+    // output.physical_volume() / TILE_HW and sizes its CBs with tile_size(). The public slice() entry
+    // point already refuses to take this path for a non-TILE input, but ttnn::prim::slice is callable
+    // directly, so re-check it here where the factory is actually chosen.
+    TT_FATAL(
+        !args.use_tensor_args || tensor_args.input.layout() == Layout::TILE,
+        "Tensor-args slice requires a TILE layout input, but got {}",
+        tensor_args.input.layout());
     TT_FATAL(
         tensor_args.input.padded_shape().rank() == args.slice_start.rank() &&
             args.slice_start.rank() == args.slice_end.rank(),
@@ -165,7 +173,21 @@ void SliceDeviceOperation::validate_on_program_cache_miss(
             tile.get_height(),
             tile.get_width());
         if (tensor_args.preallocated_output.has_value()) {
-            const auto out_tile = tensor_args.preallocated_output.value().tensor_spec().tile();
+            const auto& out_tensor = tensor_args.preallocated_output.value();
+            // Layout and dtype must be checked before the tile: PageConfig::get_tile() reports a default
+            // 32x32 Tile for a ROW_MAJOR tensor, so the comparison below would accept one. Both properties
+            // are pinned to the input by compute_output_specs, which is what the tile factories are built
+            // against, so this rejects only combinations the op never produced for itself.
+            TT_FATAL(
+                out_tensor.layout() == Layout::TILE,
+                "The preallocated output tensor must be TILE layout to match the input, but it has {} layout",
+                out_tensor.layout());
+            TT_FATAL(
+                out_tensor.dtype() == tensor_args.input.dtype(),
+                "The preallocated output tensor dtype ({}) must match the input tensor dtype ({})",
+                out_tensor.dtype(),
+                tensor_args.input.dtype());
+            const auto out_tile = out_tensor.tensor_spec().tile();
             TT_FATAL(
                 out_tile == tile,
                 "The preallocated output tensor tile ({}x{}) must match the input tensor tile ({}x{})",

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -65,6 +65,9 @@ void bind_slice(nb::module_& mod) {
         Note:
             Strided slicing (``slice_step != 1``) is not supported for ``bfloat8_b`` tensors.
 
+            TILE layout tensors must use the standard 32x32 tile, and a pre-allocated ``output_tensor`` must
+            carry the same tile as the input.
+
         Returns:
             ttnn.Tensor: the output tensor.
     )doc";

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
@@ -72,13 +72,13 @@ void TanhBwDeviceOperation::validate_on_program_cache_miss(
     const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
         TT_FATAL(
             tensor.layout() == Layout::TILE,
-            "TANH_BW operation requires TILE layout, but {} has {} layout.",
+            "TANH_BW operation does not currently support non-TILE layouts, but {} has {} layout.",
             name,
             tensor.layout());
         const auto tile = tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
-            "TANH_BW operation requires standard 32x32 tiles, but {} has a {}x{} tile.",
+            "TANH_BW operation does not currently support tiles other than 32x32, but {} has a {}x{} tile.",
             name,
             tile.get_height(),
             tile.get_width());

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tanh_bw_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "tanh_bw_program_factory.hpp"
 
@@ -61,7 +64,26 @@ void TanhBwDeviceOperation::validate_on_program_cache_miss(
         "memory layout: `{}`",
         static_cast<int>(input_tensor.memory_config().memory_layout()));
 
+    // The factory sizes its circular buffers with tt::tile_size and splits work by
+    // physical_volume() / TILE_HW, and the tile is absent from compute_program_hash, so a
+    // non-standard tile would both compile a mis-sized program and alias onto a cached 32x32 one.
+    const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
+        if (tensor.layout() != Layout::TILE) {
+            return;
+        }
+        const auto tile = tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+            "TANH_BW operation requires standard 32x32 tiles, but {} has a {}x{} tile.",
+            name,
+            tile.get_height(),
+            tile.get_width());
+    };
+    require_standard_tile(input_tensor, "the input tensor");
+    require_standard_tile(tensor_args.grad_output, "the grad_output tensor");
+
     if (preallocated_input_grad.has_value()) {
+        require_standard_tile(preallocated_input_grad.value(), "the preallocated output tensor");
         const auto computed_output_shape = compute_output_specs(args, tensor_args).logical_shape();
         const auto preallocated_output_shape = preallocated_input_grad.value().logical_shape();
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
@@ -65,12 +65,16 @@ void TanhBwDeviceOperation::validate_on_program_cache_miss(
         static_cast<int>(input_tensor.memory_config().memory_layout()));
 
     // The factory sizes its circular buffers with tt::tile_size and splits work by
-    // physical_volume() / TILE_HW, and the tile is absent from compute_program_hash, so a
-    // non-standard tile would both compile a mis-sized program and alias onto a cached 32x32 one.
+    // physical_volume() / TILE_HW, and neither the layout nor the tile is in compute_program_hash. The
+    // layout also reaches the kernels as the aligned page size inside TensorAccessorArgs, a compile-time
+    // arg no cache-hit path can refresh, so a ROW_MAJOR operand would be read as tile pages under a
+    // cached key. Only input has a layout TT_FATAL of its own, so require both properties here.
     const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
-        if (tensor.layout() != Layout::TILE) {
-            return;
-        }
+        TT_FATAL(
+            tensor.layout() == Layout::TILE,
+            "TANH_BW operation requires TILE layout, but {} has {} layout.",
+            name,
+            tensor.layout());
         const auto tile = tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
@@ -82,16 +86,42 @@ void TanhBwDeviceOperation::validate_on_program_cache_miss(
     require_standard_tile(input_tensor, "the input tensor");
     require_standard_tile(tensor_args.grad_output, "the grad_output tensor");
 
+    // The reader walks the same tile_id range in both operands with a count derived from input alone
+    // (physical_volume() / TILE_HW), so an undersized grad_output is read past the end of its
+    // allocation. Only input's storage, buffer and shape are covered above.
+    TT_FATAL(
+        tensor_args.grad_output.storage_type() == StorageType::DEVICE,
+        "TANH_BW operation requires grad_output to be on Device. grad_output storage type: {}",
+        tensor_args.grad_output.storage_type());
+    TT_FATAL(
+        tensor_args.grad_output.buffer() != nullptr,
+        "TANH_BW operation requires grad_output to be allocated in a buffer on the device. Buffer is null.");
+    TT_FATAL(
+        tensor_args.grad_output.padded_shape() == input_tensor.padded_shape(),
+        "TANH_BW operation requires grad_output and input to have the same padded shape, but got {} and {}.",
+        tensor_args.grad_output.padded_shape(),
+        input_tensor.padded_shape());
+
     if (preallocated_input_grad.has_value()) {
-        require_standard_tile(preallocated_input_grad.value(), "the preallocated output tensor");
-        const auto computed_output_shape = compute_output_specs(args, tensor_args).logical_shape();
-        const auto preallocated_output_shape = preallocated_input_grad.value().logical_shape();
+        const auto& preallocated = preallocated_input_grad.value();
+        require_standard_tile(preallocated, "the preallocated output tensor");
+        // Pin the preallocated output to the input rather than to compute_output_specs: that function
+        // returns this very tensor's spec when one is supplied, so comparing against it is a tautology
+        // that can never fire. The writer emits one page per input tile at an offset derived from
+        // input.physical_volume(), so an undersized buffer is written past its end.
         TT_FATAL(
-            preallocated_output_shape == computed_output_shape,
-            "When preallocated output tensor is used, TANH_BW operation requires its shape to match the computed "
-            "shape. Computed shape: {}, Shape in preallocated output tensor: {}",
-            computed_output_shape,
-            preallocated_output_shape);
+            preallocated.logical_shape() == input_tensor.logical_shape(),
+            "When a preallocated output tensor is used, TANH_BW operation requires its logical shape to match the "
+            "input's. Input shape: {}, preallocated output shape: {}",
+            input_tensor.logical_shape(),
+            preallocated.logical_shape());
+        TT_FATAL(
+            preallocated.padded_shape() == input_tensor.padded_shape(),
+            "When a preallocated output tensor is used, TANH_BW operation requires its padded shape to match the "
+            "input's, because the writer emits one page per input tile. Input padded shape: {}, preallocated output "
+            "padded shape: {}",
+            input_tensor.padded_shape(),
+            preallocated.padded_shape());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
@@ -136,6 +136,16 @@ ttsl::hash::hash_t TanhBwDeviceOperation::compute_program_hash(
         grad_output.memory_config(),
         input_shape.volume());
 
+    // args only carries the requested output_dtype/output_memory_config; when the caller supplies its
+    // own output tensor that is what the factory actually binds, sizing the destination CB from its
+    // dtype and baking a TensorAccessorArgs for its buffer into the writer's compile-time args. Neither
+    // can be refreshed on a cache hit, so key on the tensor that is really used.
+    if (tensor_args.preallocated_input_grad.has_value()) {
+        const auto& preallocated = tensor_args.preallocated_input_grad.value();
+        hash =
+            ttsl::hash::hash_objects(hash, preallocated.dtype(), preallocated.layout(), preallocated.memory_config());
+    }
+
     return hash;
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_nanobind.cpp
@@ -1145,7 +1145,10 @@ void py_module(nb::module_& mod) {
     bind_unary_backward_optional<"tanh_bw">(
         mod,
         &ttnn::tanh_bw,
-        R"doc(Performs backward operations for hyperbolic tangent (tanh) function on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc");
+        R"doc(Performs backward operations for hyperbolic tangent (tanh) function on :attr:`input_tensor` with given :attr:`grad_tensor`.)doc",
+        R"doc(BFLOAT16)doc",
+        R"doc(TILE)doc",
+        R"doc(All operands must use the standard 32x32 tile.)doc");
 
     bind_unary_backward_optional<"sqrt_bw">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -92,21 +92,27 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input0 = tensor_args.input0;
     const auto& input1 = tensor_args.input1;
+    const auto& intermediate = tensor_args.intermediate;
 
     auto input0_shape = input0.padded_shape();
     auto input0_memory_layout = input0.layout();
     auto input0_dtype = input0.dtype();
     auto input0_memory_config = input0.memory_config();
+    // The matmul half reads in0/in1 tiles off its operands to size every block and circular buffer,
+    // and the aggregated matmul input inherits input0's page config, so tile geometry must be keyed.
+    auto input0_page_config = input0.tensor_spec().page_config();
 
     auto input1_shape = input1.padded_shape();
     auto input1_memory_layout = input1.layout();
     auto input1_dtype = input1.dtype();
     auto input1_memory_config = input1.memory_config();
+    auto input1_page_config = input1.tensor_spec().page_config();
 
-    auto intermediate_shape = input1.padded_shape();
-    auto intermediate_memory_layout = input1.layout();
-    auto intermediate_dtype = input1.dtype();
-    auto intermediate_memory_config = input1.memory_config();
+    auto intermediate_shape = intermediate.padded_shape();
+    auto intermediate_memory_layout = intermediate.layout();
+    auto intermediate_dtype = intermediate.dtype();
+    auto intermediate_memory_config = intermediate.memory_config();
+    auto intermediate_page_config = intermediate.tensor_spec().page_config();
 
     return tt::tt_metal::operation::hash_operation<LlamaAllGatherMatmulAsyncDeviceOperation>(
         args.dim,
@@ -119,14 +125,17 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
         input0_memory_layout,
         input0_dtype,
         input0_memory_config,
+        input0_page_config,
         input1_shape,
         input1_memory_layout,
         input1_dtype,
         input1_memory_config,
+        input1_page_config,
         intermediate_shape,
         intermediate_memory_layout,
         intermediate_dtype,
-        intermediate_memory_config);
+        intermediate_memory_config,
+        intermediate_page_config);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -43,13 +43,14 @@ void LlamaAllGatherMatmulAsyncDeviceOperation::validate_on_program_cache_miss(
     const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
         TT_FATAL(
             tensor.layout() == Layout::TILE,
-            "llama_all_gather_matmul_async requires TILE layout, but {} has {} layout",
+            "llama_all_gather_matmul_async does not currently support non-TILE layouts, but {} has {} layout",
             name,
             tensor.layout());
         const auto tile = tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
-            "llama_all_gather_matmul_async requires standard 32x32 tiles, but {} has a {}x{} tile",
+            "llama_all_gather_matmul_async does not currently support tiles other than 32x32, but {} has a "
+            "{}x{} tile",
             name,
             tile.get_height(),
             tile.get_width());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -114,6 +114,9 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
     auto intermediate_memory_config = intermediate.memory_config();
     auto intermediate_page_config = intermediate.tensor_spec().page_config();
 
+    // The fused matmul half compiles from MatmulParams (program_config, compute kernel config,
+    // fused activation, output dtype/tile, untilize_out, transpose, global_cb); none of those can
+    // be refreshed on a cache hit, so the whole struct must be keyed.
     return tt::tt_metal::operation::hash_operation<LlamaAllGatherMatmulAsyncDeviceOperation>(
         args.dim,
         args.num_links,
@@ -121,6 +124,7 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
         args.output_memory_config,
         args.topology,
         args.cluster_axis,
+        args.matmul_struct,
         input0_shape,
         input0_memory_layout,
         input0_dtype,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -37,12 +37,15 @@ void LlamaAllGatherMatmulAsyncDeviceOperation::validate_on_program_cache_miss(
     // The all-gather half is only partly tile-aware: it derives the weight tensor width as
     // padded_shape[3] / 32 and both shard page counts by dividing by TILE_HW, so a non-standard tile
     // compiles a mis-sized program even though the tile is now in the key. Guard rather than rely on
-    // hashing, which would only give a wrong program its own cache entry. This op has no cache-hit
-    // validator, so the miss validator runs on both paths.
+    // hashing, which would only give a wrong program its own cache entry. Those same divisions are
+    // meaningless for a row-major operand, and no other check in this op requires TILE, so the layout
+    // is pinned here too. This op has no cache-hit validator, so the miss validator runs on both paths.
     const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
-        if (tensor.layout() != Layout::TILE) {
-            return;
-        }
+        TT_FATAL(
+            tensor.layout() == Layout::TILE,
+            "llama_all_gather_matmul_async requires TILE layout, but {} has {} layout",
+            name,
+            tensor.layout());
         const auto tile = tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/operations/matmul/device/matmul_device_operation.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -30,6 +33,27 @@ void LlamaAllGatherMatmulAsyncDeviceOperation::validate_on_program_cache_miss(
             input0.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
         "Unsupported memory layout {}.",
         input0.memory_config().memory_layout());
+
+    // The all-gather half is only partly tile-aware: it derives the weight tensor width as
+    // padded_shape[3] / 32 and both shard page counts by dividing by TILE_HW, so a non-standard tile
+    // compiles a mis-sized program even though the tile is now in the key. Guard rather than rely on
+    // hashing, which would only give a wrong program its own cache entry. This op has no cache-hit
+    // validator, so the miss validator runs on both paths.
+    const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
+        if (tensor.layout() != Layout::TILE) {
+            return;
+        }
+        const auto tile = tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+            "llama_all_gather_matmul_async requires standard 32x32 tiles, but {} has a {}x{} tile",
+            name,
+            tile.get_height(),
+            tile.get_width());
+    };
+    require_standard_tile(input0, "input0");
+    require_standard_tile(tensor_args.input1, "input1");
+    require_standard_tile(tensor_args.intermediate, "the intermediate tensor");
 }
 
 LlamaAllGatherMatmulAsyncDeviceOperation::spec_return_value_t
@@ -124,6 +148,10 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
         args.output_memory_config,
         args.topology,
         args.cluster_axis,
+        // sub_device_id selects the sender worker core pool and is forwarded to the matmul half, so it
+        // is structural to the compiled program rather than per-call data. Widened past the uint8 range
+        // so the disengaged optional cannot collide with a real sub-device id.
+        args.sub_device_id.has_value() ? static_cast<uint32_t>(args.sub_device_id->get()) : 0xFFFFFFFFu,
         args.matmul_struct,
         input0_shape,
         input0_memory_layout,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation.cpp
@@ -156,6 +156,15 @@ ttsl::hash::hash_t LlamaAllGatherMatmulAsyncDeviceOperation::compute_program_has
         // so the disengaged optional cannot collide with a real sub-device id.
         args.sub_device_id.has_value() ? static_cast<uint32_t>(args.sub_device_id->get()) : 0xFFFFFFFFu,
         args.matmul_struct,
+        // MatmulParams reaches global_cb through reflection, which covers the GCB's structure (core
+        // mapping, size, buffer type) but not which allocation it is. The matmul's remote CB is created
+        // against the GCB and bakes both addresses at build time, and UpdateDynamicCircularBufferAddress
+        // refuses to re-point a GCB-backed CB, so two same-shaped GCBs at different allocations must not
+        // share a program. Same reasoning as dram_prefetcher_validator.
+        static_cast<uint64_t>(
+            args.matmul_struct.global_cb.has_value() ? args.matmul_struct.global_cb->buffer_address() : 0),
+        static_cast<uint64_t>(
+            args.matmul_struct.global_cb.has_value() ? args.matmul_struct.global_cb->config_address() : 0),
         input0_shape,
         input0_memory_layout,
         input0_dtype,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.cpp
@@ -216,7 +216,7 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
             intermediate_tensor_shard_num_pages * intermediate_tensor_page_size, {{inter_cb_index, df}})
             .set_page_size(inter_cb_index, intermediate_tensor_page_size)
             .set_globally_allocated_address(*intermediate_tensor.buffer());
-    CreateCircularBuffer(program, intermediate_tensor_cores, cb_inter_config);
+    const auto cb_inter = CreateCircularBuffer(program, intermediate_tensor_cores, cb_inter_config);
 
     // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
     const auto reserved_packet_header_CB_index = tt::CB::c_in1;
@@ -489,6 +489,7 @@ LlamaAllGatherMatmulAsyncProgramFactory::cached_program_t LlamaAllGatherMatmulAs
          sender_worker_cores,
          intermediate_cores_vec,
          ring_index,
+         cb_inter,
          matmul_shared_variables}};
 }
 
@@ -532,6 +533,11 @@ void LlamaAllGatherMatmulAsyncProgramFactory::override_runtime_arguments(
             worker_receiver_runtime_args[0] = args.semaphore.address();
             worker_receiver_runtime_args[3] = aggregated_tensor.buffer()->address();
         }
+
+        // The intermediate CB is globally allocated over the intermediate tensor's buffer. Patching the
+        // reader/writer address args above does not move the CB itself, so without this a cached program
+        // keeps pointing every intermediate access at the first call's allocation.
+        UpdateDynamicCircularBufferAddress(program, shared_vars.cb_inter, *intermediate_tensor.buffer());
 
         ttnn::operations::llama_matmul::override_agmm_fusion_program_parameters(
             shared_vars.matmul_shared_variables,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_program_factory.hpp
@@ -17,6 +17,9 @@ struct LlamaAllGatherMatmulAsyncSharedVariables {
     std::vector<tt::tt_metal::CoreCoord> sender_worker_cores;
     std::vector<tt::tt_metal::CoreCoord> intermediate_cores_vec;
     uint32_t ring_index{};
+    // The intermediate CB is globally allocated over the intermediate tensor's buffer, so its address
+    // has to be re-pointed on every cache hit; keep the handle to do that.
+    tt::tt_metal::CBHandle cb_inter{};
     ttnn::prim::matmul_mcast_1d_common_override_variables_t matmul_shared_variables;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -29,12 +29,13 @@ void validate_standard_tile(const Matmul_RS::tensor_args_t& tensor_args) {
     const auto& input = tensor_args.rs.input_tensor;
     TT_FATAL(
         input.layout() == Layout::TILE,
-        "llama_rs_matmul requires TILE layout on the reduce-scatter input, but it has {} layout",
+        "llama_rs_matmul does not currently support a non-TILE reduce-scatter input, but it has {} layout",
         input.layout());
     const auto tile = input.tensor_spec().tile();
     TT_FATAL(
         tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
-        "llama_rs_matmul requires a standard 32x32 tile on the reduce-scatter input, got {}x{}",
+        "llama_rs_matmul does not currently support tiles other than 32x32 on the reduce-scatter input, got "
+        "{}x{}",
         tile.get_height(),
         tile.get_width());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -21,13 +21,16 @@ namespace {
 // The shared reduce-scatter factory sizes its pages with the two-argument tile_size(), which assumes
 // the architectural 32x32 tile, and derives the per-packet page counts from it. Keying page_config
 // stops a non-standard tile from aliasing onto a cached program, but the program it would compile for
-// itself is still mis-sized, so reject it outright. Called from both validators because the op defines
+// itself is still mis-sized, so reject it outright. That page sizing is equally wrong for a row-major
+// input: the delegated matmul validation pins TILE on the matmul operands only, and the reduce-scatter
+// half never checks layout, so it is pinned here. Called from both validators because the op defines
 // its own cache-hit validator, which would otherwise drop the check on hits.
 void validate_standard_tile(const Matmul_RS::tensor_args_t& tensor_args) {
     const auto& input = tensor_args.rs.input_tensor;
-    if (input.layout() != Layout::TILE) {
-        return;
-    }
+    TT_FATAL(
+        input.layout() == Layout::TILE,
+        "llama_rs_matmul requires TILE layout on the reduce-scatter input, but it has {} layout",
+        input.layout());
     const auto tile = input.tensor_spec().tile();
     TT_FATAL(
         tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -142,6 +142,17 @@ ttsl::hash::hash_t Matmul_RS::compute_program_hash(
         operation_attributes.rs_op.topology,
         operation_attributes.rs_op.use_noc1_only,
         operation_attributes.matmul,
+        // MatmulParams reaches global_cb through reflection, which covers the GCB's structure (core
+        // mapping, size, buffer type) but not which allocation it is. The matmul's remote CB is created
+        // against the GCB and bakes both addresses at build time, and UpdateDynamicCircularBufferAddress
+        // refuses to re-point a GCB-backed CB, so two same-shaped GCBs at different allocations must not
+        // share a program. Same reasoning as dram_prefetcher_validator.
+        static_cast<uint64_t>(
+            operation_attributes.matmul.global_cb.has_value() ? operation_attributes.matmul.global_cb->buffer_address()
+                                                              : 0),
+        static_cast<uint64_t>(
+            operation_attributes.matmul.global_cb.has_value() ? operation_attributes.matmul.global_cb->config_address()
+                                                              : 0),
         // output_mem_config supplies the output shard grid behind the OUTPUT_CORE_XY define and the
         // output/accumulator CB sizes; subdevice_id selects the matmul core pool and mcast origin.
         operation_attributes.rs_op.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -89,6 +89,9 @@ ttsl::hash::hash_t Matmul_RS::compute_program_hash(
     // input_tiles_per_core_width from the input's real tile, and the matmul helper reads in0/in1
     // tiles off its operands to size every block and circular buffer. Keying on each page config
     // keeps tensors that differ only in tile geometry on separate programs.
+    // The fused matmul half also compiles from MatmulParams (program_config, compute kernel
+    // config, fused activation, output dtype/tile, untilize_out, transpose, global_cb); none of
+    // those can be refreshed on a cache hit, so the whole struct must be keyed.
     return tt::tt_metal::operation::hash_operation<Matmul_RS>(
         operation_attributes.rs_op.dim,
         operation_attributes.rs_op.cluster_axis,
@@ -96,6 +99,7 @@ ttsl::hash::hash_t Matmul_RS::compute_program_hash(
         operation_attributes.rs_op.num_links,
         operation_attributes.rs_op.topology,
         operation_attributes.rs_op.use_noc1_only,
+        operation_attributes.matmul,
         tensor_args.rs.input_tensor.dtype(),
         tensor_args.rs.input_tensor.memory_config(),
         tensor_args.rs.input_tensor.device()->id(),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -4,6 +4,8 @@
 
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp"
 
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation.hpp"
@@ -13,6 +15,28 @@
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 
 namespace ttnn::operations::experimental::ccl {
+
+namespace {
+
+// The shared reduce-scatter factory sizes its pages with the two-argument tile_size(), which assumes
+// the architectural 32x32 tile, and derives the per-packet page counts from it. Keying page_config
+// stops a non-standard tile from aliasing onto a cached program, but the program it would compile for
+// itself is still mis-sized, so reject it outright. Called from both validators because the op defines
+// its own cache-hit validator, which would otherwise drop the check on hits.
+void validate_standard_tile(const Matmul_RS::tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.rs.input_tensor;
+    if (input.layout() != Layout::TILE) {
+        return;
+    }
+    const auto tile = input.tensor_spec().tile();
+    TT_FATAL(
+        tile.get_height() == tt::constants::TILE_HEIGHT && tile.get_width() == tt::constants::TILE_WIDTH,
+        "llama_rs_matmul requires a standard 32x32 tile on the reduce-scatter input, got {}x{}",
+        tile.get_height(),
+        tile.get_width());
+}
+
+}  // namespace
 
 void Matmul_RS::validate_on_program_cache_hit(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
@@ -30,6 +54,7 @@ void Matmul_RS::validate_on_program_cache_hit(
             {{tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {std::nullopt}, {}});
     }
     LlamaReduceScatterDeviceOperation::validate_on_program_cache_hit(operation_attributes.rs_op, tensor_args.rs);
+    validate_standard_tile(tensor_args);
 }
 
 void Matmul_RS::validate_on_program_cache_miss(
@@ -48,6 +73,7 @@ void Matmul_RS::validate_on_program_cache_miss(
             {{tensor_args.matmul.input_tensor, tensor_args.matmul.weight_tensor}, {std::nullopt}, {}});
     }
     LlamaReduceScatterDeviceOperation::validate_on_program_cache_miss(operation_attributes.rs_op, tensor_args.rs);
+    validate_standard_tile(tensor_args);
 }
 
 Matmul_RS::spec_return_value_t Matmul_RS::compute_output_specs(
@@ -85,6 +111,13 @@ Matmul_RS::tensor_return_value_t Matmul_RS::create_output_tensors(
 
 ttsl::hash::hash_t Matmul_RS::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // The matmul operands need their full specs, not just page configs: the helper derives M/K/N, every
+    // CB format and the work split from the real shapes and dtypes. MatmulParams pins only the
+    // caller-supplied blocking, because the fused launcher routes through create_matmul_attributes,
+    // which (unlike matmul()) never normalizes a nullopt program_config via get_program_config. So two
+    // calls that differ only in weight width or dtype would otherwise share a key.
+    const auto& mm_in = tensor_args.matmul.input_tensor;
+    const auto& mm_w = tensor_args.matmul.weight_tensor;
     // Both halves are tile-aware: the shared reduce-scatter factory derives
     // input_tiles_per_core_width from the input's real tile, and the matmul helper reads in0/in1
     // tiles off its operands to size every block and circular buffer. Keying on each page config
@@ -92,7 +125,13 @@ ttsl::hash::hash_t Matmul_RS::compute_program_hash(
     // The fused matmul half also compiles from MatmulParams (program_config, compute kernel
     // config, fused activation, output dtype/tile, untilize_out, transpose, global_cb); none of
     // those can be refreshed on a cache hit, so the whole struct must be keyed.
+    // second_weight_tensor's presence selects between two structurally different programs: a
+    // two-output matmul driven by a MatmulFusedOpSignaler versus a single-output matmul with none,
+    // which also changes the output arity that override_runtime_arguments indexes into. The launcher
+    // requires exactly one of rs_tensor / second_weight_tensor, so both modes are reachable in one
+    // process and the discriminator has to be part of the key.
     return tt::tt_metal::operation::hash_operation<Matmul_RS>(
+        tensor_args.second_weight_tensor.has_value(),
         operation_attributes.rs_op.dim,
         operation_attributes.rs_op.cluster_axis,
         operation_attributes.rs_op.ring_devices,
@@ -100,13 +139,32 @@ ttsl::hash::hash_t Matmul_RS::compute_program_hash(
         operation_attributes.rs_op.topology,
         operation_attributes.rs_op.use_noc1_only,
         operation_attributes.matmul,
+        // output_mem_config supplies the output shard grid behind the OUTPUT_CORE_XY define and the
+        // output/accumulator CB sizes; subdevice_id selects the matmul core pool and mcast origin.
+        operation_attributes.rs_op.output_mem_config,
+        operation_attributes.rs_op.subdevice_id.has_value()
+            ? static_cast<uint32_t>(operation_attributes.rs_op.subdevice_id->get())
+            : 0xFFFFFFFFu,
         tensor_args.rs.input_tensor.dtype(),
         tensor_args.rs.input_tensor.memory_config(),
         tensor_args.rs.input_tensor.device()->id(),
         tensor_args.rs.input_tensor.tensor_spec().page_config(),
+        // The shared reduce-scatter factory derives ncores_input and the SCHEDULE define from the
+        // logical shape, which the hashed memory config does not determine for an over-provisioned
+        // shard grid — a configuration this op explicitly supports.
+        tensor_args.rs.input_tensor.logical_shape(),
+        // The packet buffer's shard grid picks the packet-worker cores and, via restricted_cores, the
+        // matmul placement too, so its memory config is structural and not just its page config.
         tensor_args.rs.intermediate_packet_buffer.tensor_spec().page_config(),
-        tensor_args.matmul.input_tensor.tensor_spec().page_config(),
-        tensor_args.matmul.weight_tensor.tensor_spec().page_config());
+        tensor_args.rs.intermediate_packet_buffer.memory_config(),
+        mm_in.tensor_spec().page_config(),
+        mm_in.padded_shape(),
+        mm_in.dtype(),
+        mm_in.memory_config(),
+        mm_w.tensor_spec().page_config(),
+        mm_w.padded_shape(),
+        mm_w.dtype(),
+        mm_w.memory_config());
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -85,6 +85,10 @@ Matmul_RS::tensor_return_value_t Matmul_RS::create_output_tensors(
 
 ttsl::hash::hash_t Matmul_RS::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    // Both halves are tile-aware: the shared reduce-scatter factory derives
+    // input_tiles_per_core_width from the input's real tile, and the matmul helper reads in0/in1
+    // tiles off its operands to size every block and circular buffer. Keying on each page config
+    // keeps tensors that differ only in tile geometry on separate programs.
     return tt::tt_metal::operation::hash_operation<Matmul_RS>(
         operation_attributes.rs_op.dim,
         operation_attributes.rs_op.cluster_axis,
@@ -94,7 +98,11 @@ ttsl::hash::hash_t Matmul_RS::compute_program_hash(
         operation_attributes.rs_op.use_noc1_only,
         tensor_args.rs.input_tensor.dtype(),
         tensor_args.rs.input_tensor.memory_config(),
-        tensor_args.rs.input_tensor.device()->id());
+        tensor_args.rs.input_tensor.device()->id(),
+        tensor_args.rs.input_tensor.tensor_spec().page_config(),
+        tensor_args.rs.intermediate_packet_buffer.tensor_spec().page_config(),
+        tensor_args.matmul.input_tensor.tensor_spec().page_config(),
+        tensor_args.matmul.weight_tensor.tensor_spec().page_config());
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
@@ -80,6 +80,15 @@ void validate_runtime_args(
     };
     validate_meta(tensor_args.actual_start, "actual_start");
     validate_meta(tensor_args.actual_end, "actual_end");
+    // create_descriptor emits a single TensorAccessorArgs built from actual_start and the kernel uses it
+    // for both metadata reads, so a differing memory config on actual_end would resolve its address
+    // through the wrong bank table.
+    TT_FATAL(
+        tensor_args.actual_start.memory_config() == tensor_args.actual_end.memory_config(),
+        "metadata tensors actual_start and actual_end must share a memory config because one "
+        "TensorAccessor serves both reads (got buffer types {} and {})",
+        tensor_args.actual_start.memory_config().buffer_type(),
+        tensor_args.actual_end.memory_config().buffer_type());
 }
 
 }  // namespace
@@ -124,7 +133,10 @@ ttsl::hash::hash_t MoePaddingConfigDeviceOperation::compute_program_hash(
         config.dtype(),
         config.layout(),
         config.memory_config(),
-        config.padded_shape());
+        config.padded_shape(),
+        // The metadata accessor is baked into the writer's compile-time args, so the bank table it
+        // selects cannot be refreshed on a cache hit; validate_runtime_args pins actual_end to match.
+        tensor_args.actual_start.memory_config());
 }
 
 tt::tt_metal::ProgramDescriptor MoePaddingConfigDeviceOperation::ProgramFactory::create_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
@@ -85,8 +85,8 @@ void validate_runtime_args(
     // through the wrong bank table.
     TT_FATAL(
         tensor_args.actual_start.memory_config() == tensor_args.actual_end.memory_config(),
-        "metadata tensors actual_start and actual_end must share a memory config because one "
-        "TensorAccessor serves both reads (got buffer types {} and {})",
+        "moe_padding_config does not currently support actual_start and actual_end having different memory "
+        "configs, because one TensorAccessor serves both reads (got buffer types {} and {})",
         tensor_args.actual_start.memory_config().buffer_type(),
         tensor_args.actual_end.memory_config().buffer_type());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -91,13 +91,14 @@ void validate_runtime_args(
         // being reported here. The layout is already being read, so this costs one comparison.
         TT_FATAL(
             tensor.layout() == Layout::TILE,
-            "rotary_embedding_indexed requires TILE layout, but {} has {} layout",
+            "rotary_embedding_indexed does not currently support non-TILE layouts, but {} has {} layout",
             name,
             tensor.layout());
         const auto tile = tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
-            "rotary_embedding_indexed requires standard 32x32 tiles, but {} has a {}x{} tile",
+            "rotary_embedding_indexed does not currently support tiles other than 32x32, but {} has a {}x{} "
+            "tile",
             name,
             tile.get_height(),
             tile.get_width());

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -73,6 +73,27 @@ void validate_runtime_args(
     // divisor/modulus to derive the boundary chip; a zero-height input chunk would divide by zero.
     TT_FATAL(chunk_local_t > 0, "input chunk seq dim ({}) must be at least one tile", input.padded_shape()[-2]);
 
+    // create_at sizes every DFB entry with tt::tile_size, derives its tile counts from the
+    // architectural 32x32 constants and passes TILE_HEIGHT as the tile_height compile arg, and the tile
+    // is absent from compute_program_hash. Runs on both paths so a non-standard tile is reported here
+    // rather than as a mis-sized program on a miss or a TensorSpec mismatch on a hit.
+    const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
+        if (tensor.layout() != Layout::TILE) {
+            return;
+        }
+        const auto tile = tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "rotary_embedding_indexed requires standard 32x32 tiles, but {} has a {}x{} tile",
+            name,
+            tile.get_height(),
+            tile.get_width());
+    };
+    require_standard_tile(input, "input");
+    require_standard_tile(cos, "cos");
+    require_standard_tile(tensor_args.sin, "sin");
+    require_standard_tile(tensor_args.trans_mat, "trans_mat");
+
     if (tensor_args.metadata.has_value()) {
         // Metadata path: kv_actual_global is read on-device from element [0] of the metadata tensor, so
         // its VALUE is the caller's responsibility. But the tensor is bound as tensor::metadata and read

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -66,6 +66,13 @@ void validate_runtime_args(
 
     const auto& input = tensor_args.input;
     const auto& cos = tensor_args.cos;
+    // Dereferenced on the next line, and Tensor::device() returns nullptr for host storage. The miss
+    // validator's storage pins do not run on hits, so without this a host-storage cos faults here
+    // instead of reporting.
+    TT_FATAL(
+        cos.storage_type() == StorageType::DEVICE,
+        "rotary_embedding_indexed requires cos to be on device, but its storage type is {}",
+        cos.storage_type());
     const auto& mesh_view = cos.device()->get_view();
     TT_FATAL(mesh_view.is_mesh_2d(), "rotary_embedding_indexed requires a 2D mesh");
     const uint32_t chunk_local_t = input.padded_shape()[-2] / TILE_HEIGHT;
@@ -78,9 +85,15 @@ void validate_runtime_args(
     // is absent from compute_program_hash. Runs on both paths so a non-standard tile is reported here
     // rather than as a mis-sized program on a miss or a TensorSpec mismatch on a hit.
     const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
-        if (tensor.layout() != Layout::TILE) {
-            return;
-        }
+        // Assert the layout rather than skipping non-TILE tensors. All four operands are required to be
+        // TILE, but that pin lives in the miss validator and so does not run on a hit; without this a
+        // ROW_MAJOR operand would reach the framework's TensorSpec comparison and throw there instead of
+        // being reported here. The layout is already being read, so this costs one comparison.
+        TT_FATAL(
+            tensor.layout() == Layout::TILE,
+            "rotary_embedding_indexed requires TILE layout, but {} has {} layout",
+            name,
+            tensor.layout());
         const auto tile = tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
@@ -208,7 +221,9 @@ void RotaryEmbeddingIndexedDeviceOperation::validate_on_program_cache_miss(
 void RotaryEmbeddingIndexedDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     // kv_actual_global is not hashed and can differ from the compiled program's call; re-validate
-    // every hit. Structural constraints are hashed and so guaranteed unchanged here.
+    // every hit. Structural specs are hashed wholesale, so a structural change misses rather than
+    // arriving here -- but note the checks above the delegation in validate_on_program_cache_miss are
+    // miss-only, so anything that must hold on a hit belongs in validate_runtime_args.
     validate_runtime_args(args, tensor_args);
 }
 
@@ -230,45 +245,33 @@ ttsl::hash::hash_t RotaryEmbeddingIndexedDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     // The cache key must cover every structural spec the program is built from -- in particular every
     // TensorParameter's declared TensorSpec -- because on a cache hit UpdateProgramRunArgs REJECTS (does
-    // not recompile) a tensor whose spec doesn't match the one baked at creation. So hash the full input,
-    // cos, sin and trans_mat specs, the output spec (via output_mem_config; its dtype/shape follow input),
-    // cluster_axis, compute_kernel_config, and metadata.has_value() + the metadata tensor's spec.
+    // not recompile) a tensor whose spec doesn't match the one baked at creation. Those parameters are
+    // declared with default relaxations, so that comparison is Strict over the whole spec: logical shape,
+    // padded shape, dtype, page config and alignment.
+    //
+    // Hash tensor_spec() wholesale rather than a projection of it, so the key and the framework's
+    // accept/reject predicate agree by construction. Under a projection, two tensors differing only in a
+    // field the projection drops (logical shape, or alignment) would share a key, hit, and then throw
+    // from report_tensor_arg_mismatch instead of rebuilding. output_mem_config covers the output spec;
+    // its dtype, shape and layout all follow the input.
     //
     // Only kv_actual_global is excluded: it is a reader runtime arg patched on cache hits, so successive
     // chunks reuse one cached program. Per-device my_sp_coord is a per-coordinate compile-time arg the
-    // mesh adapter already folds into the workload hash via the target coordinates. Full shapes (not just
-    // volumes) are hashed since the work split and CB sizing derive from specific dimensions.
-    const auto& input = tensor_args.input;
-    const auto& cos = tensor_args.cos;
-    const auto& sin = tensor_args.sin;
-    const auto& trans_mat = tensor_args.trans_mat;
-    // metadata is an optional TensorParameter; stand in with defaults on the scalar path (already
-    // separated by has_value=false) so its spec still participates in the key when present.
-    const MemoryConfig metadata_mem_config =
-        tensor_args.metadata.has_value() ? tensor_args.metadata->memory_config() : MemoryConfig{};
-    const Shape metadata_padded_shape =
-        tensor_args.metadata.has_value() ? tensor_args.metadata->padded_shape() : Shape{};
-    return tt::tt_metal::operation::hash_operation<RotaryEmbeddingIndexedDeviceOperation>(
+    // mesh adapter already folds into the workload hash via the target coordinates.
+    auto hash = tt::tt_metal::operation::hash_operation<RotaryEmbeddingIndexedDeviceOperation>(
         tensor_args.metadata.has_value(),
-        metadata_mem_config,
-        metadata_padded_shape,
         args.cluster_axis,
         args.compute_kernel_config,
         args.output_mem_config,
-        input.dtype(),
-        input.memory_config(),
-        input.logical_shape(),
-        input.padded_shape(),
-        input.layout(),
-        cos.dtype(),
-        cos.memory_config(),
-        cos.padded_shape(),
-        sin.dtype(),
-        sin.memory_config(),
-        sin.padded_shape(),
-        trans_mat.dtype(),
-        trans_mat.memory_config(),
-        trans_mat.padded_shape());
+        tensor_args.input.tensor_spec(),
+        tensor_args.cos.tensor_spec(),
+        tensor_args.sin.tensor_spec(),
+        tensor_args.trans_mat.tensor_spec());
+    if (tensor_args.metadata.has_value()) {
+        // metadata is an optional TensorParameter, compared just as strictly when it is present.
+        hash = ttsl::hash::hash_objects(hash, tensor_args.metadata->tensor_spec());
+    }
+    return hash;
 }
 
 RotaryEmbeddingIndexedDeviceOperation::MeshWorkloadFactory::cached_program_t

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/rotary_embedding_indexed_nanobind.cpp
@@ -43,7 +43,8 @@ void bind_rotary_embedding_indexed(nb::module_& mod) {
 
             Args:
                 input (ttnn.Tensor): 4D per-chip input chunk on device, TILE layout
-                    [1, n_heads, chunk_local, head_dim].
+                    [1, n_heads, chunk_local, head_dim]. All four tensor operands must use the
+                    standard 32x32 tile.
                 cos (ttnn.Tensor): 4D cos cache on device, TILE layout, SP-sharded over
                     `cluster_axis` in block-cyclic order keyed by `chunk_local`.
                 sin (ttnn.Tensor): 4D sin cache, same layout/shape as `cos`.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -120,7 +120,8 @@ void validate_runtime_args(
         const auto tile = tensor.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
-            "update_padded_kv_cache requires standard 32x32 tiles, but {} has a {}x{} tile",
+            "update_padded_kv_cache does not currently support tiles other than 32x32, but {} has a {}x{} "
+            "tile",
             name,
             tile.get_height(),
             tile.get_width());
@@ -175,8 +176,9 @@ void validate_runtime_args(
             // address resolved through the wrong bank table.
             TT_FATAL(
                 meta.memory_config() == meta_memory_config,
-                "metadata tensor {} must share slot_idx's memory config because one TensorAccessor serves "
-                "every metadata read (got buffer types {} and {})",
+                "update_padded_kv_cache does not currently support metadata tensors with different memory "
+                "configs: one TensorAccessor serves every metadata read, so {} must match slot_idx (got "
+                "buffer types {} and {})",
                 name,
                 meta.memory_config().buffer_type(),
                 meta_memory_config.buffer_type());

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -103,6 +103,25 @@ void validate_runtime_args(
         !(args.valid_global.has_value() && tensor_args.slot_idx.has_value()),
         "scalar valid_global cannot be combined with the metadata path; pass the valid_global TENSOR instead");
 
+    // create_descriptor's TILE branch derives its page size, Wt/input_Ht/cache_HtWt and the
+    // writer_tile_height compile arg from the architectural 32x32 constants, and the tile is absent
+    // from compute_program_hash. Checked here rather than in the miss validator so it also runs on the
+    // cache-hit path, where a non-standard tile would otherwise alias onto a cached 32x32 program.
+    const auto require_standard_tile = [](const Tensor& tensor, const char* name) {
+        if (tensor.layout() != Layout::TILE) {
+            return;
+        }
+        const auto tile = tensor.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "update_padded_kv_cache requires standard 32x32 tiles, but {} has a {}x{} tile",
+            name,
+            tile.get_height(),
+            tile.get_width());
+    };
+    require_standard_tile(cache, "cache");
+    require_standard_tile(tensor_args.input, "input");
+
     // Metadata-path invariant: the two per-request tensors are supplied together or not at all.
     // The path is selected on `slot_idx.has_value()`, but create_descriptor / override_runtime_arguments
     // dereference `kv_actual_global` unconditionally whenever slot_idx is set — a mismatched optional

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -136,7 +136,8 @@ void validate_runtime_args(
     // UINT32, ROW_MAJOR, single-element, non-sharded) here, so a malformed tensor fails host-side with a
     // clear message instead of a hard-to-debug device-side read. Values stay off the host dispatch path.
     if (tensor_args.slot_idx.has_value()) {
-        auto validate_meta = [&cache](const Tensor& meta, const char* name) {
+        const auto& meta_memory_config = tensor_args.slot_idx->memory_config();
+        auto validate_meta = [&cache, &meta_memory_config](const Tensor& meta, const char* name) {
             TT_FATAL(meta.storage_type() == StorageType::DEVICE, "metadata tensor {} must be on device", name);
             TT_FATAL(meta.dtype() == DataType::UINT32, "metadata tensor {} must be UINT32", name);
             TT_FATAL(meta.layout() == Layout::ROW_MAJOR, "metadata tensor {} must be ROW_MAJOR", name);
@@ -149,6 +150,16 @@ void validate_runtime_args(
             // The writer resolves meta.buffer()->address() against cache.device(); a tensor on a
             // different mesh device would bake the wrong address and fail obscurely downstream.
             TT_FATAL(meta.device() == cache.device(), "metadata tensor {} must be on the same device as cache", name);
+            // create_descriptor emits a single TensorAccessorArgs built from slot_idx and the writer uses
+            // it for every metadata read, so a tensor carrying a different memory config would have its
+            // address resolved through the wrong bank table.
+            TT_FATAL(
+                meta.memory_config() == meta_memory_config,
+                "metadata tensor {} must share slot_idx's memory config because one TensorAccessor serves "
+                "every metadata read (got buffer types {} and {})",
+                name,
+                meta.memory_config().buffer_type(),
+                meta_memory_config.buffer_type());
         };
         validate_meta(tensor_args.slot_idx.value(), "slot_idx");
         validate_meta(tensor_args.kv_actual_global.value(), "kv_actual_global");
@@ -324,7 +335,11 @@ ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
         input.memory_config(),
         input.padded_shape(),
         cache.memory_config(),
-        cache.padded_shape());
+        cache.padded_shape(),
+        // On the metadata path the writer bakes a TensorAccessorArgs built from slot_idx into its
+        // compile-time args, so the bank table it selects cannot be refreshed on a cache hit. Only the
+        // config is keyed, never the value; kv_actual_global is pinned to match by validate_runtime_args.
+        tensor_args.slot_idx.has_value() ? tensor_args.slot_idx->memory_config() : MemoryConfig{});
 }
 
 tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -72,6 +72,12 @@ void validate_runtime_args(
         args.num_layers);
     // The cache is sharded across a 2D mesh; the kernel derives sp_factor from the mesh extent.
     const auto& cache = tensor_args.cache;
+    // Checked here rather than only in the miss validator because device() is dereferenced on the next
+    // line and returns nullptr for host storage, so on a hit the fault would land there instead.
+    TT_FATAL(
+        cache.storage_type() == StorageType::DEVICE,
+        "cache must be on device, but its storage type is {}",
+        cache.storage_type());
     const auto& mesh_view = cache.device()->get_view();
     TT_FATAL(mesh_view.is_mesh_2d(), "update_padded_kv_cache requires a 2D mesh");
     if (!args.cluster_axis.has_value()) {
@@ -121,6 +127,20 @@ void validate_runtime_args(
     };
     require_standard_tile(cache, "cache");
     require_standard_tile(tensor_args.input, "input");
+
+    // cache's dtype and layout are absent from the key (only input's are hashed), and both set the
+    // writer's page size, so they have to be re-checked on hits too: a second call that changes only
+    // the cache would otherwise reuse a program built for the first one's page geometry.
+    TT_FATAL(
+        cache.dtype() == tensor_args.input.dtype(),
+        "cache and input dtype must match (got {} and {})",
+        cache.dtype(),
+        tensor_args.input.dtype());
+    TT_FATAL(
+        cache.layout() == tensor_args.input.layout(),
+        "cache and input layout must match (got {} and {})",
+        cache.layout(),
+        tensor_args.input.layout());
 
     // Metadata-path invariant: the two per-request tensors are supplied together or not at all.
     // The path is selected on `slot_idx.has_value()`, but create_descriptor / override_runtime_arguments
@@ -231,16 +251,15 @@ void UpdatePaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
     const auto& cache = tensor_args.cache;
     const auto& input = tensor_args.input;
 
-    TT_FATAL(cache.storage_type() == StorageType::DEVICE, "cache must be on device");
+    // cache storage is pinned in validate_runtime_args so it also runs on hits.
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "input must be on device");
-    TT_FATAL(cache.dtype() == input.dtype(), "cache and input dtype must match");
 
     // Layout / dtype gating. The op is a pure page copy, so it supports both TILE and ROW_MAJOR;
     // the page-unit math in create_descriptor branches on layout. The two formats are mutually
     // exclusive per dtype family:
     //   - block-float (bfloat8_b/bfloat4_b) carries a per-face shared exponent and is tile-only.
     //   - fp8_e4m3 is ROW_MAJOR-only (Blackhole) in ttnn today.
-    TT_FATAL(cache.layout() == input.layout(), "cache and input layout must match");
+    // cache-vs-input dtype and layout agreement lives in validate_runtime_args so it also runs on hits.
     TT_FATAL(input.layout() == Layout::TILE || input.layout() == Layout::ROW_MAJOR, "layout must be TILE or ROW_MAJOR");
     if (tt::tt_metal::is_block_float(input.dtype())) {
         TT_FATAL(input.layout() == Layout::TILE, "block-float dtypes (bfloat8_b/bfloat4_b) require TILE layout");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/update_padded_kv_cache_nanobind.cpp
@@ -50,7 +50,8 @@ void bind_update_padded_kv_cache(nb::module_& mod) {
                     across `cluster_axis` with `sp_factor` slots per chip. Outermost dim equals
                     ``num_slots * num_layers``. Layout/dtype must match ``input``: block-float
                     (bfloat8_b/bfloat4_b) requires TILE; FP8_E4M3 requires ROW_MAJOR (Blackhole).
-                    Seq dims stay 32-aligned in both layouts.
+                    Seq dims stay 32-aligned in both layouts, and TILE layout requires the standard
+                    32x32 tile.
                 input (ttnn.Tensor): 4D input slab on device, same layout, dtype and head dim as
                     cache. Per-chip seq length = chunk_local.
                 slot_idx (int | ttnn.Tensor): scalar form: user slot in the batched prefill cache.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -107,6 +107,15 @@ void validate_runtime_args(
         };
         validate_meta(tensor_args.slot_idx.value(), "slot_idx");
         validate_meta(tensor_args.valid_global.value(), "valid_global");
+        // The reader and writer each emit a single TensorAccessorArgs built from slot_idx and use it for
+        // both metadata reads, so a differing memory config on valid_global would resolve its address
+        // through the wrong bank table.
+        TT_FATAL(
+            tensor_args.slot_idx->memory_config() == tensor_args.valid_global->memory_config(),
+            "metadata tensors slot_idx and valid_global must share a memory config because one "
+            "TensorAccessor serves both reads (got buffer types {} and {})",
+            tensor_args.slot_idx->memory_config().buffer_type(),
+            tensor_args.valid_global->memory_config().buffer_type());
     }
 
     // slot_idx is a host value only on the scalar path; on the tensor path it lives in the device
@@ -241,7 +250,11 @@ ttsl::hash::hash_t ZeroPaddedKvCacheDeviceOperation::compute_program_hash(
         cache.dtype(),
         cache.layout(),
         cache.memory_config(),
-        cache.padded_shape());
+        cache.padded_shape(),
+        // On the metadata path the reader and writer bake a TensorAccessorArgs built from slot_idx into
+        // their compile-time args, so the bank table it selects cannot be refreshed on a cache hit. Only
+        // the config is keyed, never the value; valid_global is pinned to match by validate_runtime_args.
+        tensor_args.slot_idx.has_value() ? tensor_args.slot_idx->memory_config() : MemoryConfig{});
 }
 
 tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -98,6 +98,10 @@ void validate_runtime_args(
             TT_FATAL(meta.storage_type() == StorageType::DEVICE, "metadata tensor {} must be on device", name);
             TT_FATAL(meta.dtype() == DataType::UINT32, "metadata tensor {} must be UINT32", name);
             TT_FATAL(meta.layout() == Layout::ROW_MAJOR, "metadata tensor {} must be ROW_MAJOR", name);
+            // A sharded metadata tensor changes the shape and length of the accessor block the kernels
+            // append, and both sibling ops reject it; the hashed memory config keeps it off a cached
+            // program but would still let it compile on a fresh miss.
+            TT_FATAL(!meta.is_sharded(), "metadata tensor {} must not be sharded", name);
             TT_FATAL(
                 meta.logical_volume() == 1,
                 "metadata tensor {} must be a single element (got {})",
@@ -125,6 +129,12 @@ void validate_runtime_args(
         TT_FATAL(args.slot_idx < num_slots, "slot_idx ({}) out of range for num_slots ({})", args.slot_idx, num_slots);
     }
 
+    // Checked here rather than only in the miss validator because device() is dereferenced on the next
+    // line and returns nullptr for host storage, so on a hit the fault would land there instead.
+    TT_FATAL(
+        cache.storage_type() == StorageType::DEVICE,
+        "cache must be on device, but its storage type is {}",
+        cache.storage_type());
     const auto& mesh_view = cache.device()->get_view();
     TT_FATAL(mesh_view.is_mesh_2d(), "zero_padded_kv_cache requires a 2D mesh");
     const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
@@ -177,7 +187,7 @@ ZeroPaddedKvCacheDeviceOperation::program_factory_t ZeroPaddedKvCacheDeviceOpera
 void ZeroPaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& cache = tensor_args.cache;
-    TT_FATAL(cache.storage_type() == StorageType::DEVICE, "cache must be on device");
+    // cache storage is pinned in validate_runtime_args so it also runs on hits.
     TT_FATAL(cache.buffer()->buffer_type() == BufferType::DRAM, "zero_padded_kv_cache requires a DRAM-backed cache");
     TT_FATAL(
         cache.layout() == Layout::TILE || cache.layout() == Layout::ROW_MAJOR,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -69,6 +69,20 @@ void validate_runtime_args(
     TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
     const auto& cache = tensor_args.cache;
 
+    // The TILE branch of the factory derives Wt/cache_H_pages and the cache_tile_size compile arg from
+    // the architectural 32x32 constants, and the reader's face loop hardcodes the 32x32 four-face
+    // layout; the tile is absent from compute_program_hash. Checked here rather than in the miss
+    // validator so it also runs on the cache-hit path, where a non-standard tile would otherwise alias
+    // onto a cached 32x32 program and zero the wrong region of the cache.
+    if (cache.layout() == Layout::TILE) {
+        const auto tile = cache.tensor_spec().tile();
+        TT_FATAL(
+            tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
+            "zero_padded_kv_cache requires standard 32x32 tiles, but cache has a {}x{} tile",
+            tile.get_height(),
+            tile.get_width());
+    }
+
     // Metadata-path invariant + tensor validation. The path is selected on slot_idx.has_value(), but the
     // factory dereferences valid_global->buffer() whenever slot_idx is set, so a mismatched optional would
     // null-deref -- reject it up front. Then validate each metadata tensor's structural properties (device,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -78,7 +78,8 @@ void validate_runtime_args(
         const auto tile = cache.tensor_spec().tile();
         TT_FATAL(
             tile.get_height() == TILE_HEIGHT && tile.get_width() == TILE_WIDTH,
-            "zero_padded_kv_cache requires standard 32x32 tiles, but cache has a {}x{} tile",
+            "zero_padded_kv_cache does not currently support tiles other than 32x32, but cache has a {}x{} "
+            "tile",
             tile.get_height(),
             tile.get_width());
     }
@@ -101,7 +102,10 @@ void validate_runtime_args(
             // A sharded metadata tensor changes the shape and length of the accessor block the kernels
             // append, and both sibling ops reject it; the hashed memory config keeps it off a cached
             // program but would still let it compile on a fresh miss.
-            TT_FATAL(!meta.is_sharded(), "metadata tensor {} must not be sharded", name);
+            TT_FATAL(
+                !meta.is_sharded(),
+                "zero_padded_kv_cache does not currently support sharded metadata tensors, but {} is sharded",
+                name);
             TT_FATAL(
                 meta.logical_volume() == 1,
                 "metadata tensor {} must be a single element (got {})",
@@ -116,8 +120,8 @@ void validate_runtime_args(
         // through the wrong bank table.
         TT_FATAL(
             tensor_args.slot_idx->memory_config() == tensor_args.valid_global->memory_config(),
-            "metadata tensors slot_idx and valid_global must share a memory config because one "
-            "TensorAccessor serves both reads (got buffer types {} and {})",
+            "zero_padded_kv_cache does not currently support slot_idx and valid_global having different "
+            "memory configs, because one TensorAccessor serves both reads (got buffer types {} and {})",
             tensor_args.slot_idx->memory_config().buffer_type(),
             tensor_args.valid_global->memory_config().buffer_type());
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
@@ -47,8 +47,9 @@ void bind_zero_padded_kv_cache(nb::module_& mod) {
 
             Args:
                 cache (ttnn.Tensor): 4D, DRAM-backed KV cache tensor with head dim 1. Supports
-                    TILE layout, or ROW_MAJOR layout with BF16 or FP8_E4M3 dtype. The per-element-tensor
-                    (metadata) form of slot_idx/valid_global below is TILE-only; ROW_MAJOR uses scalars.
+                    TILE layout with the standard 32x32 tile, or ROW_MAJOR layout with BF16 or FP8_E4M3
+                    dtype. The per-element-tensor (metadata) form of slot_idx/valid_global below is
+                    TILE-only; ROW_MAJOR uses scalars.
                 slot_idx (int, scalar form / ttnn.Tensor, tensor form): user slot in the batched prefill
                     cache. As a tensor: a 1-element uint32 DRAM tensor (replicated across the mesh, the
                     runner's h2d_socket_sync payload element 0 [slot_id]); read on-device from element 0.

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -58,7 +58,10 @@ ttsl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     // GlobalCircularBuffer / Tensor aren't reflection-hashable here; pick the bits that
     // determine Program shape: scalar attrs, GCB identity, the source tensor's DRAM
-    // address (compile-time arg via TensorAccessorArgs), and its dataformat.
+    // address (compile-time arg via TensorAccessorArgs), its dataformat, and its page config.
+    // create_at reads the real tile off the source tensor to derive k_tiles, total_n_tiles,
+    // tile_bytes and the CB page sizes, so two tensors differing only in tile geometry compile
+    // different programs and must not share a key.
     const auto* tensor_buffer = tensor_args.source_tensor.buffer();
     const tt::DataFormat dataformat = tt::tt_metal::datatype_to_dataformat_converter(tensor_args.source_tensor.dtype());
     return ttsl::hash::hash_objects_with_default_seed(
@@ -69,7 +72,8 @@ ttsl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
         attrs.rotation,
         static_cast<uint64_t>(attrs.global_cb->config_address()),
         static_cast<uint64_t>(tensor_buffer != nullptr ? tensor_buffer->address() : 0),
-        static_cast<uint32_t>(dataformat));
+        static_cast<uint32_t>(dataformat),
+        tensor_args.source_tensor.tensor_spec().page_config());
 }
 
 ttnn::device_operation::CachedProgram<DramPrefetcherValidatorDeviceOperation::ProgramFactory::shared_variables_t>

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -56,12 +56,13 @@ DramPrefetcherValidatorDeviceOperation::create_output_tensors(const operation_at
 
 ttsl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // GlobalCircularBuffer / Tensor aren't reflection-hashable here; pick the bits that
-    // determine Program shape: scalar attrs, GCB identity, the source tensor's DRAM
-    // address (compile-time arg via TensorAccessorArgs), its dataformat, and its page config.
-    // create_at reads the real tile off the source tensor to derive k_tiles, total_n_tiles,
-    // tile_bytes and the CB page sizes, so two tensors differing only in tile geometry compile
-    // different programs and must not share a key.
+    // Everything create_at reads has to be keyed, because override_runtime_arguments is a no-op here.
+    // The whole GlobalCircularBuffer goes in rather than just its config address: the sender/receiver
+    // core mapping becomes the kernels' core ranges and their compile- and runtime args, and the size
+    // and buffer type set the CB geometry, none of which a recycled config address distinguishes.
+    // On the tensor side, create_at derives k_tiles, total_n_tiles, n_per_recv_tiles, is_recv_contig,
+    // tile_bytes and the CB page sizes from the real shape, tile and memory config, and emits
+    // TensorAccessorArgs as compile-time args, so the address alone is not a sufficient identity.
     const auto* tensor_buffer = tensor_args.source_tensor.buffer();
     const tt::DataFormat dataformat = tt::tt_metal::datatype_to_dataformat_converter(tensor_args.source_tensor.dtype());
     return ttsl::hash::hash_objects_with_default_seed(
@@ -70,10 +71,19 @@ ttsl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
         attrs.print_stride,
         attrs.streaming,
         attrs.rotation,
-        static_cast<uint64_t>(attrs.global_cb->config_address()),
+        attrs.global_cb.has_value() ? std::hash<tt::tt_metal::experimental::GlobalCircularBuffer>{}(*attrs.global_cb)
+                                    : std::size_t{0},
+        // std::hash covers the GCB's structure (core mapping, size, buffer type) but not which
+        // allocation it is. The remote CB is created against the GCB and bakes both of these addresses
+        // at build time, and UpdateDynamicCircularBufferAddress refuses to re-point a GCB-backed CB, so
+        // two same-shaped GCBs at different allocations must not share a program.
+        static_cast<uint64_t>(attrs.global_cb.has_value() ? attrs.global_cb->buffer_address() : 0),
+        static_cast<uint64_t>(attrs.global_cb.has_value() ? attrs.global_cb->config_address() : 0),
         static_cast<uint64_t>(tensor_buffer != nullptr ? tensor_buffer->address() : 0),
         static_cast<uint32_t>(dataformat),
-        tensor_args.source_tensor.tensor_spec().page_config());
+        tensor_args.source_tensor.tensor_spec().page_config(),
+        tensor_args.source_tensor.padded_shape(),
+        tensor_args.source_tensor.memory_config());
 }
 
 ttnn::device_operation::CachedProgram<DramPrefetcherValidatorDeviceOperation::ProgramFactory::shared_variables_t>


### PR DESCRIPTION
**Summary**

This PR addresses three common program cache bugs, to enable the upcoming Metal 2.0 ports of the impacted ops. The issues are combined into one PR to make reviewing and merging easier, since there's a lot of overlap in the impacted ops. Based on review feedback though, this PR also includes fixes for other related issues in the ops that are being opened up to fix these three.

It doesn't look like the problematic situations are exercised anywhere (based on Claude searching our models), so they are probably just latent bugs.

This PR doesn't add tests because much of this PR is TT_FATALs guarding illegal inputs, and these situations don't have a real use case. The goal of this PR is also to provide more sanity for upcoming Metal 2.0 ports, rather than addressing a bug that was encountered.

The three issues this PR targets are:

**1. Op Assumes 32×32 Tiles**

For eight ops, the program factories size their CBs and calculate tile counts from 32x32 constants but don't check the tensor's tile shape.

This PR just makes this explicit by adding a TT_FATAL check and putting a note in the docs.

**2. Tile-Aware Factories Don't Hash the Tile Shape**

Three factories calculate page sizes and block shapes using the tile shape, but don't hash the tile. This means that if somehow you called the op twice with only the tile shape changing between calls, you'd get a fake cache hit.

Fixed by adding page_config to each hash. While fixing `llama_all_gather_matmul_async`, I found two more issues so included these fixes too:
- A copy-paste bug meant the intermediate tensor's hash fields were taken from `input1` instead of `intermediate`.
- The fused matmul half of `llama_all_gather_matmul_async` and
  `llama_rs_matmul` compiles from `MatmulParams` (specifies parameters like program config and fused activation) but never keyed that struct. Hashed the whole `MatmulParams`, thereby matching `all_gather_matmul_async` and `matmul_reduce_scatter_async`.

**3. Compile-time TensorAccessorArgs are Missing from Hash**

`TensorAccessorArgs::append_to` puts the `IsDram` flag and the aligned page size
into the compile-time args. These compile time args can't be updated and since they're missing from the hash, an otherwise-identical tensor in
the other memory space results in a fake cache hit.

Added the relevant tensor's memory config to the hash in 5 ops, also adding optional operands that had been overlooked (slot_idx,end_tensor, and preallocated output tensors).

While fixing these, three ops also generate a single TensorAccessor and
use it to read two different metadata tensors. This assumes they share a
layout. Added an assertion that the configs match.

The other issues existing in the ops covered by these fixes are:

**4. Cache Keys Missing Other Fields**

While auditing the same ops, several keys turned out to be missing fields that
reach the compiled program and don't get refreshed on a cache hit. Claude summary of the changes on a per-op basis:

* `llama_all_gather_matmul_async` and `llama_rs_matmul`: `sub_device_id`, which
  selects the worker core pool.
* `llama_rs_matmul`: the full matmul operand specs (the helper derives M/K/N,
  CB formats and the work split from them), `output_mem_config`, the
  reduce-scatter input's `logical_shape` (drives `ncores_input` and the
  `SCHEDULE` define for over-provisioned shard grids), the intermediate packet
  buffer's config, and `second_weight_tensor.has_value()`, which selects
  between two structurally different programs.
* `interleaved_to_sharded_partial`: `padded_shape` and the input memory config,
  both of which the non-partial sibling already keyed.
* `roll`: `output_mem_config` and `padded_shape`.
* `dram_prefetcher_validator`: the whole `GlobalCircularBuffer` plus both its
  buffer and config addresses. `std::hash` covers only the GCB's structure, and
  `UpdateDynamicCircularBufferAddress` refuses to re-point a GCB-backed CB, so
  two same-shaped GCBs at different allocations must not share a program.

`rotary_embedding_indexed` now hashes `tensor_spec()` wholesale instead of a
projection, so the key and the framework's strict accept/reject predicate agree
by construction. Under a projection, tensors differing only in a dropped field
share a key, hit, and then throw from `report_tensor_arg_mismatch` rather than
rebuilding.

**5. A Globally-Allocated CB Not Re-pointed on Cache Hits**

`llama_all_gather_matmul_async` allocates its intermediate CB over the
intermediate tensor's buffer. `override_runtime_arguments` patched the reader
and writer address args but never moved the CB, so a cached program kept
pointing every intermediate access at the first call's allocation. Fixed by
keeping the CB handle in the shared variables and re-pointing it on each hit.

**6. Missing Cache Hit Validation**

Ops that define `validate_on_program_cache_hit` do not re-run the miss
validator, so some checks that only existed in the miss validation were missing. Moved these into a
shared `validate_runtime_args` for `zero_padded_kv_cache`,
`update_padded_kv_cache`, `rotary_embedding_indexed` and `llama_rs_matmul`:


Claude summary of the changes on a per-op basis:
* `storage_type()` covering `device()` dereference — on the hit path
  a host tensor faulted as a nullptr deref instead of reporting.
* cache-vs-input dtype and layout agreement in `update_padded_kv_cache`; the
  cache's own dtype and layout are not hashed but set the writer's page size.
* the new tile and layout checks themselves.

**7. Operand Bounds and Preallocated-Output Validation**

These last issues aren't cache related but were flagged by Copilot. Claude summary of the changes on a per-op basis:

* `tanh_bw`: the reader walks the same tile_id range in both operands with a
  count derived from `input` alone, so an undersized `grad_output` was read
  past its allocation. Its storage, buffer and padded shape are now checked.
* `tanh_bw`: the preallocated output was compared against
  `compute_output_specs`, which returns that same tensor when one is supplied —
  a tautology that could never fire. Now pinned to the input, since the writer
  emits one page per input tile.
* `slice`: a preallocated output is now checked for layout and dtype before
  tile geometry, because `PageConfig::get_tile()` reports a default 32x32 tile
  for ROW_MAJOR and the comparison would otherwise accept one.
* `slice`: the tensor-args path asserts a TILE input, reachable directly via
  `ttnn::prim::slice`.
* `zero_padded_kv_cache`: metadata tensors are rejected if sharded.
*
**Notes for reviewers**

The PR isn't intended to change the ops or add functionality. However it will cause extra program compiles or crashes, in cases where previously a mis-compilation would have been silently accepted. These would have been bugged fake cache hits, though again, it doesn't look like these bugged paths are used in any of our models

Single card perf [pass](https://github.com/tenstorrent/tt-metal/actions/runs/32862133504)
Blaze prefill [ran](https://github.com/tenstorrent/tt-metal/actions/runs/33651807608) - Kimi failures are matching results in [main](https://github.com/tenstorrent/tt-metal/actions/runs/33651864287)
Blackhole E2E [run](https://github.com/tenstorrent/tt-metal/actions/runs/32861798604) with failures that match [main](https://github.com/tenstorrent/tt-metal/actions/runs/32722640876)


Sanity previously passed, but is now failing because main failed
The "All Models" run matches main, except for one timeout failure (times out at 10 min, whereas the passing run just passes at 9m 58s https://github.com/tenstorrent/tt-metal/actions/runs/33537867701/job/99959819136
 
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/Cache_Hash_Common_Bugs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/Cache_Hash_Common_Bugs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/Cache_Hash_Common_Bugs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/Cache_Hash_Common_Bugs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/Cache_Hash_Common_Bugs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/Cache_Hash_Common_Bugs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/Cache_Hash_Common_Bugs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/Cache_Hash_Common_Bugs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/Cache_Hash_Common_Bugs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/Cache_Hash_Common_Bugs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/Cache_Hash_Common_Bugs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/Cache_Hash_Common_Bugs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/Cache_Hash_Common_Bugs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/Cache_Hash_Common_Bugs)