### PR TITLE
Route bug-check Anthropic API traffic through Tailscale

### DIFF
--- a/.github/workflows/bug-check.yaml
+++ b/.github/workflows/bug-check.yaml
@@ -132,6 +132,7 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write            # OIDC for the Tailscale join below
 
     steps:
       - name: Post running notice
@@ -171,6 +172,17 @@ jobs:
       - name: Install dependencies
         run: pip install -r .github/bug_checker/requirements-bug-checker.txt
 
+      # Join the tailnet ephemerally via OIDC so egress to api.anthropic.com routes
+      # through the on-prem connectors with a stable, allowlistable exit IP. Vars are
+      # set by IT onboarding; scoped to an exact repo:branch pair. Same pattern as
+      # .github/workflows/llk-pr-review.yaml.
+      - name: Tailscale
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ vars.TS_GHA_PUBLIC_INTERNET_CLIENT_ID }}
+          audience: ${{ vars.TS_GHA_PUBLIC_INTERNET_AUDIENCE }}
+          tags: tag:tt-github-actions-public-internet-outbound
+
       - name: Run bug checker
         id: check
         env:
@@ -203,3 +215,8 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: .github/bug-checker-results.sarif
+
+      # Remove the ephemeral tailnet node immediately, even on failure.
+      - name: Tailscale cleanup
+        if: always()
+        run: sudo tailscale logout


### PR DESCRIPTION
## Why

Tenstorrent is rolling out **IP-allowlisting on the Anthropic API**. Any workflow that calls the API directly from a GitHub-hosted runner (i.e. from GitHub's shared egress IPs, not Tenstorrent's network) will start failing once it goes live.

`.github/workflows/bug-check.yaml` does exactly that today: the **Run bug checker** step invokes `.github/bug_checker/run_bug_checker.py`, which talks to `api.anthropic.com` via the `anthropic` SDK (`.github/bug_checker/llm.py`) using `BUG_CHECKER_API_KEY`. It has **no Tailscale routing at all**, unlike `.github/workflows/llk-pr-review.yaml`, which was already onboarded in #49187.

Diagnostic PRs #53938 and #53941 confirmed the workflow's API auth currently works — but only because the allowlist isn't live yet. Once it flips, this workflow breaks.

## What changed

One file, `.github/workflows/bug-check.yaml`, `bug-check` job only:

1. **`id-token: write`** added to the job's existing `permissions:` block (existing `contents: read` / `pull-requests: write` / `security-events: write` untouched) so the runner can mint an OIDC token.
2. **`Tailscale` step** inserted immediately before **Run bug checker** — after `Install dependencies`, so the tailnet join is as close as possible to the API call. The job already had a checkout step, so none was added.
3. **`Tailscale cleanup`** step (`if: always()`, `sudo tailscale logout`) appended at the end of the job to tear down the ephemeral node even on failure.

The Tailscale step is a byte-for-byte mirror of the one proven in `llk-pr-review.yaml` — same SHA pin (`tailscale/github-action@306e68a…` / v4.1.2), same `tags: tag:tt-github-actions-public-internet-outbound`, same `vars.TS_GHA_PUBLIC_INTERNET_CLIENT_ID` / `vars.TS_GHA_PUBLIC_INTERNET_AUDIENCE`.

**No new secrets.** Those two are non-secret Actions Variables already present in the repo from IT onboarding. Nothing about `BUG_CHECKER_API_KEY` was changed or referenced beyond the existing `env:` line.

YAML validated with `yaml.safe_load`; resulting step order:

```
Post running notice → Checkout repository → Set up Python → Install dependencies
  → Tailscale → Run bug checker → Upload SARIF → Tailscale cleanup
```

## Please verify after merge

**A human should trigger a real run of `bug-check.yaml` and confirm the Tailscale hop actually works end-to-end** (e.g. comment `/bug-check run` on any PR). #53938/#53941 proved the API auth path works, but nothing has yet exercised this workflow *through* Tailscale.

One thing worth an explicit check by IT / whoever owns the tailnet ACL: `llk-pr-review.yaml` is `workflow_dispatch` on `main`, so its OIDC subject is `…:ref:refs/heads/main`. `bug-check.yaml` also fires on **`pull_request`**, whose OIDC subject is `…:pull_request` instead. If the Tailscale ACL / WIF binding is scoped to the `main` ref only, the automatic on-PR-open runs may fail to join the tailnet even though `issue_comment`-triggered runs (which carry the default-branch ref) succeed. Worth confirming the binding covers both, or scoping accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=add-tailscale-routing-bug-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:add-tailscale-routing-bug-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=add-tailscale-routing-bug-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:add-tailscale-routing-bug-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=add-tailscale-routing-bug-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:add-tailscale-routing-bug-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=add-tailscale-routing-bug-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:add-tailscale-routing-bug-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=add-tailscale-routing-bug-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:add-tailscale-routing-bug-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=add-tailscale-routing-bug-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:add-tailscale-routing-bug-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=add-tailscale-routing-bug-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:add-tailscale-routing-bug-check)