### PR TITLE
Sanity Slack notify: strict one-commit-back edge detection via exact head_sha lookup

### DIFF
--- a/.github/scripts/sanity-notify/BACKTEST.md
+++ b/.github/scripts/sanity-notify/BACKTEST.md
@@ -74,6 +74,17 @@ also preempt a *green* marked parent (suppressing a legitimate notify);
 zero such cases in this window, and it falls inside the accepted
 [skip ci] trade-off.
 
+## Current-sha sibling runs: known, ACCEPTED gap (maintainer decision, 2026-08-21)
+
+`findBaseline` settles the PARENT's runs but takes the triggering run's
+final-red conclusion for the current sha as-is. Duplicate push deliveries
+can give one sha several runs, so in theory a sibling run of the failing
+sha could have succeeded (or still be in flight), making a notification a
+false blame. Deliberately not handled: this 30-day window contains exactly
+one duplicate-run pair (#13788/#13789) and its outcomes matched
+(success/success); zero split-outcome pairs were observed. Revisit if a
+bad notification is ever traced to a green sibling of the blamed sha.
+
 ## Finding that still needs a human decision
 
 **`_auto-retry-post-commit.yaml` is not 100% reliable: 4/417 (1.0%).**

--- a/.github/scripts/sanity-notify/BACKTEST.md
+++ b/.github/scripts/sanity-notify/BACKTEST.md
@@ -14,19 +14,25 @@ GITHUB_TOKEN=$(gh auth token) node .github/scripts/sanity-notify/backtest.js --d
 - Window: **2026-07-22 .. 2026-08-21** (30 days).
 - **1088** push-to-main "Sanity tests" runs fetched (chunked queries; the
   list API silently caps any single filtered query at 1000 results).
-- **416** gate-passing final-red events (unique broken head_sha) examined.
+- **417** gate-passing final-red events (unique broken head_sha) examined.
   Each was fed through the real `findBaseline()` against the live API with
   `maxWaitMs: 0` (closed history is final; the poll path must not be needed,
   and `sleep` throws if reached -- it never was).
 
-## Results
+## Results (after the [skip ci] short-circuit)
 
-| decision                        | count | share |
-|---------------------------------|------:|------:|
-| notify (parent green)           |    17 |  4.1% |
-| abstain: conclusively red       |   361 | 86.8% |
-| abstain: parent has no push run |    34 |  8.2% |
-| abstain: parent never settled   |     4 |  1.0% |
+| decision                      | count | share | before the short-circuit |
+|-------------------------------|------:|------:|--------------------------|
+| notify (parent green)         |    17 |  4.1% | 17 (byte-identical set)  |
+| abstain: conclusively red     |   361 | 86.6% | 361                      |
+| abstain: parent is [skip ci]  |    35 |  8.4% | 34 as full-budget timeouts + 1 as conclusively-red (nuance below) |
+| abstain: parent never settled |     4 |  1.0% | 4 (unchanged; distinct category, still full-budget timeouts) |
+
+The short-circuit is a latency fix, not a decision change: every event
+abstains or notifies exactly as before, but the [skip ci] cases now
+abstain instantly instead of burning the full 270-minute poll budget
+first. One extra event vs. the first pass (#13812) simply landed on main
+between the two runs.
 
 - **notify (17)**: every baseline was the parent's own run, and all 17 agreed
   with the naive time-ordered reading of the run list. Spot-checked by hand:
@@ -47,28 +53,40 @@ GITHUB_TOKEN=$(gh auth token) node .github/scripts/sanity-notify/backtest.js --d
   interleaving means list order is not commit order. A human reading the flat
   list would have pinged someone whose parent state was in fact red.
 
-## Findings that need a human decision
+## [skip ci] parents: known, ACCEPTED gap (maintainer decision, 2026-08-21)
 
-1. **`[skip ci]` parents blind the one-commit-back rule: 34/416 (8.2%).**
-   All 34 "parent has no push run" cases are commits whose parent's message
-   contains `[skip ci]` / `[ci skip]` -- those commits never get a Sanity
-   tests push run, so the parent's greenness is unknowable by this rule. The
-   logic abstains (safe: never misattributes), but in production each such
-   event polls the full 270-minute budget before giving up, and a genuine
-   break lands silently. Options if this matters: hop past parents whose
-   commit message matches a skip-ci marker (bounded by consecutive skip-ci
-   depth), or short-circuit the wait when the parent commit is already old.
-2. **`_auto-retry-post-commit.yaml` is not 100% reliable: 4/416 (1.0%).**
-   Four parents are frozen at `failure@1, completed` -- the auto-retry never
-   fired, so by the finality rule they are permanently "not settled" and the
-   notify event polls the full budget before abstaining. Example: red run
-   #12159's parent run #12119. Worth a look at the retry workflow's own
-   failure modes; a time-based finality escape hatch (a failure@<3 older than
-   N hours is final -- no retry is coming that late) would also close this.
+**8.4% (35/417)** of red events sit on top of a `[skip ci]` / `[ci skip]`
+parent. Such a parent (usually) never gets a push run, so its greenness is
+unknowable under the one-commit-back rule and the break above it goes
+un-notified. The maintainer decision is to accept that missed notification
+rather than complicate the rule -- but not to spend the poll budget
+discovering it: `findBaseline` checks the parent's commit message and its
+associated PR titles upfront and abstains immediately
+(`reason: 'parent-skip-ci'`) with a distinct log line, entering no poll
+loop at all.
 
-Both cases fail toward silence, never toward wrong blame. Combined they are
-~9% of red events; each costs a full-budget polling job and a missed
-notification.
+Nuance surfaced by the re-run: one event (#12597) has a parent whose
+message says `[skip CI]` yet a push run exists anyway (#12596, red) -- the
+marker does not always suppress CI. The short-circuit preempts that run's
+verdict, which changed the abstain *reason* (conclusively-red ->
+parent-skip-ci) but not the abstain itself. In principle this arm could
+also preempt a *green* marked parent (suppressing a legitimate notify);
+zero such cases in this window, and it falls inside the accepted
+[skip ci] trade-off.
+
+## Finding that still needs a human decision
+
+**`_auto-retry-post-commit.yaml` is not 100% reliable: 4/417 (1.0%).**
+Four parents are frozen at `failure@1, completed` -- the auto-retry never
+fired, so by the finality rule they are permanently "not settled" and the
+notify event polls the full budget before abstaining. Example: red run
+#12159's parent run #12119. These are NOT [skip ci] commits and are
+deliberately untouched by the short-circuit. Worth a look at the retry
+workflow's own failure modes; a time-based finality escape hatch (a
+failure@<3 older than N hours is final -- no retry is coming that late)
+would also close this.
+
+All abstain categories fail toward silence, never toward wrong blame.
 
 ## Method notes
 
@@ -78,4 +96,6 @@ notification.
 - The naive time-order expectation (previous distinct-sha, non-cancelled run
   in the window was green => expect notify) approximates a human reading the
   run list; it is a cross-check, not ground truth -- see #13609 above.
-- API cost: 883 calls for the full backtest, well within core rate limits.
+- API cost: 1615 calls for the full backtest (the skip-ci check adds a
+  commit lookup per event and a PR lookup for unmarked parents), well
+  within core rate limits.

--- a/.github/scripts/sanity-notify/BACKTEST.md
+++ b/.github/scripts/sanity-notify/BACKTEST.md
@@ -1,0 +1,81 @@
+# Backtest: one-commit-back sanity Slack notify vs. real main history
+
+Backtest of the decision logic in `culprits.js` (used by
+`.github/workflows/sanity-tests-slack-notify.yaml`) against real,
+already-settled "Sanity tests" push-to-main run history, run 2026-08-21
+via `backtest.js`. Reproduce with:
+
+```
+GITHUB_TOKEN=$(gh auth token) node .github/scripts/sanity-notify/backtest.js --days 30
+```
+
+## Coverage
+
+- Window: **2026-07-22 .. 2026-08-21** (30 days).
+- **1088** push-to-main "Sanity tests" runs fetched (chunked queries; the
+  list API silently caps any single filtered query at 1000 results).
+- **416** gate-passing final-red events (unique broken head_sha) examined.
+  Each was fed through the real `findBaseline()` against the live API with
+  `maxWaitMs: 0` (closed history is final; the poll path must not be needed,
+  and `sleep` throws if reached -- it never was).
+
+## Results
+
+| decision                        | count | share |
+|---------------------------------|------:|------:|
+| notify (parent green)           |    17 |  4.1% |
+| abstain: conclusively red       |   361 | 86.8% |
+| abstain: parent has no push run |    34 |  8.2% |
+| abstain: parent never settled   |     4 |  1.0% |
+
+- **notify (17)**: every baseline was the parent's own run, and all 17 agreed
+  with the naive time-ordered reading of the run list. Spot-checked by hand:
+  #13790 (the 2026-08-21 incident-day break; baseline #13789 -- matches the
+  correct notification actually sent that morning), #12717 (parent run #12714
+  success@1), and #11483 (parent run #11482 success **on attempt 2** -- a real
+  case where the auto-retry flipped a failure to green, validating the
+  any-final-success rule). Three of the 17 events were `cancelled@1` and one
+  `startup_failure@2`; the finality gate passes those immediately by design.
+- **conclusively red (361)**: main spends long stretches red; each red streak
+  is one notify followed by many correct silences. #13802 (the incident's
+  89-mention mass ping) resolves here: its parent's run #13798 is
+  failure@attempt-3, so the new logic stays silent instead of blaming 250
+  commits.
+- **One time-order disagreement, resolved in the new logic's favor**: #13609
+  abstains (its git parent's run #13607 was failure@3) even though the
+  time-ordered run list shows a later green run in between -- merge-queue
+  interleaving means list order is not commit order. A human reading the flat
+  list would have pinged someone whose parent state was in fact red.
+
+## Findings that need a human decision
+
+1. **`[skip ci]` parents blind the one-commit-back rule: 34/416 (8.2%).**
+   All 34 "parent has no push run" cases are commits whose parent's message
+   contains `[skip ci]` / `[ci skip]` -- those commits never get a Sanity
+   tests push run, so the parent's greenness is unknowable by this rule. The
+   logic abstains (safe: never misattributes), but in production each such
+   event polls the full 270-minute budget before giving up, and a genuine
+   break lands silently. Options if this matters: hop past parents whose
+   commit message matches a skip-ci marker (bounded by consecutive skip-ci
+   depth), or short-circuit the wait when the parent commit is already old.
+2. **`_auto-retry-post-commit.yaml` is not 100% reliable: 4/416 (1.0%).**
+   Four parents are frozen at `failure@1, completed` -- the auto-retry never
+   fired, so by the finality rule they are permanently "not settled" and the
+   notify event polls the full budget before abstaining. Example: red run
+   #12159's parent run #12119. Worth a look at the retry workflow's own
+   failure modes; a time-based finality escape hatch (a failure@<3 older than
+   N hours is final -- no retry is coming that late) would also close this.
+
+Both cases fail toward silence, never toward wrong blame. Combined they are
+~9% of red events; each costs a full-budget polling job and a missed
+notification.
+
+## Method notes
+
+- "Gate-passing final-red" mirrors the workflow's finality gate:
+  `conclusion != 'success' && (conclusion != 'failure' || run_attempt >= 3)`,
+  deduped per head_sha (the idempotency marker allows one post per sha).
+- The naive time-order expectation (previous distinct-sha, non-cancelled run
+  in the window was green => expect notify) approximates a human reading the
+  run list; it is a cross-check, not ground truth -- see #13609 above.
+- API cost: 883 calls for the full backtest, well within core rate limits.

--- a/.github/scripts/sanity-notify/backtest.js
+++ b/.github/scripts/sanity-notify/backtest.js
@@ -1,0 +1,189 @@
+'use strict';
+
+// Backtests the sanity-tests-slack-notify decision logic (culprits.js)
+// against real, already-settled "Sanity tests" push-to-main history.
+//
+//   GITHUB_TOKEN=$(gh auth token) node .github/scripts/sanity-notify/backtest.js [--days 30]
+//
+// For every historical run that satisfied the workflow's finality gate
+// (a "final red state"), the REAL findBaseline() is invoked against the
+// live API -- with maxWaitMs: 0 and a sleep() that throws, since closed
+// history is already final and the poll path must never be needed. Any
+// event that would still want to poll therefore resolves to a 'timeout'
+// abstain and is flagged for human eyes.
+//
+// Each decision is also compared against a naive time-ordered expectation
+// (previous distinct-sha run in the window was green -> expect notify),
+// which approximates what a human reading the run list would conclude.
+// Mismatches are listed individually; they are exactly the interesting
+// cases (merge-queue reordering, duplicate runs, out-of-window parents).
+
+const { findBaseline } = require('./culprits.js');
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+  console.error('GITHUB_TOKEN is required (e.g. GITHUB_TOKEN=$(gh auth token) node backtest.js)');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const argVal = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : dflt;
+};
+const DAYS = Number(argVal('--days', '30'));
+const [OWNER, REPO] = argVal('--repo', 'tenstorrent/tt-metal').split('/');
+const WORKFLOW_ID = 'sanity-tests.yaml';
+
+let apiCalls = 0;
+async function api(path, params = {}) {
+  const qs = new URLSearchParams(params).toString();
+  const url = `https://api.github.com${path}${qs ? '?' + qs : ''}`;
+  apiCalls += 1;
+  const res = await fetch(url, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: 'application/vnd.github+json',
+      'user-agent': 'sanity-notify-backtest',
+      'x-github-api-version': '2022-11-28',
+    },
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${url}: ${await res.text()}`);
+  return res.json();
+}
+
+// Minimal octokit-compatible client covering exactly what culprits.js uses.
+const github = {
+  rest: {
+    git: {
+      getCommit: async ({ owner, repo, commit_sha }) =>
+        ({ data: await api(`/repos/${owner}/${repo}/git/commits/${commit_sha}`) }),
+    },
+    actions: {
+      listWorkflowRuns: async ({ owner, repo, workflow_id, ...params }) =>
+        ({ data: await api(`/repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs`, params) }),
+    },
+  },
+};
+
+// The workflow's top-level finality gate, applied to a historical run.
+const isGatePassingRed = (r) =>
+  r.conclusion !== null &&
+  r.conclusion !== 'success' &&
+  (r.conclusion !== 'failure' || r.run_attempt >= 3);
+
+async function main() {
+  const until = new Date();
+  const since = new Date(until.getTime() - DAYS * 24 * 60 * 60 * 1000);
+  const created = `${since.toISOString().slice(0, 10)}..${until.toISOString().slice(0, 10)}`;
+
+  // 1. Collect the window's push-to-main run history (same filters as prod).
+  // The list endpoint silently caps any filtered query at 1000 results, so
+  // fetch in small date chunks and dedupe on run id (chunk edges overlap by
+  // a day since the `created` filter has date granularity).
+  const CHUNK_DAYS = 4;
+  const byId = new Map();
+  for (let t = since.getTime(); t < until.getTime(); t += CHUNK_DAYS * 24 * 60 * 60 * 1000) {
+    const chunkEnd = Math.min(t + CHUNK_DAYS * 24 * 60 * 60 * 1000, until.getTime());
+    const chunkCreated = `${new Date(t).toISOString().slice(0, 10)}..${new Date(chunkEnd).toISOString().slice(0, 10)}`;
+    let fetched = 0;
+    for (let page = 1; ; page++) {
+      const data = await api(`/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW_ID}/runs`, {
+        branch: 'main', event: 'push', per_page: 100, page, created: chunkCreated,
+      });
+      for (const r of data.workflow_runs) byId.set(r.id, r);
+      fetched += data.workflow_runs.length;
+      if (data.workflow_runs.length < 100) break;
+    }
+    if (fetched >= 1000) console.error(`WARNING: chunk ${chunkCreated} hit the 1000-result cap; shrink CHUNK_DAYS.`);
+  }
+  const allRuns = [...byId.values()].sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+
+  // 2. Gate-passing red events, deduped per head_sha (the idempotency marker
+  //    allows at most one notification per broken sha in production).
+  const redBySha = new Map();
+  for (const r of allRuns.filter(isGatePassingRed)) {
+    if (!redBySha.has(r.head_sha)) redBySha.set(r.head_sha, r);
+  }
+
+  console.log(`window: ${created} (${DAYS} days)`);
+  console.log(`push-to-main runs fetched: ${allRuns.length}`);
+  console.log(`gate-passing final-red events (unique head_sha): ${redBySha.size}`);
+  console.log('');
+
+  // Naive time-ordered expectation: was the previous distinct-sha run green?
+  const naiveExpectation = (redRun) => {
+    const idx = allRuns.indexOf(redRun);
+    for (let i = idx - 1; i >= 0; i--) {
+      if (allRuns[i].head_sha === redRun.head_sha) continue;
+      if (['cancelled', 'skipped'].includes(allRuns[i].conclusion)) continue;
+      return allRuns[i].conclusion === 'success' ? 'notify' : 'abstain';
+    }
+    return 'unknown (window edge)';
+  };
+
+  // 3. Run every red event through the REAL decision logic.
+  const tally = {};
+  const rows = [];
+  const flagged = [];
+  for (const [sha, redRun] of redBySha) {
+    const result = await findBaseline({
+      github,
+      owner: OWNER,
+      repo: REPO,
+      headSha: sha,
+      maxWaitMs: 0, // closed history must decide instantly; anything undecided -> 'timeout'
+      sleep: async () => { throw new Error(`sleep() reached for settled history (sha ${sha})`); },
+    });
+
+    let key = result.decision === 'notify' ? 'notify' : `abstain:${result.reason}`;
+    // With maxWaitMs: 0, 'timeout' collapses two distinct situations; split
+    // them, since for settled history they mean very different things:
+    //  - parent has NO push run at all (in production this would poll the
+    //    full budget and abstain). Check whether that is a [skip ci] commit.
+    //  - parent has a run that never settled (should be impossible for
+    //    closed history -- e.g. a failure@1 whose auto-retry never fired).
+    let skipCi = '';
+    if (result.reason === 'timeout') {
+      if (result.parentRuns.length === 0) {
+        const { data: parentCommit } = await github.rest.git.getCommit({
+          owner: OWNER, repo: REPO, commit_sha: result.parentSha,
+        });
+        skipCi = /\[skip ci\]|\[ci skip\]/i.test(parentCommit.message) ? ' (parent is [skip ci])' : '';
+        key = 'abstain:parent-has-no-push-run';
+      } else {
+        key = 'abstain:parent-never-settled';
+      }
+    }
+    tally[key] = (tally[key] ?? 0) + 1;
+
+    const expected = naiveExpectation(redRun);
+    const agree = expected.startsWith('unknown') ? 'n/a' : (expected === result.decision ? 'yes' : 'NO');
+    const row = {
+      run: `#${redRun.run_number}`,
+      created: redRun.created_at,
+      conclusion: `${redRun.conclusion}@${redRun.run_attempt}`,
+      sha: sha.slice(0, 9),
+      decision: key + skipCi,
+      baseline: result.baselineRun ? `#${result.baselineRun.run_number}` : '-',
+      timeOrderExpected: expected,
+      agree,
+    };
+    rows.push(row);
+    if (agree === 'NO' || key.startsWith('abstain:parent-') || key === 'abstain:no-parent') flagged.push(row);
+    console.log(`${row.run} ${row.created} ${row.conclusion} sha=${row.sha} -> ${row.decision}` +
+      `${result.baselineRun ? ` (baseline ${row.baseline})` : ''}  [time-order expects: ${expected}${agree === 'NO' ? ' <-- MISMATCH' : ''}]`);
+  }
+
+  console.log('\n=== summary ===');
+  for (const [k, v] of Object.entries(tally).sort()) console.log(`${k}: ${v}`);
+  console.log(`api calls: ${apiCalls}`);
+  if (flagged.length) {
+    console.log(`\n=== flagged for human review (${flagged.length}) ===`);
+    for (const f of flagged) console.log(JSON.stringify(f));
+  } else {
+    console.log('\nno mismatches or undecided-history cases flagged');
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/.github/scripts/sanity-notify/backtest.js
+++ b/.github/scripts/sanity-notify/backtest.js
@@ -59,6 +59,10 @@ const github = {
       getCommit: async ({ owner, repo, commit_sha }) =>
         ({ data: await api(`/repos/${owner}/${repo}/git/commits/${commit_sha}`) }),
     },
+    repos: {
+      listPullRequestsAssociatedWithCommit: async ({ owner, repo, commit_sha }) =>
+        ({ data: await api(`/repos/${owner}/${repo}/commits/${commit_sha}/pulls`) }),
+    },
     actions: {
       listWorkflowRuns: async ({ owner, repo, workflow_id, ...params }) =>
         ({ data: await api(`/repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs`, params) }),
@@ -137,23 +141,20 @@ async function main() {
     });
 
     let key = result.decision === 'notify' ? 'notify' : `abstain:${result.reason}`;
-    // With maxWaitMs: 0, 'timeout' collapses two distinct situations; split
-    // them, since for settled history they mean very different things:
-    //  - parent has NO push run at all (in production this would poll the
-    //    full budget and abstain). Check whether that is a [skip ci] commit.
-    //  - parent has a run that never settled (should be impossible for
-    //    closed history -- e.g. a failure@1 whose auto-retry never fired).
-    let skipCi = '';
+    // 'parent-skip-ci' is now detected upfront by findBaseline itself (the
+    // accepted-gap short-circuit; in production it abstains instantly with
+    // no polling). With maxWaitMs: 0, any remaining 'timeout' collapses two
+    // distinct situations; split them, since for settled history they mean
+    // very different things:
+    //  - parent has NO push run and is NOT [skip ci] (in production this
+    //    would poll the full budget and abstain) -- unexpected, flag it.
+    //  - parent has a run that never settled (e.g. a failure@1 whose
+    //    auto-retry never fired) -- in production this also polls the full
+    //    budget; evidence the retry workflow itself can fail.
     if (result.reason === 'timeout') {
-      if (result.parentRuns.length === 0) {
-        const { data: parentCommit } = await github.rest.git.getCommit({
-          owner: OWNER, repo: REPO, commit_sha: result.parentSha,
-        });
-        skipCi = /\[skip ci\]|\[ci skip\]/i.test(parentCommit.message) ? ' (parent is [skip ci])' : '';
-        key = 'abstain:parent-has-no-push-run';
-      } else {
-        key = 'abstain:parent-never-settled';
-      }
+      key = result.parentRuns.length === 0
+        ? 'abstain:parent-has-no-push-run'
+        : 'abstain:parent-never-settled';
     }
     tally[key] = (tally[key] ?? 0) + 1;
 
@@ -164,13 +165,16 @@ async function main() {
       created: redRun.created_at,
       conclusion: `${redRun.conclusion}@${redRun.run_attempt}`,
       sha: sha.slice(0, 9),
-      decision: key + skipCi,
+      decision: key,
       baseline: result.baselineRun ? `#${result.baselineRun.run_number}` : '-',
       timeOrderExpected: expected,
       agree,
     };
     rows.push(row);
-    if (agree === 'NO' || key.startsWith('abstain:parent-') || key === 'abstain:no-parent') flagged.push(row);
+    // parent-skip-ci is a known, accepted category (see BACKTEST.md) -- it
+    // is tallied but not flagged.
+    if (agree === 'NO' || key === 'abstain:parent-has-no-push-run' ||
+        key === 'abstain:parent-never-settled' || key === 'abstain:no-parent') flagged.push(row);
     console.log(`${row.run} ${row.created} ${row.conclusion} sha=${row.sha} -> ${row.decision}` +
       `${result.baselineRun ? ` (baseline ${row.baseline})` : ''}  [time-order expects: ${expected}${agree === 'NO' ? ' <-- MISMATCH' : ''}]`);
   }

--- a/.github/scripts/sanity-notify/culprits.js
+++ b/.github/scripts/sanity-notify/culprits.js
@@ -61,6 +61,16 @@ function describeRuns(runs) {
 // A commit with no parent aborts with { decision: 'abstain', reason: 'no-parent' }.
 // A [skip ci] parent aborts upfront with { decision: 'abstain', reason: 'parent-skip-ci' }
 // (see the comment at that check).
+//
+// Known, ACCEPTED gap (maintainer decision, 2026-08-21): headSha's OWN runs
+// are NOT settled here -- the triggering run's final-red conclusion (already
+// vetted by the caller's finality gate) is taken as-is. Duplicate push
+// deliveries can give one sha several runs, so in theory a sibling run of
+// headSha could have succeeded (or still be running), making a notification
+// on this commit a false blame. Deliberately not handled: the 30-day
+// backtest observed exactly one duplicate-run pair and its outcomes matched
+// (success/success), never a split outcome. Revisit if a bad notification is
+// ever traced to a green sibling of the blamed sha.
 async function findBaseline({
   github,
   owner,
@@ -83,12 +93,12 @@ async function findBaseline({
   }
 
   // Known, ACCEPTED gap (maintainer decision, 2026-08-21): a [skip ci]
-  // parent never gets a push run, so its greenness is unknowable under the
-  // one-commit-back rule, and the break on top of it deliberately goes
-  // un-notified. Detect that upfront -- from the parent's commit message or
-  // an associated PR title -- and abstain immediately instead of
-  // discovering it by exhausting the poll budget (~8% of red events have a
-  // [skip ci] parent per the backtest; see BACKTEST.md).
+  // parent usually gets no push run, so its greenness is unknowable under
+  // the one-commit-back rule, and the break on top of it deliberately goes
+  // un-notified. By policy the marker alone decides -- even in the odd case
+  // where a marked commit does have a run (it happens; see BACKTEST.md) --
+  // so abstain immediately instead of spending the poll budget (~8% of red
+  // events have a [skip ci] parent per the backtest).
   const SKIP_CI_RE = /\[(skip ci|ci skip)\]/i;
   const { data: parentCommit } = await github.rest.git.getCommit({ owner, repo, commit_sha: parentSha });
   let skipCiSource = SKIP_CI_RE.test(parentCommit.message) ? 'commit message' : null;
@@ -101,7 +111,8 @@ async function findBaseline({
     if (parentPulls.some((pr) => SKIP_CI_RE.test(pr.title))) skipCiSource = 'associated PR title';
   }
   if (skipCiSource) {
-    log(`Parent ${parentSha} is [skip ci] (${skipCiSource}) -- no push run will ever exist for it; abstaining immediately without polling.`);
+    log(`Parent ${parentSha} is marked [skip ci] (${skipCiSource}); by policy it carries no baseline signal ` +
+      '(accepted gap, see BACKTEST.md). Abstaining immediately without polling.');
     return { decision: 'abstain', reason: 'parent-skip-ci', parentSha, parentRuns: [] };
   }
 

--- a/.github/scripts/sanity-notify/culprits.js
+++ b/.github/scripts/sanity-notify/culprits.js
@@ -59,6 +59,8 @@ function describeRuns(runs) {
 //    yet, or some run not yet final) -> sleep and re-poll until maxWaitMs
 //                                       -> { decision: 'abstain', reason: 'timeout' }.
 // A commit with no parent aborts with { decision: 'abstain', reason: 'no-parent' }.
+// A [skip ci] parent aborts upfront with { decision: 'abstain', reason: 'parent-skip-ci' }
+// (see the comment at that check).
 async function findBaseline({
   github,
   owner,
@@ -78,6 +80,29 @@ async function findBaseline({
   if (!parentSha) {
     warn(`${headSha} has no parent commit; skipping.`);
     return { decision: 'abstain', reason: 'no-parent', parentSha: null, parentRuns: [] };
+  }
+
+  // Known, ACCEPTED gap (maintainer decision, 2026-08-21): a [skip ci]
+  // parent never gets a push run, so its greenness is unknowable under the
+  // one-commit-back rule, and the break on top of it deliberately goes
+  // un-notified. Detect that upfront -- from the parent's commit message or
+  // an associated PR title -- and abstain immediately instead of
+  // discovering it by exhausting the poll budget (~8% of red events have a
+  // [skip ci] parent per the backtest; see BACKTEST.md).
+  const SKIP_CI_RE = /\[(skip ci|ci skip)\]/i;
+  const { data: parentCommit } = await github.rest.git.getCommit({ owner, repo, commit_sha: parentSha });
+  let skipCiSource = SKIP_CI_RE.test(parentCommit.message) ? 'commit message' : null;
+  if (!skipCiSource) {
+    const { data: parentPulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+      owner,
+      repo,
+      commit_sha: parentSha,
+    });
+    if (parentPulls.some((pr) => SKIP_CI_RE.test(pr.title))) skipCiSource = 'associated PR title';
+  }
+  if (skipCiSource) {
+    log(`Parent ${parentSha} is [skip ci] (${skipCiSource}) -- no push run will ever exist for it; abstaining immediately without polling.`);
+    return { decision: 'abstain', reason: 'parent-skip-ci', parentSha, parentRuns: [] };
   }
 
   // head_sha is an exact-match filter (requires the full 40-char sha); the

--- a/.github/scripts/sanity-notify/culprits.js
+++ b/.github/scripts/sanity-notify/culprits.js
@@ -1,0 +1,193 @@
+'use strict';
+
+// Decision logic for .github/workflows/sanity-tests-slack-notify.yaml.
+//
+// ==================== ONE-COMMIT-BACK EDGE DETECTION ====================
+// Only the immediate git parent of the failing commit is ever consulted
+// (main is linear via merge queue). If any of the parent's push runs
+// finally succeeded, main was green immediately before this commit -- so
+// this commit broke it. If the parent conclusively never succeeded, or
+// never settles within the wait budget, abstain -- never guess further
+// back.
+//
+// The parent's runs are resolved by exact head_sha -- a point lookup keyed
+// by the sha we ask for -- never by position in a recency-sorted
+// listWorkflowRuns page, which is not guaranteed to be a complete or
+// current window. A lagging index can make the point lookup MISS
+// (-> keep polling, eventually abstain); it can never return the wrong
+// commit's runs. The diff is always exactly one commit (parent..current),
+// which structurally bounds who one message can blame.
+//
+// All functions take an octokit-compatible client (`github`) plus plain
+// params, and findBaseline takes injectable `now`/`sleep`/`log`/`warn`,
+// so the exact same code runs in the workflow (via actions/github-script),
+// in unit tests (fake timers), and in backtests (no waiting).
+
+// Must stay in sync with MAX_ATTEMPTS in _auto-retry-post-commit.yaml.
+const MAX_ATTEMPTS = 3;
+
+const DEFAULT_WORKFLOW_ID = 'sanity-tests.yaml';
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_WAIT_MS = 270 * 60 * 1000; // caller's job timeout minus headroom for later steps
+
+// Mirrors the notify workflow's own top-level finality gate, applied to a
+// PARENT run: success is always final; 'failure' is only final once the
+// auto-retry budget is exhausted -- before that, a retry may still be
+// queued even though the attempt already shows status 'completed'. Every
+// other conclusion is final immediately, since only 'failure' triggers a
+// retry at all.
+function isFinal(run) {
+  return run.status === 'completed' &&
+    (run.conclusion !== 'failure' || run.run_attempt >= MAX_ATTEMPTS);
+}
+
+function describeRuns(runs) {
+  return runs.length === 0
+    ? 'no runs found'
+    : runs.map((r) => `#${r.run_number}=${r.conclusion ?? r.status}(attempt ${r.run_attempt})`).join(', ');
+}
+
+// Resolves whether the commit at `headSha` freshly broke main.
+//
+// Decision per poll of the parent's push runs (a single head_sha can have
+// several push runs -- duplicate deliveries have produced two success runs
+// for one sha -- so ALL of them are fetched):
+//  - any FINAL success               -> { decision: 'notify' } immediately.
+//  - all found runs final,
+//    none succeeded                  -> { decision: 'abstain', reason: 'conclusively-red' } immediately.
+//  - anything else (no runs indexed
+//    yet, or some run not yet final) -> sleep and re-poll until maxWaitMs
+//                                       -> { decision: 'abstain', reason: 'timeout' }.
+// A commit with no parent aborts with { decision: 'abstain', reason: 'no-parent' }.
+async function findBaseline({
+  github,
+  owner,
+  repo,
+  headSha,
+  workflowId = DEFAULT_WORKFLOW_ID,
+  branch = 'main',
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  maxWaitMs = DEFAULT_MAX_WAIT_MS,
+  now = Date.now,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  log = () => {},
+  warn = () => {},
+}) {
+  const { data: commit } = await github.rest.git.getCommit({ owner, repo, commit_sha: headSha });
+  const parentSha = commit.parents[0]?.sha;
+  if (!parentSha) {
+    warn(`${headSha} has no parent commit; skipping.`);
+    return { decision: 'abstain', reason: 'no-parent', parentSha: null, parentRuns: [] };
+  }
+
+  // head_sha is an exact-match filter (requires the full 40-char sha); the
+  // event/branch filters exclude the merge_group run of the same sha.
+  const fetchParentRuns = async () => {
+    const { data: resp } = await github.rest.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: workflowId,
+      head_sha: parentSha,
+      branch,
+      event: 'push',
+      per_page: 10,
+    });
+    return resp.workflow_runs;
+  };
+
+  const startedAtMs = now();
+  for (;;) {
+    const parentRuns = await fetchParentRuns();
+
+    const baselineRun = parentRuns.find((r) => isFinal(r) && r.conclusion === 'success');
+    if (baselineRun) { // a confirmed success decides it; never wait on sibling runs
+      log(`Parent ${parentSha} was green (run #${baselineRun.run_number}); ${headSha} broke main.`);
+      return { decision: 'notify', reason: 'parent-green', parentSha, baselineRun, parentRuns };
+    }
+
+    if (parentRuns.length > 0 && parentRuns.every(isFinal)) {
+      log(`Parent ${parentSha} conclusively never succeeded (${describeRuns(parentRuns)}); main may already be red. Abstaining.`);
+      return { decision: 'abstain', reason: 'conclusively-red', parentSha, parentRuns };
+    }
+
+    const elapsedMs = now() - startedAtMs;
+    const elapsedMin = Math.round(elapsedMs / 60000);
+    if (elapsedMs + pollIntervalMs > maxWaitMs) {
+      warn(`Timed out after ${elapsedMin} min waiting for parent ${parentSha} to settle (${describeRuns(parentRuns)}); abstaining.`);
+      return { decision: 'abstain', reason: 'timeout', parentSha, parentRuns };
+    }
+    log(`[${elapsedMin} min elapsed] Parent ${parentSha} not settled yet (${describeRuns(parentRuns)}); polling again in ${pollIntervalMs / 60000} min.`);
+    await sleep(pollIntervalMs);
+  }
+}
+
+// PR titles and commit subjects are attacker-controlled (anyone who can
+// open a PR) and end up inside Slack `<url|label>` mrkdwn links -- they
+// must be entity-escaped the same way notify-slack-on-mention.yaml escapes
+// user-supplied text, or a crafted title could break out of the link
+// syntax or smuggle in a broadcast mention like <!subteam^...>.
+function escapeSlack(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Builds the culprit entry list for the baseSha..headSha range (exactly one
+// commit under the one-commit-back rule, but written against the compare
+// API so it stays correct regardless). PRs are deduped by number; a commit
+// with no associated PR (direct push, or API lag right after merge) falls
+// back to the commit's own author so a culprit is never silently dropped.
+async function buildCulpritEntries({ github, owner, repo, baseSha, headSha }) {
+  const { data: cmp } = await github.rest.repos.compareCommits({
+    owner,
+    repo,
+    base: baseSha,
+    head: headSha,
+  });
+
+  const entries = [];
+  const seenPrNumbers = new Set();
+
+  for (const commit of cmp.commits) {
+    const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+      owner,
+      repo,
+      commit_sha: commit.sha,
+    });
+
+    if (pulls.length > 0) {
+      for (const pr of pulls) {
+        if (seenPrNumbers.has(pr.number)) continue;
+        seenPrNumbers.add(pr.number);
+        entries.push({
+          type: 'pr',
+          number: pr.number,
+          url: pr.html_url,
+          title: escapeSlack(pr.title),
+          authorLogin: pr.user ? pr.user.login : null,
+        });
+      }
+    } else {
+      entries.push({
+        type: 'commit',
+        sha: commit.sha,
+        url: commit.html_url,
+        title: escapeSlack(commit.commit.message.split('\n')[0]),
+        authorLogin: commit.author ? commit.author.login : null,
+      });
+    }
+  }
+
+  const logins = [...new Set(entries.map((e) => e.authorLogin).filter((l) => l !== null))].sort();
+  return { entries, logins };
+}
+
+module.exports = {
+  MAX_ATTEMPTS,
+  DEFAULT_WORKFLOW_ID,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_MAX_WAIT_MS,
+  isFinal,
+  describeRuns,
+  escapeSlack,
+  findBaseline,
+  buildCulpritEntries,
+};

--- a/.github/scripts/sanity-notify/culprits.test.js
+++ b/.github/scripts/sanity-notify/culprits.test.js
@@ -1,0 +1,259 @@
+'use strict';
+
+// Unit tests for culprits.js (the decision logic behind
+// sanity-tests-slack-notify.yaml). Zero dependencies -- run with:
+//
+//   node --test .github/scripts/sanity-notify/
+//
+// Timers are injected (now/sleep), so multi-hour poll scenarios run
+// instantly against the exact production code path.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  isFinal,
+  findBaseline,
+  buildCulpritEntries,
+  escapeSlack,
+  DEFAULT_POLL_INTERVAL_MS,
+  DEFAULT_MAX_WAIT_MS,
+} = require('./culprits.js');
+
+// ----------------------------- helpers -----------------------------
+
+const run = (n, conclusion, attempt, status = 'completed') => ({
+  run_number: n,
+  status,
+  conclusion,
+  run_attempt: attempt,
+  html_url: `https://example.test/runs/${n}`,
+});
+
+// Builds a harness around findBaseline: fake clock, scripted sequence of
+// listWorkflowRuns responses (last one repeats), captured logs/outputs.
+function harness({ parents = [{ sha: 'PARENT' }], responses, ...overrides } = {}) {
+  let fakeNow = 0;
+  let lookups = 0;
+  const logs = [];
+  const github = {
+    rest: {
+      git: {
+        getCommit: async () => ({ data: { parents } }),
+      },
+      actions: {
+        listWorkflowRuns: async (params) => {
+          assert.equal(params.head_sha, 'PARENT'); // always the exact parent sha, never a recency scan
+          assert.equal(params.event, 'push');
+          const r = responses[Math.min(lookups, responses.length - 1)];
+          lookups += 1;
+          return { data: { workflow_runs: r } };
+        },
+      },
+    },
+  };
+  const call = () => findBaseline({
+    github,
+    owner: 'o',
+    repo: 'r',
+    headSha: 'CURRENT',
+    now: () => fakeNow,
+    sleep: async (ms) => { fakeNow += ms; },
+    log: (m) => logs.push(m),
+    warn: (m) => logs.push('WARN: ' + m),
+    ...overrides,
+  });
+  return { call, logs, elapsed: () => fakeNow, lookups: () => lookups };
+}
+
+// ----------------------------- isFinal -----------------------------
+
+test('isFinal: success is final at any attempt', () => {
+  assert.equal(isFinal(run(1, 'success', 1)), true);
+});
+
+test('isFinal: failure is final only once the retry budget is exhausted', () => {
+  assert.equal(isFinal(run(1, 'failure', 1)), false);
+  assert.equal(isFinal(run(1, 'failure', 2)), false);
+  assert.equal(isFinal(run(1, 'failure', 3)), true);
+  assert.equal(isFinal(run(1, 'failure', 4)), true); // manual re-run past the budget
+});
+
+test('isFinal: non-failure terminal conclusions are final immediately', () => {
+  for (const c of ['cancelled', 'skipped', 'timed_out', 'startup_failure']) {
+    assert.equal(isFinal(run(1, c, 1)), true, c);
+  }
+});
+
+test('isFinal: a run that is not completed is never final', () => {
+  assert.equal(isFinal(run(1, null, 1, 'in_progress')), false);
+  assert.equal(isFinal(run(1, null, 2, 'queued')), false);
+});
+
+// --------------------------- findBaseline ---------------------------
+
+test('settled green parent: notifies immediately with zero waiting', async () => {
+  const h = harness({ responses: [[run(100, 'success', 1)]] });
+  const result = await h.call();
+  assert.equal(result.decision, 'notify');
+  assert.equal(result.baselineRun.run_number, 100);
+  assert.equal(result.parentSha, 'PARENT');
+  assert.equal(h.lookups(), 1);
+  assert.equal(h.elapsed(), 0);
+});
+
+test('a confirmed success decides it even with a pending sibling run', async () => {
+  const h = harness({ responses: [[run(100, 'success', 1), run(101, null, 1, 'in_progress')]] });
+  const result = await h.call();
+  assert.equal(result.decision, 'notify');
+  assert.equal(h.elapsed(), 0);
+});
+
+test('any success among many duplicate run entries wins', async () => {
+  const h = harness({
+    responses: [[run(100, 'failure', 3), run(101, 'cancelled', 1), run(102, 'success', 1)]],
+  });
+  const result = await h.call();
+  assert.equal(result.decision, 'notify');
+  assert.equal(result.baselineRun.run_number, 102);
+});
+
+test('settled red parent (failure at max attempts): abstains immediately', async () => {
+  const h = harness({ responses: [[run(100, 'failure', 3)]] });
+  const result = await h.call();
+  assert.equal(result.decision, 'abstain');
+  assert.equal(result.reason, 'conclusively-red');
+  assert.equal(h.elapsed(), 0);
+});
+
+test('settled cancelled/skipped parent: abstains immediately (observed, never green)', async () => {
+  for (const c of ['cancelled', 'skipped']) {
+    const h = harness({ responses: [[run(100, c, 1)]] });
+    const result = await h.call();
+    assert.equal(result.decision, 'abstain', c);
+    assert.equal(result.reason, 'conclusively-red', c);
+  }
+});
+
+test('parent mid-retry (failure attempt 1) polls instead of abstaining, then abstains once conclusively red', async () => {
+  const h = harness({
+    responses: [
+      [run(100, 'failure', 1)],            // completed but NOT final: retry may be coming
+      [run(100, null, 2, 'in_progress')],  // retry running
+      [run(100, 'failure', 3)],            // budget exhausted: final red
+    ],
+  });
+  const result = await h.call();
+  assert.equal(result.decision, 'abstain');
+  assert.equal(result.reason, 'conclusively-red');
+  assert.equal(h.lookups(), 3);
+  assert.equal(h.elapsed(), 2 * DEFAULT_POLL_INTERVAL_MS);
+});
+
+test('parent mid-retry that eventually succeeds: notifies', async () => {
+  const h = harness({
+    responses: [
+      [run(100, 'failure', 1)],
+      [run(100, 'success', 2)],
+    ],
+  });
+  const result = await h.call();
+  assert.equal(result.decision, 'notify');
+  assert.equal(h.lookups(), 2);
+});
+
+test('no run ever appears: abstains on timeout after the full wait budget', async () => {
+  const h = harness({ responses: [[]] });
+  const result = await h.call();
+  assert.equal(result.decision, 'abstain');
+  assert.equal(result.reason, 'timeout');
+  // Sleeps only while elapsed + interval <= budget.
+  assert.equal(h.elapsed(), Math.floor(DEFAULT_MAX_WAIT_MS / DEFAULT_POLL_INTERVAL_MS) * DEFAULT_POLL_INTERVAL_MS);
+  assert.ok(h.logs.at(-1).startsWith('WARN: Timed out'));
+});
+
+test('maxWaitMs of zero never sleeps: undecided history resolves to timeout instantly (backtest mode)', async () => {
+  const h = harness({
+    responses: [[run(100, 'failure', 1)]],
+    maxWaitMs: 0,
+    sleep: async () => { throw new Error('sleep must not be called'); },
+  });
+  const result = await h.call();
+  assert.equal(result.decision, 'abstain');
+  assert.equal(result.reason, 'timeout');
+  assert.equal(h.lookups(), 1);
+});
+
+test('root commit (no parent): abstains without any run lookup', async () => {
+  const h = harness({ parents: [], responses: [[run(100, 'success', 1)]] });
+  const result = await h.call();
+  assert.equal(result.decision, 'abstain');
+  assert.equal(result.reason, 'no-parent');
+  assert.equal(h.lookups(), 0);
+});
+
+// ------------------------- buildCulpritEntries -------------------------
+
+function compareGithub({ commits, pullsBySha }) {
+  return {
+    rest: {
+      repos: {
+        compareCommits: async () => ({ data: { commits } }),
+        listPullRequestsAssociatedWithCommit: async ({ commit_sha }) =>
+          ({ data: pullsBySha[commit_sha] ?? [] }),
+      },
+    },
+  };
+}
+
+const commitObj = (sha, subject, login) => ({
+  sha,
+  html_url: `https://example.test/commit/${sha}`,
+  commit: { message: `${subject}\n\nbody` },
+  author: login ? { login } : null,
+});
+
+test('culprits: PR-associated commit yields one deduped PR entry per PR', async () => {
+  const github = compareGithub({
+    commits: [commitObj('C1', 'subj', 'alice')],
+    pullsBySha: {
+      C1: [
+        { number: 7, html_url: 'u7', title: 'Fix <thing> & stuff', user: { login: 'alice' } },
+        { number: 7, html_url: 'u7', title: 'dup delivery', user: { login: 'alice' } },
+        { number: 9, html_url: 'u9', title: 'other PR containing commit', user: { login: 'bob' } },
+      ],
+    },
+  });
+  const { entries, logins } = await buildCulpritEntries({ github, owner: 'o', repo: 'r', baseSha: 'B', headSha: 'H' });
+  assert.equal(entries.length, 2);
+  assert.deepEqual(entries.map((e) => e.number), [7, 9]);
+  assert.equal(entries[0].title, 'Fix &lt;thing&gt; &amp; stuff'); // Slack-escaped
+  assert.deepEqual(logins, ['alice', 'bob']);
+});
+
+test('culprits: commit with zero associated PRs falls back to the commit author', async () => {
+  const github = compareGithub({
+    commits: [commitObj('C1', 'direct push <oops>', 'carol')],
+    pullsBySha: {},
+  });
+  const { entries, logins } = await buildCulpritEntries({ github, owner: 'o', repo: 'r', baseSha: 'B', headSha: 'H' });
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].type, 'commit');
+  assert.equal(entries[0].title, 'direct push &lt;oops&gt;');
+  assert.deepEqual(logins, ['carol']);
+});
+
+test('culprits: null authors are kept as entries but excluded from mention logins', async () => {
+  const github = compareGithub({
+    commits: [commitObj('C1', 'subj', null)],
+    pullsBySha: {},
+  });
+  const { entries, logins } = await buildCulpritEntries({ github, owner: 'o', repo: 'r', baseSha: 'B', headSha: 'H' });
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].authorLogin, null);
+  assert.deepEqual(logins, []);
+});
+
+test('escapeSlack neutralizes mrkdwn metacharacters', () => {
+  assert.equal(escapeSlack('<!channel> & <http://x|y>'), '&lt;!channel&gt; &amp; &lt;http://x|y&gt;');
+});

--- a/.github/scripts/sanity-notify/culprits.test.js
+++ b/.github/scripts/sanity-notify/culprits.test.js
@@ -32,14 +32,29 @@ const run = (n, conclusion, attempt, status = 'completed') => ({
 
 // Builds a harness around findBaseline: fake clock, scripted sequence of
 // listWorkflowRuns responses (last one repeats), captured logs/outputs.
-function harness({ parents = [{ sha: 'PARENT' }], responses, ...overrides } = {}) {
+// parentMessage/parentPulls feed the [skip ci] short-circuit check.
+function harness({
+  parents = [{ sha: 'PARENT' }],
+  parentMessage = 'ordinary commit subject\n\nbody',
+  parentPulls = [],
+  responses,
+  ...overrides
+} = {}) {
   let fakeNow = 0;
   let lookups = 0;
   const logs = [];
   const github = {
     rest: {
       git: {
-        getCommit: async () => ({ data: { parents } }),
+        getCommit: async ({ commit_sha }) => commit_sha === 'CURRENT'
+          ? { data: { parents, message: 'current commit subject' } }
+          : { data: { parents: [{ sha: 'GRANDPARENT' }], message: parentMessage } },
+      },
+      repos: {
+        listPullRequestsAssociatedWithCommit: async ({ commit_sha }) => {
+          assert.equal(commit_sha, 'PARENT'); // skip-ci check inspects the parent only
+          return { data: parentPulls };
+        },
       },
       actions: {
         listWorkflowRuns: async (params) => {
@@ -190,6 +205,51 @@ test('root commit (no parent): abstains without any run lookup', async () => {
   assert.equal(result.decision, 'abstain');
   assert.equal(result.reason, 'no-parent');
   assert.equal(h.lookups(), 0);
+});
+
+// ----------------- [skip ci] parent short-circuit (accepted gap) -----------------
+
+test('[skip ci] in the parent commit message: abstains immediately, no run lookup, no sleep', async () => {
+  for (const msg of ['[skip ci] docs tweak', 'prefix [SKIP CI] suffix', '[ci skip] chore']) {
+    const h = harness({
+      parentMessage: msg,
+      responses: [[run(100, 'success', 1)]],
+      sleep: async () => { throw new Error('sleep must not be called'); },
+    });
+    const result = await h.call();
+    assert.equal(result.decision, 'abstain', msg);
+    assert.equal(result.reason, 'parent-skip-ci', msg);
+    assert.equal(h.lookups(), 0, msg); // never even queried the parent's runs
+    assert.match(h.logs.at(-1), /abstaining immediately without polling/);
+  }
+});
+
+test('[skip ci] only in an associated PR title of the parent: same immediate abstain', async () => {
+  const h = harness({
+    parentMessage: 'ordinary subject with no marker',
+    parentPulls: [
+      { number: 1, title: 'normal PR' },
+      { number: 2, title: '[skip ci] Update README' },
+    ],
+    responses: [[run(100, 'success', 1)]],
+    sleep: async () => { throw new Error('sleep must not be called'); },
+  });
+  const result = await h.call();
+  assert.equal(result.decision, 'abstain');
+  assert.equal(result.reason, 'parent-skip-ci');
+  assert.equal(h.lookups(), 0);
+});
+
+test('no run found and parent is NOT [skip ci]: still falls through to poll-then-timeout', async () => {
+  const h = harness({
+    parentMessage: 'a real change whose retry workflow silently died',
+    parentPulls: [{ number: 3, title: 'a real PR title' }],
+    responses: [[]],
+  });
+  const result = await h.call();
+  assert.equal(result.decision, 'abstain');
+  assert.equal(result.reason, 'timeout'); // NOT parent-skip-ci; the stuck-retry category is unaffected
+  assert.equal(h.elapsed(), Math.floor(DEFAULT_MAX_WAIT_MS / DEFAULT_POLL_INTERVAL_MS) * DEFAULT_POLL_INTERVAL_MS);
 });
 
 // ------------------------- buildCulpritEntries -------------------------

--- a/.github/scripts/sanity-notify/culprits.test.js
+++ b/.github/scripts/sanity-notify/culprits.test.js
@@ -220,7 +220,7 @@ test('[skip ci] in the parent commit message: abstains immediately, no run looku
     assert.equal(result.decision, 'abstain', msg);
     assert.equal(result.reason, 'parent-skip-ci', msg);
     assert.equal(h.lookups(), 0, msg); // never even queried the parent's runs
-    assert.match(h.logs.at(-1), /abstaining immediately without polling/);
+    assert.match(h.logs.at(-1), /by policy it carries no baseline signal .*Abstaining immediately without polling/);
   }
 });
 

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -187,39 +187,56 @@ jobs:
             const currentHeadSha = process.env.CURRENT_HEAD_SHA;
 
             // ==================== BASELINE LOOKUP (edge detection) ====================
-            // Deliberately NOT a scan over "the N most recent runs": that trusts a
-            // recency-sorted listWorkflowRuns page to be a complete, current window,
-            // which is not guaranteed. The API can transiently serve a stale or
-            // misaligned page, silently resolving "the previous push run" to the
-            // wrong page's first entry with no signal that anything went wrong.
-            // That is exactly what happened on 2026-08-21: a page that should have
-            // reached back ~2 days instead bottomed out 9 days early, and the old
-            // walk-back confidently diffed against a 9-day-old baseline, blaming
-            // 250 commits and pinging 89 people in one Slack message.
-            //
-            // Instead, do what a human does (edge detection): walk the git commit
-            // graph one parent at a time (main is linear via merge queue) and fetch
-            // each parent's run by exact head_sha -- an indexed point lookup keyed
-            // by the sha we ask for, not by position in a list. A stale index can
-            // make this MISS (empty result -> hop onward, or abstain loudly at the
-            // hop cap); it can never hand back the wrong commit's run.
+            // Find the previous meaningful run by walking the commit graph (main is
+            // linear via merge queue) and resolving each parent commit's run by
+            // exact head_sha -- a point lookup keyed by the sha we ask for. "The
+            // previous run" is never derived from a recency-sorted listWorkflowRuns
+            // page: such a page is not guaranteed to be a complete or current
+            // window, and a wrong page is indistinguishable from a right one. A
+            // lagging index can make a point lookup MISS, but never return the
+            // wrong commit's run; misses are retried and then abstained on, never
+            // guessed at.
             //
             // Per parent commit:
-            //  - no push run at all -> a merge-queue batch tip covered it, or brief
-            //    index lag; hop to ITS parent (the commit stays in the blame range).
-            //  - still in progress (e.g. mid auto-retry-attempt) -> the true
-            //    completion order is ambiguous; abstain rather than misattribute.
-            //    A later red commit's own event re-runs this edge detection.
-            //  - cancelled/skipped -> no real red/green signal; hop onward so it
-            //    can't permanently swallow a break.
-            //  - success -> fresh green->red transition; use it as the diff baseline.
+            //  - run not found after retries -> cannot distinguish "no run exists"
+            //    from "run exists but not yet indexed"; a hidden failed/running run
+            //    would make any hop a false green->red edge with misattributed
+            //    blame, so abstain and leave it to a human.
+            //  - still in progress (e.g. mid auto-retry-attempt) -> completion
+            //    order is ambiguous; abstain. A later red commit's own event
+            //    re-runs this edge detection.
+            //  - cancelled/skipped -> an OBSERVED run that carries no red/green
+            //    signal; hop to the next parent so it can't swallow a break.
+            //  - success -> fresh green->red transition; use as the diff baseline.
             //  - failure (or any other bad terminal conclusion) -> main was already
             //    red before us; stay silent to avoid repeat/duplicate pings.
-            //
-            // MAX_PARENT_HOPS also bounds blast radius by construction: the culprit
-            // diff can never exceed this many commits, so a mass ping like the
-            // 2026-08-21 one is structurally impossible here.
-            const MAX_PARENT_HOPS = 30;
+            const MAX_PARENT_HOPS = 30;   // bounds how far back the baseline may be
+            const MAX_MENTIONS = 15;      // bounds distinct @-mentions in one message (enforced below)
+            const LOOKUP_ATTEMPTS = 3;
+            const LOOKUP_RETRY_DELAY_MS = 15000;
+
+            // head_sha is an exact-match filter (requires the full 40-char sha);
+            // the event/branch filters exclude the merge_group run of the same
+            // sha. If the same sha were ever pushed twice, [0] is the most recent.
+            const findPushRun = async (headSha) => {
+              for (let attempt = 1; attempt <= LOOKUP_ATTEMPTS; attempt++) {
+                const { data: runsResp } = await github.rest.actions.listWorkflowRuns({
+                  owner,
+                  repo,
+                  workflow_id: 'sanity-tests.yaml',
+                  head_sha: headSha,
+                  branch: 'main',
+                  event: 'push',
+                  per_page: 5,
+                });
+                if (runsResp.workflow_runs.length > 0) return runsResp.workflow_runs[0];
+                if (attempt < LOOKUP_ATTEMPTS) {
+                  core.info(`No "Sanity tests" push run indexed for ${headSha} yet (attempt ${attempt}/${LOOKUP_ATTEMPTS}); retrying in ${LOOKUP_RETRY_DELAY_MS / 1000}s.`);
+                  await new Promise((resolve) => setTimeout(resolve, LOOKUP_RETRY_DELAY_MS));
+                }
+              }
+              return null;
+            };
 
             let sha = currentHeadSha;
             let baseline = null;
@@ -233,25 +250,13 @@ jobs:
                 return;
               }
 
-              // head_sha is an exact-match filter (full 40-char sha; partial shas
-              // match nothing). The event/branch filters exclude the merge_group
-              // run of the same sha. At most one push run per sha in practice; if
-              // the same sha were ever pushed twice, [0] is the most recent.
-              const { data: runsResp } = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: 'sanity-tests.yaml',
-                head_sha: parentSha,
-                branch: 'main',
-                event: 'push',
-                per_page: 5,
-              });
-              const run = runsResp.workflow_runs[0];
+              const run = await findPushRun(parentSha);
 
               if (!run) {
-                core.info(`No "Sanity tests" push run for parent ${parentSha} (merge-queue batch or index lag); hopping to its parent.`);
-                sha = parentSha;
-                continue;
+                core.warning(`No "Sanity tests" push run found for parent ${parentSha} after ${LOOKUP_ATTEMPTS} attempts. ` +
+                  `"Never ran" is indistinguishable from "ran but not yet indexed", so hopping past it could fabricate a green->red edge. Abstaining (needs a human look).`);
+                core.setOutput('should_notify', 'false');
+                return;
               }
               if (run.status !== 'completed') {
                 core.info(`Run #${run.run_number} for parent ${parentSha} is still ${run.status}; completion order is ambiguous. Abstaining.`);
@@ -264,9 +269,6 @@ jobs:
                 continue;
               }
               if (run.conclusion === 'success') {
-                // Log the happy path too: the old code assigned its baseline
-                // silently, which made the 2026-08-21 incident needlessly hard to
-                // reconstruct from logs.
                 core.info(`Baseline: run #${run.run_number} (${parentSha}), ${hop + 1} commit(s) back from ${currentHeadSha}.`);
                 baseline = run;
                 break;
@@ -337,12 +339,29 @@ jobs:
             }
 
             core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} between baseline run #${baseline.run_number} (${baseline.head_sha}) and ${currentHeadSha}`);
+
+            // One commit can be associated with multiple PRs, so MAX_PARENT_HOPS
+            // alone does not bound how many people one message mentions. Above
+            // MAX_MENTIONS distinct authors, send a summary without @-mentions
+            // instead of a mass ping.
+            const logins = [...new Set(entries.map(e => e.authorLogin).filter(l => l !== null))].sort();
+            if (logins.length > MAX_MENTIONS) {
+              const compareUrl = `${context.serverUrl}/${owner}/${repo}/compare/${baseline.head_sha}...${currentHeadSha}`;
+              core.warning(`${logins.length} distinct authors exceeds MAX_MENTIONS (${MAX_MENTIONS}); sending a summary-only notice without @-mentions.`);
+              core.setOutput('mention_cap_exceeded', 'true');
+              core.setOutput('summary_line',
+                `${entries.length} PRs/commits from ${logins.length} authors landed since the last green run -- too many to @-mention individually: <${compareUrl}|full comparison>`);
+              core.setOutput('entries', JSON.stringify([]));
+              core.setOutput('logins_json', JSON.stringify([]));
+              return;
+            }
+
+            core.setOutput('mention_cap_exceeded', 'false');
             core.setOutput('entries', JSON.stringify(entries));
-            core.setOutput('logins_json',
-              JSON.stringify([...new Set(entries.map(e => e.authorLogin).filter(l => l !== null))].sort()));
+            core.setOutput('logins_json', JSON.stringify(logins));
 
       - name: Checkout resolve-slack-mentions action
-        if: steps.culprits.outputs.should_notify == 'true'
+        if: steps.culprits.outputs.should_notify == 'true' && steps.culprits.outputs.mention_cap_exceeded != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 5
         with:
@@ -351,7 +370,7 @@ jobs:
 
       - name: Resolve Slack mentions for culprits
         id: mentions
-        if: steps.culprits.outputs.should_notify == 'true'
+        if: steps.culprits.outputs.should_notify == 'true' && steps.culprits.outputs.mention_cap_exceeded != 'true'
         uses: ./.github/actions/resolve-slack-mentions
         with:
           github-logins: ${{ steps.culprits.outputs.logins_json }}
@@ -369,13 +388,22 @@ jobs:
           MENTIONS_JSON: ${{ steps.mentions.outputs.mentions-json }}
           FAILING_RUN_URL: ${{ steps.context.outputs.html_url }}
           PREV_RUN_URL: ${{ steps.culprits.outputs.prev_run_url }}
+          MENTION_CAP_EXCEEDED: ${{ steps.culprits.outputs.mention_cap_exceeded }}
+          SUMMARY_LINE: ${{ steps.culprits.outputs.summary_line }}
         run: |
           set -euo pipefail
 
-          LINES=$(echo "$ENTRIES_JSON" | jq -r --argjson mentions "$MENTIONS_JSON" '
-            .[] | (if .authorLogin != null then ($mentions[.authorLogin] // ("@" + .authorLogin)) else "(unknown author)" end) as $who
-            | "\($who) <\(.url)|\(if .type == "pr" then "#\(.number) - \(.title)" else .title end)> broke sanity."
-          ')
+          if [ "$MENTION_CAP_EXCEEDED" = "true" ]; then
+            # Too many distinct authors for individual @-mentions (see the
+            # culprits step); post its pre-built summary line instead. The
+            # mentions step was skipped, so MENTIONS_JSON is empty here.
+            LINES="$SUMMARY_LINE"
+          else
+            LINES=$(echo "$ENTRIES_JSON" | jq -r --argjson mentions "$MENTIONS_JSON" '
+              .[] | (if .authorLogin != null then ($mentions[.authorLogin] // ("@" + .authorLogin)) else "(unknown author)" end) as $who
+              | "\($who) <\(.url)|\(if .type == "pr" then "#\(.number) - \(.title)" else .title end)> broke sanity."
+            ')
+          fi
 
           TEXT="${LINES}"$'\n'"Failing run on that commit: ${FAILING_RUN_URL}"$'\n'"Previous passing run: ${PREV_RUN_URL}"$'\n'"Please fix."
 

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -179,73 +179,118 @@ jobs:
         if: steps.claim.outputs.already_notified != 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
-          CURRENT_RUN_NUMBER: ${{ steps.context.outputs.run_number }}
           CURRENT_HEAD_SHA: ${{ steps.context.outputs.head_sha }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const currentRunNumber = Number(process.env.CURRENT_RUN_NUMBER);
             const currentHeadSha = process.env.CURRENT_HEAD_SHA;
 
-            const { data: runsResp } = await github.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_id: 'sanity-tests.yaml',
-              branch: 'main',
-              event: 'push',
-              per_page: 100,
-            });
-
-            // Walk backwards (by run_number, not necessarily run_number - 1, since
-            // schedule/dispatch runs of the same workflow interleave and also
-            // consume run_numbers) to find the most recent MEANINGFUL prior state:
-            //  - a still-in-progress run (e.g. mid auto-retry-attempt) makes the
-            //    true completion order ambiguous -- abstain rather than silently
-            //    skip past it and risk misattributing to the wrong set of authors.
-            //  - cancelled/skipped runs carry no real red/green signal -- skip over
-            //    them and keep looking, so they can't permanently swallow a break.
-            //  - success -> this is a fresh green->red transition; use it as baseline.
+            // ==================== BASELINE LOOKUP (edge detection) ====================
+            // Deliberately NOT a scan over "the N most recent runs": that trusts a
+            // recency-sorted listWorkflowRuns page to be a complete, current window,
+            // which is not guaranteed. The API can transiently serve a stale or
+            // misaligned page, silently resolving "the previous push run" to the
+            // wrong page's first entry with no signal that anything went wrong.
+            // That is exactly what happened on 2026-08-21: a page that should have
+            // reached back ~2 days instead bottomed out 9 days early, and the old
+            // walk-back confidently diffed against a 9-day-old baseline, blaming
+            // 250 commits and pinging 89 people in one Slack message.
+            //
+            // Instead, do what a human does (edge detection): walk the git commit
+            // graph one parent at a time (main is linear via merge queue) and fetch
+            // each parent's run by exact head_sha -- an indexed point lookup keyed
+            // by the sha we ask for, not by position in a list. A stale index can
+            // make this MISS (empty result -> hop onward, or abstain loudly at the
+            // hop cap); it can never hand back the wrong commit's run.
+            //
+            // Per parent commit:
+            //  - no push run at all -> a merge-queue batch tip covered it, or brief
+            //    index lag; hop to ITS parent (the commit stays in the blame range).
+            //  - still in progress (e.g. mid auto-retry-attempt) -> the true
+            //    completion order is ambiguous; abstain rather than misattribute.
+            //    A later red commit's own event re-runs this edge detection.
+            //  - cancelled/skipped -> no real red/green signal; hop onward so it
+            //    can't permanently swallow a break.
+            //  - success -> fresh green->red transition; use it as the diff baseline.
             //  - failure (or any other bad terminal conclusion) -> main was already
-            //    red before us; stay silent to avoid re-notifying / re-blaming.
-            const candidates = runsResp.workflow_runs
-              .filter(r => r.run_number < currentRunNumber)
-              .sort((a, b) => b.run_number - a.run_number);
+            //    red before us; stay silent to avoid repeat/duplicate pings.
+            //
+            // MAX_PARENT_HOPS also bounds blast radius by construction: the culprit
+            // diff can never exceed this many commits, so a mass ping like the
+            // 2026-08-21 one is structurally impossible here.
+            const MAX_PARENT_HOPS = 30;
 
-            let prevGood = null;
-            for (const run of candidates) {
+            let sha = currentHeadSha;
+            let baseline = null;
+
+            for (let hop = 0; hop < MAX_PARENT_HOPS; hop++) {
+              const { data: commit } = await github.rest.git.getCommit({ owner, repo, commit_sha: sha });
+              const parentSha = commit.parents[0]?.sha;
+              if (!parentSha) {
+                core.warning(`Reached a root commit walking back from ${currentHeadSha}; no baseline exists. Skipping.`);
+                core.setOutput('should_notify', 'false');
+                return;
+              }
+
+              // head_sha is an exact-match filter (full 40-char sha; partial shas
+              // match nothing). The event/branch filters exclude the merge_group
+              // run of the same sha. At most one push run per sha in practice; if
+              // the same sha were ever pushed twice, [0] is the most recent.
+              const { data: runsResp } = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: 'sanity-tests.yaml',
+                head_sha: parentSha,
+                branch: 'main',
+                event: 'push',
+                per_page: 5,
+              });
+              const run = runsResp.workflow_runs[0];
+
+              if (!run) {
+                core.info(`No "Sanity tests" push run for parent ${parentSha} (merge-queue batch or index lag); hopping to its parent.`);
+                sha = parentSha;
+                continue;
+              }
               if (run.status !== 'completed') {
-                core.info(`Push run #${run.run_number} is still in progress; completion order is ambiguous. Abstaining.`);
+                core.info(`Run #${run.run_number} for parent ${parentSha} is still ${run.status}; completion order is ambiguous. Abstaining.`);
                 core.setOutput('should_notify', 'false');
                 return;
               }
               if (run.conclusion === 'cancelled' || run.conclusion === 'skipped') {
-                core.info(`Push run #${run.run_number} was ${run.conclusion} (no real signal); looking further back.`);
+                core.info(`Run #${run.run_number} for parent ${parentSha} was ${run.conclusion} (no real signal); hopping to its parent.`);
+                sha = parentSha;
                 continue;
               }
               if (run.conclusion === 'success') {
-                prevGood = run;
-              } else {
-                core.info(`Push run #${run.run_number} also did not succeed (${run.conclusion}); ` +
-                  `main is still red from an earlier break. Not re-notifying to avoid repeat/duplicate pings.`);
+                // Log the happy path too: the old code assigned its baseline
+                // silently, which made the 2026-08-21 incident needlessly hard to
+                // reconstruct from logs.
+                core.info(`Baseline: run #${run.run_number} (${parentSha}), ${hop + 1} commit(s) back from ${currentHeadSha}.`);
+                baseline = run;
+                break;
               }
-              break;
+              core.info(`Run #${run.run_number} for parent ${parentSha} also did not succeed (${run.conclusion}); ` +
+                `main is still red from an earlier break. Not re-notifying to avoid repeat/duplicate pings.`);
+              core.setOutput('should_notify', 'false');
+              return;
             }
 
-            if (!prevGood) {
-              core.warning('No usable previous "Sanity tests" push run found on main (either none within the last 100 runs, or main is still red from an earlier break); skipping.');
+            if (!baseline) {
+              core.warning(`No completed "Sanity tests" baseline within ${MAX_PARENT_HOPS} commits back from ${currentHeadSha}; skipping (needs a human look).`);
               core.setOutput('should_notify', 'false');
               return;
             }
 
             core.setOutput('should_notify', 'true');
-            core.setOutput('prev_run_url', prevGood.html_url);
-            core.setOutput('prev_run_number', String(prevGood.run_number));
+            core.setOutput('prev_run_url', baseline.html_url);
+            core.setOutput('prev_run_number', String(baseline.run_number));
 
             const { data: cmp } = await github.rest.repos.compareCommits({
               owner,
               repo,
-              base: prevGood.head_sha,
+              base: baseline.head_sha,
               head: currentHeadSha,
             });
 
@@ -291,7 +336,7 @@ jobs:
               }
             }
 
-            core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} between #${prevGood.run_number} and #${currentRunNumber}`);
+            core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} between baseline run #${baseline.run_number} (${baseline.head_sha}) and ${currentHeadSha}`);
             core.setOutput('entries', JSON.stringify(entries));
             core.setOutput('logins_json',
               JSON.stringify([...new Set(entries.map(e => e.authorLogin).filter(l => l !== null))].sort()));

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -186,113 +186,70 @@ jobs:
             const repo = context.repo.repo;
             const currentHeadSha = process.env.CURRENT_HEAD_SHA;
 
-            // ==================== BASELINE LOOKUP (edge detection) ====================
-            // Find the previous meaningful run by walking the commit graph (main is
-            // linear via merge queue) and resolving each parent commit's run by
-            // exact head_sha -- a point lookup keyed by the sha we ask for. "The
-            // previous run" is never derived from a recency-sorted listWorkflowRuns
-            // page: such a page is not guaranteed to be a complete or current
-            // window, and a wrong page is indistinguishable from a right one. A
-            // lagging index can make a point lookup MISS, but never return the
-            // wrong commit's run; misses are retried and then abstained on, never
-            // guessed at.
+            // ================== ONE-COMMIT-BACK EDGE DETECTION ==================
+            // Only the immediate git parent is ever consulted (main is linear via
+            // merge queue). If any of the parent's push runs succeeded, main was
+            // green immediately before this commit -- so this commit broke it.
+            // Anything else about the parent (failure, cancelled, skipped, still
+            // running, or no run found even after retrying for index lag) means
+            // we cannot be certain main was green immediately before us: abstain,
+            // never guess further back.
             //
-            // Per parent commit:
-            //  - run not found after retries -> cannot distinguish "no run exists"
-            //    from "run exists but not yet indexed"; a hidden failed/running run
-            //    would make any hop a false green->red edge with misattributed
-            //    blame, so abstain and leave it to a human.
-            //  - still in progress (e.g. mid auto-retry-attempt) -> completion
-            //    order is ambiguous; abstain. A later red commit's own event
-            //    re-runs this edge detection.
-            //  - cancelled/skipped -> an OBSERVED run that carries no red/green
-            //    signal; hop to the next parent so it can't swallow a break.
-            //  - success -> fresh green->red transition; use as the diff baseline.
-            //  - failure (or any other bad terminal conclusion) -> main was already
-            //    red before us; stay silent to avoid repeat/duplicate pings.
-            const MAX_PARENT_HOPS = 30;   // bounds how far back the baseline may be
-            const MAX_MENTIONS = 15;      // bounds distinct @-mentions in one message (enforced below)
-            const LOOKUP_ATTEMPTS = 3;
-            const LOOKUP_RETRY_DELAY_MS = 15000;
-
-            // head_sha is an exact-match filter (requires the full 40-char sha);
-            // the event/branch filters exclude the merge_group run of the same
-            // sha. If the same sha were ever pushed twice, [0] is the most recent.
-            const findPushRun = async (headSha) => {
-              for (let attempt = 1; attempt <= LOOKUP_ATTEMPTS; attempt++) {
-                const { data: runsResp } = await github.rest.actions.listWorkflowRuns({
-                  owner,
-                  repo,
-                  workflow_id: 'sanity-tests.yaml',
-                  head_sha: headSha,
-                  branch: 'main',
-                  event: 'push',
-                  per_page: 5,
-                });
-                if (runsResp.workflow_runs.length > 0) return runsResp.workflow_runs[0];
-                if (attempt < LOOKUP_ATTEMPTS) {
-                  core.info(`No "Sanity tests" push run indexed for ${headSha} yet (attempt ${attempt}/${LOOKUP_ATTEMPTS}); retrying in ${LOOKUP_RETRY_DELAY_MS / 1000}s.`);
-                  await new Promise((resolve) => setTimeout(resolve, LOOKUP_RETRY_DELAY_MS));
-                }
-              }
-              return null;
-            };
-
-            let sha = currentHeadSha;
-            let baseline = null;
-
-            for (let hop = 0; hop < MAX_PARENT_HOPS; hop++) {
-              const { data: commit } = await github.rest.git.getCommit({ owner, repo, commit_sha: sha });
-              const parentSha = commit.parents[0]?.sha;
-              if (!parentSha) {
-                core.warning(`Reached a root commit walking back from ${currentHeadSha}; no baseline exists. Skipping.`);
-                core.setOutput('should_notify', 'false');
-                return;
-              }
-
-              const run = await findPushRun(parentSha);
-
-              if (!run) {
-                core.warning(`No "Sanity tests" push run found for parent ${parentSha} after ${LOOKUP_ATTEMPTS} attempts. ` +
-                  `"Never ran" is indistinguishable from "ran but not yet indexed", so hopping past it could fabricate a green->red edge. Abstaining (needs a human look).`);
-                core.setOutput('should_notify', 'false');
-                return;
-              }
-              if (run.status !== 'completed') {
-                core.info(`Run #${run.run_number} for parent ${parentSha} is still ${run.status}; completion order is ambiguous. Abstaining.`);
-                core.setOutput('should_notify', 'false');
-                return;
-              }
-              if (run.conclusion === 'cancelled' || run.conclusion === 'skipped') {
-                core.info(`Run #${run.run_number} for parent ${parentSha} was ${run.conclusion} (no real signal); hopping to its parent.`);
-                sha = parentSha;
-                continue;
-              }
-              if (run.conclusion === 'success') {
-                core.info(`Baseline: run #${run.run_number} (${parentSha}), ${hop + 1} commit(s) back from ${currentHeadSha}.`);
-                baseline = run;
-                break;
-              }
-              core.info(`Run #${run.run_number} for parent ${parentSha} also did not succeed (${run.conclusion}); ` +
-                `main is still red from an earlier break. Not re-notifying to avoid repeat/duplicate pings.`);
+            // The parent's runs are resolved by exact head_sha -- a point lookup
+            // keyed by the sha we ask for -- never by position in a recency-sorted
+            // listWorkflowRuns page, which is not guaranteed to be a complete or
+            // current window. A lagging index can make the point lookup MISS
+            // (-> abstain); it can never return the wrong commit's runs. The diff
+            // is always exactly one commit (parent..current), which structurally
+            // bounds who one message can blame.
+            const { data: commit } = await github.rest.git.getCommit({ owner, repo, commit_sha: currentHeadSha });
+            const parentSha = commit.parents[0]?.sha;
+            if (!parentSha) {
+              core.warning(`${currentHeadSha} has no parent commit; skipping.`);
               core.setOutput('should_notify', 'false');
               return;
             }
 
-            if (!baseline) {
-              core.warning(`No completed "Sanity tests" baseline within ${MAX_PARENT_HOPS} commits back from ${currentHeadSha}; skipping (needs a human look).`);
+            // A single head_sha can have several push runs (duplicate deliveries
+            // have produced two success runs for one sha) -- fetch them all; ANY
+            // success counts as a green parent. head_sha is an exact-match filter
+            // (requires the full 40-char sha); the event/branch filters exclude
+            // the merge_group run of the same sha.
+            const RETRY_DELAYS_MS = [0, 5000, 15000]; // tolerate transient index lag
+            let parentRuns = [];
+            for (const delay of RETRY_DELAYS_MS) {
+              if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+              const { data: resp } = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: 'sanity-tests.yaml',
+                head_sha: parentSha,
+                branch: 'main',
+                event: 'push',
+                per_page: 10,
+              });
+              parentRuns = resp.workflow_runs;
+              if (parentRuns.length > 0) break;
+            }
+
+            const baselineRun = parentRuns.find(r => r.conclusion === 'success');
+            if (!baselineRun) {
+              core.info(parentRuns.length === 0
+                ? `No "Sanity tests" push run found for parent ${parentSha} after retries; abstaining.`
+                : `Parent ${parentSha}'s run(s) never succeeded (${parentRuns.map(r => `#${r.run_number}=${r.conclusion ?? r.status}`).join(', ')}); main may already be red. Abstaining.`);
               core.setOutput('should_notify', 'false');
               return;
             }
 
+            core.info(`Parent ${parentSha} was green (run #${baselineRun.run_number}); ${currentHeadSha} broke main.`);
             core.setOutput('should_notify', 'true');
-            core.setOutput('prev_run_url', baseline.html_url);
-            core.setOutput('prev_run_number', String(baseline.run_number));
+            core.setOutput('prev_run_url', baselineRun.html_url);
+            core.setOutput('prev_run_number', String(baselineRun.run_number));
 
             const { data: cmp } = await github.rest.repos.compareCommits({
               owner,
               repo,
-              base: baseline.head_sha,
+              base: parentSha,
               head: currentHeadSha,
             });
 
@@ -338,30 +295,13 @@ jobs:
               }
             }
 
-            core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} between baseline run #${baseline.run_number} (${baseline.head_sha}) and ${currentHeadSha}`);
-
-            // One commit can be associated with multiple PRs, so MAX_PARENT_HOPS
-            // alone does not bound how many people one message mentions. Above
-            // MAX_MENTIONS distinct authors, send a summary without @-mentions
-            // instead of a mass ping.
-            const logins = [...new Set(entries.map(e => e.authorLogin).filter(l => l !== null))].sort();
-            if (logins.length > MAX_MENTIONS) {
-              const compareUrl = `${context.serverUrl}/${owner}/${repo}/compare/${baseline.head_sha}...${currentHeadSha}`;
-              core.warning(`${logins.length} distinct authors exceeds MAX_MENTIONS (${MAX_MENTIONS}); sending a summary-only notice without @-mentions.`);
-              core.setOutput('mention_cap_exceeded', 'true');
-              core.setOutput('summary_line',
-                `${entries.length} PRs/commits from ${logins.length} authors landed since the last green run -- too many to @-mention individually: <${compareUrl}|full comparison>`);
-              core.setOutput('entries', JSON.stringify([]));
-              core.setOutput('logins_json', JSON.stringify([]));
-              return;
-            }
-
-            core.setOutput('mention_cap_exceeded', 'false');
+            core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} for ${currentHeadSha} (parent baseline run #${baselineRun.run_number})`);
             core.setOutput('entries', JSON.stringify(entries));
-            core.setOutput('logins_json', JSON.stringify(logins));
+            core.setOutput('logins_json',
+              JSON.stringify([...new Set(entries.map(e => e.authorLogin).filter(l => l !== null))].sort()));
 
       - name: Checkout resolve-slack-mentions action
-        if: steps.culprits.outputs.should_notify == 'true' && steps.culprits.outputs.mention_cap_exceeded != 'true'
+        if: steps.culprits.outputs.should_notify == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 5
         with:
@@ -370,7 +310,7 @@ jobs:
 
       - name: Resolve Slack mentions for culprits
         id: mentions
-        if: steps.culprits.outputs.should_notify == 'true' && steps.culprits.outputs.mention_cap_exceeded != 'true'
+        if: steps.culprits.outputs.should_notify == 'true'
         uses: ./.github/actions/resolve-slack-mentions
         with:
           github-logins: ${{ steps.culprits.outputs.logins_json }}
@@ -388,22 +328,13 @@ jobs:
           MENTIONS_JSON: ${{ steps.mentions.outputs.mentions-json }}
           FAILING_RUN_URL: ${{ steps.context.outputs.html_url }}
           PREV_RUN_URL: ${{ steps.culprits.outputs.prev_run_url }}
-          MENTION_CAP_EXCEEDED: ${{ steps.culprits.outputs.mention_cap_exceeded }}
-          SUMMARY_LINE: ${{ steps.culprits.outputs.summary_line }}
         run: |
           set -euo pipefail
 
-          if [ "$MENTION_CAP_EXCEEDED" = "true" ]; then
-            # Too many distinct authors for individual @-mentions (see the
-            # culprits step); post its pre-built summary line instead. The
-            # mentions step was skipped, so MENTIONS_JSON is empty here.
-            LINES="$SUMMARY_LINE"
-          else
-            LINES=$(echo "$ENTRIES_JSON" | jq -r --argjson mentions "$MENTIONS_JSON" '
-              .[] | (if .authorLogin != null then ($mentions[.authorLogin] // ("@" + .authorLogin)) else "(unknown author)" end) as $who
-              | "\($who) <\(.url)|\(if .type == "pr" then "#\(.number) - \(.title)" else .title end)> broke sanity."
-            ')
-          fi
+          LINES=$(echo "$ENTRIES_JSON" | jq -r --argjson mentions "$MENTIONS_JSON" '
+            .[] | (if .authorLogin != null then ($mentions[.authorLogin] // ("@" + .authorLogin)) else "(unknown author)" end) as $who
+            | "\($who) <\(.url)|\(if .type == "pr" then "#\(.number) - \(.title)" else .title end)> broke sanity."
+          ')
 
           TEXT="${LINES}"$'\n'"Failing run on that commit: ${FAILING_RUN_URL}"$'\n'"Previous passing run: ${PREV_RUN_URL}"$'\n'"Please fix."
 

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -40,9 +40,9 @@ jobs:
     # minutes, and the culprits step below may legitimately wait hours for the
     # parent commit's retry cycle to settle.
     runs-on: ubuntu-latest
-    # Must cover the culprits step's parent-settling wait budget (MAX_WAIT_MS,
-    # 270 min) plus the remaining steps, while staying under GitHub's 6h
-    # hosted-runner job cap.
+    # Must cover the culprits step's parent-settling wait budget (270 min,
+    # DEFAULT_MAX_WAIT_MS in .github/scripts/sanity-notify/culprits.js) plus
+    # the remaining steps, while staying under GitHub's 6h hosted-runner cap.
     timeout-minutes: 300
     #
     # ============================ FINALITY GATE =============================
@@ -177,6 +177,18 @@ jobs:
             });
             core.setOutput('already_notified', 'false');
 
+      # Provides the decision module for the culprits step below and the
+      # composite action used after it.
+      - name: Checkout notify scripts and resolve-slack-mentions action
+        if: steps.claim.outputs.already_notified != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 5
+        with:
+          sparse-checkout: |
+            .github/scripts/sanity-notify
+            .github/actions/resolve-slack-mentions
+          sparse-checkout-cone-mode: true
+
       - name: Find culprit PRs since last green run
         id: culprits
         if: steps.claim.outputs.already_notified != 'true'
@@ -184,171 +196,48 @@ jobs:
         env:
           CURRENT_HEAD_SHA: ${{ steps.context.outputs.head_sha }}
         with:
+          # One-commit-back edge detection. The decision logic (parent
+          # resolution, per-run finality, settle-polling, culprit building)
+          # lives in .github/scripts/sanity-notify/culprits.js -- the single
+          # source of truth shared by this step, its unit tests
+          # (culprits.test.js, run with `node --test`), and the historical
+          # backtest (backtest.js). See the module for the invariants.
           script: |
+            const { findBaseline, buildCulpritEntries } = require('./.github/scripts/sanity-notify/culprits.js');
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const currentHeadSha = process.env.CURRENT_HEAD_SHA;
 
-            // ================== ONE-COMMIT-BACK EDGE DETECTION ==================
-            // Only the immediate git parent is ever consulted (main is linear via
-            // merge queue). If any of the parent's push runs finally succeeded,
-            // main was green immediately before this commit -- so this commit
-            // broke it. If the parent conclusively never succeeded, or never
-            // settles within the wait budget below, abstain -- never guess
-            // further back.
-            //
-            // The parent's runs are resolved by exact head_sha -- a point lookup
-            // keyed by the sha we ask for -- never by position in a recency-sorted
-            // listWorkflowRuns page, which is not guaranteed to be a complete or
-            // current window. A lagging index can make the point lookup MISS
-            // (-> abstain); it can never return the wrong commit's runs. The diff
-            // is always exactly one commit (parent..current), which structurally
-            // bounds who one message can blame.
-            const { data: commit } = await github.rest.git.getCommit({ owner, repo, commit_sha: currentHeadSha });
-            const parentSha = commit.parents[0]?.sha;
-            if (!parentSha) {
-              core.warning(`${currentHeadSha} has no parent commit; skipping.`);
+            const result = await findBaseline({
+              github,
+              owner,
+              repo,
+              headSha: currentHeadSha,
+              log: core.info,
+              warn: core.warning,
+            });
+
+            if (result.decision !== 'notify') {
               core.setOutput('should_notify', 'false');
               return;
             }
 
-            // A single head_sha can have several push runs (duplicate deliveries
-            // have produced two success runs for one sha) -- fetch them all; ANY
-            // final success counts as a green parent. head_sha is an exact-match
-            // filter (requires the full 40-char sha); the event/branch filters
-            // exclude the merge_group run of the same sha.
-            const fetchParentRuns = async () => {
-              const { data: resp } = await github.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: 'sanity-tests.yaml',
-                head_sha: parentSha,
-                branch: 'main',
-                event: 'push',
-                per_page: 10,
-              });
-              return resp.workflow_runs;
-            };
-
-            // Mirrors this workflow's own top-level finality gate, applied to a
-            // PARENT run: success is always final; 'failure' is only final once
-            // _auto-retry-post-commit.yaml's retry budget (MAX_ATTEMPTS = 3, must
-            // stay in sync with that workflow) is exhausted -- before that, a
-            // retry may still be queued even though the attempt already shows
-            // status 'completed'. Every other conclusion is final immediately,
-            // since only 'failure' triggers a retry at all.
-            const isFinal = (run) => run.status === 'completed' &&
-              (run.conclusion !== 'failure' || run.run_attempt >= 3);
-
-            // The parent may not be decided yet when this job starts: our own
-            // trigger can finish while the parent is still mid retry cycle, in
-            // the short window where a failed attempt reads 'completed' before
-            // the retry workflow re-queues it, or before the search index
-            // surfaces the parent's run at all. All of those are "not settled":
-            // poll until the parent settles or the wait budget runs out.
-            //  - any FINAL success               -> baseline found; proceed now.
-            //  - all found runs final,
-            //    none succeeded                  -> conclusively not green; abstain now.
-            //  - anything else (no runs yet,
-            //    or some run not yet final)      -> sleep and re-poll.
-            const POLL_INTERVAL_MS = 5 * 60 * 1000;
-            const MAX_WAIT_MS = 270 * 60 * 1000; // job timeout-minutes (300) minus headroom for later steps
-
-            const describeRuns = (runs) => runs.length === 0
-              ? 'no runs found'
-              : runs.map(r => `#${r.run_number}=${r.conclusion ?? r.status}(attempt ${r.run_attempt})`).join(', ');
-
-            const startedAtMs = Date.now();
-            let baselineRun = null;
-            for (;;) {
-              const parentRuns = await fetchParentRuns();
-
-              baselineRun = parentRuns.find(r => isFinal(r) && r.conclusion === 'success');
-              if (baselineRun) break; // a confirmed success decides it; never wait on sibling runs
-
-              if (parentRuns.length > 0 && parentRuns.every(isFinal)) {
-                core.info(`Parent ${parentSha} conclusively never succeeded (${describeRuns(parentRuns)}); main may already be red. Abstaining.`);
-                core.setOutput('should_notify', 'false');
-                return;
-              }
-
-              const elapsedMs = Date.now() - startedAtMs;
-              const elapsedMin = Math.round(elapsedMs / 60000);
-              if (elapsedMs + POLL_INTERVAL_MS > MAX_WAIT_MS) {
-                core.warning(`Timed out after ${elapsedMin} min waiting for parent ${parentSha} to settle (${describeRuns(parentRuns)}); abstaining.`);
-                core.setOutput('should_notify', 'false');
-                return;
-              }
-              core.info(`[${elapsedMin} min elapsed] Parent ${parentSha} not settled yet (${describeRuns(parentRuns)}); polling again in ${POLL_INTERVAL_MS / 60000} min.`);
-              await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-            }
-
-            core.info(`Parent ${parentSha} was green (run #${baselineRun.run_number}); ${currentHeadSha} broke main.`);
             core.setOutput('should_notify', 'true');
-            core.setOutput('prev_run_url', baselineRun.html_url);
-            core.setOutput('prev_run_number', String(baselineRun.run_number));
+            core.setOutput('prev_run_url', result.baselineRun.html_url);
+            core.setOutput('prev_run_number', String(result.baselineRun.run_number));
 
-            const { data: cmp } = await github.rest.repos.compareCommits({
+            const { entries, logins } = await buildCulpritEntries({
+              github,
               owner,
               repo,
-              base: parentSha,
-              head: currentHeadSha,
+              baseSha: result.parentSha,
+              headSha: currentHeadSha,
             });
 
-            // PR titles and commit subjects are attacker-controlled (anyone who can
-            // open a PR) and end up inside Slack `<url|label>` mrkdwn links below --
-            // must be entity-escaped the same way notify-slack-on-mention.yaml
-            // escapes user-supplied text, or a crafted title could break out of the
-            // link syntax or smuggle in a broadcast mention like <!subteam^...>.
-            const escapeSlack = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-            const entries = [];
-            const seenPrNumbers = new Set();
-
-            for (const commit of cmp.commits) {
-              const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner,
-                repo,
-                commit_sha: commit.sha,
-              });
-
-              if (pulls.length > 0) {
-                for (const pr of pulls) {
-                  if (seenPrNumbers.has(pr.number)) continue;
-                  seenPrNumbers.add(pr.number);
-                  entries.push({
-                    type: 'pr',
-                    number: pr.number,
-                    url: pr.html_url,
-                    title: escapeSlack(pr.title),
-                    authorLogin: pr.user ? pr.user.login : null,
-                  });
-                }
-              } else {
-                // No associated PR (direct push, or API lag right after merge) --
-                // fall back to the commit's own author so a culprit is never silently dropped.
-                entries.push({
-                  type: 'commit',
-                  sha: commit.sha,
-                  url: commit.html_url,
-                  title: escapeSlack(commit.commit.message.split('\n')[0]),
-                  authorLogin: commit.author ? commit.author.login : null,
-                });
-              }
-            }
-
-            core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} for ${currentHeadSha} (parent baseline run #${baselineRun.run_number})`);
+            core.info(`Found ${entries.length} culprit entr${entries.length === 1 ? 'y' : 'ies'} for ${currentHeadSha} (parent baseline run #${result.baselineRun.run_number})`);
             core.setOutput('entries', JSON.stringify(entries));
-            core.setOutput('logins_json',
-              JSON.stringify([...new Set(entries.map(e => e.authorLogin).filter(l => l !== null))].sort()));
-
-      - name: Checkout resolve-slack-mentions action
-        if: steps.culprits.outputs.should_notify == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        timeout-minutes: 5
-        with:
-          sparse-checkout: .github/actions/resolve-slack-mentions
-          sparse-checkout-cone-mode: true
+            core.setOutput('logins_json', JSON.stringify(logins));
 
       - name: Resolve Slack mentions for culprits
         id: mentions

--- a/.github/workflows/sanity-tests-slack-notify.yaml
+++ b/.github/workflows/sanity-tests-slack-notify.yaml
@@ -36,11 +36,14 @@ permissions:
 
 jobs:
   notify:
-    runs-on: ubuntu-slim
-    # Several unbounded network calls (Slack pagination, GitHub API) below --
-    # bound the whole job well under GitHub's long default so a stalled
-    # request can't occupy the runner indefinitely.
-    timeout-minutes: 10
+    # ubuntu-latest, not ubuntu-slim: slim runners hard-cap execution at 15
+    # minutes, and the culprits step below may legitimately wait hours for the
+    # parent commit's retry cycle to settle.
+    runs-on: ubuntu-latest
+    # Must cover the culprits step's parent-settling wait budget (MAX_WAIT_MS,
+    # 270 min) plus the remaining steps, while staying under GitHub's 6h
+    # hosted-runner job cap.
+    timeout-minutes: 300
     #
     # ============================ FINALITY GATE =============================
     # _auto-retry-post-commit.yaml only re-runs a "Sanity tests" push run when
@@ -188,12 +191,11 @@ jobs:
 
             // ================== ONE-COMMIT-BACK EDGE DETECTION ==================
             // Only the immediate git parent is ever consulted (main is linear via
-            // merge queue). If any of the parent's push runs succeeded, main was
-            // green immediately before this commit -- so this commit broke it.
-            // Anything else about the parent (failure, cancelled, skipped, still
-            // running, or no run found even after retrying for index lag) means
-            // we cannot be certain main was green immediately before us: abstain,
-            // never guess further back.
+            // merge queue). If any of the parent's push runs finally succeeded,
+            // main was green immediately before this commit -- so this commit
+            // broke it. If the parent conclusively never succeeded, or never
+            // settles within the wait budget below, abstain -- never guess
+            // further back.
             //
             // The parent's runs are resolved by exact head_sha -- a point lookup
             // keyed by the sha we ask for -- never by position in a recency-sorted
@@ -212,13 +214,10 @@ jobs:
 
             // A single head_sha can have several push runs (duplicate deliveries
             // have produced two success runs for one sha) -- fetch them all; ANY
-            // success counts as a green parent. head_sha is an exact-match filter
-            // (requires the full 40-char sha); the event/branch filters exclude
-            // the merge_group run of the same sha.
-            const RETRY_DELAYS_MS = [0, 5000, 15000]; // tolerate transient index lag
-            let parentRuns = [];
-            for (const delay of RETRY_DELAYS_MS) {
-              if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+            // final success counts as a green parent. head_sha is an exact-match
+            // filter (requires the full 40-char sha); the event/branch filters
+            // exclude the merge_group run of the same sha.
+            const fetchParentRuns = async () => {
               const { data: resp } = await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
@@ -228,17 +227,60 @@ jobs:
                 event: 'push',
                 per_page: 10,
               });
-              parentRuns = resp.workflow_runs;
-              if (parentRuns.length > 0) break;
-            }
+              return resp.workflow_runs;
+            };
 
-            const baselineRun = parentRuns.find(r => r.conclusion === 'success');
-            if (!baselineRun) {
-              core.info(parentRuns.length === 0
-                ? `No "Sanity tests" push run found for parent ${parentSha} after retries; abstaining.`
-                : `Parent ${parentSha}'s run(s) never succeeded (${parentRuns.map(r => `#${r.run_number}=${r.conclusion ?? r.status}`).join(', ')}); main may already be red. Abstaining.`);
-              core.setOutput('should_notify', 'false');
-              return;
+            // Mirrors this workflow's own top-level finality gate, applied to a
+            // PARENT run: success is always final; 'failure' is only final once
+            // _auto-retry-post-commit.yaml's retry budget (MAX_ATTEMPTS = 3, must
+            // stay in sync with that workflow) is exhausted -- before that, a
+            // retry may still be queued even though the attempt already shows
+            // status 'completed'. Every other conclusion is final immediately,
+            // since only 'failure' triggers a retry at all.
+            const isFinal = (run) => run.status === 'completed' &&
+              (run.conclusion !== 'failure' || run.run_attempt >= 3);
+
+            // The parent may not be decided yet when this job starts: our own
+            // trigger can finish while the parent is still mid retry cycle, in
+            // the short window where a failed attempt reads 'completed' before
+            // the retry workflow re-queues it, or before the search index
+            // surfaces the parent's run at all. All of those are "not settled":
+            // poll until the parent settles or the wait budget runs out.
+            //  - any FINAL success               -> baseline found; proceed now.
+            //  - all found runs final,
+            //    none succeeded                  -> conclusively not green; abstain now.
+            //  - anything else (no runs yet,
+            //    or some run not yet final)      -> sleep and re-poll.
+            const POLL_INTERVAL_MS = 5 * 60 * 1000;
+            const MAX_WAIT_MS = 270 * 60 * 1000; // job timeout-minutes (300) minus headroom for later steps
+
+            const describeRuns = (runs) => runs.length === 0
+              ? 'no runs found'
+              : runs.map(r => `#${r.run_number}=${r.conclusion ?? r.status}(attempt ${r.run_attempt})`).join(', ');
+
+            const startedAtMs = Date.now();
+            let baselineRun = null;
+            for (;;) {
+              const parentRuns = await fetchParentRuns();
+
+              baselineRun = parentRuns.find(r => isFinal(r) && r.conclusion === 'success');
+              if (baselineRun) break; // a confirmed success decides it; never wait on sibling runs
+
+              if (parentRuns.length > 0 && parentRuns.every(isFinal)) {
+                core.info(`Parent ${parentSha} conclusively never succeeded (${describeRuns(parentRuns)}); main may already be red. Abstaining.`);
+                core.setOutput('should_notify', 'false');
+                return;
+              }
+
+              const elapsedMs = Date.now() - startedAtMs;
+              const elapsedMin = Math.round(elapsedMs / 60000);
+              if (elapsedMs + POLL_INTERVAL_MS > MAX_WAIT_MS) {
+                core.warning(`Timed out after ${elapsedMin} min waiting for parent ${parentSha} to settle (${describeRuns(parentRuns)}); abstaining.`);
+                core.setOutput('should_notify', 'false');
+                return;
+              }
+              core.info(`[${elapsedMin} min elapsed] Parent ${parentSha} not settled yet (${describeRuns(parentRuns)}); polling again in ${POLL_INTERVAL_MS / 60000} min.`);
+              await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
             }
 
             core.info(`Parent ${parentSha} was green (run #${baselineRun.run_number}); ${currentHeadSha} broke main.`);


### PR DESCRIPTION
### Incident

On 2026-08-21 this workflow posted a Slack message to #tt-metal-pipelines mentioning 89 distinct authors across 250 culprit entries, then was disabled.

Sequence: main broke at run #13790 (6:04am PT); the first notification (8:30am, one culprit) was correct. Runs #13792-#13798 landed on already-red main and correctly stayed silent. At 10:28am, run #13802 finished and the "Find culprit PRs" step's `listWorkflowRuns(per_page: 100)` call returned a stale/misaligned page: every run between #12928 (Aug 12) and #13802 - 349 runs, verified by re-query - was absent, and #12928 (which never appears on a healthy first page) was the newest run visible below the current one. The walk-back silently adopted that 9-day-old success as "last green" and blamed the entire 250-commit range. A wrong page was indistinguishable from a right one: the code derived the identity of "the previous run" from list position and logged nothing on the success path.

### Fix: strict one-commit-back edge detection

Only the immediate git parent of the failing commit is ever consulted (main is linear via merge queue):

- Resolve `parents[0]` of the current head sha, then fetch that parent's "Sanity tests" push runs by exact `head_sha` filter - an indexed point lookup keyed by the sha we ask for, never a position in a recency-sorted page. A lagging index can only cause a miss, never a wrong baseline.
- All of the parent's runs are fetched because one sha can have several push runs (duplicate deliveries have produced two success runs for one sha, e.g. #13788/#13789).
- Each parent run is judged with the same finality rule as the workflow's own top-level gate (`isFinal`: success always final; `failure` final only at `run_attempt >= 3`, in sync with `_auto-retry-post-commit.yaml`; every other conclusion final immediately) - a parent can read `completed`/`failure`/attempt 1 in the window before the retry workflow queues attempt 2, so "completed" alone is not decisive.
- Decision per poll: any **final success** -> notify immediately; all found runs final with none succeeded -> abstain immediately (main already red); anything else (no runs indexed yet, or a run mid-retry) -> sleep and re-poll. No hopping to older commits, ever. The diff is always exactly one commit, structurally bounding blast radius.

### Runner change: ubuntu-slim -> ubuntu-latest, timeout 10 -> 300 min

ubuntu-slim hard-caps job execution at 15 minutes; waiting out a parent's retry cycle (~2.5h observed) was impossible on it. ubuntu-latest has no such ceiling and costs nothing extra on a public repo. Poll interval 5 min; wait budget 270 min; job timeout 300 min (under GitHub's 6h hosted-runner cap, with headroom for mention resolution and the Slack send). Every poll logs elapsed time and observed run states; timing out logs a warning distinct from the conclusively-red abstain.

### Single source of truth + unit tests (`.github/scripts/sanity-notify/`)

The decision logic now lives in **`culprits.js`** (`findBaseline`, `buildCulpritEntries`, `isFinal`; zero dependencies; timers and logging injectable), required by the workflow step from an up-front sparse checkout (which also absorbs the previously separate resolve-slack-mentions checkout). **`culprits.test.js`** - `node --test .github/scripts/sanity-notify/culprits.test.js`, 21 tests, no framework - covers the finality rules, settled green/red/cancelled parents, success-with-pending-sibling, any-success-among-duplicates, mid-retry poll paths (both outcomes), full-budget timeout, backtest mode (maxWaitMs 0, sleep must not be called), root commit, PR dedup + Slack escaping, direct-push fallback, and null authors. An end-to-end smoke of the exact workflow-step script against live data reproduces the correct #13790 notification (baseline #13789, 1 culprit).

### Backtest against real history (`backtest.js`, report in `BACKTEST.md`)

Every gate-passing final-red event from the last **30 days (2026-07-22..2026-08-21; 1088 push-to-main runs; 417 unique red head_shas)** was replayed through the real `findBaseline` against the live API (`maxWaitMs: 0`; `sleep` throws - never reached):

| decision | count | share |
|---|---:|---:|
| notify (parent green) | 17 | 4.1% |
| abstain: main already red | 361 | 86.6% |
| abstain: parent is [skip ci] (immediate) | 35 | 8.4% |
| abstain: parent never settled | 4 | 1.0% |

All 17 notifies use the parent's own run as baseline and agree with a naive time-ordered reading of the run list; several were hand-verified (including #13790 from the incident day, and #11483 whose baseline succeeded on attempt 2 - a real retry-flip). The incident's mass-ping sha (#13802) resolves to a correct silence. One time-order disagreement (#13609) resolves in the new logic's favor: merge-queue interleaving put a green run between two red ones in list order, but the git parent was red.

**`[skip ci]` parents - known, ACCEPTED gap, now mitigated for latency (maintainer decision):** ~8% of red events sit on a `[skip ci]`/`[ci skip]` parent that never gets a push run, so that break deliberately goes un-notified. Rather than discovering this by exhausting the 270-min poll budget, `findBaseline` now checks the parent's commit message and associated PR titles upfront and abstains immediately (`reason: 'parent-skip-ci'`, distinct log line, no polling). Backtest re-run on the same window (417 events; one new red event landed between passes): notify 17 (byte-identical set) and already-red 361 unchanged - pure latency fix; the 34 former full-budget timeouts resolve instantly; the 4 stuck-retry timeouts remain, confirming they are a distinct, deliberately untouched category. One nuance documented in BACKTEST.md: a `[skip CI]`-marked parent can occasionally still have a run (#12597's parent did, and it was red) - the short-circuit preempts that verdict, changing only the abstain reason, and any theoretical green such case falls inside the accepted trade-off (zero in this window).

**Current-sha sibling runs - known, ACCEPTED gap (maintainer decision):** `findBaseline` settles the parent's runs but takes the triggering run's final-red conclusion for the current sha as-is. Duplicate push deliveries could in theory give the failing sha a succeeded (or still-running) sibling run, making a notification a false blame. Deliberately not handled: the 30-day backtest observed exactly one duplicate-run pair (#13788/#13789) and its outcomes matched (success/success), with zero split-outcome cases. Documented in the module and BACKTEST.md; revisit if a bad notification is ever traced to a green sibling.

**Still open for a maintainer:** 4 parents frozen at `failure@1` - `_auto-retry-post-commit.yaml` never fired for them, so they read as permanently unsettled and poll the full budget. Suggests the retry workflow has its own failure modes worth a look; a time-based finality escape hatch would close this.

### Scope

The culprits step (now a thin wrapper over the module), the job's `runs-on`/`timeout-minutes`, the consolidated checkout, and the new `.github/scripts/sanity-notify/` directory. Finality gate, idempotency marker, mention resolution, and Slack compose/send are untouched; step outputs are unchanged. The runtime disable toggle is deliberately not touched here.

### Revision history

- `6dea3a2` parent-walk point lookup replacing the recency scan (up to 30 hops).
- `410d76a` review fixes: retry-then-abstain on missing lookups, mention cap, invariant-only comments.
- `3b95638` simplified per maintainer direction to strict one-commit-back; mention cap removed as obsolete.
- `b8b2133` ubuntu-latest + settle-polling: per-run finality (retry-aware), 5-min polls, 270-min budget, 300-min job timeout.
- `51cd808` logic extracted to `.github/scripts/sanity-notify/culprits.js` + 18-test suite + 30-day backtest with report.
- `d91b406` immediate abstain on [skip ci] parents (accepted-gap latency mitigation); 21 tests; backtest re-run confirming decisions unchanged.
- `9bc58f2` [skip ci] abstain log reworded as a policy statement (a marked parent can still have a run); current-sha sibling-run scenario documented as a deliberately accepted gap per maintainer decision, not implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/sanity-notify-baseline-lookup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/sanity-notify-baseline-lookup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/sanity-notify-baseline-lookup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/sanity-notify-baseline-lookup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/sanity-notify-baseline-lookup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/sanity-notify-baseline-lookup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/sanity-notify-baseline-lookup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/sanity-notify-baseline-lookup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/sanity-notify-baseline-lookup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/sanity-notify-baseline-lookup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/sanity-notify-baseline-lookup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/sanity-notify-baseline-lookup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/sanity-notify-baseline-lookup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/sanity-notify-baseline-lookup)