### PR TITLE
fix(ttnn): prevent overflow in addcdiv by changing evaluation order

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -489,3 +489,19 @@ def test_ternary_addcmul_cache_hit_refreshes_operand_addresses(device):
     assert_with_pcc(reference(2), ttnn.to_torch(out1).float(), 0.99)
 
     device.disable_and_clear_program_cache()
+
+def test_addcdiv_overflow(device):
+    # Regression test for ttnn.addcdiv scaling overflow issue #54055
+    in0 = torch.tensor([0.0] * 32 * 32, dtype=torch.float32).reshape(1, 1, 32, 32)
+    in1 = torch.tensor([3.0e38] * 32 * 32, dtype=torch.float32).reshape(1, 1, 32, 32)
+    in2 = torch.tensor([8.0] * 32 * 32, dtype=torch.float32).reshape(1, 1, 32, 32)
+    
+    in0_dev = ttnn.from_torch(in0, layout=ttnn.TILE_LAYOUT, device=device)
+    in1_dev = ttnn.from_torch(in1, layout=ttnn.TILE_LAYOUT, device=device)
+    in2_dev = ttnn.from_torch(in2, layout=ttnn.TILE_LAYOUT, device=device)
+    
+    got = ttnn.addcdiv(in0_dev, in1_dev, in2_dev, value=4.0)
+    got = ttnn.to_torch(got)
+    ref = torch.addcdiv(in0, in1, in2, value=4.0)
+    
+    assert torch.allclose(got, ref)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -32,7 +32,7 @@ inline void calculate_addcdiv(
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        sfpi::vFloat result = in0 + ((in1 * sfpu_reciprocal_iter<2>(in2)) * value_float);
         if constexpr (!is_fp32_dest_acc_en) {
             result = float32_to_bf16_rne(result);
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -34,7 +34,7 @@ inline void calculate_addcdiv(
         sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
         sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
-        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        sfpi::vFloat result = in0 + ((in1 * sfpu_reciprocal_iter<2>(in2)) * value_float);
         if constexpr (!is_fp32_dest_acc_en) {
             result = float32_to_bf16_rne(result);
         }


### PR DESCRIPTION
Fixes #54055. 

Matches torch's divide-first evaluation order to prevent intermediate overflow to infinity when the product of the numerator and value is extremely large.