### PR TITLE
[Feature] [Blackhole] matmul: opt-in fused greedy-argmax epilogue on the DRAM-sharded decode path (fused_argmax_partials)

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_fused_argmax.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_fused_argmax.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ttnn.matmul(..., fused_argmax_partials=...): the opt-in fused
+greedy-argmax epilogue on the Blackhole DRAM-sharded decode matmul (LM-head
+path). TRISC2 scans the freshly packed bf16 logit tiles in the pack shadow
+and each DRAM-bank worker emits a 32 x (global_index, bf16_value_bits)
+partials page; the final reduce is num_banks compares per row on host.
+
+Gating: the fused epilogue kernel JIT-compiles with the in-tree opt-in
+(ComputeConfigDescriptor::enable_trisc2_rvv, which adds zve32f to the TRISC2
+compile). Compile-side coverage runs device-free in CI
+(tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp); these tests execute
+on silicon, so they stay behind TT_ENABLE_RVV_TESTS=1 until a Blackhole
+runner picks them up; otherwise they skip.
+"""
+
+import math
+import os
+
+import numpy as np
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import is_blackhole
+
+pytestmark = [
+    pytest.mark.skipif(not is_blackhole(), reason="matmul fused_argmax_partials is Blackhole-only (TRISC2 Zve32f)"),
+    pytest.mark.skipif(
+        os.environ.get("TT_ENABLE_RVV_TESTS") != "1",
+        reason="RVV device-test gate: set TT_ENABLE_RVV_TESTS=1 to run the fused-argmax tests on a Blackhole device",
+    ),
+]
+
+TILE = 32
+
+
+def _bf16_bits(t: torch.Tensor) -> np.ndarray:
+    return t.contiguous().view(torch.int16).numpy().astype(np.uint16)
+
+
+def _mono(x: np.ndarray) -> np.ndarray:
+    """Monotone image of the bfloat16_greater sign-magnitude total order."""
+    x = x.astype(np.uint16)
+    return np.where(x & 0x8000, x ^ 0xFFFF, x | 0x8000).astype(np.uint16)
+
+
+_MONO_NEG_INF = int(_mono(np.array([0xFF80], dtype=np.uint16))[0])  # 0x007F
+
+
+def _reference_argmax_row(bits_row: np.ndarray):
+    """Incumbent semantics: bfloat16_greater order, smallest index, -inf init."""
+    m = _mono(bits_row)
+    idx = int(m.argmax())  # first occurrence of the max
+    if int(m[idx]) <= _MONO_NEG_INF:
+        return 0, 0xFF80
+    return idx, int(bits_row[idx])
+
+
+def _combine_partials(partials: np.ndarray, valid_rows: int, shard_w_tiles: int, valid_n_tiles: int):
+    """Host-side final reduce: num_banks (idx, val) pairs -> 1 per row.
+    Ascending bank order + first-max keeps the lowest global index on ties."""
+    num_banks = partials.shape[0]
+    nvalid = min(num_banks, (valid_n_tiles + shard_w_tiles - 1) // shard_w_tiles)
+    idx = partials[:nvalid, 0::2].astype(np.int64)  # [w, 32]
+    raw = (partials[:nvalid, 1::2] & 0xFFFF).astype(np.uint16)  # [w, 32]
+    m = _mono(raw)
+    w_best = np.argmax(m, axis=0)  # first max = lowest bank
+    out = []
+    for r in range(valid_rows):
+        if int(m[w_best[r], r]) <= _MONO_NEG_INF:
+            out.append((0, 0xFF80))
+        else:
+            out.append((int(idx[w_best[r], r]), int(raw[w_best[r], r])))
+    return out
+
+
+def _find_largest_divisor(n, max_divisor=8):
+    for d in range(max_divisor, 0, -1):
+        if n % d == 0:
+            return d
+    return 1
+
+
+def _lm_head_storage_grid(k):
+    """Mirror model_config's lm_head_core_grid derivation (8x8 down)."""
+    rows, cols = 8, 8
+    while k % (TILE * rows * cols) != 0:
+        rows -= 1
+        if rows == 0:
+            cols -= 1
+            rows = 8
+            assert cols > 0
+    return ttnn.CoreGrid(y=rows, x=cols)
+
+
+def _dram_sharded_setup(device, torch_in0, torch_w, in1_dtype):
+    """Production DRAM-sharded LM-head matmul operands + config
+    (models/tt_transformers lm_head semantics)."""
+    k = torch_in0.shape[-1]
+    v = torch_w.shape[-1]
+    assert torch_w.shape[-2] == k
+    nb = device.dram_grid_size().x
+    n_padded = math.ceil(v / (TILE * nb)) * (TILE * nb)
+    grid = _lm_head_storage_grid(k)
+    nc = grid.num_cores
+
+    in0_mem = ttnn.create_sharded_memory_config(
+        (1, 1, TILE, k),
+        core_grid=grid,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    in0_t = ttnn.from_torch(
+        torch_in0.bfloat16(), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in0_mem
+    )
+
+    in1_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(nb - 1, 0))})
+    in1_spec = ttnn.ShardSpec(in1_grid, (k, n_padded // nb), ttnn.ShardOrientation.ROW_MAJOR)
+    in1_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_spec)
+    in1_t = ttnn.from_torch(
+        torch_w.bfloat16(), dtype=in1_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in1_mem
+    )
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=_find_largest_divisor(k // TILE // nc),
+        per_core_M=1,
+        per_core_N=math.ceil(v / (TILE * nc)),
+        fused_activation=None,
+    )
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2 if in1_dtype == ttnn.bfloat16 else ttnn.MathFidelity.LoFi,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+    out_mem = ttnn.MemoryConfig(memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED, buffer_type=ttnn.BufferType.L1)
+    return dict(
+        in0_t=in0_t,
+        in1_t=in1_t,
+        program_config=program_config,
+        compute_config=compute_config,
+        out_mem=out_mem,
+        nb=nb,
+        shard_w_tiles=n_padded // TILE // nb,
+        valid_n_tiles=v // TILE,
+        valid_rows=torch_in0.shape[-2],
+    )
+
+
+def _fresh_partials(device, nb):
+    return ttnn.from_torch(
+        torch.zeros(1, 1, nb, 64, dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _run_fused(device, torch_in0, torch_w, in1_dtype):
+    """Run plain and fused matmul; return (plain bits, fused bits, combined
+    (idx, val) per row, setup dict)."""
+    s = _dram_sharded_setup(device, torch_in0, torch_w, in1_dtype)
+    kwargs = dict(
+        program_config=s["program_config"],
+        memory_config=s["out_mem"],
+        dtype=ttnn.bfloat16,
+        compute_kernel_config=s["compute_config"],
+    )
+    plain = ttnn.matmul(s["in0_t"], s["in1_t"], **kwargs)
+    partials = _fresh_partials(device, s["nb"])
+    fused = ttnn.matmul(s["in0_t"], s["in1_t"], fused_argmax_partials=partials, **kwargs)
+
+    plain_bits = _bf16_bits(ttnn.to_torch(plain))
+    fused_bits = _bf16_bits(ttnn.to_torch(fused))
+    # Device truth at logical extent (defensive 4D slice like the campaign harness).
+    v = torch_w.shape[-1]
+    logits_bits = _bf16_bits(ttnn.to_torch(fused)[0, 0, : s["valid_rows"], :v])
+    part = ttnn.to_torch(partials).numpy().astype(np.uint32).reshape(s["nb"], 64)
+    combined = _combine_partials(part, s["valid_rows"], s["shard_w_tiles"], s["valid_n_tiles"])
+    return plain_bits, fused_bits, logits_bits, combined, s
+
+
+def _check_case(device, torch_in0, torch_w, in1_dtype):
+    plain_bits, fused_bits, logits, combined, s = _run_fused(device, torch_in0, torch_w, in1_dtype)
+
+    # 1. Logits byte-identical with the epilogue on vs off.
+    assert np.array_equal(plain_bits, fused_bits), "fused epilogue changed the logits bytes"
+
+    # 2. Combined (idx, value-bits) bit-exact against the incumbent-semantics
+    # host reference computed from the same device logits (valid region only).
+    rows = s["valid_rows"]
+    for r in range(rows):
+        ref_idx, ref_val = _reference_argmax_row(logits[r])
+        got_idx, got_val = combined[r]
+        assert (got_idx, got_val) == (
+            ref_idx,
+            ref_val,
+        ), f"row {r}: got (idx={got_idx}, val={got_val:#06x}), want (idx={ref_idx}, val={ref_val:#06x})"
+
+
+K = 1024
+
+
+@pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["bf16", "bfp8"])
+@pytest.mark.parametrize("rows", [1, 32], ids=["b1", "b32"])
+def test_matmul_fused_argmax_random(device, in1_dtype, rows):
+    torch.manual_seed(1000 + rows)
+    v = 4096
+    torch_in0 = torch.randn(1, 1, rows, K) * 0.5
+    torch_w = torch.randn(1, 1, K, v) * 0.5
+    _check_case(device, torch_in0, torch_w, in1_dtype)
+
+
+def test_matmul_fused_argmax_planted_and_ties(device):
+    """Planted max columns at worker seams and cross-worker ties: the lowest
+    GLOBAL index must win, matching the incumbent rule across cores."""
+    torch.manual_seed(7)
+    v = 4096
+    nb_cols = v // 8  # columns per DRAM-bank worker at nb=8
+    torch_in0 = torch.randn(1, 1, 1, K) * 0.1
+    torch_w = torch.randn(1, 1, K, v) * 0.1
+    boost = torch_in0.flatten() * 4.0
+    # A strong column right at the worker 3 / worker 4 seam, and an identical
+    # copy in worker 6: worker-3's (lower global index) must win the combine.
+    for col in (4 * nb_cols - 1, 4 * nb_cols, 6 * nb_cols + 17):
+        torch_w[0, 0, :, col] = boost
+    _check_case(device, torch_in0, torch_w, ttnn.bfloat16)
+
+
+def test_matmul_fused_argmax_padded_vocab_no_leak(device):
+    """V not a multiple of TILE*num_banks: bank-pad tiles are zero-weight, so
+    with all-negative valid logits any scan leak past the logical width would
+    win with 0.0. The scan must stop at the logical width."""
+    torch.manual_seed(11)
+    v = 2080  # 65 tiles over 8 banks -> last worker holds valid + pad tiles
+    torch_in0 = torch.rand(1, 1, 1, K) * 0.5 + 0.1  # positive
+    torch_w = -(torch.rand(1, 1, K, v) * 0.5 + 0.1)  # negative -> all logits < 0
+    _check_case(device, torch_in0, torch_w, ttnn.bfloat16)
+
+
+def test_matmul_fused_argmax_off_path_unchanged(device):
+    """Without the flag the op must behave exactly as before (and produce the
+    same bytes as with the flag, which test cases above already assert)."""
+    torch.manual_seed(3)
+    v = 4096
+    torch_in0 = torch.randn(1, 1, 1, K) * 0.5
+    torch_w = torch.randn(1, 1, K, v) * 0.5
+    s = _dram_sharded_setup(device, torch_in0, torch_w, ttnn.bfloat16)
+    kwargs = dict(
+        program_config=s["program_config"],
+        memory_config=s["out_mem"],
+        dtype=ttnn.bfloat16,
+        compute_kernel_config=s["compute_config"],
+    )
+    out_a = ttnn.matmul(s["in0_t"], s["in1_t"], **kwargs)
+    out_b = ttnn.matmul(s["in0_t"], s["in1_t"], **kwargs)
+    assert np.array_equal(_bf16_bits(ttnn.to_torch(out_a)), _bf16_bits(ttnn.to_torch(out_b)))

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax_rvv.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax_rvv.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ttnn.argmax(..., use_rvv=True): the opt-in Blackhole TILE-layout
+last-dim argmax path that runs the reduction on TRISC2's Zve32f vector unit.
+
+Gating: the RVV kernels JIT-compile with the in-tree opt-in
+(ComputeConfigDescriptor::enable_trisc2_rvv, which adds zve32f to the TRISC2
+compile). Compile-side coverage runs device-free in CI
+(tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp); these tests execute
+on silicon, so they stay behind TT_ENABLE_RVV_TESTS=1 until a Blackhole
+runner picks them up; otherwise they skip.
+"""
+
+import os
+
+import numpy as np
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import is_blackhole
+
+pytestmark = [
+    pytest.mark.skipif(not is_blackhole(), reason="ttnn.argmax use_rvv=True is Blackhole-only (TRISC2 Zve32f)"),
+    pytest.mark.skipif(
+        os.environ.get("TT_ENABLE_RVV_TESTS") != "1",
+        reason="RVV device-test gate: set TT_ENABLE_RVV_TESTS=1 to run the RVV argmax tests on a Blackhole device",
+    ),
+]
+
+
+def _monotone(bits: np.ndarray) -> np.ndarray:
+    """Monotone uint image of the bfloat16_greater sign-magnitude total order."""
+    bits = bits.astype(np.uint32)
+    return np.where(bits >= 0x8000, (~bits) & 0xFFFF, bits | 0x8000).astype(np.uint32)
+
+
+_MONO_NEG_INF = 0x007F  # monotone(0xFF80): the incumbent argmax kernel's -inf init
+
+
+def _ref_argmax_row(bits_row: np.ndarray):
+    """Incumbent ttnn.argmax semantics: bfloat16_greater total order, smallest
+    index on ties, -inf init (a row that never beats -inf reports (0, 0xFF80))."""
+    m = _monotone(bits_row)
+    if int(m.max()) <= _MONO_NEG_INF:
+        return 0, 0xFF80
+    i = int(np.argmax(m))  # first occurrence == smallest-index tie-break
+    return i, int(bits_row[i])
+
+
+def _bits_of(t: torch.Tensor) -> np.ndarray:
+    return t.contiguous().view(torch.int16).numpy().astype(np.uint16)
+
+
+def _make_case(name: str, v: int, b: int, rng: np.random.Generator) -> np.ndarray:
+    """Row-major [b, v] bf16 bit patterns for one battery case."""
+    x = rng.standard_normal((b, v), dtype=np.float32) * 4.0
+    bits = _bits_of(torch.from_numpy(x).bfloat16()).reshape(b, v)
+    kmax, kdecoy = 0x7F7F, 0x7F7E  # largest finite bf16 + decoy the RNG cannot reach
+    if name == "random":
+        pass
+    elif name == "unique_max":
+        bits[:, 5 * v // 8] = kmax
+        bits[:, v // 3] = kdecoy
+    elif name == "tie_first_wins":
+        bits[:, 5 * v // 8] = kmax
+        bits[:, 7 * v // 8] = kmax
+    elif name == "max_at_end":
+        bits[:, v - 1] = kmax
+    elif name == "max_at_zero":
+        bits[:, 0] = kmax
+    elif name == "denormal":
+        small = rng.integers(0, 0x0080, size=(b, v), dtype=np.uint16)  # denormals and +/-0
+        sign = (rng.integers(0, 2, size=(b, v), dtype=np.uint16) << 15).astype(np.uint16)
+        bits = (small | sign).astype(np.uint16)
+    elif name == "nan_bearing":
+        bits[:, v // 4] = 0x7FC0  # +NaN sorts above +inf in the bit order
+        bits[:, v // 2] = 0xFFC0  # -NaN payload sorts below -inf
+    elif name == "all_negative":
+        bits = (bits | 0x8000).astype(np.uint16)
+        bits[bits == 0xFF80] = 0xBF80  # avoid accidental -inf
+    elif name == "all_neginf":
+        bits = np.full((b, v), 0xFF80, dtype=np.uint16)  # the -inf init corner
+    else:
+        raise ValueError(name)
+    return bits
+
+
+CASES = [
+    "random",
+    "unique_max",
+    "tie_first_wins",
+    "max_at_end",
+    "max_at_zero",
+    "denormal",
+    "nan_bearing",
+    "all_negative",
+    "all_neginf",
+]
+
+
+@pytest.mark.parametrize("v", [2048, 8192])
+@pytest.mark.parametrize("b", [1, 5, 32])
+@pytest.mark.parametrize("keepdim", [True, False])
+@pytest.mark.parametrize("with_maxval", [True, False])
+def test_argmax_rvv_battery(device, v, b, keepdim, with_maxval):
+    """Bit-exact index (and optional max-value bits) against the incumbent
+    semantics across planted-max / tie / special-value cases."""
+    rng = np.random.default_rng(1234 + v + 100 * b)
+    for name in CASES:
+        bits = _make_case(name, v, b, rng)
+        x = torch.from_numpy(bits.astype(np.int16)).view(torch.bfloat16).reshape(1, 1, b, v)
+
+        t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        mv = None
+        if with_maxval:
+            out_shape = (1, 1, b, 1) if keepdim else (1, 1, b)
+            mv = ttnn.from_torch(
+                torch.zeros(out_shape, dtype=torch.bfloat16),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+            )
+
+        idx_t = ttnn.argmax(t_tile, dim=3, keepdim=keepdim, use_rvv=True, maxval_tensor=mv)
+        got_idx = ttnn.to_torch(idx_t).flatten().numpy().astype(np.uint32)
+        got_val = _bits_of(ttnn.to_torch(mv).flatten()) if with_maxval else None
+
+        for r in range(b):
+            ref_idx, ref_val = _ref_argmax_row(bits[r])
+            assert int(got_idx[r]) == ref_idx, f"case {name} row {r}: idx {int(got_idx[r])} != {ref_idx}"
+            if with_maxval:
+                assert int(got_val[r]) == ref_val, f"case {name} row {r}: val {int(got_val[r]):#06x} != {ref_val:#06x}"
+
+
+@pytest.mark.parametrize("v", [4096])
+@pytest.mark.parametrize("b", [1, 32])
+def test_argmax_rvv_matches_upstream_tile_path(device, v, b):
+    """Index cross-check against the incumbent ttnn.argmax on the same TILE tensor."""
+    torch.manual_seed(v + b)
+    x = torch.randn(1, 1, b, v).bfloat16()
+    t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    idx_rvv = ttnn.to_torch(ttnn.argmax(t_tile, dim=3, keepdim=True, use_rvv=True))
+    idx_ref = ttnn.to_torch(ttnn.argmax(t_tile, dim=3, keepdim=True))
+    assert torch.equal(idx_rvv.to(torch.int64), idx_ref.to(torch.int64))
+
+
+def test_argmax_rvv_rejects_row_major_input(device, expect_error):
+    """use_rvv=True is a TILE-layout path; ROW_MAJOR input must be rejected."""
+    x = torch.randn(1, 1, 32, 2048).bfloat16()
+    t_rm = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    with expect_error(RuntimeError, "requires TILE layout input"):
+        ttnn.argmax(t_rm, dim=3, keepdim=True, use_rvv=True)

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax_rvv.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax_rvv.py
@@ -101,7 +101,10 @@ CASES = [
 ]
 
 
-@pytest.mark.parametrize("v", [2048, 8192])
+# v boundaries: 32 = single tile (chunk_pages = min(64, w_tiles) = 1);
+# 2016 = 63 tiles, exercising the w_tiles - tiles_done < chunk_pages remainder
+# branch; 2048/8192 = exact multiples of the 64-tile chunk.
+@pytest.mark.parametrize("v", [32, 2016, 2048, 8192])
 @pytest.mark.parametrize("b", [1, 5, 32])
 @pytest.mark.parametrize("keepdim", [True, False])
 @pytest.mark.parametrize("with_maxval", [True, False])
@@ -135,17 +138,23 @@ def test_argmax_rvv_battery(device, v, b, keepdim, with_maxval):
                 assert int(got_val[r]) == ref_val, f"case {name} row {r}: val {int(got_val[r]):#06x} != {ref_val:#06x}"
 
 
-@pytest.mark.parametrize("v", [4096])
+@pytest.mark.parametrize("name", CASES)
+@pytest.mark.parametrize("v", [32, 2016, 4096])
 @pytest.mark.parametrize("b", [1, 32])
-def test_argmax_rvv_matches_upstream_tile_path(device, v, b):
-    """Index cross-check against the incumbent ttnn.argmax on the same TILE tensor."""
-    torch.manual_seed(v + b)
-    x = torch.randn(1, 1, b, v).bfloat16()
+def test_argmax_rvv_matches_upstream_tile_path(device, name, v, b):
+    """Index cross-check against the incumbent ttnn.argmax on the same TILE
+    tensor — not just random data: every planted-max / tie / special-value
+    case from CASES runs through both paths."""
+    rng = np.random.default_rng(42 + v + 100 * b)
+    bits = _make_case(name, v, b, rng)
+    x = torch.from_numpy(bits.astype(np.int16)).view(torch.bfloat16).reshape(1, 1, b, v)
     t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     idx_rvv = ttnn.to_torch(ttnn.argmax(t_tile, dim=3, keepdim=True, use_rvv=True))
     idx_ref = ttnn.to_torch(ttnn.argmax(t_tile, dim=3, keepdim=True))
-    assert torch.equal(idx_rvv.to(torch.int64), idx_ref.to(torch.int64))
+    assert torch.equal(
+        idx_rvv.to(torch.int64), idx_ref.to(torch.int64)
+    ), f"RVV/incumbent index mismatch on case {name!r} (v={v}, b={b})"
 
 
 def test_argmax_rvv_rejects_row_major_input(device, expect_error):

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/compute_throttle_utils.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -75,8 +76,16 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     bool skip_compute,
     bool skip_in0_mcast,
     bool skip_write_back,
-    bool row_broadcast_bias) {
+    bool row_broadcast_bias,
+    // Fused greedy-argmax epilogue (opt-in, Blackhole): preallocated UINT32 partials tensor
+    // ([1,1,num_dram_banks,64]) + the LOGICAL extent of the scan (valid output columns in
+    // tiles / valid output rows). nullopt => byte-identical to the plain path.
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> fused_argmax_partials = {},
+    uint32_t fused_argmax_valid_n_tiles = 0,
+    uint32_t fused_argmax_valid_rows = 0) {
     using namespace tt;
+
+    const bool fused_argmax = fused_argmax_partials.has_value();
 
     ttsl::optional_reference<const tt::tt_metal::MeshTensor> bias;
     if (bias_tensor.has_value()) {
@@ -339,6 +348,15 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         in1_sender_writer_compile_time_args.push_back((std::uint32_t)1);
     }
 
+    // Fused argmax: one 64-word partials page per worker (32 rows x (index, value bits)).
+    constexpr uint32_t fused_argmax_partials_page_bytes = 64 * sizeof(uint32_t);
+    if (fused_argmax) {
+        // Bias is excluded by validation, so these sit at fixed compile-time-arg indices 9 (page
+        // size) and 10.. (accessor args) — the kernel parses them there under FUSED_ARGMAX.
+        in1_sender_writer_compile_time_args.push_back(fused_argmax_partials_page_bytes);
+        tt::tt_metal::TensorAccessorArgs(*fused_argmax_partials).append_to(in1_sender_writer_compile_time_args);
+    }
+
     std::map<std::string, std::string> mm_kernel_defines;
     std::map<std::string, std::string> mm_kernel_in0_sender_define;
     std::map<std::string, std::string> mm_kernel_in1_sender_writer_defines;
@@ -374,6 +392,13 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
     mm_kernel_defines["MATMUL_DRAM_SHARDED"] = "1";
     if (in1_transpose_tile) {
         mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+    if (fused_argmax) {
+        // Pack-RISC RVV argmax scan of the freshly packed output tiles (compute kernel) +
+        // per-worker partials write-out (in1 sender/writer kernel). The compute kernel opts
+        // into TRISC2 RVV codegen below (ComputeConfigDescriptor::enable_trisc2_rvv).
+        mm_kernel_defines["FUSED_ARGMAX"] = "1";
+        mm_kernel_in1_sender_writer_defines["FUSED_ARGMAX"] = "1";
     }
 
     const uint32_t num_compute_cores = all_cores_in_rect_grid.num_cores();
@@ -426,6 +451,9 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         {"cb_out", tt::CBIndex::c_4},
         {"cb_out_reshard", tt::CBIndex::c_6},
     };
+    if (fused_argmax) {
+        in1_sender_writer_kernel_desc.named_compile_time_args.push_back({"cb_argmax_partials", tt::CBIndex::c_7});
+    }
     in1_sender_writer_kernel_desc.config =
         DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
 
@@ -491,6 +519,9 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             named_compile_args.push_back({"activation_param1", params.param1});
             named_compile_args.push_back({"activation_param2", params.param2});
         }
+        if (fused_argmax) {
+            named_compile_args.push_back({"cb_argmax_partials", tt::CBIndex::c_7});
+        }
         compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
     }
     compute_kernel_desc.config = ComputeConfigDescriptor{
@@ -498,6 +529,9 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .dst_full_sync_en = dst_full_sync_en,
         .math_approx_mode = math_approx_mode,
+        // Fused argmax runs its scan on the pack RISC's vector unit: compile this kernel's
+        // TRISC2 TU with Zve32f (no effect on the plain matmul, which never sets this).
+        .enable_trisc2_rvv = fused_argmax,
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -604,6 +638,20 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             .page_size = output_single_tile_size,
             .tile = output_tile_desc});
         cb_desc.tensor = &out_tensor;
+        desc.cbs.push_back(std::move(cb_desc));
+    }
+
+    // CB 7: fused-argmax partials staging (one 256B page: 32 rows x (index, value bits) u32
+    // pairs). Raw-produced by the pack RISC after the scan finishes, drained by the in1
+    // sender/writer with plain dataflow calls (the proven raw-producer / llk-consumer pairing).
+    if (fused_argmax) {
+        CBDescriptor cb_desc;
+        cb_desc.total_size = fused_argmax_partials_page_bytes;
+        cb_desc.core_ranges = all_cores_in_rect_grid;
+        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
+            .buffer_index = tt::CBIndex::c_7,
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = fused_argmax_partials_page_bytes});
         desc.cbs.push_back(std::move(cb_desc));
     }
 
@@ -748,12 +796,15 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             std::vector<uint32_t> mm_compute_args;
             mm_compute_args.push_back((std::uint32_t)is_worker_core);
             compute_kernel_desc.runtime_args.emplace_back(core, std::move(mm_compute_args));
-        } else {
+        } else if (!fused_argmax) {
             bool is_worker_core = true;
             std::vector<uint32_t> mm_compute_args;
             mm_compute_args.push_back((std::uint32_t)is_worker_core);
             compute_kernel_desc.runtime_args.emplace_back(core, std::move(mm_compute_args));
         }
+        // fused_argmax: worker-core compute args need the per-worker column offset, which is
+        // keyed off the DRAM bank assignment — they are emplaced in the worker-ordered loop
+        // below instead.
     }
 
     // Worker cores: in1 sender/writer runtime args
@@ -869,12 +920,40 @@ static ProgramDescriptor create_program_dram_sharded_descriptor(
             mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + 5, num_cores_write_back);
         }
 
+        size_t fused_argmax_addr_idx = 0;
+        if (fused_argmax) {
+            const uint32_t worker_bank = bank_ids[i];
+            // Writer: partials tensor address + this worker's page id, appended AFTER the
+            // variable-length write-back args. The kernel recomputes this offset at runtime as
+            // 7 + 3 * num_shard_to_write_back (runtime arg [5]); assert the layout holds.
+            TT_FATAL(
+                mm_in1_sender_writer_args.size() == 7 + 3 * (size_t)mm_in1_sender_writer_args[5],
+                "fused_argmax: unexpected in1 sender/writer runtime-arg layout ({} args, {} shards)",
+                mm_in1_sender_writer_args.size(),
+                mm_in1_sender_writer_args[5]);
+            fused_argmax_addr_idx = mm_in1_sender_writer_args.size();
+            mm_in1_sender_writer_args.push_back(fused_argmax_partials->address());  // smuggled-rta-ok: rebound
+            mm_in1_sender_writer_args.push_back(worker_bank);                       // partials page id
+
+            // Compute kernel: [is_worker, n_tile_offset, valid_w_tiles, valid_rows]. The scan
+            // stops at the LOGICAL vocab boundary, so padded-tail columns never participate.
+            const uint32_t n_off = worker_bank * per_core_N_in1_sender;
+            const uint32_t valid_w = fused_argmax_valid_n_tiles > n_off
+                                         ? std::min(per_core_N_in1_sender, fused_argmax_valid_n_tiles - n_off)
+                                         : 0u;
+            compute_kernel_desc.runtime_args.emplace_back(
+                core, std::vector<uint32_t>{1u, n_off, valid_w, fused_argmax_valid_rows});
+        }
+
         // Build variant args: positions [1] and [2] are buffer addresses
         std::vector<std::variant<uint32_t, std::reference_wrapper<const tt::tt_metal::MeshTensor>>> in1_writer_args(
             mm_in1_sender_writer_args.begin(), mm_in1_sender_writer_args.end());
         in1_writer_args[1] = in1_tensor;
         if (bias.has_value()) {
             in1_writer_args[2] = *bias;
+        }
+        if (fused_argmax) {
+            in1_writer_args[fused_argmax_addr_idx] = *fused_argmax_partials;
         }
         in1_sender_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
         TT_FATAL(
@@ -1012,6 +1091,25 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
     uint32_t Nt = bshape[-1] / in1_tile_shape[1];
     uint32_t in0_last_ktile_w = a.logical_shape()[-1] % in0_tile_shape[1];
 
+    // Fused greedy-argmax epilogue (opt-in): scan extent is the LOGICAL output geometry.
+    ttsl::optional_reference<const tt::tt_metal::MeshTensor> fused_argmax_partials;
+    uint32_t fused_argmax_valid_n_tiles = 0;
+    uint32_t fused_argmax_valid_rows = 0;
+    if (tensor_args.fused_argmax_partials.has_value()) {
+        fused_argmax_partials = tensor_args.fused_argmax_partials->mesh_tensor();
+        TT_FATAL(
+            b.logical_shape()[-1] % in1_tile_shape[1] == 0,
+            "matmul fused_argmax requires the logical output width ({}) to be a multiple of the tile width {}",
+            b.logical_shape()[-1],
+            in1_tile_shape[1]);
+        fused_argmax_valid_n_tiles = b.logical_shape()[-1] / in1_tile_shape[1];
+        fused_argmax_valid_rows = a.logical_shape()[-2];
+        TT_FATAL(
+            fused_argmax_valid_rows <= in0_tile_shape[0],
+            "matmul fused_argmax supports at most one output tile-row ({} logical rows)",
+            fused_argmax_valid_rows);
+    }
+
     TT_FATAL(Kt % in0_block_w == 0, "Kt ({}) must be divisible by in0_block_w ({})", Kt, in0_block_w);
 
     const auto& output_mesh = output.mesh_tensor();
@@ -1051,7 +1149,10 @@ ProgramDescriptor MatmulMultiCoreReuseMultiCastDRAMShardedProgramFactory::create
         skip_compute,
         skip_in0_mcast,
         skip_write_back,
-        row_broadcast_bias);
+        row_broadcast_bias,
+        fused_argmax_partials,
+        fused_argmax_valid_n_tiles,
+        fused_argmax_valid_rows);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -21,6 +21,279 @@
 #include "bmm_fused_activation.hpp"
 #endif
 
+// ============================================================================
+// FUSED_ARGMAX — opt-in greedy-argmax epilogue for the DRAM-sharded decode
+// matmul (Blackhole only; factory sets the define only when the caller
+// provides the partials tensor and the eligibility gates pass: no bias, no
+// activation, TILE bf16 output, per_core_M == 1, 32x32 tiles).
+//
+// The pack RISC (TRISC2) carries a Zve32f vector unit that is idle in this
+// kernel. After each output subblock's pack sequence is QUEUED, TRISC2 scans
+// the PREVIOUS subblock's freshly packed bf16 tiles straight out of the
+// output CB and keeps per-row running argmax+maxval state; per-worker
+// (global_index, value_bits) partials are staged into a small CB that the
+// in1 sender/writer drains to the preallocated partials tensor (8 DRAM-bank
+// workers => 8 partials, combined by the caller: 8 compares).
+//
+// Deferred-consume order (the silicon-measured mechanic, THREEWAY_
+// OPPORTUNITIES.md MEASURED M.3): scanning the subblock that was just packed
+// would chain the NEXT subblock's queue behind pack_done + scan and stall the
+// math thread on DST halves (+24% measured at the LM-head cadence). Deferring
+// the scan by one FULL SUBBLOCK means the mailbox wait for subblock s-1 is
+// answered while subblock s's whole sequence sits queued in the Tensix FIFO,
+// so the scan runs entirely inside the queued-work shadow (defer-by-2 at
+// tile granularity measured +0.21% wall; a subblock defer is the same
+// mechanic at 8-tile granularity). The mailbox is the c_out received stream
+// register: the queued cb_push_back STOREREG updates it only after the pack
+// HW physically wrote the tiles — true data-ready, and legal by construction
+// because this kernel single-buffers the whole output block (pages are not
+// recycled until the writer drains them at the end).
+//
+// Semantics — exactly ttnn.argmax's bfloat16_greater + smallest-index rule:
+// bfloat16_greater is a pure sign-magnitude bit-pattern total order; the xor
+// trick (t = x ^ 0x8000) makes unsigned lane max agree with it whenever any
+// sign-0 pattern exists, and an all-negative row takes an exact unsigned-MIN
+// fix-up (both-negative order is reversed). Cross-tile combines happen in the
+// fully monotone domain m = x ^ ((x >> 15 arith) | 0x8000), seeded with
+// m(0xFF80) — the incumbent's -inf init. Strictly-greater updates plus a
+// first-match in-tile re-scan preserve the smallest-index tie-break; across
+// workers, ascending-bank host combine with strictly-greater keeps the
+// lowest GLOBAL index. The scan covers only the LOGICAL output width, so
+// padded-vocab tail columns never participate (no -inf mask add needed).
+//
+// REGISTER BUDGET (hard-earned, argmax_rvv_tile_compute.cpp): e16m4 keeps the
+// vector working set at 8 of 32 vregs; helpers stay noinline; any change must
+// be checked for vlenb-scaled stack frames (TRISC2 has ~256B of stack; e16m8
+// dual-stream spills multi-KB and hangs silicon). VLEN=128: 16 lanes of e16
+// need m2 (e16m1 caps vl at 8).
+// ============================================================================
+#if defined(FUSED_ARGMAX) && defined(TRISC_PACK)
+#include <riscv_vector.h>
+#include "api/compute/common.h"           // get_local_cb_interface / stream-register CB pointers
+#include "internal/tt-1xx/risc_common.h"  // invalidate_l1_cache(), reg_read
+
+namespace fused_argmax {
+
+constexpr uint16_t kSignBit = 0x8000u;
+// Monotone image of 0xFF80 (-inf) — the incumbent scan's initial max value.
+constexpr uint16_t kInitMono = 0x007Fu;
+
+// Running per-row state. Static => local data memory, not the (tiny) stack.
+static uint16_t s_mono[32];
+static uint16_t s_raw[32];
+static uint32_t s_idx[32];
+
+struct FaState {
+    uint32_t c_out_base = 0;     // byte address of output CB page 0 (pre-push snapshot)
+    uint32_t page_bytes = 0;     // output CB page stride (bf16 32x32 tile = 2048B)
+    uint32_t recv_reg = 0;       // MMIO address of the output CB received stream register
+    uint16_t recv_base = 0;      // its value before the first push
+    uint32_t n_tile_offset = 0;  // this worker's global column offset, in tiles
+    uint32_t valid_w = 0;        // valid (logical) output tiles on this worker
+    uint32_t valid_rows = 0;     // valid output rows (decode batch), <= 32
+    uint32_t n_groups = 0;       // row-pair groups = ceil(valid_rows / 2)
+    uint32_t sb_tiles = 0;       // tiles per subblock push
+    uint32_t total_tiles = 0;    // per-core output tiles (incl. subblock padding)
+    uint32_t sb_pushed = 0;      // subblock pack sequences queued so far
+    uint32_t sb_consumed = 0;    // subblocks scanned so far
+};
+static FaState fa;
+
+inline void init(uint32_t out_cb, uint32_t sb_tiles, uint32_t total_tiles) {
+    LocalCBInterface& intf = get_local_cb_interface(out_cb);
+    fa.c_out_base = intf.fifo_wr_ptr << 4;  // pre-push: wr ptr == base
+    fa.page_bytes = intf.fifo_page_size << 4;
+    fa.recv_reg = (uint32_t)(uintptr_t)get_cb_tiles_received_ptr((int)out_cb);
+    fa.recv_base = (uint16_t)reg_read(fa.recv_reg);
+    fa.n_tile_offset = get_arg_val<uint32_t>(1);
+    fa.valid_w = get_arg_val<uint32_t>(2);
+    fa.valid_rows = get_arg_val<uint32_t>(3);
+    fa.n_groups = (fa.valid_rows + 1) / 2;
+    fa.sb_tiles = sb_tiles;
+    fa.total_tiles = total_tiles;
+    fa.sb_pushed = 0;
+    fa.sb_consumed = 0;
+    for (uint32_t r = 0; r < 32; r++) {
+        s_mono[r] = kInitMono;
+        s_raw[r] = 0xFF80u;  // -inf: the incumbent's init value
+        s_idx[r] = 0;
+    }
+}
+
+// Scan row-pair group `g` across a run of `ntiles` CONSECUTIVE packed bf16
+// 32x32 tiles (faces 0..3, 512B each; left faces hold cols 0..15, right
+// faces +512B cols 16..31) starting at L1 address base0, and fold it into
+// the running per-row state. Batching pass A across the whole subblock
+// amortizes the (expensive) per-row lane reductions over ntiles tiles —
+// exactly the argmax-RVV op's chunk structure, with a contiguous-page walk.
+// first_tile_col is the GLOBAL column index of the first tile in the run.
+__attribute__((noinline)) static void scan_group_run(
+    uint32_t base0, uint32_t ntiles, uint32_t g, uint32_t rows_in_group, uint32_t first_tile_col) {
+    const uint32_t left_off = ((g < 8) ? 0u : 1024u) + (g & 7u) * 64u;
+    const size_t vl = __riscv_vsetvl_e16m4(32);
+
+    // Pass A: lane-wise max of x ^ 0x8000 across the run's tiles. The two
+    // 16-elem face rows of a row-pair are CONTIGUOUS in a face, so one e16m4
+    // (vl=32) load covers rows {2g, 2g+1} x one face.
+    vuint16m4_t acc_l = __riscv_vmv_v_x_u16m4(0, vl);
+    vuint16m4_t acc_r = __riscv_vmv_v_x_u16m4(0, vl);
+    for (uint32_t t = 0; t < ntiles; t++) {
+        const uint32_t base = base0 + t * fa.page_bytes;
+        vuint16m4_t va = __riscv_vle16_v_u16m4((const uint16_t*)(base + left_off), vl);
+        vuint16m4_t vb = __riscv_vle16_v_u16m4((const uint16_t*)(base + left_off + 512u), vl);
+        va = __riscv_vxor_vx_u16m4(va, kSignBit, vl);
+        vb = __riscv_vxor_vx_u16m4(vb, kSignBit, vl);
+        acc_l = __riscv_vmaxu_vv_u16m4(acc_l, va, vl);
+        acc_r = __riscv_vmaxu_vv_u16m4(acc_r, vb, vl);
+    }
+
+    for (uint32_t rr = 0; rr < rows_in_group; rr++) {
+        const uint32_t row = 2 * g + rr;
+        const uint32_t row_off = left_off + rr * 32u;  // 16 bf16 = 32B per face row
+
+        vuint16m4_t sl = rr ? __riscv_vslidedown_vx_u16m4(acc_l, 16, vl) : acc_l;
+        vuint16m4_t sr = rr ? __riscv_vslidedown_vx_u16m4(acc_r, 16, vl) : acc_r;
+        const vuint16m1_t z = __riscv_vmv_s_x_u16m1(0, 1);
+        uint16_t t_row = __riscv_vmv_x_s_u16m1_u16(__riscv_vredmaxu_vs_u16m4_u16m1(sl, z, 16));
+        const uint16_t t_r = __riscv_vmv_x_s_u16m1_u16(__riscv_vredmaxu_vs_u16m4_u16m1(sr, z, 16));
+        if (t_r > t_row) {
+            t_row = t_r;
+        }
+
+        uint16_t mono;
+        uint16_t raw;
+        if (t_row >= kSignBit) {
+            // Some sign-0 pattern exists: xor-domain max IS the winner.
+            mono = t_row;
+            raw = (uint16_t)(t_row ^ kSignBit);
+        } else {
+            // All-negative run-row: both-negative order is reversed — take
+            // the exact unsigned MIN over the (still resident) run.
+            // NOTE: 16 lanes of e16 need m2 — VLEN=128 caps e16m1 at vl=8.
+            const size_t vl1 = __riscv_vsetvl_e16m2(16);
+            vuint16m2_t mn = __riscv_vmv_v_x_u16m2(0xFFFFu, vl1);
+            for (uint32_t t = 0; t < ntiles; t++) {
+                const uint32_t base = base0 + t * fa.page_bytes;
+                vuint16m2_t a = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off), vl1);
+                vuint16m2_t b = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off + 512u), vl1);
+                a = __riscv_vxor_vx_u16m2(a, kSignBit, vl1);
+                b = __riscv_vxor_vx_u16m2(b, kSignBit, vl1);
+                mn = __riscv_vminu_vv_u16m2(mn, a, vl1);
+                mn = __riscv_vminu_vv_u16m2(mn, b, vl1);
+            }
+            const uint16_t t_min =
+                __riscv_vmv_x_s_u16m1_u16(__riscv_vredminu_vs_u16m2_u16m1(mn, __riscv_vmv_s_x_u16m1(0xFFFFu, 1), vl1));
+            mono = (uint16_t)(t_min ^ 0x7FFFu);
+            raw = (uint16_t)(t_min ^ kSignBit);
+        }
+
+        // Strictly-greater keeps the earliest occurrence across runs;
+        // ascending first-match re-scan keeps it within the run.
+        if (mono > s_mono[row]) {
+            const size_t vl1 = __riscv_vsetvl_e16m2(16);
+            uint32_t idx = 0;
+            for (uint32_t t = 0; t < ntiles; t++) {
+                const uint32_t base = base0 + t * fa.page_bytes;
+                const vuint16m2_t ca = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off), vl1);
+                const long f_l = __riscv_vfirst_m_b8(__riscv_vmseq_vx_u16m2_b8(ca, raw, vl1), vl1);
+                if (f_l >= 0) {
+                    idx = (first_tile_col + t) * 32u + (uint32_t)f_l;
+                    break;
+                }
+                const vuint16m2_t cb = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off + 512u), vl1);
+                const long f_r = __riscv_vfirst_m_b8(__riscv_vmseq_vx_u16m2_b8(cb, raw, vl1), vl1);
+                if (f_r >= 0) {
+                    idx = (first_tile_col + t) * 32u + 16u + (uint32_t)f_r;
+                    break;
+                }
+            }
+            s_mono[row] = mono;
+            s_raw[row] = raw;
+            s_idx[row] = idx;
+        }
+    }
+}
+
+// Consume one pushed subblock: mailbox-wait until the output CB received
+// stream register (updated by the queued cb_push_back STOREREG only after
+// the pack HW physically wrote the tiles) covers it, then scan its (valid)
+// tiles as one contiguous run per row-pair group.
+static void consume_subblock(uint32_t sbi) {
+    const uint32_t t0 = sbi * fa.sb_tiles;
+    uint32_t t1 = t0 + fa.sb_tiles;
+    if (t1 > fa.total_tiles) {
+        t1 = fa.total_tiles;
+    }
+    while ((uint16_t)((uint16_t)reg_read(fa.recv_reg) - fa.recv_base) < (uint16_t)t1) {
+    }
+    fa.sb_consumed = sbi + 1;
+    // Clamp to the logical width: subblock-pad DST lanes and bank-pad tiles
+    // are packed but never scanned.
+    const uint32_t tv = (t1 < fa.valid_w) ? t1 : fa.valid_w;
+    if (tv <= t0) {
+        return;
+    }
+    invalidate_l1_cache();  // BH: L1 data reads after MMIO count poll
+    const uint32_t base0 = fa.c_out_base + t0 * fa.page_bytes;
+    for (uint32_t g = 0; g < fa.n_groups; g++) {
+        const uint32_t rows_in_group = (fa.valid_rows - 2 * g < 2u) ? (fa.valid_rows - 2 * g) : 2u;
+        scan_group_run(base0, tv - t0, g, rows_in_group, fa.n_tile_offset + t0);
+    }
+}
+
+// Called right after each output subblock's pack sequence is queued:
+// defer-by-one-subblock consume order (see header note).
+//
+// MODE SPLIT (silicon-measured): for decode-b1 shapes (<= 2 row-pair groups)
+// the per-subblock scan is light enough to ride the pack shadow (+0.9%
+// per-op device span). For full-tile row counts the per-run extraction cost
+// times 16 groups exceeds the LAST inner K-block's shadow (all output packs
+// concentrate there in this kernel's K-outer loop order; measured +34%/op
+// when scanned per subblock). Those shapes skip the in-loop scans entirely
+// and take ONE full-width run per group at finalize — the argmax-RVV op's
+// chunk shape, amortizing extraction over the whole per-core width, and
+// overlapping the writer's output write-back instead.
+inline void on_subblock_pushed() {
+    fa.sb_pushed++;
+    if (fa.n_groups <= 2 && fa.sb_pushed >= 2) {
+        consume_subblock(fa.sb_pushed - 2);
+    }
+}
+
+// Tail: scan whatever is still outstanding, then publish the partials page
+// (32 x (index, value bits) u32 pairs) into the staging CB — we are its sole
+// producer; the in1 sender/writer drains it with plain dataflow calls.
+static void finalize(uint32_t cb_partials) {
+    const uint32_t n_subblocks = (fa.total_tiles + fa.sb_tiles - 1) / fa.sb_tiles;
+    if (fa.n_groups <= 2) {
+        while (fa.sb_consumed < n_subblocks) {
+            consume_subblock(fa.sb_consumed);
+        }
+    } else if (fa.valid_w > 0) {
+        // Full-tile row counts: one full-width run per group (see the mode
+        // note at on_subblock_pushed). Wait once for every tile, then scan.
+        while ((uint16_t)((uint16_t)reg_read(fa.recv_reg) - fa.recv_base) < (uint16_t)fa.total_tiles) {
+        }
+        invalidate_l1_cache();  // BH: L1 data reads after MMIO count poll
+        for (uint32_t g = 0; g < fa.n_groups; g++) {
+            const uint32_t rows_in_group = (fa.valid_rows - 2 * g < 2u) ? (fa.valid_rows - 2 * g) : 2u;
+            scan_group_run(fa.c_out_base, fa.valid_w, g, rows_in_group, fa.n_tile_offset);
+        }
+    }
+    LocalCBInterface& intf = get_local_cb_interface(cb_partials);
+    volatile uint32_t* page = (volatile uint32_t*)(intf.fifo_wr_ptr << 4);
+    for (uint32_t r = 0; r < 32; r++) {
+        page[2 * r] = s_idx[r];
+        page[2 * r + 1] = (uint32_t)s_raw[r];
+    }
+    asm volatile("fence" ::: "memory");
+    (void)page[63];                                      // read-back orders the L1 stores before the MMIO count store
+    get_cb_tiles_received_ptr((int)cb_partials)[0] = 1;  // sole producer; counter is 0 at launch
+}
+
+}  // namespace fused_argmax
+#endif  // FUSED_ARGMAX && TRISC_PACK
+
 // Please update
 // tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
 // when making any changes to this file.
@@ -266,6 +539,12 @@ void kernel_main() {
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(in0_dfb_id, in1_dfb_id, mm_partials_dfb_id);
     matmul_block_init(in0_dfb_id, in1_dfb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+
+#if defined(FUSED_ARGMAX) && defined(TRISC_PACK)
+    // Snapshot the output CB geometry BEFORE any push (wr ptr still == base) and
+    // load this worker's scan extent from the runtime args.
+    fused_argmax::init(out_dfb_id, out_subblock_num_tiles, out_block_num_tiles);
+#endif
     for (uint32_t b = 0; b < batch; b++) {
         if constexpr (get_batch_from_reader) {
             // Check whether this batch is valid
@@ -411,6 +690,12 @@ void kernel_main() {
 
                                 tile_regs_release();
                                 mm_out_dfb.push_back(out_subblock_num_tiles);
+
+#if defined(FUSED_ARGMAX) && defined(TRISC_PACK)
+                                // RVV argmax scan of the PREVIOUS subblock, in the shadow of
+                                // the sequence just queued (defer-by-one-subblock).
+                                fused_argmax::on_subblock_pushed();
+#endif
 
                             } else {
                                 tile_regs_commit();
@@ -619,5 +904,10 @@ void kernel_main() {
     if constexpr (num_blocks_w_dim == 1) {
         bias_dfb.pop_front(bias_ntiles);
     }
+#endif
+
+#if defined(FUSED_ARGMAX) && defined(TRISC_PACK)
+    // Scan the last outstanding subblock(s) and publish this worker's partials page.
+    fused_argmax::finalize(get_named_compile_time_arg_val("cb_argmax_partials"));
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -10,6 +10,9 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#ifdef FUSED_ARGMAX
+#include "internal/tt-1xx/risc_common.h"  // invalidate_l1_cache()
+#endif
 
 void kernel_main() {
     // RUNTIME ARGS
@@ -214,6 +217,32 @@ void kernel_main() {
 #endif
 
     dfb_out.pop_front(out_block_num_tiles);
+
+#ifdef FUSED_ARGMAX
+    // Fused greedy-argmax epilogue: drain this worker's partials page (32 x
+    // (global_index, value_bits) u32 pairs, raw-produced by the pack RISC once
+    // its scan finishes) and write it to page `partials_page_id` of the
+    // preallocated INTERLEAVED partials tensor. Bias is excluded by the host
+    // validation, so the compile-time args sit at fixed indices 9/10.. and the
+    // runtime args at 7 + 3 * num_shard_to_write_back.
+    {
+        constexpr uint32_t partials_page_size = get_compile_time_arg_val(9);
+        constexpr auto partials_acc_args = TensorAccessorArgs<10>();
+        constexpr uint32_t dfb_id_partials = get_named_compile_time_arg_val("cb_argmax_partials");
+
+        const uint32_t partials_rt_base = 7 + 3 * num_shard_to_write_back;
+        const uint32_t partials_addr = get_arg_val<uint32_t>(partials_rt_base);
+        const uint32_t partials_page_id = get_arg_val<uint32_t>(partials_rt_base + 1);
+
+        DataflowBuffer dfb_partials(dfb_id_partials);
+        dfb_partials.wait_front(1);
+        invalidate_l1_cache();  // BH: L1 data reads after the stream-register wait
+        const auto s_partials = TensorAccessor(partials_acc_args, partials_addr, partials_page_size);
+        noc_async_write(dfb_partials.get_read_ptr(), s_partials.get_noc_addr(partials_page_id), partials_page_size);
+        noc_async_write_barrier();
+        dfb_partials.pop_front(1);
+    }
+#endif
 
     // Restore NCRISC_RD_CMD_BUF NOC_CTRL to the firmware default (VC=1, set in
     // noc_init). set_async_read_state<NocOptions::CUSTOM_VC> writes a per-bank VC into NOC_CTRL

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -2369,6 +2369,71 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             attributes.output_mem_config,
             std::nullopt);
     }
+
+    // ---- fused greedy-argmax epilogue eligibility (opt-in via the preallocated partials tensor) ----
+    // Blackhole DRAM-sharded matmul only: the pack RISC's RVV unit scans each worker's freshly
+    // packed output tiles in the pack shadow and emits per-worker (index, value) partials.
+    // Opt-in is explicit, so an unsupported configuration is a hard error rather than a silent
+    // fallback (keeps A/B measurements unambiguous).
+    if (args.fused_argmax_partials.has_value()) {
+        const auto& partials = args.fused_argmax_partials.value();
+        TT_FATAL(
+            input_tensor_a.device()->arch() == tt::ARCH::BLACKHOLE,
+            "matmul fused_argmax requires a Blackhole device (TRISC vector unit)");
+        TT_FATAL(
+            std::holds_alternative<operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(
+                chosen_program_config),
+            "matmul fused_argmax is only supported with MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig");
+        const auto& ds_config =
+            std::get<operations::matmul::MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>(chosen_program_config);
+        TT_FATAL(!optional_bias.has_value(), "matmul fused_argmax does not support a fused bias");
+        TT_FATAL(
+            !ds_config.fused_activation.has_value(),
+            "matmul fused_argmax does not support a fused activation (greedy argmax wants the raw logits)");
+        TT_FATAL(!attributes.untilize_out, "matmul fused_argmax requires TILE output (untilize_out=false)");
+        TT_FATAL(!attributes.transpose_a && !attributes.transpose_b, "matmul fused_argmax requires no transposes");
+        TT_FATAL(
+            ds_config.per_core_M == 1,
+            "matmul fused_argmax supports decode shapes only (per_core_M == 1, got {})",
+            ds_config.per_core_M);
+        TT_FATAL(
+            a_shape_padded[-2] == in0_tile.get_tile_shape()[0] && get_batch_size(a_shape_padded) == 1,
+            "matmul fused_argmax supports a single output tile-row (padded M == tile height, no batching)");
+        TT_FATAL(
+            in0_tile.get_tile_shape()[0] == 32 && in0_tile.get_tile_shape()[1] == 32 &&
+                in1_tile.get_tile_shape()[0] == 32 && in1_tile.get_tile_shape()[1] == 32,
+            "matmul fused_argmax requires standard 32x32 tiles");
+        TT_FATAL(
+            !(in1_tile.get_transpose_of_faces() || in1_tile.get_transpose_within_face()),
+            "matmul fused_argmax does not support transposed in1 tiles");
+        const auto out_dtype = attributes.output_dtype.value_or(input_tensor_a.dtype());
+        TT_FATAL(
+            out_dtype == DataType::BFLOAT16,
+            "matmul fused_argmax requires BFLOAT16 output (the RVV scan reads packed bf16 tiles), got {}",
+            out_dtype);
+        TT_FATAL(
+            input_tensor_b.dtype() == DataType::BFLOAT16 || input_tensor_b.dtype() == DataType::BFLOAT8_B,
+            "matmul fused_argmax requires BFLOAT16 or BFLOAT8_B weights, got {}",
+            input_tensor_b.dtype());
+        // Partials tensor contract: one 64-word page per DRAM-bank worker.
+        TT_FATAL(
+            partials.dtype() == DataType::UINT32, "fused_argmax partials must be UINT32, got {}", partials.dtype());
+        TT_FATAL(
+            partials.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+            "fused_argmax partials must be ROW_MAJOR, got {}",
+            partials.layout());
+        TT_FATAL(
+            partials.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "fused_argmax partials must be INTERLEAVED, got {}",
+            partials.memory_config().memory_layout());
+        const uint32_t num_dram_banks = input_tensor_a.device()->num_dram_channels();
+        TT_FATAL(
+            partials.logical_shape()[-1] == 64 && partials.logical_shape()[-2] == num_dram_banks &&
+                partials.logical_volume() == static_cast<uint64_t>(64) * num_dram_banks,
+            "fused_argmax partials must have shape [1, 1, num_dram_banks ({}), 64], got {}",
+            num_dram_banks,
+            partials.logical_shape());
+    }
 }
 
 MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output_specs(
@@ -2738,6 +2803,10 @@ ttsl::hash::hash_t MatmulDeviceOperation::compute_descriptor_program_hash(
             hash = ttsl::hash::hash_objects(hash, optional_output_tensor.value());
         }
     }
+
+    if (args.fused_argmax_partials.has_value()) {
+        hash = ttsl::hash::hash_objects(hash, args.fused_argmax_partials.value());
+    }
     return hash;
 }
 
@@ -2880,7 +2949,8 @@ MatmulDeviceOperation::tensor_return_value_t matmul(
     const Tensor& input_tensor_b,
     const std::optional<Tensor>& bias,
     const std::optional<Tensor>& optional_output_tensor,
-    const MatmulParams& attributes) {
+    const MatmulParams& attributes,
+    const std::optional<Tensor>& fused_argmax_partials) {
     MatmulParams normalized_attributes = attributes;
     if (!normalized_attributes.program_config.has_value()) {
         uint32_t bias_single_tile_size = 0;
@@ -2900,7 +2970,8 @@ MatmulDeviceOperation::tensor_return_value_t matmul(
     operations::matmul::normalize_program_config(
         normalized_attributes.program_config.value(), input_tensor_a.device()->compute_with_storage_grid_size());
     return ttnn::device_operation::launch<MatmulDeviceOperation>(
-        normalized_attributes, {{input_tensor_a, input_tensor_b}, {bias}, {optional_output_tensor}});
+        normalized_attributes,
+        {{input_tensor_a, input_tensor_b}, {bias}, {optional_output_tensor}, fused_argmax_partials});
 }
 
 MatmulDeviceOperation::tensor_return_value_t matmul(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.hpp
@@ -69,7 +69,8 @@ MatmulDeviceOperation::tensor_return_value_t matmul(
     const Tensor& input_tensor_b,
     const std::optional<Tensor>& bias = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,
-    const MatmulParams& attributes = MatmulParams());
+    const MatmulParams& attributes = MatmulParams(),
+    const std::optional<Tensor>& fused_argmax_partials = std::nullopt);
 
 MatmulDeviceOperation::tensor_return_value_t matmul(
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation_types.hpp
@@ -33,6 +33,19 @@ struct MatmulInputs {
     std::vector<Tensor> input_tensors;                                // a,b, weights
     std::vector<std::optional<const Tensor>> optional_input_tensors;  // bias
     std::vector<std::optional<Tensor>> optional_output_tensors;       // output
+    // Opt-in fused greedy-argmax epilogue for the DRAM-sharded matmul path
+    // (Blackhole only). Preallocated UINT32 ROW_MAJOR INTERLEAVED tensor of
+    // shape [1, 1, num_dram_banks, 64]: page w receives worker w's per-row
+    // (global_col_index, bf16_value_bits) pairs — word 2*r is the winning
+    // GLOBAL column index for output row r under bfloat16_greater's
+    // sign-magnitude total order with the smallest-index tie-break, word
+    // 2*r+1 the winning value's raw bf16 bits (init 0xFF80 = -inf for rows
+    // that were never updated). The scan runs on the pack RISC's RVV unit in
+    // the pack shadow of the matmul and only covers the LOGICAL width of
+    // in1, so padded-vocab tail columns never participate (the -inf mask add
+    // callers run today is unnecessary). Providing this tensor turns the
+    // fusion ON; the plain path is untouched when it is nullopt.
+    std::optional<Tensor> fused_argmax_partials = std::nullopt;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -219,7 +219,8 @@ static ttnn::Tensor bound_matmul(
     const ttnn::Tensor& input_tensor_b,
     const std::optional<const ttnn::Tensor>& bias,
     ttnn::prim::MatmulParams& parameters,
-    std::optional<ttnn::Tensor>& optional_output_tensor) {
+    std::optional<ttnn::Tensor>& optional_output_tensor,
+    const std::optional<ttnn::Tensor>& fused_argmax_partials = std::nullopt) {
     if (input_tensor_a.logical_shape().rank() == 0 || input_tensor_b.logical_shape().rank() == 0) [[unlikely]] {
         TT_THROW(
             "ttnn.matmul: Both arguments to matmul need to be at least 1D, but got shapes {} and {}",
@@ -312,7 +313,8 @@ static ttnn::Tensor bound_matmul(
                              input_tensor_b_adjusted,
                              post_process_bias ? std::nullopt : bias,
                              optional_output_tensor,
-                             attributes)
+                             attributes,
+                             fused_argmax_partials)
                              .at(0);
 
     if (input_tensor_b.logical_shape().rank() == 1) [[unlikely]] {
@@ -376,7 +378,8 @@ Tensor matmul(
     const std::optional<const tt::tt_metal::Tile>& output_tile,
     std::optional<Tensor> optional_output_tensor,
     const std::optional<const GlobalCircularBuffer>& global_cb,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const std::optional<Tensor>& fused_argmax_partials) {
     std::optional<CoreCoord> user_core_coord;
     if (core_grid.has_value()) {
         user_core_coord = CoreCoord(core_grid->x, core_grid->y);
@@ -408,7 +411,8 @@ Tensor matmul(
         input_tensor_b,
         /*bias=*/std::nullopt,
         matmul_params,
-        optional_output_tensor);
+        optional_output_tensor,
+        fused_argmax_partials);
 }
 
 Tensor linear(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -43,7 +43,8 @@ Tensor matmul(
     const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
     std::optional<Tensor> optional_output_tensor = std::nullopt,
     const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
-    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt,
+    const std::optional<Tensor>& fused_argmax_partials = std::nullopt);
 
 std::vector<Tensor> matmul_batched_weights(
     const Tensor& input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -819,7 +819,8 @@ void py_module(nb::module_& mod) {
             nb::arg("output_tile") = nb::none(),
             nb::arg("optional_output_tensor") = nb::none(),
             nb::arg("global_cb") = nb::none(),
-            nb::arg("sub_device_id") = nb::none()));
+            nb::arg("sub_device_id") = nb::none(),
+            nb::arg("fused_argmax_partials") = nb::none()));
 
     ttnn::bind_function<"linear">(
         mod,

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -167,7 +167,9 @@ Tensor argmax(
     bool keepdim,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<MemoryConfig>& memory_config,
-    std::optional<Tensor> optional_output_tensor) {
+    std::optional<Tensor> optional_output_tensor,
+    bool use_rvv,
+    std::optional<Tensor> optional_maxval_tensor) {
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
 
     TT_FATAL(is_device_tensor(input_tensor), "Input tensor must be on device");
@@ -232,6 +234,25 @@ Tensor argmax(
 
         return preallocated_tensor;
     }
+
+    // Opt-in RVV path: TILE-layout last-dim argmax scanned on the pack RISC's
+    // vector unit (Blackhole). Takes TILE input DIRECTLY — no to_layout /
+    // untilize hop — and optionally returns the max values alongside the
+    // indices. Eligibility is validated by the device op.
+    if (use_rvv) {
+        return prim::argmax(
+            input_tensor,
+            tt::tt_metal::DataType::UINT32,
+            dim,
+            keepdim,
+            sub_core_grids,
+            output_memory_config,
+            std::move(optional_output_tensor),
+            /*use_rvv=*/true,
+            std::move(optional_maxval_tensor));
+    }
+    TT_FATAL(
+        !optional_maxval_tensor.has_value(), "argmax: the max-value output tensor is only supported with use_rvv=true");
 
     // Register-based NC path for reductions along any non-HW dimension.
     // Uses DST accumulation (similar to fast_reduce_nc). Supports sub_core_grids.

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -197,6 +197,22 @@ Tensor argmax(
         }
     }
 
+    // use_rvv / maxval contract checks must precede the zero-volume and rank-0
+    // early returns below: a scalar or empty-tensor call with use_rvv=True (or
+    // with a supplied maxval_tensor) must fail loudly rather than silently
+    // no-op through the host-side fallback, which would bypass the RVV
+    // eligibility checks and leave a supplied maxval_tensor untouched (stale).
+    TT_FATAL(
+        !optional_maxval_tensor.has_value() || use_rvv,
+        "argmax: the max-value output tensor (maxval_tensor) is only supported with use_rvv=True");
+    if (use_rvv) {
+        TT_FATAL(
+            rank > 0 && input_tensor.logical_volume() > 0,
+            "argmax: use_rvv=True supports only non-empty tensors of rank >= 1 (got rank {}, logical volume {})",
+            rank,
+            input_tensor.logical_volume());
+    }
+
     if (input_tensor.logical_volume() == 0) [[unlikely]] {
         return zero_volume_argmax(input_tensor, dim, keepdim, output_memory_config, optional_output_tensor);
     }
@@ -240,6 +256,17 @@ Tensor argmax(
     // untilize hop — and optionally returns the max values alongside the
     // indices. Eligibility is validated by the device op.
     if (use_rvv) {
+        // The reader kernel derives its output paging from the preallocated
+        // tensor, so a wrong logical shape means unwritten results or writes
+        // past the tensor's page count — reject it up front.
+        if (optional_output_tensor.has_value()) {
+            const auto expected_shape = ttnn::Shape(ttnn::prim::get_output_shape(input_tensor, dim, keepdim));
+            TT_FATAL(
+                optional_output_tensor->logical_shape() == expected_shape,
+                "argmax: preallocated output tensor has shape {}, expected the reduction output shape {}",
+                optional_output_tensor->logical_shape(),
+                expected_shape);
+        }
         return prim::argmax(
             input_tensor,
             tt::tt_metal::DataType::UINT32,
@@ -251,8 +278,6 @@ Tensor argmax(
             /*use_rvv=*/true,
             std::move(optional_maxval_tensor));
     }
-    TT_FATAL(
-        !optional_maxval_tensor.has_value(), "argmax: the max-value output tensor is only supported with use_rvv=true");
 
     // Register-based NC path for reductions along any non-HW dimension.
     // Uses DST accumulation (similar to fast_reduce_nc). Supports sub_core_grids.

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
@@ -12,6 +12,8 @@ Tensor argmax(
     bool keepdim = false,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
-    std::optional<Tensor> optional_output_tensor = std::nullopt);
+    std::optional<Tensor> optional_output_tensor = std::nullopt,
+    bool use_rvv = false,
+    std::optional<Tensor> optional_maxval_tensor = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_nanobind.cpp
@@ -27,9 +27,10 @@ void bind_reduction_argmax_operation(nb::module_& mod) {
                 sub_core_grids (CoreRangeSet, optional): Limits execution to a subset of cores. Supported on ROW_MAJOR last-dim reductions (<= 2 ranges) and batch/channel dim reductions. Default: ``None``.
                 memory_config (ttnn.MemoryConfig, optional): Output memory (INTERLEAVED DRAM/L1). Default: input's memory_config.
                 output_tensor (ttnn.Tensor, optional): Preallocated output (must be UINT32, ROW_MAJOR, INTERLEAVED, same device). Default: ``None``.
-                use_rvv (bool, optional): Opt-in Blackhole-only path: TILE-layout last-dim argmax scanned on the
-                    pack RISC's RVV vector unit. Takes TILE input directly (no untilize needed); requires BFLOAT16
-                    input whose last dim is a multiple of the tile width. Default: ``False``.
+                use_rvv (bool, optional): Opt-in Blackhole-only path. TRISC2 (the pack-thread RISC-V core) carries
+                    a Zve32f vector unit ("RVV"); with ``use_rvv=True`` the last-dim argmax reduction runs there,
+                    reading TILE layout directly (no untilize needed). Requires BFLOAT16 input whose last dim is a
+                    multiple of the tile width (32). Default: ``False``.
                 maxval_tensor (ttnn.Tensor, optional): Preallocated BFLOAT16 ROW_MAJOR tensor with the same logical
                     shape as the index output. Only with ``use_rvv=True``: receives the winning max VALUES, so greedy
                     sampling does not need a separate ``ttnn.max``. Default: ``None``.

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_nanobind.cpp
@@ -27,6 +27,12 @@ void bind_reduction_argmax_operation(nb::module_& mod) {
                 sub_core_grids (CoreRangeSet, optional): Limits execution to a subset of cores. Supported on ROW_MAJOR last-dim reductions (<= 2 ranges) and batch/channel dim reductions. Default: ``None``.
                 memory_config (ttnn.MemoryConfig, optional): Output memory (INTERLEAVED DRAM/L1). Default: input's memory_config.
                 output_tensor (ttnn.Tensor, optional): Preallocated output (must be UINT32, ROW_MAJOR, INTERLEAVED, same device). Default: ``None``.
+                use_rvv (bool, optional): Opt-in Blackhole-only path: TILE-layout last-dim argmax scanned on the
+                    pack RISC's RVV vector unit. Takes TILE input directly (no untilize needed); requires BFLOAT16
+                    input whose last dim is a multiple of the tile width. Default: ``False``.
+                maxval_tensor (ttnn.Tensor, optional): Preallocated BFLOAT16 ROW_MAJOR tensor with the same logical
+                    shape as the index output. Only with ``use_rvv=True``: receives the winning max VALUES, so greedy
+                    sampling does not need a separate ``ttnn.max``. Default: ``None``.
 
             Supported:
 
@@ -66,7 +72,9 @@ void bind_reduction_argmax_operation(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("sub_core_grids") = nb::none(),
         nb::arg("memory_config") = nb::none(),
-        nb::arg("output_tensor") = nb::none());
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("use_rvv") = false,
+        nb::arg("maxval_tensor") = nb::none());
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
@@ -7,6 +7,8 @@
 #include "ttnn/device_operation.hpp"
 #include "argmax_utils.hpp"
 
+#include <tt-metalium/hal.hpp>
+
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
@@ -75,6 +77,10 @@ ttsl::SmallVector<uint32_t> get_output_shape(const Tensor& input_tensor, const s
 
 ArgMaxDeviceOperation::program_factory_t ArgMaxDeviceOperation::select_program_factory(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (args.use_rvv) {
+        // Eligibility is enforced in validate_on_program_cache_miss.
+        return ArgMaxRvvTileProgramFactory{};
+    }
     if (uses_multicore_path(args, tensor_args)) {
         return ArgMaxMultiCoreProgramFactory{};
     }
@@ -191,6 +197,59 @@ void ArgMaxDeviceOperation::validate_on_program_cache_miss(
         grid_opts.sub_grid_label = "Multicore argmax sub_core_grids";
         validate_reduce_op_tensor(tensor_args.input, "Argmax", "input", &grid_opts);
     }
+
+    // RVV (Zve32f pack-RISC) path eligibility — opt-in, so requesting it with
+    // an unsupported configuration is a hard error rather than a silent
+    // fallback (keeps A/B measurements unambiguous).
+    if (args.use_rvv) {
+        TT_FATAL(
+            tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE,
+            "argmax use_rvv=true requires a Blackhole device (TRISC vector unit)");
+        TT_FATAL(input_layout == Layout::TILE, "argmax use_rvv=true requires TILE layout input, got {}", input_layout);
+        TT_FATAL(
+            input_tensor_a.dtype() == DataType::BFLOAT16,
+            "argmax use_rvv=true requires BFLOAT16 input, got {}",
+            input_tensor_a.dtype());
+        TT_FATAL(args.dim.has_value(), "argmax use_rvv=true requires an explicit dim (last dim)");
+        const int32_t rank = static_cast<int32_t>(input_tensor_a.logical_shape().rank());
+        const int32_t normalized_dim = normalize_dim(static_cast<int32_t>(args.dim.value()), rank);
+        TT_FATAL(
+            normalized_dim == rank - 1,
+            "argmax use_rvv=true supports only last-dim reduction, got dim={} (normalized={}) for rank {}",
+            args.dim.value(),
+            normalized_dim,
+            rank);
+        const uint32_t tile_w = input_tensor_a.tensor_spec().tile().get_width();
+        const uint32_t tile_h = input_tensor_a.tensor_spec().tile().get_height();
+        TT_FATAL(tile_w == 32 && tile_h == 32, "argmax use_rvv=true requires standard 32x32 tiles");
+        const auto& logical_shape = input_tensor_a.logical_shape();
+        TT_FATAL(
+            logical_shape[-1] % tile_w == 0,
+            "argmax use_rvv=true requires the reduction dim ({}) to be a multiple of the tile width {} "
+            "(no width padding)",
+            logical_shape[-1],
+            tile_w);
+    }
+
+    const auto& optional_maxval = tensor_args.optional_maxval_tensor;
+    if (optional_maxval.has_value()) {
+        TT_FATAL(args.use_rvv, "argmax max-value output is only produced by the use_rvv=true path");
+        const auto& maxval = optional_maxval.value();
+        TT_FATAL(
+            maxval.dtype() == DataType::BFLOAT16, "argmax max-value tensor must be BFLOAT16, got {}", maxval.dtype());
+        TT_FATAL(
+            maxval.layout() == Layout::ROW_MAJOR, "argmax max-value tensor must be ROW_MAJOR, got {}", maxval.layout());
+        TT_FATAL(
+            maxval.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+            "argmax max-value tensor must be INTERLEAVED, got {}",
+            maxval.memory_config().memory_layout());
+        const auto expected_shape = ttnn::Shape(get_output_shape(input_tensor_a, args.dim, args.keepdim));
+        TT_FATAL(
+            maxval.logical_shape() == expected_shape,
+            "argmax max-value tensor has shape {}, expected the index output shape {}",
+            maxval.logical_shape(),
+            expected_shape);
+    }
 }
 
 tt::tt_metal::TensorSpec ArgMaxDeviceOperation::compute_output_specs(
@@ -221,7 +280,9 @@ ttnn::Tensor argmax(
     bool keepdim,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    std::optional<ttnn::Tensor> optional_output_tensor) {
+    std::optional<ttnn::Tensor> optional_output_tensor,
+    bool use_rvv,
+    std::optional<ttnn::Tensor> optional_maxval_tensor) {
     return ttnn::device_operation::launch<ArgMaxDeviceOperation>(
         ArgMaxDeviceOperation::operation_attributes_t{
             .output_dtype = output_dtype,
@@ -229,9 +290,12 @@ ttnn::Tensor argmax(
             .keepdim = keepdim,
             .sub_core_grids = sub_core_grids,
             .output_mem_config = output_mem_config,
+            .use_rvv = use_rvv,
         },
         ArgMaxDeviceOperation::tensor_args_t{
-            .input = input, .optional_output_tensor = std::move(optional_output_tensor)});
+            .input = input,
+            .optional_output_tensor = std::move(optional_output_tensor),
+            .optional_maxval_tensor = std::move(optional_maxval_tensor)});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
@@ -4,6 +4,7 @@
 #include "argmax_device_operation.hpp"
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/device_operation.hpp"
 #include "argmax_utils.hpp"
 
@@ -235,6 +236,13 @@ void ArgMaxDeviceOperation::validate_on_program_cache_miss(
     if (optional_maxval.has_value()) {
         TT_FATAL(args.use_rvv, "argmax max-value output is only produced by the use_rvv=true path");
         const auto& maxval = optional_maxval.value();
+        TT_FATAL(is_device_tensor(maxval), "argmax max-value tensor must be allocated on device");
+        // Device affinity: the program is launched from the input tensor, so a
+        // maxval buffer on a different device/mesh would have its (foreign)
+        // address bound into this device's kernel.
+        TT_FATAL(
+            maxval.device() == input_tensor_a.device(),
+            "argmax max-value tensor must be on the same device/mesh as the input tensor");
         TT_FATAL(
             maxval.dtype() == DataType::BFLOAT16, "argmax max-value tensor must be BFLOAT16, got {}", maxval.dtype());
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
@@ -23,12 +23,20 @@ struct ArgMaxMultiCoreProgramFactory {
         const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value);
 };
 
+// Opt-in TILE-layout last-dim argmax on the pack RISC's RVV (Zve32f) unit
+// (Blackhole). Single core; returns indices and (optionally) max values.
+struct ArgMaxRvvTileProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value);
+};
+
 struct ArgMaxDeviceOperation {
     using operation_attributes_t = ArgmaxParams;
     using tensor_args_t = ArgmaxInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
-    using program_factory_t = std::variant<ArgMaxSingleCoreProgramFactory, ArgMaxMultiCoreProgramFactory>;
+    using program_factory_t =
+        std::variant<ArgMaxSingleCoreProgramFactory, ArgMaxMultiCoreProgramFactory, ArgMaxRvvTileProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
@@ -46,6 +54,8 @@ ttnn::Tensor argmax(
     bool keepdim,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt);
+    std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt,
+    bool use_rvv = false,
+    std::optional<ttnn::Tensor> optional_maxval_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation_types.hpp
@@ -15,11 +15,20 @@ struct ArgmaxParams {
     bool keepdim{};
     std::optional<CoreRangeSet> sub_core_grids;
     tt::tt_metal::MemoryConfig output_mem_config;
+    // Opt-in: single-core RVV (Zve32f) scan on the pack RISC for TILE-layout
+    // last-dim argmax (Blackhole only). Also enables the optional max-value
+    // output (see ArgmaxInputs::optional_maxval_tensor).
+    bool use_rvv{false};
 };
 
 struct ArgmaxInputs {
     Tensor input;
     std::optional<Tensor> optional_output_tensor;
+    // Optional preallocated BFLOAT16 ROW_MAJOR tensor (same logical shape as
+    // the index output). When provided on the RVV path, the winning max
+    // VALUES are written alongside the indices — greedy-sampling callers
+    // then don't need a separate ttnn.max over the logits.
+    std::optional<Tensor> optional_maxval_tensor;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_rvv_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_rvv_tile_program_factory.cpp
@@ -22,7 +22,7 @@ namespace ttnn::prim {
 using namespace tt::tt_metal;
 
 ProgramDescriptor ArgMaxRvvTileProgramFactory::create_descriptor(
-    const ArgmaxParams& /*operation_attributes*/, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
+    const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input.mesh_tensor();
     const auto& output = tensor_return_value.mesh_tensor();
     const bool has_maxval = tensor_args.optional_maxval_tensor.has_value();
@@ -52,7 +52,18 @@ ProgramDescriptor ArgMaxRvvTileProgramFactory::create_descriptor(
     const uint32_t in_cb_pages = 2 * chunk_pages;
 
     ProgramDescriptor desc;
+    // This single-core factory currently runs on core (0,0) only. Honoring an
+    // arbitrary sub_core_grids placement is a documented follow-up; until then
+    // a grid that excludes (0,0) must fail loudly rather than be silently
+    // ignored (the op would run outside the caller's core partition).
     const CoreCoord core{0, 0};
+    if (operation_attributes.sub_core_grids.has_value()) {
+        TT_FATAL(
+            operation_attributes.sub_core_grids->contains(core),
+            "argmax use_rvv=true currently runs on core (0,0) only, but the supplied sub_core_grids {} excludes it. "
+            "Pass a grid containing (0,0) or omit sub_core_grids.",
+            operation_attributes.sub_core_grids.value());
+    }
     const CoreRangeSet all_cores(CoreRange(core, core));
 
     constexpr auto cb_in = tt::CBIndex::c_0;         // input tiles (ring)
@@ -134,8 +145,14 @@ ProgramDescriptor ArgMaxRvvTileProgramFactory::create_descriptor(
     if (has_maxval) {
         TensorAccessorArgs(tensor_args.optional_maxval_tensor->mesh_tensor()).append_to(reader_ct_args);
     } else {
-        // Placeholder so the kernel's third accessor always has args to parse;
-        // it is never used when has_maxval == false.
+        // Placeholder — contract with reader_argmax_rvv_tile.cpp: the kernel
+        // unconditionally parses exactly THREE TensorAccessorArgs blocks at
+        // compile time (src, dst, val), because the constexpr offset chain
+        // (next_compile_time_args_offset) cannot be made conditional. When no
+        // maxval tensor is supplied, this copy of the output's accessor args
+        // fills the third slot so the arg counts line up; the has_maxval
+        // compile-time arg (== false) guards every use of the resulting
+        // accessor, so it is never dereferenced. Keep the two sides in sync.
         TensorAccessorArgs(output).append_to(reader_ct_args);
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_rvv_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_rvv_tile_program_factory.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Opt-in TILE-layout last-dim argmax on the pack RISC's RVV (Zve32f) unit —
+// Blackhole only, single core. See kernels/argmax_rvv_tile_compute.cpp for
+// the algorithm and semantics notes. Unlike the other argmax paths, this one
+// launches a compute kernel: the unpack/math threads are no-ops and the pack
+// thread does the whole scan, so the dataflow RISC only streams tiles and
+// writes results.
+
+#include "argmax_device_operation.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <algorithm>
+
+namespace ttnn::prim {
+
+using namespace tt::tt_metal;
+
+ProgramDescriptor ArgMaxRvvTileProgramFactory::create_descriptor(
+    const ArgmaxParams& /*operation_attributes*/, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
+    const bool has_maxval = tensor_args.optional_maxval_tensor.has_value();
+
+    const auto& padded_shape = input.padded_shape();
+    const uint32_t rank = padded_shape.size();
+    const uint32_t logical_rank = input.logical_shape().size();
+    const uint32_t tile_width = input.tensor_spec().tile().get_width();
+    const uint32_t tile_height = input.tensor_spec().tile().get_height();
+
+    const uint32_t w_tiles = padded_shape[rank - 1] / tile_width;
+    const uint32_t h_tiles = padded_shape[rank - 2] / tile_height;
+    const uint32_t w_logical = input.logical_shape()[logical_rank - 1];
+    const uint32_t h_logical = logical_rank > 1 ? input.logical_shape()[logical_rank - 2] : 1;
+    const uint32_t outer_dim_units = input.logical_volume() / (h_logical * w_logical);
+
+    const uint32_t src_page_size = input.tensor_spec().compute_page_size_bytes();
+    const uint32_t dst_page_size = output.tensor_spec().compute_page_size_bytes();
+    const uint32_t val_page_size =
+        has_maxval ? tensor_args.optional_maxval_tensor->mesh_tensor().tensor_spec().compute_page_size_bytes()
+                   : dst_page_size;
+    const uint32_t out_page_elems = dst_page_size / sizeof(uint32_t);
+
+    // Chunked double-buffered input streaming: the compute-side scan of chunk
+    // k overlaps the NOC staging of chunk k+1.
+    const uint32_t chunk_pages = std::min<uint32_t>(64, w_tiles);
+    const uint32_t in_cb_pages = 2 * chunk_pages;
+
+    ProgramDescriptor desc;
+    const CoreCoord core{0, 0};
+    const CoreRangeSet all_cores(CoreRange(core, core));
+
+    constexpr auto cb_in = tt::CBIndex::c_0;         // input tiles (ring)
+    constexpr auto cb_res_idx = tt::CBIndex::c_1;    // per-pass index results (u32[32])
+    constexpr auto cb_res_val = tt::CBIndex::c_2;    // per-pass maxval results (bf16[32])
+    constexpr auto cb_stage_idx = tt::CBIndex::c_3;  // output-page staging (indices)
+    constexpr auto cb_stage_val = tt::CBIndex::c_4;  // output-page staging (max values)
+
+    const tt::DataFormat in_df = datatype_to_dataformat_converter(input.dtype());
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in_cb_pages * src_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_in),
+            .data_format = in_df,
+            .page_size = src_page_size,
+        }}},
+    });
+    constexpr uint32_t res_idx_page = 32 * sizeof(uint32_t);
+    constexpr uint32_t res_val_page = 32 * sizeof(uint16_t);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * res_idx_page,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_res_idx),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = res_idx_page,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * res_val_page,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_res_val),
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = res_val_page,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = dst_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_stage_idx),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = dst_page_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = val_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_stage_val),
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = val_page_size,
+        }}},
+    });
+
+    // Reader (data-movement RISC): streams tiles, then writes collected results.
+    std::vector<uint32_t> reader_ct_args = {
+        static_cast<uint32_t>(cb_in),
+        static_cast<uint32_t>(cb_res_idx),
+        static_cast<uint32_t>(cb_res_val),
+        static_cast<uint32_t>(cb_stage_idx),
+        static_cast<uint32_t>(cb_stage_val),
+        src_page_size,
+        chunk_pages,
+        in_cb_pages,
+        w_tiles,
+        h_tiles,
+        h_logical,
+        outer_dim_units,
+        out_page_elems,
+        dst_page_size,
+        val_page_size,
+        static_cast<uint32_t>(has_maxval),
+    };
+    TensorAccessorArgs(input).append_to(reader_ct_args);
+    TensorAccessorArgs(output).append_to(reader_ct_args);
+    if (has_maxval) {
+        TensorAccessorArgs(tensor_args.optional_maxval_tensor->mesh_tensor()).append_to(reader_ct_args);
+    } else {
+        // Placeholder so the kernel's third accessor always has args to parse;
+        // it is never used when has_maxval == false.
+        TensorAccessorArgs(output).append_to(reader_ct_args);
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_rvv_tile.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    {
+        KernelDescriptor::RTArgList args;
+        args.push_back(input);
+        args.push_back(output);
+        if (has_maxval) {
+            args.push_back(tensor_args.optional_maxval_tensor->mesh_tensor());
+        }
+        reader_desc.emplace_runtime_args(core, args);
+    }
+    desc.kernels.push_back(std::move(reader_desc));
+
+    // Compute kernel: unpack/math no-op, pack thread runs the RVV scan.
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_rvv_tile_compute.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = {
+        static_cast<uint32_t>(cb_in),
+        static_cast<uint32_t>(cb_res_idx),
+        static_cast<uint32_t>(cb_res_val),
+        chunk_pages,
+        w_tiles,
+        h_tiles,
+        h_logical,
+        outer_dim_units,
+    };
+    // enable_trisc2_rvv: compile this kernel's TRISC2 (pack) TU with the Zve32f extension —
+    // the in-tree opt-in that makes the RVV scan compile in a stock build.
+    compute_desc.config = ComputeConfigDescriptor{.enable_trisc2_rvv = true};
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_rvv_tile_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_rvv_tile_compute.cpp
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// =============================================================================
+// argmax_rvv_tile_compute.cpp — TILE-layout last-dim argmax+maxval on the pack
+// RISC's RVV (Zve32f) unit. Blackhole only; opt-in via ttnn.argmax(use_rvv).
+//
+// The incumbent TILE-input argmax has NO compute kernel: the whole reduction
+// is a scalar C++ loop on a dataflow RISC at ~23 cyc/element (single core,
+// serialized NOC read + scan per tile). Here the reader streams tiles into a
+// double-buffered CB and this kernel scans them with 16-lane bf16 vector ops:
+//
+//   - TRISC0/1 (unpack/math) are complete no-ops: no Tensix instruction is
+//     ever issued, so there is no LReg/MOP/ADDR_MOD state to conflict with.
+//   - TRISC2 consumes the input CB and produces the per-row (index, maxval)
+//     results via the raw stream-register CB protocol (the counters are
+//     NOC-overlay scratch registers, MMIO-visible from any RISC; this kernel
+//     is the sole acker of the input CB and sole producer of the output CBs).
+//
+// ALGORITHM (per outer index, per 32-row tile-row, chunk-streamed):
+//   Tiles arrive in chunks of CHUNK_PAGES. Rows are processed in pairs: the
+//   two 16-element face rows of a row-pair are CONTIGUOUS in a tile face, so
+//   one e16m4 (vl=32) load covers rows {2g, 2g+1} x cols 0..15 of one face.
+//   Pass A per chunk accumulates a lane-wise unsigned max of x ^ 0x8000 over
+//   the chunk's tiles (2 loads + 2 xor + 2 vmaxu = 6 vector instrs per tile
+//   per row-pair). At the chunk boundary each valid row's 32 accumulator
+//   lanes are reduced; if the chunk's row-max beats the running max, the
+//   still-resident chunk is re-scanned (vmseq + vfirst on the raw bits) for
+//   the FIRST occurrence.
+//
+// SEMANTICS — exactly ttnn.argmax's bfloat16_greater + std::min tie-break:
+//   bfloat16_greater is a pure sign-magnitude bit-pattern total order. The
+//   xor trick (t = x ^ 0x8000) makes unsigned lane max agree with that order
+//   whenever the lane set contains any sign-0 pattern; a chunk-row whose max
+//   transformed value is < 0x8000 was all-negative, and takes an exact minu
+//   fix-up sweep (both-negative order is reversed). Comparisons across chunks
+//   happen in the fully monotone domain m = x ^ ((x >> 15 arith) | 0x8000);
+//   the running max is seeded with m(0xFF80) — the incumbent's -inf init — so
+//   even the all-negative-NaN-row corner matches the incumbent bit-for-bit.
+//   Strictly-greater updates + first-match re-scan preserve the smallest-
+//   index tie-break across lanes, faces, tiles, and chunks.
+//
+// REGISTER BUDGET (hard-earned): e16m4 dual-stream uses 16 of 32 vregs.
+// e16m8 dual-stream needs all 32 and GCC spills a multi-KB stack frame
+// against the pack RISC's ~256B stack — instant overflow hang. Keep helpers
+// noinline and check any future change's prologue for vlenb-scaled sub sp.
+// =============================================================================
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "hostdevcommon/kernel_structs.h"
+
+#ifdef TRISC_PACK
+#include <riscv_vector.h>
+#include "internal/tt-1xx/risc_common.h"  // invalidate_l1_cache()
+
+namespace {
+
+// ---- raw stream-register CB protocol (sole acker / sole producer) ----------
+inline uint16_t amx_tiles_received(uint32_t cb) {
+    return (uint16_t)reg_read((uint32_t)(uintptr_t)get_cb_tiles_received_ptr((int)cb));
+}
+
+inline void amx_in_wait(uint32_t cb, uint16_t my_acked, uint16_t want) {
+    while ((uint16_t)(amx_tiles_received(cb) - my_acked) < want) {
+    }
+}
+
+inline void amx_in_pop(uint32_t cb, uint16_t& my_acked, uint16_t n) {
+    my_acked += n;
+    get_cb_tiles_acked_ptr((int)cb)[0] = my_acked;
+}
+
+inline void amx_out_reserve(uint32_t cb, uint16_t my_received, uint16_t n) {
+    LocalCBInterface& i = get_local_cb_interface(cb);
+    while ((uint16_t)((uint16_t)i.fifo_num_pages -
+                      (uint16_t)(my_received -
+                                 (uint16_t)reg_read((uint32_t)(uintptr_t)get_cb_tiles_acked_ptr((int)cb)))) < n) {
+    }
+}
+
+inline void amx_out_push(uint32_t cb, uint16_t& my_received, uint32_t last_word_addr, uint16_t n) {
+    asm volatile("fence" ::: "memory");
+    (void)*(volatile uint32_t*)last_word_addr;
+    my_received += n;
+    get_cb_tiles_received_ptr((int)cb)[0] = my_received;
+}
+
+// Byte address of global page `t` of CB `cb`. Pack-side CB init leaves
+// fifo_wr_ptr == base and this thread never llk-pushes, so base is stable.
+inline uint32_t amx_page_addr(uint32_t cb, uint32_t t) {
+    LocalCBInterface& i = get_local_cb_interface(cb);
+    const uint32_t slot = t % i.fifo_num_pages;
+    return (i.fifo_wr_ptr + slot * i.fifo_page_size) << 4;  // 16B units
+}
+
+// Wrap-around iterator over consecutive CB pages (keeps the hot loops free of
+// the integer divide amx_page_addr costs per call).
+struct AmxPageIter {
+    uint32_t addr;
+    uint32_t base;
+    uint32_t limit;
+    uint32_t step;
+
+    AmxPageIter(uint32_t cb, uint32_t t0) {
+        LocalCBInterface& i = get_local_cb_interface(cb);
+        base = i.fifo_wr_ptr << 4;
+        step = i.fifo_page_size << 4;
+        limit = base + i.fifo_num_pages * step;
+        addr = amx_page_addr(cb, t0);
+    }
+
+    inline uint32_t next() {  // returns current page address, then advances
+        const uint32_t cur = addr;
+        addr += step;
+        if (addr >= limit) {
+            addr = base;
+        }
+        return cur;
+    }
+};
+
+// Face-quadrant byte offsets of row-pair group `g` (rows 2g, 2g+1) within a
+// 32x32 bf16 tile (faces stored 0,1,2,3; each face 16x16 row-major = 512B).
+// Left face holds cols 0..15, right face (offset +512B) cols 16..31.
+inline uint32_t amx_left_off(uint32_t g) { return ((g < 8) ? 0u : 1024u) + (g & 7u) * 64u; }
+
+constexpr uint16_t kSignBit = 0x8000u;
+// Monotone image of 0xFF80 (-inf) — the incumbent scan's initial max value.
+constexpr uint16_t kInitMono = 0x007Fu;
+
+// Running per-row state for the current tile-row pass. Static => resides in
+// local data memory, not on the (tiny) stack.
+uint16_t s_running_mono[32];
+uint32_t s_running_raw[32];
+uint32_t s_running_idx[32];
+
+// ---- pass A + extraction + (rare) fix-up + (rare) first-index re-scan ------
+// Processes row-pair group `g` of the resident chunk [t0, t0+chunk) and
+// updates the running (mono, raw, idx) state for its valid rows.
+__attribute__((noinline)) void amx_process_chunk_group(
+    uint32_t cb_in, uint32_t t0, uint32_t chunk, uint32_t g, uint32_t rows_in_group, uint32_t tiles_done) {
+    const uint32_t left_off = amx_left_off(g);
+    const size_t vl = __riscv_vsetvl_e16m4(32);
+
+    // Pass A: lane-wise max of x ^ 0x8000 across the chunk's tiles.
+    vuint16m4_t acc_l = __riscv_vmv_v_x_u16m4(0, vl);
+    vuint16m4_t acc_r = __riscv_vmv_v_x_u16m4(0, vl);
+    AmxPageIter it(cb_in, t0);
+    for (uint32_t t = 0; t < chunk; t++) {
+        const uint32_t base = it.next();
+        vuint16m4_t a = __riscv_vle16_v_u16m4((const uint16_t*)(base + left_off), vl);
+        vuint16m4_t b = __riscv_vle16_v_u16m4((const uint16_t*)(base + left_off + 512u), vl);
+        a = __riscv_vxor_vx_u16m4(a, kSignBit, vl);
+        b = __riscv_vxor_vx_u16m4(b, kSignBit, vl);
+        acc_l = __riscv_vmaxu_vv_u16m4(acc_l, a, vl);
+        acc_r = __riscv_vmaxu_vv_u16m4(acc_r, b, vl);
+    }
+
+    for (uint32_t rr = 0; rr < rows_in_group; rr++) {
+        const uint32_t row = 2 * g + rr;
+        const uint32_t row_off = left_off + rr * 32u;  // 16 bf16 = 32B per face row
+
+        // Reduce this row's 16 lanes of each accumulator (lanes 16*rr..).
+        vuint16m4_t sl = rr ? __riscv_vslidedown_vx_u16m4(acc_l, 16, vl) : acc_l;
+        vuint16m4_t sr = rr ? __riscv_vslidedown_vx_u16m4(acc_r, 16, vl) : acc_r;
+        const vuint16m1_t z = __riscv_vmv_s_x_u16m1(0, 1);
+        uint16_t t_row = __riscv_vmv_x_s_u16m1_u16(__riscv_vredmaxu_vs_u16m4_u16m1(sl, z, 16));
+        const uint16_t t_r = __riscv_vmv_x_s_u16m1_u16(__riscv_vredmaxu_vs_u16m4_u16m1(sr, z, 16));
+        if (t_r > t_row) {
+            t_row = t_r;
+        }
+
+        uint16_t mono;
+        uint16_t raw;
+        if (t_row >= kSignBit) {
+            // Some sign-0 pattern exists: xor-domain max IS the winner.
+            mono = t_row;
+            raw = (uint16_t)(t_row ^ kSignBit);
+        } else {
+            // All-negative chunk-row: both-negative order is reversed, take
+            // the exact unsigned MIN over the (still resident) chunk.
+            // NOTE: 16 lanes of e16 need m2 — VLEN=128 caps e16m1 at vl=8.
+            const size_t vl1 = __riscv_vsetvl_e16m2(16);
+            vuint16m2_t mn = __riscv_vmv_v_x_u16m2(0xFFFFu, vl1);
+            AmxPageIter fit(cb_in, t0);
+            for (uint32_t t = 0; t < chunk; t++) {
+                const uint32_t base = fit.next();
+                vuint16m2_t a = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off), vl1);
+                vuint16m2_t b = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off + 512u), vl1);
+                a = __riscv_vxor_vx_u16m2(a, kSignBit, vl1);
+                b = __riscv_vxor_vx_u16m2(b, kSignBit, vl1);
+                mn = __riscv_vminu_vv_u16m2(mn, a, vl1);
+                mn = __riscv_vminu_vv_u16m2(mn, b, vl1);
+            }
+            const uint16_t t_min =
+                __riscv_vmv_x_s_u16m1_u16(__riscv_vredminu_vs_u16m2_u16m1(mn, __riscv_vmv_s_x_u16m1(0xFFFFu, 1), vl1));
+            mono = (uint16_t)(t_min ^ 0x7FFFu);
+            raw = (uint16_t)(t_min ^ kSignBit);
+        }
+
+        // Strictly-greater update in the monotone domain keeps the earliest
+        // occurrence across chunks; first-match re-scan keeps it in-chunk.
+        if (mono > s_running_mono[row]) {
+            const size_t vl1 = __riscv_vsetvl_e16m2(16);
+            uint32_t idx = 0;
+            AmxPageIter sit(cb_in, t0);
+            for (uint32_t t = 0; t < chunk; t++) {
+                const uint32_t base = sit.next();
+                const vuint16m2_t a = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off), vl1);
+                const long fa = __riscv_vfirst_m_b8(__riscv_vmseq_vx_u16m2_b8(a, raw, vl1), vl1);
+                if (fa >= 0) {
+                    idx = (tiles_done + t) * 32u + (uint32_t)fa;
+                    break;
+                }
+                const vuint16m2_t b = __riscv_vle16_v_u16m2((const uint16_t*)(base + row_off + 512u), vl1);
+                const long fb = __riscv_vfirst_m_b8(__riscv_vmseq_vx_u16m2_b8(b, raw, vl1), vl1);
+                if (fb >= 0) {
+                    idx = (tiles_done + t) * 32u + 16u + (uint32_t)fb;
+                    break;
+                }
+            }
+            s_running_mono[row] = mono;
+            s_running_raw[row] = raw;
+            s_running_idx[row] = idx;
+        }
+    }
+}
+
+}  // namespace
+#endif  // TRISC_PACK
+
+void kernel_main() {
+#ifndef TRISC_PACK
+    // unpack + math threads: intentionally empty — no Tensix instructions.
+#else
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out_idx = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_out_val = get_compile_time_arg_val(2);
+    constexpr uint32_t chunk_pages = get_compile_time_arg_val(3);
+    constexpr uint32_t w_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t h_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t logical_height = get_compile_time_arg_val(6);
+    constexpr uint32_t outer_dim_units = get_compile_time_arg_val(7);
+
+    uint16_t acked_in = 0;  // local mirror of cb_in acked (sole acker)
+    uint16_t recv_idx = 0;  // local mirror of cb_out_idx received (sole producer)
+    uint16_t recv_val = 0;  // local mirror of cb_out_val received (sole producer)
+    uint32_t t_global = 0;  // global input page counter (matches the reader)
+
+    for (uint32_t outer = 0; outer < outer_dim_units; outer++) {
+        for (uint32_t i = 0; i < h_tiles; i++) {
+            const uint32_t row_base = i * 32u;
+            const uint32_t units = (logical_height - row_base < 32u) ? (logical_height - row_base) : 32u;
+            const uint32_t n_groups = (units + 1) / 2;
+
+            for (uint32_t r = 0; r < units; r++) {
+                s_running_mono[r] = kInitMono;
+                s_running_raw[r] = 0xFF80u;  // -inf: the incumbent's init value
+                s_running_idx[r] = 0;
+            }
+
+            uint32_t tiles_done = 0;
+            while (tiles_done < w_tiles) {
+                const uint32_t chunk = (w_tiles - tiles_done < chunk_pages) ? (w_tiles - tiles_done) : chunk_pages;
+                amx_in_wait(cb_in, acked_in, (uint16_t)chunk);
+                invalidate_l1_cache();
+                for (uint32_t g = 0; g < n_groups; g++) {
+                    const uint32_t rows_in_group = (units - 2 * g < 2u) ? (units - 2 * g) : 2u;
+                    amx_process_chunk_group(cb_in, t_global, chunk, g, rows_in_group, tiles_done);
+                }
+                amx_in_pop(cb_in, acked_in, (uint16_t)chunk);
+                t_global += chunk;
+                tiles_done += chunk;
+            }
+
+            // Emit this tile-row pass's results: one page of indices (u32)
+            // and one page of max values (bf16 raw bits).
+            amx_out_reserve(cb_out_idx, recv_idx, 1);
+            amx_out_reserve(cb_out_val, recv_val, 1);
+            const uint32_t ipage = amx_page_addr(cb_out_idx, recv_idx);
+            const uint32_t vpage = amx_page_addr(cb_out_val, recv_val);
+            volatile uint32_t* ip = (volatile uint32_t*)ipage;
+            volatile uint16_t* vp = (volatile uint16_t*)vpage;
+            for (uint32_t r = 0; r < units; r++) {
+                ip[r] = s_running_idx[r];
+                vp[r] = (uint16_t)s_running_raw[r];
+            }
+            amx_out_push(cb_out_val, recv_val, vpage + (((2u * units - 2u) & ~3u)), 1);
+            amx_out_push(cb_out_idx, recv_idx, ipage + (units - 1u) * 4u, 1);
+        }
+    }
+#endif  // TRISC_PACK
+}

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_rvv_tile_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_rvv_tile_compute.cpp
@@ -80,9 +80,17 @@ inline void amx_out_reserve(uint32_t cb, uint16_t my_received, uint16_t n) {
     }
 }
 
-inline void amx_out_push(uint32_t cb, uint16_t& my_received, uint32_t last_word_addr, uint16_t n) {
+// Publish `n` pages of CB `cb` after the caller has written `bytes_written`
+// bytes starting at the (16B-aligned) page base `page_addr`. Stores from this
+// RISC drain to L1 in program order, so reading back the aligned 4-byte word
+// that CONTAINS the last written byte — offset (bytes_written - 1) & ~3 —
+// guarantees every store into the page is L1-visible before the received
+// counter moves. Rounding DOWN is required (an aligned uint32_t load whose
+// span covers the final byte), so e.g. bytes_written == 2 fences word 0:
+// that IS the word holding the last written half-word, not an "early" fence.
+inline void amx_out_push(uint32_t cb, uint16_t& my_received, uint32_t page_addr, uint32_t bytes_written, uint16_t n) {
     asm volatile("fence" ::: "memory");
-    (void)*(volatile uint32_t*)last_word_addr;
+    (void)*(volatile uint32_t*)(page_addr + ((bytes_written - 1u) & ~3u));
     my_received += n;
     get_cb_tiles_received_ptr((int)cb)[0] = my_received;
 }
@@ -287,8 +295,11 @@ void kernel_main() {
                 ip[r] = s_running_idx[r];
                 vp[r] = (uint16_t)s_running_raw[r];
             }
-            amx_out_push(cb_out_val, recv_val, vpage + (((2u * units - 2u) & ~3u)), 1);
-            amx_out_push(cb_out_idx, recv_idx, ipage + (units - 1u) * 4u, 1);
+            // val page: `units` contiguous bf16 raw-bit half-words (2B each);
+            // idx page: `units` contiguous u32 indices (4B each). The helper
+            // fences on the aligned word containing the last written byte.
+            amx_out_push(cb_out_val, recv_val, vpage, 2u * units, 1);
+            amx_out_push(cb_out_idx, recv_idx, ipage, 4u * units, 1);
         }
     }
 #endif  // TRISC_PACK

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_rvv_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_rvv_tile.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// =============================================================================
+// reader_argmax_rvv_tile.cpp — dataflow side of the RVV TILE-layout argmax.
+//
+// Streams the input tiles of each 32-row tile-row into the (double-buffered)
+// input CB in chunks, then collects the per-row (index, maxval) results the
+// compute kernel pushes and writes them to the output tensor(s).
+//
+// The input CB is treated as a ring of pages addressed by GLOBAL page index
+// (slot = t % num_pages) on BOTH sides, so chunk batches may wrap mid-batch
+// without any linear-placement assumption. NOC reads are issued per chunk
+// with batched barriers — the scan on the compute side overlaps the next
+// chunk's staging.
+// =============================================================================
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "internal/tt-1xx/risc_common.h"  // invalidate_l1_cache()
+
+void kernel_main() {
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_res_idx = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_res_val = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_stage_idx = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_stage_val = get_compile_time_arg_val(4);
+    constexpr uint32_t src_page_size = get_compile_time_arg_val(5);
+    constexpr uint32_t chunk_pages = get_compile_time_arg_val(6);
+    constexpr uint32_t in_cb_pages = get_compile_time_arg_val(7);
+    constexpr uint32_t w_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t h_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t logical_height = get_compile_time_arg_val(10);
+    constexpr uint32_t outer_dim_units = get_compile_time_arg_val(11);
+    constexpr uint32_t out_page_elems = get_compile_time_arg_val(12);
+    constexpr uint32_t dst_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t val_page_size = get_compile_time_arg_val(14);
+    constexpr bool has_maxval = (bool)get_compile_time_arg_val(15);
+    constexpr uint32_t num_c_time_args = 16;
+
+    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
+    const uint32_t val_base_addr = has_maxval ? get_arg_val<uint32_t>(2) : 0;
+
+    constexpr auto s_src_args = TensorAccessorArgs<num_c_time_args>();
+    constexpr auto s_dst_args = TensorAccessorArgs<s_src_args.next_compile_time_args_offset()>();
+    const auto s_src = TensorAccessor(s_src_args, src_base_addr, src_page_size);
+    const auto s_dst = TensorAccessor(s_dst_args, dst_base_addr, dst_page_size);
+
+    // The maxval accessor args are appended only when the tensor is present.
+    constexpr auto s_val_args = TensorAccessorArgs<s_dst_args.next_compile_time_args_offset()>();
+    const auto s_val = TensorAccessor(s_val_args, val_base_addr, val_page_size);
+
+    // Input CB ring base (write pointer sits at base before any push).
+    const uint32_t in_base = get_write_ptr(cb_in);
+
+    // Staging buffers for output pages (plain L1 scratch, no FIFO semantics).
+    const uint32_t stage_idx_addr = get_write_ptr(cb_stage_idx);
+    const uint32_t stage_val_addr = get_write_ptr(cb_stage_val);
+    uint32_t* const stage_idx = (uint32_t*)stage_idx_addr;
+    uint16_t* const stage_val = (uint16_t*)stage_val_addr;
+
+    uint32_t t_global = 0;   // global input page counter (matches compute side)
+    uint32_t collected = 0;  // elements accumulated toward the current output page
+    uint32_t out_page_id = 0;
+
+    for (uint32_t outer = 0; outer < outer_dim_units; outer++) {
+        for (uint32_t i = 0; i < h_tiles; i++) {
+            const uint32_t row_base = i * 32u;
+            const uint32_t units = (logical_height - row_base < 32u) ? (logical_height - row_base) : 32u;
+            const uint32_t tile_row_first = (outer * h_tiles + i) * w_tiles;
+
+            uint32_t done = 0;
+            while (done < w_tiles) {
+                const uint32_t chunk = (w_tiles - done < chunk_pages) ? (w_tiles - done) : chunk_pages;
+                cb_reserve_back(cb_in, chunk);
+                for (uint32_t k = 0; k < chunk; k++) {
+                    const uint32_t slot = (t_global + k) % in_cb_pages;
+                    noc_async_read_tile(tile_row_first + done + k, s_src, in_base + slot * src_page_size);
+                    if ((k & 31u) == 31u) {
+                        noc_async_read_barrier();
+                    }
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_in, chunk);
+                t_global += chunk;
+                done += chunk;
+            }
+
+            // Collect this tile-row pass's results from the compute kernel.
+            cb_wait_front(cb_res_idx, 1);
+            cb_wait_front(cb_res_val, 1);
+            invalidate_l1_cache();
+            volatile tt_l1_ptr uint32_t* ip = (volatile tt_l1_ptr uint32_t*)get_read_ptr(cb_res_idx);
+            volatile tt_l1_ptr uint16_t* vp = (volatile tt_l1_ptr uint16_t*)get_read_ptr(cb_res_val);
+            for (uint32_t r = 0; r < units; r++) {
+                stage_idx[collected] = ip[r];
+                if constexpr (has_maxval) {
+                    stage_val[collected] = vp[r];
+                }
+                collected++;
+                if (collected == out_page_elems) {
+                    noc_async_write(stage_idx_addr, s_dst.get_noc_addr(out_page_id), dst_page_size);
+                    if constexpr (has_maxval) {
+                        noc_async_write(stage_val_addr, s_val.get_noc_addr(out_page_id), val_page_size);
+                    }
+                    noc_async_write_barrier();
+                    collected = 0;
+                    out_page_id++;
+                }
+            }
+            cb_pop_front(cb_res_idx, 1);
+            cb_pop_front(cb_res_val, 1);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_rvv_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_rvv_tile.cpp
@@ -39,6 +39,10 @@ void kernel_main() {
     constexpr bool has_maxval = (bool)get_compile_time_arg_val(15);
     constexpr uint32_t num_c_time_args = 16;
 
+    // Base addresses are positional RUNTIME args by design (repo idiom, cf.
+    // reader_argmax_tile_layout*.cpp): TensorAccessorArgs carry only the
+    // compile-time banking/layout — TensorAccessor requires the base address
+    // at construction so program-cache rebinds can update it per allocation.
     const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
     const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
     const uint32_t val_base_addr = has_maxval ? get_arg_val<uint32_t>(2) : 0;

--- a/ttnn/cpp/ttnn/operations/reduction/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/reduction/sources.cmake
@@ -4,6 +4,7 @@
 set(TTNN_OP_REDUCTION_SRCS
     argmax/device/argmax_device_operation.cpp
     argmax/device/argmax_multi_core_program_factory.cpp
+    argmax/device/argmax_rvv_tile_program_factory.cpp
     argmax/device/argmax_single_core_program_factory.cpp
     argmax/device/argmax_nc_device_operation.cpp
     argmax/device/argmax_nc_program_factory.cpp


### PR DESCRIPTION
### PR Category
Feature

> **Stacked on #54105, which is stacked on #54121** (this PR's base is
> `nkapre/argmax-rvv-tile`; only the top commit is new here). The toolchain question is
> resolved by #54121: the fused epilogue kernel opts into the in-tree
> `enable_trisc2_rvv` knob and compiles in upstream CI with the stock sfpi toolchain.
> The silicon-execution pytest suite stays gated behind `TT_ENABLE_RVV_TESTS=1` on
> Blackhole until a BH runner picks it up.

Relates to #20953.

### Summary

Greedy decode pays a whole-vocab sampling tail after the LM-head matmul, as
separate whole-tensor op launches per token:

- `ttnn.argmax`'s TILE path is a single-core scalar C++ loop on a dataflow
  RISC (~23 cyc/element): `[1,1,1,262144]` bf16 measures **9.1 ms** on P150.
- Production callers work around it in caller code: qwen36 pays
  `to_layout(ROW_MAJOR)` + `argmax` + a pad/reshape/`max` chain (argmax does
  not return the winning value); gemma4's spec-decode `_argmax_last` pads to
  32 rows and untilizes just to reach the multicore ROW_MAJOR path. Padded
  vocabs additionally pay a -inf mask add over the tail region.
- Measured tails: 0.92–4.4 ms per token per device (qwen/gemma composites,
  V=131k–262k), on top of the ~1 ms LM-head matmul itself.

Meanwhile the DRAM-sharded matmul's pack RISC carries an idle Zve32f vector
unit with perfect visibility of every freshly packed logit tile.

The base PR (#54105) adds the standalone `ttnn.argmax(..., use_rvv=True)`
op. **This PR fuses the same scan into the production LM-head matmul.**

## What the fused epilogue does

The production LM head is the DRAM-sharded matmul (8 workers on BH, one per
DRAM bank, `models/tt_transformers/tt/lm_head.py`). Passing a preallocated
UINT32 `[1,1,num_dram_banks,64]` tensor as
`ttnn.matmul(..., fused_argmax_partials=t)` makes TRISC2 scan each worker's
freshly packed bf16 output tiles **in the pack shadow of the matmul**:

- **Defer-by-one-subblock consume order** (the mechanic measured on silicon:
  consuming the just-packed tile stalls the math thread +24%; deferring so a
  full queued pack sequence sits in the Tensix FIFO while the RVV scan runs
  costs +0.2–0.6%). The mailbox is the output CB's received stream register,
  which the queued `cb_push_back` STOREREG updates only after the pack HW
  physically wrote the tiles.
- Per-row running argmax+maxval in the sign-magnitude monotone bit domain —
  exactly `bfloat16_greater` + smallest-index + the -inf init, bit-for-bit.
- Each worker writes one 256B partials page (32 rows x (global_index,
  value_bits)); the in1 sender/writer drains it to the partials tensor. The
  final reduce is **8 (idx,val) compares per row** — host-side today
  (ascending bank order preserves the lowest-global-index tie rule across
  cores); a trivial gather kernel can replace it if preferred.
- The scan stops at the **logical** width of in1, so padded-vocab tail
  columns never participate — the -inf mask add dies as a side effect.
- The logits tensor is still produced **byte-identically** (verified), so
  logprobs/debug consumers are unaffected; greedy decode simply stops
  launching the tail (mask-add -> untilize -> argmax -> max: all gone).

`fused_argmax_partials=None` (default) leaves every path untouched — no new
CBs, defines, or runtime args. Eligibility is hard-validated (Blackhole,
DRAMSharded program config, no bias/activation/transposes, TILE bf16 output,
32x32 tiles, bf16/bfp8 weights, per_core_M==1 decode shapes, logical width a
tile multiple).

## Measured (BH P150 @1350 MHz, device profiler, per-op sync, alternating plain/fused pairs)

Per DRAM-sharded split op (K=4096, 8 DRAM-bank workers, production LM-head
config: 64-core storage grid, in0_block_w=2, HiFi2, packer_l1_acc):

| per-split shape | plain | fused | delta |
|---|---|---|---|
| b1, 512 cols, bf16 | 272.8 µs | 275.2 µs | **+0.86%** (scan hidden in the pack shadow) |
| b1, 501 cols (Llama split, pad lane), bf16 | 269.1 µs | 271.2 µs | +0.76% |
| b32, 512 cols, bf16 | 273.3 µs | 345.7 µs | +26.5% (full-width scan exposed after the last pack — see note) |
| b32, 512 cols, bfp8 | 149.6 µs | 224.9 µs | +50.3% (same +75 µs scan, 2x faster matmul) |

Per greedy token (V=131072 = 8 splits as production runs it, bf16, device
op sums; the tail measured op-by-op on the same box):

| per token (device) | b1 | b32 |
|---|---|---|
| matmul x8 + tail, idx+val (to_mem+concat+untilize+argmax+max) | 3,494 µs / 20 launches | 4,229 µs |
| matmul x8 + tail, idx only (no max companion) | 2,301 µs / 19 launches | 3,032 µs |
| **fused matmul x8 + partials concat** | **2,203 µs / 9 launches** | **2,786 µs / 9 launches** |
| vs idx+val parity (what the fused op returns) | **-37%** | **-34%** |
| vs idx-only parity (fused adds maxval for free) | -4.2% | -8.1% |

Loop-order note (the one place silicon disagreed with the pre-study): this
kernel is K-outer — every output pack lands in the last inner K-block, so
full-tile (b32) scans have no pack shadow to hide in and run as an exposed
+75 µs/split tail (they win on tail deletion instead). Decode-b1 scans hide
exactly as the pre-study's microbench predicted (+0.21% there, +0.86% here).
b1 TRISC2 delta = +3.7 µs/split = 78 cyc/tile — the measured argmax-lane
cost, reproduced inside the production op.

## Correctness

- Fused battery: planted-max sweeps at every e16m2/e16m4 lane/face/tile/
  subblock boundary and at all 8 worker seams; ties within a worker, across
  workers (lowest global index), all-negative rows, all--inf rows (the -inf
  init corner), padded-vocab and bank-padded geometries where any leak past
  the logical width would win; random b1/b32 bf16+bfp8. Every case gates the
  combined (idx, value-bits) BIT-EXACT against an incumbent-semantics host
  reference computed from the same device logits, plus index cross-checks
  against the standalone RVV op.
- OFF path: logits byte-identical with the flag on vs off; no change at all
  with the flag absent.
- Fused-under-trace: partials bit-identical to eager.

## Tests

`tests/ttnn/unit_tests/operations/matmul/test_matmul_fused_argmax.py` —
random b1/b32 bf16+bfp8, worker-seam plants, cross-worker ties, a
padded-vocab no-leak geometry, and plain-vs-fused logits byte-identity, all
gated bit-exact against the host reference. Gated two ways (module-level
skips with explicit reasons): skips unless the arch is Blackhole, and skips
unless `TT_ENABLE_RVV_TESTS=1` (the JIT-toolchain gate), so stock CI
collects and skips it cleanly.

## CI readiness (verified on BH P150, chip serial 4F16EEDEAA6389ED)

- **Stock-toolchain build**: full clean build (`ninja clean` + full rebuild,
  1409 targets) with the stock sfpi 7.70.0 toolchain — green. The RVV kernel
  sources appear nowhere in the build graph (JIT-only; verified against
  `build.ninja` and the generated unity TUs — only the host-side program
  factory is host-compiled).
- **Test gating**: with the gate closed (no `TT_ENABLE_RVV_TESTS`), all 34
  new tests across both files skip at collection with the explicit
  toolchain-gate reason (0.06 s, no device opened). With the gate open on BH
  + an RVV-enabled JIT toolchain: all 7 fused-epilogue tests in this PR pass on silicon (34 across the two-PR stack, 34.6 s total), including the plain-vs-fused logits byte-identity assertions.
- **Upstream suites, feature OFF, stock toolchain** (BH P150, chip serial
  4F16EEDEAA6389ED):
  - `tests/ttnn/unit_tests/operations/reduce/test_argmax.py`: **67 passed**.
  - `tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_dram_sharded.py`
    (the program factory this stack extends): **73 passed** — and the same
    16-test `with_program_cache` family was timed against a stock
    `origin/main` build on the same box: 16/16 pass, 27.0 s both sides.
  - `tests/ttnn/unit_tests/operations/matmul/test_matmul.py -k dram_sharded`
    (tiny-tile factory coverage): **25 passed, 10 skipped** (arch-gated
    variants), 0 failed.
- **Lint**: repo pre-commit clean on every changed file (clang-format,
  black, gersemi, expect_error hook, custom ttnn hooks).

### Notes for reviewers

**Toolchain (the shared review question, same as the base PR):** the
epilogue kernel compiles the pack-thread TU with `zve32f` via a local
wrapper g++ today (`-DUCK_CHLKC_PACK` compiles only, `-fno-lto`; no other
thread changes). Upstreaming needs that flag plumbed into the JIT for
kernels that request it, or zve32f in the TRISC2 march. Kernel register
discipline is documented in-source (e16m4 + noinline + fixed frames; e16m8
spills a multi-KB frame against the ~256B TRISC2 stack and must not be
used; VLEN=128 caps e16m1 at vl=8 so 16-lane extracts use e16m2).

**Honest caveats:**
- **b32 does not hide** — the K-outer loop order leaves no pack shadow, so
  the full-tile scan is an exposed +75 µs/split; b32 still wins per token on
  tail deletion (-34%), not on hiding.
- fp32 logits / non-32x32 tiles / prefill (per_core_M > 1) are validated
  out, not built. bf16 logits are a caller-side dtype choice vs the bfp8_b
  production default.
- The host-side 8-pair combine is the least-invasive final reduce; the
  partials contract is shaped so the multi-device CCL winner-select (which
  already consumes (idx,val) pairs) can absorb it.

**Follow-ups:** `lm_head.py` greedy integration (pass the partials tensor
per split, `lm_head_dtype=bfloat16`, skip the concat + sampling tail);
optional tiny gather kernel for the 8->1 combine; Gumbel-max temperature
sampling behind the same flag (SFPU noise in the pack shadow, measured
hidden at +0.11%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/lmhead-fused-argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/lmhead-fused-argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/lmhead-fused-argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/lmhead-fused-argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/lmhead-fused-argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/lmhead-fused-argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/lmhead-fused-argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/lmhead-fused-argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/lmhead-fused-argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/lmhead-fused-argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/lmhead-fused-argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/lmhead-fused-argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/lmhead-fused-argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/lmhead-fused-argmax)