### PR TITLE
[Bug Fix] Fix dangling Buffer/AllocatorImpl pointers

### DIFF
--- a/tests/tt_metal/tt_metal/device/sources.cmake
+++ b/tests/tt_metal/tt_metal/device/sources.cmake
@@ -10,4 +10,5 @@ set(UNIT_TESTS_DEVICE_SMOKE_SOURCES
     test_galaxy_cluster_api.cpp
     test_mock_device_api.cpp
     test_mock_allocator.cpp
+    test_buffer_allocator_lifetime.cpp
 )

--- a/tests/tt_metal/tt_metal/device/test_buffer_allocator_lifetime.cpp
+++ b/tests/tt_metal/tt_metal/device/test_buffer_allocator_lifetime.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Buffer holds a non-owning allocator pointer, while the allocator tracks live buffers.
+// These lifetime invariants are architecture-independent, so the tests run under mock.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/graph_tracking.hpp>
+#include <tt-metalium/mesh_config.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/system_mesh.hpp>
+
+#include <umd/device/types/arch.hpp>
+
+#include "impl/device/mock_device_util.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+constexpr DeviceAddr kBufferSize = 2048;
+
+class BufferAllocatorLifetimeTest : public ::testing::Test {
+protected:
+    std::unique_ptr<MetalEnv> env_;
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
+
+    void SetUp() override {
+        env_ = std::make_unique<MetalEnv>(
+            MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::WORMHOLE_B0, 1)));
+        mesh_device_ = env_->create_mesh_device(distributed::MeshDeviceConfig(env_->get_system_mesh().shape()));
+        ASSERT_GT(mesh_device_->num_devices(), 0u);
+    }
+
+    void TearDown() override {
+        mesh_device_.reset();
+        env_.reset();
+    }
+
+    IDevice* device() { return mesh_device_->get_devices()[0]; }
+};
+
+// Models a graph capture that begins after allocation and suppresses deallocation.
+class DeallocateBlockingHooks : public IGraphHooks {
+public:
+    bool hook_allocate(const Buffer*) override { return false; }
+    bool hook_deallocate(Buffer*) override { return true; }
+    bool hook_program(Program*) override { return false; }
+    bool hook_write_to_device(const Buffer*) override { return false; }
+    bool hook_write_to_device(const distributed::MeshBuffer*) override { return false; }
+    bool hook_read_from_device(Buffer*) override { return false; }
+    bool hook_read_from_device(const distributed::MeshBuffer*) override { return false; }
+};
+
+}  // namespace
+
+// Buffers that outlive their allocator must be marked deallocated before its pointer dangles.
+TEST_F(BufferAllocatorLifetimeTest, BufferOutlivingItsAllocatorIsMarkedDeallocated) {
+    auto buffer = Buffer::create(device(), kBufferSize, kBufferSize, BufferType::DRAM);
+    ASSERT_TRUE(buffer->is_allocated());
+
+    mesh_device_.reset();
+
+    EXPECT_FALSE(buffer->is_allocated())
+        << "buffer still claims to be allocated after its allocator was destroyed; destroying it "
+           "will dereference the dangling allocator_";
+
+    // Destroyed here: without the fix this is the dangling call.
+    buffer.reset();
+}
+
+// Hook-suppressed deallocation must still remove a real buffer from allocator tracking.
+TEST_F(BufferAllocatorLifetimeTest, HookSuppressedDeallocateUntracksBuffer) {
+    const auto& allocator = device()->allocator();
+    const size_t baseline = allocator->get_allocated_buffers().size();
+
+    auto buffer = Buffer::create(device(), kBufferSize, kBufferSize, BufferType::DRAM);
+    ASSERT_EQ(allocator->get_allocated_buffers().size(), baseline + 1)
+        << "buffer was not registered with the allocator; the rest of this test proves nothing";
+
+    auto hooks = std::make_shared<DeallocateBlockingHooks>();
+    ASSERT_TRUE(GraphTracker::instance().add_hook(hooks));
+    buffer.reset();
+    GraphTracker::instance().clear_hook();
+
+    EXPECT_EQ(allocator->get_allocated_buffers().size(), baseline)
+        << "hook-suppressed deallocation left a dangling Buffer* in the allocator's tracking set";
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -249,6 +249,11 @@ void AllocatorImpl::deallocate_buffer(Buffer* buffer) {
     allocated_buffers_.erase(buffer);
 }
 
+void AllocatorImpl::untrack_buffer(Buffer* buffer) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    allocated_buffers_.erase(buffer);
+}
+
 void AllocatorImpl::deallocate_buffers() {
     std::lock_guard<std::mutex> lock(mutex_);
     dram_manager_->deallocate_all();
@@ -536,6 +541,13 @@ AllocatorImpl::~AllocatorImpl() {
     l1_manager_->clear();
     l1_small_manager_->clear();
     trace_buffer_manager_->clear();
+    // Mark live buffers deallocated before their non-owning allocator pointer dangles.
+    // A tracked Buffer must be removed through deallocate_buffer() or untrack_buffer() before
+    // destruction; mark_as_deallocated() may only be called while its allocator is tearing down
+    // or after it is gone.
+    for (auto* buffer : allocated_buffers_) {
+        buffer->mark_as_deallocated();
+    }
     allocated_buffers_.clear();
 }
 

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -44,6 +44,9 @@ public:
     void deallocate_buffer(Buffer* buffer);
     void deallocate_buffers();
 
+    // Stop tracking a buffer without deallocating its banks.
+    void untrack_buffer(Buffer* buffer);
+
     std::unordered_set<Buffer*> get_allocated_buffers() const;
     size_t get_num_allocated_buffers() const;
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -636,7 +636,7 @@ void Buffer::deallocate_impl() {
         return;
     }
 
-    if (device_->is_initialized() && size_ != 0) {
+    if (size_ != 0 && device_->is_initialized()) {
         // address_ is only modified from this thread, no sync required
         GraphTracker::instance().track_deallocate(this);
         if (!GraphTracker::instance().hook_deallocate(this) && !hooked_allocation_) {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -658,6 +658,10 @@ void Buffer::deallocate_impl() {
                 }
             }
             allocator_->deallocate_buffer(this);
+        } else if (!hooked_allocation_) {
+            // The hook suppresses bank deallocation, but this real allocation must still be
+            // untracked before the Buffer is destroyed.
+            allocator_->untrack_buffer(this);
         }
 
         // Capture deallocates here instead of higher levels.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
A Buffer holds a raw, non-owning pointer to its allocator. If it outlives the allocator, destroying it calls through that dangling pointer.

### What changed
- Mark live buffers deallocated before their allocator is destroyed, preventing calls through dangling allocator and device pointers.
- Untrack real buffers when graph hooks suppress bank deallocation.
- Add hardware-free regression tests for allocator teardown and hook-suppressed deallocation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ckaravasilisTT/bufferDealloc01)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ckaravasilisTT/bufferDealloc01)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ckaravasilisTT/bufferDealloc01)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ckaravasilisTT/bufferDealloc01)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ckaravasilisTT/bufferDealloc01)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ckaravasilisTT/bufferDealloc01)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ckaravasilisTT/bufferDealloc01)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ckaravasilisTT/bufferDealloc01)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ckaravasilisTT/bufferDealloc01)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ckaravasilisTT/bufferDealloc01)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ckaravasilisTT/bufferDealloc01)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ckaravasilisTT/bufferDealloc01)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ckaravasilisTT/bufferDealloc01)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ckaravasilisTT/bufferDealloc01)