### PR TITLE
[Bug fix] Fix off-by-one DRAM shard grid in test_llama_mlp_width_sharded_to_interleaved_pcc_err

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1631,7 +1631,7 @@ def test_llama_mlp_width_sharded_to_interleaved_pcc_err(device, seq_len):
         {
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(device.dram_grid_size().x, 0),
+                ttnn.CoreCoord(device.dram_grid_size().x - 1, 0),
             ),
         }
     )


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #54035
Closes #54036

`test_llama_mlp_width_sharded_to_interleaved_pcc_err` builds its DRAM shard grid with

```python
ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device.dram_grid_size().x, 0))
```

`CoreRange` end coordinates are inclusive, so this asks for `dram_grid_size().x + 1` cores — one past the last DRAM bank. That is core `(12, 0)` on wh_n150 and `(8, 0)` on bh_p150b, exactly the cores the two CI failures name.

The extra core never held a shard: the shard widths immediately below divide the tensor over `dram_grid_size().x` banks, so it was inert padding on the end of the spec. It stayed invisible until #53263 started validating each shard core against the allocator's banks, which turned it into a hard `TT_FATAL`. Hence the regression timeline in both issues pointing at a commit that only touched `buffer.cpp`.

The off-by-one itself came in with #23064, which replaced the hardcoded `CoreCoord(11, 0)` (WH) / `CoreCoord(7, 0)` (BH) with a device-derived value and dropped the `-1`.

Restoring the `-1` reproduces the original geometry exactly on both architectures — the derived shard widths land on the same constants the hardcoded grids were paired with before #23064:

| | banks | `w1_w3` width | `w2` width |
|---|---|---|---|
| WH | 12 | `nearest_32(3584/12)` = 320 | `nearest_32(4096/12)` = 352 |
| BH | 8 | `nearest_32(3584/8)` = 448 | `nearest_32(4096/8)` = 512 |

### Notes for reviewers

**This does not weaken what the test covers.** The test is the regression repro from #15113, "Fix s2i op when shard grid is larger than actual used grid" — so it is fair to ask whether the oversized grid was the point. It was not. The oversized grid under test is the **L1 matmul output** grid, which the ops derive internally from the in0 grids (`CoreGrid(x=8, y=4)` feeding a 28-core matmul, then `CoreGrid(x=7, y=4)` feeding a 26-core one); both are untouched here. The `assert passing_input` line is the actual detector — `tt_input` is a bystander L1 tensor checked after the `sharded_to_interleaved` to prove it wasn't stomped. The **DRAM weight grid** was always exactly bank-sized in every prior revision of this test.

Verified on a local p100a, which has 7 DRAM banks:

- Before: `TT_FATAL ... shard core (7, 0) has no DRAM bank on this device, which has 7 of them` — same signature as the CI failures, at the local bank count.
- After: `PASSED`, with `w2_out` PCC 0.9997, `input` PCC 0.99997, `residual` PCC 0.9996.

p100a is not either of the CI configs (wh_n150, bh_p150b), so this validates the mechanism rather than those exact geometries — the table above is the argument that the other two bank counts are also restored to their pre-#23064 values.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-dram-shard-grid-off-by-one)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-dram-shard-grid-off-by-one)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-dram-shard-grid-off-by-one)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-dram-shard-grid-off-by-one)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-dram-shard-grid-off-by-one)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-dram-shard-grid-off-by-one)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-dram-shard-grid-off-by-one)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-dram-shard-grid-off-by-one)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-dram-shard-grid-off-by-one)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-dram-shard-grid-off-by-one)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-dram-shard-grid-off-by-one)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-dram-shard-grid-off-by-one)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-dram-shard-grid-off-by-one)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-dram-shard-grid-off-by-one)