### PR TITLE
docs: restore bare uint32_t spelling in compute_kernel_api.h (fixes build-docs on #53557)

### DIFF
--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -131,7 +131,7 @@ ALWI void sigmoid_tile_init() {
  */
 // clang-format on
 template <VectorMode vec_mode = VectorMode::RC, bool fast_and_approx = false>
-ALWI void sigmoid_tile(std::uint32_t idst) {
+ALWI void sigmoid_tile(uint32_t idst) {
 #ifdef ARCH_QUASAR
     MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sigmoid, (8 /*ITERATIONS*/), idst, vec_mode));
 #else
@@ -160,7 +160,7 @@ ALWI void sigmoid_tile(std::uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void silu_tile(std::uint32_t idst) {
+ALWI void silu_tile(uint32_t idst) {
 #ifdef ARCH_QUASAR
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_silu, (8 /*ITERATIONS*/), idst, ::ckernel::VectorMode::RC));
@@ -213,7 +213,7 @@ ALWI void tanh_tile_init() {
  */
 // clang-format on
 template <bool fast_and_approx = false>
-ALWI void tanh_tile(std::uint32_t idst) {
+ALWI void tanh_tile(uint32_t idst) {
 #ifndef ARCH_QUASAR
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
@@ -242,7 +242,7 @@ ALWI void tanh_tile(std::uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void square_tile(std::uint32_t idst) {
+ALWI void square_tile(uint32_t idst) {
 #ifndef ARCH_QUASAR
     MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX), idst, VectorMode::RC));
 #else
@@ -269,7 +269,7 @@ ALWI void sigmoid_tile_init_pack() {
 }
 
 template <VectorMode vec_mode = VectorMode::RC, bool fast_and_approx = false>
-ALWI void sigmoid_tile_pack(std::uint32_t idst) {
+ALWI void sigmoid_tile_pack(uint32_t idst) {
     PACK(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -306,7 +306,7 @@ ALWI void log_tile_init() {
  */
 // clang-format on
 template <bool fast_and_approx = false>
-ALWI void log_tile(std::uint32_t idst) {
+ALWI void log_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -342,7 +342,7 @@ ALWI void log_with_base_tile_init() {
  */
 // clang-format on
 template <bool fast_and_approx = false>
-ALWI void log_with_base_tile(std::uint32_t idst, std::uint32_t base_scale) {
+ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -359,7 +359,7 @@ ALWI void tanh_tile_init_pack() {
 }
 
 template <bool fast_and_approx = false>
-ALWI void tanh_tile_pack(std::uint32_t idst) {
+ALWI void tanh_tile_pack(uint32_t idst) {
     PACK(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -390,7 +390,7 @@ ALWI void signbit_tile_init() {
  * | idst            | The index of the tile in DST register buffer to modify the sign bit of     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void signbit_tile(std::uint32_t idst) {
+ALWI void signbit_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_signbit, (APPROX, 8 /* ITERATIONS */), idst, VectorMode::RC));
 }
@@ -416,7 +416,7 @@ ALWI void signbit_tile_int32_init() {
  * | idst            | The index of the tile in DST register buffer to modify the sign bit of     | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void signbit_tile_int32(std::uint32_t idst) {
+ALWI void signbit_tile_int32(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_signbit_int32, (APPROX, 8 /* ITERATIONS */), idst, VectorMode::RC));
 }
@@ -435,7 +435,7 @@ ALWI void signbit_tile_int32(std::uint32_t idst) {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void abs_tile(std::uint32_t idst) {
+ALWI void abs_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_abs, (APPROX), idst, VectorMode::RC));
 }
 
@@ -460,7 +460,7 @@ ALWI void abs_tile_init() { MATH(SFPU_UNARY_INIT(abs)); }
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void abs_tile_int32(std::uint32_t idst) {
+ALWI void abs_tile_int32(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_abs_int32, (APPROX), idst, VectorMode::RC));
 }
 
@@ -478,7 +478,7 @@ ALWI void abs_tile_int32(std::uint32_t idst) {
  * | idst           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void sign_tile(std::uint32_t idst) {
+ALWI void sign_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sign, (APPROX), idst, VectorMode::RC, 1 /* exponent_size_8 */));
 }
@@ -502,7 +502,7 @@ ALWI void sign_tile_init() { MATH(SFPU_UNARY_INIT(sign)); }
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void tiled_prod_tile(std::uint32_t idst) {
+ALWI void tiled_prod_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tiled_prod, (APPROX), idst, VectorMode::RC));
 }
 
@@ -527,7 +527,7 @@ ALWI void tiled_prod_tile_init() { MATH(SFPU_UNARY_INIT(tiled_prod)); }
  * | param0          | The exponent as IEEE 754 float bits                                        | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void power_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void power_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -563,7 +563,7 @@ ALWI void power_tile_init() {
  * | param0          | The integer exponent value                                                 | uint32_t | Must be a non-negative integer exponent               | True     |
  */
 // clang-format on
-ALWI void power_iterative_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void power_iterative_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -594,7 +594,7 @@ ALWI void power_iterative_tile_init() { MATH(SFPU_UNARY_INIT(power)); }
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void exp2_tile(std::uint32_t idst) {
+ALWI void exp2_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_exp2, (true /* APPROXIMATE */, DST_ACCUM_MODE), idst, VectorMode::RC));
 }
@@ -620,7 +620,7 @@ ALWI void exp2_tile_init() { MATH(SFPU_UNARY_INIT_FN(exp2, sfpu::exp2_init, (tru
  * | param0          | The value the output is if the input is greater than 0                     | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void heaviside_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void heaviside_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_heaviside, (APPROX), idst, VectorMode::RC, param0));
 }
 
@@ -645,7 +645,7 @@ ALWI void heaviside_tile_init() { MATH(SFPU_UNARY_INIT(heaviside)); }
  */
 // clang-format on
 template <bool approx = false>
-ALWI void expm1_tile(std::uint32_t idst) {
+ALWI void expm1_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -663,7 +663,7 @@ ALWI void expm1_tile_init() {
     MATH(SFPU_UNARY_INIT_FN(expm1, sfpu::expm1_init, (approx, DST_ACCUM_MODE)));
 }
 
-ALWI void silu_tile_pack(std::uint32_t idst) {
+ALWI void silu_tile_pack(uint32_t idst) {
     PACK(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_silu, (DST_ACCUM_MODE, 8 /* ITERATIONS */), idst, VectorMode::RC));
 }
@@ -714,7 +714,7 @@ ALWI void silu_tile_init_pack() { PACK(SFPU_UNARY_INIT_FN(silu, sfpu::silu_init,
 // clang-format on
 template <bool stable_sort = false, bool fused = false>
 ALWI void topk_local_sort(
-    std::uint32_t idst, int idir, int i_end_phase, int i_start_phase = 0, int i_end_step = 0, int i_start_step = 0) {
+    uint32_t idst, int idir, int i_end_phase, int i_start_phase = 0, int i_end_step = 0, int i_start_step = 0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -762,7 +762,7 @@ ALWI void topk_local_sort(
  */
 // clang-format on
 template <bool idir = false, bool stable_sort = false, bool fused = false>
-ALWI void topk_merge(std::uint32_t idst, int m_iter, int k) {
+ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -809,7 +809,7 @@ ALWI void topk_merge(std::uint32_t idst, int m_iter, int k) {
  */
 // clang-format on
 template <bool stable_sort = false, bool fused = false>
-ALWI void topk_rebuild(std::uint32_t idst, bool idir, int m_iter, int k, int logk, int skip_second) {
+ALWI void topk_rebuild(uint32_t idst, bool idir, int m_iter, int k, int logk, int skip_second) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -851,7 +851,7 @@ ALWI void topk_tile_init() {
  */
 // clang-format on
 template <bool largest>
-ALWI void topk_fuse_tile(std::uint32_t idst) {
+ALWI void topk_fuse_tile(uint32_t idst) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -879,7 +879,7 @@ ALWI void topk_fuse_tile(std::uint32_t idst) {
  */
 // clang-format on
 template <bool largest>
-ALWI void topk_defuse_tile(std::uint32_t idst, std::uint32_t num_tiles) {
+ALWI void topk_defuse_tile(uint32_t idst, uint32_t num_tiles) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -913,7 +913,7 @@ ALWI void topk_set_stable_descending_mode(bool descending) {
  * No-op unless the compute kernel was built with TOPK_UINT16_FP32_DEST. Must run on MATH while DEST is
  * still acquired (before tile_regs_commit / pack_tile). See #50215.
  */
-ALWI void topk_uint16_prepare_value_tile_for_pack(std::uint32_t idst) {
+ALWI void topk_uint16_prepare_value_tile_for_pack(uint32_t idst) {
     MATH((ckernel::sfpu::topk_uint16_prepare_value_tile_for_pack(idst)));
 }
 
@@ -923,7 +923,7 @@ ALWI void topk_uint16_prepare_value_tile_for_pack(std::uint32_t idst) {
  * the fused-key TopK final extraction; unconditional (not gated on TOPK_UINT16_FP32_DEST). Must
  * run on MATH while DEST is still acquired (before tile_regs_commit / pack_tile).
  */
-ALWI void topk_uint16_move_dest_tile_to_pack_half(std::uint32_t idst) {
+ALWI void topk_uint16_move_dest_tile_to_pack_half(uint32_t idst) {
     MATH((ckernel::sfpu::_topk_uint16_move_dest_tile_to_pack_half_(idst)));
 }
 
@@ -952,7 +952,7 @@ template <
     ckernel::DataLayout layout = ckernel::DataLayout::TILE,
     bool accumulate = false,
     int ITERATIONS = 8>
-ALWI void max_reduce_with_indices(std::uint32_t idst, std::uint32_t idst_idx, std::uint32_t chunk = 0) {
+ALWI void max_reduce_with_indices(uint32_t idst, uint32_t idst_idx, uint32_t chunk = 0) {
     static_assert(num_rows <= 32, "num_rows must be <= 32");
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
@@ -998,7 +998,7 @@ ALWI void max_reduce_with_indices_init() {
  */
 // clang-format on
 template <PoolType pool_type, DataFormat format, ReduceDim reduce_dim = ReduceDim::REDUCE_COL>
-ALWI void sfpu_reduce(std::uint32_t idst, std::uint32_t ct_dim = 1, std::uint32_t rt_dim = 1) {
+ALWI void sfpu_reduce(uint32_t idst, uint32_t ct_dim = 1, uint32_t rt_dim = 1) {
     static_assert(
         reduce_dim == ReduceDim::REDUCE_COL ||
             (reduce_dim == ReduceDim::REDUCE_ROW &&
@@ -1067,7 +1067,7 @@ ALWI void sfpu_reduce_init() {
  */
 // clang-format on
 template <DataFormat format>
-ALWI void sfpu_add_top_row(std::uint32_t dst_tile_0, std::uint32_t dst_tile_1, std::uint32_t dst_tile_out) {
+ALWI void sfpu_add_top_row(uint32_t dst_tile_0, uint32_t dst_tile_1, uint32_t dst_tile_out) {
     static_assert(
         format == DataFormat::Float32 || format == DataFormat::Int32 || format == DataFormat::UInt32,
         "Unsupported data format. Supported formats: Float32, Int32, UInt32");
@@ -1122,7 +1122,7 @@ ALWI void dbg_unhalt() {
  * Return value: None
  */
 // clang-format on
-ALWI void dbg_read_dest_acc_row(int row_addr, std::uint32_t* rd_data) {
+ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
     MATH((dbg_get_array_row(dbg_array_id::DEST, row_addr, rd_data)));
 }
 
@@ -1142,7 +1142,7 @@ ALWI void dbg_read_dest_acc_row(int row_addr, std::uint32_t* rd_data) {
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void unary_max_int32_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void unary_max_int32_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -1176,7 +1176,7 @@ ALWI void unary_max_int32_tile_init() {
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void unary_max_uint32_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void unary_max_uint32_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -1210,7 +1210,7 @@ ALWI void unary_max_uint32_tile_init() {
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void unary_max_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void unary_max_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -1241,7 +1241,7 @@ ALWI void unary_max_tile_init() { MATH(SFPU_UNARY_INIT_FN(unary_max, sfpu::unary
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void alt_complex_rotate90_tile(std::uint32_t idst) {
+ALWI void alt_complex_rotate90_tile(uint32_t idst) {
     MATH(
         SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_alt_complex_rotate90, (APPROX), idst, VectorMode::RC));
 }
@@ -1267,7 +1267,7 @@ ALWI void alt_complex_rotate90_tile_init() { MATH(SFPU_UNARY_INIT(alt_complex_ro
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void unary_min_int32_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void unary_min_int32_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -1302,7 +1302,7 @@ ALWI void unary_min_int32_tile_init() {
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void unary_min_uint32_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void unary_min_uint32_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -1337,7 +1337,7 @@ ALWI void unary_min_uint32_tile_init() {
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
 // clang-format on
-ALWI void unary_min_tile(std::uint32_t idst, std::uint32_t param0) {
+ALWI void unary_min_tile(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -1354,20 +1354,20 @@ ALWI void unary_min_tile(std::uint32_t idst, std::uint32_t param0) {
 ALWI void unary_min_tile_init() { MATH(SFPU_UNARY_INIT_FN(unary_min, sfpu::unary_max_min_init, (false /* IS_MAX */))); }
 
 #if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
-ALWI std::uint32_t get_compute_special_value_flags() {
-    std::uint32_t ret_val = 0;
+ALWI uint32_t get_compute_special_value_flags() {
+    uint32_t ret_val = 0;
     MATH((ret_val = llk_math_get_compute_special_value_flags()));
     return ret_val;
 }
 
-ALWI std::uint32_t get_compute_special_value_flags_fpu(std::uint32_t special_value_flags_reg) {
-    std::uint32_t ret_val = 0;
+ALWI uint32_t get_compute_special_value_flags_fpu(uint32_t special_value_flags_reg) {
+    uint32_t ret_val = 0;
     MATH((ret_val = llk_math_extract_compute_special_value_flags<true /* isFpu */>(special_value_flags_reg)));
     return ret_val;
 }
 
-ALWI std::uint32_t get_compute_special_value_flags_sfpu(std::uint32_t special_value_flags_reg) {
-    std::uint32_t ret_val = 0;
+ALWI uint32_t get_compute_special_value_flags_sfpu(uint32_t special_value_flags_reg) {
+    uint32_t ret_val = 0;
     MATH((ret_val = llk_math_extract_compute_special_value_flags<false /* isFpu */>(special_value_flags_reg)));
     return ret_val;
 }


### PR DESCRIPTION
## Summary

One-commit fix for the `build-docs` failure this branch currently carries: the packed-key pipeline commit swept `uint32_t` → `std::uint32_t` across 46 signatures in `tt_metal/hw/inc/api/compute/compute_kernel_api.h`, but the checked-in doxygenfunction directives (`docs/source/tt-metalium/.../compute/*.rst`) declare the bare spelling, so Sphinx fails on the first mismatch:

```
abs_tile.rst:5: doxygenfunction: Unable to resolve function "abs_tile" with arguments (uint32_t) …
Potential matches: - void abs_tile(std::uint32_t idst)
```

Main has zero `std::uint32_t` in this header; this restores the file's convention (the `llk: fix std::uint*_t` pre-commit hook governs `tt-llk/` paths only and skips this file, so it won't re-flip).

Mechanical `s/std::uint32_t/uint32_t/g`, 46 lines, no functional change. The same fix currently rides inside #54008 (`afbeb2676f5`) to keep that stack's CI green — once this lands on your branch, that copy drops out on the next rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/53557-docs-uint32-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/53557-docs-uint32-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/53557-docs-uint32-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/53557-docs-uint32-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/53557-docs-uint32-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/53557-docs-uint32-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/53557-docs-uint32-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/53557-docs-uint32-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/53557-docs-uint32-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/53557-docs-uint32-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/53557-docs-uint32-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/53557-docs-uint32-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/53557-docs-uint32-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/53557-docs-uint32-fix)