### PR TITLE
AGMM: use the correct core grid on transpose; H3 projections run auto

### DIFF
--- a/models/tt_dit/layers/feedforward.py
+++ b/models/tt_dit/layers/feedforward.py
@@ -113,20 +113,26 @@ class ParallelFeedForward(Module):
         )
 
     def forward(
-        self, x: ttnn.Tensor, compute_kernel_config=None, parallel_config=None, default_block_size=None
+        self,
+        x: ttnn.Tensor,
+        compute_kernel_config=None,
+        parallel_config=None,
+        default_block_size=None,
+        force_transpose: bool = True,
     ) -> ttnn.Tensor:
         """
         Expects x to be replicated.
         Return output fractured on columns.
 
-        `default_block_size` is forwarded to ff1 only, for callers that have measured block sizes for
-        their ff1 shape; ff2 keeps the generic path.
+        `default_block_size` and `force_transpose` are forwarded to ff1 only, for callers that have
+        measured block sizes for their ff1 shape; ff2 keeps the generic path.
         """
         ff1_out = self.ff1(
             x,
             compute_kernel_config=compute_kernel_config,
             parallel_config=parallel_config,
             default_block_size=default_block_size,
+            force_transpose=force_transpose,
         )
         return self.ff2(ff1_out, compute_kernel_config=compute_kernel_config)
 
@@ -140,6 +146,7 @@ class ParallelFeedForward(Module):
         parallel_config=None,
         default_block_size=None,
         core_grid=None,
+        force_transpose: bool = True,
     ) -> ttnn.Tensor:
         """Fused FFN forward with addcmul fused at the RS final write step.
 
@@ -147,7 +154,7 @@ class ParallelFeedForward(Module):
         Both addcmul_a and addcmul_b are already at their per-TP-device [D/tp] slice —
         no AllGather or scatter matmul is required.
 
-        `default_block_size` is forwarded to ff1 only, as in `forward`.
+        `default_block_size` and `force_transpose` are forwarded to ff1 only, as in `forward`.
         """
         ff1_out = self.ff1(
             x,
@@ -155,6 +162,7 @@ class ParallelFeedForward(Module):
             parallel_config=parallel_config,
             default_block_size=default_block_size,
             core_grid=core_grid,
+            force_transpose=force_transpose,
         )
         return self.ff2.forward_fused_addcmul(
             ff1_out,

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -9,7 +9,13 @@ import torch
 import ttnn
 from models.common.utility_functions import is_blackhole
 
-from ..utils.matmul import get_fabric_agmm_config, get_fused_mmrs_config, get_matmul_config, get_matmul_core_grid
+from ..utils.matmul import (
+    agmm_worker_grid,
+    get_fabric_agmm_config,
+    get_fused_mmrs_config,
+    get_matmul_config,
+    get_matmul_core_grid,
+)
 from ..utils.tensor import prepare_for_fused_swiglu
 from .module import Module, Parameter
 
@@ -348,6 +354,7 @@ class ColParallelLinear(Module):
         addcmul_scalar: float = 1.0,
         core_grid=None,
         use_heuristic_mmcfg=False,
+        force_transpose: bool = True,
     ) -> ttnn.Tensor | list[ttnn.Tensor]:
         """
         Expects x to be replicated.
@@ -400,7 +407,12 @@ class ColParallelLinear(Module):
             if fabric_cfg is not None and self.chunks in (None, 1) and has_unit_batch and addcmul_a is None:
                 return self._forward_fabric_agmm(x, weight, fabric_cfg, parallel_config, compute_kernel_config, dtype)
 
-            core_grid = core_grid or ttnn.CoreCoord(full_grid.x, full_grid.y - 1)
+            # The op transposes the core grid when force_transpose is set or the output is wide
+            # (M > N). The worker grid must reserve the mux axis to match (row when transposed,
+            # column when not) -- otherwise a non-transposed shape gets a row reserved and loses an
+            # M-core. Only used when the caller didn't pass an explicit core_grid.
+            transpose_core_grid = force_transpose or M > N
+            core_grid = core_grid or agmm_worker_grid(full_grid, transpose_core_grid)
             matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size, use_heuristic=use_heuristic_mmcfg)
 
             ag_persistent_buffer = self.ccl_manager.get_ag_ping_pong_buffer(
@@ -422,7 +434,14 @@ class ColParallelLinear(Module):
                 topology=self.ccl_manager.topology,
                 cluster_axis=parallel_config.tensor_parallel.mesh_axis,
                 barrier_semaphore=None,
-                num_workers_per_link=full_grid.x // self.ccl_manager.num_links,
+                force_transpose=force_transpose,
+                # in0 (activation) senders group along the M-parallel axis: grid.x when transposed,
+                # grid.y when not. Split it into exactly num_links groups (ceil), matching the op's
+                # `ceil(in0_axis / num_workers_per_link) == num_links` assert for either orientation.
+                num_workers_per_link=(
+                    (core_grid.x if transpose_core_grid else core_grid.y) + self.ccl_manager.num_links - 1
+                )
+                // self.ccl_manager.num_links,
                 num_buffers_per_channel=48 if not is_blackhole() else 24,
                 chunks=self.chunks if self.chunks is not None else 1,
                 # Op's N is per-device, so pass per-device widths (each global width is % TP == 0).

--- a/models/tt_dit/models/transformers/minimax_h3/agmm_config.py
+++ b/models/tt_dit/models/transformers/minimax_h3/agmm_config.py
@@ -4,55 +4,108 @@
 
 """Matmul block sizes for the MiniMax-H3 all-gather-matmul shapes.
 
-Keyed on `(K, N)` only. `get_matmul_config` keys its own tables on `(M, K, N)`, but in
-this model M is the per-device packed sequence length, which changes with the requested video
-duration -- 4768 / 9216 / 13632 at 768P for 5s / 10s / 15s, and anything else a caller asks for. K and
-N are fixed by the architecture and the TP factor. M only sets how many blocks each core walks
-through, and it is large enough at every duration that the block shape does not want to change with
-it, so keying on `(K, N)` gives one entry per matmul instead of one per matmul per duration.
+Keyed on `(K, N, per_core_M)`. K and N are fixed by the architecture and the TP factor; the block
+shape that wins, however, depends on how many M-tiles land on each core (`per_core_M`), which changes
+with the requested video duration. So this table holds one entry per swept `per_core_M` operating
+point, and `agmm_block_size` picks the right one for the runtime M.
 
-Passed to the linear layers as `default_block_size`, which `get_matmul_config` uses when its own
-`(M, K, N)` lookup misses -- so these apply without registering anything globally.
+`per_core_M` follows the op's own worker grid: the op reserves the mux axis, so M parallelizes over
+12 cores when the output is narrow (transposed, M > N) and 10 cores otherwise. Passed to the linear
+layers as `default_block_size`, which `get_matmul_config` uses when its own `(M, K, N)` lookup misses.
 
-Two hard constraints the op asserts on, both hit while bringing this up:
+Two hard constraints the op asserts on:
 
 `N_block` must be divisible by `subblock_w`, which `get_matmul_config` leaves at 2 -- so N_block must
 be even. (For a fused-SwiGLU ff1 it must be even anyway: gate/up tile pairs interleave along N and a
 block must never split a pair.)
 
-`K_block` must divide `K_tiles_per_device`
-(`K / 32 / tp_factor`). The ring delivers the gathered K in `K_block`-sized chunks and a partial
-final chunk is unsupported; the op asserts on it. With TP=4 that means K_block divides 42 for
-K=5376 and 56 for K=7168 -- 8 (the generic default) divides neither, which is why these shapes need
-an entry at all rather than falling back.
-Measured with `models/tt_dit/utils/sweep_mm_block_sizes.py` on 4x8 Blackhole Galaxy at the 12x9 grid
-the model uses (one core column reserved for CCL), 811 combos over the three shapes, at M=4768:
-
-    (5376, 5376)  to_qkv   (8, 7, 12)  1416 us   vs (8, 7, 8): 1634 us, -13.4%
-    (7168, 1344)  to_out   (8,  8, 6)   890 us   best among usable combos
-    (5376, 7168)  ff1      (8, 3, 14)  2089 us   vs (8, 7, 8): 2365 us, -11.7%
-
-The sweep's own best for to_out was (8, 8, 5) at 875 us -- 1.7% faster -- but it needs subblock
-(4, 1), and `get_matmul_config` hardcodes subblock (2, 2) for anything supplied via
-`default_block_size`. Expressing it would mean registering a full `(M, K, N)` entry with an explicit
-subblock, which reintroduces the M-keying this table exists to avoid, for 15 us on a 0.9 ms matmul.
-So these are the best combos reachable at subblock (2, 2), which for the other two shapes is also the
-global best.
+`K_block` must divide `K_tiles_per_device` (`K / 32 / tp_factor`). The ring delivers the gathered K
+in `K_block`-sized chunks and a partial final chunk is unsupported. With TP=4 that means K_block
+divides 42 for K=5376 and 56 for K=7168 -- 8 (the generic default) divides neither, which is why
+these shapes need an entry rather than falling back.
 """
 
 from __future__ import annotations
 
-# (K, N) -> (M_block, K_block, N_block). N is the *per-device* output width.
+# The op derives its worker grid from the device, reserving the mux axis: M parallelizes over 12
+# cores when transposed (narrow output, M > N) and 10 otherwise. per_core_M -- the M-tiles each core
+# walks -- follows.
+_TILE = 32
+_M_CORES_TRANSPOSED = 12
+_M_CORES_NON_TRANSPOSED = 10
+
+
+def _per_core_m(m: int, n: int) -> int:
+    """M-tiles each core walks, for an AGMM of M rows / N cols on the op's worker grid."""
+    m_tiles = -(-m // _TILE)  # ceil
+    cores = _M_CORES_TRANSPOSED if m > n else _M_CORES_NON_TRANSPOSED
+    return -(-m_tiles // cores)  # ceil
+
+
+# (K, N, per_core_M) -> (M_block, K_block, N_block). N is the *per-device* output width; the key's
+# per_core_M is the operating point the shape was swept at, and the value is the best block at
+# subblock (2, 2) (what get_matmul_config applies to a default_block_size). Swept with
+# models/tt_dit/utils/sweep_mm_block_sizes.py on 4x8 Blackhole Galaxy, one profiler session per
+# shape, at the op's worker grid (non-transposed M over 10 cores / transposed over 12).
 #   (5376, 5376)  attention to_qkv   K_tiles_per_device = 42
 #   (7168, 1344)  attention to_out   K_tiles_per_device = 56
 #   (5376, 7168)  feed-forward ff1   K_tiles_per_device = 42, fused SwiGLU so N_block must be even
-AGMM_BLOCK_SIZES: dict[tuple[int, int], tuple[int, int, int]] = {
-    (5376, 5376): (8, 7, 12),
-    (7168, 1344): (8, 8, 6),
-    (5376, 7168): (8, 3, 14),
+# to_out per_core_M 1..3 are non-transposed (M < N), 4..12 transposed (M > N) -- agmm_block_size uses
+# the same M>N test, so the runtime per_core_M lands on the matching entry across the crossover.
+AGMM_BLOCK_SIZES: dict[tuple[int, int, int], tuple[int, int, int]] = {
+    # (5376, 5376) attention to_qkv, non-transposed (M over 10)
+    (5376, 5376, 1): (2, 6, 16),
+    (5376, 5376, 2): (2, 7, 16),
+    (5376, 5376, 3): (4, 6, 16),
+    (5376, 5376, 4): (6, 7, 16),
+    (5376, 5376, 5): (6, 7, 16),
+    (5376, 5376, 6): (6, 3, 16),
+    (5376, 5376, 7): (4, 6, 16),
+    (5376, 5376, 8): (4, 6, 16),
+    (5376, 5376, 9): (6, 6, 16),
+    (5376, 5376, 10): (6, 6, 16),
+    (5376, 5376, 11): (4, 6, 16),
+    (5376, 5376, 12): (4, 6, 16),
+    # (5376, 7168) feed-forward ff1, fused SwiGLU (N_block even), non-transposed (M over 10)
+    (5376, 7168, 1): (2, 21, 6),
+    (5376, 7168, 2): (2, 6, 12),
+    (5376, 7168, 3): (4, 3, 14),
+    (5376, 7168, 4): (4, 3, 16),
+    (5376, 7168, 5): (6, 3, 16),
+    (5376, 7168, 6): (6, 3, 16),
+    (5376, 7168, 7): (4, 6, 14),
+    (5376, 7168, 8): (4, 3, 16),
+    (5376, 7168, 9): (6, 3, 14),
+    (5376, 7168, 10): (6, 3, 16),
+    (5376, 7168, 11): (6, 3, 16),
+    (5376, 7168, 12): (4, 3, 16),
+    # (7168, 1344) attention to_out (fused addcmul); per_core_M 1..3 non-transposed, 4..12 transposed
+    (7168, 1344, 1): (2, 14, 6),
+    (7168, 1344, 2): (2, 8, 6),
+    (7168, 1344, 3): (6, 7, 4),
+    (7168, 1344, 4): (8, 8, 6),
+    (7168, 1344, 5): (6, 8, 6),
+    (7168, 1344, 6): (10, 8, 6),
+    (7168, 1344, 7): (8, 8, 6),
+    (7168, 1344, 8): (8, 8, 6),
+    (7168, 1344, 9): (10, 8, 6),
+    (7168, 1344, 10): (10, 8, 6),
+    (7168, 1344, 11): (6, 8, 6),
+    (7168, 1344, 12): (6, 8, 8),
 }
 
 
-def agmm_block_size(k: int, n: int) -> tuple[int, int, int] | None:
-    """Block sizes for an all-gather matmul of this `(K, N)`, or None to let the generic path decide."""
-    return AGMM_BLOCK_SIZES.get((k, n))
+def agmm_block_size(k: int, n: int, m: int) -> tuple[int, int, int] | None:
+    """Block sizes for an all-gather matmul of this `(K, N)` at sequence length `M`, or None to let
+    the generic path decide.
+
+    `M` sets `per_core_M` (how many M-tiles each core walks). Among the swept `per_core_M` entries
+    for this `(K, N)`, pick the largest that divides the runtime `per_core_M` evenly -- so M tiles
+    into whole blocks with no wasteful partial last block -- and return its block shape.
+    """
+    per_core_m = _per_core_m(m, n)
+    swept = [pcm for (kk, nn, pcm) in AGMM_BLOCK_SIZES if kk == k and nn == n]
+    divisors = [pcm for pcm in swept if per_core_m % pcm == 0]
+    if not divisors:
+        return None
+    return AGMM_BLOCK_SIZES[(k, n, max(divisors))]

--- a/models/tt_dit/models/transformers/minimax_h3/attention_minimax_h3.py
+++ b/models/tt_dit/models/transformers/minimax_h3/attention_minimax_h3.py
@@ -337,7 +337,10 @@ class MiniMaxH3Attention(Module):
             spatial_1BND,
             compute_kernel_config=self.mm_compute_kernel_config,
             parallel_config=matmul_parallel_config,
-            default_block_size=agmm_block_size(self.hidden_size, 3 * self.inner_dim // tp_factor),
+            default_block_size=agmm_block_size(
+                self.hidden_size, 3 * self.inner_dim // tp_factor, spatial_1BND.padded_shape[-2]
+            ),
+            force_transpose=False,  # let the op pick by M>N; H3 qkv is M<N -> non-transposed
         )
 
         def create_heads(inp: ttnn.Tensor) -> ttnn.Tensor:
@@ -420,7 +423,10 @@ class MiniMaxH3Attention(Module):
             spatial_1BND,
             compute_kernel_config=self.mm_compute_kernel_config,
             parallel_config=matmul_parallel_config,
-            default_block_size=agmm_block_size(self.inner_dim, self.hidden_size // tp_factor),
+            default_block_size=agmm_block_size(
+                self.inner_dim, self.hidden_size // tp_factor, spatial_1BND.padded_shape[-2]
+            ),
+            force_transpose=False,  # let the op pick by M>N; to_out is M>N -> transposed
             addcmul_a=addcmul_residual if fuse_gate else None,
             addcmul_b=addcmul_gate if fuse_gate else None,
         )

--- a/models/tt_dit/models/transformers/minimax_h3/transformer_block_minimax_h3.py
+++ b/models/tt_dit/models/transformers/minimax_h3/transformer_block_minimax_h3.py
@@ -151,7 +151,9 @@ class MiniMaxH3TransformerBlock(Module):
         )
         self.use_fused_agmm = ccl_manager.topology == ttnn.Topology.Ring and self.tp_factor > 1
         # ff1 packs gate and up together for the fused SwiGLU, so its per-device N is 2 * ffn_dim / tp.
-        self.ff1_block_size = agmm_block_size(hidden_size, 2 * ffn_dim // self.tp_factor)
+        # ff1's block depends on per_core_M (hence M), so it's chosen per-forward; stash (K, N) here.
+        # ff1 packs gate and up together for the fused SwiGLU, so its per-device N is 2 * ffn_dim / tp.
+        self._ff1_kn = (hidden_size, 2 * ffn_dim // self.tp_factor)
 
     # ------------------------------------------------------------------ weights
 
@@ -317,6 +319,8 @@ class MiniMaxH3TransformerBlock(Module):
         # Async only supports Ring topology"), so a line-cabled mesh has to take the unfused path
         # below. Gated here rather than left to fail, because the assert fires on the first denoise
         # step of the first request -- long after warmup reports the model loaded.
+        # ff1's block depends on per_core_M (hence M = the packed sequence length), only known here.
+        ff1_block_size = agmm_block_size(*self._ff1_kn, normed.padded_shape[-2])
         ff2_shape = (normed.shape[2], self.ffn_dim // self.tp_factor, self.hidden_size)
         if self.tp_factor > 1 and self.ccl_manager.topology == ttnn.Topology.Ring and has_mmrs_config(*ff2_shape):
             # M is only known here (it tracks the packed sequence length), so the blocking is
@@ -328,12 +332,14 @@ class MiniMaxH3TransformerBlock(Module):
                 modulation(_GATE_MLP),
                 compute_kernel_config=self.mm_compute_kernel_config,
                 parallel_config=self.parallel_config if self.use_fused_agmm else None,
-                default_block_size=self.ff1_block_size,
+                default_block_size=ff1_block_size,
+                force_transpose=False,  # M<N -> non-transposed via the op's M>N decision
             )
         ff_out = self.ff(
             normed,
             compute_kernel_config=self.mm_compute_kernel_config,
             parallel_config=self.parallel_config if self.use_fused_agmm else None,
-            default_block_size=self.ff1_block_size,
+            default_block_size=ff1_block_size,
+            force_transpose=False,  # M<N -> non-transposed via the op's M>N decision
         )
         return ttnn.addcmul(residual, ff_out, modulation(_GATE_MLP))

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -372,6 +372,18 @@ def get_matmul_core_grid(mesh_device):
     return core_grid
 
 
+def agmm_worker_grid(full_grid, transpose):
+    """all_gather_minimal_matmul_async matmul worker grid, sized to leave the mux axis free.
+
+    The op places its input muxes on the device's last ROW when the core grid is transposed and its
+    last COLUMN when it is not (see the program factory's `in0_mux_in_column` logic). The matmul
+    workers must therefore avoid that row/column: reserve a row when transposed -> (x, y-1); reserve a
+    column when not -> (x-1, y). `transpose` should be the op's own decision, i.e.
+    `force_transpose or (M > N)`.
+    """
+    return ttnn.CoreCoord(full_grid.x, full_grid.y - 1) if transpose else ttnn.CoreCoord(full_grid.x - 1, full_grid.y)
+
+
 def _compute_heuristic_blocking(M: int, K: int, N: int, grid_x: int, grid_y: int, tp_factor: int = -1):
     """Heuristic matmul blocking for shapes absent from the per-grid lookup tables.
 


### PR DESCRIPTION
## What

Two changes so the all-gather-minimal-matmul (AGMM) reserves the correct core-grid mux axis regardless of transpose, and MiniMax-H3's projections run in the orientation the op picks by shape.

### 1. Caller reserves the correct mux axis by transpose (`3fe075db5d8`)
`all_gather_minimal_matmul_async` places its input muxes on the device's last **row** when the core grid is transposed and its last **column** when not, so the matmul worker grid must reserve that axis. `ColParallelLinear` always reserved a row (`(x, y-1)`), which is wrong for a non-transposed (M<N) shape — it should reserve a column (`(x-1, y)`) and keep the full M-core count.
- New `matmul.agmm_worker_grid(full_grid, transpose)` helper + a `force_transpose` param on `ColParallelLinear.forward`.
- Grid computed to match the op's own `force_transpose ? true : (M > N)` decision; `num_workers_per_link` derived from the actual in0 axis (`grid.x` transposed / `grid.y` not) so it splits into exactly `num_links` groups either way.
- Default `force_transpose=True` → every existing caller is unchanged.

### 2. H3 runs the AGMM projections auto, with M-aware blocking (`b9c04a11a3a`)
- H3's `to_qkv`/`to_out`/`ff1` pass `force_transpose=False` → qkv/ff1 go non-transposed (M over 10 cores, mux column), to_out stays transposed (M over 12, mux row).
- `agmm_config` is now keyed on `(K, N, per_core_M)`; `agmm_block_size(k, n, m)` picks the largest swept `per_core_M` that divides the runtime one. Values are the subblock-(2,2) optima swept per-M_device on 4×8 Blackhole Galaxy.
- `force_transpose` threaded through `ParallelFeedForward` to reach ff1.

## Notes
- Python-only; no op/C++ change (main's op already honors the passed grid + `force_transpose`).
- The `sweep_mm_block_sizes.py` port is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jonathansu/agmm-use-correct-grid-on-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jonathansu/agmm-use-correct-grid-on-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jonathansu/agmm-use-correct-grid-on-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jonathansu/agmm-use-correct-grid-on-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jonathansu/agmm-use-correct-grid-on-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jonathansu/agmm-use-correct-grid-on-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jonathansu/agmm-use-correct-grid-on-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jonathansu/agmm-use-correct-grid-on-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jonathansu/agmm-use-correct-grid-on-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jonathansu/agmm-use-correct-grid-on-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jonathansu/agmm-use-correct-grid-on-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jonathansu/agmm-use-correct-grid-on-transpose)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jonathansu/agmm-use-correct-grid-on-transpose)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jonathansu/agmm-use-correct-grid-on-transpose)