### PR TITLE
Add optional-binding lookups for Metal 2.0 kernel resources

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -53,6 +53,7 @@
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
+#include "tt_metal/hw/inc/api/optional_binding.h"  // binding::MAX_BINDING_NAME_LEN
 
 #include "test_helpers.hpp"
 
@@ -3900,6 +3901,34 @@ TEST_F(ProgramSpecTestGen1, InvalidTensorAccessorNameFails) {
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("tensor accessor_name 'has-dash' must be a valid C++ identifier")));
+}
+
+TEST_F(ProgramSpecTestGen1, OverlongTensorAccessorNameFails) {
+    // A binding's accessor_name is also baked into the device-side optional-binding lookups
+    // (try_get_tensor_binding<"name">()), whose ::binding::Name template parameter holds a
+    // fixed-capacity buffer and silently truncates past MAX_BINDING_NAME_LEN. Two names agreeing
+    // on that many leading characters would become indistinguishable there and a lookup would
+    // hand back the wrong binding, so the host rejects the name up front instead.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    const std::string too_long = "a" + std::string(::binding::MAX_BINDING_NAME_LEN, 'b');  // one over
+    spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor")};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", too_long);
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("characters long, which exceeds the")));
+}
+
+TEST_F(ProgramSpecTestGen1, MaxLengthTensorAccessorNameSucceeds) {
+    // The boundary itself is legal — the cap rejects only names the lookups cannot distinguish.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    const std::string at_limit = "a" + std::string(::binding::MAX_BINDING_NAME_LEN - 1, 'b');
+    spec.tensor_parameters = {MakeMinimalTensorParameter("input_tensor")};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", at_limit);
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
 TEST_F(ProgramSpecTestGen1, AccessorNamesAcrossCategoriesAreSeparateNamespaces) {

--- a/tests/tt_metal/tt_metal/jit_build/sources.cmake
+++ b/tests/tt_metal/tt_metal/jit_build/sources.cmake
@@ -9,5 +9,6 @@ set(UNIT_TESTS_JIT_BUILD_SRC
     test_jit_compile_deduper.cpp
     test_kernel_signature_parser.cpp
     test_named_ct_arg_map.cpp
+    test_optional_binding_lookups.cpp
     test_sync_build_steps.cpp
 )

--- a/tests/tt_metal/tt_metal/jit_build/test_optional_binding_lookups.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_optional_binding_lookups.cpp
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "jit_build/jit_build_utils.hpp"
+#include "llrt/rtoptions.hpp"
+
+// A Metal 2.0 kernel's resources arrive as codegen-emitted namespace-scope tokens (tensor::x,
+// dfb::x, scratch::x). A token is emitted only if the host bound that resource to that kernel, so
+// merely naming an unbound resource is a compile error -- which leaves no way to write a kernel
+// parameter that the host may or may not supply. Today's only workaround is a host-set -D and an
+// #ifdef in the kernel.
+//
+// format_optional_binding_lookups() closes that gap device-side: it emits three name-keyed lookups
+// that answer "did the host bind this?" as a compile-time constant, so the absent branch is
+// provably dead rather than ill-formed. These tests pin the emitted text (the exact spelling is
+// part of the contract -- it is what kernels are written against and what the emule path must
+// reproduce byte-for-byte) and then compile it, which is what actually proves the shape is valid
+// C++ and that presence folds away at compile time.
+namespace tt::jit_build::utils {
+namespace {
+
+// ---------------------------------------------------------------------------------------------
+// Emitted text
+// ---------------------------------------------------------------------------------------------
+
+// The lookups exist precisely so a kernel can ask about a resource it may not have, so a kernel
+// that binds nothing at all is not a degenerate case to skip -- it is the primary one.
+TEST(OptionalBindingLookups, KernelWithNoBindingsStillGetsAllThreeLookups) {
+    const std::string out = format_optional_binding_lookups({}, {}, {});
+
+    EXPECT_EQ(
+        out,
+        R"(template <::binding::Name NAME>
+[[nodiscard]] constexpr auto try_get_tensor_binding() {
+    // This kernel has no tensor bindings, so every name is absent.
+    return std::optional<::binding::NullTensorBindingToken>();
+}
+
+template <::binding::Name NAME>
+[[nodiscard]] constexpr std::optional<::DFBBindingToken> try_get_dfb_binding() {
+    // This kernel has no bindings of this kind, so every name is absent.
+    return std::optional<::DFBBindingToken>();
+}
+
+template <::binding::Name NAME>
+[[nodiscard]] constexpr std::optional<::ScratchpadBindingToken> try_get_scratchpad_binding() {
+    // This kernel has no bindings of this kind, so every name is absent.
+    return std::optional<::ScratchpadBindingToken>();
+}
+)");
+}
+
+// Each tensor binding has its own TensorBindingToken specialization, so the tensor lookup's return
+// type differs per arm and the function is deduced (`auto`) rather than a fixed std::optional<T>.
+TEST(OptionalBindingLookups, TensorLookupReturnsThePerBindingTokenType) {
+    const std::string out = format_optional_binding_lookups({"in", "out"}, {}, {});
+
+    EXPECT_NE(
+        out.find(
+            R"(template <::binding::Name NAME>
+[[nodiscard]] constexpr auto try_get_tensor_binding() {
+    if constexpr (NAME == ::binding::Name("in")) {
+        return std::optional<::tensor::in_t>(::tensor::in);
+    } else if constexpr (NAME == ::binding::Name("out")) {
+        return std::optional<::tensor::out_t>(::tensor::out);
+    } else {
+        return std::optional<::binding::NullTensorBindingToken>();
+    }
+}
+)"),
+        std::string::npos)
+        << out;
+}
+
+// DFBBindingToken is a single concrete type for every DFB binding, so this lookup can name its
+// return type outright -- no null stand-in needed, and no `auto`.
+TEST(OptionalBindingLookups, DfbLookupReturnsOptionalOfTheConcreteToken) {
+    const std::string out = format_optional_binding_lookups({}, {"gamma", "beta"}, {});
+
+    EXPECT_NE(
+        out.find(
+            R"(template <::binding::Name NAME>
+[[nodiscard]] constexpr std::optional<::DFBBindingToken> try_get_dfb_binding() {
+    if constexpr (NAME == ::binding::Name("gamma")) {
+        return std::optional<::DFBBindingToken>(::dfb::gamma);
+    } else if constexpr (NAME == ::binding::Name("beta")) {
+        return std::optional<::DFBBindingToken>(::dfb::beta);
+    } else {
+        return std::optional<::DFBBindingToken>();
+    }
+}
+)"),
+        std::string::npos)
+        << out;
+}
+
+TEST(OptionalBindingLookups, ScratchpadLookupReturnsOptionalOfTheConcreteToken) {
+    const std::string out = format_optional_binding_lookups({}, {}, {"tmp"});
+
+    EXPECT_NE(
+        out.find(
+            R"(template <::binding::Name NAME>
+[[nodiscard]] constexpr std::optional<::ScratchpadBindingToken> try_get_scratchpad_binding() {
+    if constexpr (NAME == ::binding::Name("tmp")) {
+        return std::optional<::ScratchpadBindingToken>(::scratch::tmp);
+    } else {
+        return std::optional<::ScratchpadBindingToken>();
+    }
+}
+)"),
+        std::string::npos)
+        << out;
+}
+
+// The three kinds are independent: binding one must not change what the other two emit. A kernel
+// with tensors but no scratchpads still needs a working try_get_scratchpad_binding.
+TEST(OptionalBindingLookups, EachKindIsEmittedIndependentlyOfTheOthers) {
+    const std::string mixed = format_optional_binding_lookups({"in"}, {"gamma"}, {});
+    const std::string tensor_only = format_optional_binding_lookups({"in"}, {}, {});
+    const std::string all_empty = format_optional_binding_lookups({}, {}, {});
+
+    // The scratchpad arm of the mixed kernel is the same text as for a kernel that binds nothing.
+    const std::size_t marker = all_empty.find("try_get_scratchpad_binding");
+    ASSERT_NE(marker, std::string::npos);
+    EXPECT_NE(mixed.find(all_empty.substr(marker)), std::string::npos);
+    EXPECT_NE(tensor_only.find(all_empty.substr(marker)), std::string::npos);
+}
+
+// Ordering is caller-supplied and must be preserved verbatim: the emitted arms reference the
+// per-binding `<name>_t` aliases emitted alongside the tokens in the same header, and this text
+// feeds a per-object dephash cache, so it has to be byte-stable for a given binding set.
+TEST(OptionalBindingLookups, ArmOrderFollowsTheCallerSuppliedNameOrder) {
+    const std::string forward = format_optional_binding_lookups({}, {"a", "b"}, {});
+    const std::string reverse = format_optional_binding_lookups({}, {"b", "a"}, {});
+
+    EXPECT_NE(forward, reverse);
+    EXPECT_LT(forward.find(R"(Name("a"))"), forward.find(R"(Name("b"))"));
+    EXPECT_LT(reverse.find(R"(Name("b"))"), reverse.find(R"(Name("a"))"));
+    EXPECT_EQ(format_optional_binding_lookups({}, {"a", "b"}, {}), forward);
+}
+
+// Every lookup must be constexpr (emptiness has to be a compile-time constant, or the absent
+// branch is not dead code) and [[nodiscard]] (calling one and dropping the result is a mistake).
+TEST(OptionalBindingLookups, EveryLookupIsConstexprAndNodiscard) {
+    const std::string out = format_optional_binding_lookups({"in"}, {"gamma"}, {"tmp"});
+
+    for (std::string_view fn : {"try_get_tensor_binding", "try_get_dfb_binding", "try_get_scratchpad_binding"}) {
+        const std::size_t at = out.find(fn);
+        ASSERT_NE(at, std::string::npos) << fn;
+        const std::size_t line_start = out.rfind('\n', at) + 1;
+        const std::string_view signature(out.data() + line_start, at - line_start);
+        EXPECT_NE(signature.find("[[nodiscard]]"), std::string_view::npos) << fn;
+        EXPECT_NE(signature.find("constexpr"), std::string_view::npos) << fn;
+    }
+}
+
+// The include block is emitted unconditionally, so it must cover every type the lookups can name --
+// including DFBBindingToken and ScratchpadBindingToken, which a kernel with no bindings of that kind
+// would otherwise never have declared. That is why the two headers below are here and not, as they
+// once were, emitted only when the kernel actually binds a resource of that kind.
+TEST(OptionalBindingLookups, IncludeBlockCoversEveryTypeTheLookupsName) {
+    for (std::string_view header : {"api/optional_binding.h", "api/dataflow/dataflow_buffer.h", "api/scratchpad.h"}) {
+        EXPECT_NE(OPTIONAL_BINDING_LOOKUP_INCLUDES.find(header), std::string_view::npos) << header;
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Compile check
+// ---------------------------------------------------------------------------------------------
+
+// Namespace bodies as genfiles.cpp emits them, so the lookups' arms have real tokens to return.
+constexpr std::string_view BINDING_NAMESPACES = R"(
+namespace tensor {
+using in_t = ::tensor_accessor::TensorBindingToken<0u, 16u>;
+constexpr in_t in{};
+}  // namespace tensor
+
+namespace dfb {
+constexpr DFBBindingToken gamma{5};
+}  // namespace dfb
+
+namespace scratch {
+constexpr ScratchpadBindingToken tmp{12u, 256u};
+}  // namespace scratch
+)";
+
+// None of the three real token types is compilable off-device: TensorBindingToken pulls in the CTA
+// plumbing and arch headers, and DFBBindingToken and ScratchpadBindingToken live inside
+// dataflow_buffer.h and scratchpad.h, which pull in the NOC and L1 layers around them. Stand-ins
+// reproduce the only properties this test depends on, copied from the real declarations:
+//   - TensorBindingToken is a class TEMPLATE, so the tensor lookup's per-arm return types differ,
+//     which is the whole reason that lookup returns `auto` and needs a null stand-in type;
+//   - the other two are single concrete types, which is why their lookups can name
+//     std::optional<Token> outright.
+// binding::Name and binding::NullTensorBindingToken come from the real api/optional_binding.h --
+// they are what this change actually adds, so standing them in would test nothing.
+constexpr std::string_view TOKEN_STANDINS = R"(
+namespace tensor_accessor {
+template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
+struct TensorBindingToken {
+    static constexpr uint32_t addr_crta_offset = ADDR_CRTA_OFFSET;
+};
+}  // namespace tensor_accessor
+
+struct DFBBindingToken {
+    explicit constexpr DFBBindingToken(uint16_t id) noexcept : id_(id) {}
+    constexpr operator uint32_t() const noexcept { return id_; }
+private:
+    uint16_t id_;
+};
+
+class ScratchpadBindingToken {
+public:
+    explicit constexpr ScratchpadBindingToken(uint32_t crta_offset, uint32_t size_in_bytes) noexcept :
+        crta_offset_(crta_offset), size_in_bytes_(size_in_bytes) {}
+private:
+    template <typename T>
+    friend class Scratchpad;
+
+    uint32_t crta_offset_;
+    uint32_t size_in_bytes_;
+};
+)";
+
+// Mirrors the constructor surface of the three real consumers, including the
+// NullTensorBindingToken overload added to hw/inc/api/tensor/local_tensor_accessor.h. That overload
+// is what makes an absent tensor branch well-formed: a discarded `if constexpr` branch is only left
+// uninstantiated inside a template, and kernel_main is not a template.
+constexpr std::string_view CONSUMER_STANDINS = R"(
+template <typename T>
+class LocalTensorAccessor {
+public:
+    template <uint32_t C, uint32_t A>
+    explicit LocalTensorAccessor(tensor_accessor::TensorBindingToken<C, A>) noexcept : addr_(A) {}
+    explicit LocalTensorAccessor(::binding::NullTensorBindingToken) noexcept : LocalTensorAccessor(uint32_t{0}) {}
+    explicit LocalTensorAccessor(uint32_t base) noexcept : addr_(base) {}
+    constexpr uint32_t addr() const { return addr_; }
+private:
+    uint32_t addr_;
+};
+class DataflowBuffer {
+public:
+    DataflowBuffer(DFBBindingToken t) : id_(static_cast<uint32_t>(t)) {}
+    constexpr uint32_t id() const { return id_; }
+private:
+    uint32_t id_;
+};
+template <typename T>
+class Scratchpad {
+public:
+    explicit Scratchpad(const ScratchpadBindingToken& t) noexcept :
+        crta_offset_(t.crta_offset_), size_(t.size_in_bytes_) {}
+    constexpr uint32_t size() const { return crta_offset_ + size_; }
+private:
+    uint32_t crta_offset_;
+    uint32_t size_;
+};
+)";
+
+// A kernel that treats all three resource kinds as optional parameters, written against the
+// generated lookups. The static_asserts are the substance of the test: they assert that presence is
+// known at compile time, which is exactly the property that lets the compiler delete the branch a
+// kernel could not otherwise even name. The unbound names are the case that is a hard compile error
+// today.
+constexpr std::string_view OPTIONAL_PARAM_KERNEL = R"(
+uint32_t kernel_main_test() {
+    uint32_t acc = 0;
+
+    constexpr auto t = try_get_tensor_binding<"in">();
+    static_assert(t.has_value(), "a bound tensor must be reported present");
+    LocalTensorAccessor<uint32_t> a(*t);
+    acc += a.addr();
+
+    constexpr auto d = try_get_dfb_binding<"gamma">();
+    static_assert(d.has_value(), "a bound dfb must be reported present");
+    DataflowBuffer dd(*d);
+    acc += dd.id();
+
+    constexpr auto s = try_get_scratchpad_binding<"tmp">();
+    static_assert(s.has_value(), "a bound scratchpad must be reported present");
+    Scratchpad<int> sp(*s);
+    acc += sp.size();
+
+    // Unbound names of all three kinds. Naming the token directly would not compile at all; here
+    // absence is a compile-time constant, so both idioms below are well-formed and both branches
+    // are dead code. `if constexpr` additionally requires the absent branch to still type-check.
+    constexpr auto t_absent = try_get_tensor_binding<"not_bound">();
+    static_assert(!t_absent.has_value(), "an unbound tensor name must be reported absent");
+    if (t_absent.has_value()) {
+        LocalTensorAccessor<uint32_t> b(*t_absent);
+        acc += b.addr();
+    }
+    if constexpr (t_absent.has_value()) {
+        LocalTensorAccessor<uint32_t> b(*t_absent);
+        acc += b.addr();
+    }
+
+    constexpr auto d_absent = try_get_dfb_binding<"not_bound">();
+    static_assert(!d_absent.has_value(), "an unbound dfb name must be reported absent");
+    if constexpr (d_absent.has_value()) {
+        DataflowBuffer dy(*d_absent);
+        acc += dy.id();
+    }
+
+    constexpr auto s_absent = try_get_scratchpad_binding<"not_bound">();
+    static_assert(!s_absent.has_value(), "an unbound scratchpad name must be reported absent");
+    if constexpr (s_absent.has_value()) {
+        Scratchpad<int> sp2(*s_absent);
+        (void)sp2;
+    }
+
+    return acc;
+}
+)";
+
+// End-to-end check that the emitted text is valid C++ and that presence/absence resolves at compile
+// time, using the real api/optional_binding.h from the source tree. The other two headers the
+// emitted block names (dataflow_buffer.h, scratchpad.h) are device-only, so the token types they
+// carry are stood in for -- see TOKEN_STANDINS.
+//
+// Compiled with the host compiler at -std=c++20 and -fsyntax-only: what is under test is the shape
+// of the emitted code and its constant-folding, not code generation, so this needs neither a device
+// nor the RISC-V toolchain. C++20 is required only because the lookups take a class-type
+// non-type template parameter (binding::Name); the real device build is C++17 and gets the same
+// capability from the -ftt-nttp extension in JitBuildEnv's flags.
+TEST(OptionalBindingLookups, EmittedLookupsCompileAndResolvePresenceAtCompileTime) {
+    namespace fs = std::filesystem;
+
+    const fs::path hw_inc = fs::path(llrt::RunTimeOptions().get_root_dir()) / "tt_metal" / "hw" / "inc";
+    if (!fs::exists(hw_inc / "api" / "optional_binding.h")) {
+        GTEST_SKIP() << "device headers not found under " << hw_inc << " (is TT_METAL_HOME set?)";
+    }
+
+    const fs::path dir = fs::temp_directory_path() / "tt_optional_binding_lookups_test";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+
+    const fs::path src = dir / "kernel.cpp";
+    {
+        std::ofstream f(src);
+        f << "#include <cstdint>\n"
+          << "#include \"api/optional_binding.h\"\n"  // the real header; the rest is stood in for
+          << TOKEN_STANDINS << BINDING_NAMESPACES << "\n"
+          << format_optional_binding_lookups({"in"}, {"gamma"}, {"tmp"}) << CONSUMER_STANDINS << OPTIONAL_PARAM_KERNEL;
+        ASSERT_TRUE(f.good());
+    }
+
+    const std::vector<std::string> args = {
+        "c++", "-std=c++20", "-fsyntax-only", "-Wall", "-Werror", "-I", hw_inc.string(), src.string()};
+    if (!exec_command(args, dir.string(), (dir / "compile.log").string())) {
+        std::ifstream log(dir / "compile.log");
+        const std::string output((std::istreambuf_iterator<char>(log)), std::istreambuf_iterator<char>());
+        // A host compiler is not guaranteed at test runtime; a missing one is not a product failure.
+        if (output.find("c++") != std::string::npos && output.find("not found") != std::string::npos) {
+            GTEST_SKIP() << "no host c++ compiler available";
+        }
+        FAIL() << "generated optional-binding lookups failed to compile:\n" << output;
+    }
+
+    fs::remove_all(dir);
+}
+
+}  // namespace
+}  // namespace tt::jit_build::utils

--- a/tt_metal/hw/inc/api/optional_binding.h
+++ b/tt_metal/hw/inc/api/optional_binding.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+
+// Support types for the optional-binding lookups that kernel_bindings_generated.h declares:
+//
+//   template <::binding::Name NAME> constexpr auto try_get_tensor_binding();
+//   template <::binding::Name NAME> constexpr std::optional<DFBBindingToken> try_get_dfb_binding();
+//   template <::binding::Name NAME> constexpr std::optional<ScratchpadBindingToken> try_get_scratchpad_binding();
+//
+// THE PROBLEM THESE SOLVE
+//
+// A Metal 2.0 kernel names a bound resource through a codegen-emitted namespace-scope token:
+// `tensor::in`, `dfb::gamma`, `scratch::tmp`. A token is emitted only if the host actually bound
+// that resource to that kernel, so a kernel that merely *mentions* a resource the host did not
+// bind fails to compile -- the name does not exist. That makes a genuinely optional parameter
+// inexpressible: `if constexpr (have_gamma) { DataflowBuffer g(dfb::gamma); }` does not help,
+// because `dfb::gamma` must still resolve for the discarded branch to be parsed. Today's
+// workaround is a host-defined `-DFUSE_GAMMA` and an `#ifdef` around the use, so the text is
+// removed before the compiler sees it. That spreads a single "is gamma present?" decision across
+// the program factory, the define, and the kernel.
+//
+// HOW THE LOOKUPS SOLVE IT
+//
+// A lookup takes the resource name as a compile-time template argument rather than as an
+// identifier, so the name is a *value* being compared, not a symbol being resolved. Every kernel
+// gets all three lookups whether or not it has bindings of that kind, so a name that was not bound
+// is not an error -- it simply returns an empty optional. Emptiness is a compile-time constant, so
+// the absent branch is provably dead and the compiler deletes it; the generated code is identical
+// to the `#ifdef` version.
+//
+//   constexpr auto gamma = try_get_dfb_binding<"gamma">();
+//   if (gamma.has_value()) {
+//       DataflowBuffer g(*gamma);
+//       ...
+//   }
+//
+// THE TRADE-OFF, STATED PLAINLY
+//
+// Because an unbound name is legal, a *misspelled* name is legal too: it compiles and reports
+// absent forever. A kernel that requires a binding should therefore assert on it, which turns a
+// typo back into a compile error:
+//
+//   static_assert(try_get_tensor_binding<"in">().has_value(), "kernel requires tensor binding 'in'");
+
+namespace binding {
+
+// Maximum binding-name length a lookup can distinguish. The cap exists because `Name` must be a
+// structural type with a fixed-size member (see below); 63 is far beyond any plausible accessor
+// name.
+//
+// This limit is ENFORCED ON THE HOST, not here: ProgramSpec validation rejects any tensor, DFB or
+// scratchpad accessor_name longer than this (see ValidateBindingNameLength in program_spec.cpp,
+// which includes this header so the two cannot drift). Without that check a longer name would be
+// silently truncated by the constructor below, and two names agreeing on their first
+// MAX_BINDING_NAME_LEN characters would become indistinguishable — a lookup would quietly hand
+// back the wrong binding. The host check turns that into a loud error naming the kernel.
+inline constexpr size_t MAX_BINDING_NAME_LEN = 63;
+
+// A binding name usable as a non-type template parameter.
+//
+// This is deliberately a concrete, fixed-capacity type rather than the more idiomatic
+// `template <size_t N> struct StringLiteral { char value[N]; }` with a deduction guide: device
+// kernels build with `-std=c++17 -ftt-nttp`, and while that TT extension permits class-type NTTPs,
+// it does not permit NTTPs of *deduced* class type (a C++20 feature). A single non-template type
+// keeps `try_get_tensor_binding<"in">()` spelled the same way while staying inside C++17.
+//
+// All members are public and it has no user-declared copy/move/destructor, so it is a structural
+// type and therefore valid as an NTTP.
+struct Name {
+    // Always NUL-padded to full capacity: `value` is zero-initialized and the constructor only ever
+    // writes up to MAX_BINDING_NAME_LEN characters. That makes the fixed-length comparison in
+    // operator== well-defined, and it makes two Names with the same characters compare equal
+    // regardless of how they were spelled.
+    char value[MAX_BINDING_NAME_LEN + 1] = {};
+
+    // Implicit by design, so a call site can write try_get_dfb_binding<"gamma">() rather than
+    // try_get_dfb_binding<::binding::Name("gamma")>().
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    constexpr Name(const char* str) {
+        for (size_t i = 0; i < MAX_BINDING_NAME_LEN && str[i] != '\0'; ++i) {
+            value[i] = str[i];
+        }
+    }
+
+    // Compares the whole fixed-capacity buffer rather than stopping at the first NUL. Both operands
+    // are NUL-padded (see above), so this is equivalent to a string comparison, and it avoids
+    // needing a constexpr strcmp in a header that device kernels include.
+    constexpr bool operator==(const Name& other) const {
+        for (size_t i = 0; i <= MAX_BINDING_NAME_LEN; ++i) {
+            if (value[i] != other.value[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+    constexpr bool operator!=(const Name& other) const { return !(*this == other); }
+};
+
+// The value type of an *absent* try_get_tensor_binding result.
+//
+// The DFB and scratchpad lookups need no equivalent: their tokens (DFBBindingToken,
+// ScratchpadBindingToken) are concrete types, so present and absent can both be
+// std::optional<Token>. A tensor binding token is TensorBindingToken<CTA_OFFSET,
+// ADDR_CRTA_OFFSET> -- a distinct type per binding -- so there is no such token type to be empty
+// of when the binding does not exist. This stand-in supplies one.
+//
+// LocalTensorAccessor has a constructor taking this type. That is not optional politeness: a
+// discarded `if constexpr` branch is only left uninstantiated inside a template, and kernel_main
+// is not a template, so the absent branch is still fully type-checked. Were the accessor to reject
+// this token, a kernel could not compile the very branch these lookups exist to let it write.
+struct NullTensorBindingToken {};
+
+}  // namespace binding

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -8,6 +8,7 @@
 
 #include "api/core_local_mem.h"
 #include "api/debug/assert.h"
+#include "api/optional_binding.h"
 #include "api/tensor/tensor_accessor_args.h"
 #include "api/tensor/tensor_binding_token.h"
 
@@ -64,6 +65,22 @@ public:
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");
     }
+
+    // Construct from the stand-in token that try_get_tensor_binding<"name">() yields when the host
+    // bound no such tensor. This overload exists so that the absent branch of such a lookup is
+    // still *well-formed*: a discarded `if constexpr` branch is only left uninstantiated inside a
+    // template, and kernel_main is not a template, so the absent branch is fully type-checked.
+    // Without this overload a kernel could not compile the very branch the lookup exists to let it
+    // write. See api/optional_binding.h.
+    //
+    // The resulting accessor is inert and unreachable: the only way to obtain a
+    // NullTensorBindingToken is by dereferencing the empty optional an absent lookup returns, and
+    // that optional's emptiness is a compile-time constant, so the branch is dead code the compiler
+    // deletes outright. Base address 0 is used rather than an indeterminate value so that a
+    // hypothetical reachable path is caught by the L1 address sanitizer on first access in debug
+    // builds, rather than quietly reading an arbitrary L1 location.
+    [[nodiscard]] explicit LocalTensorAccessor(binding::NullTensorBindingToken) noexcept :
+        LocalTensorAccessor(uint32_t{0}) {}
 
     // Legacy constructor: from a raw node-local L1 base address (a byte address).
     // (Typically a legacy Buffer's address passed into the kernel as a CRTA.)

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -30,6 +30,7 @@ set(HW_JIT_API_HEADERS
     inc/api/tensor/pages_address_iterator.h
     inc/api/tensor/page.h
     inc/api/scratchpad.h
+    inc/api/optional_binding.h
     inc/api/compute/compute_kernel_api.h
     inc/api/compute/add_int_sfpu.h
     inc/api/compute/atan2.h

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -828,8 +828,8 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
     return s;
 }
 
-// Emits args::/dfb::/sem::/tensor:: namespaces into the JIT wrapper, replacing
-// kernel_args_generated.h + kernel_bindings_generated.h that upstream's JIT
+// Emits args::/dfb::/sem::/tensor::/scratch:: namespaces and the optional-binding lookups into the
+// JIT wrapper, replacing kernel_args_generated.h + kernel_bindings_generated.h that upstream's JIT
 // build produces. Must stay text-equivalent to genfiles.cpp's
 // write_kernel_{args,bindings}_generated_header.
 static void emit_metal2_namespaces(
@@ -841,17 +841,29 @@ static void emit_metal2_namespaces(
     if (has_args) {
         f << "#include \"experimental/kernel_args.h\"\n";
     }
-    if (!s.dfb_accessors.empty()) {
-        f << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+    if (s.is_metal2) {
+        // Headers needed by the optional-binding lookups emitted below. Gated on is_metal2 to match
+        // genfiles.cpp, which only writes kernel_bindings_generated.h for Metal 2.0 kernels, and
+        // emitted in this position for the same reason: that is where
+        // write_kernel_bindings_generated_header puts it. It also subsumes the dataflow_buffer.h and
+        // scratchpad.h includes a Metal 2.0 kernel would otherwise get conditionally below, since a
+        // lookup names DFBBindingToken and ScratchpadBindingToken whether or not the kernel binds
+        // one. See OPTIONAL_BINDING_LOOKUP_INCLUDES.
+        f << tt::jit_build::utils::OPTIONAL_BINDING_LOOKUP_INCLUDES;
+    } else {
+        // A legacy kernel gets no lookups, so it needs only the headers its own bindings use.
+        if (!s.dfb_accessors.empty()) {
+            f << "#include \"api/dataflow/dataflow_buffer.h\"\n";
+        }
+        if (!s.scratch_accessors.empty()) {
+            f << "#include \"api/scratchpad.h\"\n";
+        }
     }
     if (!s.sem_accessors.empty()) {
         f << "#include <cstdint>\n";
     }
     if (!s.ta_accessors.empty()) {
         f << "#include \"api/tensor/tensor_binding_token.h\"\n";
-    }
-    if (!s.scratch_accessors.empty()) {
-        f << "#include \"api/scratchpad.h\"\n";
     }
 
     if (has_args) {
@@ -917,6 +929,29 @@ static void emit_metal2_namespaces(
               << "u};\n";
         }
         f << "}  // namespace scratch\n";
+    }
+
+    // Optional-binding lookups — always emitted for Metal 2.0 kernels, including ones that bind
+    // nothing, since "nothing was bound" is an answer the kernel is entitled to ask for. Rendered
+    // by the same shared formatter genfiles.cpp uses, so the two cannot drift.
+    if (s.is_metal2) {
+        std::vector<std::string> ta_names;
+        ta_names.reserve(s.ta_accessors.size());
+        for (const auto& ta : s.ta_accessors) {
+            ta_names.push_back(ta.name);
+        }
+        std::vector<std::string> dfb_names;
+        dfb_names.reserve(s.dfb_accessors.size());
+        for (const auto& dfb : s.dfb_accessors) {
+            dfb_names.push_back(dfb.first);
+        }
+        std::vector<std::string> scratch_names;
+        scratch_names.reserve(s.scratch_accessors.size());
+        for (const auto& sp : s.scratch_accessors) {
+            scratch_names.push_back(sp.name);
+        }
+        f << "\n";
+        f << tt::jit_build::utils::format_optional_binding_lookups(ta_names, dfb_names, scratch_names);
     }
 
     // Vararg helpers — always emitted for Metal 2.0 kernels (mirrors

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -32,6 +32,7 @@
 #include "impl/dispatch/dispatch_core_manager.hpp"
 #include "distributed/mesh_workload_impl.hpp"
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
+#include "tt_metal/hw/inc/api/optional_binding.h"  // binding::MAX_BINDING_NAME_LEN
 #include <core_descriptor.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <variant>
@@ -248,6 +249,28 @@ bool IsValidCppIdentifier(std::string_view s) {
     return !kCppKeywords.contains(s);
 }
 
+// A resource binding's accessor_name is also baked into the device-side optional-binding lookups
+// (try_get_tensor_binding<"name">() and friends), whose template parameter carries a fixed-capacity
+// buffer of binding::MAX_BINDING_NAME_LEN characters. A longer name is silently truncated there, so
+// two names agreeing on their first MAX_BINDING_NAME_LEN characters would become indistinguishable
+// and a lookup would quietly hand back the wrong binding. Reject it here instead, where the failure
+// is loud and names the kernel.
+//
+// Only the three kinds the lookups cover are capped. Semaphores and named CT/RT args are not
+// reachable through a lookup, so their names are not subject to this limit.
+template <typename KernelId>
+void ValidateBindingNameLength(std::string_view name, std::string_view kind, const KernelId& kernel_id) {
+    TT_FATAL(
+        name.size() <= ::binding::MAX_BINDING_NAME_LEN,
+        "Kernel '{}' {} accessor_name '{}' is {} characters long, which exceeds the {}-character "
+        "limit that the device-side binding lookups can distinguish",
+        kernel_id,
+        kind,
+        name,
+        name.size(),
+        ::binding::MAX_BINDING_NAME_LEN);
+}
+
 // ============================================================================
 // Step 1: Spec Collection & Validation
 // ============================================================================
@@ -327,6 +350,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                     "Kernel '{}' DFB accessor_name '{}' must be a valid C++ identifier",
                     kernel.unique_id,
                     dfb_binding.accessor_name);
+                ValidateBindingNameLength(dfb_binding.accessor_name, "DFB", kernel.unique_id);
             } else {
                 TT_FATAL(
                     info.dfb_spec_name == dfb_binding.dfb_spec_name,
@@ -470,6 +494,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' scratchpad accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            ValidateBindingNameLength(binding.accessor_name, "scratchpad", kernel.unique_id);
             TT_FATAL(
                 collected.scratchpad_by_name.contains(binding.scratchpad_spec_name),
                 "Kernel '{}' references unknown scratchpad '{}'",
@@ -525,6 +550,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' tensor accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            ValidateBindingNameLength(binding.accessor_name, "tensor", kernel.unique_id);
             TT_FATAL(
                 collected.tensor_parameter_by_name.contains(binding.tensor_parameter_name),
                 "Kernel '{}' references unknown TensorParameter '{}'",

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -194,74 +194,98 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n";
     if (dfb_entries.empty() && sem_entries.empty() && ta_entries.empty() && scratch_entries.empty()) {
+        // Such a kernel still gets the optional-binding lookups below: they are how it asks whether
+        // a resource was bound, and "nothing was bound" is an answer it is entitled to receive.
         content << "// No bindings for this kernel.\n";
-    } else {
-        if (!dfb_entries.empty()) {
-            content << "#include \"api/dataflow/dataflow_buffer.h\"\n";
-        }
-        if (!sem_entries.empty()) {
-            content << "#include <cstdint>\n";
-        }
-        if (!ta_entries.empty()) {
-            // This header defines TensorBindingToken, a type which can be used
-            // to construct a TensorAccessor or LocalTensorAccessor.
-            content << "#include \"api/tensor/tensor_binding_token.h\"\n";
-        }
-        if (!scratch_entries.empty()) {
-            // The full Scratchpad type (NOC-free, so it compiles on both data-movement and
-            // compute/TRISC builds), which also pulls in the ScratchpadBindingToken type.
-            content << "#include \"api/scratchpad.h\"\n";
-        }
-        content << "\n";
-
-        if (!dfb_entries.empty()) {
-            content << "namespace dfb {\n";
-            for (const auto& [name, id] : dfb_entries) {
-                content << "constexpr DFBBindingToken " << name << "{" << id << "};\n";
-            }
-            content << "}  // namespace dfb\n";
-        }
-
-        if (!sem_entries.empty()) {
-            content << "namespace sem {\n";
-            for (const auto& [name, id] : sem_entries) {
-                content << "constexpr std::uint32_t " << name << " = " << id << "u;\n";
-            }
-            content << "}  // namespace sem\n";
-        }
-
-        if (!ta_entries.empty()) {
-            // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
-            // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
-            // its implicit base-address CRTA.
-            // The kernel-side TensorAccessor (or LocalTensorAccessor) constructor unpacks both pieces.
-            //
-            // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
-            // template with extra metadata in the future without touching kernel source.
-            content << "namespace tensor {\n";
-            for (const auto& entry : ta_entries) {
-                content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset
-                        << "u, " << entry.addr_crta_offset << "u>;\n";
-                content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
-            }
-            content << "}  // namespace tensor\n";
-        }
-
-        if (!scratch_entries.empty()) {
-            // ScratchpadBindingToken scratchpad_accessor_name{ADDR_CRTA_WORD, SIZE_BYTES}
-            // Carries the word index of the scratchpad's (framework-allocated) base-address CRTA
-            // and the scratchpad's compile-time per-node size.
-            // The kernel-side Scratchpad(token) constructor unpacks both.
-            // The token's members are opaque, so the framework can extend it later without touching
-            // kernel source.
-            content << "namespace scratch {\n";
-            for (const auto& entry : scratch_entries) {
-                content << "constexpr ScratchpadBindingToken " << entry.name << "{" << entry.addr_crta_word << "u, "
-                        << entry.size_bytes << "u};\n";
-            }
-            content << "}  // namespace scratch\n";
-        }
     }
+
+    // Unconditional: the optional-binding lookups are emitted for every Metal 2.0 kernel, so the
+    // headers their signatures need are too. This subsumes what used to be conditional includes of
+    // api/dataflow/dataflow_buffer.h (for dfb_entries) and api/scratchpad.h (for scratch_entries) --
+    // a lookup has to name DFBBindingToken and ScratchpadBindingToken whether or not the kernel has
+    // a binding of that kind. See OPTIONAL_BINDING_LOOKUP_INCLUDES.
+    content << jit_build::utils::OPTIONAL_BINDING_LOOKUP_INCLUDES;
+    if (!sem_entries.empty()) {
+        content << "#include <cstdint>\n";
+    }
+    if (!ta_entries.empty()) {
+        // This header defines TensorBindingToken, a type which can be used
+        // to construct a TensorAccessor or LocalTensorAccessor.
+        content << "#include \"api/tensor/tensor_binding_token.h\"\n";
+    }
+    content << "\n";
+
+    if (!dfb_entries.empty()) {
+        content << "namespace dfb {\n";
+        for (const auto& [name, id] : dfb_entries) {
+            content << "constexpr DFBBindingToken " << name << "{" << id << "};\n";
+        }
+        content << "}  // namespace dfb\n";
+    }
+
+    if (!sem_entries.empty()) {
+        content << "namespace sem {\n";
+        for (const auto& [name, id] : sem_entries) {
+            content << "constexpr std::uint32_t " << name << " = " << id << "u;\n";
+        }
+        content << "}  // namespace sem\n";
+    }
+
+    if (!ta_entries.empty()) {
+        // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
+        // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
+        // its implicit base-address CRTA.
+        // The kernel-side TensorAccessor (or LocalTensorAccessor) constructor unpacks both pieces.
+        //
+        // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
+        // template with extra metadata in the future without touching kernel source.
+        content << "namespace tensor {\n";
+        for (const auto& entry : ta_entries) {
+            content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset
+                    << "u, " << entry.addr_crta_offset << "u>;\n";
+            content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
+        }
+        content << "}  // namespace tensor\n";
+    }
+
+    if (!scratch_entries.empty()) {
+        // ScratchpadBindingToken scratchpad_accessor_name{ADDR_CRTA_WORD, SIZE_BYTES}
+        // Carries the word index of the scratchpad's (framework-allocated) base-address CRTA
+        // and the scratchpad's compile-time per-node size.
+        // The kernel-side Scratchpad(token) constructor unpacks both.
+        // The token's members are opaque, so the framework can extend it later without touching
+        // kernel source.
+        content << "namespace scratch {\n";
+        for (const auto& entry : scratch_entries) {
+            content << "constexpr ScratchpadBindingToken " << entry.name << "{" << entry.addr_crta_word << "u, "
+                    << entry.size_bytes << "u};\n";
+        }
+        content << "}  // namespace scratch\n";
+    }
+
+    // The optional-binding lookups, which let a kernel ask whether a resource was bound instead of
+    // naming its token directly. Emitted unconditionally -- a kernel with no DFB bindings still
+    // needs try_get_dfb_binding to exist in order to ask, and that is the case the lookups serve.
+    // Rendered by a shared formatter because the emulated program runner must emit byte-identical
+    // text; see format_optional_binding_lookups.
+    vector<string> ta_names;
+    ta_names.reserve(ta_entries.size());
+    for (const auto& entry : ta_entries) {
+        ta_names.push_back(entry.name);
+    }
+    vector<string> dfb_names;
+    dfb_names.reserve(dfb_entries.size());
+    for (const auto& entry : dfb_entries) {
+        dfb_names.push_back(entry.first);
+    }
+    vector<string> scratch_names;
+    scratch_names.reserve(scratch_entries.size());
+    for (const auto& entry : scratch_entries) {
+        scratch_names.push_back(entry.name);
+    }
+    content << "\n";
+    content << jit_build::utils::format_optional_binding_lookups(ta_names, dfb_names, scratch_names);
+
     write_file(path, content.str());
 }
 

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -253,6 +253,82 @@ std::string format_named_ct_arg_map_header(const std::unordered_map<std::string,
            format_named_ct_arg_map(named_args) + "\n";
 }
 
+namespace {
+
+// The `if constexpr (NAME == ...) {` line opening one arm of a lookup's chain. The first arm opens
+// the chain, each later one closes the previous arm first.
+std::string lookup_arm_opener(bool is_first, const std::string& name) {
+    std::string arm = is_first ? "    if" : "    } else if";
+    arm += " constexpr (NAME == ::binding::Name(\"" + name + "\")) {\n";
+    return arm;
+}
+
+// Emit one lookup whose present-case value type is the same for every binding of its kind, which
+// is the case for DFB and scratchpad bindings. `token_type` is the fully-qualified token type and
+// `ns` the namespace holding the emitted tokens.
+void append_concrete_token_lookup(
+    std::string& out,
+    std::string_view fn_name,
+    std::string_view token_type,
+    std::string_view ns,
+    const std::vector<std::string>& names) {
+    const std::string optional_of = "std::optional<" + std::string(token_type) + ">";
+
+    out += "template <::binding::Name NAME>\n";
+    out += "[[nodiscard]] constexpr " + optional_of + " " + std::string(fn_name) + "() {\n";
+    if (names.empty()) {
+        out += "    // This kernel has no bindings of this kind, so every name is absent.\n";
+        out += "    return " + optional_of + "();\n";
+    } else {
+        for (std::size_t i = 0; i < names.size(); ++i) {
+            out += lookup_arm_opener(/*is_first=*/i == 0, names[i]);
+            out += "        return " + optional_of + "(::" + std::string(ns) + "::" + names[i] + ");\n";
+        }
+        out += "    } else {\n";
+        out += "        return " + optional_of + "();\n";
+        out += "    }\n";
+    }
+    out += "}\n";
+}
+
+// Emit the tensor lookup. Unlike the other two, its present-case return type differs per binding:
+// a tensor binding token is TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>, a distinct type for
+// each binding. Hence the deduced `auto` return type, and hence binding::NullTensorBindingToken --
+// there is no single tensor token type for the absent case to be an empty optional of.
+void append_tensor_lookup(std::string& out, const std::vector<std::string>& names) {
+    out += "template <::binding::Name NAME>\n";
+    out += "[[nodiscard]] constexpr auto try_get_tensor_binding() {\n";
+    if (names.empty()) {
+        out += "    // This kernel has no tensor bindings, so every name is absent.\n";
+        out += "    return std::optional<::binding::NullTensorBindingToken>();\n";
+    } else {
+        for (std::size_t i = 0; i < names.size(); ++i) {
+            out += lookup_arm_opener(/*is_first=*/i == 0, names[i]);
+            out += "        return std::optional<::tensor::" + names[i] + "_t>(::tensor::" + names[i] + ");\n";
+        }
+        out += "    } else {\n";
+        out += "        return std::optional<::binding::NullTensorBindingToken>();\n";
+        out += "    }\n";
+    }
+    out += "}\n";
+}
+
+}  // namespace
+
+std::string format_optional_binding_lookups(
+    const std::vector<std::string>& tensor_binding_names,
+    const std::vector<std::string>& dfb_binding_names,
+    const std::vector<std::string>& scratchpad_binding_names) {
+    std::string out;
+    append_tensor_lookup(out, tensor_binding_names);
+    out += "\n";
+    append_concrete_token_lookup(out, "try_get_dfb_binding", "::DFBBindingToken", "dfb", dfb_binding_names);
+    out += "\n";
+    append_concrete_token_lookup(
+        out, "try_get_scratchpad_binding", "::ScratchpadBindingToken", "scratch", scratchpad_binding_names);
+    return out;
+}
+
 void create_file(const std::string& file_path_str) {
     namespace fs = std::filesystem;
 

--- a/tt_metal/jit_build/jit_build_utils.hpp
+++ b/tt_metal/jit_build/jit_build_utils.hpp
@@ -76,6 +76,51 @@ std::string format_named_ct_arg_map(const std::unordered_map<std::string, std::u
 // Full contents of NAMED_CT_ARG_MAP_HEADER for |named_args|.
 std::string format_named_ct_arg_map_header(const std::unordered_map<std::string, std::uint32_t>& named_args);
 
+// The #include lines that kernel_bindings_generated.h must always carry, regardless of what the
+// kernel binds, so that format_optional_binding_lookups()'s output below compiles.
+//
+// api/optional_binding.h supplies binding::Name, binding::NullTensorBindingToken and <optional>.
+//
+// The other two are the homes of DFBBindingToken and ScratchpadBindingToken. A lookup names its
+// token type in its return type even for a kernel with no bindings of that kind -- which is
+// precisely the case the lookups exist to serve -- so both headers are needed unconditionally,
+// where previously each was included only when the kernel had a binding of that kind. That does
+// mean every Metal 2.0 kernel now sees the full DataflowBuffer and Scratchpad definitions; both are
+// already guarded for TRISC (see the COMPILE_FOR_TRISC branches in dataflow_buffer.h and the
+// trisc.cc symbols that exist so TRISC kernels including DFB headers link cleanly), so this is a
+// configuration the headers already support.
+inline constexpr std::string_view OPTIONAL_BINDING_LOOKUP_INCLUDES =
+    "#include \"api/optional_binding.h\"\n"
+    "#include \"api/dataflow/dataflow_buffer.h\"\n"
+    "#include \"api/scratchpad.h\"\n";
+
+// Render the three optional-binding lookups that every Metal 2.0 kernel's
+// kernel_bindings_generated.h carries:
+//
+//   try_get_tensor_binding<"name">()      -> std::optional<::tensor::name_t>
+//                                            or std::optional<::binding::NullTensorBindingToken>
+//   try_get_dfb_binding<"name">()         -> std::optional<::DFBBindingToken>
+//   try_get_scratchpad_binding<"name">()  -> std::optional<::ScratchpadBindingToken>
+//
+// These let a kernel ask whether the host bound a given resource instead of naming its token
+// directly, which is what makes a genuinely optional kernel parameter expressible: a token exists
+// only if the host bound it, so naming an unbound one is a compile error, whereas asking for an
+// unbound name here just yields an empty optional. Emptiness is a compile-time constant, so the
+// absent branch is provably dead and the compiler removes it. See hw/inc/api/optional_binding.h
+// for the full rationale and the typo trade-off it accepts.
+//
+// The lookups are emitted for EVERY Metal 2.0 kernel, including one that binds nothing at all --
+// a kernel with no DFB bindings still needs try_get_dfb_binding to exist in order to ask.
+//
+// Each name list must be the accessor names already emitted into the corresponding namespace
+// (`tensor`, `dfb`, `scratch`) of the same header, in the same order: the tensor lookup refers to
+// the per-binding `<name>_t` aliases emitted alongside those tokens. Names are host-validated C++
+// identifiers (ProgramSpec::IsValidCppIdentifier), so they need no escaping here.
+std::string format_optional_binding_lookups(
+    const std::vector<std::string>& tensor_binding_names,
+    const std::vector<std::string>& dfb_binding_names,
+    const std::vector<std::string>& scratchpad_binding_names);
+
 void create_file(const std::string& file_path_str);
 
 // Read the entire contents of a binary file into a byte vector.


### PR DESCRIPTION
### Problem

A Metal 2.0 kernel's resources arrive as codegen-emitted namespace-scope tokens — `tensor::x`, `dfb::x`, `scratch::x`. A token is emitted **only if the host bound that resource to that kernel**, so merely *naming* an unbound resource is a compile error. There is currently no way to express a kernel parameter the host may or may not supply; the only workaround is a host-set `-D` plus an `#ifdef` in the kernel.

### Approach

This implements **option 3** of the optional-memory-construct-arguments design notes — the device-side lookup, chosen there for the lowest implementation and maintenance burden ("self-contained in genfile"). The host `ProgramSpec` API is untouched and still lists only what actually exists.

Every Metal 2.0 kernel's `kernel_bindings_generated.h` now carries three name-keyed lookups:

```cpp
try_get_tensor_binding<"name">()      -> std::optional<::tensor::name_t>
                                         // or std::optional<::binding::NullTensorBindingToken>
try_get_dfb_binding<"name">()         -> std::optional<::DFBBindingToken>
try_get_scratchpad_binding<"name">()  -> std::optional<::ScratchpadBindingToken>
```

They are emitted **unconditionally**, including for a kernel that binds nothing at all — "nothing was bound" is an answer the kernel is entitled to ask for, and that is the case the lookups exist to serve.

A kernel then writes:

```cpp
constexpr auto gamma = try_get_dfb_binding<"gamma">();
if constexpr (gamma.has_value()) {
    DataflowBuffer g(*gamma);
    // ... fused path
}
```

Two properties make this work:

- **`constexpr`** — emptiness is a compile-time constant, so the absent branch is *provably dead* rather than ill-formed. Both the plain runtime `if` and `if constexpr` idioms are supported.
- **class-type NTTP** (`binding::Name`) rather than a runtime string — a runtime name could defeat inlining, which the design notes call out as a performance risk.

### What each resource kind needed

| Kind | Change |
|---|---|
| **DFB** | none — `DFBBindingToken` is one concrete type, so the optional's type is uniform |
| **Scratchpad** | none — same, `ScratchpadBindingToken` |
| **LocalTensorAccessor** | a null stand-in token + one constructor |

The tensor path is the odd one out because each binding has its own `TensorBindingToken<CTA, ADDR>` specialization. The absent arm therefore needs a stand-in type (`binding::NullTensorBindingToken`), and `LocalTensorAccessor` needs a constructor taking it — a discarded `if constexpr` branch is only left *uninstantiated* inside a template, and `kernel_main` is not a template, so the absent branch is still fully type-checked. Without that overload a kernel could not compile the very branch the lookup exists to let it write.

### One consequence worth flagging

The generated file's include block is now **unconditional**. A lookup names `DFBBindingToken` / `ScratchpadBindingToken` in its return type whether or not the kernel binds a resource of that kind — which is exactly the case the lookups exist to serve — so `api/dataflow/dataflow_buffer.h` and `api/scratchpad.h` are now included for **every** Metal 2.0 kernel, where previously each was included only when the kernel had a binding of that kind.

Both headers already support that configuration: `dataflow_buffer.h` has `COMPILE_FOR_TRISC` branches, and `trisc.cc` defines symbols specifically "so kernels that include dataflow_buffer headers link cleanly". So this is a supported shape, not a new one — but it does mean more preprocessing per kernel, and it is the part of this PR most worth a second opinion.

### Anti-drift

`genfiles.cpp` and `emulated_program_runner.cpp` both emit these namespaces and must stay text-equivalent, and today they do so by duplicating the emission text. The rendering here lives in one shared formatter in `tt::jit_build::utils` (`format_optional_binding_lookups` + `OPTIONAL_BINDING_LOOKUP_INCLUDES`) that both call, so the two paths cannot diverge.

### Accepted trade-off

**A misspelled name compiles and reports absent forever.** This is the con the design notes explicitly accept for option 3. A kernel that genuinely requires a binding can pin it:

```cpp
static_assert(try_get_tensor_binding<"in">().has_value(), "kernel requires tensor binding \"in\"");
```

### Host-side name-length cap (new)

`binding::Name` carries a fixed-capacity buffer, and its constructor silently truncates past `MAX_BINDING_NAME_LEN` (63). Two names agreeing on their first 63 characters would therefore become **indistinguishable** in a lookup, which would quietly hand back the wrong binding — a silent wrong answer, materially worse than the accepted "typo → always absent" above.

There was **no prior length limit** on accessor names: `IsValidCppIdentifier` checks only the character set. So `ProgramSpec` validation now rejects an over-long **tensor / DFB / scratchpad** `accessor_name` up front, where the failure is loud and names the kernel. Semaphores and named CT/RT args are not reachable through a lookup and are deliberately not capped. `program_spec.cpp` includes `optional_binding.h`, so the host check and the device buffer cannot drift.

### Known limitation / follow-up

`TensorAccessor` (the NOC/global accessor) is **not** covered — only `LocalTensorAccessor`. `TensorAccessor` is CTAD-based on a `DSpec`, so an absent arm would need a synthetic DSpec deduction guide, which is a materially bigger change than the rest of this PR. That does partly limit the canonical optional-`gamma` layernorm case when gamma is a DRAM tensor. Worth doing as a follow-up.

### Validation

- `genfiles.cpp`, `jit_build_utils.cpp` and the new test TU all pass `-fsyntax-only` clean under the project's own compile flags (`-std=c++20 -Wall -Werror`).
- **Generated code compiles on the real toolchain.** The formatter's actual output was fed through the pinned **sfpi 7.70.0** with the production device flag set (`-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval -ftt-no-dyninit -ffast-math ... -Wall -Werror`) for three scenarios — nothing bound / partial / all three kinds — using the same optional-parameter kernel source in each case. All compile clean.
- **Presence and absence fold away entirely.** `objdump` of those three objects, where the expected sums were 7000 / 4003 / 17:

  ```
  nothing bound:  lui a0,0x2; addi a0,a0,-1192  # 0x1b58 = 7000
  partial:        lui a0,0x1; addi a0,a0,-93    # 0x0fa3 = 4003
  all three:      li  a0,17
  ```

  Three instructions each — every lookup resolved at compile time and every absent branch deleted outright. Zero runtime cost.
- New unit tests in `tests/tt_metal/tt_metal/jit_build/test_optional_binding_lookups.cpp`: exact emitted text per kind (the spelling is the contract, and it is what the emule path must reproduce), independence of the three kinds, arm-order stability (this text feeds a per-object dephash cache), `constexpr`/`[[nodiscard]]` on every lookup, include-block coverage, and an end-to-end compile of the emitted lookups asserting presence/absence resolves at compile time (against the real `api/optional_binding.h`; the three token types are stood in for, since all three real ones are device-only).

- The host cap is covered by two new `test_program_spec.cpp` cases beside the existing `IsValidCppIdentifier` smoke test: a 64-character name is rejected, and a name at exactly the 63-character limit is accepted (the boundary itself is legal).

`emulated_program_runner.cpp` was **not** locally syntax-checked — it is gated on `TT_METAL_USE_EMULE` and so appears in no `compile_commands.json`. The change there is three name-extraction loops plus two calls to a signature already proven to compile, in a TU that already uses `tt::jit_build::utils::format_named_ct_arg_map`. Leaving that to CI.

`program_spec.cpp` and `test_program_spec.cpp` could not be locally syntax-checked either, for a different reason: both reach `llrt/hal.hpp`, which includes the CMake-generated `hal/generated/dev_msgs.hpp` — a file that does not exist without a configured build. Verified that this failure is **identical on the pristine baseline**, i.e. not introduced here. Instead the two new pieces were checked in isolation with the real flag sets: the `ValidateBindingNameLength` helper compiles verbatim against the real `TT_FATAL` and real fmt (which validates the format string's arity at compile time), and the new test's include of `api/optional_binding.h` plus its `MAX_BINDING_NAME_LEN` expressions compile under the test target's own flags. A runtime check of the predicate confirms 1/8/62/63 accepted and 64/200 rejected.

Not linkable end-to-end locally (no build tree in this environment), hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
