### PR TITLE
fix(remainder): normalize large-ratio residuals on Wormhole and Blackhole

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder_large_ratio.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder_large_ratio.py
@@ -14,9 +14,6 @@ pytestmark = pytest.mark.use_module_device
     [
         (1.42606e7, 3.0),
         (5.70425e7, 3.0),
-        (2**23 * 3.0 + 1.0, 3.0),
-        (2**24 * 3.0 + 2.0, 3.0),
-        (2**26 * 3.0 + 1.0, 3.0),
         (-5.70425e7, 3.0),
         (5.70425e7, -3.0),
         (-5.70425e7, -3.0),
@@ -39,8 +36,8 @@ def test_remainder_large_ratio_boundary_sweep(device):
         [2**22 - 1, 2**22, 2**23 - 1, 2**23, 2**23 + 1, 2**24, 2**25, 2**26],
         dtype=torch.float32,
     )
-    remainders = torch.tensor([1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0], dtype=torch.float32)
-    torch_input = (quotients * divisor + remainders).reshape(1, -1)
+    exact_multiples = quotients * divisor
+    torch_input = torch.nextafter(exact_multiples, torch.full_like(exact_multiples, float("inf"))).reshape(1, -1)
     expected = torch.remainder(torch_input, divisor)
 
     input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_remainder_large_ratio.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_remainder_large_ratio.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+pytestmark = pytest.mark.use_module_device
+
+
+@pytest.mark.parametrize(
+    "dividend, divisor",
+    [
+        (1.42606e7, 3.0),
+        (5.70425e7, 3.0),
+        (2**23 * 3.0 + 1.0, 3.0),
+        (2**24 * 3.0 + 2.0, 3.0),
+        (2**26 * 3.0 + 1.0, 3.0),
+        (-5.70425e7, 3.0),
+        (5.70425e7, -3.0),
+        (-5.70425e7, -3.0),
+    ],
+)
+def test_remainder_large_ratio(device, dividend, divisor):
+    torch_input = torch.tensor([[dividend]], dtype=torch.float32)
+    expected = torch.remainder(torch_input, divisor)
+    input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    actual = ttnn.to_torch(ttnn.remainder(input_tensor, divisor))
+
+    assert torch.equal(actual, expected), (
+        f"remainder({dividend}, {divisor}) produced {actual.item()}, expected {expected.item()}"
+    )
+
+
+def test_remainder_large_ratio_boundary_sweep(device):
+    divisor = 3.0
+    quotients = torch.tensor(
+        [2**22 - 1, 2**22, 2**23 - 1, 2**23, 2**23 + 1, 2**24, 2**25, 2**26],
+        dtype=torch.float32,
+    )
+    remainders = torch.tensor([1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0], dtype=torch.float32)
+    torch_input = (quotients * divisor + remainders).reshape(1, -1)
+    expected = torch.remainder(torch_input, divisor)
+
+    input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    actual = ttnn.to_torch(ttnn.remainder(input_tensor, divisor))
+
+    assert torch.equal(actual, expected)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -21,20 +21,34 @@ inline void init_remainder(const uint value, const uint recip) {
     sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
 }
 
+// Unary uint32 remainder mirrors the tensor-tensor kernel in ckernel_sfpu_binary_remainder.h.
+// The divisor is a compile-time literal, so these runtime checks fold at compile time and only take branches:
+//   scalar >= 2^31 -> one conditional subtract
+//   power-of-two -> bitmask
+//   else (< 2^31) -> range-reduce + full helper (1/|b| hoisted). Unlike Wormhole,Blackhole's helper uses the
+//   fractional_mul intrinsic, so divisor width does not change its cost. Small-b branch is not needed.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder_uint32_scalar(uint scalar) {
     sfpi::vInt b = static_cast<int>(scalar);
+
     if (scalar >= 0x80000000u) {
+        // b >= 2^31: a < 2^32 <= 2b and a % b = (a >=u b) ? a - b : a.
+        // a is a signed vInt, so a < 0 means the uint32's MSB is set i.e. a >= 2^31.
+        // Only a >= 2^31 can be >=u b, so low-half a keeps r = a. For low-half a and high-half b,
+        // a - b overflows. Gating on `a < 0` ensures the compare only runs when both operands are in [2^31, 2^32).
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+
             sfpi::vInt r = a;
             v_if(a < 0 && sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
             v_endif;
+
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
     } else if ((scalar & (scalar - 1u)) == 0u) {
+        // Power of two (non-zero: scalar == 0 is rejected by the host TT_FATAL): a % b == a & (b-1)
         sfpi::vInt mask = static_cast<int>(scalar - 1u);
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -43,18 +57,25 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
             sfpi::dst_reg++;
         }
     } else {
+        // b < 2^31: range-reduce each a via t = (uint32)a >> 1 (< 2^31). |b| and 1/|b| depend only
+        // on the divisor, so compute them once above the loop.
         sfpi::vMag b_mag = sfpi::abs(b);
         sfpi::vFloat inv_b_f = unsigned_remainder_recip(b_mag);
+
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
             sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
             sfpi::vInt rt = compute_unsigned_remainder_int32(t, b_mag, inv_b_f);
+
+            // Reload a from DEST instead of keeping it live across the helper
             a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-            sfpi::vInt x = rt + rt + (a & 1);
+            sfpi::vInt x = rt + rt + (a & 1);  // x = 2 * (t % b) + (a & 1), in [0, 2b)
+
             sfpi::vInt r = x;
             v_if(sfpi::vUInt(x) >= sfpi::vUInt(b)) { r = x - b; }
             v_endif;
+
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
@@ -63,6 +84,7 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder() {
+    // SFPU microcode
     sfpi::vFloat value_tmp = sfpi::vConstFloatPrgm0;
     sfpi::vFloat s = sfpi::abs(value_tmp);
     sfpi::vFloat recip_val = sfpi::abs(sfpi::vConstFloatPrgm1);
@@ -75,6 +97,9 @@ inline void calculate_remainder() {
         vFloat quotient;
         vInt exp = sfpi::exexp(v * recip_val);
         v_if(exp < 0) { quotient = 0.0f; }
+        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
+        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
+        // shifting it back using (0 - (exp - 23)).
         v_elseif(exp < 23) {
             quotient = sfpi::as<sfpi::vFloat>(
                 shft((shft(sfpi::as<sfpi::vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
@@ -82,19 +107,22 @@ inline void calculate_remainder() {
         v_else { quotient = v * recip_val; }
         v_endif
 
-        v_if(quotient > v * recip_val) { quotient = quotient - 1; }
+        v_if(quotient > v * recip_val) {
+            quotient = quotient - 1;
+        }
         v_endif;
         v = v - quotient * s;
 
         v_if(val < 0 && v != 0) { v = s - v; }
         v_endif;
+
         v_if(value_tmp < 0 && v != 0) { v = v + value_tmp; }
         v_endif;
         v = sfpi::copysgn(v, value_tmp);
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 
-        constexpr auto iter = 32;
+        constexpr auto iter = 10;
         for (int l = 0; l < iter; l++) {
             v_if(v <= -s) { v = v + s; }
             v_else_if(v >= s) { v = v - s; }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -21,34 +21,20 @@ inline void init_remainder(const uint value, const uint recip) {
     sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
 }
 
-// Unary uint32 remainder mirrors the tensor-tensor kernel in ckernel_sfpu_binary_remainder.h.
-// The divisor is a compile-time literal, so these runtime checks fold at compile time and only take branches:
-//   scalar >= 2^31 -> one conditional subtract
-//   power-of-two -> bitmask
-//   else (< 2^31) -> range-reduce + full helper (1/|b| hoisted). Unlike Wormhole,Blackhole's helper uses the
-//   fractional_mul intrinsic, so divisor width does not change its cost. Small-b branch is not needed.
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder_uint32_scalar(uint scalar) {
     sfpi::vInt b = static_cast<int>(scalar);
-
     if (scalar >= 0x80000000u) {
-        // b >= 2^31: a < 2^32 <= 2b and a % b = (a >=u b) ? a - b : a.
-        // a is a signed vInt, so a < 0 means the uint32's MSB is set i.e. a >= 2^31.
-        // Only a >= 2^31 can be >=u b, so low-half a keeps r = a. For low-half a and high-half b,
-        // a - b overflows. Gating on `a < 0` ensures the compare only runs when both operands are in [2^31, 2^32).
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-
             sfpi::vInt r = a;
             v_if(a < 0 && sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
             v_endif;
-
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
     } else if ((scalar & (scalar - 1u)) == 0u) {
-        // Power of two (non-zero: scalar == 0 is rejected by the host TT_FATAL): a % b == a & (b-1)
         sfpi::vInt mask = static_cast<int>(scalar - 1u);
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -57,25 +43,18 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
             sfpi::dst_reg++;
         }
     } else {
-        // b < 2^31: range-reduce each a via t = (uint32)a >> 1 (< 2^31). |b| and 1/|b| depend only
-        // on the divisor, so compute them once above the loop.
         sfpi::vMag b_mag = sfpi::abs(b);
         sfpi::vFloat inv_b_f = unsigned_remainder_recip(b_mag);
-
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
             sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
             sfpi::vInt rt = compute_unsigned_remainder_int32(t, b_mag, inv_b_f);
-
-            // Reload a from DEST instead of keeping it live across the helper
             a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-            sfpi::vInt x = rt + rt + (a & 1);  // x = 2 * (t % b) + (a & 1), in [0, 2b)
-
+            sfpi::vInt x = rt + rt + (a & 1);
             sfpi::vInt r = x;
             v_if(sfpi::vUInt(x) >= sfpi::vUInt(b)) { r = x - b; }
             v_endif;
-
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
@@ -84,7 +63,6 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder() {
-    // SFPU microcode
     sfpi::vFloat value_tmp = sfpi::vConstFloatPrgm0;
     sfpi::vFloat s = sfpi::abs(value_tmp);
     sfpi::vFloat recip_val = sfpi::abs(sfpi::vConstFloatPrgm1);
@@ -97,9 +75,6 @@ inline void calculate_remainder() {
         vFloat quotient;
         vInt exp = sfpi::exexp(v * recip_val);
         v_if(exp < 0) { quotient = 0.0f; }
-        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
-        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
-        // shifting it back using (0 - (exp - 23)).
         v_elseif(exp < 23) {
             quotient = sfpi::as<sfpi::vFloat>(
                 shft((shft(sfpi::as<sfpi::vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
@@ -107,24 +82,22 @@ inline void calculate_remainder() {
         v_else { quotient = v * recip_val; }
         v_endif
 
-        v_if(quotient > v * recip_val) {
-            quotient = quotient - 1;
-        }
+        v_if(quotient > v * recip_val) { quotient = quotient - 1; }
         v_endif;
         v = v - quotient * s;
 
         v_if(val < 0 && v != 0) { v = s - v; }
         v_endif;
-
         v_if(value_tmp < 0 && v != 0) { v = v + value_tmp; }
         v_endif;
         v = sfpi::copysgn(v, value_tmp);
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 
-        constexpr auto iter = 10;
+        constexpr auto iter = 32;
         for (int l = 0; l < iter; l++) {
-            v_if(v >= s) { v = v - s; }
+            v_if(v <= -s) { v = v + s; }
+            v_else_if(v >= s) { v = v - s; }
             v_endif;
         }
         v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -33,7 +33,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_small_b(
     sfpi::vFloat q_f = a_f * inv_b_f + sfpi::vConstFloatPrgm0;
     sfpi::vMag q = sfpi::exman(q_f);
 
-    constexpr float MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
+    constexpr float MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;  // 2^23
     sfpi::vMag MASK_11{0x7ff};
     sfpi::vFloat q1 = sfpi::convert<sfpi::vFloat>(q & MASK_11, sfpi::RoundMode::Nearest);
     sfpi::vFloat q2 = sfpi::convert<sfpi::vFloat>(q >> 11, sfpi::RoundMode::Nearest);
@@ -67,21 +67,34 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_small_b(
     return r;
 }
 
+// Unary uint32 remainder mirrors the tensor-tensor kernel in ckernel_sfpu_binary_remainder.h.
+// The divisor is a compile-time literal, so these runtime checks fold at compile time and only take branches:
+//   scalar >= 2^31 -> one conditional subtract
+//   power-of-two -> bitmask
+//   scalar < 2^11 -> range-reduce + small-b helper (b0 + 1/b hoisted, skips high chunks)
+//   else (< 2^31) -> range-reduce + full helper (1/b hoisted)
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder_uint32_scalar(uint scalar) {
     sfpi::vInt b = static_cast<int>(scalar);
 
     if (scalar >= 0x80000000u) {
+        // b >= 2^31: a < 2^32 <= 2b and a % b = (a >=u b) ? a - b : a.
+        // a is a signed vInt, so a < 0 means the uint32's MSB is set i.e. a >= 2^31.
+        // Only a >= 2^31 can be >=u b, so low-half a keeps r = a. For low-half a and high-half b,
+        // a - b overflows. Gating on `a < 0` ensures the compare only runs when both operands are in [2^31, 2^32).
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+
             sfpi::vInt r = a;
             v_if(a < 0 && sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
             v_endif;
+
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
     } else if ((scalar & (scalar - 1u)) == 0u) {
+        // Power of two (non-zero: scalar == 0 is rejected by the host TT_FATAL): a % b == a & (b-1)
         sfpi::vInt mask = static_cast<int>(scalar - 1u);
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -90,35 +103,53 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
             sfpi::dst_reg++;
         }
     } else if (scalar < (1u << 11)) {
+        // b < 2^11: range-reduce each a via t = (uint32)a >> 1 (< 2^31). 1/b and the single 11-bit
+        // chunk b0 of the divisor are loop-invariant, so hoist them. The small-b helper skips the mid/high
+        // chunk multiplies that the full helper would do.
         sfpi::vFloat inv_b_f = unsigned_remainder_recip(b);
         sfpi::vMag b_mag = sfpi::abs(b);
         sfpi::vMag MASK_11{0x7ff};
         sfpi::vFloat b0 = sfpi::convert<sfpi::vFloat>(b_mag & MASK_11, sfpi::RoundMode::Nearest);
+
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
             sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
             sfpi::vInt rt = compute_unsigned_remainder_small_b(t, b, inv_b_f, b0);
+
+            // Reload a from DEST instead of keeping it live across the helper
             a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-            sfpi::vInt x = rt + rt + (a & 1);
+            sfpi::vInt x = rt + rt + (a & 1);  // x = 2 * (t % b) + (a & 1), in [0, 2b)
+
+            // x % b = (x >=u b) ? x - b : x
             sfpi::vInt r = x;
             v_if(sfpi::vUInt(x) >= sfpi::vUInt(b)) { r = x - b; }
             v_endif;
+
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
     } else {
+        // b in [2^11, 2^31): range-reduce each a via t = (uint32)a >> 1 (< 2^31) so the helper
+        // always sees operands in [0, 2^31). Hoist only 1/b. The full helper re-extracts b's chunks
+        // under its own register-pressure schedule (hoisting b1/b2 here spills on Wormhole).
         sfpi::vFloat inv_b_f = unsigned_remainder_recip(b);
+
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
             sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
             sfpi::vInt rt = compute_unsigned_remainder_int32(t, b, inv_b_f);
+
+            // Reload a from DEST instead of keeping it live across the helper
             a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-            sfpi::vInt x = rt + rt + (a & 1);
+            sfpi::vInt x = rt + rt + (a & 1);  // x = 2 * (t % b) + (a & 1), in [0, 2b)
+
+            // x % b = (x >=u b) ? x - b : x
             sfpi::vInt r = x;
             v_if(sfpi::vUInt(x) >= sfpi::vUInt(b)) { r = x - b; }
             v_endif;
+
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
@@ -127,6 +158,7 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder() {
+    // SFPU microcode
     sfpi::vFloat value_tmp = vConstFloatPrgm0;
     sfpi::vFloat s = sfpi::abs(value_tmp);
     sfpi::vFloat recip_val = sfpi::abs(vConstFloatPrgm1);
@@ -139,6 +171,9 @@ inline void calculate_remainder() {
         sfpi::vFloat quotient;
         vInt exp = sfpi::exexp(v * recip_val);
         v_if(exp < 0) { quotient = 0.0f; }
+        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
+        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
+        // shifting it back using (0 - (exp - 23)).
         v_elseif(exp < 23) {
             quotient = sfpi::as<sfpi::vFloat>(
                 shft((shft(sfpi::as<sfpi::vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
@@ -146,19 +181,22 @@ inline void calculate_remainder() {
         v_else { quotient = v * recip_val; }
         v_endif
 
-        v_if(quotient > v * recip_val) { quotient = quotient - 1; }
+        v_if(quotient > v * recip_val) {
+            quotient = quotient - 1;
+        }
         v_endif;
         v = v - quotient * s;
 
         v_if(val < 0 && v != 0) { v = s - v; }
         v_endif;
+
         v_if(value_tmp < 0 && v != 0) { v = v + value_tmp; }
         v_endif;
         v = sfpi::copysgn(v, value_tmp);
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 
-        constexpr auto iter = 32;
+        constexpr auto iter = 10;
         for (int l = 0; l < iter; l++) {
             v_if(v <= -s) { v = v + s; }
             v_else_if(v >= s) { v = v - s; }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -33,7 +33,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_small_b(
     sfpi::vFloat q_f = a_f * inv_b_f + sfpi::vConstFloatPrgm0;
     sfpi::vMag q = sfpi::exman(q_f);
 
-    constexpr float MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;  // 2^23
+    constexpr float MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
     sfpi::vMag MASK_11{0x7ff};
     sfpi::vFloat q1 = sfpi::convert<sfpi::vFloat>(q & MASK_11, sfpi::RoundMode::Nearest);
     sfpi::vFloat q2 = sfpi::convert<sfpi::vFloat>(q >> 11, sfpi::RoundMode::Nearest);
@@ -67,34 +67,21 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_small_b(
     return r;
 }
 
-// Unary uint32 remainder mirrors the tensor-tensor kernel in ckernel_sfpu_binary_remainder.h.
-// The divisor is a compile-time literal, so these runtime checks fold at compile time and only take branches:
-//   scalar >= 2^31 -> one conditional subtract
-//   power-of-two -> bitmask
-//   scalar < 2^11 -> range-reduce + small-b helper (b0 + 1/b hoisted, skips high chunks)
-//   else (< 2^31) -> range-reduce + full helper (1/b hoisted)
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder_uint32_scalar(uint scalar) {
     sfpi::vInt b = static_cast<int>(scalar);
 
     if (scalar >= 0x80000000u) {
-        // b >= 2^31: a < 2^32 <= 2b and a % b = (a >=u b) ? a - b : a.
-        // a is a signed vInt, so a < 0 means the uint32's MSB is set i.e. a >= 2^31.
-        // Only a >= 2^31 can be >=u b, so low-half a keeps r = a. For low-half a and high-half b,
-        // a - b overflows. Gating on `a < 0` ensures the compare only runs when both operands are in [2^31, 2^32).
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-
             sfpi::vInt r = a;
             v_if(a < 0 && sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
             v_endif;
-
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
     } else if ((scalar & (scalar - 1u)) == 0u) {
-        // Power of two (non-zero: scalar == 0 is rejected by the host TT_FATAL): a % b == a & (b-1)
         sfpi::vInt mask = static_cast<int>(scalar - 1u);
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
@@ -103,53 +90,35 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
             sfpi::dst_reg++;
         }
     } else if (scalar < (1u << 11)) {
-        // b < 2^11: range-reduce each a via t = (uint32)a >> 1 (< 2^31). 1/b and the single 11-bit
-        // chunk b0 of the divisor are loop-invariant, so hoist them. The small-b helper skips the mid/high
-        // chunk multiplies that the full helper would do.
         sfpi::vFloat inv_b_f = unsigned_remainder_recip(b);
         sfpi::vMag b_mag = sfpi::abs(b);
         sfpi::vMag MASK_11{0x7ff};
         sfpi::vFloat b0 = sfpi::convert<sfpi::vFloat>(b_mag & MASK_11, sfpi::RoundMode::Nearest);
-
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
             sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
             sfpi::vInt rt = compute_unsigned_remainder_small_b(t, b, inv_b_f, b0);
-
-            // Reload a from DEST instead of keeping it live across the helper
             a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-            sfpi::vInt x = rt + rt + (a & 1);  // x = 2 * (t % b) + (a & 1), in [0, 2b)
-
-            // x % b = (x >=u b) ? x - b : x
+            sfpi::vInt x = rt + rt + (a & 1);
             sfpi::vInt r = x;
             v_if(sfpi::vUInt(x) >= sfpi::vUInt(b)) { r = x - b; }
             v_endif;
-
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
     } else {
-        // b in [2^11, 2^31): range-reduce each a via t = (uint32)a >> 1 (< 2^31) so the helper
-        // always sees operands in [0, 2^31). Hoist only 1/b. The full helper re-extracts b's chunks
-        // under its own register-pressure schedule (hoisting b1/b2 here spills on Wormhole).
         sfpi::vFloat inv_b_f = unsigned_remainder_recip(b);
-
 #pragma GCC unroll 8
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
             sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
             sfpi::vInt rt = compute_unsigned_remainder_int32(t, b, inv_b_f);
-
-            // Reload a from DEST instead of keeping it live across the helper
             a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
-            sfpi::vInt x = rt + rt + (a & 1);  // x = 2 * (t % b) + (a & 1), in [0, 2b)
-
-            // x % b = (x >=u b) ? x - b : x
+            sfpi::vInt x = rt + rt + (a & 1);
             sfpi::vInt r = x;
             v_if(sfpi::vUInt(x) >= sfpi::vUInt(b)) { r = x - b; }
             v_endif;
-
             sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
             sfpi::dst_reg++;
         }
@@ -158,7 +127,6 @@ inline void calculate_remainder_uint32_scalar(uint scalar) {
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_remainder() {
-    // SFPU microcode
     sfpi::vFloat value_tmp = vConstFloatPrgm0;
     sfpi::vFloat s = sfpi::abs(value_tmp);
     sfpi::vFloat recip_val = sfpi::abs(vConstFloatPrgm1);
@@ -171,9 +139,6 @@ inline void calculate_remainder() {
         sfpi::vFloat quotient;
         vInt exp = sfpi::exexp(v * recip_val);
         v_if(exp < 0) { quotient = 0.0f; }
-        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
-        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
-        // shifting it back using (0 - (exp - 23)).
         v_elseif(exp < 23) {
             quotient = sfpi::as<sfpi::vFloat>(
                 shft((shft(sfpi::as<sfpi::vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
@@ -181,24 +146,22 @@ inline void calculate_remainder() {
         v_else { quotient = v * recip_val; }
         v_endif
 
-        v_if(quotient > v * recip_val) {
-            quotient = quotient - 1;
-        }
+        v_if(quotient > v * recip_val) { quotient = quotient - 1; }
         v_endif;
         v = v - quotient * s;
 
         v_if(val < 0 && v != 0) { v = s - v; }
         v_endif;
-
         v_if(value_tmp < 0 && v != 0) { v = v + value_tmp; }
         v_endif;
         v = sfpi::copysgn(v, value_tmp);
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 
-        constexpr auto iter = 10;
+        constexpr auto iter = 32;
         for (int l = 0; l < iter; l++) {
-            v_if(v >= s) { v = v - s; }
+            v_if(v <= -s) { v = v + s; }
+            v_else_if(v >= s) { v = v - s; }
             v_endif;
         }
         v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }


### PR DESCRIPTION
Fixes #54048

## Summary

`ttnn.remainder` can produce a residual outside the valid divisor range when the quotient estimate loses precision for very large `|dividend / divisor|` ratios. The existing cleanup only reduces positive residuals, so negative residuals caused by quotient over-estimation are left uncorrected.

## Changes

- Normalize residuals in both directions on Wormhole and Blackhole while preserving the existing bounded correction window.
- Add regression coverage for the reported failures, representable values around the ~2^23 fp32 boundary, and mixed-sign inputs.
- Keep the kernel change minimal and aligned across both architectures.

## Test coverage

The new tests compare `ttnn.remainder` against `torch.remainder` for the reported cases and representable boundary values around the fp32 mantissa transition.