### PR TITLE
[Bug fix] Increase wh_n150_civ2 data-movement timeout to 50 minutes

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -92,7 +92,7 @@ ttnn:
     bh_galaxy: 40
     bh_p100: 805
     bh_p150b_civ2: 1045
-    wh_n150_civ2: 1205
+    wh_n150_civ2: 1215
     wh_n300_civ2: 1180
     bh_p150b_civ2_viommu: 115
     bh_p300: 60

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -278,7 +278,7 @@
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/data_movement -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
     wh_n150_civ2:
-      timeout: 40
+      timeout: 50
     wh_n300_civ2:
       timeout: 40
     bh_p100:


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The `wh_n150_civ2` nightly data-movement shard is consistently finishing at
the current 40-minute GitHub Actions limit.

This is an aggregate suite-runtime problem, not a demonstrated hang or failure
in the reshape tests named by #53243. The pytest `--timeout=600` setting is a
separate per-test timeout.

#### N150 evidence

I reran the exact failing workflow job at SHA
`d5f9bc4a43b1287523458f1af6a470c6b2adc180`, retaining the unchanged
40-minute action timeout. The full-duration observations used distinct N150
runners and cold JIT caches:

| Job | Action time | Result | Margin |
|---|---:|---|---:|
| [96408671305](https://github.com/tenstorrent/tt-metal/actions/runs/32338190649/job/96408671305) | 40:00 | Timed out while still progressing through the 2,980 collected cases | 0 s |
| [96595755779](https://github.com/tenstorrent/tt-metal/actions/runs/32338190649/job/96595755779) | 39:39 | 2,825 passed, 153 skipped, 2 xfailed | 21 s |
| [96612183203](https://github.com/tenstorrent/tt-metal/actions/runs/32338190649/job/96612183203) | 40:00 | 2,825 passed, 153 skipped, 2 xfailed | 0 s at API timestamp precision |
| [96683059297](https://github.com/tenstorrent/tt-metal/actions/runs/32338190649/job/96683059297) | 39:22 | 2,825 passed, 153 skipped, 2 xfailed | 38 s |

One additional rerun stopped after 19:47 on an unrelated intermittent
numerical assertion. It was excluded from the timeout sample because `-x`
ended the run early; the following two full reruns passed all cases.

These results show that 40 minutes has effectively no operational margin.
Current main has also added one more nightly data-movement parameter case since
the controlled SHA.

#### Change

- Increase only the `wh_n150_civ2` data-movement action timeout from 40 to 50
  minutes.
- Increase the corresponding `ttnn.unit.wh_n150_civ2` aggregate budget from
  1205 to 1215 minutes.
- Leave pytest's per-test `--timeout=600` unchanged.
- Leave all other SKU timeouts unchanged.

#### Validation

- Time-budget validation passes: requested 1215 minutes, budget 1215 minutes.
- The generated N150 matrix contains an action timeout of 50 minutes and
  preserves `--timeout=600`.
- All 49 `test_prepare_test_matrix.py` tests pass.
- `git diff --check` passes.

Relates to #53243.

### Notes for reviewers

A duration-balanced split of this compile-heavy directory would be the more
durable solution. This change provides reliable CI headroom while that split is
measured and implemented.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/53243-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/53243-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/53243-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/53243-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/53243-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/53243-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/53243-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/53243-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/53243-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/53243-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/53243-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/53243-n150-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/53243-n150-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/53243-n150-timeout)