### PR TITLE
Fix pytest-xdist collection mismatch in test_copy.py; dedupe DRAM grid helper

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -16,8 +16,8 @@ from tests.ttnn.utils_for_testing import (
     assert_equal,
     assert_allclose,
     assert_with_pcc,
-    make_disjoint_dram_core_range_set,
     make_full_dram_core_range_set,
+    resolve_dram_grid,
 )
 
 pytestmark = pytest.mark.use_module_device
@@ -409,21 +409,47 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
     "tensor_shape, shard_shape, grid",
     [
         # 3-D tensor, single DRAM bank
-        ([1, 32, 64], [1, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})),
+        pytest.param(
+            [1, 32, 64],
+            [1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            id="1x32x64-1bank",
+        ),
         # 3-D tensor sharded across first dim → 3 shards on 3 DRAM banks
-        ([6, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))})),
+        pytest.param(
+            [6, 32, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+            id="6x32x64-3banks",
+        ),
         # 3-D tensor sharded across first two dims → 6 shards on 6 DRAM banks
-        ([6, 8, 64], [2, 4, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))})),
+        pytest.param(
+            [6, 8, 64],
+            [2, 4, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0))}),
+            id="6x8x64-6banks",
+        ),
         # 4-D tensor sharded across batch dim → 4 shards on 4 DRAM banks
-        (
+        pytest.param(
             [4, 1, 32, 64],
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x1x32x64-4banks",
         ),
         # 4-D tensor → 6 shards on disjoint DRAM banks
-        ([4, 3, 16, 32], [2, 1, 16, 32], make_disjoint_dram_core_range_set),
+        pytest.param(
+            [4, 3, 16, 32],
+            [2, 1, 16, 32],
+            "disjoint_dram",
+            id="4x3x16x32-disjoint_dram",
+        ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
+        pytest.param(
+            [5, 32, 64],
+            [2, 32, 64],
+            "full_dram",
+            id="5x32x64-full_dram",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -433,8 +459,7 @@ def test_copy_rm_interleaved_to_nd_sharded(device, tensor_shape, shard_shape, gr
 def test_copy_rm_interleaved_to_nd_sharded_dram(device, tensor_shape, shard_shape, grid, shard_orientation):
     torch.manual_seed(0)
 
-    if callable(grid):
-        grid = grid(device)
+    grid = resolve_dram_grid(grid, device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1148,27 +1173,54 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
     "tensor_shape, shard_shape, grid",
     [
         # 3-D tensor, single DRAM bank
-        ([1, 32, 64], [1, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})),
+        pytest.param(
+            [1, 32, 64],
+            [1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            id="1x32x64-1bank",
+        ),
         # 3-D tensor sharded across first dim → 3 shards on 3 DRAM banks
-        ([6, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))})),
+        pytest.param(
+            [6, 32, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+            id="6x32x64-3banks",
+        ),
         # 3-D tensor sharded across first two dims → 4 shards on 4 DRAM banks
-        ([4, 64, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})),
+        pytest.param(
+            [4, 64, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x64x64-4banks",
+        ),
         # 4-D tensor sharded across batch dim → 4 shards on 4 DRAM banks
-        (
+        pytest.param(
             [4, 1, 32, 64],
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x1x32x64-4banks",
         ),
         # 4-D tensor → 6 shards on disjoint DRAM banks
-        (
+        pytest.param(
             [4, 3, 32, 64],
             [2, 1, 32, 64],
-            make_disjoint_dram_core_range_set,
+            "disjoint_dram",
+            id="4x3x32x64-disjoint_dram",
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
+        pytest.param(
+            [5, 32, 64],
+            [2, 32, 64],
+            "full_dram",
+            id="5x32x64-full_dram",
+        ),
         # 3-D tensor sharded across all dims → 8 shards on the full DRAM bank grid
-        ([4, 64, 64], [2, 32, 32], make_full_dram_core_range_set),
+        pytest.param(
+            [4, 64, 64],
+            [2, 32, 32],
+            "full_dram",
+            id="4x64x64-full_dram",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -1178,8 +1230,7 @@ def test_copy_tilized_interleaved_to_nd_sharded_dtype_conversion(
 def test_copy_tilized_interleaved_to_nd_sharded_dram(device, tensor_shape, shard_shape, grid, shard_orientation):
     torch.manual_seed(0)
 
-    if callable(grid):
-        grid = grid(device)
+    grid = resolve_dram_grid(grid, device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()
@@ -1209,19 +1260,40 @@ def test_copy_tilized_interleaved_to_nd_sharded_dram(device, tensor_shape, shard
     "tensor_shape, shard_shape, grid",
     [
         # 3-D tensor, single DRAM bank
-        ([1, 32, 64], [1, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})),
+        pytest.param(
+            [1, 32, 64],
+            [1, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            id="1x32x64-1bank",
+        ),
         # 3-D tensor sharded across first dim → 3 shards on 3 DRAM banks
-        ([6, 32, 64], [2, 32, 64], ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))})),
+        pytest.param(
+            [6, 32, 64],
+            [2, 32, 64],
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0))}),
+            id="6x32x64-3banks",
+        ),
         # 4-D tensor sharded across batch dim → 4 shards on 4 DRAM banks
-        (
+        pytest.param(
             [4, 1, 32, 64],
             [1, 1, 32, 64],
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+            id="4x1x32x64-4banks",
         ),
         # 3-D tensor with uneven shards → 3 shards, more DRAM banks than shards
-        ([5, 32, 64], [2, 32, 64], make_full_dram_core_range_set),
+        pytest.param(
+            [5, 32, 64],
+            [2, 32, 64],
+            "full_dram",
+            id="5x32x64-full_dram",
+        ),
         # 3-D tensor sharded across all dims → disjoint DRAM banks
-        ([3, 160, 160], [2, 64, 64], make_disjoint_dram_core_range_set),
+        pytest.param(
+            [3, 160, 160],
+            [2, 64, 64],
+            "disjoint_dram",
+            id="3x160x160-disjoint_dram",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -1242,8 +1314,7 @@ def test_copy_tilized_interleaved_to_nd_sharded_dram_dtype_conversion(
 ):
     torch.manual_seed(0)
 
-    if callable(grid):
-        grid = grid(device)
+    grid = resolve_dram_grid(grid, device)
 
     num_dram_banks = device.dram_grid_size().x
     num_cores_in_grid = grid.num_cores()

--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -11,31 +11,11 @@ import math
 from tests.ttnn.utils_for_testing import (
     assert_equal,
     assert_allclose,
-    make_disjoint_dram_core_range_set,
     make_full_dram_core_range_set,
+    resolve_dram_grid,
 )
 
 pytestmark = pytest.mark.use_module_device
-
-
-# DRAM core grids that can only be built once a device is available are referenced from
-# `@pytest.mark.parametrize` by a stable string key instead of by the factory callable
-# itself, so that every pytest-xdist worker collects an identical set of test IDs.
-DRAM_GRID_FACTORIES = {
-    "disjoint_dram": make_disjoint_dram_core_range_set,
-    "full_dram": make_full_dram_core_range_set,
-}
-
-
-def resolve_dram_grid(grid, device):
-    """Resolve a parametrized `grid` value into a concrete `ttnn.CoreRangeSet`.
-
-    String values are looked up in `DRAM_GRID_FACTORIES` and built for `device`;
-    already-concrete `CoreRangeSet` values are returned unchanged.
-    """
-    if isinstance(grid, str):
-        return DRAM_GRID_FACTORIES[grid](device)
-    return grid
 
 
 # Test for int types

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -74,6 +74,28 @@ def make_full_dram_core_range_set(device):
     return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
 
 
+# DRAM core grids that can only be built once a device is available are referenced from
+# `@pytest.mark.parametrize` by a stable string key instead of by the factory callable
+# itself, so that every pytest-xdist worker collects an identical set of test IDs.
+# (A bare function object renders as `<function ... at 0x...>`, whose address differs per
+# worker process, which makes xdist abort with "different tests were collected".)
+DRAM_GRID_FACTORIES = {
+    "disjoint_dram": make_disjoint_dram_core_range_set,
+    "full_dram": make_full_dram_core_range_set,
+}
+
+
+def resolve_dram_grid(grid, device):
+    """Resolve a parametrized `grid` value into a concrete `ttnn.CoreRangeSet`.
+
+    String values are looked up in `DRAM_GRID_FACTORIES` and built for `device`;
+    already-concrete `CoreRangeSet` values are returned unchanged.
+    """
+    if isinstance(grid, str):
+        return DRAM_GRID_FACTORIES[grid](device)
+    return grid
+
+
 def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorch_result):
     messages = []
     messages.append(message)


### PR DESCRIPTION
Follow-up to #54015 (already merged). Same bug class, second location, plus the deduplication that should have happened the first time.

## Why this is needed

#54015 fixed a pytest-xdist `different tests were collected between workers` failure in `test_to_memory_config.py`. **After that PR merged, CI on `main` failed again with the identical root cause**, this time in a different file:

- Failing test: `tests/ttnn/unit_tests/base_functionality/test_copy.py::test_copy_tilized_interleaved_to_nd_sharded_dram_dtype_conversion`
- CI run: https://github.com/tenstorrent/tt-metal/actions/runs/32538288678
- The triage output quotes `<function make_disjoint_dram_core_range_set at 0x7f474e8fb5b0>` from one worker versus a different address from another.

So this is not a theoretical hardening change; it is the real-world confirmation that #54015 fixed only one of the two call sites.

## Root cause (unchanged from #54015)

`make_disjoint_dram_core_range_set` and `make_full_dram_core_range_set` live in the shared `tests/ttnn/utils_for_testing.py` and were embedded **directly as `@pytest.mark.parametrize` values** in both `test_to_memory_config.py` (fixed in #54015) and `test_copy.py` (fixed here).

When a bare callable is a parametrize value, pytest derives the test ID from its `repr()`, which contains the function object's memory address. That address differs in every worker process, so xdist workers disagree on the collected test IDs and abort the whole run.

## What changed

**1. Deduplicated the helper into the shared module.** Since the same pattern is now needed in two files, `DRAM_GRID_FACTORIES` and `resolve_dram_grid()` moved out of `test_to_memory_config.py` and into `tests/ttnn/utils_for_testing.py`, directly next to the two factory functions they wrap. `test_to_memory_config.py` now imports the helper instead of carrying a local copy (net -22 lines there), so a third caller gets the safe pattern for free.

**2. Applied the identical fix to all three affected parametrize blocks in `test_copy.py`** — callables replaced with the stable string keys `"disjoint_dram"` / `"full_dram"`, resolved inside the test body via `resolve_dram_grid(grid, device)`:

| Test function | Rows converted to `pytest.param(..., id=...)` |
|---|---|
| `test_copy_rm_interleaved_to_nd_sharded_dram` | 6 |
| `test_copy_tilized_interleaved_to_nd_sharded_dram` | 7 |
| `test_copy_tilized_interleaved_to_nd_sharded_dram_dtype_conversion` (the one CI caught) | 5 |

Following the convention from #54015, **every** row in a touched block gets an explicit unique `id=`, not just the previously-callable rows, so IDs stay consistent within each block. The IDs reuse the names already chosen for the equivalent blocks in `test_to_memory_config.py` (e.g. `1x32x64-1bank`, `4x3x16x32-disjoint_dram`, `5x32x64-full_dram`).

The three `if callable(grid): grid = grid(device)` bodies collapse to `grid = resolve_dram_grid(grid, device)`.

**No test behavior changes** — same shapes, same grids, same coverage. Only the collected IDs become deterministic.

## Verification

- `python3 -m py_compile` passes on all three touched files.
- `black --check` passes on all three files with the repo-pinned `black==23.10.1` (`.pre-commit-config.yaml`) and `line-length = 120` (`pyproject.toml`).
- An AST sweep over all of `tests/ttnn/` for bare function references used as parametrize *values* now reports **zero** remaining sites in these two files. The only other matches are in `test_to_layout.py`, where `_cases_*()` helpers are **called** at collection time and return lists — that is the correct pattern, not this bug.
- Hardware tests were not run (no device available in this environment).

Note: `make_full_dram_core_range_set` is still imported in both test files because each calls it directly inside one test body; `make_disjoint_dram_core_range_set` is no longer imported in either, as it is now reached only through `DRAM_GRID_FACTORIES`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/xdist-collection-mismatch-test-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/xdist-collection-mismatch-test-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/xdist-collection-mismatch-test-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/xdist-collection-mismatch-test-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/xdist-collection-mismatch-test-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/xdist-collection-mismatch-test-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/xdist-collection-mismatch-test-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/xdist-collection-mismatch-test-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/xdist-collection-mismatch-test-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/xdist-collection-mismatch-test-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/xdist-collection-mismatch-test-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/xdist-collection-mismatch-test-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/xdist-collection-mismatch-test-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/xdist-collection-mismatch-test-copy)