### PR TITLE
fix(sfpu): xielu neg-exp underflow returns 0 instead of garbage reconstruction

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -616,6 +616,43 @@ def test_xielu(alpha_p, alpha_n, dtype, device):
 
 
 @pytest.mark.parametrize(
+    "dtype",
+    [
+        "float32",
+        "bfloat16",
+    ],
+)
+@pytest.mark.parametrize("alpha_p, alpha_n", [(0.8, 0.8), (1.0, 0.5)])
+def test_xielu_underflow_region(dtype, alpha_p, alpha_n, device):
+    """Regression test for #54046.
+
+    For x < -87.68 (= -126.5 * ln(2)), exp(x) underflows the fp32 normal
+    range. The negative-input branch of xielu used to clamp the
+    range-reduction driver instead of guarding the reconstructed exponent,
+    so the residual grew unbounded and the kernel returned garbage
+    magnitudes up to ~2.7e38 or NaN in that region. The correct output is
+    dominated by the -x term there and must stay finite.
+    """
+    torch_dtype = getattr(torch, dtype)
+    ttnn_dtype = getattr(ttnn, dtype)
+
+    x_values = [-80.0, -87.5, -88.0, -90.0, -100.0, -126.0, -200.0, -300.0, -1000.0]
+    torch_input = torch.tensor([x_values] * 32, dtype=torch_dtype)
+    golden_fn = ttnn.get_golden_function(ttnn.xielu)
+    torch_output = golden_fn(torch_input, alpha_p=alpha_p, alpha_n=alpha_n)
+
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_output = ttnn.xielu(ttnn_input, alpha_p=alpha_p, alpha_n=alpha_n)
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert torch.isfinite(ttnn_output.float()).all(), "xielu produced non-finite values in the underflow region"
+    if dtype == "float32":
+        assert_allclose(torch_output, ttnn_output, rtol=6e-05, atol=1e-06)
+    else:
+        assert_with_ulp(torch_output, ttnn_output, 1)
+
+
+@pytest.mark.parametrize(
     "shapes",
     [
         (3, 4, 64, 32),

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -15,14 +15,15 @@ namespace ckernel::sfpu {
 sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
     sfpi::vFloat result = 0.0f;
 
-    constexpr float UNDERFLOW_THRESHOLD = -126.5f;
-
     // Step 1: Compute k = round(x / ln(2))
     // z = x / ln(2) = x * (1/ln(2))
+    //
+    // NOTE: do NOT clamp z here. Clamping the range-reduction driver makes
+    // k (and therefore r = x - k*ln(2)) freeze while the residual keeps
+    // growing for more negative inputs, pushing r far outside the domain
+    // of the polynomial below and producing garbage after reconstruction.
+    // Instead, the underflow is handled on the OUTPUT exponent below.
     sfpi::vFloat z = val * sfpi::vConstFloatPrgm0;
-
-    // Clamp z to -126.5: exp(x) underflows to 0 for large negative x
-    z = sfpi::max(z, UNDERFLOW_THRESHOLD);
 
     // Round z to nearest integer using round-to-nearest
     sfpi::vInt k_int;
@@ -82,8 +83,17 @@ sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
     // Add k_int to get the new exponent
     sfpi::vInt new_exp = p_exp + k_int;
 
-    // Set the new exponent
-    result = sfpi::setexp(p, new_exp);
+    // Guard the OUTPUT exponent: for x below ~-87.7 (=-126.5*ln(2)) the true
+    // exp(x) is subnormal or zero, which the SFPU cannot represent. Returning
+    // 0 keeps the absolute error below FLT_MIN, while reconstructing with an
+    // out-of-range exponent produced garbage magnitudes / NaN.
+    // (Same underflow guard as the exp kernel: reconstruct only when the
+    // biased exponent is >= 1.)
+    result = 0.0f;
+    v_if(new_exp >= 1) {
+        result = sfpi::setexp(p, new_exp);
+    }
+    v_endif;
 
     return result;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_xielu.h
@@ -15,14 +15,15 @@ namespace ckernel::sfpu {
 sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
     sfpi::vFloat result = 0.0f;
 
-    constexpr float UNDERFLOW_THRESHOLD = -126.5f;
-
     // Step 1: Compute k = round(x / ln(2))
     // z = x / ln(2) = x * (1/ln(2))
+    //
+    // NOTE: do NOT clamp z here. Clamping the range-reduction driver makes
+    // k (and therefore r = x - k*ln(2)) freeze while the residual keeps
+    // growing for more negative inputs, pushing r far outside the domain
+    // of the polynomial below and producing garbage after reconstruction.
+    // Instead, the underflow is handled on the OUTPUT exponent below.
     sfpi::vFloat z = val * sfpi::vConstFloatPrgm0;
-
-    // Clamp z to -126.5: exp(x) underflows to 0 for large negative x
-    z = sfpi::max(z, UNDERFLOW_THRESHOLD);
 
     // Round z to nearest integer using round-to-nearest
     sfpi::vInt k_int;
@@ -79,8 +80,17 @@ sfpi_inline sfpi::vFloat _sfpu_neg_exp_f32_(sfpi::vFloat val) {
     // Add k_int to get the new exponent
     sfpi::vInt new_exp = p_exp + k_int;
 
-    // Set the new exponent
-    result = sfpi::setexp(p, new_exp);
+    // Guard the OUTPUT exponent: for x below ~-87.7 (=-126.5*ln(2)) the true
+    // exp(x) is subnormal or zero, which the SFPU cannot represent. Returning
+    // 0 keeps the absolute error below FLT_MIN, while reconstructing with an
+    // out-of-range exponent produced garbage magnitudes / NaN.
+    // (Same underflow guard as the exp kernel: reconstruct only when the
+    // biased exponent is >= 1.)
+    result = 0.0f;
+    v_if(new_exp >= 1) {
+        result = sfpi::setexp(p, new_exp);
+    }
+    v_endif;
 
     return result;
 }


### PR DESCRIPTION
## Problem

`ttnn.xielu`'s negative branch calls `_sfpu_neg_exp_f32_` to compute `exp(x)`. That helper clamped the range-reduction driver `z = x/ln(2)` to `-126.5` *before* rounding:

```cpp
z = sfpi::max(z, UNDERFLOW_THRESHOLD);
```

Once `x < -126.5 * ln(2) ≈ -87.68`, `k` froze at ~-126 while the Cody-Waite residual `r = x - k*ln(2)` kept growing unboundedly negative (e.g. `r ≈ -87` at `x = -200`). The 7-term Taylor polynomial is only valid for `|r| ≲ 0.35`, so the reconstructed value became garbage — magnitudes up to `±2.7e38` and, when `p` overflowed inside the polynomial, `NaN` — exactly as reported in #54046.

## Fix

Remove the driver clamp and guard the **output** exponent instead, mirroring the underflow idiom already used by the exp kernel (`ckernel_sfpu_exp.h`, `v_if(e >= 1)`):

- With no clamp, `k = round(x/ln(2))` tracks the input for any magnitude and `r` stays inside the polynomial's domain.
- After reconstruction, `new_exp = exexp(p) + k_int` is only fed to `setexp` when it is a representable fp32 normal exponent (`>= 1`). Below that point the true `exp(x)` is subnormal or zero; returning `0` keeps the absolute error below `FLT_MIN`, which is negligible next to xielu's dominant `-x` term.

Applied identically to the Wormhole and Blackhole kernel copies (Blackhole's copy differs only in comments).

## Testing

- Added `test_xielu_underflow_region` (fp32 + bf16): sweeps `x ∈ {-80, -87.5, -88, -90, -100, -126, -200, -300, -1000}` across two `(alpha_p, alpha_n)` parameter sets, asserts all outputs are finite and matches the torch golden with the same tolerances as the existing `test_xielu`.
  - On current main the garbage/NaN region makes this fail; with the fix the sweep passes.
- Existing `test_xielu` cases are unaffected: for `x > -87.68` the removed clamp was inactive (`max` identity), so behavior in the valid region is bit-identical.

Fixes #54046

DCCO signed-off commit included.
