### PR TITLE
Fix pytest-xdist collection mismatch in test_to_memory_config.py

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -18,6 +18,26 @@ from tests.ttnn.utils_for_testing import (
 pytestmark = pytest.mark.use_module_device
 
 
+# DRAM core grids that can only be built once a device is available are referenced from
+# `@pytest.mark.parametrize` by a stable string key instead of by the factory callable
+# itself, so that every pytest-xdist worker collects an identical set of test IDs.
+DRAM_GRID_FACTORIES = {
+    "disjoint_dram": make_disjoint_dram_core_range_set,
+    "full_dram": make_full_dram_core_range_set,
+}
+
+
+def resolve_dram_grid(grid, device):
+    """Resolve a parametrized `grid` value into a concrete `ttnn.CoreRangeSet`.
+
+    String values are looked up in `DRAM_GRID_FACTORIES` and built for `device`;
+    already-concrete `CoreRangeSet` values are returned unchanged.
+    """
+    if isinstance(grid, str):
+        return DRAM_GRID_FACTORIES[grid](device)
+    return grid
+
+
 # Test for int types
 @pytest.mark.parametrize("shape", [[1, 1, 32, 256], [64, 64], [9, 32, 768], [128]])
 @pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32])
@@ -366,25 +386,47 @@ def test_to_memory_config_rm_interleaved_to_nd_sharded(
     "tensor_shape, shard_shape, grid",
     [
         # 3-D tensor, single DRAM bank
-        ([1, 32, 64], [1, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})),
+        pytest.param(
+            [1, 32, 64],
+            [1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            id="1x32x64-1bank",
+        ),
         # 3-D tensor sharded across first dim → 3 shards on 3 DRAM banks
-        ([6, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))})),
+        pytest.param(
+            [6, 32, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+            id="6x32x64-3banks",
+        ),
         # 3-D tensor sharded across first two dims → 6 shards on 6 DRAM banks
-        ([6, 8, 64], [2, 4, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))})),
+        pytest.param(
+            [6, 8, 64],
+            [2, 4, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            id="6x8x64-6banks",
+        ),
         # 4-D tensor sharded across batch dim → 4 shards on 4 DRAM banks
-        (
+        pytest.param(
             [4, 1, 32, 64],
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x1x32x64-4banks",
         ),
         # 4-D tensor → 6 shards on disjoint DRAM banks
-        (
+        pytest.param(
             [4, 3, 16, 32],
             [2, 1, 16, 32],
-            make_disjoint_dram_core_range_set,
+            "disjoint_dram",
+            id="4x3x16x32-disjoint_dram",
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
+        pytest.param(
+            [5, 32, 64],
+            [2, 32, 64],
+            "full_dram",
+            id="5x32x64-full_dram",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -394,8 +436,7 @@ def test_to_memory_config_rm_interleaved_to_nd_sharded(
 def test_to_memory_config_rm_interleaved_to_nd_sharded_dram(device, tensor_shape, shard_shape, grid, shard_orientation):
     torch.manual_seed(0)
 
-    if callable(grid):
-        grid = grid(device)
+    grid = resolve_dram_grid(grid, device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1112,27 +1153,54 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dtype_conversion(
     "tensor_shape, shard_shape, grid",
     [
         # 3-D tensor, single DRAM bank
-        ([1, 32, 64], [1, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})),
+        pytest.param(
+            [1, 32, 64],
+            [1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            id="1x32x64-1bank",
+        ),
         # 3-D tensor sharded across first dim → 3 shards on 3 DRAM banks
-        ([6, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))})),
+        pytest.param(
+            [6, 32, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+            id="6x32x64-3banks",
+        ),
         # 3-D tensor sharded across first two dims → 4 shards on 4 DRAM banks
-        ([4, 64, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})),
+        pytest.param(
+            [4, 64, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x64x64-4banks",
+        ),
         # 4-D tensor sharded across batch dim → 4 shards on 4 DRAM banks
-        (
+        pytest.param(
             [4, 1, 32, 64],
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x1x32x64-4banks",
         ),
         # 4-D tensor → 6 shards on disjoint DRAM banks
-        (
+        pytest.param(
             [4, 3, 32, 64],
             [2, 1, 32, 64],
-            make_disjoint_dram_core_range_set,
+            "disjoint_dram",
+            id="4x3x32x64-disjoint_dram",
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
+        pytest.param(
+            [5, 32, 64],
+            [2, 32, 64],
+            "full_dram",
+            id="5x32x64-full_dram",
+        ),
         # 3-D tensor sharded across all dims → 8 shards on the full DRAM bank grid
-        ([4, 64, 64], [2, 32, 32], make_full_dram_core_range_set),
+        pytest.param(
+            [4, 64, 64],
+            [2, 32, 32],
+            "full_dram",
+            id="4x64x64-full_dram",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -1144,8 +1212,7 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dram(
 ):
     torch.manual_seed(0)
 
-    if callable(grid):
-        grid = grid(device)
+    grid = resolve_dram_grid(grid, device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1175,22 +1242,39 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dram(
     "tensor_shape, shard_shape, grid",
     [
         # 3-D tensor, single DRAM bank
-        ([1, 32, 64], [1, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})),
+        pytest.param(
+            [1, 32, 64],
+            [1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            id="1x32x64-1bank",
+        ),
         # 3-D tensor sharded across first dim → 3 shards on 3 DRAM banks
-        ([6, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))})),
+        pytest.param(
+            [6, 32, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+            id="6x32x64-3banks",
+        ),
         # 4-D tensor sharded across batch dim → 4 shards on 4 DRAM banks
-        (
+        pytest.param(
             [4, 1, 32, 64],
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x1x32x64-4banks",
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
+        pytest.param(
+            [5, 32, 64],
+            [2, 32, 64],
+            "full_dram",
+            id="5x32x64-full_dram",
+        ),
         # 3-D tensor sharded across all dims → disjoint DRAM banks
-        (
+        pytest.param(
             [3, 160, 160],
             [2, 64, 64],
-            make_disjoint_dram_core_range_set,
+            "disjoint_dram",
+            id="3x160x160-disjoint_dram",
         ),
     ],
 )
@@ -1212,8 +1296,7 @@ def test_to_memory_config_tilized_interleaved_to_nd_sharded_dram_dtype_conversio
 ):
     torch.manual_seed(0)
 
-    if callable(grid):
-        grid = grid(device)
+    grid = resolve_dram_grid(grid, device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()


### PR DESCRIPTION
### Problem

CI fails while collecting `tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py` under pytest-xdist:

```
Different tests were collected between gw0/gw1/gw2/gw3
```

### Root cause

Diagnosis credit: **GitHub Copilot's CI failure analysis.**

Several `@pytest.mark.parametrize` argsets for the DRAM ND-sharding tests embedded **callable objects** directly as parameter values — `make_disjoint_dram_core_range_set` and `make_full_dram_core_range_set`.

These two grids depend on `device.dram_grid_size()`, so they can't be built at import time. The existing workaround passed the factory *function itself* through `parametrize` and called it in the test body:

```python
([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
...
if callable(grid):
    grid = grid(device)
```

Test IDs for those argsets were therefore derived from these objects rather than from anything written in the source. That leaves collection dependent on how each worker process stringifies them, so workers can disagree on the collected ID set — which is exactly the failure signature above.

### Fix

Reference the device-dependent grids by **stable string keys** and resolve them to real `CoreRangeSet`s inside the test:

```python
DRAM_GRID_FACTORIES = {
    "disjoint_dram": make_disjoint_dram_core_range_set,
    "full_dram": make_full_dram_core_range_set,
}

def resolve_dram_grid(grid, device):
    if isinstance(grid, str):
        return DRAM_GRID_FACTORIES[grid](device)
    return grid
```

```python
pytest.param([5, 32, 64], [2, 32, 64], "full_dram", id="5x32x64-full_dram"),
...
grid = resolve_dram_grid(grid, device)
```

Additionally, every argset in the three affected `parametrize` blocks now carries an explicit `id=`. Those blocks also contain opaque `ttnn.CoreRangeSet(...)` values whose auto-generated IDs were positional and uninformative (`grid0`, `grid1`, …); naming them makes the collected IDs fully determined by the source file, and makes failures readable (`[ROW_MAJOR-4x3x16x32-disjoint_dram]` rather than `[ROW_MAJOR-tensor_shape4-shard_shape4-grid4]`).

Scope was kept tight: only the three blocks that contained callables were touched. The other ~84 `parametrize` blocks in this file already use cheaply-stringifiable values (ints, short strings, enums, small tuples) and are left alone.

### Tests affected

| Test | Argsets |
|---|---|
| `test_to_memory_config_rm_interleaved_to_nd_sharded_dram` | 6 |
| `test_to_memory_config_tilized_interleaved_to_nd_sharded_dram` | 7 |
| `test_to_memory_config_tilized_interleaved_to_nd_sharded_dram_dtype_conversion` | 5 |

### Behavior

Collection-stability only — no logic or coverage change.

- All parameter values are semantically identical before/after. Verified by an AST comparison of every argset in the three blocks (callable `Name` → equivalent string key), not by eyeballing the diff.
- The same grids are still produced by the same factory functions, just resolved by key instead of by passing the function object.
- `resolve_dram_grid` is equivalent to the previous `if callable(grid)` guard: `CoreRangeSet` values pass through untouched in both.
- The unrelated direct call `make_full_dram_core_range_set(device)` inside another test body is untouched — it was never a parametrize value.
- Explicit IDs verified unique within each block (duplicate IDs would otherwise get index suffixes and reintroduce positional fragility).

### Validation performed

- `python3 -m py_compile` on the modified file — clean.
- `black==23.10.1` (repo-pinned, `line-length = 120`) `--check` — unchanged.
- AST equivalence check of all parametrize argsets, plus per-block ID-uniqueness check.

Not run: the tests themselves, and `pytest --collect-only`. This environment has no `ttnn`/`torch`/`pytest` and no hardware, so collection can't be exercised here — **the xdist collection run in CI is the real verification** and should be watched on this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/xdist-collection-mismatch-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/xdist-collection-mismatch-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/xdist-collection-mismatch-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/xdist-collection-mismatch-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/xdist-collection-mismatch-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/xdist-collection-mismatch-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/xdist-collection-mismatch-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/xdist-collection-mismatch-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/xdist-collection-mismatch-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/xdist-collection-mismatch-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/xdist-collection-mismatch-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/xdist-collection-mismatch-to-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/xdist-collection-mismatch-to-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/xdist-collection-mismatch-to-memory-config)