### PR TITLE
[Fabric] Temporarily remove non-default handshake NoC test

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -413,8 +413,7 @@ void FabricUnicastCommon(
     NocPacketType noc_packet_type,
     const std::vector<std::tuple<RoutingDirection, uint32_t /*num_hops*/>>& pair_ordered_dirs,
     FabricApiType api_type = FabricApiType::Linear,
-    bool with_state = false,
-    bool use_non_default_handshake_noc = false);
+    bool with_state = false);
 
 void UDMFabricUnicastCommon(
     BaseFabricFixture* fixture,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
@@ -67,13 +67,7 @@ void kernel_main() {
 
     auto route_id = PacketHeaderPool::allocate_header_n(num_send_dir);
     tt::tt_fabric::RoutingPlaneConnectionManager connections;
-#ifdef TEST_NON_DEFAULT_HANDSHAKE_NOC
-    // Exercise the explicit template path with the NoC opposite the helper's default.
-    constexpr uint8_t worker_handshake_noc = 1 - tt::tt_fabric::get_fabric_worker_noc();
-    open_connections<worker_handshake_noc>(connections, num_send_dir, rt_arg_idx);
-#else
     open_connections(connections, num_send_dir, rt_arg_idx);
-#endif
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -378,11 +372,7 @@ void kernel_main() {
     }
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
-#ifdef TEST_NON_DEFAULT_HANDSHAKE_NOC
-    close_connections<worker_handshake_noc>(connections);
-#else
     close_connections(connections);
-#endif
 
     noc_async_write_barrier();
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -1882,15 +1882,6 @@ TEST_F(Galaxy1x32Fabric1DFixture, TestUnicastRaw_AllHops) {
 }
 
 TEST_F(Fabric1DFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
-TEST_F(Fabric1DFixture, TestUnicastNonDefaultHandshakeNoc) {
-    FabricUnicastCommon(
-        this,
-        NocPacketType::NOC_UNICAST_WRITE,
-        {std::make_tuple(RoutingDirection::E, 1)},
-        FabricApiType::Linear,
-        false,
-        true);
-}
 TEST_F(Fabric1DFixture, TestUnicastConnAPIDRAM) { RunTestUnicastConnAPI(this, 1, RoutingDirection::E, true); }
 TEST_F(Fabric1DFixture, TestUnicastTGGateways) { RunTestUnicastTGGateways(this); }
 TEST_F(Fabric1DFixture, TestMCastConnAPI) { RunTestMCastConnAPI(this); }
@@ -2105,8 +2096,7 @@ void FabricUnicastCommon(
     NocPacketType noc_packet_type,
     const std::vector<std::tuple<RoutingDirection, uint32_t>>& pair_ordered_dirs,
     FabricApiType api_type,
-    bool with_state,
-    bool use_non_default_handshake_noc) {
+    bool with_state) {
     tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
     tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     uint32_t num_packets = 10;
@@ -2186,11 +2176,6 @@ void FabricUnicastCommon(
         worker_mem_map.packet_payload_size_bytes = 4;
     }
 
-    std::map<std::string, std::string> sender_defines;
-    if (use_non_default_handshake_noc) {
-        sender_defines["TEST_NON_DEFAULT_HANDSHAKE_NOC"] = "1";
-    }
-
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
         (noc_packet_type == NocPacketType::NOC_FUSED_UNICAST_ATOMIC_INC ||
@@ -2202,8 +2187,7 @@ void FabricUnicastCommon(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args,
-            .defines = sender_defines});
+            .compile_args = compile_time_args});
 
     std::vector<uint32_t> sender_runtime_args = {
         worker_mem_map.source_l1_buffer_address,


### PR DESCRIPTION
#### Summary

- Remove `Fabric1DFixture.TestUnicastNonDefaultHandshakeNoc`.
- Remove the test-only kernel define and fixture plumbing used by that test.
- Leave the production handshake-NoC API from #50506 unchanged.


Fixes #54026.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkodkani/54026-remove-handshake-noc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkodkani/54026-remove-handshake-noc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkodkani/54026-remove-handshake-noc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkodkani/54026-remove-handshake-noc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkodkani/54026-remove-handshake-noc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkodkani/54026-remove-handshake-noc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkodkani/54026-remove-handshake-noc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkodkani/54026-remove-handshake-noc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkodkani/54026-remove-handshake-noc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkodkani/54026-remove-handshake-noc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkodkani/54026-remove-handshake-noc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkodkani/54026-remove-handshake-noc-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkodkani/54026-remove-handshake-noc-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkodkani/54026-remove-handshake-noc-test)