### PR TITLE
fix(sfpu): add overflow guard to fp32 exp2 kernel to return +inf for x >= 128

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_exp2.py
@@ -193,6 +193,52 @@ def test_exp2_fp32_special_values(device):
 # to +inf before the tensor reaches the SFPU (same root cause as the xfail in
 # tests/.../test_fmod.py: "NaN is packed as inf for ttnn.bfloat16"), so a
 # device-side NaN-propagation test is not expressible at this dtype.
+
+def test_exp2_fp32_overflow_range(device):
+    """Regression test for #54054: exp2(x) must return +inf for x >= 128.
+
+    The kernel's setexp path previously overwrote the correct +inf with NaN
+    (for x in [128, 128.5)) or wrapped finite garbage (for x >= 128.5).
+    """
+    # Cover the exact boundary, the NaN-producing range [128, 128.5),
+    # and representative points across the wrapped-garbage range.
+    input_tensor = torch.tensor(
+        [
+            127.999,
+            128.0,
+            128.001,
+            128.25,
+            128.4999,
+            128.5,
+            129.0,
+            160.0,
+            200.0,
+            255.0,
+            256.0,
+            300.0,
+            1000.0,
+            float("inf"),
+        ],
+        dtype=torch.float32,
+    ).reshape(1, 1, -1)
+
+    tt_in = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.exp2(tt_in)
+    result = ttnn.to_torch(tt_result).reshape(-1)
+
+    for i, x in enumerate(input_tensor.reshape(-1).tolist()):
+        assert torch.isposinf(result[i]), (
+            f"exp2({x}): expected +inf, got {result[i].item()}"
+        )
+
+
 def test_exp2_special_values(device):
     # Tile must be 32x32; pack edge-case scalars then pad the rest of the tile
     # with a value (0.0) whose result is known and stable.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -52,7 +52,13 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_fp32_accurate_(sfpi::vFloat x) {
         // e < 255
         v_block {
             sfpi::vInt e_lt_255 = __builtin_rvtt_sfpiadd_i(e.get(), -255, sfpi::SFPIADD_MOD1_CC_LT0);
-            y = sfpi::setexp(r, e);
+            // Only rebuild via setexp when the biased exponent is representable.
+            // For e >= 255, y already holds inf (from r * inf above); overwriting
+            // it with setexp would produce NaN or wrapped garbage.
+            v_if(e_lt_255 < 0) {
+                y = sfpi::setexp(r, e);
+            }
+            v_endif;
             // e < 1
             v_if(e_lt_255 < -254) {
                 // Underflow, including subnormals.

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -52,7 +52,13 @@ sfpi_inline sfpi::vFloat _sfpu_exp2_fp32_accurate_(sfpi::vFloat x) {
         // e < 255
         v_block {
             sfpi::vInt e_lt_255 = __builtin_rvtt_sfpiadd_i(e.get(), -255, sfpi::SFPIADD_MOD1_CC_LT0);
-            y = sfpi::setexp(r, e);
+            // Only rebuild via setexp when the biased exponent is representable.
+            // For e >= 255, y already holds inf (from r * inf above); overwriting
+            // it with setexp would produce NaN or wrapped garbage.
+            v_if(e_lt_255 < 0) {
+                y = sfpi::setexp(r, e);
+            }
+            v_endif;
             // e < 1
             v_if(e_lt_255 < -254) {
                 // Underflow, including subnormals.


### PR DESCRIPTION
/claim #54054

Fixes #54054

## Root Cause

`_sfpu_exp2_fp32_accurate_` unconditionally calls `setexp(r, e)` even when the biased exponent `e >= 255`. For x in [128, 128.5) this produces NaN; for x >= 128.5 the 8-bit exponent wraps and returns finite garbage (e.g. `exp2(256) = 1.0`).

The correct overflow result (`+inf`) was already computed by `y *= infinity()` one line earlier but was then overwritten by the unconditional `setexp`.

## Fix

Wraps `setexp(r, e)` in a `v_if(e_lt_255 < 0)` guard on both wormhole_b0 and blackhole. When the exponent is representable (< 255), the result is rebuilt via setexp as before; when it overflows, the precomputed `+inf` is preserved.

## Test

Adds `test_exp2_fp32_overflow_range` covering x in {127.999, 128.0, 128.001, 128.25, 128.4999, 128.5, 129.0, 160.0, 200.0, 255.0, 256.0, 300.0, 1000.0, inf} — all must return +inf.
