### PR TITLE
[skip ci] Suppress noisy bug-check comments on automatic (non-actionable) runs

### DIFF
--- a/.github/bug_checker/__main__.py
+++ b/.github/bug_checker/__main__.py
@@ -53,6 +53,15 @@ def main() -> int:
         help="Post findings as PR comments (requires --pr).",
     )
     parser.add_argument(
+        "--quiet-if-clean",
+        action="store_true",
+        help=(
+            "Skip posting a PR comment when the run has nothing to report "
+            "(no findings, no failed rules, no truncated-diff warnings). "
+            "Findings, failures, and truncation warnings still post normally."
+        ),
+    )
+    parser.add_argument(
         "--labels",
         type=str,
         nargs="*",
@@ -129,6 +138,7 @@ def main() -> int:
                 pr_info=pr_info,
                 sarif_path=sarif_path,
                 post_comments=args.post_comments,
+                suppress_empty_result=args.quiet_if_clean,
             )
     except BugCheckFailed:
         return 1

--- a/.github/bug_checker/orchestrator.py
+++ b/.github/bug_checker/orchestrator.py
@@ -28,6 +28,7 @@ def run_bug_check(
     pr_info: PRInfo,
     sarif_path: Optional[Path] = None,
     post_comments: bool = False,
+    suppress_empty_result: bool = False,
 ) -> list[Finding]:
     """Run all matching rules against a PR and produce output.
 
@@ -35,6 +36,10 @@ def run_bug_check(
         pr_info: PR metadata including diff, changed files, and labels.
         sarif_path: If set, write SARIF output to this path.
         post_comments: If True, post findings as PR comments.
+        suppress_empty_result: If True, skip posting a PR comment when there is
+            nothing to report (no findings, no failed rules, no truncated-diff
+            warnings). Used for automatic (non-comment-triggered) runs so a clean
+            PR doesn't get a "no issues found" comment with no actionable signal.
 
     Returns:
         List of all findings.
@@ -46,7 +51,7 @@ def run_bug_check(
     if not matched_rules:
         logger.info("No rules matched this PR.")
         print_findings([])
-        if post_comments:
+        if post_comments and not suppress_empty_result:
             post_pr_comment(
                 pr_number=pr_info.number,
                 body="## Bug Checker\nNo rules matched the files in this PR — nothing to check." + RERUN_FOOTER,
@@ -68,7 +73,9 @@ def run_bug_check(
             write_sarif([], failed_rules, sarif_path)
             logger.info(f"SARIF output written to {sarif_path}")
         if post_comments:
-            _post_findings_as_comments(pr_info, [], failed_rules, [], rule_paths)
+            _post_findings_as_comments(
+                pr_info, [], failed_rules, [], rule_paths, suppress_empty_result=suppress_empty_result
+            )
         raise BugCheckFailed("Bug Checker failed during LLM setup") from e
 
     all_findings: list[Finding] = []
@@ -131,7 +138,14 @@ def run_bug_check(
 
     # Output: PR comments
     if post_comments:
-        _post_findings_as_comments(pr_info, all_findings, failed_rules, truncated_rules, rule_paths)
+        _post_findings_as_comments(
+            pr_info,
+            all_findings,
+            failed_rules,
+            truncated_rules,
+            rule_paths,
+            suppress_empty_result=suppress_empty_result,
+        )
 
     if failed_rules:
         raise BugCheckFailed(
@@ -349,6 +363,7 @@ def _post_findings_as_comments(
     failed_rules: list[str],
     truncated_rules: list[str],
     rule_paths: dict[str, str],
+    suppress_empty_result: bool = False,
 ) -> None:
     """Post findings as PR comments (inline where valid, general otherwise) plus a summary."""
     valid_diff_lines = diff_line_numbers(pr_info.diff)
@@ -382,6 +397,10 @@ def _post_findings_as_comments(
             logger.warning(f"Failed to post comment for {finding.rule_id} at {finding.file}:{finding.line}: {e}")
 
     logger.info(f"Comments: {inline_posted} inline, {general_posted} general, {failed} failed")
+
+    if suppress_empty_result and not findings and not failed_rules and not truncated_rules:
+        logger.info("Nothing to report and suppress_empty_result is set — skipping summary comment.")
+        return
 
     # Post summary comment
     try:

--- a/.github/bug_checker/tests/test_orchestrator.py
+++ b/.github/bug_checker/tests/test_orchestrator.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bug_checker.github_client import PRInfo
+from bug_checker.llm import Finding
 from bug_checker.orchestrator import BugCheckFailed, _filter_diff_for_rule, run_bug_check
 from bug_checker.output import RERUN_FOOTER
 from bug_checker.rules import Rule
@@ -171,3 +172,192 @@ def test_run_bug_check_no_matched_rules_comment_has_rerun_footer(mock_load, mock
     body = mock_post.call_args[1]["body"]
     assert "No rules matched the files in this PR" in body
     assert body.endswith(RERUN_FOOTER)
+
+
+@patch("bug_checker.orchestrator.post_pr_comment")
+@patch("bug_checker.orchestrator.select_rules")
+@patch("bug_checker.orchestrator.load_rules")
+def test_run_bug_check_suppresses_no_rules_matched_comment_when_quiet(mock_load, mock_select, mock_post):
+    """suppress_empty_result=True means an automatic run with no matched rules
+    posts nothing at all — that comment has no actionable signal."""
+    mock_load.return_value = [_rule(["foo/**"])]
+    mock_select.return_value = []
+
+    pr = PRInfo(
+        number=99,
+        title="Test PR",
+        base_sha="aaa",
+        head_sha="bbb",
+        diff="",
+        changed_files=["docs/readme.md"],
+        labels=[],
+    )
+
+    result = run_bug_check(pr, post_comments=True, suppress_empty_result=True)
+    assert result == []
+    mock_post.assert_not_called()
+
+
+@patch("bug_checker.orchestrator.post_pr_comment")
+@patch("bug_checker.orchestrator.LLMSession")
+@patch("bug_checker.orchestrator.select_rules")
+@patch("bug_checker.orchestrator.load_rules")
+def test_run_bug_check_suppresses_summary_when_quiet_and_clean(mock_load, mock_select, mock_llm_cls, mock_post):
+    """suppress_empty_result=True with matched rules but zero findings, zero
+    failures, and zero truncated rules posts no summary comment either."""
+    rule = _rule(["foo/**"])
+    mock_load.return_value = [rule]
+    mock_select.return_value = [rule]
+
+    mock_session = MagicMock()
+    mock_session.analyze_rule.return_value = []
+    mock_llm_cls.side_effect = [MagicMock(), mock_session]
+
+    pr = PRInfo(
+        number=99,
+        title="Test PR",
+        base_sha="aaa",
+        head_sha="bbb",
+        diff=DIFF_TWO_FILES,
+        changed_files=["foo/bar.cpp"],
+        labels=[],
+    )
+
+    result = run_bug_check(pr, post_comments=True, suppress_empty_result=True)
+    assert result == []
+    mock_post.assert_not_called()
+
+
+@patch("bug_checker.orchestrator.post_pr_comment")
+@patch("bug_checker.orchestrator.LLMSession")
+@patch("bug_checker.orchestrator.select_rules")
+@patch("bug_checker.orchestrator.load_rules")
+def test_run_bug_check_still_posts_findings_when_quiet(mock_load, mock_select, mock_llm_cls, mock_post):
+    """suppress_empty_result=True must never hide real findings — only the
+    genuinely-empty case is silenced."""
+    rule = _rule(["foo/**"])
+    mock_load.return_value = [rule]
+    mock_select.return_value = [rule]
+
+    finding = Finding(
+        rule_id="test-rule",
+        file="foo/bar.cpp",
+        line=1,
+        message="Something is wrong here.",
+        severity="warning",
+    )
+    mock_session = MagicMock()
+    mock_session.analyze_rule.return_value = [finding]
+    mock_llm_cls.side_effect = [MagicMock(), mock_session]
+
+    pr = PRInfo(
+        number=99,
+        title="Test PR",
+        base_sha="aaa",
+        head_sha="bbb",
+        diff=DIFF_TWO_FILES,
+        changed_files=["foo/bar.cpp"],
+        labels=[],
+    )
+
+    result = run_bug_check(pr, post_comments=True, suppress_empty_result=True)
+    assert result == [finding]
+    # One inline comment (line 1 is in the diff) plus the summary comment.
+    assert mock_post.call_count == 2
+    summary_body = mock_post.call_args_list[-1][1]["body"]
+    assert "Bug Checker Results" in summary_body
+
+
+@patch("bug_checker.orchestrator.post_pr_comment")
+@patch("bug_checker.orchestrator.LLMSession")
+@patch("bug_checker.orchestrator.select_rules")
+@patch("bug_checker.orchestrator.load_rules")
+def test_run_bug_check_still_posts_failure_when_quiet(mock_load, mock_select, mock_llm_cls, mock_post):
+    """suppress_empty_result=True must never hide a failed analysis — silence is
+    only for the genuinely-clean case, never for a broken run."""
+    rule = _rule(["foo/**"])
+    mock_load.return_value = [rule]
+    mock_select.return_value = [rule]
+
+    mock_session = MagicMock()
+    mock_session.analyze_rule.side_effect = RuntimeError("rate limited")
+    mock_llm_cls.side_effect = [MagicMock(), mock_session]
+
+    pr = PRInfo(
+        number=99,
+        title="Test PR",
+        base_sha="aaa",
+        head_sha="bbb",
+        diff=DIFF_TWO_FILES,
+        changed_files=["foo/bar.cpp", "baz/qux.cpp"],
+        labels=[],
+    )
+
+    with patch("bug_checker.orchestrator.print_failure"):
+        with pytest.raises(BugCheckFailed):  # allow-pytest.raises: not a device error
+            run_bug_check(pr, post_comments=True, suppress_empty_result=True)
+
+    mock_post.assert_called_once()
+    body = mock_post.call_args[1]["body"]
+    assert "Bug Checker Failed" in body
+
+
+@patch("bug_checker.orchestrator.post_pr_comment")
+@patch("bug_checker.orchestrator.LLMSession")
+@patch("bug_checker.orchestrator.select_rules")
+@patch("bug_checker.orchestrator.load_rules")
+def test_run_bug_check_still_posts_truncated_warning_when_quiet(mock_load, mock_select, mock_llm_cls, mock_post):
+    """suppress_empty_result=True must never hide a truncated-diff warning —
+    only a genuinely clean run (no findings/failures/truncations) is silenced."""
+    rule = _rule(["foo/**"])
+    mock_load.return_value = [rule]
+    mock_select.return_value = [rule]
+    mock_llm_cls.return_value = MagicMock()
+
+    pr = PRInfo(
+        number=99,
+        title="Test PR",
+        base_sha="aaa",
+        head_sha="bbb",
+        diff="",
+        changed_files=["foo/bar.cpp"],
+        labels=[],
+        truncated_files=["foo/bar.cpp"],
+    )
+
+    result = run_bug_check(pr, post_comments=True, suppress_empty_result=True)
+    assert result == []
+    mock_post.assert_called_once()
+    body = mock_post.call_args[1]["body"]
+    assert "truncated" in body.lower()
+
+
+@patch("bug_checker.orchestrator.post_pr_comment")
+@patch("bug_checker.orchestrator.LLMSession")
+@patch("bug_checker.orchestrator.select_rules")
+@patch("bug_checker.orchestrator.load_rules")
+def test_run_bug_check_still_posts_llm_setup_failure_when_quiet(mock_load, mock_select, mock_llm_cls, mock_post):
+    """suppress_empty_result=True must never hide an LLM-setup (preflight)
+    failure — distinct code path from the per-rule failure covered above."""
+    rule = _rule(["foo/**"])
+    mock_load.return_value = [rule]
+    mock_select.return_value = [rule]
+    mock_llm_cls.side_effect = RuntimeError("bad config")
+
+    pr = PRInfo(
+        number=99,
+        title="Test PR",
+        base_sha="aaa",
+        head_sha="bbb",
+        diff=DIFF_TWO_FILES,
+        changed_files=["foo/bar.cpp"],
+        labels=[],
+    )
+
+    with patch("bug_checker.orchestrator.print_failure"):
+        with pytest.raises(BugCheckFailed):  # allow-pytest.raises: not a device error
+            run_bug_check(pr, post_comments=True, suppress_empty_result=True)
+
+    mock_post.assert_called_once()
+    body = mock_post.call_args[1]["body"]
+    assert "Bug Checker Failed" in body

--- a/.github/workflows/bug-check.yaml
+++ b/.github/workflows/bug-check.yaml
@@ -136,6 +136,10 @@ jobs:
 
     steps:
       - name: Post running notice
+        # Automatic (pull_request-triggered) runs skip this: an "I'm running" ack
+        # with no findings yet is noise. Manual /bug-check comment runs keep it as
+        # confirmation the command was received.
+        if: github.event_name == 'issue_comment'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}
@@ -194,6 +198,7 @@ jobs:
           PR_NUMBER: ${{ needs.parse-comment.outputs.pr-number }}
           SUBCOMMAND: ${{ needs.parse-comment.outputs.subcommand }}
           RULE_ID: ${{ needs.parse-comment.outputs.rule-id }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           cmd=(python .github/bug_checker/run_bug_checker.py)
           cmd+=(--pr "$PR_NUMBER")
@@ -203,6 +208,13 @@ jobs:
           fi
           if [ "$SUBCOMMAND" = "run" ] || [ "$SUBCOMMAND" = "check-rule" ]; then
             cmd+=(--sarif .github/bug-checker-results.sarif)
+          fi
+          # Automatic (pull_request-triggered) runs shouldn't post a comment when
+          # there's nothing to report — that's noise without signal. Manual
+          # /bug-check comment runs keep posting "no issues found" etc. as
+          # confirmation the command ran.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            cmd+=(--quiet-if-clean)
           fi
           cmd+=(--post-comments --verbose)
           "${cmd[@]}"


### PR DESCRIPTION
## Problem

Automatic (`pull_request`-triggered) bug-check runs currently post two low-value comments even when there's nothing actionable:

1. An **"I'm running"** acknowledgment (`**Bug Checker** — scanning PR for known bug patterns…`) before analysis even starts.
2. A **zero-findings result** (`No issues found.` / `No rules matched the files in this PR — nothing to check.`) when the run had nothing to report.

Neither carries any signal on a clean, automatically-triggered run — see [#51572](https://github.com/tenstorrent/tt-metal/pull/51572) for a real example of both.

## Fix

Both changes apply **only to automatic (`github.event_name == 'pull_request'`) runs**. Manual `/bug-check` comment-triggered runs are completely unchanged — the running notice and zero-findings comments both still post there, since they act as confirmation that the command was received and ran.

1. `.github/workflows/bug-check.yaml`: the "Post running notice" step now has `if: github.event_name == 'issue_comment'`, so it only fires for manual comment-triggered runs.
2. Added a `--quiet-if-clean` CLI flag to `bug_checker`, passed by the workflow only when `github.event_name == 'pull_request'`. It threads a `suppress_empty_result` bool through `run_bug_check()` / `_post_findings_as_comments()` in `orchestrator.py`: when set, and there are **zero findings, zero failed rules, and zero truncated-rule warnings**, no PR comment is posted at all. If there are findings, failures, or truncation warnings, comments post exactly as before — those are real signal, not noise.

## Testing

- Added 6 new tests to `test_orchestrator.py` covering: no-matched-rules+quiet (no comment), matched-but-clean+quiet (no comment), findings-present+quiet (comment still posts), per-rule-failure+quiet (still posts), LLM-setup-failure+quiet (still posts), and truncated-rules-only+quiet (still posts) — the last two specifically verify the flag can never silently swallow a real failure or truncation warning.
- `black --check` clean, all 29 tests in `test_orchestrator.py` + `test_commands.py` pass.
- Validated `bug-check.yaml` parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by an independent Opus pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/bug-check-quiet-if-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/bug-check-quiet-if-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/bug-check-quiet-if-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/bug-check-quiet-if-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/bug-check-quiet-if-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/bug-check-quiet-if-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/bug-check-quiet-if-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/bug-check-quiet-if-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/bug-check-quiet-if-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/bug-check-quiet-if-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/bug-check-quiet-if-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/bug-check-quiet-if-clean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/bug-check-quiet-if-clean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/bug-check-quiet-if-clean)