### PR TITLE
Run host-only (no-silicon) validation-smoke suites on GitHub-hosted CPU runners

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -202,6 +202,15 @@ skus:
       - tt-ubuntu-2204-medium-stable
     merge_queue_sku: cpu_medium_prio
 
+  # GitHub-hosted CPU-only runner: no Tenstorrent device, no Harbor access.
+  # Used for host-only (CPU_-prefixed) subsets of device test binaries so scarce
+  # self-hosted device runners only execute tests that actually need silicon.
+  # No merge_queue_sku: GitHub-hosted capacity is not a contended prio pool
+  # (same as the sim_* ubuntu-latest SKUs below).
+  github_hosted_cpu:
+    runs_on:
+      - ubuntu-latest
+
   # ---------------------------------------------------------------------------
   # Merge-queue prio SKUs (merge_group events only).
   # Referenced from logical SKUs via merge_queue_sku; do not list these in test

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -235,11 +235,13 @@ scaleout:
 runtime:
   pr_gate:
     wh_n150_civ2: 15
+    github_hosted_cpu: 15
   merge_gate:
     wh_n150_civ2: 45
     wh_n300_civ2: 15
     wh_llmbox_civ2_viommu: 15
     bh_p150b_civ2_viommu: 45
+    github_hosted_cpu: 15
   sanity:
     wh_n150_civ2: 13
     bh_p150b_civ2: 13

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -280,6 +280,9 @@ jobs:
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
+      # Canonical (non-Harbor-prefixed) ref for the github_hosted_cpu leg, which runs
+      # on GitHub-hosted runners without Harbor access.
+      cpu-docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
       per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -190,7 +190,7 @@ jobs:
         uses: ./.github/actions/find-changed-files
 
   runtime-smoke-tests:
-    needs: [asan-build, find-changed-files]
+    needs: [asan-build, build-docker-images, find-changed-files]
     if: ${{
       github.ref_name == 'main' ||
       needs.find-changed-files.outputs.cmake-changed == 'true' ||
@@ -201,6 +201,10 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.asan-build.outputs.ci-test-docker-image }}
+      # github_hosted_cpu runs on ubuntu-latest (external runner) — no harbor access.
+      # Use raw GHCR tag from build-docker-images, not the harbor-prefixed ref from
+      # asan-build (same as build-docs below).
+      cpu-docker-image: ${{ needs.build-docker-images.outputs.ci-test-tag }}
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-metalium
       test-category: pr_gate

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -10,6 +10,15 @@ on:
         required: false
         type: string
         default: ""
+      cpu-docker-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Canonical (non-Harbor-prefixed, publicly pullable) image ref used for the
+          github_hosted_cpu SKU. GitHub-hosted runners have no Harbor access, so the
+          Harbor-prefixed docker-image ref cannot be pulled there. Same idea as
+          docs-latest-public.yaml, which pulls the raw GHCR tag on ubuntu-latest.
       package-artifact-name:
         required: true
         type: string
@@ -108,7 +117,10 @@ jobs:
     timeout-minutes: 30
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ (inputs.docker-image && (contains(join(matrix.test-group.runs_on, ','), 'dedicated-merge-gate') && inputs.docker-image || format('{0}{1}', inputs.harbor-prefix, inputs.docker-image))) || 'docker-image-unresolved!' }}
+      # github_hosted_cpu runs on GitHub-hosted runners with no Harbor access, so it
+      # needs the canonical (publicly pullable) cpu-docker-image ref instead of the
+      # Harbor-prefixed one (same reason dedicated-merge-gate uses the raw ref).
+      image: ${{ (matrix.test-group.sku == 'github_hosted_cpu' && (inputs.cpu-docker-image || inputs.docker-image)) || (inputs.docker-image && (contains(join(matrix.test-group.runs_on, ','), 'dedicated-merge-gate') && inputs.docker-image || format('{0}{1}', inputs.harbor-prefix, inputs.docker-image))) || 'docker-image-unresolved!' }}
       env:
         ASAN_OPTIONS: "color=always"
         TSAN_OPTIONS: "color=always"
@@ -116,9 +128,11 @@ jobs:
         LLVM_PROFILE_FILE: "/work/coverage/%p-%m.profraw"
       volumes:
         - /work
-        - ${{ (!contains(join(matrix.test-group.runs_on, ','), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
+        # No hugepages on viommu runners or on GitHub-hosted CPU-only runners.
+        - ${{ (!contains(join(matrix.test-group.runs_on, ','), 'viommu') && matrix.test-group.sku != 'github_hosted_cpu' && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
       # Memory reduction in WH LB coming up: https://github.com/tenstorrent/metal-internal-workflows/issues/786
-      options: --device /dev/tenstorrent ${{ contains(matrix.test-group.sku, 'llmbox') && '--memory 256g' || '' }}
+      # github_hosted_cpu has no /dev/tenstorrent to pass through.
+      options: ${{ matrix.test-group.sku != 'github_hosted_cpu' && '--device /dev/tenstorrent' || '' }} ${{ contains(matrix.test-group.sku, 'llmbox') && '--memory 256g' || '' }}
     defaults:
       run:
         shell: bash

--- a/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
@@ -7,7 +7,9 @@
 # Note: wh_n150_civ2 is intentionally omitted here (PR-gate smoke covers n150).
 
 - name: runtime validation smoke
-  cmd: /usr/bin/tt-metalium-validation-smoke
+  # CPU_-prefixed test cases are host-only (no silicon); they run on the
+  # github_hosted_cpu entry below instead of burning device-runner time.
+  cmd: /usr/bin/tt-metalium-validation-smoke --gtest_filter='-*CPU_*'
   skus:
     wh_n300_civ2:
       timeout: 15
@@ -15,5 +17,19 @@
       timeout: 15
     bh_p150b_civ2_viommu:
       timeout: 15
+  team: runtime
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+
+- name: runtime validation smoke cpu-only
+  # Host-only (no-silicon) subset of the smoke binary: test cases whose names carry
+  # the CPU_ prefix. Runs on a GitHub-hosted runner (github_hosted_cpu) so scarce
+  # device runners only execute tests that actually need hardware.
+  # TT_METAL_MOCK_CLUSTER_DESC_PATH keeps any implicit MetalContext creation on the
+  # device-less runner in mock mode instead of aborting on silicon discovery
+  # (tests that call configure_mock_mode() themselves still take precedence).
+  cmd: TT_METAL_MOCK_CLUSTER_DESC_PATH=/usr/libexec/tt-metalium/tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N150.yaml /usr/bin/tt-metalium-validation-smoke --gtest_filter='*CPU_*'
+  skus:
+    github_hosted_cpu:
+      timeout: 10
   team: runtime
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/runtime_validation_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_pr_gate_tests.yaml
@@ -4,9 +4,25 @@
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> pr_gate).
 
 - name: runtime validation smoke
-  cmd: /usr/bin/tt-metalium-validation-smoke
+  # CPU_-prefixed test cases are host-only (no silicon); they run on the
+  # github_hosted_cpu entry below instead of burning device-runner time.
+  cmd: /usr/bin/tt-metalium-validation-smoke --gtest_filter='-*CPU_*'
   skus:
     wh_n150_civ2:
       timeout: 15
+  team: runtime
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+
+- name: runtime validation smoke cpu-only
+  # Host-only (no-silicon) subset of the smoke binary: test cases whose names carry
+  # the CPU_ prefix. Runs on a GitHub-hosted runner (github_hosted_cpu) so scarce
+  # device runners only execute tests that actually need hardware.
+  # TT_METAL_MOCK_CLUSTER_DESC_PATH keeps any implicit MetalContext creation on the
+  # device-less runner in mock mode instead of aborting on silicon discovery
+  # (tests that call configure_mock_mode() themselves still take precedence).
+  cmd: TT_METAL_MOCK_CLUSTER_DESC_PATH=/usr/libexec/tt-metalium/tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N150.yaml /usr/bin/tt-metalium-validation-smoke --gtest_filter='*CPU_*'
+  skus:
+    github_hosted_cpu:
+      timeout: 10
   team: runtime
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
@@ -17,7 +17,7 @@ constexpr size_t operator""_KiB(unsigned long long x) { return x * 1024; }
 constexpr size_t operator""_MiB(unsigned long long x) { return x * 1024 * 1024; }
 constexpr size_t operator""_GiB(unsigned long long x) { return x * 1024 * 1024 * 1024; }
 
-TEST(FreeListOptTest, Allocation) {
+TEST(FreeListOptTest, CPU_Allocation) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     ASSERT_TRUE(a.has_value());
@@ -28,7 +28,7 @@ TEST(FreeListOptTest, Allocation) {
     ASSERT_EQ(b.value(), 1_KiB);
 }
 
-TEST(FreeListOptTest, Alignment) {
+TEST(FreeListOptTest, CPU_Alignment) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1, 1_KiB);
     auto a = allocator.allocate(64);
     ASSERT_TRUE(a.has_value());
@@ -38,7 +38,7 @@ TEST(FreeListOptTest, Alignment) {
     ASSERT_EQ(b.value(), 1_KiB);
 }
 
-TEST(FreeListOptTest, MinAllocationSize) {
+TEST(FreeListOptTest, CPU_MinAllocationSize) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1);
     auto a = allocator.allocate(1);
     ASSERT_TRUE(a.has_value());
@@ -48,7 +48,7 @@ TEST(FreeListOptTest, MinAllocationSize) {
     ASSERT_EQ(b.value(), 1_KiB);
 }
 
-TEST(FreeListOptTest, Clear) {
+TEST(FreeListOptTest, CPU_Clear) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     auto b = allocator.allocate(1_KiB);
@@ -60,7 +60,7 @@ TEST(FreeListOptTest, Clear) {
     ASSERT_EQ(c.value(), 0);
 }
 
-TEST(FreeListOptTest, AllocationAndDeallocation) {
+TEST(FreeListOptTest, CPU_AllocationAndDeallocation) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     std::vector<std::optional<tt::tt_metal::DeviceAddr>> allocations(10);
 
@@ -85,7 +85,7 @@ TEST(FreeListOptTest, AllocationAndDeallocation) {
     }
 }
 
-TEST(FreeListOptTest, AllocateAtAddress) {
+TEST(FreeListOptTest, CPU_AllocateAtAddress) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     ASSERT_TRUE(a.has_value());
@@ -109,7 +109,7 @@ TEST(FreeListOptTest, AllocateAtAddress) {
     ASSERT_EQ(e.value(), 0);
 }
 
-TEST(FreeListOptTest, AllocateAtAddressInteractions) {
+TEST(FreeListOptTest, CPU_AllocateAtAddressInteractions) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     allocator.allocate_at_address(32_KiB, 1_KiB);
 
@@ -126,7 +126,7 @@ TEST(FreeListOptTest, AllocateAtAddressInteractions) {
     ASSERT_EQ(b.value(), 1_KiB);
 }
 
-TEST(FreeListOptTest, ShrinkAndReset) {
+TEST(FreeListOptTest, CPU_ShrinkAndReset) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     auto b = allocator.allocate(1_KiB);
@@ -148,7 +148,7 @@ TEST(FreeListOptTest, ShrinkAndReset) {
     ASSERT_TRUE(e.has_value());
 }
 
-TEST(FreeListOptTest, Statistics) {
+TEST(FreeListOptTest, CPU_Statistics) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     auto b = allocator.allocate(1_KiB);
@@ -160,7 +160,7 @@ TEST(FreeListOptTest, Statistics) {
     ASSERT_EQ(stats.total_allocated_bytes, 1_KiB);
 }
 
-TEST(FreeListOptTest, AllocateFromTop) {
+TEST(FreeListOptTest, CPU_AllocateFromTop) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB, false);
     ASSERT_TRUE(a.has_value());
@@ -175,7 +175,7 @@ TEST(FreeListOptTest, AllocateFromTop) {
     ASSERT_EQ(c.value(), 0);
 }
 
-TEST(FreeListOptTest, Coalescing) {
+TEST(FreeListOptTest, CPU_Coalescing) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     auto b = allocator.allocate(1_KiB);
@@ -191,7 +191,7 @@ TEST(FreeListOptTest, Coalescing) {
     ASSERT_EQ(d.value(), 0);
 }
 
-TEST(FreeListOptTest, CoalescingAfterResetShrink) {
+TEST(FreeListOptTest, CPU_CoalescingAfterResetShrink) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     auto b = allocator.allocate(1_KiB);
@@ -209,7 +209,7 @@ TEST(FreeListOptTest, CoalescingAfterResetShrink) {
     ASSERT_EQ(e.value(), 0);
 }
 
-TEST(FreeListOptTest, OutOfMemory) {
+TEST(FreeListOptTest, CPU_OutOfMemory) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_GiB);
     ASSERT_TRUE(a.has_value());
@@ -223,7 +223,7 @@ TEST(FreeListOptTest, OutOfMemory) {
     ASSERT_FALSE(d.has_value());
 }
 
-TEST(FreeListOptTest, AvailableAddresses) {
+TEST(FreeListOptTest, CPU_AvailableAddresses) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     auto aval = allocator.available_addresses(1_KiB);
@@ -266,7 +266,7 @@ TEST(FreeListOptTest, AvailableAddresses) {
     ASSERT_EQ(aval[0].second, 1_GiB); // End address
 }
 
-TEST(FreeListOptTest, LowestOccupiedAddress) {
+TEST(FreeListOptTest, CPU_LowestOccupiedAddress) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);
     auto b = allocator.allocate(1_KiB);
@@ -290,7 +290,7 @@ TEST(FreeListOptTest, LowestOccupiedAddress) {
     ASSERT_FALSE(loa.has_value());
 }
 
-TEST(FreeListOptTest, LowestOccupiedAddressWithAllocateAt) {
+TEST(FreeListOptTest, CPU_LowestOccupiedAddressWithAllocateAt) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate_at_address(1_KiB, 1_KiB);
     ASSERT_TRUE(a.has_value());
@@ -302,7 +302,7 @@ TEST(FreeListOptTest, LowestOccupiedAddressWithAllocateAt) {
     ASSERT_FALSE(loa.has_value());
 }
 
-TEST(FreeListOptTest, FirstFit) {
+TEST(FreeListOptTest, CPU_FirstFit) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB, tt::tt_metal::allocator::FreeListOpt::SearchPolicy::FIRST);
     auto a = allocator.allocate(1_KiB);
     auto b = allocator.allocate(3_KiB);
@@ -329,7 +329,7 @@ TEST(FreeListOptTest, FirstFit) {
     ASSERT_EQ(f.value(), 1_KiB);
 }
 
-TEST(FreeListOptTest, FirstFitAllocateAtAddressInteractions) {
+TEST(FreeListOptTest, CPU_FirstFitAllocateAtAddressInteractions) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB, tt::tt_metal::allocator::FreeListOpt::SearchPolicy::FIRST);
     allocator.allocate_at_address(32_KiB, 1_KiB);
 
@@ -346,7 +346,7 @@ TEST(FreeListOptTest, FirstFitAllocateAtAddressInteractions) {
     ASSERT_EQ(b.value(), 1_KiB);
 }
 
-TEST(FreeListOptTest, ReallocateAtSameAddressWithAllocateAtAddress) {
+TEST(FreeListOptTest, CPU_ReallocateAtSameAddressWithAllocateAtAddress) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
 
     /*
@@ -371,7 +371,7 @@ TEST(FreeListOptTest, ReallocateAtSameAddressWithAllocateAtAddress) {
     ASSERT_THAT(a_realloc, ::testing::Optional(alloc_address));
 }
 
-TEST(FreeListOptTest, AllocatedAddresses) {
+TEST(FreeListOptTest, CPU_AllocatedAddresses) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
 
     // Check that allocated addresses is empty
@@ -429,7 +429,7 @@ TEST(FreeListOptTest, AllocatedAddresses) {
     ASSERT_EQ(after_reset, after_top);
 }
 
-TEST(FreeListOptTest, AddressesAPIWithNonzeroOffset) {
+TEST(FreeListOptTest, CPU_AddressesAPIWithNonzeroOffset) {
     // Test APIs that expose addresses as inputs/outputs correctly expose absolute addresses with offset added
     const size_t offset = 2_KiB;
     const size_t alloc_size = 1_GiB;

--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -55,12 +55,12 @@ using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
 /*******************************
  * AllocatorDependencies Tests *
  *******************************/
-TEST(AllocatorDependencies, DefaultAllocatorDependencies) {
+TEST(AllocatorDependencies, CPU_DefaultAllocatorDependencies) {
     BankManager::AllocatorDependencies allocator_dependencies;
     EXPECT_EQ(allocator_dependencies.dependencies, BankManager::AllocatorDependencies::AdjacencyList{{}});
 }
 
-TEST(AllocatorDependencies, DuplicateDependencies) {
+TEST(AllocatorDependencies, CPU_DuplicateDependencies) {
     const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> dependencies_map = {
         {AllocatorID{0}, ttsl::SmallVector<AllocatorID>{AllocatorID{1}, AllocatorID{1}}}};
 
@@ -70,7 +70,7 @@ TEST(AllocatorDependencies, DuplicateDependencies) {
             ::testing::HasSubstr("Duplicate dependency for allocator 0: 1 appears more than once!")));
 }
 
-TEST(AllocatorDependencies, EquivalentDependenciesMaps) {
+TEST(AllocatorDependencies, CPU_EquivalentDependenciesMaps) {
     const std::unordered_map<AllocatorID, ttsl::SmallVector<AllocatorID>> dependencies_map1 = {
         {AllocatorID{0}, ttsl::SmallVector<AllocatorID>{AllocatorID{1}}},
         {AllocatorID{1}, ttsl::SmallVector<AllocatorID>{AllocatorID{0}}}};
@@ -87,7 +87,7 @@ TEST(AllocatorDependencies, EquivalentDependenciesMaps) {
 
 class AllocatorDependenciesParamTest : public ::testing::TestWithParam<AllocatorDependenciesParam> {};
 
-TEST_P(AllocatorDependenciesParamTest, ValidateDependencies) {
+TEST_P(AllocatorDependenciesParamTest, CPU_ValidateDependencies) {
     const auto& params = GetParam();
 
     BankManager::AllocatorDependencies allocator_dependencies{params.input};
@@ -155,7 +155,7 @@ INSTANTIATE_TEST_SUITE_P(
 /********************************
  * Overlapped BankManager Tests *
  ********************************/
-TEST(OverlappedAllocators, InvalidAllocator) {
+TEST(OverlappedAllocators, CPU_InvalidAllocator) {
     // Create bank manager with 2 allocators (0 and 1)
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
     BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
@@ -179,7 +179,7 @@ TEST(OverlappedAllocators, InvalidAllocator) {
             ::testing::HasSubstr("Invalid allocator ID 2 (num_allocators=2)")));
 }
 
-TEST(OverlappedAllocators, InvalidAPIsForOverlappedAllocators) {
+TEST(OverlappedAllocators, CPU_InvalidAPIsForOverlappedAllocators) {
     // Create bank manager with 2 allocators (0 and 1)
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
     BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
@@ -199,7 +199,7 @@ TEST(OverlappedAllocators, InvalidAPIsForOverlappedAllocators) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Expected single allocator!")));
 }
 
-TEST(OverlappedAllocators, DeallocateAllAndClear) {
+TEST(OverlappedAllocators, CPU_DeallocateAllAndClear) {
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
     BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
@@ -249,7 +249,7 @@ TEST(OverlappedAllocators, DeallocateAllAndClear) {
     EXPECT_EQ(new_addr2, new_addr1 + alloc_size_2K);
 }
 
-TEST(OverlappedAllocators, IndependentAllocAndDeallocBottomUp) {
+TEST(OverlappedAllocators, CPU_IndependentAllocAndDeallocBottomUp) {
     // 2 independent allocators, no overlaps
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
     BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
@@ -332,7 +332,7 @@ TEST(OverlappedAllocators, IndependentAllocAndDeallocBottomUp) {
     EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{0}), alloc0_addr1);
 }
 
-TEST(OverlappedAllocators, IndependentAllocAndDeallocTopDown) {
+TEST(OverlappedAllocators, CPU_IndependentAllocAndDeallocTopDown) {
     // 2 independent allocators, no overlaps
     const uint64_t total_size = 1024 * 1024;
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {}}, {AllocatorID{1}, {}}}};
@@ -416,7 +416,7 @@ TEST(OverlappedAllocators, IndependentAllocAndDeallocTopDown) {
     EXPECT_EQ(bank_manager.lowest_occupied_address(bank_id, AllocatorID{0}), alloc0_addr1);
 }
 
-TEST(OverlappedAllocators, OverlappedAllocAndDeallocBottomUp) {
+TEST(OverlappedAllocators, CPU_OverlappedAllocAndDeallocBottomUp) {
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
     BankManager bank_manager = get_bank_manager_with_allocator_dependencies(1024 * 1024, 1024, deps);
@@ -562,7 +562,7 @@ TEST(OverlappedAllocators, OverlappedAllocAndDeallocBottomUp) {
     EXPECT_EQ(alloc2_addr1, alloc0_addr1);
 }
 
-TEST(OverlappedAllocators, OverlappedAllocAndDeallocTopDown) {
+TEST(OverlappedAllocators, CPU_OverlappedAllocAndDeallocTopDown) {
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
     const uint64_t total_size = 1024 * 1024;
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
@@ -709,7 +709,7 @@ TEST(OverlappedAllocators, OverlappedAllocAndDeallocTopDown) {
     EXPECT_EQ(alloc2_addr1, alloc0_addr1);
 }
 
-TEST(OverlappedAllocators, OverlappedAllocationsWithUnalignedSizesBottomUp) {
+TEST(OverlappedAllocators, CPU_OverlappedAllocationsWithUnalignedSizesBottomUp) {
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
     const uint32_t alignment = 1024;
     BankManager::AllocatorDependencies deps{{{AllocatorID{0}, {AllocatorID{2}}}, {AllocatorID{1}, {AllocatorID{2}}}}};
@@ -787,7 +787,7 @@ TEST(OverlappedAllocators, OverlappedAllocationsWithUnalignedSizesBottomUp) {
     EXPECT_EQ(alloc0_addr1, alloc2_addr0 + alloc_size_aligned);
 }
 
-TEST(OverlappedAllocators, OverlappedAllocationsWithUnalignedSizesTopDown) {
+TEST(OverlappedAllocators, CPU_OverlappedAllocationsWithUnalignedSizesTopDown) {
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
     const uint64_t total_size = 1024 * 1024;
     const uint32_t alignment = 1024;
@@ -866,7 +866,7 @@ TEST(OverlappedAllocators, OverlappedAllocationsWithUnalignedSizesTopDown) {
     EXPECT_EQ(alloc0_addr1, alloc2_addr0 - alloc_size_2K);
 }
 
-TEST(OverlappedAllocators, OverlappedAllocationsFromBothSides) {
+TEST(OverlappedAllocators, CPU_OverlappedAllocationsFromBothSides) {
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
     const uint64_t total_size = 1024 * 1024;
     const uint32_t alignment = 1024;
@@ -996,7 +996,7 @@ TEST(OverlappedAllocators, OverlappedAllocationsFromBothSides) {
     EXPECT_EQ(alloc2_addr3, alloc2_addr0 + alloc_size_1K);
 }
 
-TEST(OverlappedAllocators, NonzeroAddressLimit) {
+TEST(OverlappedAllocators, CPU_NonzeroAddressLimit) {
     // Tests the clamping logic in BankManager::allocate_buffer when address_limit is not 0
 
     // Two independent allocators (0 and 1); allocator 2 overlaps both 0 and 1
@@ -1107,7 +1107,7 @@ TEST(OverlappedAllocators, NonzeroAddressLimit) {
     EXPECT_EQ(alloc0_addr0_realloc, address_limit);  // Should still start at 256KB
 }
 
-TEST(OverlappedAllocators, NonzeroAllocOffset) {
+TEST(OverlappedAllocators, CPU_NonzeroAllocOffset) {
     // Tests that BankManager::allocate_buffer properly accounts for allocator offsets
     // If there are dependencies, allocate_buffer will rely on available_addresses, allocated_addresses, and
     // allocate_at_address APIs. Returned addresses must be absolute addresses otherwise possible bugs:

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_bank_manager.cpp
@@ -67,7 +67,7 @@ constexpr AllocatorID BANK1{2};
 using namespace per_core_bank_manager_tests;
 
 // Per-bank allocators are independent: different sizes yield different second-alloc offsets.
-TEST(PerCoreAllocation, BanksAllocateDifferentSizes) {
+TEST(PerCoreAllocation, CPU_BanksAllocateDifferentSizes) {
     auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
 
     auto addr_b0 = alloc(bm, 1024, BANK0);
@@ -82,7 +82,7 @@ TEST(PerCoreAllocation, BanksAllocateDifferentSizes) {
 }
 
 // Lockstep allocation must skip regions occupied by any per-bank allocator.
-TEST(PerCoreAllocation, LockstepAvoidsPerBankRegions) {
+TEST(PerCoreAllocation, CPU_LockstepAvoidsPerBankRegions) {
     auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
 
     alloc(bm, 4096, BANK0);  // [0, 4096)
@@ -94,7 +94,7 @@ TEST(PerCoreAllocation, LockstepAvoidsPerBankRegions) {
 }
 
 // Per-bank allocation must skip regions occupied by the lockstep allocator.
-TEST(PerCoreAllocation, PerBankAvoidsLockstepRegion) {
+TEST(PerCoreAllocation, CPU_PerBankAvoidsLockstepRegion) {
     auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
 
     alloc(bm, 4096, LOCKSTEP);  // [0, 4096) on all banks
@@ -106,7 +106,7 @@ TEST(PerCoreAllocation, PerBankAvoidsLockstepRegion) {
 }
 
 // Deallocating per-bank regions lets lockstep reuse that space.
-TEST(PerCoreAllocation, DeallocatePerBankFreesForLockstep) {
+TEST(PerCoreAllocation, CPU_DeallocatePerBankFreesForLockstep) {
     auto bm = make_per_core_bank_manager(1024 * 1024, 1024, 2);
 
     auto b0 = alloc(bm, 4096, BANK0);
@@ -121,7 +121,7 @@ TEST(PerCoreAllocation, DeallocatePerBankFreesForLockstep) {
 }
 
 // Scale test: 110 banks (realistic Blackhole core count).
-TEST(PerCoreAllocation, HundredTenBanksScaling) {
+TEST(PerCoreAllocation, CPU_HundredTenBanksScaling) {
     constexpr uint32_t NUM_BANKS = 110;
     auto deps = make_per_core_dependencies(NUM_BANKS);
     EXPECT_EQ(deps.num_allocators(), NUM_BANKS + 1);

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_construct.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_construct.cpp
@@ -11,7 +11,7 @@
 
 namespace basic_tests::CoreRangeSet {
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetValidConstruct) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetValidConstruct) {
     EXPECT_NO_THROW(::CoreRangeSet(std::vector{this->sc1, this->cr2}));
     EXPECT_NO_THROW(::CoreRangeSet(std::vector{this->cr1, this->cr2}));
 
@@ -19,7 +19,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeSetValidConstruct) {
     EXPECT_EQ(valid_ranges.ranges().size(), 2);
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetInvalidConstruct) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetInvalidConstruct) {
     ::CoreRange overlapping_range({1, 2}, {3, 3});
     EXPECT_ANY_THROW(::CoreRangeSet(std::vector{this->cr1, this->cr2, overlapping_range}));
     EXPECT_ANY_THROW(::CoreRangeSet(std::vector{this->sc1, this->cr1}));

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_contains.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_contains.cpp
@@ -10,7 +10,7 @@
 
 namespace basic_tests::CoreRangeSet {
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetContains) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetContains) {
     // Contains CoreCoord
     EXPECT_TRUE(::CoreRangeSet(this->cr1).contains(this->cr5.start_coord));
     EXPECT_TRUE(::CoreRangeSet(this->cr5).contains(this->cr1.end_coord));
@@ -33,7 +33,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeSetContains) {
     EXPECT_TRUE(::CoreRangeSet(this->cr12).contains(::CoreRangeSet(std::vector{this->sc6, this->cr11})));
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetNotContains) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetNotContains) {
     // Not Contains CoreCoord
     EXPECT_FALSE(::CoreRangeSet(this->cr1).contains(this->cr2.start_coord));
     EXPECT_FALSE(

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_intersects.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_intersects.cpp
@@ -10,7 +10,7 @@
 
 namespace basic_tests::CoreRangeSet {
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetIntersects) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetIntersects) {
     // Intersects CoreCoord
     EXPECT_TRUE(::CoreRangeSet(this->cr1).intersects(this->cr5.start_coord));
     EXPECT_TRUE(::CoreRangeSet(this->cr5).intersects(this->cr1.end_coord));
@@ -32,7 +32,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeSetIntersects) {
     EXPECT_TRUE(::CoreRangeSet(this->sc2).intersects(::CoreRangeSet(std::vector{this->cr7, this->cr1})));
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetNotIntersects) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetNotIntersects) {
     // Not Intersects CoreCoord
     EXPECT_FALSE(::CoreRangeSet(this->cr1).intersects(this->cr2.start_coord));
     EXPECT_FALSE(

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_merge.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRangeSet_merge.cpp
@@ -12,14 +12,14 @@
 
 namespace basic_tests::CoreRangeSet {
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetMergeNoSolution) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetMergeNoSolution) {
     EXPECT_EQ(::CoreRangeSet(sc1).merge(std::set{sc3}), ::CoreRangeSet(std::set{sc1, sc3}));
     EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr2}), ::CoreRangeSet(std::set{cr1, cr2}));
     EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr1, cr2}), ::CoreRangeSet(std::set{cr1, cr2}));
     EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr2}).merge(std::set{cr3}), ::CoreRangeSet(std::set{cr1, cr2, cr3}));
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetMergeCoreCoord) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetMergeCoreCoord) {
     ::CoreRangeSet empty_crs;
     EXPECT_EQ(empty_crs.merge(std::set{this->sc1}).ranges().size(), 1);
     EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{sc3, sc4}), ::CoreRangeSet(std::set{cr16}));
@@ -49,7 +49,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeSetMergeCoreCoord) {
             ::CoreRange{{3, 4}, {4, 5}}}));
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeSetMergeCoreRange) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeSetMergeCoreRange) {
     EXPECT_EQ(::CoreRangeSet(cr1).merge(std::set{cr1}), ::CoreRangeSet(std::set{cr1}));
     EXPECT_EQ(::CoreRangeSet(cr7).merge(std::set{cr6}).merge(std::set{cr4}), ::CoreRangeSet(std::set{cr8}));
     EXPECT_EQ(

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_adjacent.cpp
@@ -10,7 +10,7 @@
 
 namespace basic_tests::CoreRange {
 
-TEST_F(CoreCoordFixture, TestCoreRangeAdjacent) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeAdjacent) {
     EXPECT_TRUE(this->cr1.adjacent(this->cr9));
     EXPECT_TRUE(this->cr9.adjacent(this->cr1));
     EXPECT_TRUE(this->cr1.adjacent(this->cr10));
@@ -21,7 +21,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeAdjacent) {
     EXPECT_TRUE(this->cr1.adjacent(this->cr7));
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeNotAdjacent) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeNotAdjacent) {
     EXPECT_FALSE(this->cr2.adjacent(this->cr3));
     EXPECT_FALSE(this->cr1.adjacent(this->cr6));
     EXPECT_FALSE(this->cr1.adjacent(this->cr11));

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_contains.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_contains.cpp
@@ -10,7 +10,7 @@
 
 namespace basic_tests::CoreRange {
 
-TEST_F(CoreCoordFixture, TestCoreRangeContains) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeContains) {
     // Contains CoreCoord
     EXPECT_TRUE(this->cr1.contains(this->sc1.start_coord));
     EXPECT_TRUE(this->cr1.contains(this->cr1.start_coord));
@@ -25,7 +25,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeContains) {
     EXPECT_TRUE(this->cr4.contains(::CoreRangeSet(std::vector{this->cr1, this->cr2, this->cr3})));
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeNotContains) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeNotContains) {
     // Not Contains CoreCoord
     EXPECT_FALSE(this->sc1.contains(this->cr1.start_coord));
     EXPECT_FALSE(this->sc1.contains(this->sc2.start_coord));

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_intersects.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_intersects.cpp
@@ -11,7 +11,7 @@
 
 namespace basic_tests::CoreRange {
 
-TEST_F(CoreCoordFixture, TestCoreRangeIntersects) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeIntersects) {
     EXPECT_TRUE(this->cr1.intersects(this->cr5));
     EXPECT_EQ(this->cr1.intersection(this->cr5).value(), ::CoreRange({1, 0}, {1, 1}));
 
@@ -28,7 +28,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeIntersects) {
     EXPECT_EQ(this->cr7.intersection(this->cr8).value(), this->cr7);
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeNotIntersects) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeNotIntersects) {
     EXPECT_FALSE(this->cr1.intersects(this->cr2));
     EXPECT_FALSE(this->sc1.intersects(this->cr2));
     EXPECT_FALSE(this->cr1.intersects(this->cr7));

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_iterator.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_iterator.cpp
@@ -12,7 +12,7 @@ using std::vector;
 
 namespace basic_tests::CoreRange {
 
-TEST_F(CoreCoordFixture, TestCoreRangeIterator) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeIterator) {
     vector<tt::tt_metal::CoreCoord> cores_in_core_range;
 
     vector<tt::tt_metal::CoreCoord> cores_iterated;

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_merge.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_merge.cpp
@@ -11,7 +11,7 @@
 
 namespace basic_tests::CoreRange {
 
-TEST_F(CoreCoordFixture, TestCoreRangeMerge) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeMerge) {
     EXPECT_EQ(this->sc1.merge(this->sc1).value(), this->sc1);
     EXPECT_EQ(this->cr4.merge(this->cr5).value(), this->cr6);
     EXPECT_EQ(this->cr4.merge(this->cr6).value(), this->cr6);
@@ -24,7 +24,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeMerge) {
     EXPECT_EQ(this->sc2.merge(this->sc3).value(), this->cr15);
 }
 
-TEST_F(CoreCoordFixture, TestCoreRangeNotMergeable) {
+TEST_F(CoreCoordFixture, CPU_TestCoreRangeNotMergeable) {
     EXPECT_FALSE(this->cr1.merge(this->cr3));
     EXPECT_FALSE(this->cr2.merge(this->cr3));
     EXPECT_FALSE(this->cr1.merge(this->cr6));

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -1760,7 +1760,7 @@ CONFIG_TC_TEST_2_0(DMTest1xDFB2Sx4BConfig, DM, DM, 2, 4, STRIDED, ALL, 4, 2)
 // =====================================================================================
 
 // Host-only: DFB pool is [DFB_TXN_ID_BASE, HW_TXN_ID_MAX], allocated top-down in ascending blocks.
-TEST(TxnIdAllocatorTest, AllocatesTopDownFromDfbPool) {
+TEST(TxnIdAllocatorTest, CPU_AllocatesTopDownFromDfbPool) {
     using tt::tt_metal::experimental::dfb::detail::TxnIdAllocator;
     TxnIdAllocator alloc;
 

--- a/tests/tt_metal/tt_metal/api/disaggregation/test_kv_chunk_address_table.cpp
+++ b/tests/tt_metal/tt_metal/api/disaggregation/test_kv_chunk_address_table.cpp
@@ -27,7 +27,7 @@ KvCacheLocation make_location(uint64_t noc_addr, uint32_t size_bytes, DeviceGrou
 
 // --- Construction Tests ---
 
-TEST(KvChunkAddressTable, ConstructWithValidConfig) {
+TEST(KvChunkAddressTable, CPU_ConstructWithValidConfig) {
     KvChunkAddressTableConfig config{
         .num_layers = 10, .max_sequence_length = 1024, .num_slots = 4, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
@@ -40,7 +40,7 @@ TEST(KvChunkAddressTable, ConstructWithValidConfig) {
     EXPECT_EQ(table.total_entries(), 10u * 32u * 4u);
 }
 
-TEST(KvChunkAddressTable, ConstructWithNonAlignedSequenceLength) {
+TEST(KvChunkAddressTable, CPU_ConstructWithNonAlignedSequenceLength) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 100, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -49,12 +49,12 @@ TEST(KvChunkAddressTable, ConstructWithNonAlignedSequenceLength) {
     EXPECT_EQ(table.total_entries(), 1u * 4u * 1u);
 }
 
-TEST(KvChunkAddressTable, ConstructWithZeroChunkSizeThrows) {
+TEST(KvChunkAddressTable, CPU_ConstructWithZeroChunkSizeThrows) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 0};
     EXPECT_ANY_THROW(KvChunkAddressTable table(config));
 }
 
-TEST(KvChunkAddressTable, ConstructEmptyTable) {
+TEST(KvChunkAddressTable, CPU_ConstructEmptyTable) {
     KvChunkAddressTableConfig config{.num_layers = 0, .max_sequence_length = 0, .num_slots = 0, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
     EXPECT_EQ(table.total_entries(), 0u);
@@ -62,7 +62,7 @@ TEST(KvChunkAddressTable, ConstructEmptyTable) {
 
 // --- Device Group Tests ---
 
-TEST(KvChunkAddressTable, AddDeviceGroupSingle) {
+TEST(KvChunkAddressTable, CPU_AddDeviceGroupSingle) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -75,7 +75,7 @@ TEST(KvChunkAddressTable, AddDeviceGroupSingle) {
     EXPECT_EQ(group.fabric_node_ids[0], make_fnid(0, 0));
 }
 
-TEST(KvChunkAddressTable, AddDeviceGroupDeduplicates) {
+TEST(KvChunkAddressTable, CPU_AddDeviceGroupDeduplicates) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -85,7 +85,7 @@ TEST(KvChunkAddressTable, AddDeviceGroupDeduplicates) {
     EXPECT_EQ(table.num_device_groups(), 1u);
 }
 
-TEST(KvChunkAddressTable, AddDeviceGroupSortsForDedup) {
+TEST(KvChunkAddressTable, CPU_AddDeviceGroupSortsForDedup) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -103,7 +103,7 @@ TEST(KvChunkAddressTable, AddDeviceGroupSortsForDedup) {
     EXPECT_EQ(group.fabric_node_ids[2], make_fnid(0, 2));
 }
 
-TEST(KvChunkAddressTable, AddDeviceGroupDistinctGroups) {
+TEST(KvChunkAddressTable, CPU_AddDeviceGroupDistinctGroups) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -113,7 +113,7 @@ TEST(KvChunkAddressTable, AddDeviceGroupDistinctGroups) {
     EXPECT_EQ(table.num_device_groups(), 2u);
 }
 
-TEST(KvChunkAddressTable, GetDeviceGroupOutOfRangeThrows) {
+TEST(KvChunkAddressTable, CPU_GetDeviceGroupOutOfRangeThrows) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -122,7 +122,7 @@ TEST(KvChunkAddressTable, GetDeviceGroupOutOfRangeThrows) {
 
 // --- Set/Lookup Tests ---
 
-TEST(KvChunkAddressTable, SetAndLookupSingleEntry) {
+TEST(KvChunkAddressTable, CPU_SetAndLookupSingleEntry) {
     KvChunkAddressTableConfig config{.num_layers = 2, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -139,7 +139,7 @@ TEST(KvChunkAddressTable, SetAndLookupSingleEntry) {
     EXPECT_EQ(group.fabric_node_ids[0], make_fnid(0, 1));
 }
 
-TEST(KvChunkAddressTable, SetAndLookupMultipleLayers) {
+TEST(KvChunkAddressTable, CPU_SetAndLookupMultipleLayers) {
     KvChunkAddressTableConfig config{
         .num_layers = 80, .max_sequence_length = 8192, .num_slots = 8, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
@@ -156,7 +156,7 @@ TEST(KvChunkAddressTable, SetAndLookupMultipleLayers) {
     }
 }
 
-TEST(KvChunkAddressTable, SetAndLookupMultiplePositions) {
+TEST(KvChunkAddressTable, CPU_SetAndLookupMultiplePositions) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
     auto grp = table.add_device_group({make_fnid(0, 0)});
@@ -172,7 +172,7 @@ TEST(KvChunkAddressTable, SetAndLookupMultiplePositions) {
     }
 }
 
-TEST(KvChunkAddressTable, SetAndLookupMultipleSlots) {
+TEST(KvChunkAddressTable, CPU_SetAndLookupMultipleSlots) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 4, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -196,7 +196,7 @@ TEST(KvChunkAddressTable, SetAndLookupMultipleSlots) {
     }
 }
 
-TEST(KvChunkAddressTable, SetAndLookupMultipleSlotsAndLayersAndPositions) {
+TEST(KvChunkAddressTable, CPU_SetAndLookupMultipleSlotsAndLayersAndPositions) {
     // Asymmetric dimensions: 5 layers, 7 slots, 384 tokens (12 chunks of 32).
     constexpr uint32_t kNumLayers = 5;
     constexpr uint32_t kSeqLen = 384;
@@ -260,7 +260,7 @@ TEST(KvChunkAddressTable, SetAndLookupMultipleSlotsAndLayersAndPositions) {
     }
 }
 
-TEST(KvChunkAddressTable, ReplicatedLocation) {
+TEST(KvChunkAddressTable, CPU_ReplicatedLocation) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -275,7 +275,7 @@ TEST(KvChunkAddressTable, ReplicatedLocation) {
 
 // --- Overwrite Tests ---
 
-TEST(KvChunkAddressTable, OverwriteEntry) {
+TEST(KvChunkAddressTable, CPU_OverwriteEntry) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -293,7 +293,7 @@ TEST(KvChunkAddressTable, OverwriteEntry) {
 
 // --- Range Lookup Tests ---
 
-TEST(KvChunkAddressTable, LookupRangeContiguous) {
+TEST(KvChunkAddressTable, CPU_LookupRangeContiguous) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
     auto grp = table.add_device_group({make_fnid(0, 0)});
@@ -311,7 +311,7 @@ TEST(KvChunkAddressTable, LookupRangeContiguous) {
     EXPECT_EQ(range[3].noc_addr, 160u);
 }
 
-TEST(KvChunkAddressTable, LookupRangeFullSequence) {
+TEST(KvChunkAddressTable, CPU_LookupRangeFullSequence) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
     auto grp = table.add_device_group({make_fnid(0, 0)});
@@ -324,7 +324,7 @@ TEST(KvChunkAddressTable, LookupRangeFullSequence) {
     EXPECT_EQ(range.size(), 4u);
 }
 
-TEST(KvChunkAddressTable, LookupRangeEmptyWhenStartEqualsEnd) {
+TEST(KvChunkAddressTable, CPU_LookupRangeEmptyWhenStartEqualsEnd) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -332,7 +332,7 @@ TEST(KvChunkAddressTable, LookupRangeEmptyWhenStartEqualsEnd) {
     EXPECT_TRUE(range.empty());
 }
 
-TEST(KvChunkAddressTable, LookupRangeIsZeroCopy) {
+TEST(KvChunkAddressTable, CPU_LookupRangeIsZeroCopy) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
     auto grp = table.add_device_group({make_fnid(0, 0)});
@@ -347,28 +347,28 @@ TEST(KvChunkAddressTable, LookupRangeIsZeroCopy) {
 
 // --- Boundary / Error Tests ---
 
-TEST(KvChunkAddressTable, LookupOutOfRangeLayerThrows) {
+TEST(KvChunkAddressTable, CPU_LookupOutOfRangeLayerThrows) {
     KvChunkAddressTableConfig config{.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
     EXPECT_ANY_THROW(table.lookup(2, 0, 0));
 }
 
-TEST(KvChunkAddressTable, LookupOutOfRangePositionThrows) {
+TEST(KvChunkAddressTable, CPU_LookupOutOfRangePositionThrows) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
     EXPECT_ANY_THROW(table.lookup(0, 64, 0));
 }
 
-TEST(KvChunkAddressTable, LookupOutOfRangeSlotThrows) {
+TEST(KvChunkAddressTable, CPU_LookupOutOfRangeSlotThrows) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 2, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
     EXPECT_ANY_THROW(table.lookup(0, 0, 2));
 }
 
-TEST(KvChunkAddressTable, SetOutOfRangeThrows) {
+TEST(KvChunkAddressTable, CPU_SetOutOfRangeThrows) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -377,7 +377,7 @@ TEST(KvChunkAddressTable, SetOutOfRangeThrows) {
     EXPECT_ANY_THROW(table.set(0, 0, 1, KvCacheLocation{}));
 }
 
-TEST(KvChunkAddressTable, LookupRangeEndPosBeyondMaxThrows) {
+TEST(KvChunkAddressTable, CPU_LookupRangeEndPosBeyondMaxThrows) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -386,7 +386,7 @@ TEST(KvChunkAddressTable, LookupRangeEndPosBeyondMaxThrows) {
 
 // --- FabricNodeId -> Host Mapping Tests ---
 
-TEST(KvChunkAddressTable, SetAndGetHost) {
+TEST(KvChunkAddressTable, CPU_SetAndGetHost) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -397,7 +397,7 @@ TEST(KvChunkAddressTable, SetAndGetHost) {
     EXPECT_EQ(table.get_host(fnid), "host-0");
 }
 
-TEST(KvChunkAddressTable, GetHostThrowsForUnknownNode) {
+TEST(KvChunkAddressTable, CPU_GetHostThrowsForUnknownNode) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -405,7 +405,7 @@ TEST(KvChunkAddressTable, GetHostThrowsForUnknownNode) {
     EXPECT_ANY_THROW(table.get_host(make_fnid(0, 0)));
 }
 
-TEST(KvChunkAddressTable, MultipleHostMappings) {
+TEST(KvChunkAddressTable, CPU_MultipleHostMappings) {
     KvChunkAddressTableConfig config{.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -427,7 +427,7 @@ TEST(KvChunkAddressTable, MultipleHostMappings) {
 
 // --- Realistic Scale Test ---
 
-TEST(KvChunkAddressTable, RealisticPrefillScale) {
+TEST(KvChunkAddressTable, CPU_RealisticPrefillScale) {
     // Simulates a realistic prefill scenario:
     // 80 layers, 102400 seq_len (3200 chunks of 32), 8 slots
     constexpr uint32_t kNumLayers = 80;
@@ -464,7 +464,7 @@ TEST(KvChunkAddressTable, RealisticPrefillScale) {
 
 // --- Decode Scale Test ---
 
-TEST(KvChunkAddressTable, DecodeAccessPattern) {
+TEST(KvChunkAddressTable, CPU_DecodeAccessPattern) {
     // Simulates the decode migrate() access pattern:
     // For a fixed slot, iterate layers, then iterate positions.
     constexpr uint32_t kNumLayers = 80;
@@ -508,7 +508,7 @@ TEST(KvChunkAddressTable, DecodeAccessPattern) {
 
 // --- Multi-Config Tests ---
 
-TEST(KvChunkAddressTable, SingleConfigConstructorHasOneConfigNamedZero) {
+TEST(KvChunkAddressTable, CPU_SingleConfigConstructorHasOneConfigNamedZero) {
     KvChunkAddressTableConfig config{.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32};
     KvChunkAddressTable table(config);
 
@@ -520,7 +520,7 @@ TEST(KvChunkAddressTable, SingleConfigConstructorHasOneConfigNamedZero) {
     EXPECT_EQ(table.num_position_chunks(), 64u / 32u);
 }
 
-TEST(KvChunkAddressTable, SpanConstructorNamesAreStringIndices) {
+TEST(KvChunkAddressTable, CPU_SpanConstructorNamesAreStringIndices) {
     std::vector<KvChunkAddressTableConfig> configs = {
         {.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
         {.num_layers = 4, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32},
@@ -542,7 +542,7 @@ TEST(KvChunkAddressTable, SpanConstructorNamesAreStringIndices) {
     EXPECT_EQ(table.num_position_chunks(2), 256u / 64u);
 }
 
-TEST(KvChunkAddressTable, MapConstructorAssignsIdsInSortedKeyOrder) {
+TEST(KvChunkAddressTable, CPU_MapConstructorAssignsIdsInSortedKeyOrder) {
     std::map<std::string, KvChunkAddressTableConfig> configs = {
         {"kv", {.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32}},
         {"index_k", {.num_layers = 4, .max_sequence_length = 128, .num_slots = 1, .chunk_n_tokens = 32}},
@@ -559,7 +559,7 @@ TEST(KvChunkAddressTable, MapConstructorAssignsIdsInSortedKeyOrder) {
     EXPECT_EQ(table.config(table.config_id_of("index_k")).num_layers, 4u);
 }
 
-TEST(KvChunkAddressTable, SetAndLookupByIdAndNameAreEquivalent) {
+TEST(KvChunkAddressTable, CPU_SetAndLookupByIdAndNameAreEquivalent) {
     std::map<std::string, KvChunkAddressTableConfig> configs = {
         {"kv", {.num_layers = 2, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32}},
         {"index_k", {.num_layers = 2, .max_sequence_length = 128, .num_slots = 2, .chunk_n_tokens = 32}},
@@ -581,7 +581,7 @@ TEST(KvChunkAddressTable, SetAndLookupByIdAndNameAreEquivalent) {
     EXPECT_EQ(table.lookup(1, 64, 1, "index_k").noc_addr, 0u);
 }
 
-TEST(KvChunkAddressTable, ConfigsWithDifferentChunkSizesIndexIndependently) {
+TEST(KvChunkAddressTable, CPU_ConfigsWithDifferentChunkSizesIndexIndependently) {
     std::vector<KvChunkAddressTableConfig> configs = {
         {.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 32},
         {.num_layers = 1, .max_sequence_length = 256, .num_slots = 1, .chunk_n_tokens = 64},
@@ -608,7 +608,7 @@ TEST(KvChunkAddressTable, ConfigsWithDifferentChunkSizesIndexIndependently) {
     EXPECT_ANY_THROW(table.set(0, 32, 0, KvCacheLocation{}, 1u));
 }
 
-TEST(KvChunkAddressTable, TotalEntriesSumsAcrossConfigs) {
+TEST(KvChunkAddressTable, CPU_TotalEntriesSumsAcrossConfigs) {
     std::vector<KvChunkAddressTableConfig> configs = {
         {.num_layers = 2, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},   // 2*2*1 = 4
         {.num_layers = 1, .max_sequence_length = 128, .num_slots = 3, .chunk_n_tokens = 32},  // 1*4*3 = 12
@@ -617,7 +617,7 @@ TEST(KvChunkAddressTable, TotalEntriesSumsAcrossConfigs) {
     EXPECT_EQ(table.total_entries(), 4u + 12u);
 }
 
-TEST(KvChunkAddressTable, DeviceGroupsAreSharedAcrossConfigs) {
+TEST(KvChunkAddressTable, CPU_DeviceGroupsAreSharedAcrossConfigs) {
     std::vector<KvChunkAddressTableConfig> configs = {
         {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
         {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
@@ -633,7 +633,7 @@ TEST(KvChunkAddressTable, DeviceGroupsAreSharedAcrossConfigs) {
     EXPECT_EQ(table.get_device_group(table.lookup(0, 0, 0, 1u).device_group_index).fabric_node_ids[0], make_fnid(0, 5));
 }
 
-TEST(KvChunkAddressTable, EmptyConfigSpanThrows) {
+TEST(KvChunkAddressTable, CPU_EmptyConfigSpanThrows) {
     std::vector<KvChunkAddressTableConfig> empty;
     EXPECT_ANY_THROW(KvChunkAddressTable table(std::span<const KvChunkAddressTableConfig>{empty}));
 
@@ -641,7 +641,7 @@ TEST(KvChunkAddressTable, EmptyConfigSpanThrows) {
     EXPECT_ANY_THROW(KvChunkAddressTable table(empty_map));
 }
 
-TEST(KvChunkAddressTable, OutOfRangeConfigIdThrows) {
+TEST(KvChunkAddressTable, CPU_OutOfRangeConfigIdThrows) {
     std::vector<KvChunkAddressTableConfig> configs = {
         {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
     };
@@ -653,7 +653,7 @@ TEST(KvChunkAddressTable, OutOfRangeConfigIdThrows) {
     EXPECT_ANY_THROW(table.config_name(1));
 }
 
-TEST(KvChunkAddressTable, UnknownConfigNameThrows) {
+TEST(KvChunkAddressTable, CPU_UnknownConfigNameThrows) {
     std::vector<KvChunkAddressTableConfig> configs = {
         {.num_layers = 1, .max_sequence_length = 64, .num_slots = 1, .chunk_n_tokens = 32},
     };

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -537,7 +537,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Device-free check of the shard->core placement formula for both 1D strategies.
 // 8 single-page shards over 2 cores (R = 4 shards per core). Round-robin spreads
 // consecutive shards across cores; CONTIGUOUS_1D (shard-contiguous) packs a contiguous run per core.
-TEST(BufferDistributionSpecContiguous, ShardContiguousVsRoundRobinPlacement) {
+TEST(BufferDistributionSpecContiguous, CPU_ShardContiguousVsRoundRobinPlacement) {
     const tt::tt_metal::Shape tensor_in_pages{8, 1};
     const tt::tt_metal::Shape shard_in_pages{1, 1};
     const CoreRangeSet grid(CoreRange({0, 0}, {1, 0}));  // 2 cores
@@ -563,7 +563,7 @@ TEST(BufferDistributionSpecContiguous, ShardContiguousVsRoundRobinPlacement) {
 }
 
 // CONTIGUOUS_1D requires a uniform shards-per-core; an indivisible count must fatal.
-TEST(BufferDistributionSpecContiguous, ShardContiguousRequiresUniformShardsPerCore) {
+TEST(BufferDistributionSpecContiguous, CPU_ShardContiguousRequiresUniformShardsPerCore) {
     const tt::tt_metal::Shape tensor_in_pages{7, 1};  // 7 shards over 2 cores -> not uniform
     const tt::tt_metal::Shape shard_in_pages{1, 1};
     const CoreRangeSet grid(CoreRange({0, 0}, {1, 0}));  // 2 cores

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -189,7 +189,7 @@ inline ProgramRunArgs MakeRunArgsForMinimalSpec(
 // SECTION: Validation Tests (expect failure)
 // ============================================================================
 
-TEST_F(ProgramRunArgsTestQuasar, UnknownKernelNameFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UnknownKernelNameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -210,7 +210,7 @@ TEST_F(ProgramRunArgsTestQuasar, UnknownKernelNameFails) {
             ::testing::HasSubstr("Kernel 'nonexistent_kernel' has no RTA schema registered")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, InvalidNodeForKernelFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_InvalidNodeForKernelFails) {
     NodeCoord node{0, 0};
     NodeCoord wrong_node{1, 1};  // Kernel doesn't run on this node
     ProgramSpec spec = MakeSpecWithRTAs(node, 2, 0);
@@ -233,7 +233,7 @@ TEST_F(ProgramRunArgsTestQuasar, InvalidNodeForKernelFails) {
             ::testing::HasSubstr("Kernel 'dm_kernel' is setting runtime_varargs for node")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, WrongRuntimeArgsCountFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_WrongRuntimeArgsCountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -247,7 +247,7 @@ TEST_F(ProgramRunArgsTestQuasar, WrongRuntimeArgsCountFails) {
             ::testing::HasSubstr("expects 3 vararg runtime args, but 2 were provided")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, WrongCommonRuntimeArgsCountFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_WrongCommonRuntimeArgsCountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/2);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -263,7 +263,7 @@ TEST_F(ProgramRunArgsTestQuasar, WrongCommonRuntimeArgsCountFails) {
 
 // TODO: Currently, we require that all kernels in a ProgramSpec have params specified.
 // Should relax this to omit kernels with no RTAs or CRTAs.
-TEST_F(ProgramRunArgsTestQuasar, EmptySchemaKernelOmittedFromRunArgsSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_EmptySchemaKernelOmittedFromRunArgsSucceeds) {
     NodeCoord node{0, 0};
     // Both kernels have empty RTA/CRTA schemas — neither has anything to supply per enqueue.
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
@@ -277,7 +277,7 @@ TEST_F(ProgramRunArgsTestQuasar, EmptySchemaKernelOmittedFromRunArgsSucceeds) {
     EXPECT_NO_THROW({ SetProgramRunArgs(program, params); });
 }
 
-TEST_F(ProgramRunArgsTestQuasar, NonEmptySchemaKernelMissingFromRunArgsFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_NonEmptySchemaKernelMissingFromRunArgsFails) {
     NodeCoord node{0, 0};
     // compute_kernel has a non-empty schema (2 vararg RTAs).
     ProgramSpec spec = MakeSpecWithBothKernelRTAs(
@@ -300,7 +300,7 @@ TEST_F(ProgramRunArgsTestQuasar, NonEmptySchemaKernelMissingFromRunArgsFails) {
             "but has no runtime parameters specified in ProgramRunArgs")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, MissingNodeRTAsFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_MissingNodeRTAsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -324,7 +324,7 @@ TEST_F(ProgramRunArgsTestQuasar, MissingNodeRTAsFails) {
 }
 
 // First-launch override: entry_size only (per-TC base/limit recompute; capacity unchanged).
-TEST_F(ProgramRunArgsTestQuasar, DFBEntrySizeOverrideSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DFBEntrySizeOverrideSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -342,7 +342,7 @@ TEST_F(ProgramRunArgsTestQuasar, DFBEntrySizeOverrideSucceeds) {
 }
 
 // First-launch override: num_entries only (changes capacity).
-TEST_F(ProgramRunArgsTestQuasar, DFBNumEntriesOverrideSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DFBNumEntriesOverrideSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -360,7 +360,7 @@ TEST_F(ProgramRunArgsTestQuasar, DFBNumEntriesOverrideSucceeds) {
 }
 
 // First-launch override: both entry_size and num_entries.
-TEST_F(ProgramRunArgsTestQuasar, DFBBothOverridesSucceed) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DFBBothOverridesSucceed) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -376,7 +376,7 @@ TEST_F(ProgramRunArgsTestQuasar, DFBBothOverridesSucceed) {
     EXPECT_EQ(dfb->capacity, 8u);
 }
 
-TEST_F(ProgramRunArgsTestQuasar, DFBEntrySizeOverrideZeroFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DFBEntrySizeOverrideZeroFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -390,7 +390,7 @@ TEST_F(ProgramRunArgsTestQuasar, DFBEntrySizeOverrideZeroFails) {
             ::testing::HasSubstr("entry_size must be set to a non-zero value")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, DFBNumEntriesOverrideZeroFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DFBNumEntriesOverrideZeroFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -404,7 +404,7 @@ TEST_F(ProgramRunArgsTestQuasar, DFBNumEntriesOverrideZeroFails) {
             ::testing::HasSubstr("num_entries must be set to a non-zero value")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, DFBSizeOverrideUnknownNameFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DFBSizeOverrideUnknownNameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -418,7 +418,7 @@ TEST_F(ProgramRunArgsTestQuasar, DFBSizeOverrideUnknownNameFails) {
 }
 
 // Isolated change on the primary: entry_size and num_entries traded so total_size is unchanged.
-TEST_F(ProgramRunArgsTestQuasar, AliasIsolatedResizeSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_AliasIsolatedResizeSucceeds) {
     NodeCoord node{0, 0};
     // dfb_a = 512*8 = 4096, dfb_b = 1024*4 = 4096 (equal totals).
     ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
@@ -445,7 +445,7 @@ TEST_F(ProgramRunArgsTestQuasar, AliasIsolatedResizeSucceeds) {
 }
 
 // Isolated change on the secondary alias.
-TEST_F(ProgramRunArgsTestQuasar, AliasSecondaryIsolatedResizeSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_AliasSecondaryIsolatedResizeSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -464,7 +464,7 @@ TEST_F(ProgramRunArgsTestQuasar, AliasSecondaryIsolatedResizeSucceeds) {
 }
 
 // Agreed group resize: BOTH members overridden to the same new total size.
-TEST_F(ProgramRunArgsTestQuasar, AliasGroupAgreedResizeSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_AliasGroupAgreedResizeSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -485,7 +485,7 @@ TEST_F(ProgramRunArgsTestQuasar, AliasGroupAgreedResizeSucceeds) {
 }
 
 // Total-size change on one alias without overriding the rest of the group -> rejected.
-TEST_F(ProgramRunArgsTestQuasar, AliasPartialGroupResizeFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_AliasPartialGroupResizeFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -499,7 +499,7 @@ TEST_F(ProgramRunArgsTestQuasar, AliasPartialGroupResizeFails) {
 }
 
 // Group members overridden to DIFFERENT new total sizes -> rejected.
-TEST_F(ProgramRunArgsTestQuasar, AliasGroupDisagreeResizeFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_AliasGroupDisagreeResizeFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -517,7 +517,7 @@ TEST_F(ProgramRunArgsTestQuasar, AliasGroupDisagreeResizeFails) {
 // SECTION: Uniqueness Tests (duplicate detection)
 // ============================================================================
 
-TEST_F(ProgramRunArgsTestQuasar, DuplicateKernelParamsFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DuplicateKernelParamsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -533,7 +533,7 @@ TEST_F(ProgramRunArgsTestQuasar, DuplicateKernelParamsFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate kernel 'dm_kernel'")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, DuplicateDFBParamsFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_DuplicateDFBParamsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -552,7 +552,7 @@ TEST_F(ProgramRunArgsTestQuasar, DuplicateDFBParamsFails) {
 // SECTION: Success Tests (basic functionality)
 // ============================================================================
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_ZeroRTAs) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsSucceeds_ZeroRTAs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -562,7 +562,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_ZeroRTAs) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_PerNodeRTAsOnly) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsSucceeds_PerNodeRTAsOnly) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -572,7 +572,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_PerNodeRTAsOnly) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_CommonRTAsOnly) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsSucceeds_CommonRTAsOnly) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/2);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -582,7 +582,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_CommonRTAsOnly) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_BothRTATypes) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsSucceeds_BothRTATypes) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/2);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -592,7 +592,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_BothRTATypes) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_BothKernelsWithRTAs) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsSucceeds_BothKernelsWithRTAs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithBothKernelRTAs(
         node,
@@ -612,7 +612,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_BothKernelsWithRTAs) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_DFBRunOverridesWithNoOverrides) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsSucceeds_DFBRunOverridesWithNoOverrides) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -632,7 +632,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_DFBRunOverridesWithNoOverrid
 // SECTION: Repeated Call Tests
 // ============================================================================
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsTwice_SameValuesSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsTwice_SameValuesSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/1);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -645,7 +645,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsTwice_SameValuesSucceeds) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsTwice_DifferentValuesSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsTwice_DifferentValuesSucceeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/1);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -659,7 +659,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsTwice_DifferentValuesSucceeds) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params2));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsTwice_ChangingCommonRTACountFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsTwice_ChangingCommonRTACountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/0, /*num_common_rtas=*/2);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -682,7 +682,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsTwice_ChangingCommonRTACountFails) {
             ::testing::HasSubstr("expects 2 vararg common runtime args, but 3 were provided")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsMultipleTimes_Succeeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsMultipleTimes_Succeeds) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, /*num_per_node_rtas=*/2, /*num_common_rtas=*/2);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -698,7 +698,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsMultipleTimes_Succeeds) {
 // SECTION: Multi-Node Tests
 // ============================================================================
 
-TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_MultiNodeKernel) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_SetRunArgsSucceeds_MultiNodeKernel) {
     // Create a program with kernels spanning multiple nodes
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
@@ -750,7 +750,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_MultiNodeKernel) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, MultiNode_MissingOneNodeFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_MultiNode_MissingOneNodeFails) {
     // Create a program with kernels spanning multiple nodes
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
@@ -825,7 +825,7 @@ inline ProgramSpec MakeSpecWithNamedArgs(
     return spec;
 }
 
-TEST_F(ProgramRunArgsTestQuasar, NamedRTAsAndCRTAsSucceed) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_NamedRTAsAndCRTAsSucceed) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr", "output_ptr"}, {"tile_count"});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -841,7 +841,7 @@ TEST_F(ProgramRunArgsTestQuasar, NamedRTAsAndCRTAsSucceed) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, MissingNamedRTAForNodeFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_MissingNamedRTAForNodeFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr"}, {});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -859,7 +859,7 @@ TEST_F(ProgramRunArgsTestQuasar, MissingNamedRTAForNodeFails) {
             ::testing::HasSubstr("has named RTAs declared but no runtime_arg_values provided for node")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, MissingDeclaredNamedRTANameFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_MissingDeclaredNamedRTANameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr", "output_ptr"}, {});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -878,7 +878,7 @@ TEST_F(ProgramRunArgsTestQuasar, MissingDeclaredNamedRTANameFails) {
             ::testing::HasSubstr("expects 2 named RTAs, but 1 were provided")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, UndeclaredNamedRTAFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UndeclaredNamedRTAFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"input_ptr"}, {});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -896,7 +896,7 @@ TEST_F(ProgramRunArgsTestQuasar, UndeclaredNamedRTAFails) {
             ::testing::HasSubstr("expects 1 named RTAs, but 2 were provided")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, NamedCRTACountMismatchFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_NamedCRTACountMismatchFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"tile_count", "scale"});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -921,7 +921,7 @@ TEST_F(ProgramRunArgsTestQuasar, NamedCRTACountMismatchFails) {
 //
 // These document the "legacy kernel migrated lazily to Metal 2.0" pattern: all args as
 // positional varargs, no named RTAs/CRTAs/CTAs.
-TEST_F(ProgramRunArgsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_VarargOnlyMultiNodeDifferingCountsSucceeds) {
     // A kernel on two nodes with DIFFERENT vararg counts per node. Exercises the advanced
     // num_runtime_varargs_per_node override path. The RTA dispatch buffer must be sized
     // per-node, which is a common failure mode for layout bugs.
@@ -948,7 +948,7 @@ TEST_F(ProgramRunArgsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_VarargPerNodeOverrideMixedEntryTypesSucceeds) {
     // Per-node override with a MIX of entry shapes: one entry groups two nodes via a
     // NodeRangeSet, another names a single NodeCoord. Exercises the schema-side expansion
     // from heterogeneous Nodes variants into per-coord validation entries — if the expansion
@@ -982,7 +982,7 @@ TEST_F(ProgramRunArgsTestQuasar, VarargPerNodeOverrideMixedEntryTypesSucceeds) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_VarargScalarDefaultWithSparseOverrideSucceeds) {
     // Scalar provides the default count for every node the kernel runs on; the per-node
     // override covers only specific nodes. Unlisted nodes fall back to the scalar value.
     // This is the "3 on most nodes, 5 on the edges" shape that motivates the sparse
@@ -1020,7 +1020,7 @@ TEST_F(ProgramRunArgsTestQuasar, VarargScalarDefaultWithSparseOverrideSucceeds) 
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_VarargSparseOverrideZeroErasesScalarDefault) {
     // An explicit override of 0 on a node erases the scalar default for that node.
     // Regression canary for the expansion logic: if the erase is missing, the node would
     // carry the scalar-default count and run-params validation would either require an
@@ -1052,7 +1052,7 @@ TEST_F(ProgramRunArgsTestQuasar, VarargSparseOverrideZeroErasesScalarDefault) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, VarargOnlyAcrossMultipleKernelsSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_VarargOnlyAcrossMultipleKernelsSucceeds) {
     // Two kernels, each with only vararg RTAs / CRTAs — the shape of a whole-program
     // migration where nothing has been upgraded to named args yet.
     NodeCoord node{0, 0};
@@ -1067,7 +1067,7 @@ TEST_F(ProgramRunArgsTestQuasar, VarargOnlyAcrossMultipleKernelsSucceeds) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_VarargOnlyRTAsMissingNodeCoverageFails) {
     // If the schema declares varargs for a node, SetProgramRunArgs must insist on
     // values for that node. Regression canary for per-node coverage in the vararg path.
     NodeCoord node_a{0, 0};
@@ -1095,7 +1095,7 @@ TEST_F(ProgramRunArgsTestQuasar, VarargOnlyRTAsMissingNodeCoverageFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("missing vararg runtime args for node")));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, VarargOnlyUnknownNodeFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_VarargOnlyUnknownNodeFails) {
     // Host passes runtime_varargs for a node the kernel doesn't run on. Regression canary for
     // the domain check added alongside named-RTA validation.
     NodeCoord node{0, 0};
@@ -1125,7 +1125,7 @@ TEST_F(ProgramRunArgsTestQuasar, VarargOnlyUnknownNodeFails) {
 // A kernel can legitimately declare no RTAs / CRTAs / CTAs of any kind (named or vararg).
 // Verify the whole MakeProgramFromSpec + SetProgramRunArgs pipeline handles this case
 // cleanly — no missing-schema TT_FATALs, no empty-buffer write attempts, no validation errors.
-TEST_F(ProgramRunArgsTestQuasar, AllEmptySchemaSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_AllEmptySchemaSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     // spec.kernels already default to empty runtime_arg_values / common_runtime_arg_values /
     // compile_time_args, num_runtime_varargs = 0, num_common_runtime_varargs = 0,
@@ -1139,7 +1139,7 @@ TEST_F(ProgramRunArgsTestQuasar, AllEmptySchemaSucceeds) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_NamedAndVarargRTAsCoexistSucceeds) {
     // A kernel with both named RTAs (schema) and varargs (num_runtime_varargs).
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalValidProgramSpec();
@@ -1236,7 +1236,7 @@ inline uint32_t PeekBorrowedDFBAddress(Program& program, const std::string& dfb_
     return dfb->groups[0].l1_by_core[0].second;
 }
 
-TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_BorrowsFlagPropagatesToConfig) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_BorrowedDFB_BorrowsFlagPropagatesToConfig) {
     // MakeProgramFromSpec should set config.borrows_memory = true on the device-side DFB
     // config when (and only when) DataflowBufferSpec::borrowed_from is set.
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
@@ -1247,7 +1247,7 @@ TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_BorrowsFlagPropagatesToConfig) {
     EXPECT_TRUE(dfb->borrows_memory()) << "DFB declared borrowed_from should have config.borrows_memory = true";
 }
 
-TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_AttachWritesTensorAddressToDFB) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_BorrowedDFB_AttachWritesTensorAddressToDFB) {
     // After SetProgramRunArgs, the bound MeshTensor's address should appear in the
     // DFB's per-core L1 base address tables (overwriting Almeet's 0 placeholder).
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
@@ -1270,7 +1270,7 @@ TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_AttachWritesTensorAddressToDFB) {
         << "DFB base addr should match the borrowed MeshTensor's address after attach";
 }
 
-TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_UpdateTensorArgsRefreshesAddress) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_BorrowedDFB_UpdateTensorArgsRefreshesAddress) {
     // The cache-hit path: UpdateTensorArgs should re-attach the borrowed Buffer, refreshing
     // the DFB's base address to the new MeshTensor's address.
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
@@ -1300,7 +1300,7 @@ TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_UpdateTensorArgsRefreshesAddress) {
 // Guard: resizing a borrowed-memory DFB on the partial-update path without supplying its backing
 // tensor is rejected — otherwise the per-bank fit check in AttachBorrowedDFBBuffers never re-runs
 // against the new size, and a grown DFB could silently overflow its borrowed buffer at execution.
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithoutTensorFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_ResizingBorrowedDFBWithoutTensorFails) {
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     program.impl().finalize_dataflow_buffer_configs();
@@ -1321,7 +1321,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithout
 
 // Supplying the backing tensor alongside the resize is accepted: the fit check re-runs and the new
 // size (48 B) still fits the 64 B backing.
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithTensorSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_ResizingBorrowedDFBWithTensorSucceeds) {
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     program.impl().finalize_dataflow_buffer_configs();
@@ -1344,7 +1344,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithTen
 
 // The payoff: with the backing tensor supplied, an over-large resize is now caught by the per-bank fit
 // check on the partial path (16 * 64 = 1024 B >> the 64 B backing) — the overflow the guard keeps checkable.
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBBeyondBackingFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_ResizingBorrowedDFBBeyondBackingFails) {
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
     program.impl().finalize_dataflow_buffer_configs();
@@ -1367,7 +1367,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBBeyondB
 // the binding's base address into that kernel's CRTA buffer via its second pass — the binding
 // address is per-enqueue state that has to reach the device whether or not the user supplies an
 // (otherwise-empty) kernel_run_args entry.
-TEST_F(ProgramRunArgsTestQuasar, BindingOnlyKernelOmittedFromRunArgsSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_BindingOnlyKernelOmittedFromRunArgsSucceeds) {
     // dm_kernel binds a TensorParameter but has an empty RTA/CRTA schema; compute_kernel is empty
     // too. Neither has scalar args, so neither needs a kernel_run_args entry.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
@@ -1394,7 +1394,7 @@ TEST_F(ProgramRunArgsTestQuasar, BindingOnlyKernelOmittedFromRunArgsSucceeds) {
         << "binding base address should be written even though the kernel was omitted from kernel_run_args";
 }
 
-TEST_F(ProgramRunArgsTestQuasar, BindingOnlyKernelOmittedFromRunArgsReSetSucceeds) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_BindingOnlyKernelOmittedFromRunArgsReSetSucceeds) {
     // Regression: SetProgramRunArgs must be re-callable on a program whose binding-only kernel is
     // omitted from kernel_run_args. The first call allocates the kernel's CRTA buffer in the second
     // pass; a second call must patch it in place — set_common_runtime_args fatals if called twice, so
@@ -1461,7 +1461,7 @@ inline ProgramSpec MakeGen1SpecWithRTAs(const NodeCoord& /*node*/, size_t num_pe
     return spec;
 }
 
-TEST_F(ProgramRunArgsTestGen1, SetRunArgsSucceeds_ZeroRTAs) {
+TEST_F(ProgramRunArgsTestGen1, CPU_SetRunArgsSucceeds_ZeroRTAs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeGen1SpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -1471,7 +1471,7 @@ TEST_F(ProgramRunArgsTestGen1, SetRunArgsSucceeds_ZeroRTAs) {
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestGen1, SetRunArgsSucceeds_PerNodeAndCommonRTAs) {
+TEST_F(ProgramRunArgsTestGen1, CPU_SetRunArgsSucceeds_PerNodeAndCommonRTAs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeGen1SpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/2);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -1488,7 +1488,7 @@ TEST_F(ProgramRunArgsTestGen1, SetRunArgsSucceeds_PerNodeAndCommonRTAs) {
 //   - a second SetProgramRunArgs (the in-place fast path that writes into the already-allocated
 //     buffer) must overwrite every slot correctly.
 // Together these cover both the scatter (slot placement) and the first-vs-subsequent buffer paths.
-TEST_F(ProgramRunArgsTestGen1, SetRunArgs_NamedPerNodeRTAs_ScatterToDeclarationSlots) {
+TEST_F(ProgramRunArgsTestGen1, CPU_SetRunArgs_NamedPerNodeRTAs_ScatterToDeclarationSlots) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.runtime_arg_names = {"a", "b", "c"};  // declaration slots 0,1,2
@@ -1534,7 +1534,7 @@ TEST_F(ProgramRunArgsTestGen1, SetRunArgs_NamedPerNodeRTAs_ScatterToDeclarationS
 // place. Pins that the vararg section lands AFTER the named section and that a re-Set overwrites
 // both correctly — distinct from the named-only test above, and the layout most likely to regress
 // if the fast/first-call split mishandles the named-vs-vararg offset.
-TEST_F(ProgramRunArgsTestGen1, SetRunArgs_NamedPlusVarargs_FastPathLayout) {
+TEST_F(ProgramRunArgsTestGen1, CPU_SetRunArgs_NamedPlusVarargs_FastPathLayout) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.runtime_arg_names = {"a", "b"};  // declaration slots 0,1
@@ -1576,7 +1576,7 @@ TEST_F(ProgramRunArgsTestGen1, SetRunArgs_NamedPlusVarargs_FastPathLayout) {
     }
 }
 
-TEST_F(ProgramRunArgsTestGen1, WrongRuntimeArgsCountFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_WrongRuntimeArgsCountFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeGen1SpecWithRTAs(node, /*num_per_node_rtas=*/3, /*num_common_rtas=*/0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -1596,7 +1596,7 @@ TEST_F(ProgramRunArgsTestGen1, WrongRuntimeArgsCountFails) {
 // Validation paths exercised by SetProgramRunArgs / ValidateProgramRunArgs for the
 // Metal 2.0 TensorAccessor binding feature.
 
-TEST_F(ProgramRunArgsTestGen1, MissingTensorArgFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_MissingTensorArgFails) {
     // Spec declares a TensorParameter; user supplies no TensorArgument entry for it.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
@@ -1614,7 +1614,7 @@ TEST_F(ProgramRunArgsTestGen1, MissingTensorArgFails) {
             "TensorParameter 'input_tensor' is declared in the Program but has no TensorArgument entry")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, UnknownTensorParameterInRunArgsFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UnknownTensorParameterInRunArgsFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");
@@ -1637,7 +1637,7 @@ TEST_F(ProgramRunArgsTestGen1, UnknownTensorParameterInRunArgsFails) {
             ::testing::HasSubstr("TensorArgument references unknown TensorParameter 'ghost_tensor'")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, TensorSpecMismatchFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_TensorSpecMismatchFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -1695,7 +1695,7 @@ inline uint32_t ReadBindingAddressFromCRTA(
     return 0;
 }
 
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_BeforeSetProgramRunArgsFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_BeforeSetProgramRunArgsFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");
     spec.tensor_parameters = {binding};
@@ -1715,7 +1715,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_BeforeSetProgramRunArgsFails) {
             ::testing::HasSubstr("UpdateTensorArgs called on Program before SetProgramRunArgs")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_MissingTensorArgFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_MissingTensorArgFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");
@@ -1740,7 +1740,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_MissingTensorArgFails) {
             "TensorParameter 'input_tensor' is declared in the Program but has no TensorArgument entry")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_UnknownTensorParameterFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_UnknownTensorParameterFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");
@@ -1765,7 +1765,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_UnknownTensorParameterFails) {
             ::testing::HasSubstr("TensorArgument references unknown TensorParameter 'ghost_tensor'")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_TensorSpecMismatchFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_TensorSpecMismatchFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
@@ -1800,7 +1800,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_TensorSpecMismatchFails) {
 
 // Locks the gate's polarity: the three tests above prove UpdateTensorArgs validates by default, so
 // this one proves skip_validation=true is what turns it off — and still performs the address patch.
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_SkipValidationBypassesSpecCheck) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_SkipValidationBypassesSpecCheck) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
@@ -1832,7 +1832,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_SkipValidationBypassesSpecCheck)
         << "skip_validation should bypass only the checks, not the address patch";
 }
 
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_PatchesBindingAddress) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_PatchesBindingAddress) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");
@@ -1865,7 +1865,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_PatchesBindingAddress) {
         ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor2.address()));
 }
 
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");
@@ -1908,7 +1908,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
         ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor2.address()));
 }
 
-TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTensor) {
+TEST_F(ProgramRunArgsTestGen1, CPU_UpdateTensorArgs_PatchesAllKernelsBoundToSameTensor) {
     // Binds the shared tensor to both a DM kernel and the compute kernel (kernels[1]) — now legal,
     // since a compute kernel constructs a LocalTensorAccessor from the binding token. Exercises the
     // host-side address patching reaching every kernel bound to the same tensor.
@@ -1952,7 +1952,7 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTens
 //     CRTAs immediately after the binding's address slot, on both SetProgramRunArgs
 //     and UpdateTensorArgs.
 
-TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_InterleavedAcceptsDifferentShape) {
+TEST_F(ProgramRunArgsTestGen1, CPU_DynamicTensorShape_InterleavedAcceptsDifferentShape) {
     // Declared shape {1, 32}; runtime tensor with shape {1, 64} is accepted because
     // dynamic_tensor_shape is set and everything else matches.
     NodeCoord node{0, 0};
@@ -1976,7 +1976,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_InterleavedAcceptsDifferentSha
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_DTypeMismatchStillFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_DynamicTensorShape_DTypeMismatchStillFails) {
     // dynamic_tensor_shape loosens shape only — dtype (part of tensor_layout) must still match.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
@@ -2005,7 +2005,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_DTypeMismatchStillFails) {
             ::testing::HasSubstr("tensor_layout does not match the binding's declared layout")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_RankMismatchFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_DynamicTensorShape_RankMismatchFails) {
     // dynamic_tensor_shape lets per-dim shape values vary, but the rank must remain constant.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
@@ -2068,7 +2068,7 @@ inline std::vector<uint32_t> ExpectedShapeInPagesFromSpec(const tt::tt_metal::Te
     return out;
 }
 
-TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_ShardedSetWritesShapeIntoCRTAs) {
+TEST_F(ProgramRunArgsTestGen1, CPU_DynamicTensorShape_ShardedSetWritesShapeIntoCRTAs) {
     // Sharded + dynamic_tensor_shape: SetProgramRunArgs must write the actual runtime
     // tensor's tensor_shape_in_pages into the CRTA section that follows the binding's address.
     // Layout: HEIGHT_SHARDED with shard_shape {32, 32} on 2 cores → 2 shards along height.
@@ -2095,7 +2095,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_ShardedSetWritesShapeIntoCRTAs
         ReadBindingShapeFromCRTA(program, "dm_kernel", "input_tensor"), ExpectedShapeInPagesFromSpec(binding.spec));
 }
 
-TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_ShardedUpdateRefreshesShape) {
+TEST_F(ProgramRunArgsTestGen1, CPU_DynamicTensorShape_ShardedUpdateRefreshesShape) {
     // Sharded + dynamic_tensor_shape: UpdateTensorArgs must refresh BOTH the address slot and
     // the runtime shape slots when bound to a tensor of different shape (but same layout).
     NodeCoord node{0, 0};
@@ -2141,7 +2141,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_ShardedUpdateRefreshesShape) {
 //   - logical_shape() may differ provided the resulting padded_shape is unchanged.
 //   - Strictly weaker than dynamic_tensor_shape; no device-side CTA/CRTA effect.
 
-TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_AcceptsDifferentLogicalShape) {
+TEST_F(ProgramRunArgsTestGen1, CPU_MatchPaddedShapeOnly_AcceptsDifferentLogicalShape) {
     // Declared logical shape {1, 1, 32, 32} on TILE layout produces padded_shape {1, 1, 32, 32}.
     // A runtime tensor with logical_shape {1, 1, 20, 20} pads up to the same {1, 1, 32, 32}, so
     // match_padded_shape_only accepts the rebind.
@@ -2175,7 +2175,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_AcceptsDifferentLogicalShape
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
 }
 
-TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_PaddedShapeMismatchFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_MatchPaddedShapeOnly_PaddedShapeMismatchFails) {
     // Same TensorLayout, but a logical shape that pads to a DIFFERENT padded_shape is rejected.
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
@@ -2210,7 +2210,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_PaddedShapeMismatchFails) {
             ::testing::HasSubstr("padded_shape does not match the binding's declared padded_shape")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DTypeMismatchStillFails) {
+TEST_F(ProgramRunArgsTestGen1, CPU_MatchPaddedShapeOnly_DTypeMismatchStillFails) {
     // match_padded_shape_only loosens only along logical_shape. tensor_layout fields (dtype here)
     // must still match exactly.
     NodeCoord node{0, 0};
@@ -2239,7 +2239,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DTypeMismatchStillFails) {
             ::testing::HasSubstr("tensor_layout does not match the binding's declared layout")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, TensorBindingOnlyKernelOmittedFromRunArgsSucceeds) {
+TEST_F(ProgramRunArgsTestGen1, CPU_TensorBindingOnlyKernelOmittedFromRunArgsSucceeds) {
     // A kernel with tensor bindings but an empty RTA/CRTA schema may be omitted from
     // kernel_run_args: SetProgramRunArgs fills its binding-section CRTAs (base addresses, dynamic
     // accessor fields) in a second pass over all binding-bearing kernels, so the binding address
@@ -2265,7 +2265,7 @@ TEST_F(ProgramRunArgsTestGen1, TensorBindingOnlyKernelOmittedFromRunArgsSucceeds
         << "binding address should be written even though the kernel was omitted from kernel_run_args";
 }
 
-TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
+TEST_F(ProgramRunArgsTestGen1, CPU_MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
     // When both match_padded_shape_only and dynamic_tensor_shape are set, dynamic is more
     // permissive and wins. A runtime tensor whose padded_shape differs from declared should
     // be accepted (which match_padded_shape_only alone would reject).
@@ -2296,7 +2296,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
 
 // --- The core contract: omitted args are retained, supplied args are updated ---
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedCRTA) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_RetainsOmittedCRTA) {
     NodeCoord node{0, 0};
     // Declaration order: keep @ slot 0 (omitted from the update), change @ slot 1 (supplied).
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
@@ -2323,7 +2323,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedCRTA) {
     EXPECT_EQ(crta[1], 99u) << "supplied 'change' must be updated";
 }
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedPerNodeRTA) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_RetainsOmittedPerNodeRTA) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"keep", "change"}, {});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2351,7 +2351,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedPerNodeRTA) 
 
 // --- Still enforced: a supplied name must be declared in the schema (no extras) ---
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_UndeclaredCRTANameFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_UndeclaredCRTANameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2377,7 +2377,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_UndeclaredCRTANameFails) {
 
 // --- Precondition: a partial update before any full set fails ---
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BeforeSetFails) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_BeforeSetFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2394,7 +2394,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BeforeSetFails) {
 
 // --- Kernel omission: an omitted kernel retains all of its args ---
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingKernelRetainsArgs) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_OmittingKernelRetainsArgs) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"change"});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2421,7 +2421,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingKernelRetainsArgs)
 // common section — plus the untouched node's values intact. Guards against (a) a re-introduced
 // vararg completeness check (would FATAL on the omission) and (b) a patch that clobbers a retained
 // section or writes the wrong node.
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedVarargsAcrossNodes) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_RetainsOmittedVarargsAcrossNodes) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
     NodeRangeSet all_nodes(std::set<NodeRange>{NodeRange{node0, node0}, NodeRange{node1, node1}});
@@ -2496,7 +2496,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedVarargsAcros
 // --- DFB size overrides on the fast path (mock fixture: inspects config, no enqueue) ---
 
 // UpdateProgramRunArgs applies a DFB size override, mirroring the SetProgramRunArgs path.
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_AppliesDFBSizeOverride) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_AppliesDFBSizeOverride) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2515,7 +2515,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_AppliesDFBSizeOverride) {
 
 // DFB size overrides are stateful: a DFB not re-specified in a later update keeps its current
 // size rather than reverting to the ProgramSpec default.
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsDFBSizeOverrideWhenUnspecified) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_RetainsDFBSizeOverrideWhenUnspecified) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2544,7 +2544,7 @@ const ProgramRunArgs::KernelRunArgs* FindKernel(const ProgramRunArgs& p, const s
     return nullptr;
 }
 
-TEST(MergeProgramRunArgs, UnionsDisjointCRTAsForSameKernel) {
+TEST(MergeProgramRunArgs, CPU_UnionsDisjointCRTAsForSameKernel) {
     // The motivating pattern: two pieces carrying disjoint named CRTAs for the SAME kernel merge
     // into one kernel entry holding both.
     ProgramRunArgs first_piece;
@@ -2571,7 +2571,7 @@ TEST(MergeProgramRunArgs, UnionsDisjointCRTAsForSameKernel) {
     EXPECT_EQ(*change, 20u);
 }
 
-TEST(MergeProgramRunArgs, ConflictingArgFails) {
+TEST(MergeProgramRunArgs, CPU_ConflictingArgFails) {
     ProgramRunArgs a;
     a.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
         .kernel = KernelSpecName{"dm_kernel"},
@@ -2589,7 +2589,7 @@ TEST(MergeProgramRunArgs, ConflictingArgFails) {
             ::testing::HasSubstr("specified in more than one ProgramRunArgs")));
 }
 
-TEST(MergeProgramRunArgs, AppendsDistinctKernel) {
+TEST(MergeProgramRunArgs, CPU_AppendsDistinctKernel) {
     ProgramRunArgs a;
     a.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
         .kernel = KernelSpecName{"dm_kernel"},
@@ -2675,7 +2675,7 @@ public:
     }
 };
 
-TEST_F(ProgramRunArgsTestQuasar, TrackProgramCollapsesAliasedDataflowBuffers) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_TrackProgramCollapsesAliasedDataflowBuffers) {
     // Equal totals (512*8 == 1024*4) so the assertion holds whichever member becomes primary.
     ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2696,7 +2696,7 @@ TEST_F(ProgramRunArgsTestQuasar, TrackProgramCollapsesAliasedDataflowBuffers) {
     EXPECT_TRUE(processor->cb_sizes.empty()) << "a dataflow buffer is not a circular buffer";
 }
 
-TEST_F(ProgramRunArgsTestQuasar, TrackProgramFlagsBorrowedDataflowBuffer) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_TrackProgramFlagsBorrowedDataflowBuffer) {
     // entry_size 16 * num_entries 2 = 32 bytes.
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2715,7 +2715,7 @@ TEST_F(ProgramRunArgsTestQuasar, TrackProgramFlagsBorrowedDataflowBuffer) {
 
 // Scratchpads are program-scope L1 stacked on top of the DFB region, so a consumer summing L1 has
 // to see them too or it under-reports — the wrong direction for a "does this fit" query.
-TEST_F(ProgramRunArgsTestQuasar, TrackProgramReportsKernelScratchpads) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_TrackProgramReportsKernelScratchpads) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();  // one DFB, entry_size 1024 * num_entries 2
     spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"scratch_0"}, .size_per_node = 1024}};
     spec.kernels[0].scratchpad_bindings = {
@@ -2736,7 +2736,7 @@ TEST_F(ProgramRunArgsTestQuasar, TrackProgramReportsKernelScratchpads) {
 
 // Without a hook the program goes on to run, and its allocations report themselves with real
 // addresses. Reporting here too would double-count them.
-TEST_F(ProgramRunArgsTestQuasar, TrackProgramSkipsDataflowBuffersWhenProgramIsNotHooked) {
+TEST_F(ProgramRunArgsTestQuasar, CPU_TrackProgramSkipsDataflowBuffersWhenProgramIsNotHooked) {
     ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -131,7 +131,7 @@ static_assert(hashable_v<DFBAdvancedOptions>, "DFBAdvancedOptions must be hashab
 static_assert(hashable_v<SemaphoreAdvancedOptions>, "SemaphoreAdvancedOptions must be hashable via ttsl reflection");
 static_assert(hashable_v<TensorSpecRelaxations>, "TensorSpecRelaxations must be hashable via ttsl reflection");
 
-TEST(ProgramSpecReflectionTest, IsHashable) {
+TEST(ProgramSpecReflectionTest, CPU_IsHashable) {
     const ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Deterministic: hashing the same spec twice yields the same value.
@@ -179,7 +179,7 @@ protected:
 // ============================================================================
 // These test the structural integrity checks that happen during spec collection.
 
-TEST_F(ProgramSpecTestQuasar, DuplicateKernelNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DuplicateKernelNameFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add a kernel with duplicate name
@@ -192,7 +192,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateKernelNameFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate KernelSpec name 'dm_kernel'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DuplicateDFBNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DuplicateDFBNameFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add a DFB with duplicate name
@@ -205,7 +205,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateDFBNameFails) {
             ::testing::HasSubstr("Duplicate DataflowBufferSpec name 'dfb_0'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DuplicateSemaphoreNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DuplicateSemaphoreNameFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add two semaphores with the same name
@@ -224,7 +224,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateSemaphoreNameFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate SemaphoreSpec name 'sem_0'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, SharedLocalAccessorNameForDifferentDFBsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_SharedLocalAccessorNameForDifferentDFBsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -249,7 +249,7 @@ TEST_F(ProgramSpecTestQuasar, SharedLocalAccessorNameForDifferentDFBsFails) {
             ::testing::HasSubstr("Kernel 'kernel' uses accessor_name 'same_accessor' for two different DFBs")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DuplicateProducerBindingForSameLocalAccessorNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DuplicateProducerBindingForSameLocalAccessorNameFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -275,7 +275,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateProducerBindingForSameLocalAccessorNameFa
             ::testing::HasSubstr("duplicate PRODUCER binding for accessor_name 'shared'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, SelfLoopWithSharedLocalAccessorNameSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_SelfLoopWithSharedLocalAccessorNameSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -299,7 +299,7 @@ TEST_F(ProgramSpecTestQuasar, SelfLoopWithSharedLocalAccessorNameSucceeds) {
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, DMKernelSelfLoopOnGen2Fails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DMKernelSelfLoopOnGen2Fails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -330,7 +330,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelSelfLoopOnGen2Fails) {
             ::testing::HasSubstr("not supported for data-movement kernels on Gen2 architectures"))));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBBoundTwiceInSameRoleUnderDifferentNamesFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBBoundTwiceInSameRoleUnderDifferentNamesFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -359,7 +359,7 @@ TEST_F(ProgramSpecTestQuasar, DFBBoundTwiceInSameRoleUnderDifferentNamesFails) {
             ::testing::HasSubstr("has two CONSUMER bindings to DFB 'dfb' under different accessor names")));
 }
 
-TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_InvalidLocalAccessorNameFails) {
     NodeCoord node{0, 0};
 
     const std::vector<std::string> invalid_names = {
@@ -397,7 +397,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidLocalAccessorNameFails) {
     }
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_KernelReferencesUnknownDFBFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -416,7 +416,7 @@ TEST_F(ProgramSpecTestQuasar, KernelReferencesUnknownDFBFails) {
             ::testing::HasSubstr("Kernel 'kernel' references unknown DFB 'nonexistent_dfb'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithNoBindingsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithNoBindingsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -438,7 +438,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithNoBindingsFails) {
             ::testing::HasSubstr("DFB 'orphan_dfb' is defined but not bound by any kernel")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithOnlyProducerFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithOnlyProducerFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -459,7 +459,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyProducerFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has no consumer")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithOnlyConsumerFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -480,7 +480,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithOnlyConsumerFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has no producer")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInSameWorkUnitFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithMultipleProducersInSameWorkUnitFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -509,7 +509,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInSameWorkUnitFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("2 producer instance(s)")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithMultipleConsumersInSameWorkUnitFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -538,7 +538,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("2 consumer instance(s)")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInDifferentWorkUnitsSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithMultipleConsumersInDifferentWorkUnitsSucceeds) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -567,7 +567,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInDifferentWorkUnitsSuccee
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInDifferentWorkUnitsSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithMultipleProducersInDifferentWorkUnitsSucceeds) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -595,7 +595,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInDifferentWorkUnitsSuccee
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, MultiBindingFlagOnGen2Fails) {
+TEST_F(ProgramSpecTestQuasar, CPU_MultiBindingFlagOnGen2Fails) {
     // allow_instance_multi_binding is a Gen1-only escape hatch. Setting it on a Gen2 target is a hard
     // error regardless of whether any instance is actually multi-bound — here the DFB is a plain
     // single-producer/single-consumer buffer that would otherwise be perfectly valid.
@@ -623,7 +623,7 @@ TEST_F(ProgramSpecTestQuasar, MultiBindingFlagOnGen2Fails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("only supported on Gen1")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBProducerConsumerCoverageMismatchFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -657,7 +657,7 @@ TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
 // separate specialized DM producer per node group. The producer role has several KernelSpecs (one
 // per group's WorkUnitSpec); the single consumer joins every group's WorkUnitSpec. Each node ends
 // up with exactly one producer and one consumer instance, so the per-node census accepts it.
-TEST_F(ProgramSpecTestQuasar, LocalDFBAllGridConsumerWithPerGroupProducersSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_LocalDFBAllGridConsumerWithPerGroupProducersSucceeds) {
     ProgramSpec spec;
     spec.name = "test_program";
 
@@ -685,7 +685,7 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBAllGridConsumerWithPerGroupProducersSuccee
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBMultiBindingAccessPatternMismatchFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBMultiBindingAccessPatternMismatchFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -716,7 +716,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingAccessPatternMismatchFails) {
             ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER bindings with mismatched access_pattern")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBMultiBindingNumThreadsMismatchFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBMultiBindingNumThreadsMismatchFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -747,7 +747,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingNumThreadsMismatchFails) {
             ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER KernelSpecs with mismatched num_threads")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBMultiBindingMixingComputeAndDMOnSameRoleFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBMultiBindingMixingComputeAndDMOnSameRoleFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -781,7 +781,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingMixingComputeAndDMOnSameRoleFails) 
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("mixing compute and data-movement kinds")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -814,7 +814,7 @@ TEST_F(ProgramSpecTestQuasar, DFBMultiBindingSelfLoopWithMatchingSidesSucceeds) 
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBSelfLoopWithExtraProducerSideKernelFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -863,7 +863,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopWithExtraProducerSideKernelFails) {
 // opt out per-DFB (disable_dfb_implicit_sync_for) or for all the DFBs it binds at once
 // (disable_dfb_implicit_sync_for_all). These tests pin the per-kernel "all" hammer.
 
-TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllDisablesProducerSide) {
+TEST_F(ProgramSpecTestQuasar, CPU_DisableImplicitSyncForAllDisablesProducerSide) {
     // Build the canonical DM-producer -> compute-consumer DFB, optionally hammering the
     // producer's implicit sync off, and read back the lowered DataflowBufferConfig.
     auto make_spec = [](bool disable_all) {
@@ -902,7 +902,7 @@ TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllDisablesProducerSide) {
     }
 }
 
-TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllDisagreementAcrossProducersFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DisableImplicitSyncForAllDisagreementAcrossProducersFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -938,7 +938,7 @@ TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllDisagreementAcrossProduce
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("disagreeing implicit-sync opt-out state")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllAgreesWithExplicitList) {
+TEST_F(ProgramSpecTestQuasar, CPU_DisableImplicitSyncForAllAgreesWithExplicitList) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -981,7 +981,7 @@ TEST_F(ProgramSpecTestQuasar, DisableImplicitSyncForAllAgreesWithExplicitList) {
 // Semantic Validation Tests (ValidateProgramSpec)
 // ============================================================================
 
-TEST_F(ProgramSpecTestQuasar, EmptyKernelsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_EmptyKernelsFails) {
     ProgramSpec spec;
     spec.name = "empty_program";
     spec.work_units = std::vector<WorkUnitSpec>{};  // Empty work_units too
@@ -992,7 +992,7 @@ TEST_F(ProgramSpecTestQuasar, EmptyKernelsFails) {
             ::testing::HasSubstr("A ProgramSpec must have at least one KernelSpec")));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelWithZeroThreadsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_KernelWithZeroThreadsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1007,7 +1007,7 @@ TEST_F(ProgramSpecTestQuasar, KernelWithZeroThreadsFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("KernelSpec 'kernel' has no threads")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DMKernelExceedingMaxThreadsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DMKernelExceedingMaxThreadsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1024,7 +1024,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelExceedingMaxThreadsFails) {
             ::testing::HasSubstr("KernelSpec 'kernel' has too many data movement threads")));
 }
 
-TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_ComputeKernelExceedingMaxThreadsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1041,7 +1041,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeKernelExceedingMaxThreadsFails) {
             "KernelSpec 'kernel' has too many threads. The architecture supports up to 4 for compute kernels")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DMKernelWithGen1ConfigFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DMKernelWithGen1ConfigFails) {
     // The config's generation must match the target platform: on Gen2 (Quasar) a DM kernel must
     // carry a DataMovementGen2Config. Supplying an explicit Gen1 config is a hard error — it is not
     // silently substituted with a default Gen2 config.
@@ -1067,7 +1067,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithGen1ConfigFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("holds a DataMovementGen1Config")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DMKernelWithDefaultGen2ConfigSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_DMKernelWithDefaultGen2ConfigSucceeds) {
     // On Gen2 a DM kernel needs no explicit tuning: Gen2 has a unified NOC and fully automated DM
     // placement, and a default Gen2Config (empty disable_dfb_implicit_sync_for) is all that's required.
     NodeCoord node{0, 0};
@@ -1084,7 +1084,7 @@ TEST_F(ProgramSpecTestQuasar, DMKernelWithDefaultGen2ConfigSucceeds) {
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, RoleBasedGen1ConfigOnGen2Fails) {
+TEST_F(ProgramSpecTestQuasar, CPU_RoleBasedGen1ConfigOnGen2Fails) {
     // MakeMinimalReaderDMKernel builds a Gen1 placement (DataMovementGen1Config), which
     // is the wrong generation for Gen2 (Quasar): the platform requires a DataMovementGen2Config, so the
     // mismatch is a hard error rather than a silently-ignored role hint.
@@ -1104,7 +1104,7 @@ TEST_F(ProgramSpecTestQuasar, RoleBasedGen1ConfigOnGen2Fails) {
 }
 
 // Cross-node DFBs are part of the API surface but not yet supported by the runtime.
-TEST_F(ProgramSpecTestQuasar, CrossNodeDFBNotYetSupportedAtRuntime) {
+TEST_F(ProgramSpecTestQuasar, CPU_CrossNodeDFBNotYetSupportedAtRuntime) {
     NodeCoord producer_node{0, 0};
     NodeCoord consumer_node{1, 0};
 
@@ -1171,13 +1171,13 @@ inline ProgramSpec MakeBorrowedDFBProgramSpec(
     return spec;
 }
 
-TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_BorrowedMemoryDFBSucceeds) {
     // Positive baseline: borrowed-memory DFB whose TensorParameter is L1-resident and large enough.
     ProgramSpec spec = MakeBorrowedDFBProgramSpec();
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBBackingParameterNeedNotBeKernelBoundSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_BorrowedMemoryDFBBackingParameterNeedNotBeKernelBoundSucceeds) {
     // Regression: a TensorParameter used ONLY as a borrowed-memory DFB's backing (referenced via
     // borrowed_from, never bound by a kernel) is a legitimate use. The validator must count
     // borrowed_from toward referential integrity rather than rejecting the parameter as "defined
@@ -1192,7 +1192,7 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBBackingParameterNeedNotBeKernelBo
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBUnknownTensorParameterFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_BorrowedMemoryDFBUnknownTensorParameterFails) {
     ProgramSpec spec = MakeBorrowedDFBProgramSpec("borrowed_tensor");
     // Re-target the DFB at a TensorParameter that wasn't declared.
     spec.dataflow_buffers[0].borrowed_from = TensorParamName{"nonexistent_tensor"};
@@ -1203,7 +1203,7 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBUnknownTensorParameterFails) {
             ::testing::HasSubstr("borrows memory from TensorParameter 'nonexistent_tensor'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBNonL1TensorParameterFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_BorrowedMemoryDFBNonL1TensorParameterFails) {
     // DRAM-resident TensorParameter is not a legal borrow source.
     ProgramSpec spec = MakeBorrowedDFBProgramSpec("borrowed_tensor", tt::tt_metal::BufferType::DRAM);
 
@@ -1212,7 +1212,7 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBNonL1TensorParameterFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is not L1-resident")));
 }
 
-TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOversizedFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_BorrowedMemoryDFBOversizedFails) {
     // DFB total bytes exceed the TensorParameter's packed size: 1*32*sizeof(bfloat16) = 64 bytes,
     // so 128 bytes of DFB (entry_size 64, num_entries 2) overruns.
     ProgramSpec spec = MakeBorrowedDFBProgramSpec(
@@ -1224,7 +1224,7 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOversizedFails) {
             ::testing::HasSubstr("is larger than its borrowed TensorParameter")));
 }
 
-TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
+TEST_F(ProgramSpecTestQuasar, CPU_SemaphoresSucceed) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreSpec sem;
@@ -1235,7 +1235,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
+TEST_F(ProgramSpecTestQuasar, CPU_KernelSemaphoreBindingsSucceed) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreSpec sem;
@@ -1251,7 +1251,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingsSucceed) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
+TEST_F(ProgramSpecTestQuasar, CPU_SemaphoreBoundToComputeKernelFailsOnQuasar) {
     // Compute kernels cannot have semaphore bindings on any arch.
     // (This may later change for Quasar.)
     ProgramSpec spec = MakeMinimalValidProgramSpec();
@@ -1272,7 +1272,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreBoundToComputeKernelFailsOnQuasar) {
             ::testing::HasSubstr("Semaphore bindings are not supported for compute kernels.")));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_KernelSemaphoreBindingUnknownSemaphoreFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreBinding binding;
@@ -1286,7 +1286,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingUnknownSemaphoreFails) {
             ::testing::HasSubstr("references unknown semaphore 'missing_sem'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_KernelSemaphoreBindingInvalidAccessorFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreSpec sem;
@@ -1305,7 +1305,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingInvalidAccessorFails) {
             ::testing::HasSubstr("semaphore accessor_name 'has-dash' must be a valid C++ identifier")));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_KernelSemaphoreBindingDuplicateAccessorFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreSpec sem0;
@@ -1339,7 +1339,7 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
 // above: build on MakeMinimalValidProgramSpec() and bind the scratchpad to the DM kernel
 // (kernels[0]).
 
-TEST_F(ProgramSpecTestQuasar, ValidScratchpadSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_ValidScratchpadSucceeds) {
     // Positive baseline: one ScratchpadSpec bound by exactly one kernel.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
@@ -1350,7 +1350,7 @@ TEST_F(ProgramSpecTestQuasar, ValidScratchpadSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DuplicateScratchpadNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DuplicateScratchpadNameFails) {
     // Two ScratchpadSpecs declared with the same unique_id.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
@@ -1366,7 +1366,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateScratchpadNameFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Duplicate ScratchpadSpec name")));
 }
 
-TEST_F(ProgramSpecTestQuasar, ZeroSizeScratchpadFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_ZeroSizeScratchpadFails) {
     // A ScratchpadSpec with size_per_node == 0 (the default) reserves no L1, so the device-side
     // accessor's operator[] would be out of bounds on first use. Bound to a kernel here so the
     // size check — not the unbound check — is what fires.
@@ -1381,7 +1381,7 @@ TEST_F(ProgramSpecTestQuasar, ZeroSizeScratchpadFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("size_per_node == 0")));
 }
 
-TEST_F(ProgramSpecTestQuasar, UnknownScratchpadReferenceFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_UnknownScratchpadReferenceFails) {
     // A scratchpad_binding referencing a scratchpad_spec_name that isn't declared in spec.scratchpads.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
@@ -1394,7 +1394,7 @@ TEST_F(ProgramSpecTestQuasar, UnknownScratchpadReferenceFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("references unknown scratchpad")));
 }
 
-TEST_F(ProgramSpecTestQuasar, UnboundScratchpadFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_UnboundScratchpadFails) {
     // A ScratchpadSpec declared in spec.scratchpads that no kernel binds. An unbound scratchpad
     // reserves L1 no kernel can reach.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
@@ -1407,7 +1407,7 @@ TEST_F(ProgramSpecTestQuasar, UnboundScratchpadFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("declared but not bound")));
 }
 
-TEST_F(ProgramSpecTestQuasar, ScratchpadBoundByTwoKernelsSameNodeFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_ScratchpadBoundByTwoKernelsSameNodeFails) {
     // One ScratchpadSpec bound by two kernels that share a node. A scratchpad is private node-local
     // L1; binding it from two kernels on the SAME node would be true sharing, which is not yet
     // supported (the disjoint-node case IS allowed — see the next test). MakeMinimalValidProgramSpec
@@ -1426,7 +1426,7 @@ TEST_F(ProgramSpecTestQuasar, ScratchpadBoundByTwoKernelsSameNodeFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("kernel instances on node")));
 }
 
-TEST_F(ProgramSpecTestQuasar, ScratchpadBoundByTwoKernelsDisjointNodesSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_ScratchpadBoundByTwoKernelsDisjointNodesSucceeds) {
     // Complement of the same-node case above: one ScratchpadSpec bound by two kernels on DISJOINT
     // nodes is legal. Each node hosts exactly one binding kernel instance, so the per-node scratchpad
     // stays private to that kernel (allocation + CRTA delivery are per-binding-kernel, so the two
@@ -1455,7 +1455,7 @@ TEST_F(ProgramSpecTestQuasar, ScratchpadBoundByTwoKernelsDisjointNodesSucceeds) 
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, ScratchpadBoundTwiceInOneKernelFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_ScratchpadBoundTwiceInOneKernelFails) {
     // One kernel binds the SAME scratchpad twice under two different accessor_names. Illegal: a kernel
     // may bind a given scratchpad at most once (two bindings would request two separate per-node
     // allocations under one name). This is a structural input error with no node-set dependency, so
@@ -1474,7 +1474,7 @@ TEST_F(ProgramSpecTestQuasar, ScratchpadBoundTwiceInOneKernelFails) {
             ::testing::HasSubstr("binds scratchpad 'scratch_0' more than once")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DuplicateScratchpadAccessorNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DuplicateScratchpadAccessorNameFails) {
     // One kernel with two scratchpad_bindings to two DIFFERENT scratchpads but sharing the same
     // accessor_name. The accessor_name is the kernel-local C++ symbol, so it must be unique per
     // kernel (the per-kernel duplicate check fires before the bound-more-than-once check, since
@@ -1495,7 +1495,7 @@ TEST_F(ProgramSpecTestQuasar, DuplicateScratchpadAccessorNameFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("duplicate scratchpad accessor_name")));
 }
 
-TEST_F(ProgramSpecTestQuasar, InvalidScratchpadAccessorNameFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_InvalidScratchpadAccessorNameFails) {
     // The accessor_name becomes a C++ identifier in the generated kernel_bindings header, so it must
     // be a valid C++ identifier. (Mirrors InvalidLocalAccessorNameFails / the semaphore-accessor
     // equivalent; here we just spot-check a couple of clearly-invalid names.)
@@ -1517,7 +1517,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidScratchpadAccessorNameFails) {
     }
 }
 
-TEST_F(ProgramSpecTestQuasar, MultipleScratchpadsEachBoundToOwnKernelSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_MultipleScratchpadsEachBoundToOwnKernelSucceeds) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -1555,7 +1555,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleScratchpadsEachBoundToOwnKernelSucceeds) {
 // ScratchpadBindingHandles, so a kernel that binds a scratchpad must NOT hash equal to one that
 // doesn't — otherwise it would silently reuse a stale cached binary.
 
-TEST_F(ProgramSpecTestQuasar, ScratchpadBindingAffectsKernelHash) {
+TEST_F(ProgramSpecTestQuasar, CPU_ScratchpadBindingAffectsKernelHash) {
     // Same kernel source, differing only in whether the kernel binds a scratchpad. The bound variant
     // carries an extra ScratchpadBindingHandle, so the hashes must differ.
     auto make_bound_spec = [] {
@@ -1587,7 +1587,7 @@ TEST_F(ProgramSpecTestQuasar, ScratchpadBindingAffectsKernelHash) {
         << "A kernel that binds a scratchpad must not share a JIT cache slot with one that doesn't.";
 }
 
-TEST_F(ProgramSpecTestQuasar, DifferentScratchpadSizeProducesDifferentKernelHash) {
+TEST_F(ProgramSpecTestQuasar, CPU_DifferentScratchpadSizeProducesDifferentKernelHash) {
     // Same kernel source and accessor name; the two scratchpads differ only in size_per_node, which
     // flows into the ScratchpadBindingHandle's size (and the generated scratch:: token), so the
     // hashes must differ.
@@ -1611,7 +1611,7 @@ TEST_F(ProgramSpecTestQuasar, DifferentScratchpadSizeProducesDifferentKernelHash
     EXPECT_NE(hash_small, hash_large) << "Scratchpads of different sizes must produce different kernel hashes.";
 }
 
-TEST_F(ProgramSpecTestQuasar, TensorBindingOnComputeKernelIsAccepted) {
+TEST_F(ProgramSpecTestQuasar, CPU_TensorBindingOnComputeKernelIsAccepted) {
     // A tensor binding on a compute kernel is legal: the kernel constructs a LocalTensorAccessor
     // (NOC-free) from the binding token rather than a TensorAccessor. ValidateProgramSpec accepts it;
     // there is no host-side residency check. (The compile/dispatch path is proven in the HW test
@@ -1623,7 +1623,7 @@ TEST_F(ProgramSpecTestQuasar, TensorBindingOnComputeKernelIsAccepted) {
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
+TEST_F(ProgramSpecTestQuasar, CPU_SemaphoreNonZeroInitialValueFailsOnQuasar) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     SemaphoreSpec sem;
@@ -1640,7 +1640,7 @@ TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
 
 // ---- Named RTA / CRTA / CTA schema validation ----
 
-TEST_F(ProgramSpecTestQuasar, NamedRuntimeArgsSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_NamedRuntimeArgsSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.runtime_arg_names = {"input_ptr", "output_ptr"};
     spec.kernels[0].runtime_arg_schema.common_runtime_arg_names = {"tile_count"};
@@ -1649,7 +1649,7 @@ TEST_F(ProgramSpecTestQuasar, NamedRuntimeArgsSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, InvalidNamedRtaIdentifierFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_InvalidNamedRtaIdentifierFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.runtime_arg_names = {"int"};  // C++ keyword
 
@@ -1659,7 +1659,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidNamedRtaIdentifierFails) {
             ::testing::HasSubstr("named RTA name 'int' is not a valid C++ identifier")));
 }
 
-TEST_F(ProgramSpecTestQuasar, InvalidNamedCrtaIdentifierFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_InvalidNamedCrtaIdentifierFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.common_runtime_arg_names = {"has-dash"};
 
@@ -1669,7 +1669,7 @@ TEST_F(ProgramSpecTestQuasar, InvalidNamedCrtaIdentifierFails) {
             ::testing::HasSubstr("named CRTA name 'has-dash' is not a valid C++ identifier")));
 }
 
-TEST_F(ProgramSpecTestQuasar, NamedRtaCrtaCollisionFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_NamedRtaCrtaCollisionFails) {
     // A single name cannot be both a named RTA and a named CRTA (they share the user namespace).
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.runtime_arg_names = {"count"};
@@ -1681,7 +1681,7 @@ TEST_F(ProgramSpecTestQuasar, NamedRtaCrtaCollisionFails) {
             ::testing::HasSubstr("naming collision: 'count' is declared as both a named RTA and a named CRTA")));
 }
 
-TEST_F(ProgramSpecTestQuasar, NamedRtaCtaCollisionFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_NamedRtaCtaCollisionFails) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.runtime_arg_names = {"block_size"};
     spec.kernels[0].compile_time_args = {{"block_size", 64}};  // same name as CTA
@@ -1692,7 +1692,7 @@ TEST_F(ProgramSpecTestQuasar, NamedRtaCtaCollisionFails) {
             ::testing::HasSubstr("naming collision: 'block_size' is declared as both a named RTA and a named CTA")));
 }
 
-TEST_F(ProgramSpecTestQuasar, DifferentKernelsMayReuseArgNames) {
+TEST_F(ProgramSpecTestQuasar, CPU_DifferentKernelsMayReuseArgNames) {
     // Collision rule is per-kernel. Two different kernels may have identically-named args.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     spec.kernels[0].runtime_arg_schema.runtime_arg_names = {"shared_name"};
@@ -1701,7 +1701,7 @@ TEST_F(ProgramSpecTestQuasar, DifferentKernelsMayReuseArgNames) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBWithComputeEndpointRequiresDataFormat) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1725,7 +1725,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithComputeEndpointRequiresDataFormat) {
             ::testing::HasSubstr("DFB 'dfb' is used by a compute kernel, but no data_format_metadata is specified")));
 }
 
-TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnboundDFBFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_ComputeConfigUnpackToDestModeReferencesUnboundDFBFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1756,13 +1756,13 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigUnpackToDestModeReferencesUnboundDFBF
                                  "which the kernel does not bind")));
 }
 
-TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithoutUnpackToDestModeEntrySucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_NonFP32DFBWithoutUnpackToDestModeEntrySucceeds) {
     // Non-FP32 DFBs default to Default; omitting an entry is the expected idiom.
     ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b (non-FP32)
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithExplicitDefaultUnpackToDestModeSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_NonFP32DFBWithExplicitDefaultUnpackToDestModeSucceeds) {
     // Existing call sites that explicitly spell out Default for non-FP32 DFBs keep working.
     ProgramSpec spec = MakeMinimalValidProgramSpec();  // dfb_0 is Float16_b
     for (auto& kernel : spec.kernels) {
@@ -1774,7 +1774,7 @@ TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithExplicitDefaultUnpackToDestModeSucce
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithUnpackToDestFp32ModeSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_NonFP32DFBWithUnpackToDestFp32ModeSucceeds) {
     // UnpackToDest on a non-Float32 DFB is INERT: the LLK ignores the mode where the data
     // isn't FP32. The validator tolerates it (rejecting it would force porters to dtype-gate
     // legacy unpack_to_dest_mode vectors that set UnpackToDestFp32 unconditionally). With
@@ -1790,7 +1790,7 @@ TEST_F(ProgramSpecTestQuasar, NonFP32DFBWithUnpackToDestFp32ModeSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, FP32ConsumerWithFp32DestAccEnAndNoEntryFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_FP32ConsumerWithFp32DestAccEnAndNoEntryFails) {
     // The narrow case where a choice is required: CONSUMER + FP32 + enable_32_bit_dest=true.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     for (auto& dfb : spec.dataflow_buffers) {
@@ -1813,7 +1813,7 @@ TEST_F(ProgramSpecTestQuasar, FP32ConsumerWithFp32DestAccEnAndNoEntryFails) {
             "provides no unpack_modes entry for this DFB")));
 }
 
-TEST_F(ProgramSpecTestQuasar, FP32ConsumerWithoutFp32DestAccEnDoesNotRequireEntry) {
+TEST_F(ProgramSpecTestQuasar, CPU_FP32ConsumerWithoutFp32DestAccEnDoesNotRequireEntry) {
     // Without enable_32_bit_dest, UnpackToDest is incoherent (Dest is 16-bit), so there's
     // no real choice — UnpackToSrc is the only valid value. No explicit entry required.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
@@ -1826,7 +1826,7 @@ TEST_F(ProgramSpecTestQuasar, FP32ConsumerWithoutFp32DestAccEnDoesNotRequireEntr
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, FP32ProducerOnlyBindingDoesNotRequireEntry) {
+TEST_F(ProgramSpecTestQuasar, CPU_FP32ProducerOnlyBindingDoesNotRequireEntry) {
     // A compute kernel that only PRODUCES an FP32 DFB never unpacks it, so the unpack mode
     // is dead config — no explicit entry required regardless of enable_32_bit_dest.
     NodeCoord node{0, 0};
@@ -1854,7 +1854,7 @@ TEST_F(ProgramSpecTestQuasar, FP32ProducerOnlyBindingDoesNotRequireEntry) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32OnProducerBindingSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestFp32OnProducerBindingSucceeds) {
     // UnpackToDest on a producer-only binding is INERT (producers don't unpack), so the
     // validator tolerates it rather than rejecting. With enable_32_bit_dest=true it is coherent.
     NodeCoord node{0, 0};
@@ -1883,7 +1883,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32OnProducerBindingSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32WithoutFp32DestAccEnFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestFp32WithoutFp32DestAccEnFails) {
     // A 32-bit-format DFB (here Float32) cannot be unpacked into a 16-bit Dest, so UnpackToDest
     // on a consumed 32-bit DFB with enable_32_bit_dest=false is rejected on every generation.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
@@ -1905,7 +1905,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestFp32WithoutFp32DestAccEnFails) {
             ::testing::HasSubstr("A 32-bit datum cannot be unpacked into a 16-bit Dest register")));
 }
 
-TEST_F(ProgramSpecTestQuasar, ConsumerUnpackToDestBelow32BitWithoutEnableSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_ConsumerUnpackToDestBelow32BitWithoutEnableSucceeds) {
     // Gen2 has no unpack-to-Dest performance penalty, so UnpackToDest on a consumed <=16-bit DFB
     // is accepted even without enable_32_bit_dest (a 16-bit Dest holds a <=16-bit datum). On Gen1
     // the same spec is rejected as bad-for-perf — see the ProgramSpecTestGen1 counterpart.
@@ -1920,7 +1920,7 @@ TEST_F(ProgramSpecTestQuasar, ConsumerUnpackToDestBelow32BitWithoutEnableSucceed
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, FP32DFBWithDefaultUnpackToDestModeSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_FP32DFBWithDefaultUnpackToDestModeSucceeds) {
     // UnpackToSrc is always a valid value, even outside the (CONSUMER + FP32 + enable_32_bit_dest) triple.
     ProgramSpec spec = MakeMinimalValidProgramSpec();
     for (auto& dfb : spec.dataflow_buffers) {
@@ -1938,7 +1938,7 @@ TEST_F(ProgramSpecTestQuasar, FP32DFBWithDefaultUnpackToDestModeSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_DataFormatNotSupportedOnTargetArchitectureFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1963,7 +1963,7 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB 'dfb' has data format")));
 }
 
-TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
+TEST_F(ProgramSpecTestQuasar, CPU_TooManyDFBsFailsValidation) {
     // Device slots are per-core: exceeding the per-node slot count on a single node must fail
     // validation rather than blowing up downstream during JIT / enqueue.
     NodeCoord node{0, 0};
@@ -1997,7 +1997,7 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
 // WorkUnitSpec Validation Tests
 // ============================================================================
 
-TEST_F(ProgramSpecTestQuasar, EmptyWorkUnitSpecsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_EmptyWorkUnitSpecsFails) {
     ProgramSpec spec;
     spec.name = "test_program";
 
@@ -2011,7 +2011,7 @@ TEST_F(ProgramSpecTestQuasar, EmptyWorkUnitSpecsFails) {
             ::testing::HasSubstr("Kernel 'kernel' is not referenced by any WorkUnitSpec")));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkUnitSpecWithNoKernelsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_WorkUnitSpecWithNoKernelsFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -2032,7 +2032,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitSpecWithNoKernelsFails) {
             ::testing::HasSubstr("Kernel 'kernel' is not referenced by any WorkUnitSpec")));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkUnitSpecReferencesUnknownKernelFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_WorkUnitSpecReferencesUnknownKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -2050,7 +2050,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitSpecReferencesUnknownKernelFails) {
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' references unknown kernel 'nonexistent_kernel'")));
 }
 
-TEST_F(ProgramSpecTestQuasar, OverlappingWorkUnitSpecsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_OverlappingWorkUnitSpecsFails) {
     // Two work_units cannot target overlapping nodes
     NodeCoord node{0, 0};
 
@@ -2070,7 +2070,7 @@ TEST_F(ProgramSpecTestQuasar, OverlappingWorkUnitSpecsFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("overlap in target nodes")));
 }
 
-TEST_F(ProgramSpecTestQuasar, KernelNotInAnyWorkUnitSpecFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_KernelNotInAnyWorkUnitSpecFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -2088,7 +2088,7 @@ TEST_F(ProgramSpecTestQuasar, KernelNotInAnyWorkUnitSpecFails) {
             ::testing::HasSubstr("Kernel 'kernel2' is not referenced by any WorkUnitSpec")));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsDMCoreBudgetFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_WorkUnitExceedsDMCoreBudgetFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -2108,7 +2108,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsDMCoreBudgetFails) {
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' requests 9 data movement cores")));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsComputeCoreBudgetFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_WorkUnitExceedsComputeCoreBudgetFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -2128,7 +2128,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitExceedsComputeCoreBudgetFails) {
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' needs 6 Tensix engines")));
 }
 
-TEST_F(ProgramSpecTestQuasar, WorkUnitWithMultipleComputeKernelsFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_WorkUnitWithMultipleComputeKernelsFails) {
     // A work_unit can have at most one compute kernel
     NodeCoord node{0, 0};
 
@@ -2147,7 +2147,7 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitWithMultipleComputeKernelsFails) {
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' has more than one compute kernel")));
 }
 
-TEST_F(ProgramSpecTestQuasar, LocalDFBConsumerOnNodeWithoutProducerFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_LocalDFBConsumerOnNodeWithoutProducerFails) {
     // A local DFB requires every node it lives on to host both a producer and a consumer. Here the
     // consumer covers an extra node where no producer runs, so the per-node census rejects it.
     NodeCoord node0{0, 0};
@@ -2185,13 +2185,13 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBConsumerOnNodeWithoutProducerFails) {
 // Coverage gaps (JIT compilation, device-side execution) are covered by HW tests.
 // (see test_program_spec_hw.cpp)
 
-TEST_F(ProgramSpecTestQuasar, MinimalValidProgramSpecSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_MinimalValidProgramSpecSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBSelfLoopOnComputeKernelSucceeds) {
     // A compute kernel that self-loops a DFB (binds it as both producer and consumer) is legal: it
     // lowers to the intra-Tensix packer->unpacker flow (TensixScope::INTRA), which the Metal 2.0
     // layer applies automatically. There is no user-facing self-loop scope option.
@@ -2217,7 +2217,7 @@ TEST_F(ProgramSpecTestQuasar, DFBSelfLoopOnComputeKernelSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_DMOnlyProgramSucceeds) {
     // A program with only DM kernels (no compute)
     NodeCoord node{0, 0};
 
@@ -2239,7 +2239,7 @@ TEST_F(ProgramSpecTestQuasar, DMOnlyProgramSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_MultiNodeProgramSucceeds) {
     // A program spanning multiple nodes
     NodeRange nodes{{0, 0}, {1, 1}};  // 2x2 grid
 
@@ -2260,7 +2260,7 @@ TEST_F(ProgramSpecTestQuasar, MultiNodeProgramSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, MultipleWorkUnitsOnDifferentNodesSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_MultipleWorkUnitsOnDifferentNodesSucceeds) {
     // Multiple work_units on non-overlapping nodes
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
@@ -2280,7 +2280,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleWorkUnitsOnDifferentNodesSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_MaxDMThreadsSucceeds) {
     // Use exactly 6 DM threads (the maximum available to the user)
     NodeCoord node{0, 0};
 
@@ -2302,7 +2302,7 @@ TEST_F(ProgramSpecTestQuasar, MaxDMThreadsSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_MaxComputeThreadsSucceeds) {
     // Use exactly 4 compute threads (the maximum available)
     NodeCoord node{0, 0};
 
@@ -2326,7 +2326,7 @@ TEST_F(ProgramSpecTestQuasar, MaxComputeThreadsSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_MultipleDFBsSucceeds) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -2352,7 +2352,7 @@ TEST_F(ProgramSpecTestQuasar, MultipleDFBsSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, CompilerOptionsDefinesSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_CompilerOptionsDefinesSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add some defines
@@ -2361,7 +2361,7 @@ TEST_F(ProgramSpecTestQuasar, CompilerOptionsDefinesSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, CompileTimeArgBindingsSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_CompileTimeArgBindingsSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add compile-time arg bindings
@@ -2370,7 +2370,7 @@ TEST_F(ProgramSpecTestQuasar, CompileTimeArgBindingsSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, RuntimeArgsSchemaSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_RuntimeArgsSchemaSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Add runtime args schema
@@ -2379,7 +2379,7 @@ TEST_F(ProgramSpecTestQuasar, RuntimeArgsSchemaSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
+TEST_F(ProgramSpecTestQuasar, CPU_VarargPerNodeOverlapFails) {
     // Rule: overlapping entries in num_runtime_varargs_per_node are an error, even when
     // their counts agree. Overlap suggests a user mistake.
     NodeCoord node_a{0, 0};
@@ -2404,7 +2404,7 @@ TEST_F(ProgramSpecTestQuasar, VarargPerNodeOverlapFails) {
 // Edge Cases and Boundary Tests
 // ============================================================================
 
-TEST_F(ProgramSpecTestQuasar, NodeRangeSetTargetNodesSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_NodeRangeSetTargetNodesSucceeds) {
     // Test with NodeRangeSet (multiple disjoint ranges)
     NodeRangeSet nodes(std::set<NodeRange>{NodeRange{{0, 0}, {0, 1}}, NodeRange{{2, 0}, {2, 1}}});
 
@@ -2425,7 +2425,7 @@ TEST_F(ProgramSpecTestQuasar, NodeRangeSetTargetNodesSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, SourceCodeKernelSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_SourceCodeKernelSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Change to inline source code
@@ -2434,7 +2434,7 @@ TEST_F(ProgramSpecTestQuasar, SourceCodeKernelSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, ComputeConfigMathFidelitySucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_ComputeConfigMathFidelitySucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // Find the compute kernel and set math fidelity options
@@ -2450,7 +2450,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeConfigMathFidelitySucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_ValidUnpackToDestModeSucceeds) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 
     // The full meaningfulness triple: FP32 DFB, consumed by a compute kernel with
@@ -2471,7 +2471,7 @@ TEST_F(ProgramSpecTestQuasar, ValidUnpackToDestModeSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
+TEST_F(ProgramSpecTestQuasar, CPU_UnpackToDestModePlacedAtDfbIdSlot) {
     // Regression test for the unpack_to_dest_mode sizing bug: the JIT consumer
     // iterates hal::get_arch_num_circular_buffers() slots, so BuildUnpackToDestModeVector
     // must size the vector to that count and place each user-supplied mode at slot dfb_id.
@@ -2536,7 +2536,7 @@ TEST_F(ProgramSpecTestQuasar, UnpackToDestModePlacedAtDfbIdSlot) {
 // testable here; the TTNN ComputeKernelConfig -> public bridge lives above this
 // layer and is out of scope for a Metal unit test.)
 
-TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigDefaultsMapToInternalDefaults) {
+TEST_F(ProgramSpecTestQuasar, CPU_ComputeGen2ConfigDefaultsMapToInternalDefaults) {
     // A default ComputeGen2Config{} must yield the historical internal QuasarComputeConfig defaults.
     ProgramSpec spec = MakeMinimalValidProgramSpec();  // compute_kernel carries a default ComputeGen2Config
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -2550,7 +2550,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigDefaultsMapToInternalDefaults) {
     EXPECT_FALSE(built.enable_2x_src_format);  // enable_2x_src_register defaults false
 }
 
-TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigInversionAndEnumMapToInternal) {
+TEST_F(ProgramSpecTestQuasar, CPU_ComputeGen2ConfigInversionAndEnumMapToInternal) {
     // Non-default polarity: the double_buffer_dest inversion and the SFPU precision-enum mapping
     // must reach the internal config correctly. Guards the case a defaults-only check would miss
     // (a flip compensated by a changed default).
@@ -2608,7 +2608,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigInversionAndEnumMapToInternal) {
 // Category A: Order-Independence Test
 // This test verifies that the backtracking solver finds valid assignments,
 // regardless of kernel and work_unit orderings.
-TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrder) {
+TEST_F(ProgramSpecTestQuasar, CPU_BacktrackingSolverFindsAssignment_RegardlessOfOrder) {
     // This test verifies that semantically identical ProgramSpecs succeed
     // regardless of the order of:
     //  - work_units in spec.work_units
@@ -2714,7 +2714,7 @@ TEST_F(ProgramSpecTestQuasar, BacktrackingSolverFindsAssignment_RegardlessOfOrde
 // Category B: True Simplifying Assumption Violation
 // This test is UNSOLVABLE with the simplifying assumption - no algorithm can help.
 // When this case arises in production, the assumption must be removed from the codebase.
-TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNodeKernels) {
+TEST_F(ProgramSpecTestQuasar, CPU_SimplifyingAssumptionViolation_OverlappingMultiNodeKernels) {
     // This test constructs a valid ProgramSpec that CANNOT work with the
     // "same DM cores on every node" simplifying assumption, regardless of
     // how clever the solver is.
@@ -2778,7 +2778,7 @@ TEST_F(ProgramSpecTestQuasar, SimplifyingAssumptionViolation_OverlappingMultiNod
 // kernel competing for lanes on one zone could push the producers to different lanes on
 // their respective nodes — passing the greedy assignment but failing per-role mask
 // uniformity.
-TEST_F(ProgramSpecTestQuasar, DFBMultiBindingForcesUniformRiscMaskAcrossProducers) {
+TEST_F(ProgramSpecTestQuasar, CPU_DFBMultiBindingForcesUniformRiscMaskAcrossProducers) {
     // Scenario: zone-specialized DM producers (producer_a on node0, producer_b on node1)
     // both bound as PRODUCER of the same DFB. An unrelated 2-thread DM kernel on node0
     // consumes lanes DM2-DM3 (the lanes the un-constrained solver would greedily hand to
@@ -2869,7 +2869,7 @@ static_assert(
 // These tests document the intended construction pattern using designated initializers.
 // They serve as living documentation and will fail to compile if aggregate status is broken.
 
-TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_KernelSpecDesignatedInitializers) {
     // Demonstrates constructing KernelSpec with designated initializers
     KernelSpec dm_kernel{
         .unique_id = KernelSpecName{"my_dm_kernel"},
@@ -2904,7 +2904,7 @@ TEST(AggregateSpecTypes, KernelSpecDesignatedInitializers) {
     EXPECT_TRUE(compute_kernel.is_compute_kernel());
 }
 
-TEST(AggregateSpecTypes, DataflowBufferSpecDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_DataflowBufferSpecDesignatedInitializers) {
     // Demonstrates constructing DataflowBufferSpec with designated initializers
     DataflowBufferSpec dfb{
         .unique_id = DFBSpecName{"my_dfb"},
@@ -2928,7 +2928,7 @@ TEST(AggregateSpecTypes, DataflowBufferSpecDesignatedInitializers) {
     EXPECT_EQ(borrowed_dfb.borrowed_from, std::optional<TensorParamName>{TensorParamName{"input_tensor"}});
 }
 
-TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_WorkUnitSpecDesignatedInitializers) {
     // Demonstrates constructing WorkUnitSpec with designated initializers
     WorkUnitSpec work_unit{
         .name = "my_work_unit",
@@ -2940,7 +2940,7 @@ TEST(AggregateSpecTypes, WorkUnitSpecDesignatedInitializers) {
     EXPECT_EQ(work_unit.kernels.size(), 2u);
 }
 
-TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_RuntimeArgSchemaDesignatedInitializers) {
     // Named RTAs + CRTAs via designated initializers; vararg counts now live on
     // KernelAdvancedOptions (see VarargCountsOnAdvancedOptions below).
     KernelSpec::RuntimeArgSchema schema{
@@ -2952,7 +2952,7 @@ TEST(AggregateSpecTypes, RuntimeArgSchemaDesignatedInitializers) {
     EXPECT_EQ(schema.common_runtime_arg_names.size(), 1u);
 }
 
-TEST(AggregateSpecTypes, VarargCountsOnAdvancedOptions) {
+TEST(AggregateSpecTypes, CPU_VarargCountsOnAdvancedOptions) {
     // Scalar vararg counts via designated initializers on KernelAdvancedOptions.
     KernelAdvancedOptions adv{
         .num_runtime_varargs = 4,
@@ -2964,7 +2964,7 @@ TEST(AggregateSpecTypes, VarargCountsOnAdvancedOptions) {
     EXPECT_TRUE(adv.num_runtime_varargs_per_node.empty());
 }
 
-TEST(AggregateSpecTypes, VarargPerNodeOverrideOnAdvancedOptions) {
+TEST(AggregateSpecTypes, CPU_VarargPerNodeOverrideOnAdvancedOptions) {
     // Per-node override path (advanced): ensure designated-init works.
     using NumVarargsPerNode = Table<Nodes, uint32_t>;
     KernelAdvancedOptions adv{
@@ -2975,7 +2975,7 @@ TEST(AggregateSpecTypes, VarargPerNodeOverrideOnAdvancedOptions) {
     EXPECT_EQ(adv.num_runtime_varargs, 0u);  // scalar left at default in this example
 }
 
-TEST(AggregateSpecTypes, KernelSpecNamedRuntimeArgsDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_KernelSpecNamedRuntimeArgsDesignatedInitializers) {
     KernelSpec k{
         .unique_id = KernelSpecName{"k"},
         .source = KernelSpec::SourceCode{"void kernel_main() {}"},
@@ -2988,7 +2988,7 @@ TEST(AggregateSpecTypes, KernelSpecNamedRuntimeArgsDesignatedInitializers) {
     EXPECT_EQ(k.runtime_arg_schema.runtime_arg_names.size(), 1u);
 }
 
-TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_SemaphoreSpecDesignatedInitializers) {
     // Demonstrates constructing SemaphoreSpec with designated initializers
     SemaphoreSpec sem{
         .unique_id = SemaphoreSpecName{"my_semaphore"},
@@ -3000,7 +3000,7 @@ TEST(AggregateSpecTypes, SemaphoreSpecDesignatedInitializers) {
     EXPECT_EQ(sem.advanced_options.initial_value, 7u);
 }
 
-TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_ProgramSpecDesignatedInitializers) {
     // Demonstrates constructing a complete ProgramSpec with designated initializers
     ProgramSpec spec{
         .name = "my_program",
@@ -3060,7 +3060,7 @@ TEST(AggregateSpecTypes, ProgramSpecDesignatedInitializers) {
     EXPECT_EQ(spec.work_units.size(), 1u);
 }
 
-TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
+TEST(AggregateSpecTypes, CPU_NestedStructsDesignatedInitializers) {
     // Demonstrates constructing nested configuration structs with designated initializers
     DFBBinding binding{
         .dfb_spec_name = DFBSpecName{"my_dfb"},
@@ -3131,7 +3131,7 @@ protected:
 // Gen1 counterpart of the compute-config translation-stability tests (the Gen2 pair lives in the
 // Quasar suite): a default ComputeGen1Config{} must yield the historical internal ComputeConfig
 // defaults. Guards the perf/precision knobs that don't move a functional pass/fail result.
-TEST_F(ProgramSpecTestGen1, ComputeGen1ConfigDefaultsMapToInternalDefaults) {
+TEST_F(ProgramSpecTestGen1, CPU_ComputeGen1ConfigDefaultsMapToInternalDefaults) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();  // compute_kernel carries a default ComputeGen1Config
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
@@ -3144,7 +3144,7 @@ TEST_F(ProgramSpecTestGen1, ComputeGen1ConfigDefaultsMapToInternalDefaults) {
     EXPECT_FALSE(built.math_approx_mode);   // sfpu_precision_mode defaults Precise
 }
 
-TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_MinimalValidProgramSpecSucceeds) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
@@ -3152,7 +3152,7 @@ TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecSucceeds) {
 // Device slots are per-core: a ProgramSpec may declare more DFBs than
 // get_arch_num_circular_buffers() when each core hosts at most one. This is the Metal 2.0
 // path that issue #51409 needs — previously ValidateProgramSpec rejected on total count.
-TEST_F(ProgramSpecTestGen1, DisjointNodeDFBsExceedSlotCountSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_DisjointNodeDFBsExceedSlotCountSucceeds) {
     const uint32_t max_slots = tt::tt_metal::hal::get_arch_num_circular_buffers();
     const uint32_t num_dfbs = max_slots + 1;
     constexpr uint32_t grid_x = 8;  // WH mock worker grid width
@@ -3187,7 +3187,7 @@ TEST_F(ProgramSpecTestGen1, DisjointNodeDFBsExceedSlotCountSucceeds) {
     }
 }
 
-TEST_F(ProgramSpecTestGen1, TooManyDFBsOnSameNodeFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TooManyDFBsOnSameNodeFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -3215,7 +3215,7 @@ TEST_F(ProgramSpecTestGen1, TooManyDFBsOnSameNodeFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(expected_substr)));
 }
 
-TEST_F(ProgramSpecTestGen1, ConsumerUnpackToDestBelow32BitWithoutEnableFailsForPerf) {
+TEST_F(ProgramSpecTestGen1, CPU_ConsumerUnpackToDestBelow32BitWithoutEnableFailsForPerf) {
     // On Gen1, UnpackToDest on a consumed <=16-bit DFB without enable_32_bit_dest bypasses the
     // SrcA/B path for no precision benefit — rejected as bad-for-perf. (On Gen2 the identical spec
     // is accepted — see ProgramSpecTestQuasar.ConsumerUnpackToDestBelow32BitWithoutEnableSucceeds.)
@@ -3232,7 +3232,7 @@ TEST_F(ProgramSpecTestGen1, ConsumerUnpackToDestBelow32BitWithoutEnableFailsForP
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("leads to worse performance")));
 }
 
-TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_DMOnlyProgramSucceeds) {
     // Two DM kernels on different processors (RISCV_0 producer, RISCV_1 consumer)
     NodeCoord node{0, 0};
 
@@ -3253,7 +3253,7 @@ TEST_F(ProgramSpecTestGen1, DMOnlyProgramSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, DMKernelSelfLoopOnGen1Succeeds) {
+TEST_F(ProgramSpecTestGen1, CPU_DMKernelSelfLoopOnGen1Succeeds) {
     // On Gen1 (WH/BH) a DFB lowers to a plain circular buffer, so a single DM kernel may bind it as
     // both PRODUCER and CONSUMER (self-loop) — the classic scratch pattern of one DM engine filling
     // and draining an L1 FIFO. There is no tile-counter credit machinery requiring disjoint
@@ -3276,7 +3276,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelSelfLoopOnGen1Succeeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsDifferentProcessorsSucceeds) {
     // RISCV_0 and RISCV_1 on the same node — should succeed. (MakeMinimalGen1DMKernel gives them
     // distinct NOCs, so they also satisfy the dedicated-NOC distinctness rule.)
     NodeCoord node{0, 0};
@@ -3293,7 +3293,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, DFBMultipleProducersOnSameNodeFailsWithoutFlag) {
+TEST_F(ProgramSpecTestGen1, CPU_DFBMultipleProducersOnSameNodeFailsWithoutFlag) {
     // Baseline: without allow_instance_multi_binding, two producer instances on one node are rejected
     // by the per-node census even on Gen1. This is the counterpart the escape-hatch test unlocks.
     NodeCoord node{0, 0};
@@ -3322,7 +3322,7 @@ TEST_F(ProgramSpecTestGen1, DFBMultipleProducersOnSameNodeFailsWithoutFlag) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("2 producer instance(s)")));
 }
 
-TEST_F(ProgramSpecTestGen1, DFBMultipleProducersOnSameNodeSucceedsWithFlag) {
+TEST_F(ProgramSpecTestGen1, CPU_DFBMultipleProducersOnSameNodeSucceedsWithFlag) {
     // The allow_instance_multi_binding escape hatch: on Gen1 a DFB lowers to a plain circular buffer,
     // so one node may host more than one producer instance — here a RISCV_0 and a RISCV_1 DM kernel
     // both feeding one DFB, drained by a compute consumer. Identical to the FailsWithoutFlag case
@@ -3352,7 +3352,7 @@ TEST_F(ProgramSpecTestGen1, DFBMultipleProducersOnSameNodeSucceedsWithFlag) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, DFBMultipleConsumersOnSameNodeSucceedsWithFlag) {
+TEST_F(ProgramSpecTestGen1, CPU_DFBMultipleConsumersOnSameNodeSucceedsWithFlag) {
     // Mirror of the multi-producer escape-hatch case: a compute producer feeding two DM consumers
     // (RISCV_0 and RISCV_1) on one node. (Two DM consumers exhaust both DM processors, so the
     // producer must be the compute engine.) Unlocked by the flag.
@@ -3381,7 +3381,7 @@ TEST_F(ProgramSpecTestGen1, DFBMultipleConsumersOnSameNodeSucceedsWithFlag) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, DFBMixedKindProducersOnSameNodeFailsWithoutFlag) {
+TEST_F(ProgramSpecTestGen1, CPU_DFBMixedKindProducersOnSameNodeFailsWithoutFlag) {
     // Baseline: a single role mixing a compute and a DM kernel is rejected by the per-role
     // kind-uniformity check (the DFB's hardware config nominally carries one processor mask per role).
     NodeCoord node{0, 0};
@@ -3410,7 +3410,7 @@ TEST_F(ProgramSpecTestGen1, DFBMixedKindProducersOnSameNodeFailsWithoutFlag) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("mixing compute and data-movement kinds")));
 }
 
-TEST_F(ProgramSpecTestGen1, DFBMixedKindProducersOnSameNodeSucceedsWithFlag) {
+TEST_F(ProgramSpecTestGen1, CPU_DFBMixedKindProducersOnSameNodeSucceedsWithFlag) {
     // The escape hatch imposes no RISC-type restriction on Gen1: a compute kernel and a DM kernel may
     // both produce to one DFB on one node (it lowers to a plain shared circular buffer). Identical to
     // the FailsWithoutFlag case except for the flag, which is what drops the kind-uniformity check.
@@ -3439,7 +3439,7 @@ TEST_F(ProgramSpecTestGen1, DFBMixedKindProducersOnSameNodeSucceedsWithFlag) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
+TEST_F(ProgramSpecTestGen1, CPU_MultiThreadedDMKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -3456,7 +3456,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("does not support multi-threaded kernels")));
 }
 
-TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
+TEST_F(ProgramSpecTestGen1, CPU_MultiThreadedComputeKernelFails) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -3473,7 +3473,7 @@ TEST_F(ProgramSpecTestGen1, MultiThreadedComputeKernelFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("does not support multi-threaded kernels")));
 }
 
-TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
+TEST_F(ProgramSpecTestGen1, CPU_DMKernelWithGen2ConfigFails) {
     // The config's generation must match the target platform: on Gen1 (WH/BH) a DM kernel carrying a
     // Gen2 config is a hard error — it has no way to resolve its processor/NOC placement.
     NodeCoord node{0, 0};
@@ -3492,7 +3492,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelWithGen2ConfigFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("holds a DataMovementGen2Config")));
 }
 
-TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
+TEST_F(ProgramSpecTestGen1, CPU_ProcessorConflictFails) {
     // Two DM kernels both targeting RISCV_0 on the same node
     NodeCoord node{0, 0};
 
@@ -3510,7 +3510,7 @@ TEST_F(ProgramSpecTestGen1, ProcessorConflictFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("both claim the same DM processor")));
 }
 
-TEST_F(ProgramSpecTestGen1, TwoDMKernelsSameNocDedicatedFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsSameNocDedicatedFails) {
     // Two DM kernels on distinct processors (RISCV_0, RISCV_1) but pinned to the SAME NOC in
     // dedicated mode. Each kernel's NoC traffic is statically compiled to its config.noc, so both
     // would drive NOC_0 and hang the device. Validation must reject this.
@@ -3534,7 +3534,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsSameNocDedicatedFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("pinned to NOC_0")));
 }
 
-TEST_F(ProgramSpecTestGen1, TwoDMKernelsDistinctNocDedicatedSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsDistinctNocDedicatedSucceeds) {
     // Two dedicated-NOC DM kernels on distinct processors AND distinct NOCs — the correct pairing.
     NodeCoord node{0, 0};
 
@@ -3552,7 +3552,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsDistinctNocDedicatedSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, TwoDMKernelsSameNocDynamicSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsSameNocDynamicSucceeds) {
     // In DM_DYNAMIC_NOC mode, two DM kernels may intentionally share a NOC (it frees the other NOC
     // for fabric). The NOC-distinctness rule is dedicated-mode only, so this is accepted even though
     // both kernels name NOC_0.
@@ -3576,7 +3576,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsSameNocDynamicSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, DMProcessorBeyondRiscv1Fails) {
+TEST_F(ProgramSpecTestGen1, CPU_DMProcessorBeyondRiscv1Fails) {
     // Gen1 has only RISCV_0 (BRISC) and RISCV_1 (NCRISC); RISCV_2..7 are Gen2/Quasar-only. A Gen1 DM
     // kernel requesting one must be rejected (parity with the legacy CreateDataMovementKernel guard).
     NodeCoord node{0, 0};
@@ -3596,7 +3596,7 @@ TEST_F(ProgramSpecTestGen1, DMProcessorBeyondRiscv1Fails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Gen1 has only")));
 }
 
-TEST_F(ProgramSpecTestGen1, TwoDMKernelsMixedNocModeFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TwoDMKernelsMixedNocModeFails) {
     // NOC mode configures shared per-core NOC hardware (and is compiled into each kernel binary), so
     // two DM kernels on the same node must agree on it. One dedicated + one dynamic is incoherent.
     NodeCoord node{0, 0};
@@ -3621,7 +3621,7 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsMixedNocModeFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("different NOC modes")));
 }
 
-TEST_F(ProgramSpecTestGen1, DMKernelsSameProcessorAndNocOnDistinctNodesSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_DMKernelsSameProcessorAndNocOnDistinctNodesSucceeds) {
     // Node-scoping guard: two DM kernels with identical processor (RISCV_0), NOC (NOC_0), and
     // DM_DEDICATED_NOC mode are legal when placed on DISTINCT nodes — the processor- and
     // NOC-distinctness censuses are per-node. This would wrongly fail if either map were keyed
@@ -3644,7 +3644,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelsSameProcessorAndNocOnDistinctNodesSucceeds)
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, DMKernelsDifferentNocModesOnDistinctNodesSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_DMKernelsDifferentNocModesOnDistinctNodesSucceeds) {
     // Node-scoping guard for NOC-mode agreement: a DM_DEDICATED_NOC kernel on one node and a
     // DM_DYNAMIC_NOC kernel on another are legal — agreement is enforced per-node, not globally.
     // This would wrongly fail if node_noc_mode were keyed without the node component.
@@ -3670,7 +3670,7 @@ TEST_F(ProgramSpecTestGen1, DMKernelsDifferentNocModesOnDistinctNodesSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, ReaderAndWriterRolesOnSameNodeSucceed) {
+TEST_F(ProgramSpecTestGen1, CPU_ReaderAndWriterRolesOnSameNodeSucceed) {
     // A READER and a WRITER role resolve to distinct processors (RISCV_1 and RISCV_0
     // respectively), so two role-driven DM kernels coexist on one node without conflict.
     NodeCoord node{0, 0};
@@ -3687,7 +3687,7 @@ TEST_F(ProgramSpecTestGen1, ReaderAndWriterRolesOnSameNodeSucceed) {
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-TEST_F(ProgramSpecTestGen1, TwoReaderRolesOnSameNodeConflict) {
+TEST_F(ProgramSpecTestGen1, CPU_TwoReaderRolesOnSameNodeConflict) {
     // Both READER kernels resolve to the same processor (RISCV_1), so placing them on the
     // same node is a conflict — confirming the role hint resolves to a fixed, deterministic
     // processor (the same uniqueness rule as explicit configs).
@@ -3716,7 +3716,7 @@ TEST_F(ProgramSpecTestGen1, TwoReaderRolesOnSameNodeConflict) {
 //
 // These tests use the WH mock device, not real hardware.
 
-TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
+TEST_F(ProgramSpecTestGen1, CPU_KernelTargetsNodeBeyondGridYFails) {
     // y=9 is just outside the 9-row slow-dispatch grid (also outside the 8-row fast-dispatch grid).
     const NodeCoord oob_node{0, 9};
 
@@ -3732,7 +3732,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsNodeBeyondGridYFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
 }
 
-TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
+TEST_F(ProgramSpecTestGen1, CPU_KernelTargetsOutOfBoundsNodeFails) {
     // x=8 is just outside the 8-column grid (same in fast and slow dispatch).
     const NodeCoord oob_node{8, 0};
 
@@ -3748,7 +3748,7 @@ TEST_F(ProgramSpecTestGen1, KernelTargetsOutOfBoundsNodeFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("out of bounds")));
 }
 
-TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
+TEST_F(ProgramSpecTestGen1, CPU_SemaphoreBoundToComputeKernelFailsOnGen1) {
     // Compute kernels cannot have semaphore bindings on Gen 1
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -3768,7 +3768,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToComputeKernelFailsOnGen1) {
             ::testing::HasSubstr("Semaphore bindings are not supported for compute kernels.")));
 }
 
-TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {
+TEST_F(ProgramSpecTestGen1, CPU_SemaphoreBoundToDMKernelSucceedsOnGen1) {
     // Sanity check: binding a semaphore to a DM kernel on WH/BH is allowed.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -3785,7 +3785,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoreBoundToDMKernelSucceedsOnGen1) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
+TEST_F(ProgramSpecTestGen1, CPU_SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
     // Gen1 accepts non-zero initial values (only Quasar rejects them).
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -3801,7 +3801,7 @@ TEST_F(ProgramSpecTestGen1, SemaphoresWithNonZeroInitialValueSucceedOnGen1) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {
+TEST_F(ProgramSpecTestGen1, CPU_DuplicateKernelNameFails) {
     // Structural validation (CollectSpecData) must catch this on gen1 too
     NodeCoord node{0, 0};
 
@@ -3829,7 +3829,7 @@ TEST_F(ProgramSpecTestGen1, DuplicateKernelNameFails) {
 
 // (BindTensorParameterToKernel and MakeMinimalTensorParameter using-declarations hoisted to top-of-file.)
 
-TEST_F(ProgramSpecTestGen1, DuplicateTensorParameterNameFails) {
+TEST_F(ProgramSpecTestGen1, CPU_DuplicateTensorParameterNameFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     auto binding_a = MakeMinimalTensorParameter("input_tensor");
@@ -3846,7 +3846,7 @@ TEST_F(ProgramSpecTestGen1, DuplicateTensorParameterNameFails) {
             ::testing::HasSubstr("Duplicate TensorParameter name 'input_tensor'")));
 }
 
-TEST_F(ProgramSpecTestGen1, KernelReferencesUnknownTensorParameterFails) {
+TEST_F(ProgramSpecTestGen1, CPU_KernelReferencesUnknownTensorParameterFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     // Reference a TensorParameter that doesn't exist in the program.
@@ -3858,7 +3858,7 @@ TEST_F(ProgramSpecTestGen1, KernelReferencesUnknownTensorParameterFails) {
             ::testing::HasSubstr("references unknown TensorParameter 'nonexistent_tensor'")));
 }
 
-TEST_F(ProgramSpecTestGen1, UnboundTensorParameterFails) {
+TEST_F(ProgramSpecTestGen1, CPU_UnboundTensorParameterFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     // Declare a TensorParameter but don't bind it to any kernel.
@@ -3870,7 +3870,7 @@ TEST_F(ProgramSpecTestGen1, UnboundTensorParameterFails) {
             ::testing::HasSubstr("TensorParameter 'orphan_tensor' is defined but not bound by any kernel")));
 }
 
-TEST_F(ProgramSpecTestGen1, DuplicateTensorAccessorNameWithinKernelFails) {
+TEST_F(ProgramSpecTestGen1, CPU_DuplicateTensorAccessorNameWithinKernelFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     spec.tensor_parameters = {
@@ -3887,7 +3887,7 @@ TEST_F(ProgramSpecTestGen1, DuplicateTensorAccessorNameWithinKernelFails) {
             ::testing::HasSubstr("has duplicate tensor accessor_name 'same_accessor'")));
 }
 
-TEST_F(ProgramSpecTestGen1, InvalidTensorAccessorNameFails) {
+TEST_F(ProgramSpecTestGen1, CPU_InvalidTensorAccessorNameFails) {
     // Smoke-tests the IsValidCppIdentifier check on tensor accessor names. The check is the
     // same one DFB / Semaphore use; one bad name here is sufficient (full coverage lives in
     // the DFB version of this test).
@@ -3902,7 +3902,7 @@ TEST_F(ProgramSpecTestGen1, InvalidTensorAccessorNameFails) {
             ::testing::HasSubstr("tensor accessor_name 'has-dash' must be a valid C++ identifier")));
 }
 
-TEST_F(ProgramSpecTestGen1, AccessorNamesAcrossCategoriesAreSeparateNamespaces) {
+TEST_F(ProgramSpecTestGen1, CPU_AccessorNamesAcrossCategoriesAreSeparateNamespaces) {
     // DFB / Semaphore / TensorAccessor accessor names live in separate namespaces (each gets
     // its own emitted namespace in kernel_bindings_generated.h: dfb::, sem::, tensor::). Reusing
     // the same identifier across categories within one kernel must be allowed.
@@ -3923,7 +3923,7 @@ TEST_F(ProgramSpecTestGen1, AccessorNamesAcrossCategoriesAreSeparateNamespaces) 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecWithTensorParameterSucceeds) {
+TEST_F(ProgramSpecTestGen1, CPU_MinimalValidProgramSpecWithTensorParameterSucceeds) {
     // Positive baseline: a program with one TensorParameter bound to one kernel constructs
     // successfully. Exercises CollectSpecData validation, the host-side resolution helper
     // (TensorSpec → CTA payload using mesh_device.allocator() + virtual_core_from_logical_core),
@@ -3951,7 +3951,7 @@ TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecWithTensorParameterSucceeds) 
 // Compute-kernel TensorAccessor bindings are unsupported in this PR; making them work would
 // require restructuring tensor_accessor.h to isolate the constexpr-only parts.
 
-TEST_F(ProgramSpecTestGen1, TensorAccessorBindingJITSmokeDMKernel) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorAccessorBindingJITSmokeDMKernel) {
     // DM kernel constructs a TensorAccessor from a binding token + invokes a NoC-using method.
     // Exercises: tensor:: namespace token, type alias <name>_t, the token ctor and its deduction
     // guide, get_common_arg_val for the implicit base address.
@@ -3989,7 +3989,7 @@ void kernel_main() {
 // the mock Wormhole device (Gen1: the Quasar TRISC firmware isn't built in this checkout, so a
 // Quasar JIT-compile would fail at link).
 
-TEST_F(ProgramSpecTestGen1, ScratchpadAccessorBindingJITSmokeDMKernel) {
+TEST_F(ProgramSpecTestGen1, CPU_ScratchpadAccessorBindingJITSmokeDMKernel) {
     // DM kernel constructs a Scratchpad from its binding token and reads the CRTA-injected base address.
     NodeCoord node{0, 0};
 
@@ -4020,7 +4020,7 @@ void kernel_main() {
 // forward-declares get_common_arg_val (resolved by the kernel's own API header — api/compute/common.h
 // on TRISC, api/dataflow/dataflow_api.h on DM) and is otherwise NOC-free, so the device-side
 // Scratchpad<T> ctor composes on the compute (TRISC) build path as well as DM.
-TEST_F(ProgramSpecTestGen1, ScratchpadAccessorBindingJITSmokeComputeKernel) {
+TEST_F(ProgramSpecTestGen1, CPU_ScratchpadAccessorBindingJITSmokeComputeKernel) {
     // MakeMinimalGen1ValidProgramSpec wires a DM producer (kernels[0]) into a compute consumer
     // (kernels[1]) through a DFB; bind the scratchpad to the compute kernel and have it construct a
     // Scratchpad from its binding token.
@@ -4048,7 +4048,7 @@ void kernel_main() {
 // CoreLocalMem<T> iterator ops the loop desugars to (operator++, operator!=, operator*). Compile-only on
 // the mock Gen1 device — no run: reading the uninitialized region would be UB at runtime, but this test
 // only JIT-compiles the kernel, so the loop just needs to be well-formed.
-TEST_F(ProgramSpecTestGen1, ScratchpadRangeBasedForCompiles) {
+TEST_F(ProgramSpecTestGen1, CPU_ScratchpadRangeBasedForCompiles) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -4110,7 +4110,7 @@ TT_KERNEL void compute_entry(uint32_t input_offset, uint32_t num_tiles) {  // RT
 }
 )";
 
-TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
+TEST_F(ProgramSpecTestGen1, CPU_TtKernelComputeShimCompiles) {
     const NodeCoord node{0, 0};
     constexpr uint32_t entry_size = 1024;
 
@@ -4147,7 +4147,7 @@ TEST_F(ProgramSpecTestGen1, TtKernelComputeShimCompiles) {
 // Kernel: get_compile_time_vararg* — thin wrappers over kernel_compile_time_args[0..N).
 // TensorBinding CTA payloads follow that prefix in KERNEL_COMPILE_TIME_ARGS.
 
-TEST_F(ProgramSpecTestGen1, CompileTimeVarargsReadableFromKernel) {
+TEST_F(ProgramSpecTestGen1, CPU_CompileTimeVarargsReadableFromKernel) {
     NodeCoord node{0, 0};
     const std::vector<uint32_t> cta_varargs = {0xCAFEBABEu, 0xDEADBEEFu, 0x11112222u};
 
@@ -4175,7 +4175,7 @@ void kernel_main() {
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
-TEST_F(ProgramSpecTestGen1, EmptyCompileTimeVarargsReadableFromKernel) {
+TEST_F(ProgramSpecTestGen1, CPU_EmptyCompileTimeVarargsReadableFromKernel) {
     NodeCoord node{0, 0};
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
@@ -4198,7 +4198,7 @@ void kernel_main() {
 
 // Template accessor bounds-checks at compile time: size==1 but get_compile_time_vararg<1>()
 // must fail JIT (static_assert in the generated helper).
-TEST_F(ProgramSpecTestGen1, OutOfRangeCompileTimeVarargTemplateFailsToCompile) {
+TEST_F(ProgramSpecTestGen1, CPU_OutOfRangeCompileTimeVarargTemplateFailsToCompile) {
     NodeCoord node{0, 0};
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
@@ -4220,7 +4220,7 @@ void kernel_main() {
 }
 
 // Stress: bake 1024 iota words and constexpr-walk them on the kernel side.
-TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIota1024ReadableFromKernel) {
+TEST_F(ProgramSpecTestGen1, CPU_CompileTimeVarargsIota1024ReadableFromKernel) {
     NodeCoord node{0, 0};
     constexpr uint32_t kNumVarargs = 1024u;
     std::vector<uint32_t> cta_varargs(kNumVarargs);
@@ -4257,7 +4257,7 @@ void kernel_main() {}
 }
 
 // Same stress as above, on a compute (TRISC) kernel — CTA varargs are available on DM and compute.
-TEST_F(ProgramSpecTestGen1, CompileTimeVarargsIota1024ReadableFromComputeKernel) {
+TEST_F(ProgramSpecTestGen1, CPU_CompileTimeVarargsIota1024ReadableFromComputeKernel) {
     NodeCoord node{0, 0};
     constexpr uint32_t kNumVarargs = 1024u;
     std::vector<uint32_t> cta_varargs(kNumVarargs);
@@ -4294,7 +4294,7 @@ void kernel_main() {}
 }
 
 // CTA varargs are a positional prefix ahead of TensorBinding CTA payloads.
-TEST_F(ProgramSpecTestGen1, CompileTimeVarargsPrefixBeforeTensorBindingCTAs) {
+TEST_F(ProgramSpecTestGen1, CPU_CompileTimeVarargsPrefixBeforeTensorBindingCTAs) {
     NodeCoord node{0, 0};
     constexpr uint32_t kVararg0 = 0xCAFEBABEu;
     constexpr uint32_t kVararg1 = 0xDEADBEEFu;
@@ -4345,7 +4345,7 @@ void kernel_main() {
     EXPECT_NO_THROW(detail::CompileProgram(device, program));
 }
 
-TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargsProducesDifferentKernelHash) {
+TEST_F(ProgramSpecTestGen1, CPU_DifferentCompileTimeVarargsProducesDifferentKernelHash) {
     auto make_program = [this](std::vector<uint32_t> varargs) {
         NodeCoord node{0, 0};
         auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
@@ -4364,7 +4364,7 @@ TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargsProducesDifferentKernelHa
         prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash());
 }
 
-TEST_F(ProgramSpecTestGen1, IdenticalCompileTimeVarargsProducesIdenticalKernelHash) {
+TEST_F(ProgramSpecTestGen1, CPU_IdenticalCompileTimeVarargsProducesIdenticalKernelHash) {
     auto make_program = [this] {
         NodeCoord node{0, 0};
         auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
@@ -4384,7 +4384,7 @@ TEST_F(ProgramSpecTestGen1, IdenticalCompileTimeVarargsProducesIdenticalKernelHa
 }
 
 // Prefix length is part of the cache key even when positional CTA words are unchanged.
-TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKernelHash) {
+TEST_F(ProgramSpecTestGen1, CPU_DifferentCompileTimeVarargCountProducesDifferentKernelHash) {
     NodeCoord node{0, 0};
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.advanced_options.compile_time_varargs = {0xCAFEBABEu, 0xDEADBEEFu};
@@ -4415,7 +4415,7 @@ TEST_F(ProgramSpecTestGen1, DifferentCompileTimeVarargCountProducesDifferentKern
 // These tests ensure that this caveat is properly handled. The assertion-on environment is
 // simulated in a lightweight (and hacky) way by defining the assertion-enable macro manually.
 
-TEST_F(ProgramSpecTestGen1, InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
+TEST_F(ProgramSpecTestGen1, CPU_InRangeCompileTimeVarargCompilesWithAssertsEnabled) {
     NodeCoord node{0, 0};
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
@@ -4448,7 +4448,7 @@ void kernel_main() {
 // Out-of-range index in a constant expression, asserts on: must still fail the build. Constant
 // evaluation reaches the non-constexpr out-of-range report, which is not a constant expression --
 // so this is a clean build failure rather than a read past kernel_compile_time_args.
-TEST_F(ProgramSpecTestGen1, OutOfRangeCompileTimeVarargFailsToCompileWithAssertsEnabled) {
+TEST_F(ProgramSpecTestGen1, CPU_OutOfRangeCompileTimeVarargFailsToCompileWithAssertsEnabled) {
     NodeCoord node{0, 0};
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
@@ -4483,7 +4483,7 @@ void kernel_main() {
 // the CTA payload, or changes compute_hash to skip compile_time_args_, the silent failure mode is
 // a stale cached binary running with mismatched layout metadata — nasty to debug in prod.
 
-TEST_F(ProgramSpecTestGen1, DifferentTensorSpecProducesDifferentKernelHash) {
+TEST_F(ProgramSpecTestGen1, CPU_DifferentTensorSpecProducesDifferentKernelHash) {
     // Same kernel source, same accessor name. The two TensorParameters differ only in BufferType
     // (DRAM vs L1), which flips the is_dram bit in the binding's args_config CTA word.
     auto make_spec = [](tt::tt_metal::BufferType buffer_type) {
@@ -4500,7 +4500,7 @@ TEST_F(ProgramSpecTestGen1, DifferentTensorSpecProducesDifferentKernelHash) {
     EXPECT_NE(hash_dram, hash_l1);
 }
 
-TEST_F(ProgramSpecTestGen1, IdenticalTensorSpecProducesIdenticalKernelHash) {
+TEST_F(ProgramSpecTestGen1, CPU_IdenticalTensorSpecProducesIdenticalKernelHash) {
     // Determinism canary: two specs constructed identically must hash identically. If this ever
     // fails, something nondeterministic crept into the hash (iteration order over a hash map,
     // pointer values, timestamps, etc.).
@@ -4529,7 +4529,7 @@ TEST_F(ProgramSpecTestGen1, IdenticalTensorSpecProducesIdenticalKernelHash) {
 //   - CTA stability: same kernel hash across different shapes when the flag is set.
 //   - Handle layout: num_runtime_field_crta_words tracks the rank when needed.
 
-TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcrossShapes_TileLayout) {
+TEST_F(ProgramSpecTestGen1, CPU_DynamicTensorShape_InterleavedKernelHashStableAcrossShapes_TileLayout) {
     // Interleaved + TILE layout: page_size is constant per dtype regardless of logical_shape, so
     // the CTAs ([args_config.raw(), aligned_page_size]) are stable across shape variations.
     // The dynamic flag thus enables JIT cache reuse for tile-layout eltwise.
@@ -4563,7 +4563,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcross
            "same compiled kernel binary is reused.";
 }
 
-TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedRowMajorKernelHashStableAcrossWidths) {
+TEST_F(ProgramSpecTestGen1, CPU_DynamicTensorShape_InterleavedRowMajorKernelHashStableAcrossWidths) {
     // The payoff of the page-size fold. For a ROW-MAJOR interleaved TensorParameter the page size
     // (last_dim_width * elem_size) is shape-dependent. WITHOUT the flag it rides a compile-time arg,
     // so two different-width tensors hash differently -- distinct cache entries, and (worse) a stale
@@ -4604,7 +4604,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedRowMajorKernelHashStab
            "widths hash equally (program-cache reuse; prevents the stale-page-size bug).";
 }
 
-TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedKernelHashStableAcrossShapes) {
+TEST_F(ProgramSpecTestGen1, CPU_DynamicTensorShape_ShardedKernelHashStableAcrossShapes) {
     // Sharded TensorParameters DO encode tensor_shape_in_pages in CTAs by default — so without
     // the dynamic flag, two different-shape sharded TPs hash differently. With the flag, the
     // tensor_shape words move to CRTAs and the CTAs become stable across shape variations.
@@ -4639,7 +4639,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedKernelHashStableAcrossShap
            "must be stable across shape variations.";
 }
 
-TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedBindingTracksShapeCRTASlots) {
+TEST_F(ProgramSpecTestGen1, CPU_DynamicTensorShape_ShardedBindingTracksShapeCRTASlots) {
     // Sharded + dynamic_tensor_shape: the TensorBindingHandle's num_runtime_field_crta_words
     // should equal the BufferDistributionSpec's tensor_shape_in_pages rank (one CRTA word per
     // shape dim, written at enqueue).
@@ -4666,7 +4666,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedBindingTracksShapeCRTASlot
         << "Sharded + dynamic_tensor_shape: runtime-field CRTA words should equal BDS shape rank.";
 }
 
-TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedRowMajorBindingTracksPageSizeCRTASlot) {
+TEST_F(ProgramSpecTestGen1, CPU_DynamicTensorShape_InterleavedRowMajorBindingTracksPageSizeCRTASlot) {
     // Row-major interleaved + dynamic_tensor_shape: the page size (= last_dim_width * elem_size) is
     // part of the varying shape, so the resolver folds it from a compile-time arg into a single
     // per-binding CRTA word ("A-collapse": the page-size CTA slot is dropped and the RuntimePageSize
@@ -4712,7 +4712,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedRowMajorBindingTracksP
         << "Without the flag, the RuntimePageSize bit must NOT be set.";
 }
 
-TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedTileBindingHasNoRuntimeFieldCRTAs) {
+TEST_F(ProgramSpecTestGen1, CPU_DynamicTensorShape_InterleavedTileBindingHasNoRuntimeFieldCRTAs) {
     // Interleaved + TILE layout: the page size is dtype/tile-fixed, independent of logical shape, so
     // dynamic_tensor_shape does NOT demote it to a CRTA (the fold gates on ROW_MAJOR). The flag is a
     // pure host-side validation loosening here; the binding carries no runtime field words. Guards
@@ -4739,7 +4739,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedTileBindingHasNoRuntim
     EXPECT_FALSE(handles[0].runtime_field_is_page_size);
 }
 
-TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {
+TEST_F(ProgramSpecTestGen1, CPU_KernelCrtaLayout_AllThreeSectionsConsistent) {
     // The Kernel's stored KernelCrtaLayout must equal what a fresh walk of (named CRTAs +
     // binding handles) would compute. This test exercises a Program in which ALL THREE
     // sections of the CRTA buffer are non-empty:
@@ -4798,7 +4798,7 @@ TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {
            "calculation degenerates to the pre-refactor case.";
 }
 
-TEST_F(ProgramSpecTestGen1, CompilerIncludePathsForwardedToKernelConfig) {
+TEST_F(ProgramSpecTestGen1, CPU_CompilerIncludePathsForwardedToKernelConfig) {
     // KernelSpec.compiler_options.include_paths should be picked up as `-I<path>` flags
     NodeCoord node{0, 0};
 
@@ -4868,7 +4868,7 @@ ProgramSpec MakeAliasProgramSpec(
 }
 }  // anonymous namespace
 
-TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnMismatchedTotalSize) {
+TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnMismatchedTotalSize) {
     // DFB_A: 512 * 8 = 4096 bytes, DFB_B: 256 * 8 = 2048 bytes — different totals → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/8);
@@ -4884,7 +4884,7 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnMismatchedTotalSize) {
             ::testing::HasSubstr("different total sizes")));
 }
 
-TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnAsymmetricDeclaration) {
+TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnAsymmetricDeclaration) {
     // DFB_A lists DFB_B but DFB_B does not list DFB_A — clique violation → TT_FATAL
     auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/512, /*num_entries=*/8);
     auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/256, /*num_entries=*/16);
@@ -4899,7 +4899,7 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnAsymmetricDeclaration) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("do not declare the same alias group")));
 }
 
-TEST_F(ProgramSpecTestQuasar, AliasDFBMatmulStyleSucceeds) {
+TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBMatmulStyleSucceeds) {
     // This is the nasty case from the matmul op....
     // Two DFBs share L1 but are bound to different kernels.
     //  - DFB_A is bound to {producer_kernel, consumer_kernel};
@@ -4935,7 +4935,7 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBMatmulStyleSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
-TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentNodeCoverage) {
+TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnDifferentNodeCoverage) {
     // Two DFBs aliased, but bound to kernels running on disjoint nodes. The shared L1
     // region only makes sense if both members cover the same cores; otherwise the
     // secondary's address propagation would alias into L1 the primary never reserved.
@@ -4969,7 +4969,7 @@ TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnDifferentNodeCoverage) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("cover different sets of nodes")));
 }
 
-TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedFrom) {
+TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnInconsistentBorrowedFrom) {
     // DFB_A borrows from a TensorParameter, DFB_B does not. Within an alias group, either
     // no member borrows or all members borrow from the same TensorParameter.
     const NodeCoord node{0, 0};
@@ -5138,23 +5138,23 @@ void CheckAccessorsFollowTheHeldAlternative() {
     EXPECT_EQ(std::get<ToConfig>(config).fpu_math_fidelity, kAccessorFidelity);
 }
 
-TEST(ComputeHardwareConfigAccessors, Gen1DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen1Config>(); }
+TEST(ComputeHardwareConfigAccessors, CPU_Gen1DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen1Config>(); }
 
-TEST(ComputeHardwareConfigAccessors, Gen2DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen2Config>(); }
+TEST(ComputeHardwareConfigAccessors, CPU_Gen2DefaultsReadThrough) { CheckAccessorDefaultsReadThrough<ComputeGen2Config>(); }
 
-TEST(ComputeHardwareConfigAccessors, Gen1WritesLandOnHeldAlternative) {
+TEST(ComputeHardwareConfigAccessors, CPU_Gen1WritesLandOnHeldAlternative) {
     CheckAccessorWritesLandOnHeldAlternative<ComputeGen1Config>();
 }
 
-TEST(ComputeHardwareConfigAccessors, Gen2WritesLandOnHeldAlternative) {
+TEST(ComputeHardwareConfigAccessors, CPU_Gen2WritesLandOnHeldAlternative) {
     CheckAccessorWritesLandOnHeldAlternative<ComputeGen2Config>();
 }
 
-TEST(ComputeHardwareConfigAccessors, FollowsSwitchFromGen1ToGen2) {
+TEST(ComputeHardwareConfigAccessors, CPU_FollowsSwitchFromGen1ToGen2) {
     CheckAccessorsFollowTheHeldAlternative<ComputeGen1Config, ComputeGen2Config>();
 }
 
-TEST(ComputeHardwareConfigAccessors, FollowsSwitchFromGen2ToGen1) {
+TEST(ComputeHardwareConfigAccessors, CPU_FollowsSwitchFromGen2ToGen1) {
     CheckAccessorsFollowTheHeldAlternative<ComputeGen2Config, ComputeGen1Config>();
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -43,14 +43,14 @@ static_assert(
 
 // ---- construction / emptiness ------------------------------------------------
 
-TEST(TableTest, DefaultConstructedIsEmpty) {
+TEST(TableTest, CPU_DefaultConstructedIsEmpty) {
     StrIntTable t;
     EXPECT_TRUE(t.empty());
     EXPECT_EQ(t.size(), 0u);
     EXPECT_EQ(t.begin(), t.end());
 }
 
-TEST(TableTest, InitializerListConstruction) {
+TEST(TableTest, CPU_InitializerListConstruction) {
     StrIntTable t{{"a", 1}, {"b", 2}, {"c", 3}};
     EXPECT_FALSE(t.empty());
     EXPECT_EQ(t.size(), 3u);
@@ -59,7 +59,7 @@ TEST(TableTest, InitializerListConstruction) {
     EXPECT_EQ(*t.get("c"), 3);
 }
 
-TEST(TableTest, SpanConstruction) {
+TEST(TableTest, CPU_SpanConstruction) {
     std::vector<StrIntTable::value_type> entries{{"a", 1}, {"b", 2}};
     std::span<const StrIntTable::value_type> entries_view(entries);
     StrIntTable t(entries_view);
@@ -68,7 +68,7 @@ TEST(TableTest, SpanConstruction) {
     EXPECT_EQ(*t.get("b"), 2);
 }
 
-TEST(TableTest, RangeConstructionFromUnorderedMap) {
+TEST(TableTest, CPU_RangeConstructionFromUnorderedMap) {
     std::unordered_map<std::string, int> src{{"a", 1}, {"b", 2}, {"c", 3}};
     StrIntTable t(src);
     EXPECT_EQ(t.size(), 3u);
@@ -77,7 +77,7 @@ TEST(TableTest, RangeConstructionFromUnorderedMap) {
     EXPECT_EQ(*t.get("c"), 3);
 }
 
-TEST(TableTest, RangeConstructionFromMap) {
+TEST(TableTest, CPU_RangeConstructionFromMap) {
     std::map<std::string, int> src{{"a", 1}, {"b", 2}};
     StrIntTable t(src);
     EXPECT_EQ(t.size(), 2u);
@@ -85,7 +85,7 @@ TEST(TableTest, RangeConstructionFromMap) {
     EXPECT_EQ(*t.get("b"), 2);
 }
 
-TEST(TableTest, RangeConstructionFromVectorOfPlainPairs) {
+TEST(TableTest, CPU_RangeConstructionFromVectorOfPlainPairs) {
     std::vector<std::pair<std::string, int>> src{{"a", 1}, {"b", 2}};  // non-const key
     StrIntTable t(src);
     EXPECT_EQ(t.size(), 2u);
@@ -93,20 +93,20 @@ TEST(TableTest, RangeConstructionFromVectorOfPlainPairs) {
     EXPECT_EQ(*t.get("b"), 2);
 }
 
-TEST(TableTest, RangeConstructionDuplicateThrows) {
+TEST(TableTest, CPU_RangeConstructionDuplicateThrows) {
     std::vector<std::pair<std::string, int>> src{{"a", 1}, {"a", 2}};
     EXPECT_ANY_THROW(StrIntTable{src});
 }
 
 // ---- operator[] --------------------------------------------------------------
 
-TEST(TableTest, SubscriptInsertsDefaultOnMiss) {
+TEST(TableTest, CPU_SubscriptInsertsDefaultOnMiss) {
     StrIntTable t;
     EXPECT_EQ(t["a"], 0);  // default-constructed int
     EXPECT_EQ(t.size(), 1u);
 }
 
-TEST(TableTest, SubscriptAssignThenOverwrite) {
+TEST(TableTest, CPU_SubscriptAssignThenOverwrite) {
     StrIntTable t;
     t["a"] = 1;
     EXPECT_EQ(t.size(), 1u);
@@ -116,7 +116,7 @@ TEST(TableTest, SubscriptAssignThenOverwrite) {
     EXPECT_EQ(*t.get("a"), 2);
 }
 
-TEST(TableTest, SubscriptReadsExistingWithoutOverwriting) {
+TEST(TableTest, CPU_SubscriptReadsExistingWithoutOverwriting) {
     StrIntTable t{{"a", 5}};
     EXPECT_EQ(t["a"], 5);
     EXPECT_EQ(t.size(), 1u);
@@ -124,7 +124,7 @@ TEST(TableTest, SubscriptReadsExistingWithoutOverwriting) {
 
 // ---- insert (insert-if-absent) -----------------------------------------------
 
-TEST(TableTest, InsertNewKey) {
+TEST(TableTest, CPU_InsertNewKey) {
     StrIntTable t;
     auto [it, inserted] = t.insert({"a", 1});
     EXPECT_TRUE(inserted);
@@ -132,7 +132,7 @@ TEST(TableTest, InsertNewKey) {
     EXPECT_EQ(t.size(), 1u);
 }
 
-TEST(TableTest, InsertExistingKeyDoesNotOverwrite) {
+TEST(TableTest, CPU_InsertExistingKeyDoesNotOverwrite) {
     StrIntTable t{{"a", 1}};
     auto [it, inserted] = t.insert({"a", 2});
     EXPECT_FALSE(inserted);
@@ -143,7 +143,7 @@ TEST(TableTest, InsertExistingKeyDoesNotOverwrite) {
 
 // ---- erase -------------------------------------------------------------------
 
-TEST(TableTest, EraseRemovesPresentKey) {
+TEST(TableTest, CPU_EraseRemovesPresentKey) {
     StrIntTable t{{"a", 1}, {"b", 2}};
     EXPECT_EQ(t.erase("a"), 1u);
     EXPECT_EQ(t.size(), 1u);
@@ -151,14 +151,14 @@ TEST(TableTest, EraseRemovesPresentKey) {
     EXPECT_EQ(*t.get("b"), 2);  // surviving entry intact
 }
 
-TEST(TableTest, EraseAbsentKeyIsNoop) {
+TEST(TableTest, CPU_EraseAbsentKeyIsNoop) {
     StrIntTable t{{"a", 1}};
     EXPECT_EQ(t.erase("missing"), 0u);
     EXPECT_EQ(t.size(), 1u);
     EXPECT_EQ(*t.get("a"), 1);
 }
 
-TEST(TableTest, EraseThenReinsert) {
+TEST(TableTest, CPU_EraseThenReinsert) {
     StrIntTable t{{"a", 1}};
     EXPECT_EQ(t.erase("a"), 1u);
     EXPECT_TRUE(t.empty());
@@ -169,7 +169,7 @@ TEST(TableTest, EraseThenReinsert) {
 
 // ---- emplace (insert-if-absent, in place) ------------------------------------
 
-TEST(TableTest, EmplaceNewKey) {
+TEST(TableTest, CPU_EmplaceNewKey) {
     StrIntTable t;
     auto [it, inserted] = t.emplace("a", 1);
     EXPECT_TRUE(inserted);
@@ -177,7 +177,7 @@ TEST(TableTest, EmplaceNewKey) {
     EXPECT_EQ(t.size(), 1u);
 }
 
-TEST(TableTest, EmplaceExistingKeyDoesNotOverwrite) {
+TEST(TableTest, CPU_EmplaceExistingKeyDoesNotOverwrite) {
     StrIntTable t;
     t.emplace("a", 1);
     auto [it, inserted] = t.emplace("a", 2);
@@ -188,7 +188,7 @@ TEST(TableTest, EmplaceExistingKeyDoesNotOverwrite) {
 
 // ---- get ---------------------------------------------------------------------
 
-TEST(TableTest, GetPresentAndAbsent) {
+TEST(TableTest, CPU_GetPresentAndAbsent) {
     StrIntTable t{{"a", 7}};
     auto present = t.get("a");
     ASSERT_TRUE(present);
@@ -196,13 +196,13 @@ TEST(TableTest, GetPresentAndAbsent) {
     EXPECT_FALSE(t.get("missing"));
 }
 
-TEST(TableTest, GetMutatesThroughReference) {
+TEST(TableTest, CPU_GetMutatesThroughReference) {
     StrIntTable t{{"a", 1}};
     *t.get("a") = 42;
     EXPECT_EQ(*t.get("a"), 42);
 }
 
-TEST(TableTest, GetOnConstTable) {
+TEST(TableTest, CPU_GetOnConstTable) {
     const StrIntTable t{{"a", 3}};
     auto v = t.get("a");
     ASSERT_TRUE(v);
@@ -212,7 +212,7 @@ TEST(TableTest, GetOnConstTable) {
 
 // ---- find --------------------------------------------------------------------
 
-TEST(TableTest, FindHitAndMiss) {
+TEST(TableTest, CPU_FindHitAndMiss) {
     StrIntTable t{{"a", 1}};
     auto it = t.find("a");
     ASSERT_NE(it, t.end());
@@ -222,7 +222,7 @@ TEST(TableTest, FindHitAndMiss) {
 
 // ---- size / clear ------------------------------------------------------------
 
-TEST(TableTest, Clear) {
+TEST(TableTest, CPU_Clear) {
     StrIntTable t{{"a", 1}, {"b", 2}};
     EXPECT_EQ(t.size(), 2u);
     t.clear();
@@ -232,7 +232,7 @@ TEST(TableTest, Clear) {
 
 // ---- iteration ---------------------------------------------------------------
 
-TEST(TableTest, IterationVisitsAllEntries) {
+TEST(TableTest, CPU_IterationVisitsAllEntries) {
     StrIntTable t{{"a", 1}, {"b", 2}, {"c", 3}};
     std::map<std::string, int> seen;
     for (const auto& [k, v] : t) {
@@ -241,7 +241,7 @@ TEST(TableTest, IterationVisitsAllEntries) {
     EXPECT_EQ(seen, (std::map<std::string, int>{{"a", 1}, {"b", 2}, {"c", 3}}));
 }
 
-TEST(TableTest, RangeConstructsStdMap) {
+TEST(TableTest, CPU_RangeConstructsStdMap) {
     StrIntTable t{{"a", 1}, {"b", 2}};
     std::map<std::string, int> m(t.begin(), t.end());
     EXPECT_EQ(m.size(), 2u);
@@ -251,7 +251,7 @@ TEST(TableTest, RangeConstructsStdMap) {
 
 // ---- equality (order independent) --------------------------------------------
 
-TEST(TableTest, EqualityIsOrderIndependent) {
+TEST(TableTest, CPU_EqualityIsOrderIndependent) {
     StrIntTable a{{"a", 1}, {"b", 2}};
     StrIntTable b;
     b["b"] = 2;
@@ -259,7 +259,7 @@ TEST(TableTest, EqualityIsOrderIndependent) {
     EXPECT_EQ(a, b);
 }
 
-TEST(TableTest, InequalityCases) {
+TEST(TableTest, CPU_InequalityCases) {
     StrIntTable base{{"a", 1}, {"b", 2}};
     EXPECT_NE(base, (StrIntTable{{"a", 1}}));             // different size
     EXPECT_NE(base, (StrIntTable{{"a", 1}, {"b", 99}}));  // different value
@@ -268,12 +268,12 @@ TEST(TableTest, InequalityCases) {
 
 // ---- duplicate-key rejection at construction ---------------------------------
 
-TEST(TableTest, InitializerListDuplicateThrows) {
+TEST(TableTest, CPU_InitializerListDuplicateThrows) {
     auto build = [] { return StrIntTable{{"a", 1}, {"a", 2}}; };
     EXPECT_ANY_THROW(build());
 }
 
-TEST(TableTest, SpanDuplicateThrows) {
+TEST(TableTest, CPU_SpanDuplicateThrows) {
     std::vector<StrIntTable::value_type> dup{{"a", 1}, {"a", 2}};
     std::span<const StrIntTable::value_type> sp(dup);
     EXPECT_ANY_THROW(StrIntTable{sp});
@@ -281,7 +281,7 @@ TEST(TableTest, SpanDuplicateThrows) {
 
 // ---- genericity over other K/V types -----------------------------------------
 
-TEST(TableMiscTest, IntKeyStringValue) {
+TEST(TableMiscTest, CPU_IntKeyStringValue) {
     m2::Table<int, std::string> t;
     t[1] = "one";
     t.emplace(2, "two");
@@ -293,24 +293,24 @@ TEST(TableMiscTest, IntKeyStringValue) {
 
 // ---- contains ----------------------------------------------------------------
 
-TEST(TableTest, ContainsReturnsTrueForPresentKey) {
+TEST(TableTest, CPU_ContainsReturnsTrueForPresentKey) {
     StrIntTable t{{"a", 1}, {"b", 2}};
     EXPECT_TRUE(t.contains("a"));
     EXPECT_TRUE(t.contains("b"));
 }
 
-TEST(TableTest, ContainsReturnsFalseForAbsentKey) {
+TEST(TableTest, CPU_ContainsReturnsFalseForAbsentKey) {
     StrIntTable t{{"a", 1}};
     EXPECT_FALSE(t.contains("missing"));
     EXPECT_FALSE(t.contains(""));
 }
 
-TEST(TableTest, ContainsOnEmptyTable) {
+TEST(TableTest, CPU_ContainsOnEmptyTable) {
     StrIntTable t;
     EXPECT_FALSE(t.contains("anything"));
 }
 
-TEST(TableTest, ContainsReflectsInsertAndErase) {
+TEST(TableTest, CPU_ContainsReflectsInsertAndErase) {
     StrIntTable t;
     EXPECT_FALSE(t.contains("a"));
     t.insert({"a", 1});
@@ -319,13 +319,13 @@ TEST(TableTest, ContainsReflectsInsertAndErase) {
     EXPECT_FALSE(t.contains("a"));
 }
 
-TEST(TableTest, ContainsWorksOnConstTable) {
+TEST(TableTest, CPU_ContainsWorksOnConstTable) {
     const StrIntTable t{{"a", 1}, {"b", 2}};
     EXPECT_TRUE(t.contains("a"));
     EXPECT_FALSE(t.contains("z"));
 }
 
-TEST(TableTest, ContainsDoesNotMutateTable) {
+TEST(TableTest, CPU_ContainsDoesNotMutateTable) {
     StrIntTable t{{"a", 1}, {"b", 2}};
     const auto size_before = t.size();
     EXPECT_TRUE(t.contains("a"));
@@ -333,7 +333,7 @@ TEST(TableTest, ContainsDoesNotMutateTable) {
     EXPECT_EQ(t.size(), size_before);
 }
 
-TEST(TableMiscTest, ContainsWithIntKey) {
+TEST(TableMiscTest, CPU_ContainsWithIntKey) {
     m2::Table<int, std::string> t;
     t[1] = "one";
     t.emplace(2, "two");
@@ -362,40 +362,40 @@ struct TaggedTable {
     auto attribute_values() const { return std::forward_as_tuple(tag, table); }
 };
 
-TEST(TableHashTest, HashIsDeterministic) {
+TEST(TableHashTest, CPU_HashIsDeterministic) {
     StrIntTable t{{"a", 1}, {"b", 2}};
     EXPECT_EQ(hash_of(t), hash_of(t));  // same object hashes identically every time
 }
 
-TEST(TableHashTest, EqualTablesHashEqual) {
+TEST(TableHashTest, CPU_EqualTablesHashEqual) {
     StrIntTable a{{"a", 1}, {"b", 2}, {"c", 3}};
     StrIntTable b{{"a", 1}, {"b", 2}, {"c", 3}};
     ASSERT_EQ(a, b);
     EXPECT_EQ(hash_of(a), hash_of(b));
 }
 
-TEST(TableHashTest, EmptyTables) {
+TEST(TableHashTest, CPU_EmptyTables) {
     EXPECT_EQ(hash_of(StrIntTable{}), hash_of(StrIntTable{}));
     EXPECT_NE(hash_of(StrIntTable{}), hash_of(StrIntTable{{"a", 1}}));
 }
 
-TEST(TableHashTest, DifferentValueChangesHash) {
+TEST(TableHashTest, CPU_DifferentValueChangesHash) {
     StrIntTable base{{"a", 1}, {"b", 2}};
     StrIntTable diff{{"a", 1}, {"b", 99}};
     EXPECT_NE(hash_of(base), hash_of(diff));
 }
 
-TEST(TableHashTest, DifferentKeyChangesHash) {
+TEST(TableHashTest, CPU_DifferentKeyChangesHash) {
     EXPECT_NE(hash_of(StrIntTable{{"a", 1}}), hash_of(StrIntTable{{"z", 1}}));
 }
 
-TEST(TableHashTest, DifferentSizeChangesHash) {
+TEST(TableHashTest, CPU_DifferentSizeChangesHash) {
     StrIntTable small{{"a", 1}};
     StrIntTable big{{"a", 1}, {"b", 2}};
     EXPECT_NE(hash_of(small), hash_of(big));
 }
 
-TEST(TableHashTest, HashIsOrderIndependent) {
+TEST(TableHashTest, CPU_HashIsOrderIndependent) {
     // Two tables that compare equal but were built in opposite order must hash equally:
     // std::hash<Table> folds the per-entry hashes in sorted order, so insertion order drops out
     // (consistent with operator==, which ignores order).
@@ -409,7 +409,7 @@ TEST(TableHashTest, HashIsOrderIndependent) {
     EXPECT_EQ(hash_of(a), hash_of(b));
 }
 
-TEST(TableHashTest, NonStringKeyValueHashes) {
+TEST(TableHashTest, CPU_NonStringKeyValueHashes) {
     // Reflection recurses into K and V, so any hashable key/value type works.
     m2::Table<int, std::string> a;
     a[1] = "one";
@@ -421,7 +421,7 @@ TEST(TableHashTest, NonStringKeyValueHashes) {
     EXPECT_NE(hash_of(a), hash_of(m2::Table<int, std::string>{{1, "one"}}));
 }
 
-TEST(TableHashTest, NestedInReflectedStruct) {
+TEST(TableHashTest, CPU_NestedInReflectedStruct) {
     TaggedTable a{.tag = 7, .table = {{"a", 1}, {"b", 2}}};
     TaggedTable b{.tag = 7, .table = {{"a", 1}, {"b", 2}}};
     EXPECT_EQ(hash_of(a), hash_of(b));

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_tensor_spec_relaxations.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_tensor_spec_relaxations.cpp
@@ -28,7 +28,7 @@ TensorSpec make_spec(Shape shape, Layout layout = Layout::TILE, DataType dtype =
 }
 
 // Strict (default-constructed) relaxation demands an exact TensorSpec match.
-TEST(TensorSpecRelaxations, StrictRequiresExactMatch) {
+TEST(TensorSpecRelaxations, CPU_StrictRequiresExactMatch) {
     const TensorSpecRelaxations strict{};
     const auto a = make_spec(Shape{1, 1, 32, 32});
     const auto same = make_spec(Shape{1, 1, 32, 32});
@@ -46,7 +46,7 @@ TEST(TensorSpecRelaxations, StrictRequiresExactMatch) {
 }
 
 // Strict match is exactly TensorSpec equality.
-TEST(TensorSpecRelaxations, StrictEqualsTensorSpecEquality) {
+TEST(TensorSpecRelaxations, CPU_StrictEqualsTensorSpecEquality) {
     const TensorSpecRelaxations strict{};
     const auto a = make_spec(Shape{1, 1, 32, 32});
     const auto b = make_spec(Shape{1, 1, 32, 64});
@@ -56,7 +56,7 @@ TEST(TensorSpecRelaxations, StrictEqualsTensorSpecEquality) {
 
 // dynamic_tensor_shape: same layout and rank, differing per-dim shape values -> match + equal hash.
 // Differing rank or layout still breaks the match.
-TEST(TensorSpecRelaxations, DynamicToleratesShapeWithinRank) {
+TEST(TensorSpecRelaxations, CPU_DynamicToleratesShapeWithinRank) {
     const TensorSpecRelaxations dyn{.dynamic_tensor_shape = true};
     const auto a = make_spec(Shape{1, 1, 32, 32});
     const auto b = make_spec(Shape{1, 1, 64, 128});  // same rank(4) + layout, different values
@@ -74,7 +74,7 @@ TEST(TensorSpecRelaxations, DynamicToleratesShapeWithinRank) {
 }
 
 // match_padded_shape_only: same layout and padded_shape, differing logical_shape -> match + equal hash.
-TEST(TensorSpecRelaxations, PaddedShapeOnlyToleratesLogicalWithinPadding) {
+TEST(TensorSpecRelaxations, CPU_PaddedShapeOnlyToleratesLogicalWithinPadding) {
     const TensorSpecRelaxations padded{.match_padded_shape_only = true};
     // TILE pads the last two dims up to the 32x32 tile: {..,5,5} and {..,30,30} both pad to {..,32,32}.
     const auto a = make_spec(Shape{1, 1, 5, 5});
@@ -92,7 +92,7 @@ TEST(TensorSpecRelaxations, PaddedShapeOnlyToleratesLogicalWithinPadding) {
 }
 
 // Precedence: dynamic_tensor_shape subsumes match_padded_shape_only when both are set.
-TEST(TensorSpecRelaxations, DynamicSubsumesPaddedShapeOnly) {
+TEST(TensorSpecRelaxations, CPU_DynamicSubsumesPaddedShapeOnly) {
     const auto a = make_spec(Shape{1, 1, 32, 32});
     const auto b = make_spec(Shape{1, 1, 64, 64});  // same rank+layout, DIFFERENT padded_shape
     ASSERT_NE(a.padded_shape(), b.padded_shape());
@@ -109,7 +109,7 @@ TEST(TensorSpecRelaxations, DynamicSubsumesPaddedShapeOnly) {
 // (match => equal-hash is guaranteed by construction; the reverse holds here absent a 64-bit
 // collision, which won't occur across this small fixed set — so the biconditional is a strong check
 // that the hash is neither too fine nor too coarse relative to the match.)
-TEST(TensorSpecRelaxations, HashConsistentWithMatch) {
+TEST(TensorSpecRelaxations, CPU_HashConsistentWithMatch) {
     const std::vector<TensorSpec> specs = {
         make_spec(Shape{1, 1, 32, 32}),
         make_spec(Shape{1, 1, 64, 64}),

--- a/tests/tt_metal/tt_metal/api/test_bit_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/test_bit_utils.cpp
@@ -9,7 +9,7 @@
 
 #include "tt_metal/hw/inc/internal/bit_utils.h"
 
-TEST(Host, ExtractBitArray) {
+TEST(Host, CPU_ExtractBitArray) {
     uint32_t src[4] = {0x12345678, 0x9abcdef0, 0x13579bdf, 0x2468ace0};
     // 1. Extract the 20-bit elements from the 32-bit source array.
     uint32_t dest[4];
@@ -28,7 +28,7 @@ TEST(Host, ExtractBitArray) {
     EXPECT_EQ(dest[3], 0x9abc);
 }
 
-TEST(Host, PackBitArray) {
+TEST(Host, CPU_PackBitArray) {
     uint32_t src[8] = {1, 2, 3, 4, 5, 6, 7, 7};
     uint32_t dest[8];
 
@@ -57,7 +57,7 @@ TEST(Host, PackBitArray) {
     EXPECT_EQ(dest[0], expected);
 }
 
-TEST(Host, PackExtractBitArray) {
+TEST(Host, CPU_PackExtractBitArray) {
     uint32_t src[8] = {1, 2, 3, 4, 5, 6, 7, 7};
 
     for (uint num_pack_bits = 3; num_pack_bits <= 31; num_pack_bits++) {
@@ -71,7 +71,7 @@ TEST(Host, PackExtractBitArray) {
     }
 }
 
-TEST(Host, ExtractPackBitArray) {
+TEST(Host, CPU_ExtractPackBitArray) {
     uint32_t src[4] = {0x12345678, 0x9abcdef0, 0x13579bdf, 0x2468ace0};
 
     // Compute the number of 3-bit elements that can be packed into 4 x 32-bit elements

--- a/tests/tt_metal/tt_metal/api/test_blaze_named_args_hashing.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blaze_named_args_hashing.cpp
@@ -95,19 +95,19 @@ const CoreCoord kCore1{1, 0};
 // Tier 1a -- hash_named_args_schema() directly
 // ============================================================================
 
-TEST(NamedArgsHashSchema, EmptyEqualsEmpty) {
+TEST(NamedArgsHashSchema, CPU_EmptyEqualsEmpty) {
     EXPECT_EQ(blaze_hash_schema(NamedKernelArgs{}), blaze_hash_schema(NamedKernelArgs{}))
         << "Two empty schemas must hash identically";
 }
 
 // --- value-insensitivity: same schema, different runtime values => SAME hash ---
 
-TEST(NamedArgsHashSchema, CommonScalarValueInsensitive) {
+TEST(NamedArgsHashSchema, CPU_CommonScalarValueInsensitive) {
     EXPECT_EQ(blaze_hash_schema(blaze_common_scalar("a.x", 1)), blaze_hash_schema(blaze_common_scalar("a.x", 999)))
         << "Common-scalar value is runtime data and must not affect the schema hash";
 }
 
-TEST(NamedArgsHashSchema, PerCoreScalarValueInsensitive) {
+TEST(NamedArgsHashSchema, CPU_PerCoreScalarValueInsensitive) {
     // Same name, different per-core values AND a different core set / core count.
     // None of the value data (nor the number of cores it targets) is part of the schema.
     EXPECT_EQ(
@@ -116,14 +116,14 @@ TEST(NamedArgsHashSchema, PerCoreScalarValueInsensitive) {
         << "Per-core-scalar values and core count are runtime data and must not affect the schema hash";
 }
 
-TEST(NamedArgsHashSchema, CommonArrayValueInsensitive) {
+TEST(NamedArgsHashSchema, CPU_CommonArrayValueInsensitive) {
     EXPECT_EQ(
         blaze_hash_schema(blaze_common_array("a.x", {1, 2, 3})),
         blaze_hash_schema(blaze_common_array("a.x", {9, 8, 7})))
         << "Common-array values are runtime data; only the array LENGTH is schema";
 }
 
-TEST(NamedArgsHashSchema, PerCoreArrayValueInsensitive) {
+TEST(NamedArgsHashSchema, CPU_PerCoreArrayValueInsensitive) {
     // Same name, same per-core array WIDTH (3), different values and different core count.
     EXPECT_EQ(
         blaze_hash_schema(blaze_per_core_array("a.x", {{kCore0, {1, 2, 3}}})),
@@ -133,17 +133,17 @@ TEST(NamedArgsHashSchema, PerCoreArrayValueInsensitive) {
 
 // --- schema-sensitivity: any schema difference => DIFFERENT hash ---
 
-TEST(NamedArgsHashSchema, DifferentFieldNameDiffers) {
+TEST(NamedArgsHashSchema, CPU_DifferentFieldNameDiffers) {
     EXPECT_NE(blaze_hash_schema(blaze_common_scalar("a.x", 0)), blaze_hash_schema(blaze_common_scalar("a.y", 0)))
         << "Different field name => different generated header => different hash";
 }
 
-TEST(NamedArgsHashSchema, DifferentNamespaceDiffers) {
+TEST(NamedArgsHashSchema, CPU_DifferentNamespaceDiffers) {
     EXPECT_NE(blaze_hash_schema(blaze_common_scalar("a.x", 0)), blaze_hash_schema(blaze_common_scalar("b.x", 0)))
         << "Different namespace => different generated header => different hash";
 }
 
-TEST(NamedArgsHashSchema, CommonVsPerCoreScalarDiffers) {
+TEST(NamedArgsHashSchema, CPU_CommonVsPerCoreScalarDiffers) {
     // Same name "a.x", but common-dispatch vs per-core-dispatch => different Arg descriptor.
     EXPECT_NE(
         blaze_hash_schema(blaze_common_scalar("a.x", 0)),
@@ -151,19 +151,19 @@ TEST(NamedArgsHashSchema, CommonVsPerCoreScalarDiffers) {
         << "Dispatch kind (common vs per-core) is schema and must change the hash";
 }
 
-TEST(NamedArgsHashSchema, ScalarVsArrayKindDiffers) {
+TEST(NamedArgsHashSchema, CPU_ScalarVsArrayKindDiffers) {
     // Same name "a.x", common dispatch, but scalar (Arg) vs length-1 array (ArrayArg).
     EXPECT_NE(blaze_hash_schema(blaze_common_scalar("a.x", 0)), blaze_hash_schema(blaze_common_array("a.x", {0})))
         << "Scalar vs array kind is schema and must change the hash even at length 1";
 }
 
-TEST(NamedArgsHashSchema, CommonArrayLengthDiffers) {
+TEST(NamedArgsHashSchema, CPU_CommonArrayLengthDiffers) {
     EXPECT_NE(
         blaze_hash_schema(blaze_common_array("a.x", {0, 0})), blaze_hash_schema(blaze_common_array("a.x", {0, 0, 0})))
         << "Common-array length is baked into the header and must change the hash";
 }
 
-TEST(NamedArgsHashSchema, PerCoreArrayLengthDiffers) {
+TEST(NamedArgsHashSchema, CPU_PerCoreArrayLengthDiffers) {
     // Regression: the per-core-array variant was entirely absent from the old hashers.
     EXPECT_NE(
         blaze_hash_schema(blaze_per_core_array("a.x", {{kCore0, {0, 0}}})),
@@ -171,7 +171,7 @@ TEST(NamedArgsHashSchema, PerCoreArrayLengthDiffers) {
         << "Per-core-array width is schema and must change the hash";
 }
 
-TEST(NamedArgsHashSchema, PerCoreArrayNameDiffers) {
+TEST(NamedArgsHashSchema, CPU_PerCoreArrayNameDiffers) {
     // Regression: names in the per-core-array variant were never hashed before WS5.
     EXPECT_NE(
         blaze_hash_schema(blaze_per_core_array("a.x", {{kCore0, {0, 0}}})),
@@ -179,7 +179,7 @@ TEST(NamedArgsHashSchema, PerCoreArrayNameDiffers) {
         << "Per-core-array field name is schema and must change the hash";
 }
 
-TEST(NamedArgsHashSchema, OrderSwapDiffers) {
+TEST(NamedArgsHashSchema, CPU_OrderSwapDiffers) {
     // Two common scalars in swapped order. Order determines the assigned RT-arg indices,
     // so [a.x, b.y] and [b.y, a.x] generate different headers.
     NamedKernelArgs ab{.named_common_runtime_args = {{"a.x", 0}, {"b.y", 0}}};
@@ -188,7 +188,7 @@ TEST(NamedArgsHashSchema, OrderSwapDiffers) {
         << "Order within a section shifts indices => different hash";
 }
 
-TEST(NamedArgsHashSchema, CountCollisionGuard) {
+TEST(NamedArgsHashSchema, CPU_CountCollisionGuard) {
     // Two names ["a","b"] must not collide with a single concatenated name ["ab"].
     // Per-section counts are hashed first precisely to prevent this.
     NamedKernelArgs two{.named_common_runtime_args = {{"a", 0}, {"b", 0}}};
@@ -200,13 +200,13 @@ TEST(NamedArgsHashSchema, CountCollisionGuard) {
 // Tier 1b -- hash_kernel_descriptor via public std::hash<ProgramDescriptor>
 // ============================================================================
 
-TEST(NamedArgsHashProgramDescriptor, SchemaDifferenceChangesProgramHash) {
+TEST(NamedArgsHashProgramDescriptor, CPU_SchemaDifferenceChangesProgramHash) {
     // Two descriptors identical except for a named-arg field name.
     EXPECT_NE(blaze_program_hash(blaze_common_scalar("a.x", 0)), blaze_program_hash(blaze_common_scalar("a.y", 0)))
         << "A named-arg schema difference must propagate into the program hash";
 }
 
-TEST(NamedArgsHashProgramDescriptor, PerCoreArrayLengthChangesProgramHash) {
+TEST(NamedArgsHashProgramDescriptor, CPU_PerCoreArrayLengthChangesProgramHash) {
     // Regression: the per-core-array variant was missing from the descriptor hasher
     // before WS5, so a change here would previously have collided.
     EXPECT_NE(
@@ -215,7 +215,7 @@ TEST(NamedArgsHashProgramDescriptor, PerCoreArrayLengthChangesProgramHash) {
         << "A per-core-array schema difference must propagate into the program hash";
 }
 
-TEST(NamedArgsHashProgramDescriptor, ValueOnlyDifferenceKeepsProgramHash) {
+TEST(NamedArgsHashProgramDescriptor, CPU_ValueOnlyDifferenceKeepsProgramHash) {
     // Identical schema across all four variants, differing only in runtime values
     // (and per-core core count). The program hash must be unchanged so the cache hits.
     NamedKernelArgs a{

--- a/tests/tt_metal/tt_metal/api/test_blaze_named_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blaze_named_runtime_args.cpp
@@ -504,7 +504,7 @@ void blaze_expect_cache_hit_values(
 
 }  // namespace
 
-TEST(NamedArgsDescriptorCacheHit, SameSchemaDifferentValuesShareProgramHash) {
+TEST(NamedArgsDescriptorCacheHit, CPU_SameSchemaDifferentValuesShareProgramHash) {
     // Premise of the staleness bug (and of the regression test below): the two
     // invocations must land on the SAME cache entry.  Values are deliberately
     // excluded from the schema hash; if that ever changes, this test fails first
@@ -517,7 +517,7 @@ TEST(NamedArgsDescriptorCacheHit, SameSchemaDifferentValuesShareProgramHash) {
         << "Same named-arg schema with different values must share a program-cache hash";
 }
 
-TEST(NamedArgsDescriptorCacheHit, NamedValuesReappliedOnCacheHit) {
+TEST(NamedArgsDescriptorCacheHit, CPU_NamedValuesReappliedOnCacheHit) {
     const CoreCoord core0{0, 0};
     const CoreCoord core1{1, 0};
     ProgramDescriptor desc_v1{.kernels = {blaze_cache_hit_kernel(core0, core1, 0)}};
@@ -536,7 +536,7 @@ TEST(NamedArgsDescriptorCacheHit, NamedValuesReappliedOnCacheHit) {
     blaze_expect_cache_hit_values(program, core0, core1, 1000);
 }
 
-TEST(NamedArgsDescriptorCacheHit, NamedOnlyValuesReappliedOnCacheHit) {
+TEST(NamedArgsDescriptorCacheHit, CPU_NamedOnlyValuesReappliedOnCacheHit) {
     // No positional args at all: before the fix, apply_descriptor_runtime_args had
     // nothing to copy for this descriptor, so EVERY named value stayed frozen at the
     // first invocation's.  Covers all four named-RT-arg variants in this configuration.
@@ -577,7 +577,7 @@ TEST(NamedArgsDescriptorCacheHit, NamedOnlyValuesReappliedOnCacheHit) {
     EXPECT_EQ(common_args[2], 400u) << "named common array[1] must be desc_v2's value";
 }
 
-TEST(NamedArgsDescriptorCacheHit, RepeatedCacheHitsKeepReapplyingValues) {
+TEST(NamedArgsDescriptorCacheHit, CPU_RepeatedCacheHitsKeepReapplyingValues) {
     // Repeated same-schema invocations are the production norm.  The patch must be a
     // pure function of the current descriptor on EVERY hit — a works-once or otherwise
     // stateful re-application (e.g. one that corrupts sizes or skips later hits) must
@@ -598,7 +598,7 @@ TEST(NamedArgsDescriptorCacheHit, RepeatedCacheHitsKeepReapplyingValues) {
     blaze_expect_cache_hit_values(program, core0, core1, 2000);
 }
 
-TEST(NamedArgsDescriptorCacheHit, MultipleNamedArgsPerVariantReappliedOnCacheHit) {
+TEST(NamedArgsDescriptorCacheHit, CPU_MultipleNamedArgsPerVariantReappliedOnCacheHit) {
     // Two entries per variant (arrays of different lengths) pack into adjacent slots
     // in declaration order: positional, then scalars, then arrays.  Every packed
     // offset must be re-applied on a cache hit, not just the first named slot.

--- a/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
+++ b/tests/tt_metal/tt_metal/api/test_blockfloat_common.cpp
@@ -36,13 +36,13 @@ struct ConvertU32ToBfpParams {
 
 class ConvertU32ToBfpTests : public ::testing::TestWithParam<ConvertU32ToBfpParams> {};
 
-TEST_P(ConvertU32ToBfpTests, MantissaRoundingWithPositiveFloat) {
+TEST_P(ConvertU32ToBfpTests, CPU_MantissaRoundingWithPositiveFloat) {
     const auto& params = GetParam();
     roundtrip_test_for_mantissa_rounding_with_bfp8(
         params.float_input, params.expected_mantissa, params.expected_float_output);
 }
 
-TEST_P(ConvertU32ToBfpTests, MantissaRoundingWithNegativeFloat) {
+TEST_P(ConvertU32ToBfpTests, CPU_MantissaRoundingWithNegativeFloat) {
     const auto& params = GetParam();
     const auto float_input = -1 * params.float_input;
     const auto expected_mantissa = params.expected_mantissa | 0x80;

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -79,7 +79,7 @@ MeshTensor MakeSingleTileL1MeshTensor(const std::shared_ptr<distributed::MeshDev
 // SECTION 1: Pure unit tests — no device required
 // ============================================================================
 
-TEST(DescriptorPatching, EmplaceRuntimeArgs_AllUint32_NoBufferBindings) {
+TEST(DescriptorPatching, CPU_EmplaceRuntimeArgs_AllUint32_NoBufferBindings) {
     KernelDescriptor kd;
     kd.emplace_runtime_args({0, 0}, {10u, 20u, 30u});
 
@@ -89,7 +89,7 @@ TEST(DescriptorPatching, EmplaceRuntimeArgs_AllUint32_NoBufferBindings) {
     EXPECT_TRUE(kd.buffer_bindings.empty());
 }
 
-TEST(DescriptorPatching, EmplaceRuntimeArgs_MultipleCores_AllUint32) {
+TEST(DescriptorPatching, CPU_EmplaceRuntimeArgs_MultipleCores_AllUint32) {
     KernelDescriptor kd;
     kd.emplace_runtime_args({0, 0}, {1u, 2u});
     kd.emplace_runtime_args({1, 0}, {3u, 4u});
@@ -100,7 +100,7 @@ TEST(DescriptorPatching, EmplaceRuntimeArgs_MultipleCores_AllUint32) {
     EXPECT_TRUE(kd.buffer_bindings.empty());
 }
 
-TEST(DescriptorPatching, EmplaceCommonRuntimeArgs_AllUint32_NoBindings) {
+TEST(DescriptorPatching, CPU_EmplaceCommonRuntimeArgs_AllUint32_NoBindings) {
     KernelDescriptor kd;
     kd.emplace_common_runtime_args({100u, 200u, 300u});
 
@@ -111,7 +111,7 @@ TEST(DescriptorPatching, EmplaceCommonRuntimeArgs_AllUint32_NoBindings) {
 // Regression: emplace_runtime_args must accept nullptr Buffer* as a placeholder for
 // an absent optional tensor.  It emits 0u into the runtime arg slot and registers no
 // binding, so the cache-hit fast path stays valid for ops with optional inputs.
-TEST(DescriptorPatching, EmplaceRuntimeArgs_NullBuffer_EmitsZero_NoBinding) {
+TEST(DescriptorPatching, CPU_EmplaceRuntimeArgs_NullBuffer_EmitsZero_NoBinding) {
     KernelDescriptor kd;
     Buffer* null_buf = nullptr;
     kd.emplace_runtime_args({0, 0}, {1u, null_buf, 3u});
@@ -121,7 +121,7 @@ TEST(DescriptorPatching, EmplaceRuntimeArgs_NullBuffer_EmitsZero_NoBinding) {
     EXPECT_TRUE(kd.buffer_bindings.empty());
 }
 
-TEST(DescriptorPatching, EmplaceCommonRuntimeArgs_NullBuffer_EmitsZero_NoBinding) {
+TEST(DescriptorPatching, CPU_EmplaceCommonRuntimeArgs_NullBuffer_EmitsZero_NoBinding) {
     KernelDescriptor kd;
     Buffer* null_buf = nullptr;
     kd.emplace_common_runtime_args({7u, null_buf, 9u});
@@ -130,7 +130,7 @@ TEST(DescriptorPatching, EmplaceCommonRuntimeArgs_NullBuffer_EmitsZero_NoBinding
     EXPECT_TRUE(kd.common_buffer_bindings.empty());
 }
 
-TEST(DescriptorPatching, RTArgList_Uint32Only_NoBufferBindings) {
+TEST(DescriptorPatching, CPU_RTArgList_Uint32Only_NoBufferBindings) {
     KernelDescriptor kd;
     KernelDescriptor::RTArgList args;
     args.push_back(7u);
@@ -143,7 +143,7 @@ TEST(DescriptorPatching, RTArgList_Uint32Only_NoBufferBindings) {
     EXPECT_TRUE(kd.buffer_bindings.empty());
 }
 
-TEST(DescriptorPatching, RTArgList_Append_ConcatenatesUint32s) {
+TEST(DescriptorPatching, CPU_RTArgList_Append_ConcatenatesUint32s) {
     KernelDescriptor kd;
     KernelDescriptor::RTArgList args;
     args.push_back(1u);
@@ -153,18 +153,18 @@ TEST(DescriptorPatching, RTArgList_Append_ConcatenatesUint32s) {
     EXPECT_EQ(kd.runtime_args[0].second, (std::vector<uint32_t>{1u, 2u, 3u, 4u}));
 }
 
-TEST(DescriptorPatching, ResolvedBindings_DefaultIsEmpty) {
+TEST(DescriptorPatching, CPU_ResolvedBindings_DefaultIsEmpty) {
     ResolvedBindings b;
     EXPECT_TRUE(b.empty());
 }
 
-TEST(DescriptorPatching, ResolvedBindings_EmptyAfterAddingRtArg_IsFalse) {
+TEST(DescriptorPatching, CPU_ResolvedBindings_EmptyAfterAddingRtArg_IsFalse) {
     ResolvedBindings b;
     b.rt_args.push_back({});
     EXPECT_FALSE(b.empty());
 }
 
-TEST(DescriptorPatching, ResolvedBindings_EmptyAfterAddingCb_IsFalse) {
+TEST(DescriptorPatching, CPU_ResolvedBindings_EmptyAfterAddingCb_IsFalse) {
     ResolvedBindings b;
     b.cbs.push_back({});
     EXPECT_FALSE(b.empty());

--- a/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
+++ b/tests/tt_metal/tt_metal/api/test_filesystem_utils.cpp
@@ -53,7 +53,7 @@ protected:
 // Basic Operations Tests
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, SafeCreateDirectories_CreatesNewDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeCreateDirectories_CreatesNewDirectory) {
     std::filesystem::path new_dir = temp_dir_ / "new_directory";
     EXPECT_FALSE(std::filesystem::exists(new_dir));
 
@@ -63,7 +63,7 @@ TEST_F(FilesystemUtilsTest, SafeCreateDirectories_CreatesNewDirectory) {
     EXPECT_TRUE(std::filesystem::is_directory(new_dir));
 }
 
-TEST_F(FilesystemUtilsTest, SafeCreateDirectories_CreatesNestedDirectories) {
+TEST_F(FilesystemUtilsTest, CPU_SafeCreateDirectories_CreatesNestedDirectories) {
     std::filesystem::path nested_dir = temp_dir_ / "a" / "b" / "c" / "d";
     EXPECT_FALSE(std::filesystem::exists(nested_dir));
 
@@ -73,7 +73,7 @@ TEST_F(FilesystemUtilsTest, SafeCreateDirectories_CreatesNestedDirectories) {
     EXPECT_TRUE(std::filesystem::is_directory(nested_dir));
 }
 
-TEST_F(FilesystemUtilsTest, SafeCreateDirectories_IdempotentOnExistingDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeCreateDirectories_IdempotentOnExistingDirectory) {
     std::filesystem::path existing_dir = create_test_directory("existing");
     EXPECT_TRUE(std::filesystem::exists(existing_dir));
 
@@ -82,7 +82,7 @@ TEST_F(FilesystemUtilsTest, SafeCreateDirectories_IdempotentOnExistingDirectory)
     EXPECT_TRUE(std::filesystem::exists(existing_dir));
 }
 
-TEST_F(FilesystemUtilsTest, SafeExists_ReturnsTrueForExistingPath) {
+TEST_F(FilesystemUtilsTest, CPU_SafeExists_ReturnsTrueForExistingPath) {
     std::filesystem::path file = create_test_file("exists_test.txt");
 
     auto result = safe_exists(file);
@@ -90,7 +90,7 @@ TEST_F(FilesystemUtilsTest, SafeExists_ReturnsTrueForExistingPath) {
     EXPECT_TRUE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeExists_ReturnsFalseForNonExistentPath) {
+TEST_F(FilesystemUtilsTest, CPU_SafeExists_ReturnsFalseForNonExistentPath) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
 
     auto result = safe_exists(non_existent);
@@ -98,7 +98,7 @@ TEST_F(FilesystemUtilsTest, SafeExists_ReturnsFalseForNonExistentPath) {
     EXPECT_FALSE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsTrueForDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeIsDirectory_ReturnsTrueForDirectory) {
     std::filesystem::path dir = create_test_directory("test_dir");
 
     auto result = safe_is_directory(dir);
@@ -106,7 +106,7 @@ TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsTrueForDirectory) {
     EXPECT_TRUE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsFalseForFile) {
+TEST_F(FilesystemUtilsTest, CPU_SafeIsDirectory_ReturnsFalseForFile) {
     std::filesystem::path file = create_test_file("test_file.txt");
 
     auto result = safe_is_directory(file);
@@ -114,7 +114,7 @@ TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsFalseForFile) {
     EXPECT_FALSE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsFalseForNonExistentPath) {
+TEST_F(FilesystemUtilsTest, CPU_SafeIsDirectory_ReturnsFalseForNonExistentPath) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist";
 
     auto result = safe_is_directory(non_existent);
@@ -122,7 +122,7 @@ TEST_F(FilesystemUtilsTest, SafeIsDirectory_ReturnsFalseForNonExistentPath) {
     EXPECT_FALSE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsTrueForFile) {
+TEST_F(FilesystemUtilsTest, CPU_SafeIsRegularFile_ReturnsTrueForFile) {
     std::filesystem::path file = create_test_file("regular_file.txt");
 
     auto result = safe_is_regular_file(file);
@@ -130,7 +130,7 @@ TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsTrueForFile) {
     EXPECT_TRUE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsFalseForDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeIsRegularFile_ReturnsFalseForDirectory) {
     std::filesystem::path dir = create_test_directory("test_dir");
 
     auto result = safe_is_regular_file(dir);
@@ -138,7 +138,7 @@ TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsFalseForDirectory) {
     EXPECT_FALSE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsFalseForNonExistentPath) {
+TEST_F(FilesystemUtilsTest, CPU_SafeIsRegularFile_ReturnsFalseForNonExistentPath) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
 
     auto result = safe_is_regular_file(non_existent);
@@ -146,7 +146,7 @@ TEST_F(FilesystemUtilsTest, SafeIsRegularFile_ReturnsFalseForNonExistentPath) {
     EXPECT_FALSE(result.value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeFileSize_ReturnsCorrectSize) {
+TEST_F(FilesystemUtilsTest, CPU_SafeFileSize_ReturnsCorrectSize) {
     std::string content = "Hello, World!";
     std::filesystem::path file = create_test_file("size_test.txt", content);
 
@@ -155,14 +155,14 @@ TEST_F(FilesystemUtilsTest, SafeFileSize_ReturnsCorrectSize) {
     EXPECT_EQ(result.value(), content.size());
 }
 
-TEST_F(FilesystemUtilsTest, SafeFileSize_ReturnsNulloptForNonExistentFile) {
+TEST_F(FilesystemUtilsTest, CPU_SafeFileSize_ReturnsNulloptForNonExistentFile) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
 
     auto result = safe_file_size(non_existent);
     EXPECT_FALSE(result.has_value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeLastWriteTime_ReturnsValidTime) {
+TEST_F(FilesystemUtilsTest, CPU_SafeLastWriteTime_ReturnsValidTime) {
     std::filesystem::path file = create_test_file("time_test.txt");
 
     auto result = safe_last_write_time(file);
@@ -192,14 +192,14 @@ TEST_F(FilesystemUtilsTest, SafeLastWriteTime_ReturnsValidTime) {
     EXPECT_LE(diff_ms, 1000);  // 1000ms = 1 second
 }
 
-TEST_F(FilesystemUtilsTest, SafeLastWriteTime_ReturnsNulloptForNonExistentFile) {
+TEST_F(FilesystemUtilsTest, CPU_SafeLastWriteTime_ReturnsNulloptForNonExistentFile) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
 
     auto result = safe_last_write_time(non_existent);
     EXPECT_FALSE(result.has_value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeRemove_RemovesExistingFile) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRemove_RemovesExistingFile) {
     std::filesystem::path file = create_test_file("to_remove.txt");
     EXPECT_TRUE(std::filesystem::exists(file));
 
@@ -208,7 +208,7 @@ TEST_F(FilesystemUtilsTest, SafeRemove_RemovesExistingFile) {
     EXPECT_FALSE(std::filesystem::exists(file));
 }
 
-TEST_F(FilesystemUtilsTest, SafeRemove_IdempotentOnNonExistentFile) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRemove_IdempotentOnNonExistentFile) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
     EXPECT_FALSE(std::filesystem::exists(non_existent));
 
@@ -216,7 +216,7 @@ TEST_F(FilesystemUtilsTest, SafeRemove_IdempotentOnNonExistentFile) {
     EXPECT_TRUE(safe_remove(non_existent));
 }
 
-TEST_F(FilesystemUtilsTest, SafeRemoveAll_RemovesDirectoryWithContents) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRemoveAll_RemovesDirectoryWithContents) {
     std::filesystem::path dir = create_test_directory("to_remove_all");
     create_test_file("to_remove_all/file1.txt");
     create_test_file("to_remove_all/file2.txt");
@@ -230,7 +230,7 @@ TEST_F(FilesystemUtilsTest, SafeRemoveAll_RemovesDirectoryWithContents) {
     EXPECT_FALSE(std::filesystem::exists(dir));
 }
 
-TEST_F(FilesystemUtilsTest, SafeRemoveAll_IdempotentOnNonExistentPath) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRemoveAll_IdempotentOnNonExistentPath) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist";
     EXPECT_FALSE(std::filesystem::exists(non_existent));
 
@@ -242,7 +242,7 @@ TEST_F(FilesystemUtilsTest, SafeRemoveAll_IdempotentOnNonExistentPath) {
 // Hard Link or Copy Tests
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_CreatesHardLink) {
+TEST_F(FilesystemUtilsTest, CPU_SafeHardLinkOrCopy_CreatesHardLink) {
     std::filesystem::path target = create_test_file("target.txt", "hard link target");
     std::filesystem::path link = temp_dir_ / "hard_link.txt";
 
@@ -266,7 +266,7 @@ TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_CreatesHardLink) {
     }
 }
 
-TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_WorksWithDirectoryInPath) {
+TEST_F(FilesystemUtilsTest, CPU_SafeHardLinkOrCopy_WorksWithDirectoryInPath) {
     // Creating a hard link to a file inside a directory should work
     std::filesystem::path target = create_test_file("source.txt", "source content");
     std::filesystem::path link = create_test_directory("dest_dir") / "linked.txt";
@@ -284,7 +284,7 @@ TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_WorksWithDirectoryInPath) {
     }
 }
 
-TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_OverwritesExisting) {
+TEST_F(FilesystemUtilsTest, CPU_SafeHardLinkOrCopy_OverwritesExisting) {
     std::filesystem::path target = create_test_file("target.txt", "new content here");
     std::filesystem::path existing = create_test_file("existing.txt", "old");
 
@@ -301,7 +301,7 @@ TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_OverwritesExisting) {
 // Directory Entries Tests
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsAllEntries) {
+TEST_F(FilesystemUtilsTest, CPU_SafeDirectoryEntries_ReturnsAllEntries) {
     std::filesystem::path dir = create_test_directory("list_dir");
     create_test_file("list_dir/file1.txt");
     create_test_file("list_dir/file2.txt");
@@ -325,7 +325,7 @@ TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsAllEntries) {
     EXPECT_EQ(dir_count, 1);
 }
 
-TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsEmptyForNonExistentDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeDirectoryEntries_ReturnsEmptyForNonExistentDirectory) {
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist";
 
     auto entries = safe_directory_entries(non_existent);
@@ -333,7 +333,7 @@ TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsEmptyForNonExistentDirec
     EXPECT_TRUE(entries.empty());
 }
 
-TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsEmptyForEmptyDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeDirectoryEntries_ReturnsEmptyForEmptyDirectory) {
     std::filesystem::path empty_dir = create_test_directory("empty");
 
     auto entries = safe_directory_entries(empty_dir);
@@ -341,7 +341,7 @@ TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_ReturnsEmptyForEmptyDirectory) 
     EXPECT_TRUE(entries.empty());
 }
 
-TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_HandlesNestedDirectories) {
+TEST_F(FilesystemUtilsTest, CPU_SafeDirectoryEntries_HandlesNestedDirectories) {
     std::filesystem::path dir = create_test_directory("nested");
     create_test_directory("nested/level1");
     create_test_directory("nested/level1/level2");
@@ -358,7 +358,7 @@ TEST_F(FilesystemUtilsTest, SafeDirectoryEntries_HandlesNestedDirectories) {
 // Rename Tests
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, SafeRename_RenamesFile) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRename_RenamesFile) {
     std::filesystem::path source = create_test_file("original.txt", "content");
     std::filesystem::path dest = temp_dir_ / "renamed.txt";
 
@@ -369,7 +369,7 @@ TEST_F(FilesystemUtilsTest, SafeRename_RenamesFile) {
     EXPECT_EQ(std::filesystem::file_size(dest), 7);  // "content"
 }
 
-TEST_F(FilesystemUtilsTest, SafeRename_OverwritesExisting) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRename_OverwritesExisting) {
     std::filesystem::path source = create_test_file("source.txt", "new content");
     std::filesystem::path dest = create_test_file("dest.txt", "old content");
 
@@ -380,14 +380,14 @@ TEST_F(FilesystemUtilsTest, SafeRename_OverwritesExisting) {
     EXPECT_EQ(std::filesystem::file_size(dest), 11);  // "new content"
 }
 
-TEST_F(FilesystemUtilsTest, SafeRename_ReturnsFalseForNonExistentSource) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRename_ReturnsFalseForNonExistentSource) {
     std::filesystem::path source = temp_dir_ / "does_not_exist.txt";
     std::filesystem::path dest = temp_dir_ / "dest.txt";
 
     EXPECT_FALSE(safe_rename(source, dest));
 }
 
-TEST_F(FilesystemUtilsTest, SafeRename_IgnoreMissingReturnsTrueForNonExistentSource) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRename_IgnoreMissingReturnsTrueForNonExistentSource) {
     std::filesystem::path source = temp_dir_ / "does_not_exist.txt";
     std::filesystem::path dest = temp_dir_ / "dest.txt";
 
@@ -399,19 +399,19 @@ TEST_F(FilesystemUtilsTest, SafeRename_IgnoreMissingReturnsTrueForNonExistentSou
 // Retry Constants Tests
 // ============================================================================
 
-TEST(FilesystemUtilsConstants, MaxRetriesIsReasonable) {
+TEST(FilesystemUtilsConstants, CPU_MaxRetriesIsReasonable) {
     // kMaxFsRetries should be a positive, reasonable number
     EXPECT_GT(kMaxFsRetries, 0);
     EXPECT_LE(kMaxFsRetries, 100);  // Should not be excessively high
 }
 
-TEST(FilesystemUtilsConstants, RetryDelayIsReasonable) {
+TEST(FilesystemUtilsConstants, CPU_RetryDelayIsReasonable) {
     // kFsRetryDelayMs should be a positive, reasonable number
     EXPECT_GT(kFsRetryDelayMs, 0);
     EXPECT_LE(kFsRetryDelayMs, 10000);  // Should not be excessively high (10 seconds)
 }
 
-TEST(FilesystemUtilsConstants, TotalMaxDelayIsReasonable) {
+TEST(FilesystemUtilsConstants, CPU_TotalMaxDelayIsReasonable) {
     // Calculate total maximum delay across all retries
     // Formula: sum of (kFsRetryDelayMs * attempt + random(0-100)) for each attempt
     // This is an upper bound calculation
@@ -428,12 +428,12 @@ TEST(FilesystemUtilsConstants, TotalMaxDelayIsReasonable) {
 // Error Detection Tests
 // ============================================================================
 
-TEST(FilesystemUtilsErrors, IsEstaleError_DetectsEstale) {
+TEST(FilesystemUtilsErrors, CPU_IsEstaleError_DetectsEstale) {
     std::error_code ec(ESTALE, std::system_category());
     EXPECT_TRUE(is_estale_error(ec));
 }
 
-TEST(FilesystemUtilsErrors, IsEstaleError_ReturnsFalseForOtherErrors) {
+TEST(FilesystemUtilsErrors, CPU_IsEstaleError_ReturnsFalseForOtherErrors) {
     std::error_code ecENOENT = std::make_error_code(std::errc::no_such_file_or_directory);
     EXPECT_FALSE(is_estale_error(ecENOENT));
 
@@ -441,12 +441,12 @@ TEST(FilesystemUtilsErrors, IsEstaleError_ReturnsFalseForOtherErrors) {
     EXPECT_FALSE(is_estale_error(ecACCES));
 }
 
-TEST(FilesystemUtilsErrors, IsNotFoundError_DetectsNoSuchFile) {
+TEST(FilesystemUtilsErrors, CPU_IsNotFoundError_DetectsNoSuchFile) {
     std::error_code ec = std::make_error_code(std::errc::no_such_file_or_directory);
     EXPECT_TRUE(is_not_found_error(ec));
 }
 
-TEST(FilesystemUtilsErrors, IsNotFoundError_ReturnsFalseForOtherErrors) {
+TEST(FilesystemUtilsErrors, CPU_IsNotFoundError_ReturnsFalseForOtherErrors) {
     std::error_code ecESTALE(ESTALE, std::system_category());
     EXPECT_FALSE(is_not_found_error(ecESTALE));
 
@@ -458,7 +458,7 @@ TEST(FilesystemUtilsErrors, IsNotFoundError_ReturnsFalseForOtherErrors) {
 // Retry Helper Tests
 // ============================================================================
 
-TEST(FilesystemUtilsRetry, RetryOnEstale_SucceedsOnFirstAttempt) {
+TEST(FilesystemUtilsRetry, CPU_RetryOnEstale_SucceedsOnFirstAttempt) {
     // Test that retry_on_estale succeeds when the operation succeeds immediately
     int call_count = 0;
     auto operation = [&call_count]() -> bool {
@@ -473,7 +473,7 @@ TEST(FilesystemUtilsRetry, RetryOnEstale_SucceedsOnFirstAttempt) {
     EXPECT_EQ(call_count, 1);
 }
 
-TEST(FilesystemUtilsRetry, RetryOnEstale_FailsOnNonEstaleError) {
+TEST(FilesystemUtilsRetry, CPU_RetryOnEstale_FailsOnNonEstaleError) {
     // Test that retry_on_estale fails immediately on non-ESTALE errors
     int call_count = 0;
     auto operation = [&call_count]() -> bool {
@@ -488,7 +488,7 @@ TEST(FilesystemUtilsRetry, RetryOnEstale_FailsOnNonEstaleError) {
     set_nfs_safety(false);
 }
 
-TEST(FilesystemUtilsRetry, RetryOnEstaleEc_SucceedsOnFirstAttempt) {
+TEST(FilesystemUtilsRetry, CPU_RetryOnEstaleEc_SucceedsOnFirstAttempt) {
     // Test that retry_on_estale_ec succeeds when the operation succeeds immediately
     int call_count = 0;
     auto operation = [&call_count](std::error_code& ec) -> bool {
@@ -503,7 +503,7 @@ TEST(FilesystemUtilsRetry, RetryOnEstaleEc_SucceedsOnFirstAttempt) {
     EXPECT_EQ(call_count, 1);
 }
 
-TEST(FilesystemUtilsRetry, RetryOnEstaleEc_FailsOnNonEstaleError) {
+TEST(FilesystemUtilsRetry, CPU_RetryOnEstaleEc_FailsOnNonEstaleError) {
     // Test that retry_on_estale_ec fails immediately on non-ESTALE errors
     int call_count = 0;
     auto operation = [&call_count](std::error_code& ec) -> bool {
@@ -523,7 +523,7 @@ TEST(FilesystemUtilsRetry, RetryOnEstaleEc_FailsOnNonEstaleError) {
 // Edge Cases and Error Handling
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, SafeRemove_ReturnsTrueForEmptyDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRemove_ReturnsTrueForEmptyDirectory) {
     std::filesystem::path dir = create_test_directory("empty_dir");
     EXPECT_TRUE(std::filesystem::exists(dir));
 
@@ -532,7 +532,7 @@ TEST_F(FilesystemUtilsTest, SafeRemove_ReturnsTrueForEmptyDirectory) {
     EXPECT_FALSE(std::filesystem::exists(dir));
 }
 
-TEST_F(FilesystemUtilsTest, SafeRemove_ReturnsFalseForNonEmptyDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRemove_ReturnsFalseForNonEmptyDirectory) {
     std::filesystem::path dir = create_test_directory("non_empty_dir");
     create_test_file("non_empty_dir/file.txt", "content");
 
@@ -541,7 +541,7 @@ TEST_F(FilesystemUtilsTest, SafeRemove_ReturnsFalseForNonEmptyDirectory) {
     EXPECT_TRUE(std::filesystem::exists(dir));
 }
 
-TEST_F(FilesystemUtilsTest, SafeFileSize_WorksOnDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeFileSize_WorksOnDirectory) {
     std::filesystem::path dir = create_test_directory("dir_for_size");
 
     auto result = safe_file_size(dir);
@@ -549,7 +549,7 @@ TEST_F(FilesystemUtilsTest, SafeFileSize_WorksOnDirectory) {
     EXPECT_FALSE(result.has_value());
 }
 
-TEST_F(FilesystemUtilsTest, SafeLastWriteTime_WorksOnDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SafeLastWriteTime_WorksOnDirectory) {
     std::filesystem::path dir = create_test_directory("dir_for_time");
 
     auto result = safe_last_write_time(dir);
@@ -558,7 +558,7 @@ TEST_F(FilesystemUtilsTest, SafeLastWriteTime_WorksOnDirectory) {
     EXPECT_NE(result.value(), std::filesystem::file_time_type::min());
 }
 
-TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_ReturnsFalseForNonExistentSource) {
+TEST_F(FilesystemUtilsTest, CPU_SafeHardLinkOrCopy_ReturnsFalseForNonExistentSource) {
     std::filesystem::path source = temp_dir_ / "does_not_exist.txt";
     std::filesystem::path dest = temp_dir_ / "dest.txt";
 
@@ -566,14 +566,14 @@ TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_ReturnsFalseForNonExistentSource)
     EXPECT_FALSE(std::filesystem::exists(dest));
 }
 
-TEST_F(FilesystemUtilsTest, SafeHardLinkOrCopy_ReturnsFalseForNonExistentDestParent) {
+TEST_F(FilesystemUtilsTest, CPU_SafeHardLinkOrCopy_ReturnsFalseForNonExistentDestParent) {
     std::filesystem::path source = create_test_file("source.txt");
     std::filesystem::path dest = temp_dir_ / "non_existent_parent" / "dest.txt";
 
     EXPECT_FALSE(safe_hard_link_or_copy(source, dest));
 }
 
-TEST_F(FilesystemUtilsTest, SafeRename_ReturnsFalseWhenDestParentDoesNotExist) {
+TEST_F(FilesystemUtilsTest, CPU_SafeRename_ReturnsFalseWhenDestParentDoesNotExist) {
     std::filesystem::path source = create_test_file("source.txt");
     std::filesystem::path dest = temp_dir_ / "non_existent_parent" / "dest.txt";
 
@@ -583,7 +583,7 @@ TEST_F(FilesystemUtilsTest, SafeRename_ReturnsFalseWhenDestParentDoesNotExist) {
 }
 
 // Test that verifies operations work on symlinks (if supported)
-TEST_F(FilesystemUtilsTest, SafeOperations_HandleSymlinks) {
+TEST_F(FilesystemUtilsTest, CPU_SafeOperations_HandleSymlinks) {
     std::filesystem::path target = create_test_file("symlink_target.txt", "symlinked content");
     std::filesystem::path link = temp_dir_ / "symlink";
 
@@ -611,7 +611,7 @@ TEST_F(FilesystemUtilsTest, SafeOperations_HandleSymlinks) {
 // sync_filesystem Tests
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, SyncFilesystem_SyncsDirectory) {
+TEST_F(FilesystemUtilsTest, CPU_SyncFilesystem_SyncsDirectory) {
     // Create a directory and a file within it
     std::filesystem::path test_dir = create_test_directory("sync_test_dir");
     std::filesystem::path test_file = test_dir / "sync_test_file.txt";
@@ -630,7 +630,7 @@ TEST_F(FilesystemUtilsTest, SyncFilesystem_SyncsDirectory) {
     EXPECT_TRUE(std::filesystem::exists(test_file));
 }
 
-TEST_F(FilesystemUtilsTest, SyncFilesystem_SyncsFile) {
+TEST_F(FilesystemUtilsTest, CPU_SyncFilesystem_SyncsFile) {
     // Create a test file
     std::filesystem::path test_file = create_test_file("sync_test.txt", "content to sync");
 
@@ -641,7 +641,7 @@ TEST_F(FilesystemUtilsTest, SyncFilesystem_SyncsFile) {
     EXPECT_TRUE(std::filesystem::exists(test_file));
 }
 
-TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesEmptyParentPath) {
+TEST_F(FilesystemUtilsTest, CPU_SyncFilesystem_HandlesEmptyParentPath) {
     // Test with a relative path that has no directory component
     // This should not crash when trying to get parent_path()
     std::filesystem::path relative_file = "relative_test_file.txt";
@@ -660,7 +660,7 @@ TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesEmptyParentPath) {
     std::filesystem::remove(relative_file);
 }
 
-TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesNonExistentPath) {
+TEST_F(FilesystemUtilsTest, CPU_SyncFilesystem_HandlesNonExistentPath) {
     // Test with a non-existent path - on Linux, tries to open parent directory
     // and falls back to sync() if that also fails. This is best-effort sync.
     std::filesystem::path non_existent = temp_dir_ / "definitely_does_not_exist" / "subdir";
@@ -673,7 +673,7 @@ TEST_F(FilesystemUtilsTest, SyncFilesystem_HandlesNonExistentPath) {
 // remove_empty_parent_directories Tests
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_RemovesEmptyDirs) {
+TEST_F(FilesystemUtilsTest, CPU_RemoveEmptyParentDirectories_RemovesEmptyDirs) {
     // Create a guard file in temp_dir_ to prevent it from becoming empty
     // (which would cause the function to try removing temp_dir_ itself)
     create_test_file("guard.txt", "prevents temp_dir_ removal");
@@ -718,7 +718,7 @@ TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_RemovesEmptyDirs) {
     }
 }
 
-TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_StopsAtNonEmpty) {
+TEST_F(FilesystemUtilsTest, CPU_RemoveEmptyParentDirectories_StopsAtNonEmpty) {
     // Create a nested structure with a file at level b
     std::filesystem::path dir_a = create_test_directory("cleanup_b");
     std::filesystem::path dir_b = dir_a / "b";
@@ -740,7 +740,7 @@ TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_StopsAtNonEmpty) {
     EXPECT_FALSE(std::filesystem::exists(dir_d));
 }
 
-TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesNonExistentPath) {
+TEST_F(FilesystemUtilsTest, CPU_RemoveEmptyParentDirectories_HandlesNonExistentPath) {
     // Test with a non-existent path - should not crash
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist" / "subdir";
 
@@ -750,7 +750,7 @@ TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesNonExistentPath)
     EXPECT_EQ(removed, 0);
 }
 
-TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesSingleEmptyDir) {
+TEST_F(FilesystemUtilsTest, CPU_RemoveEmptyParentDirectories_HandlesSingleEmptyDir) {
     // Test with a single empty directory
     std::filesystem::path single_dir = create_test_directory("single_cleanup");
 
@@ -768,7 +768,7 @@ TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesSingleEmptyDir) 
     }
 }
 
-TEST_F(FilesystemUtilsTest, RemoveEmptyParentDirectories_HandlesDirWithFiles) {
+TEST_F(FilesystemUtilsTest, CPU_RemoveEmptyParentDirectories_HandlesDirWithFiles) {
     // Test with a directory that has files - should not remove anything
     std::filesystem::path dir_with_file = create_test_directory("with_file");
     create_test_file("with_file/test.txt", "content");
@@ -796,7 +796,7 @@ protected:
     }
 };
 
-TEST_F(FilesystemUtilsNfsSafetyTest, SafeCreateDirectories) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_SafeCreateDirectories) {
     auto dir = temp_dir_ / "nfs_test" / "nested" / "dir";
     EXPECT_TRUE(safe_create_directories(dir));
     EXPECT_TRUE(std::filesystem::is_directory(dir));
@@ -804,7 +804,7 @@ TEST_F(FilesystemUtilsNfsSafetyTest, SafeCreateDirectories) {
     EXPECT_TRUE(safe_create_directories(dir));
 }
 
-TEST_F(FilesystemUtilsNfsSafetyTest, SafeRemoveFile) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_SafeRemoveFile) {
     auto file = create_test_file("nfs_remove_me.txt");
     EXPECT_TRUE(safe_remove(file));
     EXPECT_FALSE(std::filesystem::exists(file));
@@ -812,13 +812,13 @@ TEST_F(FilesystemUtilsNfsSafetyTest, SafeRemoveFile) {
     EXPECT_TRUE(safe_remove(file));
 }
 
-TEST_F(FilesystemUtilsNfsSafetyTest, SafeRemoveEmptyDirectory) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_SafeRemoveEmptyDirectory) {
     auto dir = create_test_directory("nfs_empty_dir");
     EXPECT_TRUE(safe_remove(dir));
     EXPECT_FALSE(std::filesystem::exists(dir));
 }
 
-TEST_F(FilesystemUtilsNfsSafetyTest, SafeRename) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_SafeRename) {
     auto src = create_test_file("nfs_src.txt", "data");
     auto dst = temp_dir_ / "nfs_dst.txt";
     EXPECT_TRUE(safe_rename(src, dst));
@@ -826,7 +826,7 @@ TEST_F(FilesystemUtilsNfsSafetyTest, SafeRename) {
     EXPECT_TRUE(std::filesystem::exists(dst));
 }
 
-TEST_F(FilesystemUtilsNfsSafetyTest, SafeExistsAndQueries) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_SafeExistsAndQueries) {
     auto file = create_test_file("nfs_query.txt", "hello");
     auto dir = create_test_directory("nfs_query_dir");
 
@@ -843,21 +843,21 @@ TEST_F(FilesystemUtilsNfsSafetyTest, SafeExistsAndQueries) {
     EXPECT_TRUE(mtime.has_value());
 }
 
-TEST_F(FilesystemUtilsNfsSafetyTest, SafeDirectoryEntries) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_SafeDirectoryEntries) {
     create_test_file("nfs_dir_a.txt");
     create_test_file("nfs_dir_b.txt");
     auto entries = safe_directory_entries(temp_dir_);
     EXPECT_GE(entries.size(), 2u);
 }
 
-TEST_F(FilesystemUtilsNfsSafetyTest, SafeHardLinkOrCopy) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_SafeHardLinkOrCopy) {
     auto target = create_test_file("nfs_link_target.txt", "link content");
     auto link = temp_dir_ / "nfs_link.txt";
     EXPECT_TRUE(safe_hard_link_or_copy(target, link));
     EXPECT_TRUE(std::filesystem::exists(link));
 }
 
-TEST_F(FilesystemUtilsNfsSafetyTest, RemoveEmptyParentDirectories) {
+TEST_F(FilesystemUtilsNfsSafetyTest, CPU_RemoveEmptyParentDirectories) {
     // Create a guard file in temp_dir_ to prevent it from becoming empty
     // (which would cause the function to try removing temp_dir_ itself)
     create_test_file("nfs_guard.txt", "prevents temp_dir_ removal");
@@ -895,7 +895,7 @@ TEST_F(FilesystemUtilsNfsSafetyTest, RemoveEmptyParentDirectories) {
 // NFS Safety Mode Toggle Tests
 // ============================================================================
 
-TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyCanBeEnabled) {
+TEST(FilesystemUtilsNfsSafetyToggle, CPU_NfsSafetyCanBeEnabled) {
     // Save original state
     bool original = nfs_safety_enabled();
 
@@ -907,7 +907,7 @@ TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyCanBeEnabled) {
     set_nfs_safety(original);
 }
 
-TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyCanBeDisabled) {
+TEST(FilesystemUtilsNfsSafetyToggle, CPU_NfsSafetyCanBeDisabled) {
     // Save original state
     bool original = nfs_safety_enabled();
 
@@ -919,7 +919,7 @@ TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyCanBeDisabled) {
     set_nfs_safety(original);
 }
 
-TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyDefaultsToDisabled) {
+TEST(FilesystemUtilsNfsSafetyToggle, CPU_NfsSafetyDefaultsToDisabled) {
     // NFS safety should be disabled by default for performance
     // (This test assumes a fresh process - may not work if other tests ran first)
     // We mainly want to verify the getter/setter work correctly
@@ -938,7 +938,7 @@ TEST(FilesystemUtilsNfsSafetyToggle, NfsSafetyDefaultsToDisabled) {
 // fsync_file Tests
 // ============================================================================
 
-TEST_F(FilesystemUtilsTest, FsyncFile_SyncsExistingFile) {
+TEST_F(FilesystemUtilsTest, CPU_FsyncFile_SyncsExistingFile) {
     // Create a test file
     std::filesystem::path test_file = create_test_file("fsync_test.txt", "content to fsync");
 
@@ -949,7 +949,7 @@ TEST_F(FilesystemUtilsTest, FsyncFile_SyncsExistingFile) {
     EXPECT_TRUE(std::filesystem::exists(test_file));
 }
 
-TEST_F(FilesystemUtilsTest, FsyncFile_HandlesNonExistentFile) {
+TEST_F(FilesystemUtilsTest, CPU_FsyncFile_HandlesNonExistentFile) {
     // Test with a non-existent file - should not crash
     std::filesystem::path non_existent = temp_dir_ / "does_not_exist.txt";
 
@@ -960,7 +960,7 @@ TEST_F(FilesystemUtilsTest, FsyncFile_HandlesNonExistentFile) {
 // Jitter Tests
 // ============================================================================
 
-TEST(FilesystemUtilsConstants, RetryJitterIsWithinBounds) {
+TEST(FilesystemUtilsConstants, CPU_RetryJitterIsWithinBounds) {
     // Test that get_retry_jitter_ms returns values within expected bounds
     for (int i = 0; i < 100; ++i) {
         int jitter = get_retry_jitter_ms();

--- a/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
+++ b/tests/tt_metal/tt_metal/api/test_graph_tracking.cpp
@@ -39,7 +39,7 @@ public:
 
 }  // namespace
 
-TEST(GraphTrackerThreading, SingleThreadCapturesEachEventOnce) {
+TEST(GraphTrackerThreading, CPU_SingleThreadCapturesEachEventOnce) {
     auto& tracker = GraphTracker::instance();
     tracker.clear();
 
@@ -64,7 +64,7 @@ TEST(GraphTrackerThreading, SingleThreadCapturesEachEventOnce) {
 // pushes its processor before either starts dispatching (via a barrier), so
 // if storage were shared both threads would iterate both processors and each
 // would see 2 * kIterations events.
-TEST(GraphTrackerThreading, ProcessorsAreIsolatedPerThread) {
+TEST(GraphTrackerThreading, CPU_ProcessorsAreIsolatedPerThread) {
     constexpr int kIterations = 1000;
     constexpr int kNumThreads = 2;
 
@@ -110,7 +110,7 @@ TEST(GraphTrackerThreading, ProcessorsAreIsolatedPerThread) {
 
 // Reproduces the race from tt-mlir#8302. One thread spins push/pop_processor
 // while another spins track_function_start.
-TEST(GraphTrackerThreading, ConcurrentPushPopAndTrackDoNotRace) {
+TEST(GraphTrackerThreading, CPU_ConcurrentPushPopAndTrackDoNotRace) {
     constexpr auto kDuration = std::chrono::milliseconds(200);
 
     std::atomic<bool> stop{false};

--- a/tests/tt_metal/tt_metal/api/test_host_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_host_buffer.cpp
@@ -18,12 +18,12 @@ namespace {
 using ::testing::Eq;
 using ::testing::Pointwise;
 
-TEST(HostBufferTest, Empty) {
+TEST(HostBufferTest, CPU_Empty) {
     HostBuffer buffer;
     EXPECT_TRUE(buffer.view_bytes().empty());
 }
 
-TEST(HostBufferTest, BasicOwned) {
+TEST(HostBufferTest, CPU_BasicOwned) {
     HostBuffer buffer(std::vector<int>{1, 2, 3});
 
     EXPECT_THAT(buffer.view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
@@ -34,7 +34,7 @@ TEST(HostBufferTest, BasicOwned) {
     EXPECT_THAT(buffer.view_as<int>(), Pointwise(Eq(), {1, 5, 3}));
 }
 
-TEST(HostBufferTest, BasicBorrowed) {
+TEST(HostBufferTest, CPU_BasicBorrowed) {
     int num_increments = 0;
     int num_decrements = 0;
     std::vector<int> vec = {1, 2, 3};
@@ -51,12 +51,12 @@ TEST(HostBufferTest, BasicBorrowed) {
     EXPECT_THAT(buffer.view_as<int>(), Pointwise(Eq(), {1, 5, 3}));
 }
 
-TEST(HostBufferTest, IncorrectCast) {
+TEST(HostBufferTest, CPU_IncorrectCast) {
     HostBuffer buffer(std::vector<int>{1, 2, 3});
     EXPECT_ANY_THROW({ buffer.view_as<float>(); });
 }
 
-TEST(HostBufferTest, ShallowCopy) {
+TEST(HostBufferTest, CPU_ShallowCopy) {
     HostBuffer buffer(std::vector<int>{1, 2, 3});
     HostBuffer copy = buffer;
 

--- a/tests/tt_metal/tt_metal/api/test_memory_pin.cpp
+++ b/tests/tt_metal/tt_metal/api/test_memory_pin.cpp
@@ -15,7 +15,7 @@
 namespace tt::tt_metal {
 namespace {
 
-TEST(MemoryPinTest, Lifecycle) {
+TEST(MemoryPinTest, CPU_Lifecycle) {
     int inc_count = 0;
     int dec_count = 0;
     {
@@ -27,7 +27,7 @@ TEST(MemoryPinTest, Lifecycle) {
     EXPECT_EQ(dec_count, 1);
 }
 
-TEST(MemoryPinTest, EmptyPin) {
+TEST(MemoryPinTest, CPU_EmptyPin) {
     {
         MemoryPin pin;
         EXPECT_EQ(pin, nullptr);
@@ -41,7 +41,7 @@ TEST(MemoryPinTest, EmptyPin) {
     }
 }
 
-TEST(MemoryPinTest, FromSharedPtr) {
+TEST(MemoryPinTest, CPU_FromSharedPtr) {
     auto ptr = std::make_shared<int>(42);
     MemoryPin pin(ptr);
 
@@ -55,7 +55,7 @@ TEST(MemoryPinTest, FromSharedPtr) {
     EXPECT_EQ(ptr.use_count(), 2);
 }
 
-TEST(MemoryPinTest, FinalReleaseCallbackRunsBeforeLastDecrement) {
+TEST(MemoryPinTest, CPU_FinalReleaseCallbackRunsBeforeLastDecrement) {
     std::vector<std::string> events;
     {
         MemoryPin pin([]() {}, [&events]() { events.push_back("decrement"); });
@@ -70,7 +70,7 @@ TEST(MemoryPinTest, FinalReleaseCallbackRunsBeforeLastDecrement) {
     EXPECT_THAT(events, ::testing::ElementsAre("decrement", "final_release", "decrement"));
 }
 
-TEST(MemoryPinTest, CopyConstruction) {
+TEST(MemoryPinTest, CPU_CopyConstruction) {
     int inc_count = 0;
     int dec_count = 0;
     MemoryPin pin1([&]() { inc_count++; }, [&]() { dec_count++; });
@@ -85,7 +85,7 @@ TEST(MemoryPinTest, CopyConstruction) {
     EXPECT_EQ(dec_count, 1);
 }
 
-TEST(MemoryPinTest, CopyAssignment) {
+TEST(MemoryPinTest, CPU_CopyAssignment) {
     int inc_count1 = 0;
     int dec_count1 = 0;
     int inc_count2 = 0;
@@ -112,7 +112,7 @@ TEST(MemoryPinTest, CopyAssignment) {
     EXPECT_EQ(dec_count2, 1);
 }
 
-TEST(MemoryPinTest, CopyAssignmentToEmpty) {
+TEST(MemoryPinTest, CPU_CopyAssignmentToEmpty) {
     int inc_count = 0;
     int dec_count = 0;
     MemoryPin pin1([&]() { inc_count++; }, [&]() { dec_count++; });
@@ -129,7 +129,7 @@ TEST(MemoryPinTest, CopyAssignmentToEmpty) {
     EXPECT_EQ(dec_count, 1);
 }
 
-TEST(MemoryPinTest, MoveConstruction) {
+TEST(MemoryPinTest, CPU_MoveConstruction) {
     int inc_count = 0;
     int dec_count = 0;
     MemoryPin pin1([&]() { inc_count++; }, [&]() { dec_count++; });
@@ -147,7 +147,7 @@ TEST(MemoryPinTest, MoveConstruction) {
     EXPECT_EQ(dec_count, 1);
 }
 
-TEST(MemoryPinTest, MoveAssignment) {
+TEST(MemoryPinTest, CPU_MoveAssignment) {
     int inc_count1 = 0;
     int dec_count1 = 0;
     int inc_count2 = 0;
@@ -176,7 +176,7 @@ TEST(MemoryPinTest, MoveAssignment) {
     EXPECT_EQ(dec_count2, 1);
 }
 
-TEST(MemoryPinTest, MoveAssignmentToEmpty) {
+TEST(MemoryPinTest, CPU_MoveAssignmentToEmpty) {
     int inc_count = 0;
     int dec_count = 0;
     MemoryPin pin1([&]() { inc_count++; }, [&]() { dec_count++; });

--- a/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
@@ -127,7 +127,7 @@ void seed_precompiled_root(
     experimental::CompileKernelOffline(kernel_path, kernel_config, params);
 }
 
-TEST_F(OfflineKernelCompileMockFixture, MetadataFromProgramDerivesConfiguredCbMetadata) {
+TEST_F(OfflineKernelCompileMockFixture, CPU_MetadataFromProgramDerivesConfiguredCbMetadata) {
     Program program = CreateProgram();
     const Tile tile({16, 32});
     const auto page_size = tile.get_tile_size(DataFormat::Float16_b);
@@ -144,7 +144,7 @@ TEST_F(OfflineKernelCompileMockFixture, MetadataFromProgramDerivesConfiguredCbMe
     EXPECT_EQ(*cb_compile_configs[0].tile, tile);
 }
 
-TEST_F(OfflineKernelCompileMockFixture, CBCompileConfigsFromProgramDeduplicatesOverlappingCbIndex) {
+TEST_F(OfflineKernelCompileMockFixture, CPU_CBCompileConfigsFromProgramDeduplicatesOverlappingCbIndex) {
     Program program = CreateProgram();
     const CoreRange left_core(CoreCoord{0, 0}, CoreCoord{0, 0});
     const CoreRange right_core(CoreCoord{1, 0}, CoreCoord{1, 0});
@@ -168,7 +168,7 @@ TEST_F(OfflineKernelCompileMockFixture, CBCompileConfigsFromProgramDeduplicatesO
     EXPECT_EQ(cb_compile_configs[0].cb_index, 0);
 }
 
-TEST_F(OfflineKernelCompileMockFixture, CompileKernelOfflineRejectsInvalidExplicitCbMetadata) {
+TEST_F(OfflineKernelCompileMockFixture, CPU_CompileKernelOfflineRejectsInvalidExplicitCbMetadata) {
     using Params = experimental::OfflineKernelCompileParams;
     Params params{
         .mode = Params::AllSupportedProducts{},
@@ -183,7 +183,7 @@ TEST_F(OfflineKernelCompileMockFixture, CompileKernelOfflineRejectsInvalidExplic
     EXPECT_THROW(experimental::CompileKernelOffline(kReaderKernelPath, kReaderDmConfig, params), std::invalid_argument);
 }
 
-TEST_F(OfflineKernelCompileMockFixture, CompileKernelOfflineRejectsEmptyOutputDir) {
+TEST_F(OfflineKernelCompileMockFixture, CPU_CompileKernelOfflineRejectsEmptyOutputDir) {
     using Params = experimental::OfflineKernelCompileParams;
     Params params{
         .mode = Params::AllSupportedProducts{},
@@ -223,7 +223,7 @@ bool contains_nonempty_elf(const fs::path& dir) {
     return false;
 }
 
-TEST_F(OfflineKernelCompileMockFixture, CompileKernelOfflineEmitsExpectedSubtreeForReaderKernel) {
+TEST_F(OfflineKernelCompileMockFixture, CPU_CompileKernelOfflineEmitsExpectedSubtreeForReaderKernel) {
     if (offline_compile_unsupported_under_simulator()) {
         GTEST_SKIP() << "CompileKernelOffline has no precompiled firmware for the simulator build_key "
                         "(multi-erisc disabled); skipping under TT_METAL_SIMULATOR.";

--- a/tests/tt_metal/tt_metal/api/test_shape.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shape.cpp
@@ -13,7 +13,7 @@ namespace tt::tt_metal {
 // must produce different hashes. ShapeBase::init() pads value_ to min-4D with
 // leading 1s, so [128, 128] and [1, 128, 128] both store {1, 1, 128, 128}.
 // The rank must be included in the hash to distinguish them.
-TEST(TensorShapeTests, DifferentRankShapesProduceDifferentHashes) {
+TEST(TensorShapeTests, CPU_DifferentRankShapesProduceDifferentHashes) {
     tt::tt_metal::Shape shape_2d({128, 128});
     tt::tt_metal::Shape shape_3d({1, 128, 128});
 
@@ -29,7 +29,7 @@ TEST(TensorShapeTests, DifferentRankShapesProduceDifferentHashes) {
     EXPECT_NE(hash_2d, hash_3d);
 }
 
-TEST(TensorShapeTests, SameRankShapesWithDifferentDimsProduceDifferentHashes) {
+TEST(TensorShapeTests, CPU_SameRankShapesWithDifferentDimsProduceDifferentHashes) {
     tt::tt_metal::Shape shape_a({32, 64});
     tt::tt_metal::Shape shape_b({64, 32});
 
@@ -38,7 +38,7 @@ TEST(TensorShapeTests, SameRankShapesWithDifferentDimsProduceDifferentHashes) {
     EXPECT_NE(hash_a, hash_b);
 }
 
-TEST(TensorShapeTests, IdenticalShapesProduceSameHash) {
+TEST(TensorShapeTests, CPU_IdenticalShapesProduceSameHash) {
     tt::tt_metal::Shape shape_a({1, 128, 128});
     tt::tt_metal::Shape shape_b({1, 128, 128});
 

--- a/tests/tt_metal/tt_metal/api/test_shape_base.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shape_base.cpp
@@ -11,7 +11,7 @@
 
 namespace tt::tt_metal {
 
-TEST(TensorShapeBaseTests, General4D) {
+TEST(TensorShapeBaseTests, CPU_General4D) {
     tt::tt_metal::ShapeBase vec({20, 30, 40, 50});
     EXPECT_EQ(vec.view().size(), vec.view().size());
     EXPECT_EQ(vec.view().size(), 4);
@@ -27,7 +27,7 @@ TEST(TensorShapeBaseTests, General4D) {
     EXPECT_THROW(vec[-5], std::exception);
 }
 
-TEST(TensorVectorBaseTests, General5D) {
+TEST(TensorVectorBaseTests, CPU_General5D) {
     tt::tt_metal::ShapeBase vec({20, 30, 40, 50, 60});
     EXPECT_EQ(vec.view().size(), vec.view().size());
     EXPECT_EQ(vec.view().size(), 5);
@@ -41,7 +41,7 @@ TEST(TensorVectorBaseTests, General5D) {
     EXPECT_THROW(vec[-6], std::exception);
 }
 
-TEST(TensorShapeBaseTests, Empty) {
+TEST(TensorShapeBaseTests, CPU_Empty) {
     tt::tt_metal::ShapeBase vec({});
     EXPECT_EQ(vec.view().size(), vec.view().size());
     EXPECT_EQ(vec.view().size(), 0);
@@ -57,7 +57,7 @@ TEST(TensorShapeBaseTests, Empty) {
     EXPECT_THROW(vec[-5], std::exception);
 }
 
-TEST(TensorVectorBaseTests, SingleElement) {
+TEST(TensorVectorBaseTests, CPU_SingleElement) {
     tt::tt_metal::ShapeBase vec({20});
     EXPECT_EQ(vec.view().size(), vec.view().size());
     EXPECT_EQ(vec.view().size(), 1);
@@ -70,7 +70,7 @@ TEST(TensorVectorBaseTests, SingleElement) {
     EXPECT_THROW(vec[-5], std::exception);
 }
 
-TEST(TensorShapeBaseTests, TwoElements) {
+TEST(TensorShapeBaseTests, CPU_TwoElements) {
     tt::tt_metal::ShapeBase vec({20, 30});
     EXPECT_EQ(vec.view().size(), vec.view().size());
     EXPECT_EQ(vec.view().size(), 2);

--- a/tests/tt_metal/tt_metal/api/test_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tilize_untilize.cpp
@@ -346,7 +346,7 @@ using TilizeUntilizeParams = std::tuple<
 
 class TilizeUntilizeTestsFixture : public ::testing::TestWithParam<TilizeUntilizeParams> {};
 
-TEST_P(TilizeUntilizeTestsFixture, ConvertLayout) {
+TEST_P(TilizeUntilizeTestsFixture, CPU_ConvertLayout) {
     auto params = GetParam();
     int n_batches = std::get<0>(params);
     PhysicalSize shape = std::get<1>(params);
@@ -400,7 +400,7 @@ TEST_P(TilizeUntilizeTestsFixture, ConvertLayout) {
     run_for_type(uint32_t{});
 }
 
-TEST_P(TilizeUntilizeTestsFixture, TilizeUntilize) {
+TEST_P(TilizeUntilizeTestsFixture, CPU_TilizeUntilize) {
     auto params = GetParam();
     int n_batches = std::get<0>(params);
     PhysicalSize shape = std::get<1>(params);
@@ -472,7 +472,7 @@ INSTANTIATE_TEST_SUITE_P(
 using ThrowableTilizeUntilizeParams = std::tuple<PhysicalSize, TensorLayoutType, TensorLayoutType, size_t>;
 
 class ThrowableTilizeUntilizeFixture : public ::testing::TestWithParam<ThrowableTilizeUntilizeParams> {};
-TEST_P(ThrowableTilizeUntilizeFixture, TilizeUntilize) {
+TEST_P(ThrowableTilizeUntilizeFixture, CPU_TilizeUntilize) {
     auto params = GetParam();
     PhysicalSize shape = std::get<0>(params);
     auto from_layout = std::get<1>(params);
@@ -523,7 +523,7 @@ using NonSquareTilesParams =
 
 class NonSquareTilesTestFixture : public ::testing::TestWithParam<NonSquareTilesParams> {};
 
-TEST_P(NonSquareTilesTestFixture, ConvertLayout) {
+TEST_P(NonSquareTilesTestFixture, CPU_ConvertLayout) {
     auto params = GetParam();
     PhysicalSize shape = std::get<0>(params);
     auto from_layout = std::get<1>(params);

--- a/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
@@ -27,7 +27,7 @@ std::vector<std::pair<std::uint64_t, std::uint32_t>> span_order(const memory& m)
 // DISCRETE loading must emit spans in ascending address order even when the address sort is a
 // non-identity permutation. An ncrisc-style binary places its data segment at a LOWER address than
 // text, which produces exactly such a permutation, so it exercises that ordering.
-TEST(MemorySegmentOrdering, DiscreteEmitsSpansInAscendingAddressOrder) {
+TEST(MemorySegmentOrdering, CPU_DiscreteEmitsSpansInAscendingAddressOrder) {
     // segments[0] is text (the loader treats the first segment as text), placed high in memory;
     // the data segment is placed lower -- the ncrisc layout that triggers a non-identity sort.
     const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // addr 0x2000, 2 words
@@ -55,7 +55,7 @@ TEST(MemorySegmentOrdering, DiscreteEmitsSpansInAscendingAddressOrder) {
 
 // The identity-permutation paths (non-DISCRETE) coalesce contiguous segments into a single span.
 // This guards that non-DISCRETE behaviour: contiguous segments must still collapse to one span.
-TEST(MemorySegmentOrdering, ContiguousCoalescesIntoSingleSpan) {
+TEST(MemorySegmentOrdering, CPU_ContiguousCoalescesIntoSingleSpan) {
     const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // lma 0x1000, 2 words
     const std::vector<word_t> data_contents = {0x3333'3333};               // lma 0x1008, 1 word
 
@@ -77,7 +77,7 @@ TEST(MemorySegmentOrdering, ContiguousCoalescesIntoSingleSpan) {
 // order has none (a .bss-only PT_LOAD has p_filesz == 0, so zero content words) link_spans_ is
 // still empty when the accumulate step runs, and link_spans_.back() writes 8 bytes before the
 // start of the buffer. Such a segment carries no data, so it must simply contribute no span.
-TEST(MemorySegmentOrdering, DiscreteHandlesEmptyFirstSegmentInAddressOrder) {
+TEST(MemorySegmentOrdering, CPU_DiscreteHandlesEmptyFirstSegmentInAddressOrder) {
     // segments[0] is text (the loader requires the first segment to be text), placed high in
     // memory; a .bss-only segment sits lower, so the address sort puts the empty one first.
     const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // addr 0x2000, 2 words
@@ -100,7 +100,7 @@ TEST(MemorySegmentOrdering, DiscreteHandlesEmptyFirstSegmentInAddressOrder) {
 
 // A contentless segment that does not sort first must also be dropped -- this already worked, and
 // guards that the underflow fix did not change the behaviour of the previously-reachable case.
-TEST(MemorySegmentOrdering, DiscreteDropsEmptyTrailingSegment) {
+TEST(MemorySegmentOrdering, CPU_DiscreteDropsEmptyTrailingSegment) {
     const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // addr 0x1000, 2 words
 
     std::vector<ElfFile::Segment> segments;

--- a/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
@@ -21,7 +21,7 @@ using namespace tt::tt_metal;
 
 namespace worker_config_buffer_tests {
 
-TEST(WorkerConfigBuffer, MarkCompletelyFull) {
+TEST(WorkerConfigBuffer, CPU_MarkCompletelyFull) {
     WorkerConfigBufferMgr mgr;
     mgr.init_add_buffer(1024, 1024);
     mgr.init_add_buffer(2, 1024);
@@ -47,7 +47,7 @@ TEST(WorkerConfigBuffer, MarkCompletelyFull) {
 }
 
 // Test that small-sized, tightly-packed ringbuffers work.
-TEST(WorkerConfigBuffer, SmallSize) {
+TEST(WorkerConfigBuffer, CPU_SmallSize) {
     WorkerConfigBufferMgr mgr;
     mgr.init_add_buffer(0, 5);
     for (size_t i = 0; i < 5; i++) {
@@ -66,7 +66,7 @@ TEST(WorkerConfigBuffer, SmallSize) {
 }
 
 // Test that allocating buffers of size 0 doesn't eventually cause some to be ignored.
-TEST(WorkerConfigBuffer, SizeOne) {
+TEST(WorkerConfigBuffer, CPU_SizeOne) {
     WorkerConfigBufferMgr mgr;
     mgr.init_add_buffer(0, 100);
     mgr.init_add_buffer(0, 100);
@@ -112,7 +112,7 @@ TEST(WorkerConfigBuffer, SizeOne) {
 
 // Test that we don't throw away the old sync counts when the number of outstanding buffers is >
 // kernel_config_entry_count.
-TEST(WorkerConfigBuffer, LoopAround) {
+TEST(WorkerConfigBuffer, CPU_LoopAround) {
     WorkerConfigBufferMgr mgr;
     mgr.init_add_buffer(0, 10);
 
@@ -129,7 +129,7 @@ TEST(WorkerConfigBuffer, LoopAround) {
     }
 }
 
-TEST(WorkerConfigBuffer, Randomized) {
+TEST(WorkerConfigBuffer, CPU_Randomized) {
     const uint32_t seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(time(nullptr)));
     log_info(tt::LogTest, "Using seed: {}", seed);
     srand(seed);
@@ -185,7 +185,7 @@ TEST(WorkerConfigBuffer, Randomized) {
 }
 
 // Test reserving when one buffer type is completely empty.
-TEST(WorkerConfigBuffer, VeryBasic) {
+TEST(WorkerConfigBuffer, CPU_VeryBasic) {
     WorkerConfigBufferMgr mgr;
     mgr.init_add_buffer(0, 1024);
     mgr.init_add_buffer(0, 10);
@@ -207,7 +207,7 @@ TEST(WorkerConfigBuffer, VeryBasic) {
 // free_index_, so the `while (free_index != alloc_index_)` loop was immediately false and no queued
 // entries were ever visited. Exercise the walk (now factored into get_queued_entry_indices) and
 // confirm it returns the queued (freeable) entries. Prior to the fix this vector was always empty.
-TEST(WorkerConfigBuffer, PrintStatusWalksQueuedEntries) {
+TEST(WorkerConfigBuffer, CPU_PrintStatusWalksQueuedEntries) {
     WorkerConfigBufferMgr mgr;
     mgr.init_add_buffer(0, 1024);
 

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -71,7 +71,25 @@ bool load_all_blank_kernels(const std::shared_ptr<distributed::MeshDevice>& mesh
 }
 }  // namespace unit_tests_common::basic::test_device_init
 
-INSTANTIATE_TEST_SUITE_P(DeviceInit, DeviceParamFixture, ::testing::Values(1, tt::tt_metal::GetNumAvailableDevices()));
+namespace {
+// gtest evaluates INSTANTIATE_TEST_SUITE_P generators at test-registration time
+// (inside InitGoogleTest), BEFORE --gtest_filter is applied. Calling
+// GetNumAvailableDevices() directly here forces full MetalContext/Cluster creation
+// at process startup, which throws on hosts without silicon (arch detection yields
+// ARCH::Invalid) and would abort the whole binary — including the host-only CPU_*
+// tests that run on the device-less github_hosted_cpu CI runner. Fall back to a
+// single-device parameterization on such hosts; the DeviceParamFixture tests
+// themselves are excluded there by the CPU_-filter split anyway.
+unsigned int num_available_devices_or_one() {
+    try {
+        return tt::tt_metal::GetNumAvailableDevices();
+    } catch (...) {
+        return 1;
+    }
+}
+}  // namespace
+
+INSTANTIATE_TEST_SUITE_P(DeviceInit, DeviceParamFixture, ::testing::Values(1, num_available_devices_or_one()));
 
 TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
     unsigned int num_devices = GetParam();
@@ -134,7 +152,7 @@ private:
     std::optional<std::string> prev_;
 };
 
-TEST_F(TdpLimitEnvFixture, ParsesEnvVar) {
+TEST_F(TdpLimitEnvFixture, CPU_ParsesEnvVar) {
     unsetenv(kTdpLimitEnvVar);
     EXPECT_FALSE(llrt::RunTimeOptions().get_tdp_limit_watts().has_value());
 
@@ -156,7 +174,7 @@ TEST_F(TdpLimitEnvFixture, ParsesEnvVar) {
 
 // A typo must not quietly leave the run at full power, so parsing is strict. Neither of these is
 // usable as a watt count: one is not a number, the other does not fit the uint32_t that holds it.
-TEST_F(TdpLimitEnvFixture, MalformedEnvVarThrows) {
+TEST_F(TdpLimitEnvFixture, CPU_MalformedEnvVarThrows) {
     setenv(kTdpLimitEnvVar, "abc", /*overwrite=*/1);
     EXPECT_ANY_THROW(llrt::RunTimeOptions());
 

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -20,6 +20,7 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
+#include "llrt/get_platform_architecture.hpp"
 #include "llrt/rtoptions.hpp"
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
@@ -75,17 +76,23 @@ namespace {
 // gtest evaluates INSTANTIATE_TEST_SUITE_P generators at test-registration time
 // (inside InitGoogleTest), BEFORE --gtest_filter is applied. Calling
 // GetNumAvailableDevices() directly here forces full MetalContext/Cluster creation
-// at process startup, which throws on hosts without silicon (arch detection yields
-// ARCH::Invalid) and would abort the whole binary — including the host-only CPU_*
-// tests that run on the device-less github_hosted_cpu CI runner. Fall back to a
-// single-device parameterization on such hosts; the DeviceParamFixture tests
-// themselves are excluded there by the CPU_-filter split anyway.
+// at process startup, which throws on hosts without silicon and would abort the
+// whole binary — including the host-only CPU_* tests that run on the device-less
+// github_hosted_cpu CI runner.
+//
+// Probe for silicon first via PCI enumeration only (get_physical_architecture()
+// does not create a MetalContext and returns ARCH::Invalid when no devices are
+// present). Fall back to a single-device parameterization only in that genuinely
+// hardware-less case; on a device runner any discovery failure from
+// GetNumAvailableDevices() (malformed cluster descriptor, UMD errors, ...) must
+// propagate and fail loudly rather than silently shrink the parameterization.
+// The DeviceParamFixture tests themselves are device tests and are excluded on
+// the CPU-only leg by the CPU_-filter split anyway.
 unsigned int num_available_devices_or_one() {
-    try {
-        return tt::tt_metal::GetNumAvailableDevices();
-    } catch (...) {
+    if (get_physical_architecture() == tt::ARCH::Invalid) {
         return 1;
     }
+    return tt::tt_metal::GetNumAvailableDevices();
 }
 }  // namespace
 

--- a/tests/tt_metal/tt_metal/device/test_mock_allocator.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_allocator.cpp
@@ -47,7 +47,7 @@ protected:
     }
 };
 
-TEST_F(MockAllocatorTest, MockDeviceCreationAndQueries) {
+TEST_F(MockAllocatorTest, CPU_MockDeviceCreationAndQueries) {
     EXPECT_EQ(mock_env_->get_arch(), tt::ARCH::WORMHOLE_B0);
     EXPECT_GT(mock_env_->get_l1_size(), 0u);
     EXPECT_GT(mock_env_->get_dram_alignment(), 0u);
@@ -55,7 +55,7 @@ TEST_F(MockAllocatorTest, MockDeviceCreationAndQueries) {
     EXPECT_EQ(mock_device_->num_devices(), 1u);
 }
 
-TEST_F(MockAllocatorTest, BufferAllocationOnMockDevice) {
+TEST_F(MockAllocatorTest, CPU_BufferAllocationOnMockDevice) {
     constexpr size_t page_size = 4096;
     constexpr size_t buffer_size = page_size * 12;
     distributed::DeviceLocalBufferConfig local_config{.page_size = buffer_size, .buffer_type = BufferType::L1};
@@ -67,12 +67,12 @@ TEST_F(MockAllocatorTest, BufferAllocationOnMockDevice) {
     EXPECT_FALSE(buffer->is_allocated());
 }
 
-TEST_F(MockAllocatorTest, GetMockAllocatorReturnsNonNull) {
+TEST_F(MockAllocatorTest, CPU_GetMockAllocatorReturnsNonNull) {
     auto* mock_alloc = experimental::get_mock_allocator(*mock_device_);
     ASSERT_NE(mock_alloc, nullptr);
 }
 
-TEST_F(MockAllocatorTest, ExtractAndOverrideRoundtrip) {
+TEST_F(MockAllocatorTest, CPU_ExtractAndOverrideRoundtrip) {
     // Fresh mock device — extracted state should be empty.
     auto empty_state = experimental::extract_mock_allocator_state(*mock_device_);
     EXPECT_TRUE(empty_state.is_empty(BufferType::L1));
@@ -106,7 +106,7 @@ TEST_F(MockAllocatorTest, ExtractAndOverrideRoundtrip) {
     EXPECT_EQ(stats_empty.total_allocated_bytes, 0u);
 }
 
-TEST_F(MockAllocatorTest, CheckpointRestoreViaMeshBuffer) {
+TEST_F(MockAllocatorTest, CPU_CheckpointRestoreViaMeshBuffer) {
     constexpr size_t small_size = 4096 * 4;
     constexpr size_t large_size = 4096 * 16;
 

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -25,7 +25,7 @@ protected:
     void TearDown() override { experimental::disable_mock_mode(); }
 };
 
-TEST_F(MockDeviceAPIFixture, ConfigureMockModeRegistersConfig) {
+TEST_F(MockDeviceAPIFixture, CPU_ConfigureMockModeRegistersConfig) {
     EXPECT_FALSE(experimental::is_mock_mode_registered());
     experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
     EXPECT_TRUE(experimental::is_mock_mode_registered());
@@ -34,7 +34,7 @@ TEST_F(MockDeviceAPIFixture, ConfigureMockModeRegistersConfig) {
     EXPECT_EQ(*desc, "blackhole_P150.yaml");
 }
 
-TEST_F(MockDeviceAPIFixture, ConfigureMockModeWormholeMultiChip) {
+TEST_F(MockDeviceAPIFixture, CPU_ConfigureMockModeWormholeMultiChip) {
     experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 8);
     EXPECT_TRUE(experimental::is_mock_mode_registered());
     auto desc = experimental::get_mock_cluster_desc();
@@ -42,7 +42,7 @@ TEST_F(MockDeviceAPIFixture, ConfigureMockModeWormholeMultiChip) {
     EXPECT_EQ(*desc, "t3k_cluster_desc.yaml");
 }
 
-TEST_F(MockDeviceAPIFixture, DisableMockModeClearsConfig) {
+TEST_F(MockDeviceAPIFixture, CPU_DisableMockModeClearsConfig) {
     experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
     EXPECT_TRUE(experimental::is_mock_mode_registered());
     experimental::disable_mock_mode();
@@ -50,7 +50,7 @@ TEST_F(MockDeviceAPIFixture, DisableMockModeClearsConfig) {
     EXPECT_FALSE(experimental::get_mock_cluster_desc().has_value());
 }
 
-TEST_F(MockDeviceAPIFixture, WormholeConfigurationsAreValid) {
+TEST_F(MockDeviceAPIFixture, CPU_WormholeConfigurationsAreValid) {
     experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
     EXPECT_EQ(*experimental::get_mock_cluster_desc(), "wormhole_N150.yaml");
     experimental::disable_mock_mode();
@@ -70,7 +70,7 @@ TEST_F(MockDeviceAPIFixture, WormholeConfigurationsAreValid) {
     // Note: 32-chip TG configuration removed as tg_cluster_desc.yaml doesn't exist in UMD
 }
 
-TEST_F(MockDeviceAPIFixture, BlackholeConfigurationsAreValid) {
+TEST_F(MockDeviceAPIFixture, CPU_BlackholeConfigurationsAreValid) {
     experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
     EXPECT_EQ(*experimental::get_mock_cluster_desc(), "blackhole_P150.yaml");
     experimental::disable_mock_mode();
@@ -79,12 +79,12 @@ TEST_F(MockDeviceAPIFixture, BlackholeConfigurationsAreValid) {
     EXPECT_EQ(*experimental::get_mock_cluster_desc(), "blackhole_P300_both_mmio.yaml");
 }
 
-TEST_F(MockDeviceAPIFixture, QuasarConfigurationsAreValid) {
+TEST_F(MockDeviceAPIFixture, CPU_QuasarConfigurationsAreValid) {
     experimental::configure_mock_mode(tt::ARCH::QUASAR, 1);
     EXPECT_EQ(*experimental::get_mock_cluster_desc(), "quasar_Q1.yaml");
 }
 
-TEST_F(MockDeviceAPIFixture, UnsupportedConfigurationThrows) {
+TEST_F(MockDeviceAPIFixture, CPU_UnsupportedConfigurationThrows) {
     bool threw_during_configure = false;
     try {
         experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 99);
@@ -97,7 +97,7 @@ TEST_F(MockDeviceAPIFixture, UnsupportedConfigurationThrows) {
     }
 }
 
-TEST_F(MockDeviceAPIFixture, ConfigureMockModeFromHwDetectsArchitecture) {
+TEST_F(MockDeviceAPIFixture, CPU_ConfigureMockModeFromHwDetectsArchitecture) {
     tt::ARCH detected_arch = get_physical_architecture();
     if (detected_arch == tt::ARCH::Invalid) {
         GTEST_SKIP() << "No TT hardware detected - skipping configure_mock_mode_from_hw test";
@@ -109,7 +109,7 @@ TEST_F(MockDeviceAPIFixture, ConfigureMockModeFromHwDetectsArchitecture) {
     ASSERT_TRUE(desc.has_value());
 }
 
-TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardware) {
+TEST_F(MockDeviceAPIFixture, CPU_SwitchFromMockToRealHardware) {
     // Test API state transitions: configure, disable, reconfigure
     experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
     EXPECT_TRUE(experimental::is_mock_mode_registered());
@@ -165,7 +165,7 @@ protected:
 };
 
 // Verify that the device profiler is not enabled on mock device.
-TEST_F(MockDeviceProfilerFixture, DeviceProfilerIsNotStartedOnMockDevice) {
+TEST_F(MockDeviceProfilerFixture, CPU_DeviceProfilerIsNotStartedOnMockDevice) {
     experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
 
     ASSERT_TRUE(MetalContext::instance().rtoptions().get_profiler_enabled())

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -97,7 +97,9 @@ TEST_F(MockDeviceAPIFixture, CPU_UnsupportedConfigurationThrows) {
     }
 }
 
-TEST_F(MockDeviceAPIFixture, CPU_ConfigureMockModeFromHwDetectsArchitecture) {
+// NOT CPU_-prefixed: this test probes real silicon (get_physical_architecture())
+// and skips when none is present, so it only provides coverage on device runners.
+TEST_F(MockDeviceAPIFixture, ConfigureMockModeFromHwDetectsArchitecture) {
     tt::ARCH detected_arch = get_physical_architecture();
     if (detected_arch == tt::ARCH::Invalid) {
         GTEST_SKIP() << "No TT hardware detected - skipping configure_mock_mode_from_hw test";

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_BufferCorePageMapping_Iterator.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_BufferCorePageMapping_Iterator.cpp
@@ -121,7 +121,7 @@ struct Test_BufferCorePageMapping_Iterator_params {
 class Test_BufferCorePageMapping_Iterator
     : public ::testing::TestWithParam<Test_BufferCorePageMapping_Iterator_params> {};
 
-TEST_P(Test_BufferCorePageMapping_Iterator, Runs) {
+TEST_P(Test_BufferCorePageMapping_Iterator, CPU_Runs) {
     const auto& p = GetParam();
     test_BufferCorePageMapping_Iterator(p.page_mapping, p.pages_per_txn);
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -17,7 +17,7 @@
 
 namespace tt::tt_metal {
 
-TEST(DeviceCommandTest, AddDispatchWait) {
+TEST(DeviceCommandTest, CPU_AddDispatchWait) {
     DeviceCommandCalculator calculator;
     calculator.add_dispatch_wait();
 
@@ -26,7 +26,7 @@ TEST(DeviceCommandTest, AddDispatchWait) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchWaitWithPrefetchStall) {
+TEST(DeviceCommandTest, CPU_AddDispatchWaitWithPrefetchStall) {
     DeviceCommandCalculator calculator;
     calculator.add_dispatch_wait_with_prefetch_stall();
 
@@ -35,7 +35,7 @@ TEST(DeviceCommandTest, AddDispatchWaitWithPrefetchStall) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddPrefetchRelayLinear) {
+TEST(DeviceCommandTest, CPU_AddPrefetchRelayLinear) {
     DeviceCommandCalculator calculator;
     calculator.add_prefetch_relay_linear();
 
@@ -44,7 +44,7 @@ TEST(DeviceCommandTest, AddPrefetchRelayLinear) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddData) {
+TEST(DeviceCommandTest, CPU_AddData) {
     DeviceCommandCalculator calculator;
     calculator.add_data(32);
 
@@ -54,7 +54,7 @@ TEST(DeviceCommandTest, AddData) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchWriteLinear) {
+TEST(DeviceCommandTest, CPU_AddDispatchWriteLinear) {
     {
         DeviceCommandCalculator calculator;
         calculator.add_dispatch_write_linear<false, false>(5);
@@ -91,7 +91,7 @@ TEST(DeviceCommandTest, AddDispatchWriteLinear) {
     }
 }
 
-TEST(DeviceCommandTest, AddDispatchGoSignalMcast) {
+TEST(DeviceCommandTest, CPU_AddDispatchGoSignalMcast) {
     DeviceCommandCalculator calculator;
     calculator.add_dispatch_go_signal_mcast();
 
@@ -100,7 +100,7 @@ TEST(DeviceCommandTest, AddDispatchGoSignalMcast) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddNotifyDispatchSGoSignalCmd) {
+TEST(DeviceCommandTest, CPU_AddNotifyDispatchSGoSignalCmd) {
     DeviceCommandCalculator calculator;
     calculator.add_notify_dispatch_s_go_signal_cmd();
 
@@ -109,7 +109,7 @@ TEST(DeviceCommandTest, AddNotifyDispatchSGoSignalCmd) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchSetNumWorkerSems) {
+TEST(DeviceCommandTest, CPU_AddDispatchSetNumWorkerSems) {
     DeviceCommandCalculator calculator;
     calculator.add_dispatch_set_num_worker_sems();
 
@@ -118,7 +118,7 @@ TEST(DeviceCommandTest, AddDispatchSetNumWorkerSems) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchSetSubDeviceWorkerCounts) {
+TEST(DeviceCommandTest, CPU_AddDispatchSetSubDeviceWorkerCounts) {
     constexpr uint32_t num_sub_devices = 3;
     std::array<uint32_t, num_sub_devices> workers_per_sub_device = {4, 7, 2};
 
@@ -132,7 +132,7 @@ TEST(DeviceCommandTest, AddDispatchSetSubDeviceWorkerCounts) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchSetGoSignalNocData) {
+TEST(DeviceCommandTest, CPU_AddDispatchSetGoSignalNocData) {
     DeviceCommandCalculator calculator;
     calculator.add_dispatch_set_go_signal_noc_data(5);
 
@@ -142,7 +142,7 @@ TEST(DeviceCommandTest, AddDispatchSetGoSignalNocData) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchSetWriteOffsets) {
+TEST(DeviceCommandTest, CPU_AddDispatchSetWriteOffsets) {
     DeviceCommandCalculator calculator;
     calculator.add_dispatch_set_write_offsets(CQ_DISPATCH_MAX_WRITE_OFFSETS);
 
@@ -152,7 +152,7 @@ TEST(DeviceCommandTest, AddDispatchSetWriteOffsets) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchTerminate) {
+TEST(DeviceCommandTest, CPU_AddDispatchTerminate) {
     DeviceCommandCalculator calculator;
     calculator.add_dispatch_terminate();
 
@@ -161,7 +161,7 @@ TEST(DeviceCommandTest, AddDispatchTerminate) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddDispatchWritePaged) {
+TEST(DeviceCommandTest, CPU_AddDispatchWritePaged) {
     {
         DeviceCommandCalculator calculator;
         calculator.add_dispatch_write_paged<false>(1, 5);
@@ -183,7 +183,7 @@ TEST(DeviceCommandTest, AddDispatchWritePaged) {
     }
 }
 
-TEST(DeviceCommandTest, AddPrefetchRelayPaged) {
+TEST(DeviceCommandTest, CPU_AddPrefetchRelayPaged) {
     DeviceCommandCalculator calculator;
     calculator.add_prefetch_relay_paged();
 
@@ -192,7 +192,7 @@ TEST(DeviceCommandTest, AddPrefetchRelayPaged) {
     EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
 }
 
-TEST(DeviceCommandTest, AddPrefetchRelayPagedPacked) {
+TEST(DeviceCommandTest, CPU_AddPrefetchRelayPagedPacked) {
     DeviceCommandCalculator calculator;
     calculator.add_prefetch_relay_paged_packed(1);
 
@@ -208,7 +208,7 @@ class WritePackedCommandTest : public ::testing::Test {};
 using TestTypes = testing::Types<CQDispatchWritePackedMulticastSubCmd, CQDispatchWritePackedUnicastSubCmd>;
 TYPED_TEST_SUITE(WritePackedCommandTest, TestTypes);
 
-TYPED_TEST(WritePackedCommandTest, AddDispatchWritePacked) {
+TYPED_TEST(WritePackedCommandTest, CPU_AddDispatchWritePacked) {
     {
         DeviceCommandCalculator calculator;
         calculator.add_dispatch_write_packed<TypeParam>(2, 5, 100, /*no_stride*/ false);
@@ -233,7 +233,7 @@ TYPED_TEST(WritePackedCommandTest, AddDispatchWritePacked) {
     }
 }
 
-TEST(DeviceCommandTest, AddDispatchWritePackedLarge) {
+TEST(DeviceCommandTest, CPU_AddDispatchWritePackedLarge) {
     {
         DeviceCommandCalculator calculator;
         calculator.add_dispatch_write_packed_large(1);
@@ -258,7 +258,7 @@ TEST(DeviceCommandTest, AddDispatchWritePackedLarge) {
     }
 }
 
-TYPED_TEST(WritePackedCommandTest, RandomAddDispatchWritePacked) {
+TYPED_TEST(WritePackedCommandTest, CPU_RandomAddDispatchWritePacked) {
     srand(0);
     for (size_t i = 0; i < 100; i++) {
         DeviceCommandCalculator calculator;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -20,16 +20,16 @@ namespace tt::tt_metal {
 
 static constexpr uint32_t default_l1_alignment = 16;
 
-TEST(DispatchSettingsTest, TestDispatchSettingsDefaultUnsupportedCoreType) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsDefaultUnsupportedCoreType) {
     const auto unsupported_core = CoreType::ARC;
     EXPECT_THROW(DispatchSettings(1, unsupported_core, false, false, default_l1_alignment, 4), std::runtime_error);
 }
 
-TEST(DispatchSettingsTest, TestDispatchSettingsInvalidPrefetchQEntrySize) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsInvalidPrefetchQEntrySize) {
     EXPECT_THROW(DispatchSettings(1, CoreType::WORKER, false, false, default_l1_alignment, 3), std::runtime_error);
 }
 
-TEST(DispatchSettingsTest, TestDispatchSettingsEq) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsEq) {
     const uint32_t hw_cqs = 2;
     DispatchSettings settings(hw_cqs, CoreType::WORKER, false, false, default_l1_alignment, 4);
     DispatchSettings settings_2 = settings;  // Copy
@@ -38,7 +38,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsEq) {
     EXPECT_NE(settings, settings_2);
 }
 
-TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetPrefetchDBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0xcafe;
     const uint32_t expected_page_count =
@@ -49,7 +49,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
     EXPECT_EQ(settings.prefetch_d_pages_, expected_page_count);
 }
 
-TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetPrefetchQBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * 4;
@@ -60,7 +60,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
     EXPECT_EQ(settings.prefetch_q_entry_size_bytes_, 4);
 }
 
-TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBufferWith2ByteEntries) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetPrefetchQBufferWith2ByteEntries) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * 2;
@@ -71,7 +71,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBufferWith2ByteEntrie
     EXPECT_EQ(settings.prefetch_q_entry_size_bytes_, 2);
 }
 
-TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchBuffer) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetDispatchBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
@@ -81,7 +81,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchBuffer) {
     EXPECT_EQ(settings.dispatch_pages_, expected_page_count);
 }
 
-TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchSBuffer) {
+TEST(DispatchSettingsTest, CPU_TestDispatchSettingsSetDispatchSBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -124,7 +124,7 @@ INSTANTIATE_TEST_SUITE_P(
             .pgm_ids = std::make_pair(0, 4000),
             .pgm_sizes = std::make_pair(100, 200)}));
 
-TEST_P(RingbufferCacheRandomizedTestsFixture, RandomizedQueries) {
+TEST_P(RingbufferCacheRandomizedTestsFixture, CPU_RandomizedQueries) {
     CacheTestParams params = GetParam();
     setup(params);
     auto pgm_ids = params.pgm_ids;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_simple_trace_allocator.cpp
@@ -197,35 +197,35 @@ protected:
 
 // --- intersects ---
 
-TEST_F(SimpleTraceAllocatorFixture, IntersectsNonOverlapping) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_IntersectsNonOverlapping) {
     EXPECT_FALSE(intersects(0, 10, 10, 10));
     EXPECT_FALSE(intersects(10, 10, 0, 10));
     EXPECT_FALSE(intersects(0, 5, 100, 5));
 }
 
-TEST_F(SimpleTraceAllocatorFixture, IntersectsOverlapping) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_IntersectsOverlapping) {
     EXPECT_TRUE(intersects(0, 10, 5, 10));
     EXPECT_TRUE(intersects(5, 10, 0, 10));
 }
 
-TEST_F(SimpleTraceAllocatorFixture, IntersectsContainment) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_IntersectsContainment) {
     EXPECT_TRUE(intersects(0, 100, 10, 5));
     EXPECT_TRUE(intersects(10, 5, 0, 100));
 }
 
-TEST_F(SimpleTraceAllocatorFixture, IntersectsSameRegion) { EXPECT_TRUE(intersects(5, 10, 5, 10)); }
+TEST_F(SimpleTraceAllocatorFixture, CPU_IntersectsSameRegion) { EXPECT_TRUE(intersects(5, 10, 5, 10)); }
 
 // --- merge_syncs ---
 
-TEST_F(SimpleTraceAllocatorFixture, MergeSyncsBothNullopt) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_MergeSyncsBothNullopt) {
     EXPECT_EQ(merge_syncs(std::nullopt, std::nullopt), std::nullopt);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, MergeSyncsFirstOnly) { EXPECT_EQ(merge_syncs(5, std::nullopt), 5); }
+TEST_F(SimpleTraceAllocatorFixture, CPU_MergeSyncsFirstOnly) { EXPECT_EQ(merge_syncs(5, std::nullopt), 5); }
 
-TEST_F(SimpleTraceAllocatorFixture, MergeSyncsSecondOnly) { EXPECT_EQ(merge_syncs(std::nullopt, 7), 7); }
+TEST_F(SimpleTraceAllocatorFixture, CPU_MergeSyncsSecondOnly) { EXPECT_EQ(merge_syncs(std::nullopt, 7), 7); }
 
-TEST_F(SimpleTraceAllocatorFixture, MergeSyncsBothPicksMax) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_MergeSyncsBothPicksMax) {
     EXPECT_EQ(merge_syncs(3, 9), 9);
     EXPECT_EQ(merge_syncs(9, 3), 9);
     EXPECT_EQ(merge_syncs(4, 4), 4);
@@ -233,7 +233,7 @@ TEST_F(SimpleTraceAllocatorFixture, MergeSyncsBothPicksMax) {
 
 // --- allocate_region ---
 
-TEST_F(SimpleTraceAllocatorFixture, ZeroSizeAllocation) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_ZeroSizeAllocation) {
     extra_data_.resize(1);
     auto alloc = make_allocator(1024);
     auto [sync, addr] = alloc.allocate_region(0, 0, ExtraData::kNonBinary, 100);
@@ -241,7 +241,7 @@ TEST_F(SimpleTraceAllocatorFixture, ZeroSizeAllocation) {
     EXPECT_EQ(addr, 0u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, BasicAllocationEmptyBuffer) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_BasicAllocationEmptyBuffer) {
     extra_data_.resize(1);
     auto alloc = make_allocator(1024);
     auto [sync, addr] = alloc.allocate_region(100, 0, ExtraData::kNonBinary, 100);
@@ -250,7 +250,7 @@ TEST_F(SimpleTraceAllocatorFixture, BasicAllocationEmptyBuffer) {
     EXPECT_EQ(*addr, 0u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, SequentialAllocationsNoOverlap) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_SequentialAllocationsNoOverlap) {
     extra_data_.resize(3);
     extra_data_[0].next_use_idx[ExtraData::kNonBinary] = 2;
     extra_data_[1].next_use_idx[ExtraData::kNonBinary] = 2;
@@ -266,14 +266,14 @@ TEST_F(SimpleTraceAllocatorFixture, SequentialAllocationsNoOverlap) {
     EXPECT_EQ(*addr1, 100u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, AllocationTooLargeForBuffer) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_AllocationTooLargeForBuffer) {
     extra_data_.resize(1);
     auto alloc = make_allocator(50);
     auto [sync, addr] = alloc.allocate_region(100, 0, ExtraData::kNonBinary, 100);
     EXPECT_FALSE(addr.has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, AllocationExactFit) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_AllocationExactFit) {
     extra_data_.resize(1);
     auto alloc = make_allocator(100);
     auto [sync, addr] = alloc.allocate_region(100, 0, ExtraData::kNonBinary, 100);
@@ -281,7 +281,7 @@ TEST_F(SimpleTraceAllocatorFixture, AllocationExactFit) {
     EXPECT_EQ(*addr, 0u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, TopDownScanIncludesPreviousOverlappingRegion) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_TopDownScanIncludesPreviousOverlappingRegion) {
     extra_data_.resize(2);
     auto alloc = make_allocator(300);
     add_memory_usage(alloc, 220, 0, ExtraData::kNonBinary, 40, 20);
@@ -294,7 +294,7 @@ TEST_F(SimpleTraceAllocatorFixture, TopDownScanIncludesPreviousOverlappingRegion
     EXPECT_FALSE(sync.has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, EvictionWhenBufferFull) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_EvictionWhenBufferFull) {
     // Buffer of size 100, allocate two 60-byte regions. The second must evict the first.
     extra_data_.resize(2);
     auto alloc = make_allocator(100);
@@ -312,7 +312,7 @@ TEST_F(SimpleTraceAllocatorFixture, EvictionWhenBufferFull) {
     EXPECT_EQ(*sync1, 0u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, CurrentNodeEvictionPenalty) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_CurrentNodeEvictionPenalty) {
     // Two regions. One has next_use == current trace_idx (penalized), the other has next_use far away.
     // Use wide spacing to isolate the penalty from stall-avoidance costs.
     constexpr uint32_t spacing = 100;
@@ -332,7 +332,7 @@ TEST_F(SimpleTraceAllocatorFixture, CurrentNodeEvictionPenalty) {
     EXPECT_EQ(*addr, 100u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, NowInUseSkipsPlacement) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_NowInUseSkipsPlacement) {
     // A region with the same trace_idx as the current allocation cannot be evicted.
     extra_data_.resize(2);
 
@@ -347,7 +347,7 @@ TEST_F(SimpleTraceAllocatorFixture, NowInUseSkipsPlacement) {
     EXPECT_FALSE(addr.has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, NowInUseWithRoomAfter) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_NowInUseWithRoomAfter) {
     extra_data_.resize(2);
 
     auto alloc = make_allocator(200);
@@ -360,7 +360,7 @@ TEST_F(SimpleTraceAllocatorFixture, NowInUseWithRoomAfter) {
     EXPECT_EQ(*addr, 60u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, EvictionReturnsSyncIdx) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_EvictionReturnsSyncIdx) {
     extra_data_.resize(3);
     auto alloc = make_allocator(100);
 
@@ -375,7 +375,7 @@ TEST_F(SimpleTraceAllocatorFixture, EvictionReturnsSyncIdx) {
     EXPECT_EQ(*sync, 1u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, ResetAllocatorClearsState) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_ResetAllocatorClearsState) {
     extra_data_.resize(2);
     auto alloc = make_allocator(100);
 
@@ -394,7 +394,7 @@ TEST_F(SimpleTraceAllocatorFixture, ResetAllocatorClearsState) {
     EXPECT_FALSE(sync.has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, AddAndGetRegion) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_AddAndGetRegion) {
     extra_data_.resize(1);
     auto alloc = make_allocator(100);
 
@@ -404,7 +404,7 @@ TEST_F(SimpleTraceAllocatorFixture, AddAndGetRegion) {
     EXPECT_FALSE(alloc.get_region(ExtraData::kNonBinary, 42).has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, UpdateRegionTraceIdx) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_UpdateRegionTraceIdx) {
     extra_data_.resize(3);
     extra_data_[0].next_use_idx[ExtraData::kNonBinary] = 2;
 
@@ -421,7 +421,7 @@ TEST_F(SimpleTraceAllocatorFixture, UpdateRegionTraceIdx) {
     EXPECT_EQ(*addr, 50u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, UpdateRegionTraceIdxNonexistent) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_UpdateRegionTraceIdxNonexistent) {
     extra_data_.resize(1);
     auto alloc = make_allocator(100);
 
@@ -429,7 +429,7 @@ TEST_F(SimpleTraceAllocatorFixture, UpdateRegionTraceIdxNonexistent) {
     alloc.update_region_trace_idx(999, 0);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, MultipleDataTypes) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_MultipleDataTypes) {
     // Two allocations with different data_types at the same trace_idx are independent.
     // The second allocation can't overlap the first (same trace_idx → now_in_use), so it goes after.
     extra_data_.resize(1);
@@ -444,7 +444,7 @@ TEST_F(SimpleTraceAllocatorFixture, MultipleDataTypes) {
     EXPECT_EQ(*a1, 100u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, OldRegionsWithNoFutureUseDeleted) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_OldRegionsWithNoFutureUseDeleted) {
     // Regions with no future uses that are old enough get cleaned up from the internal map.
     // Use a large gap to ensure we exceed max_stall_history_size regardless of its compile-time value.
     constexpr uint32_t gap = 100;
@@ -465,7 +465,7 @@ TEST_F(SimpleTraceAllocatorFixture, OldRegionsWithNoFutureUseDeleted) {
     EXPECT_FALSE(alloc.get_region(ExtraData::kNonBinary, 10).has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, BeladyEvictsLowestCostRegion) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_BeladyEvictsLowestCostRegion) {
     // Fill a buffer with three regions, then request one that requires evicting.
     // Use trace indices spaced far apart to avoid the stall-avoidance cost dominating.
     constexpr uint32_t spacing = 100;
@@ -494,7 +494,7 @@ TEST_F(SimpleTraceAllocatorFixture, BeladyEvictsLowestCostRegion) {
     EXPECT_EQ(*addr, 200u);
 }
 
-TEST_F(SimpleTraceAllocatorFixture, ProgramIdsMemoryMapCleanedOnEviction) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_ProgramIdsMemoryMapCleanedOnEviction) {
     extra_data_.resize(2);
     auto alloc = make_allocator(100);
 
@@ -509,7 +509,7 @@ TEST_F(SimpleTraceAllocatorFixture, ProgramIdsMemoryMapCleanedOnEviction) {
     EXPECT_FALSE(alloc.get_region(ExtraData::kNonBinary, 42).has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, ZeroCostEarlyExit) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_ZeroCostEarlyExit) {
     // When a placement has zero cost (no overlapping regions), the search stops immediately.
     extra_data_.resize(2);
     auto alloc = make_allocator(1000);
@@ -523,7 +523,7 @@ TEST_F(SimpleTraceAllocatorFixture, ZeroCostEarlyExit) {
     EXPECT_FALSE(sync.has_value());
 }
 
-TEST_F(SimpleTraceAllocatorFixture, StallAvoidanceIncreasesCost) {
+TEST_F(SimpleTraceAllocatorFixture, CPU_StallAvoidanceIncreasesCost) {
     // Evicting a region with a very recent trace_idx should have a much higher cost than evicting
     // one with an older trace_idx (beyond desired_write_ahead).
     // desired_write_ahead = min(launch_msg_buffer_num_entries, 7) = min(8, 7) = 7.

--- a/tests/tt_metal/tt_metal/dispatch/sources.cmake
+++ b/tests/tt_metal/tt_metal/dispatch/sources.cmake
@@ -8,6 +8,10 @@ set(UNIT_TESTS_DISPATCH_SMOKE_SOURCES
     dispatch_program/test_dispatch_stress.cpp
     dispatch_program/test_sub_device.cpp
     dispatch_program/test_kernel_config_buffer.cpp
+    # Host-only (no-silicon) suites; their test cases carry the CPU_ prefix and run
+    # on the github_hosted_cpu leg of the smoke pipeline instead of device runners.
+    dispatch_buffer/test_BufferCorePageMapping_Iterator.cpp
+    dispatch_util/test_ringbuffer_cache.cpp
     dispatch_util/test_device_command.cpp
     dispatch_util/test_dispatch_telemetry.cpp
     dispatch_util/test_dispatch_settings.cpp
@@ -17,13 +21,11 @@ set(UNIT_TESTS_DISPATCH_SMOKE_SOURCES
 set(UNIT_TESTS_DISPATCH_BASIC_SOURCES
     test_service_core_manager.cpp
     dispatch_buffer/test_sub_device.cpp
-    dispatch_buffer/test_BufferCorePageMapping_Iterator.cpp
     dispatch_program/test_dispatch.cpp
     dispatch_program/test_dataflow_cb.cpp
     dispatch_program/test_global_circular_buffers.cpp
     dispatch_program/test_realtime_profiler_sanity.cpp
     dispatch_trace/test_sub_device.cpp
-    dispatch_util/test_ringbuffer_cache.cpp
 )
 
 set(UNIT_TESTS_DISPATCH_SLOW_SOURCES

--- a/tt_stl/tests/test_cleanup.cpp
+++ b/tt_stl/tests/test_cleanup.cpp
@@ -14,7 +14,7 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
-TEST(CleanupTest, Basic) {
+TEST(CleanupTest, CPU_Basic) {
     int counter = 0;
     {
         auto cleanup = make_cleanup([&counter]() { counter++; });
@@ -23,7 +23,7 @@ TEST(CleanupTest, Basic) {
     EXPECT_EQ(counter, 1);
 }
 
-TEST(CleanupTest, MultipleCleanupsInOrder) {
+TEST(CleanupTest, CPU_MultipleCleanupsInOrder) {
     std::vector<int> log;
     log.reserve(3);
     {
@@ -34,7 +34,7 @@ TEST(CleanupTest, MultipleCleanupsInOrder) {
     EXPECT_THAT(log, ElementsAre(3, 2, 1));
 }
 
-TEST(CleanupTest, CancelCleanup) {
+TEST(CleanupTest, CPU_CancelCleanup) {
     int counter = 0;
     {
         auto cleanup = make_cleanup([&counter]() { counter++; });
@@ -44,7 +44,7 @@ TEST(CleanupTest, CancelCleanup) {
     EXPECT_EQ(counter, 0);
 }
 
-TEST(CleanupTest, MoveConstruction) {
+TEST(CleanupTest, CPU_MoveConstruction) {
     int counter = 0;
     {
         auto cleanup1 = make_cleanup([&counter]() { counter++; });
@@ -54,7 +54,7 @@ TEST(CleanupTest, MoveConstruction) {
     EXPECT_EQ(counter, 1);
 }
 
-TEST(CleanupTest, ExceptionSafety) {
+TEST(CleanupTest, CPU_ExceptionSafety) {
     bool cleanup_called = false;
     try {
         [[maybe_unused]] auto cleanup = make_cleanup([&cleanup_called]() { cleanup_called = true; });
@@ -66,7 +66,7 @@ TEST(CleanupTest, ExceptionSafety) {
     EXPECT_TRUE(cleanup_called);
 }
 
-TEST(CleanupTest, PerfectForwarding) {
+TEST(CleanupTest, CPU_PerfectForwarding) {
     std::vector<int> captured = {1, 2, 3};
     {
         auto cleanup = make_cleanup([captured = std::move(captured)]() {

--- a/tt_stl/tests/test_fmt.cpp
+++ b/tt_stl/tests/test_fmt.cpp
@@ -34,7 +34,7 @@ namespace {
 using ::testing::HasSubstr;
 
 // Test std::vector<int> formatting
-TEST(FmtTest, VectorInt) {
+TEST(FmtTest, CPU_VectorInt) {
     std::vector<int> vec = {1, 2, 3, 4, 5};
     std::string result = fmt::format("{}", vec);
     EXPECT_THAT(result, HasSubstr("1"));
@@ -45,7 +45,7 @@ TEST(FmtTest, VectorInt) {
 // Test std::vector<bool> formatting (proxy reference edge case)
 // vector<bool> uses bit-packing; operator[] returns a proxy type, not a real bool.
 // This test guards against fmt 11's unformattable-type hard error regressing.
-TEST(FmtTest, VectorBool) {
+TEST(FmtTest, CPU_VectorBool) {
     // Mixed values
     std::vector<bool> mixed = {true, false, true};
     std::string result = fmt::format("{}", mixed);
@@ -65,7 +65,7 @@ TEST(FmtTest, VectorBool) {
 }
 
 // Test std::optional<T> formatting
-TEST(FmtTest, Optional) {
+TEST(FmtTest, CPU_Optional) {
     std::optional<int> opt_val = 42;
     std::string result1 = fmt::format("{}", opt_val);
     EXPECT_THAT(result1, HasSubstr("42"));
@@ -79,14 +79,14 @@ TEST(FmtTest, Optional) {
 }
 
 // Test std::optional<const T> (edge case mentioned in fmt.hpp comments)
-TEST(FmtTest, OptionalConst) {
+TEST(FmtTest, CPU_OptionalConst) {
     std::optional<const bool> opt_const = true;
     std::string result = fmt::format("{}", opt_const);
     EXPECT_TRUE(result.find("true") != std::string::npos || result.find('1') != std::string::npos);
 }
 
 // Test container of non-void pointers (critical edge case)
-TEST(FmtTest, VectorOfPointers) {
+TEST(FmtTest, CPU_VectorOfPointers) {
     MockDevice d1{1}, d2{2}, d3{3};
     std::vector<MockDevice*> ptrs = {&d1, &d2, &d3};
     std::string result = fmt::format("{}", ptrs);
@@ -97,7 +97,7 @@ TEST(FmtTest, VectorOfPointers) {
 }
 
 // Test std::array
-TEST(FmtTest, Array) {
+TEST(FmtTest, CPU_Array) {
     std::array<int, 3> arr = {10, 20, 30};
     std::string result = fmt::format("{}", arr);
     EXPECT_THAT(result, HasSubstr("10"));
@@ -106,7 +106,7 @@ TEST(FmtTest, Array) {
 }
 
 // Test std::map
-TEST(FmtTest, Map) {
+TEST(FmtTest, CPU_Map) {
     std::map<std::string, int> m = {{"a", 1}, {"b", 2}, {"c", 3}};
     std::string result = fmt::format("{}", m);
     EXPECT_TRUE(result.find('a') != std::string::npos || result.find("\"a\"") != std::string::npos);
@@ -114,7 +114,7 @@ TEST(FmtTest, Map) {
 }
 
 // Test std::set
-TEST(FmtTest, Set) {
+TEST(FmtTest, CPU_Set) {
     std::set<int> s = {3, 1, 4, 1, 5};
     std::string result = fmt::format("{}", s);
     EXPECT_THAT(result, HasSubstr("1"));
@@ -124,7 +124,7 @@ TEST(FmtTest, Set) {
 }
 
 // Test std::unordered_map
-TEST(FmtTest, UnorderedMap) {
+TEST(FmtTest, CPU_UnorderedMap) {
     std::unordered_map<std::string, int> um = {{"x", 10}, {"y", 20}};
     std::string result = fmt::format("{}", um);
     EXPECT_TRUE(result.find('x') != std::string::npos || result.find("\"x\"") != std::string::npos);
@@ -132,7 +132,7 @@ TEST(FmtTest, UnorderedMap) {
 }
 
 // Test std::tuple
-TEST(FmtTest, Tuple) {
+TEST(FmtTest, CPU_Tuple) {
     std::tuple<int, std::string, bool> t = {42, "test", true};
     std::string result = fmt::format("{}", t);
     EXPECT_THAT(result, HasSubstr("42"));
@@ -141,7 +141,7 @@ TEST(FmtTest, Tuple) {
 }
 
 // Test std::variant
-TEST(FmtTest, Variant) {
+TEST(FmtTest, CPU_Variant) {
     std::variant<int, std::string> v1 = 100;
     std::string result1 = fmt::format("{}", v1);
     EXPECT_THAT(result1, HasSubstr("100"));
@@ -152,7 +152,7 @@ TEST(FmtTest, Variant) {
 }
 
 // Test enum formatting (via enchantum)
-TEST(FmtTest, Enum) {
+TEST(FmtTest, CPU_Enum) {
     TestEnum e = TestEnum::Value2;
     std::string result = fmt::format("{}", e);
     EXPECT_FALSE(result.empty());
@@ -163,14 +163,14 @@ TEST(FmtTest, Enum) {
 }
 
 // Test std::filesystem::path
-TEST(FmtTest, FilesystemPath) {
+TEST(FmtTest, CPU_FilesystemPath) {
     std::filesystem::path p = "/some/path/to/file.txt";
     std::string result = fmt::format("{}", p);
     EXPECT_TRUE(result.find("file.txt") != std::string::npos || result.find("path") != std::string::npos);
 }
 
 // Test ttsl::SmallVector
-TEST(FmtTest, SmallVector) {
+TEST(FmtTest, CPU_SmallVector) {
     ttsl::SmallVector<int, 4> sv = {1, 2, 3};
     std::string result = fmt::format("{}", sv);
     EXPECT_THAT(result, HasSubstr("1"));
@@ -179,7 +179,7 @@ TEST(FmtTest, SmallVector) {
 }
 
 // Test ttsl::StrongType
-TEST(FmtTest, StrongType) {
+TEST(FmtTest, CPU_StrongType) {
     using UserId = ttsl::StrongType<int, struct UserIdTag>;
     UserId id{12345};
     std::string result = fmt::format("{}", id);
@@ -187,7 +187,7 @@ TEST(FmtTest, StrongType) {
 }
 
 // Test nested containers
-TEST(FmtTest, NestedContainers) {
+TEST(FmtTest, CPU_NestedContainers) {
     std::vector<std::vector<int>> nested = {{1, 2}, {3, 4}, {5}};
     std::string result = fmt::format("{}", nested);
     EXPECT_THAT(result, HasSubstr("1"));
@@ -196,7 +196,7 @@ TEST(FmtTest, NestedContainers) {
 }
 
 // Test empty containers
-TEST(FmtTest, EmptyContainers) {
+TEST(FmtTest, CPU_EmptyContainers) {
     std::vector<int> empty_vec;
     std::string result = fmt::format("{}", empty_vec);
     EXPECT_FALSE(result.empty());  // Should format something, even if empty

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -40,14 +40,14 @@ std::string canonical_dims(const std::array<uint32_t, N>& dims) {
 
 // --- Regression: the exact collision from issue #45821 -------------------------------------
 
-TEST(HashCollisionTest, Issue45821_ShapesDoNotCollide) {
+TEST(HashCollisionTest, CPU_Issue45821_ShapesDoNotCollide) {
     // These two shapes flow through the same ttnn::permute path inside batch_norm; under the
     // old combiner they produced an identical 64-bit hash, so the second op wrongly hit the
     // first op's cached program.
     EXPECT_NE(hash_shape({3, 17, 1, 1}), hash_shape({1, 152, 1, 1}));
 }
 
-TEST(HashCollisionTest, Issue45821_TruncatedPrefixDoesNotCollide) {
+TEST(HashCollisionTest, CPU_Issue45821_TruncatedPrefixDoesNotCollide) {
     // The collision is already present at the 2-element prefix [3,17] vs [1,152] -- the trailing
     // [1, 1] is incidental. Pin the prefix too so a future regression is localized.
     EXPECT_NE(hash_shape({3, 17}), hash_shape({1, 152}));
@@ -55,7 +55,7 @@ TEST(HashCollisionTest, Issue45821_TruncatedPrefixDoesNotCollide) {
 
 // --- Order sensitivity ---------------------------------------------------------------------
 
-TEST(HashCollisionTest, OrderMatters) {
+TEST(HashCollisionTest, CPU_OrderMatters) {
     // A hash used as a cache key must distinguish permutations of the same multiset of dims;
     // otherwise e.g. a [2, 3] tensor and a [3, 2] tensor would share a program.
     EXPECT_NE(hash_shape({2, 3, 5}), hash_shape({5, 3, 2}));
@@ -64,7 +64,7 @@ TEST(HashCollisionTest, OrderMatters) {
 
 // --- Determinism ---------------------------------------------------------------------------
 
-TEST(HashCollisionTest, Deterministic) {
+TEST(HashCollisionTest, CPU_Deterministic) {
     // The same input must hash identically across calls (cache hits depend on it).
     EXPECT_EQ(hash_shape({3, 17, 1, 1}), hash_shape({3, 17, 1, 1}));
     EXPECT_EQ(
@@ -74,7 +74,7 @@ TEST(HashCollisionTest, Deterministic) {
 
 // --- Quality sweep: no collisions over realistic small 4-D shapes --------------------------
 
-TEST(HashCollisionTest, NoCollisionsOverSmall4DShapes) {
+TEST(HashCollisionTest, CPU_NoCollisionsOverSmall4DShapes) {
     // Sweep all 4-D shapes with each dim in [0, 40). The old combiner collided ~94k times over
     // this set; the splitmix64-based combiner must be collision-free here.
     constexpr uint32_t kMax = 40;
@@ -97,7 +97,7 @@ TEST(HashCollisionTest, NoCollisionsOverSmall4DShapes) {
 
 // --- Quality sweep: scalar pairs (the smallest structured keys) ----------------------------
 
-TEST(HashCollisionTest, NoCollisionsOverScalarPairs) {
+TEST(HashCollisionTest, CPU_NoCollisionsOverScalarPairs) {
     constexpr uint32_t kMax = 256;
     std::unordered_set<hash_t> seen;
     seen.reserve(kMax * kMax);
@@ -114,7 +114,7 @@ TEST(HashCollisionTest, NoCollisionsOverScalarPairs) {
 
 // Adversarial values: powers of two and values that differ only in high bits are exactly the
 // inputs that defeat shift-and-add combiners (the high bits never propagate down).
-TEST(HashCollisionTest, NoCollisionsOverHighBitAndPowerOfTwoShapes) {
+TEST(HashCollisionTest, CPU_NoCollisionsOverHighBitAndPowerOfTwoShapes) {
     std::unordered_set<uint32_t> unique_vals;
     for (uint32_t shift = 0; shift < 32; ++shift) {
         unique_vals.insert(1u << shift);          // powers of two
@@ -140,7 +140,7 @@ TEST(HashCollisionTest, NoCollisionsOverHighBitAndPowerOfTwoShapes) {
 
 // 64-bit keys (e.g. addresses, sizes) sharing low words but differing in the high word must not
 // collapse -- the old 32-bit-constant combiner under-mixed the high half.
-TEST(HashCollisionTest, DistinguishesHighWordOf64BitValues) {
+TEST(HashCollisionTest, CPU_DistinguishesHighWordOf64BitValues) {
     EXPECT_NE(
         hash_objects_with_default_seed(uint64_t{0x0000'0001'0000'0000ULL}),
         hash_objects_with_default_seed(uint64_t{0x0000'0002'0000'0000ULL}));
@@ -152,7 +152,7 @@ TEST(HashCollisionTest, DistinguishesHighWordOf64BitValues) {
 // leaves long runs of output bits untouched. We require every single-bit input flip to change
 // at least a quarter of the output bits (16/64) -- a loose bound a good mixer clears easily and
 // a shift-and-add combiner fails on the high input bits.
-TEST(HashCollisionTest, SingleBitFlipAvalanche) {
+TEST(HashCollisionTest, CPU_SingleBitFlipAvalanche) {
     const uint64_t base = 0x0123456789abcdefULL;
     const hash_t base_hash = hash_objects_with_default_seed(base);
     int worst = 64;
@@ -170,7 +170,7 @@ TEST(HashCollisionTest, SingleBitFlipAvalanche) {
 // The mixer must spread bits across the whole 64-bit space, not cluster small keys in a corner.
 // Hash a run of consecutive small integers and require the OR of all results to light up every
 // bit -- a combiner that only touches low bits (the old one, for small inputs) fails this.
-TEST(HashCollisionTest, SmallKeysCoverAllOutputBits) {
+TEST(HashCollisionTest, CPU_SmallKeysCoverAllOutputBits) {
     hash_t or_all = 0;
     hash_t and_all = ~hash_t{0};
     for (uint32_t i = 0; i < 4096; ++i) {
@@ -190,26 +190,26 @@ std::string canonical_shape(const std::vector<uint32_t>& dims) {
     return canonical_key(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
 }
 
-TEST(CanonicalKeyTest, DistinguishesShapes) {
+TEST(CanonicalKeyTest, CPU_DistinguishesShapes) {
     // The shapes that collided under the old 64-bit hash (issue #45821) must be distinct as exact
     // keys regardless of the hash, so a collision can always be resolved to a correct (rebuild) miss.
     EXPECT_NE(canonical_shape({3, 17, 1, 1}), canonical_shape({1, 152, 1, 1}));
     EXPECT_NE(canonical_shape({3, 17}), canonical_shape({1, 152}));
 }
 
-TEST(CanonicalKeyTest, EqualForEqualInputs) {
+TEST(CanonicalKeyTest, CPU_EqualForEqualInputs) {
     EXPECT_EQ(canonical_shape({3, 17, 1, 1}), canonical_shape({3, 17, 1, 1}));
     EXPECT_EQ(canonical_key(uint32_t{42}, uint32_t{7}), canonical_key(uint32_t{42}, uint32_t{7}));
 }
 
-TEST(CanonicalKeyTest, OrderAndLengthSensitive) {
+TEST(CanonicalKeyTest, CPU_OrderAndLengthSensitive) {
     EXPECT_NE(canonical_shape({2, 3}), canonical_shape({3, 2}));
     // Length-prefixing prevents [1,2],[3] from encoding the same as [1],[2,3] etc.
     EXPECT_NE(canonical_shape({1, 2, 3}), canonical_shape({1, 2}));
     EXPECT_NE(canonical_shape({1, 1}), canonical_shape({1}));
 }
 
-TEST(CanonicalKeyTest, DistinguishesScalarsEnumsOptionals) {
+TEST(CanonicalKeyTest, CPU_DistinguishesScalarsEnumsOptionals) {
     EXPECT_NE(canonical_key(uint32_t{1}, uint32_t{2}), canonical_key(uint32_t{2}, uint32_t{1}));
     enum class E : int { A, B };
     EXPECT_NE(canonical_key(E::A), canonical_key(E::B));
@@ -220,7 +220,7 @@ TEST(CanonicalKeyTest, DistinguishesScalarsEnumsOptionals) {
 
 // std::vector<bool> is bit-packed: its iterator yields a proxy reference, not bool&, so it needs a
 // dedicated encoding branch (the generic vector branch fails to compile).
-TEST(CanonicalKeyTest, DistinguishesVectorBool) {
+TEST(CanonicalKeyTest, CPU_DistinguishesVectorBool) {
     EXPECT_EQ(
         canonical_key(std::vector<bool>{true, false, false}), canonical_key(std::vector<bool>{true, false, false}));
     EXPECT_NE(
@@ -244,7 +244,7 @@ TEST(CanonicalKeyTest, DistinguishesVectorBool) {
     }
 }
 
-TEST(CanonicalKeyTest, ToHashTakesPrecedenceOverReflection) {
+TEST(CanonicalKeyTest, CPU_ToHashTakesPrecedenceOverReflection) {
     struct ReflectableWithToHash {
         uint32_t reflected_value;
         uint32_t hash_key;
@@ -268,7 +268,7 @@ TEST(CanonicalKeyTest, ToHashTakesPrecedenceOverReflection) {
 
 // Coverage over the same adversarial set used for the hash: the exact key must be injective here
 // (it is by construction, but pin it so a future encoding change can't silently regress).
-TEST(CanonicalKeyTest, NoCollisionsOverSmall4DShapes) {
+TEST(CanonicalKeyTest, CPU_NoCollisionsOverSmall4DShapes) {
     constexpr uint32_t kMax = 40;
     std::unordered_set<std::string> seen;
     size_t count = 0;
@@ -293,7 +293,7 @@ TEST(CanonicalKeyTest, NoCollisionsOverSmall4DShapes) {
 // free of tt_metal dependencies.
 // =============================================================================================
 
-TEST(ProgramCacheKeyTest, HashCollisionResolvedByCanonicalKey) {
+TEST(ProgramCacheKeyTest, CPU_HashCollisionResolvedByCanonicalKey) {
     struct Key {
         uint64_t hash;
         std::string canonical;
@@ -339,7 +339,7 @@ struct CostAttrs {
     auto attribute_values() const { return std::forward_as_tuple(a, b, c, e, f); }
 };
 
-TEST(CanonicalKeyTest, RelativeCostVsHash) {
+TEST(CanonicalKeyTest, CPU_RelativeCostVsHash) {
     const CostAttrs attrs{1, 2, 3, 4, 5.0f};
     const std::vector<uint32_t> shape{1, 152, 24, 32};
     constexpr int N = 1'000'000;

--- a/tt_stl/tests/test_indestructible.cpp
+++ b/tt_stl/tests/test_indestructible.cpp
@@ -9,7 +9,7 @@
 namespace ttsl {
 namespace {
 
-TEST(IndestructibleTest, Basic) {
+TEST(IndestructibleTest, CPU_Basic) {
     struct DangerouslyDestructible {
         ~DangerouslyDestructible() {
             // Wrapping in a lambda, as `FAIL()` returns `void`.

--- a/tt_stl/tests/test_optional_reference.cpp
+++ b/tt_stl/tests/test_optional_reference.cpp
@@ -9,19 +9,19 @@
 namespace ttsl {
 namespace {
 
-TEST(OptionalReferenceTest, DefaultConstruction) {
+TEST(OptionalReferenceTest, CPU_DefaultConstruction) {
     optional_reference<int> ref;
     EXPECT_FALSE(ref.has_value());
     EXPECT_FALSE(ref);
 }
 
-TEST(OptionalReferenceTest, NulloptConstruction) {
+TEST(OptionalReferenceTest, CPU_NulloptConstruction) {
     optional_reference<int> ref(std::nullopt);
     EXPECT_FALSE(ref.has_value());
     EXPECT_FALSE(ref);
 }
 
-TEST(OptionalReferenceTest, LvalueConstruction) {
+TEST(OptionalReferenceTest, CPU_LvalueConstruction) {
     int value = 42;
     optional_reference<int> ref(value);
     EXPECT_TRUE(ref.has_value());
@@ -30,14 +30,14 @@ TEST(OptionalReferenceTest, LvalueConstruction) {
     EXPECT_EQ(*ref, 42);
 }
 
-TEST(OptionalReferenceTest, ConstLvalueConstruction) {
+TEST(OptionalReferenceTest, CPU_ConstLvalueConstruction) {
     const int value = 42;
     optional_reference<const int> ref(value);
     EXPECT_TRUE(ref.has_value());
     EXPECT_EQ(*ref, 42);
 }
 
-TEST(OptionalReferenceTest, ImplicitConversionToConst) {
+TEST(OptionalReferenceTest, CPU_ImplicitConversionToConst) {
     int value = 42;
     optional_reference<const int> ref(value);
     EXPECT_TRUE(ref.has_value());
@@ -48,7 +48,7 @@ TEST(OptionalReferenceTest, ImplicitConversionToConst) {
     EXPECT_EQ(*ref, 100);  // Reference should see the change
 }
 
-TEST(OptionalReferenceTest, OptionalConstruction) {
+TEST(OptionalReferenceTest, CPU_OptionalConstruction) {
     std::optional<int> opt = 42;
     optional_reference<int> ref(opt);
     EXPECT_TRUE(ref.has_value());
@@ -59,20 +59,20 @@ TEST(OptionalReferenceTest, OptionalConstruction) {
     EXPECT_EQ(*ref, 100);
 }
 
-TEST(OptionalReferenceTest, ConstOptionalConstruction) {
+TEST(OptionalReferenceTest, CPU_ConstOptionalConstruction) {
     const std::optional<int> opt = 42;
     optional_reference<const int> ref(opt);
     EXPECT_TRUE(ref.has_value());
     EXPECT_EQ(*ref, 42);
 }
 
-TEST(OptionalReferenceTest, EmptyOptionalConstruction) {
+TEST(OptionalReferenceTest, CPU_EmptyOptionalConstruction) {
     std::optional<int> opt;
     optional_reference<int> ref(opt);
     EXPECT_FALSE(ref.has_value());
 }
 
-TEST(OptionalReferenceTest, CopyConstruction) {
+TEST(OptionalReferenceTest, CPU_CopyConstruction) {
     int value = 42;
     optional_reference<int> ref1(value);
     optional_reference<int> ref2(ref1);
@@ -82,7 +82,7 @@ TEST(OptionalReferenceTest, CopyConstruction) {
     EXPECT_EQ(*ref2, 42);
 }
 
-TEST(OptionalReferenceTest, MoveConstruction) {
+TEST(OptionalReferenceTest, CPU_MoveConstruction) {
     int value = 42;
     optional_reference<int> ref1(value);
     optional_reference<int> ref2(std::move(ref1)); // NOLINT(performance-move-const-arg)
@@ -94,7 +94,7 @@ TEST(OptionalReferenceTest, MoveConstruction) {
     EXPECT_TRUE(ref1.has_value());
 }
 
-TEST(OptionalReferenceTest, CopyAssignment) {
+TEST(OptionalReferenceTest, CPU_CopyAssignment) {
     int value1 = 42;
     int value2 = 100;
     optional_reference<int> ref1(value1);
@@ -105,7 +105,7 @@ TEST(OptionalReferenceTest, CopyAssignment) {
     EXPECT_EQ(*ref2, 42);
 }
 
-TEST(OptionalReferenceTest, Reset) {
+TEST(OptionalReferenceTest, CPU_Reset) {
     int value = 42;
     optional_reference<int> ref(value);
     EXPECT_TRUE(ref.has_value());
@@ -114,7 +114,7 @@ TEST(OptionalReferenceTest, Reset) {
     EXPECT_FALSE(ref.has_value());
 }
 
-TEST(OptionalReferenceTest, ArrowOperator) {
+TEST(OptionalReferenceTest, CPU_ArrowOperator) {
     struct TestStruct {
         int value = 42;
         int get() const { return value; }
@@ -126,7 +126,7 @@ TEST(OptionalReferenceTest, ArrowOperator) {
     EXPECT_EQ(ref->get(), 42);
 }
 
-TEST(OptionalReferenceTest, ValueMethod) {
+TEST(OptionalReferenceTest, CPU_ValueMethod) {
     int val = 42;
     optional_reference<int> ref(val);
     EXPECT_EQ(ref.value(), 42);
@@ -136,7 +136,7 @@ TEST(OptionalReferenceTest, ValueMethod) {
     EXPECT_EQ(val, 100);
 }
 
-TEST(OptionalReferenceTest, EqualityOperators) {
+TEST(OptionalReferenceTest, CPU_EqualityOperators) {
     int value1 = 42;
     int value2 = 42;
 
@@ -159,7 +159,7 @@ TEST(OptionalReferenceTest, EqualityOperators) {
     EXPECT_NE(ref1, empty1);
 }
 
-TEST(OptionalReferenceTest, ModifyThroughReference) {
+TEST(OptionalReferenceTest, CPU_ModifyThroughReference) {
     int value = 42;
     optional_reference<int> ref(value);
 
@@ -170,7 +170,7 @@ TEST(OptionalReferenceTest, ModifyThroughReference) {
     EXPECT_EQ(value, 200);
 }
 
-TEST(OptionalReferenceTest, ConstCorrectness) {
+TEST(OptionalReferenceTest, CPU_ConstCorrectness) {
     int value = 42;
     const optional_reference<int> ref(value);
 
@@ -179,7 +179,7 @@ TEST(OptionalReferenceTest, ConstCorrectness) {
     EXPECT_EQ(value, 100);
 }
 
-TEST(OptionalReferenceTest, UseCaseExample) {
+TEST(OptionalReferenceTest, CPU_UseCaseExample) {
     auto test_function = [](optional_reference<const int> val) {
         if (val) {
             EXPECT_GE(*val, 0);
@@ -194,7 +194,7 @@ TEST(OptionalReferenceTest, UseCaseExample) {
     test_function(std::nullopt);
 }
 
-TEST(OptionalReferenceTest, TemporaryBindingToConst) {
+TEST(OptionalReferenceTest, CPU_TemporaryBindingToConst) {
     auto test_function = [](optional_reference<const int> val) { EXPECT_EQ(*val, 42); };
     test_function(42);
     test_function(std::make_optional(42));

--- a/tt_stl/tests/test_reflection.cpp
+++ b/tt_stl/tests/test_reflection.cpp
@@ -48,7 +48,7 @@ using test_types::ReflectablePoint;
 using test_types::ReflectableRect;
 using ::testing::HasSubstr;
 
-TEST(ReflectionTest, PrintReflectableStruct) {
+TEST(ReflectionTest, CPU_PrintReflectableStruct) {
     ReflectablePoint p{10, 20};
     std::stringstream ss;
     ss << p;
@@ -59,7 +59,7 @@ TEST(ReflectionTest, PrintReflectableStruct) {
     EXPECT_THAT(result, HasSubstr("y=20"));
 }
 
-TEST(ReflectionTest, PrintNestedReflectableStruct) {
+TEST(ReflectionTest, CPU_PrintNestedReflectableStruct) {
     ReflectableRect rect{{1, 2}, {3, 4}};
     std::stringstream ss;
     ss << rect;
@@ -70,7 +70,7 @@ TEST(ReflectionTest, PrintNestedReflectableStruct) {
     EXPECT_THAT(result, HasSubstr("bottom_right="));
 }
 
-TEST(ReflectionTest, PrintStructWithCompileTimeAttributesContainingReflectable) {
+TEST(ReflectionTest, CPU_PrintStructWithCompileTimeAttributesContainingReflectable) {
     // This test verifies that the template ordering is correct.
     // ContainerWithReflectable uses compile-time attributes (supports_conversion_to_string_v),
     // and contains a ReflectablePoint field that needs the Reflectable operator<<.
@@ -87,7 +87,7 @@ TEST(ReflectionTest, PrintStructWithCompileTimeAttributesContainingReflectable) 
     EXPECT_THAT(result, HasSubstr("y=10"));
 }
 
-TEST(ReflectionTest, PrintVectorOfReflectable) {
+TEST(ReflectionTest, CPU_PrintVectorOfReflectable) {
     std::vector<ReflectablePoint> points{{1, 2}, {3, 4}};
     std::stringstream ss;
     ss << points;
@@ -99,7 +99,7 @@ TEST(ReflectionTest, PrintVectorOfReflectable) {
     EXPECT_THAT(result, HasSubstr("y=4"));
 }
 
-TEST(ReflectionTest, PrintOptionalReflectable) {
+TEST(ReflectionTest, CPU_PrintOptionalReflectable) {
     std::optional<ReflectablePoint> opt_point = ReflectablePoint{7, 8};
     std::stringstream ss;
     ss << opt_point;
@@ -109,14 +109,14 @@ TEST(ReflectionTest, PrintOptionalReflectable) {
     EXPECT_THAT(result, HasSubstr("y=8"));
 }
 
-TEST(ReflectionTest, PrintOptionalNullopt) {
+TEST(ReflectionTest, CPU_PrintOptionalNullopt) {
     std::optional<ReflectablePoint> opt_point = std::nullopt;
     std::stringstream ss;
     ss << opt_point;
     EXPECT_EQ(ss.str(), "std::nullopt");
 }
 
-TEST(ReflectionTest, FmtFormatReflectable) {
+TEST(ReflectionTest, CPU_FmtFormatReflectable) {
     ReflectablePoint p{42, 99};
     std::string result = fmt::format("{}", p);
 
@@ -125,7 +125,7 @@ TEST(ReflectionTest, FmtFormatReflectable) {
     EXPECT_THAT(result, HasSubstr("y=99"));
 }
 
-TEST(ReflectionTest, FmtFormatContainerWithReflectable) {
+TEST(ReflectionTest, CPU_FmtFormatContainerWithReflectable) {
     ContainerWithReflectable container{"fmt_test", {15, 25}};
     std::string result = fmt::format("{}", container);
 
@@ -139,7 +139,7 @@ TEST(ReflectionTest, FmtFormatContainerWithReflectable) {
 // operator() return type as std::map<K, V> while returning a std::unordered_map, so any
 // instantiation of from_json for an unordered_map failed to compile. Exercising that
 // instantiation here guards it (and asserts the declared return type is unordered_map).
-TEST(ReflectionTest, FromJsonUnorderedMapRoundTrip) {
+TEST(ReflectionTest, CPU_FromJsonUnorderedMapRoundTrip) {
     const std::unordered_map<std::string, int> original{{"a", 1}, {"b", 2}, {"c", 3}};
 
     const nlohmann::json json_object = ttsl::json::to_json(original);
@@ -152,7 +152,7 @@ TEST(ReflectionTest, FromJsonUnorderedMapRoundTrip) {
 }
 
 // The sibling std::map specialization (the correct one the bug was copy-pasted from) still works.
-TEST(ReflectionTest, FromJsonMapRoundTrip) {
+TEST(ReflectionTest, CPU_FromJsonMapRoundTrip) {
     const std::map<std::string, int> original{{"a", 1}, {"b", 2}, {"c", 3}};
 
     const nlohmann::json json_object = ttsl::json::to_json(original);

--- a/tt_stl/tests/test_small_vector.cpp
+++ b/tt_stl/tests/test_small_vector.cpp
@@ -109,7 +109,7 @@ protected:
 // verify that destructors run the correct number of times when the vector
 // goes out of scope.
 
-TEST_F(SmallVectorIntTest, DefaultConstructionIsEmpty) {
+TEST_F(SmallVectorIntTest, CPU_DefaultConstructionIsEmpty) {
     // A default constructed vector should have zero size and be empty.  The
     // capacity should be at least the statically defined N (kInlineCapacity in this case).
     Vec vec;
@@ -118,7 +118,7 @@ TEST_F(SmallVectorIntTest, DefaultConstructionIsEmpty) {
     EXPECT_GE(vec.capacity(), kInlineCapacity);
 }
 
-TEST_F(SmallVectorIntTest, ConstructionFromIteratorRange) {
+TEST_F(SmallVectorIntTest, CPU_ConstructionFromIteratorRange) {
     // Constructing from a pair of iterators should populate the vector with
     // the values in that range.
     int arr[] = {1, 2, 3, 4};
@@ -129,7 +129,7 @@ TEST_F(SmallVectorIntTest, ConstructionFromIteratorRange) {
     }
 }
 
-TEST_F(SmallVectorIntTest, InitializerListConstruction) {
+TEST_F(SmallVectorIntTest, CPU_InitializerListConstruction) {
     // An initializer list constructor should take the list of values and store
     // them in order.
     Vec vec{5, 6, 7};
@@ -139,7 +139,7 @@ TEST_F(SmallVectorIntTest, InitializerListConstruction) {
     EXPECT_EQ(vec[2], 7);
 }
 
-TEST_F(SmallVectorTrackedTest, CopyConstructorSmallAndLarge) {
+TEST_F(SmallVectorTrackedTest, CPU_CopyConstructorSmallAndLarge) {
     // Copying a vector that fits in the small buffer should result in another
     // vector using its own small buffer and containing the same elements.
     Vec small;
@@ -172,7 +172,7 @@ TEST_F(SmallVectorTrackedTest, CopyConstructorSmallAndLarge) {
     EXPECT_GE(copyLarge.capacity(), large.size());
 }
 
-TEST_F(SmallVectorTrackedTest, MoveConstructorSmallAndLarge) {
+TEST_F(SmallVectorTrackedTest, CPU_MoveConstructorSmallAndLarge) {
     // Moving a vector should transfer its contents.  After the move the
     // destination should contain the original elements and the source should
     // be in a valid but unspecified state (size zero is acceptable).  For
@@ -212,7 +212,7 @@ TEST_F(SmallVectorTrackedTest, MoveConstructorSmallAndLarge) {
     }
 }
 
-TEST_F(SmallVectorTrackedTest, DestructorCalls) {
+TEST_F(SmallVectorTrackedTest, CPU_DestructorCalls) {
     {
         Vec vec;
         for (int i = 0; i < kInlineCapacity; ++i) {
@@ -231,7 +231,7 @@ TEST_F(SmallVectorTrackedTest, DestructorCalls) {
 // The following tests verify that the vector uses the inlined buffer for up
 // to `N` elements and correctly transitions to heap storage when necessary.
 
-TEST_F(SmallVectorIntTest, PushWithinSmallBufferKeepsInplaceStorage) {
+TEST_F(SmallVectorIntTest, CPU_PushWithinSmallBufferKeepsInplaceStorage) {
     Vec vec;
     // Push elements one at a time; after the first push record the pointer
     // returned by data().  Subsequent pushes up to the inline capacity
@@ -247,7 +247,7 @@ TEST_F(SmallVectorIntTest, PushWithinSmallBufferKeepsInplaceStorage) {
     EXPECT_EQ(vec.size(), kInlineCapacity);
 }
 
-TEST_F(SmallVectorIntTest, PushBeyondSmallBufferTriggersHeapAllocation) {
+TEST_F(SmallVectorIntTest, CPU_PushBeyondSmallBufferTriggersHeapAllocation) {
     Vec vec;
     for (int i = 0; i < kInlineCapacity; ++i) {
         vec.push_back(i);
@@ -265,7 +265,7 @@ TEST_F(SmallVectorIntTest, PushBeyondSmallBufferTriggersHeapAllocation) {
 // Element Access & Iterators
 //
 
-TEST_F(SmallVectorIntTest, FrontAndBackAccessors) {
+TEST_F(SmallVectorIntTest, CPU_FrontAndBackAccessors) {
     Vec vec{1, 2, 3};
     EXPECT_EQ(vec.front(), 1);
     EXPECT_EQ(vec.back(), 3);
@@ -275,7 +275,7 @@ TEST_F(SmallVectorIntTest, FrontAndBackAccessors) {
     EXPECT_EQ(vec[2], 5);
 }
 
-TEST_F(SmallVectorIntTest, ForwardAndReverseIterators) {
+TEST_F(SmallVectorIntTest, CPU_ForwardAndReverseIterators) {
     Vec vec{1, 2, 3, 4};
     // Sum elements via forward iterators.
     int sum = 0;
@@ -301,7 +301,7 @@ TEST_F(SmallVectorIntTest, ForwardAndReverseIterators) {
     EXPECT_EQ(crev, reversed);
 }
 
-TEST_F(SmallVectorIntTest, ConstVsNonConstIteratorTypes) {
+TEST_F(SmallVectorIntTest, CPU_ConstVsNonConstIteratorTypes) {
     Vec vec{1, 2, 3};
     // The type of *cbegin should be const int& and not modifiable.
     using ConstRef = decltype(*vec.cbegin());
@@ -325,7 +325,7 @@ TEST_F(SmallVectorIntTest, ConstVsNonConstIteratorTypes) {
 // swap, resize, reserve and shrink_to_fit.  Each operation is checked for
 // correctness of the resulting contents, size/capacity and element lifetime.
 
-TEST_F(SmallVectorIntTest, emplaceBackWithArray) {
+TEST_F(SmallVectorIntTest, CPU_emplaceBackWithArray) {
     // Original implementation didn't support emplace_back for std::array, which led to compilation error.
     // This test verifies that it works now.
     SmallVector<std::array<int, 3>, kInlineCapacity> vec;
@@ -333,7 +333,7 @@ TEST_F(SmallVectorIntTest, emplaceBackWithArray) {
     ASSERT_EQ(vec.size(), 1u);
 }
 
-TEST_F(SmallVectorTrackedTest, PushPopEmplaceBack) {
+TEST_F(SmallVectorTrackedTest, CPU_PushPopEmplaceBack) {
     Vec vec;
     // Emplace constructs in place; constructor count will increase.
     vec.emplace_back(1);
@@ -352,7 +352,7 @@ TEST_F(SmallVectorTrackedTest, PushPopEmplaceBack) {
     EXPECT_EQ(Tracked::copyCtorCount, 1);
 }
 
-TEST_F(SmallVectorIntTest, InsertAtVariousPositions) {
+TEST_F(SmallVectorIntTest, CPU_InsertAtVariousPositions) {
     Vec vec{1, 4};
     // Insert a single element in the middle.
     auto* it = vec.insert(vec.begin() + 1, 2);
@@ -374,7 +374,7 @@ TEST_F(SmallVectorIntTest, InsertAtVariousPositions) {
     EXPECT_TRUE(std::equal(vec.begin(), vec.end(), expected.begin()));
 }
 
-TEST_F(SmallVectorIntTest, EraseSingleAndRange) {
+TEST_F(SmallVectorIntTest, CPU_EraseSingleAndRange) {
     Vec vec{0, 1, 2, 3, 4};
     // Erase a single element.
     auto* it = vec.erase(vec.begin() + 1);
@@ -390,7 +390,7 @@ TEST_F(SmallVectorIntTest, EraseSingleAndRange) {
     EXPECT_TRUE(std::equal(vec.begin(), vec.end(), expected2.begin()));
 }
 
-TEST_F(SmallVectorIntTest, SwapExchangesContentsAndStorage) {
+TEST_F(SmallVectorIntTest, CPU_SwapExchangesContentsAndStorage) {
     Vec small{1, 2, 3};
     Vec large;
     // Force large to allocate on the heap by pushing beyond inline capacity.
@@ -418,7 +418,7 @@ TEST_F(SmallVectorIntTest, SwapExchangesContentsAndStorage) {
     EXPECT_EQ(large[2], 3);
 }
 
-TEST_F(SmallVectorTrackedTest, ResizeAndReserve) {
+TEST_F(SmallVectorTrackedTest, CPU_ResizeAndReserve) {
     Vec vec;
     // Increase size; default constructed values have value 0.
     vec.resize(3);
@@ -447,7 +447,7 @@ TEST_F(SmallVectorTrackedTest, ResizeAndReserve) {
 // Simple checks of size(), capacity() and empty() in both small and large
 // configurations.
 
-TEST_F(SmallVectorIntTest, SizeCapacityAndEmpty) {
+TEST_F(SmallVectorIntTest, CPU_SizeCapacityAndEmpty) {
     Vec vec;
     EXPECT_TRUE(vec.empty());
     EXPECT_EQ(vec.size(), 0u);
@@ -474,7 +474,7 @@ TEST_F(SmallVectorIntTest, SizeCapacityAndEmpty) {
 // Tests for zero inline capacity, large element types and alignment
 // requirements.
 
-TEST(SmallVectorEdgeCaseTest, ZeroCapacityUsesHeapAlways) {
+TEST(SmallVectorEdgeCaseTest, CPU_ZeroCapacityUsesHeapAlways) {
     // When N == 0 there is no inline storage; the vector must allocate from
     // the heap for every element.
     SmallVector<int, 0> vec;
@@ -490,7 +490,7 @@ TEST(SmallVectorEdgeCaseTest, ZeroCapacityUsesHeapAlways) {
     EXPECT_GE(vec.capacity(), 2u);
 }
 
-TEST(SmallVectorEdgeCaseTest, LargeTypesWithNonTrivialDestructors) {
+TEST(SmallVectorEdgeCaseTest, CPU_LargeTypesWithNonTrivialDestructors) {
     // Use a large array type as the element to ensure the implementation can
     // handle large sizes.  The destructor should be called for each element.
 
@@ -504,7 +504,7 @@ TEST(SmallVectorEdgeCaseTest, LargeTypesWithNonTrivialDestructors) {
     EXPECT_EQ(Large::dtorCount, 5);
 }
 
-TEST(SmallVectorEdgeCaseTest, OverAlignedTypesAreProperlyAllocated) {
+TEST(SmallVectorEdgeCaseTest, CPU_OverAlignedTypesAreProperlyAllocated) {
     // Over‐aligned types should still have their alignment honoured in the
     // vector's storage.  We check the returned data pointer alignment.
     SmallVector<OverAligned, 2> vec;

--- a/tt_stl/tests/test_span.cpp
+++ b/tt_stl/tests/test_span.cpp
@@ -18,7 +18,7 @@ namespace {
 using ::testing::Eq;
 using ::testing::Pointwise;
 
-TEST(SpanTest, AsBytes) {
+TEST(SpanTest, CPU_AsBytes) {
     std::vector<uint32_t> src = {1, 2, 3, 4, 5};
     std::vector<uint32_t> dst = {0, 0, 0, 0, 0};
 

--- a/tt_stl/tests/test_strong_type.cpp
+++ b/tt_stl/tests/test_strong_type.cpp
@@ -21,7 +21,7 @@ using ::testing::ElementsAre;
 using ::testing::IsNull;
 using ::testing::UnorderedElementsAre;
 
-TEST(StrongTypeTest, Basic) {
+TEST(StrongTypeTest, CPU_Basic) {
     MyIntId my_int_id1(42);
     MyIntId my_int_id2(43);
 
@@ -32,7 +32,7 @@ TEST(StrongTypeTest, Basic) {
     EXPECT_EQ(my_int_id1, my_int_id2);
 }
 
-TEST(StrongTypeTest, GuaranteedUnique) {
+TEST(StrongTypeTest, CPU_GuaranteedUnique) {
     StrongType<int> one{1};
     StrongType<int> otherone{1};
 
@@ -45,7 +45,7 @@ TEST(StrongTypeTest, GuaranteedUnique) {
     EXPECT_EQ(*one, *otherone);
 }
 
-TEST(StrongTypeTest, UseInContainers) {
+TEST(StrongTypeTest, CPU_UseInContainers) {
     std::unordered_set<MyIntId> unordered;
     std::set<MyIntId> ordered;
 
@@ -60,13 +60,13 @@ TEST(StrongTypeTest, UseInContainers) {
     EXPECT_THAT(ordered, ElementsAre(MyIntId(1), MyIntId(2), MyIntId(3)));
 }
 
-TEST(StrongTypeTest, StreamingOperator) {
+TEST(StrongTypeTest, CPU_StreamingOperator) {
     std::stringstream ss;
     ss << MyStringId("hello world");
     EXPECT_EQ(ss.str(), "hello world");
 }
 
-TEST(StrongTypeTest, MoveOnlyType) {
+TEST(StrongTypeTest, CPU_MoveOnlyType) {
     using MoveOnlyType = StrongType<std::unique_ptr<int>, struct MoveOnlyTag>;
 
     MoveOnlyType from(std::make_unique<int>(42));

--- a/tt_stl/tests/test_tt_pause.cpp
+++ b/tt_stl/tests/test_tt_pause.cpp
@@ -12,14 +12,14 @@
 namespace ttsl {
 namespace {
 
-TEST(TTPauseTest, PauseDoesNotCrash) {
+TEST(TTPauseTest, CPU_PauseDoesNotCrash) {
     // Simply verify that pause can be called without crashing
     for (int i = 0; i < 1000; ++i) {
         pause();
     }
 }
 
-TEST(TTNiceSpinUntilTest, ImmediateReturnWhenPredicateTrue) {
+TEST(TTNiceSpinUntilTest, CPU_ImmediateReturnWhenPredicateTrue) {
     // Predicate is immediately true, should return without spinning
     auto start = std::chrono::steady_clock::now();
     nice_spin_until([] { return true; });
@@ -30,7 +30,7 @@ TEST(TTNiceSpinUntilTest, ImmediateReturnWhenPredicateTrue) {
     EXPECT_LT(duration.count(), 1000);
 }
 
-TEST(TTNiceSpinUntilTest, WaitsUntilPredicateBecomesTrueWithAtomicFlag) {
+TEST(TTNiceSpinUntilTest, CPU_WaitsUntilPredicateBecomesTrueWithAtomicFlag) {
     std::atomic<bool> flag{false};
 
     // Record start BEFORE thread construction so the setter's sleep is always
@@ -53,7 +53,7 @@ TEST(TTNiceSpinUntilTest, WaitsUntilPredicateBecomesTrueWithAtomicFlag) {
     setter.join();
 }
 
-TEST(TTNiceSpinUntilTest, WaitsUntilPredicateBecomesTrueWithCounter) {
+TEST(TTNiceSpinUntilTest, CPU_WaitsUntilPredicateBecomesTrueWithCounter) {
     std::atomic<int> counter{0};
 
     std::thread incrementer([&counter] {
@@ -69,7 +69,7 @@ TEST(TTNiceSpinUntilTest, WaitsUntilPredicateBecomesTrueWithCounter) {
     incrementer.join();
 }
 
-TEST(TTNiceSpinUntilTest, CustomNSpinsParameter) {
+TEST(TTNiceSpinUntilTest, CPU_CustomNSpinsParameter) {
     std::atomic<int> call_count{0};
 
     // With N_SPINS=10, we should hit the sleep branch more frequently
@@ -82,7 +82,7 @@ TEST(TTNiceSpinUntilTest, CustomNSpinsParameter) {
     EXPECT_GE(call_count.load(), 50);
 }
 
-TEST(TTNiceSpinUntilTest, CustomMaxWaitUSParameter) {
+TEST(TTNiceSpinUntilTest, CPU_CustomMaxWaitUSParameter) {
     std::atomic<bool> flag{false};
 
     std::thread setter([&flag] {
@@ -97,7 +97,7 @@ TEST(TTNiceSpinUntilTest, CustomMaxWaitUSParameter) {
     setter.join();
 }
 
-TEST(TTNiceSpinUntilTest, PredicateWithArguments) {
+TEST(TTNiceSpinUntilTest, CPU_PredicateWithArguments) {
     std::atomic<int> value{0};
 
     std::thread setter([&value] {
@@ -114,7 +114,7 @@ TEST(TTNiceSpinUntilTest, PredicateWithArguments) {
     setter.join();
 }
 
-TEST(TTNiceSpinUntilTest, PredicateWithMultipleArguments) {
+TEST(TTNiceSpinUntilTest, CPU_PredicateWithMultipleArguments) {
     std::atomic<int> a{0};
     std::atomic<int> b{0};
 
@@ -136,7 +136,7 @@ TEST(TTNiceSpinUntilTest, PredicateWithMultipleArguments) {
     setter.join();
 }
 
-TEST(TTNiceSpinUntilTest, ExponentialBackoffBehavior) {
+TEST(TTNiceSpinUntilTest, CPU_ExponentialBackoffBehavior) {
     // This test verifies the exponential backoff by checking that the function
     // doesn't consume excessive CPU time when waiting for a longer duration
     std::atomic<bool> flag{false};
@@ -159,7 +159,7 @@ TEST(TTNiceSpinUntilTest, ExponentialBackoffBehavior) {
     setter.join();
 }
 
-TEST(TTNiceSpinUntilTest, ZeroSpinsGoesDirectlyToSleep) {
+TEST(TTNiceSpinUntilTest, CPU_ZeroSpinsGoesDirectlyToSleep) {
     // With N_SPINS=1, should hit sleep on every iteration
     std::atomic<bool> flag{false};
 

--- a/tt_stl/tests/test_type_visitor.cpp
+++ b/tt_stl/tests/test_type_visitor.cpp
@@ -45,7 +45,7 @@ using test_types::TargetType;
 // update_object_of_type tests
 // =============================================================================
 
-TEST(UpdateObjectOfTypeTest, DirectTypeMatch) {
+TEST(UpdateObjectOfTypeTest, CPU_DirectTypeMatch) {
     TargetType target{42};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value *= 2; }, target);
@@ -53,12 +53,12 @@ TEST(UpdateObjectOfTypeTest, DirectTypeMatch) {
     EXPECT_EQ(target.value, 84);
 }
 
-TEST(UpdateObjectOfTypeTest, NonMatchingTypeThrows) {
+TEST(UpdateObjectOfTypeTest, CPU_NonMatchingTypeThrows) {
     int non_target = 123;
     EXPECT_THROW(update_object_of_type<TargetType>([](TargetType&) {}, non_target), std::runtime_error);
 }
 
-TEST(UpdateObjectOfTypeTest, OptionalWithValue) {
+TEST(UpdateObjectOfTypeTest, CPU_OptionalWithValue) {
     std::optional<TargetType> opt_target = TargetType{50};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value += 10; }, opt_target);
@@ -67,7 +67,7 @@ TEST(UpdateObjectOfTypeTest, OptionalWithValue) {
     EXPECT_EQ(opt_target->value, 60);
 }
 
-TEST(UpdateObjectOfTypeTest, OptionalWithoutValue) {
+TEST(UpdateObjectOfTypeTest, CPU_OptionalWithoutValue) {
     std::optional<TargetType> opt_target = std::nullopt;
     bool callback_called = false;
 
@@ -77,7 +77,7 @@ TEST(UpdateObjectOfTypeTest, OptionalWithoutValue) {
     EXPECT_FALSE(opt_target.has_value());
 }
 
-TEST(UpdateObjectOfTypeTest, VectorOfTargetType) {
+TEST(UpdateObjectOfTypeTest, CPU_VectorOfTargetType) {
     std::vector<TargetType> targets{{1}, {2}, {3}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value *= 10; }, targets);
@@ -88,7 +88,7 @@ TEST(UpdateObjectOfTypeTest, VectorOfTargetType) {
     EXPECT_EQ(targets[2].value, 30);
 }
 
-TEST(UpdateObjectOfTypeTest, ArrayOfTargetType) {
+TEST(UpdateObjectOfTypeTest, CPU_ArrayOfTargetType) {
     std::array<TargetType, 3> targets{{{5}, {10}, {15}}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value += 100; }, targets);
@@ -98,7 +98,7 @@ TEST(UpdateObjectOfTypeTest, ArrayOfTargetType) {
     EXPECT_EQ(targets[2].value, 115);
 }
 
-TEST(UpdateObjectOfTypeTest, TupleOfTargetTypes) {
+TEST(UpdateObjectOfTypeTest, CPU_TupleOfTargetTypes) {
     std::tuple<TargetType, TargetType, TargetType> tuple{TargetType{10}, TargetType{20}, TargetType{30}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value *= 2; }, tuple);
@@ -108,7 +108,7 @@ TEST(UpdateObjectOfTypeTest, TupleOfTargetTypes) {
     EXPECT_EQ(std::get<2>(tuple).value, 60);
 }
 
-TEST(UpdateObjectOfTypeTest, NestedOptionalInVector) {
+TEST(UpdateObjectOfTypeTest, CPU_NestedOptionalInVector) {
     std::vector<std::optional<TargetType>> targets{TargetType{1}, std::nullopt, TargetType{3}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value *= 100; }, targets);
@@ -121,7 +121,7 @@ TEST(UpdateObjectOfTypeTest, NestedOptionalInVector) {
     EXPECT_EQ(targets[2]->value, 300);
 }
 
-TEST(UpdateObjectOfTypeTest, NestedVectorInVector) {
+TEST(UpdateObjectOfTypeTest, CPU_NestedVectorInVector) {
     std::vector<std::vector<TargetType>> nested{{{1}, {2}}, {{3}, {4}, {5}}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value += 10; }, nested);
@@ -136,7 +136,7 @@ TEST(UpdateObjectOfTypeTest, NestedVectorInVector) {
     EXPECT_EQ(nested[1][2].value, 15);
 }
 
-TEST(UpdateObjectOfTypeTest, ArrayOfOptionals) {
+TEST(UpdateObjectOfTypeTest, CPU_ArrayOfOptionals) {
     std::array<std::optional<TargetType>, 3> targets{TargetType{10}, std::nullopt, TargetType{30}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value = -t.value; }, targets);
@@ -148,7 +148,7 @@ TEST(UpdateObjectOfTypeTest, ArrayOfOptionals) {
     EXPECT_EQ(targets[2]->value, -30);
 }
 
-TEST(UpdateObjectOfTypeTest, EmptyVector) {
+TEST(UpdateObjectOfTypeTest, CPU_EmptyVector) {
     std::vector<TargetType> empty_targets;
     bool callback_called = false;
 
@@ -158,7 +158,7 @@ TEST(UpdateObjectOfTypeTest, EmptyVector) {
     EXPECT_TRUE(empty_targets.empty());
 }
 
-TEST(UpdateObjectOfTypeTest, CountingCallback) {
+TEST(UpdateObjectOfTypeTest, CPU_CountingCallback) {
     std::vector<TargetType> targets{{1}, {2}, {3}, {4}, {5}};
     int call_count = 0;
 
@@ -167,7 +167,7 @@ TEST(UpdateObjectOfTypeTest, CountingCallback) {
     EXPECT_EQ(call_count, 5);
 }
 
-TEST(UpdateObjectOfTypeTest, TupleOfVectors) {
+TEST(UpdateObjectOfTypeTest, CPU_TupleOfVectors) {
     std::tuple<std::vector<TargetType>, std::vector<TargetType>> tuple{
         std::vector<TargetType>{{1}, {2}}, std::vector<TargetType>{{3}, {4}, {5}}};
 
@@ -192,7 +192,7 @@ using test_types::ContainerHolder;
 using test_types::NestedHolder;
 using test_types::PairOfTargets;
 
-TEST(UpdateObjectOfTypeTest, ReflectableWithTargetMembers) {
+TEST(UpdateObjectOfTypeTest, CPU_ReflectableWithTargetMembers) {
     PairOfTargets pair{TargetType{10}, TargetType{20}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value *= 3; }, pair);
@@ -201,7 +201,7 @@ TEST(UpdateObjectOfTypeTest, ReflectableWithTargetMembers) {
     EXPECT_EQ(pair.second.value, 60);
 }
 
-TEST(UpdateObjectOfTypeTest, ReflectableWithContainerMembers) {
+TEST(UpdateObjectOfTypeTest, CPU_ReflectableWithContainerMembers) {
     ContainerHolder holder{.targets = {{1}, {2}, {3}}, .maybe_target = TargetType{100}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value += 10; }, holder);
@@ -214,7 +214,7 @@ TEST(UpdateObjectOfTypeTest, ReflectableWithContainerMembers) {
     EXPECT_EQ(holder.maybe_target->value, 110);
 }
 
-TEST(UpdateObjectOfTypeTest, ReflectableWithEmptyOptionalMember) {
+TEST(UpdateObjectOfTypeTest, CPU_ReflectableWithEmptyOptionalMember) {
     ContainerHolder holder{.targets = {{5}}, .maybe_target = std::nullopt};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value *= 2; }, holder);
@@ -224,7 +224,7 @@ TEST(UpdateObjectOfTypeTest, ReflectableWithEmptyOptionalMember) {
     EXPECT_FALSE(holder.maybe_target.has_value());
 }
 
-TEST(UpdateObjectOfTypeTest, NestedReflectableStructs) {
+TEST(UpdateObjectOfTypeTest, CPU_NestedReflectableStructs) {
     NestedHolder nested{.pair = {TargetType{1}, TargetType{2}}, .single = TargetType{3}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value *= 100; }, nested);
@@ -234,7 +234,7 @@ TEST(UpdateObjectOfTypeTest, NestedReflectableStructs) {
     EXPECT_EQ(nested.single.value, 300);
 }
 
-TEST(UpdateObjectOfTypeTest, VectorOfReflectable) {
+TEST(UpdateObjectOfTypeTest, CPU_VectorOfReflectable) {
     std::vector<PairOfTargets> pairs{{TargetType{1}, TargetType{2}}, {TargetType{3}, TargetType{4}}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value += 100; }, pairs);
@@ -246,7 +246,7 @@ TEST(UpdateObjectOfTypeTest, VectorOfReflectable) {
     EXPECT_EQ(pairs[1].second.value, 104);
 }
 
-TEST(UpdateObjectOfTypeTest, OptionalReflectable) {
+TEST(UpdateObjectOfTypeTest, CPU_OptionalReflectable) {
     std::optional<PairOfTargets> opt_pair = PairOfTargets{TargetType{7}, TargetType{8}};
 
     update_object_of_type<TargetType>([](TargetType& t) { t.value = -t.value; }, opt_pair);


### PR DESCRIPTION
## What

`tt-metalium-validation-smoke`/`-basic` run ~2,400 gtests on scarce self-hosted device runners, but a source audit found most of them never touch silicon. This PR moves the host-only subset to GitHub-hosted `ubuntu-latest`, freeing **~176.8s** off the smoke run and **~23.2s** off the basic run, per merge-gate/PR-gate invocation.

## Estimated device-time saved

Measured against real `main` CI history (~24h sample of actual merge-gate/pr-gate runs, not just this branch):

| Gate | Basis | Daily savings |
|---|---|---:|
| Merge-gate smoke | ~25 runs/day × 3 SKUs (`wh_llmbox_civ2_prio`, `wh_n300_civ2`, `bh_p150b_civ2_viommu_prio`) × 176.8s | 13,260s |
| Merge-gate basic | ~24 runs/day × 2 SKUs (`wh_n150_civ2`, `bh_p150b_civ2_viommu_prio`) × 23.2s | 1,114s |
| PR-gate smoke | ~40 runs/day × 1 SKU (`wh_n150_civ2`) × 176.8s | 7,072s |
| **Total** | | **~6.0 device-hours/day (~42/week)** |

`wh_llmbox_civ2_prio` alone gets back ~1.2 hours/day. PR-gate uses an ASan build I haven't separately timed for the CPU-only subset (approximated from the TSan/Release figures above — could be somewhat higher or lower). The new `github_hosted_cpu` job itself completes in 170–181s wall-clock end-to-end, well inside its 10-min budget.

## How

- Renamed 807 test *cases* (not suites) with a `CPU_` prefix across 53 files, so they're selectable via `--gtest_filter` — e.g. `TEST_F(SmallVectorIntTest, PushBack)` → `TEST_F(SmallVectorIntTest, CPU_PushBack)`.
- Device legs now run `--gtest_filter='-*CPU_*'`; a new `runtime validation smoke cpu-only` entry on a new `github_hosted_cpu` SKU (`ubuntu-latest`) runs `--gtest_filter='*CPU_*'`. Same binaries, no new build targets.
- Two dispatch suites (`RingbufferCacheRandomizedTestsFixture`, `Test_BufferCorePageMapping_Iterator`) moved from the Basic to the Smoke CMake source list so they land in a binary that already has the CPU-leg plumbing — avoids duplicating that setup for `basic.yaml`.
- `smoke.yaml`: skip `--device`/hugepages for the CPU SKU; use a raw (non-Harbor) GHCR image for that leg only, since Harbor isn't reachable from GitHub-hosted runners (same pattern `docs-latest-public.yaml` already uses).

## Fixed along the way

- `DeviceParamFixture`'s parameterized-test generator called real hardware discovery at gtest *registration* time, before any filter applies — this crashed the binary outright with no device present. Replaced with a hardware-presence probe that doesn't touch `MetalContext` when no device exists.
- One test (`ConfigureMockModeFromHwDetectsArchitecture`) was mistakenly tagged `CPU_` despite needing real hardware — untagged it (still covered by `unit_tests_device`'s unfiltered runs elsewhere).

## Known gaps / for reviewers

- **Runner-topology change** — new SKU routed to `ubuntu-latest`; flagging per `.github/instructions/ci-cd.instructions.md` for infra/CI review.
- 7 files with trivial (~6ms combined) host-only tests mixed into otherwise device-only files were left as-is — not worth the code-surgery for that little time.
- Validated end-to-end on a Release build (1,636 tests, 1,457 passed / 82 skipped / 97 local-sandbox-only failures, no device-access failures). TSan (merge-gate) and ASan (pr-gate) builds weren't separately timed — should fit the 10-min CPU-leg timeout but worth watching on first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=braincl/cpu-only-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:braincl/cpu-only-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=braincl/cpu-only-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:braincl/cpu-only-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=braincl/cpu-only-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:braincl/cpu-only-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=braincl/cpu-only-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:braincl/cpu-only-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=braincl/cpu-only-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:braincl/cpu-only-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=braincl/cpu-only-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:braincl/cpu-only-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=braincl/cpu-only-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:braincl/cpu-only-smoke-tests)

