### PR TITLE
[skip ci] Add new bug_checker rules

### DIFF
--- a/.github/bug_checker/README.md
+++ b/.github/bug_checker/README.md
@@ -156,6 +156,9 @@ python .github/bug_checker/run_bug_checker.py --branch --subcommand dry-run
   - `reshape-dim-check` — warning, paths: `ttnn/cpp/ttnn/operations/data_movement/**`, labels: `area:ops`
   - `program-cache-hash-collision` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `tt-train/sources/**/device/*device*`
   - `smuggled-buffer-runtime-arg` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*program_factory*`, `tt_metal/impl/program/**`, `tt-train/sources/**/device/*program_factory*`
+  - `override-rebuild-in-cache-hit` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*program_factory*`, `ttnn/cpp/ttnn/operations/**/device/*device_operation*`
+  - `llk-stale-hw-config-state` — blocking, paths: `tt_metal/tt-llk/**/llk_lib/**`, `tt_metal/tt-llk/**/common/inc/**`, `tt_metal/hw/ckernels/**/llk_api/**`, labels: `area:llk`
+  - `op-shard-layout-validation` — warning, paths: `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `ttnn/cpp/ttnn/operations/**/device/*_op.cpp`, `ttnn/cpp/ttnn/operations/**/device/*_op.hpp`, labels: `area:ops`
 
 ### LLM Analysis — `llm.py` : `LLMSession.analyze_rule()`
 

--- a/.github/bug_checker/README.md
+++ b/.github/bug_checker/README.md
@@ -154,9 +154,9 @@ python .github/bug_checker/run_bug_checker.py --branch --subcommand dry-run
 - Current rules:
   - `ccl-ring-buffer-mismatch` — blocking, paths: `tt_metal/impl/ccl/**`, `ttnn/cpp/ttnn/operations/ccl/**`, labels: `area:ccl`
   - `reshape-dim-check` — warning, paths: `ttnn/cpp/ttnn/operations/data_movement/**`, labels: `area:ops`
-  - `program-cache-hash-collision` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `tt-train/sources/**/device/*device*`
-  - `smuggled-buffer-runtime-arg` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*program_factory*`, `tt_metal/impl/program/**`, `tt-train/sources/**/device/*program_factory*`
-  - `override-rebuild-in-cache-hit` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*program_factory*`, `ttnn/cpp/ttnn/operations/**/device/*device_operation*`
+  - `program-cache-hash-collision` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `ttnn/cpp/ttnn/operations/**/device/*_op.cpp`, `ttnn/cpp/ttnn/operations/**/device/*_op.hpp`, `tt-train/sources/**/device/*device*`
+  - `smuggled-buffer-runtime-arg` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*factory*`, `ttnn/cpp/ttnn/operations/**/device/*program*`, `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `ttnn/cpp/ttnn/operations/**/device/*_op.cpp`, `ttnn/cpp/ttnn/operations/**/device/*_op.hpp`, `ttnn/cpp/ttnn/operations/**/device/*fusion*`, `tt_metal/impl/program/**`, `tt-train/sources/**/device/*program_factory*`
+  - `override-rebuild-in-cache-hit` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*factory*`, `ttnn/cpp/ttnn/operations/**/device/*program*`, `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `ttnn/cpp/ttnn/operations/**/device/*_op.cpp`, `ttnn/cpp/ttnn/operations/**/device/*_op.hpp`, `ttnn/cpp/ttnn/operations/**/device/*fusion*`
   - `llk-stale-hw-config-state` — blocking, paths: `tt_metal/tt-llk/**/llk_lib/**`, `tt_metal/tt-llk/**/common/inc/**`, `tt_metal/hw/ckernels/**/llk_api/**`, labels: `area:llk`
   - `op-shard-layout-validation` — warning, paths: `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `ttnn/cpp/ttnn/operations/**/device/*_op.cpp`, `ttnn/cpp/ttnn/operations/**/device/*_op.hpp`, labels: `area:ops`
 

--- a/.github/bug_checker/README.md
+++ b/.github/bug_checker/README.md
@@ -154,6 +154,8 @@ python .github/bug_checker/run_bug_checker.py --branch --subcommand dry-run
 - Current rules:
   - `ccl-ring-buffer-mismatch` — blocking, paths: `tt_metal/impl/ccl/**`, `ttnn/cpp/ttnn/operations/ccl/**`, labels: `area:ccl`
   - `reshape-dim-check` — warning, paths: `ttnn/cpp/ttnn/operations/data_movement/**`, labels: `area:ops`
+  - `program-cache-hash-collision` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `tt-train/sources/**/device/*device*`
+  - `smuggled-buffer-runtime-arg` — blocking, paths: `ttnn/cpp/ttnn/operations/**/device/*program_factory*`, `tt_metal/impl/program/**`, `tt-train/sources/**/device/*program_factory*`
 
 ### LLM Analysis — `llm.py` : `LLMSession.analyze_rule()`
 

--- a/.github/bug_checker/manifest.yaml
+++ b/.github/bug_checker/manifest.yaml
@@ -26,7 +26,13 @@ rules:
     suggest_fix: true
     model: null
     paths:
+      # Modern convention (*_device_operation.cpp/hpp) plus the legacy
+      # *_op.cpp/hpp family, which still carries ~9 custom
+      # compute_program_hash() implementations (reshape_op, pool_op,
+      # rs_matmul_op, strided_all_gather_async_op, ...).
       - "ttnn/cpp/ttnn/operations/**/device/*device_operation*"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.cpp"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.hpp"
       - "tt-train/sources/**/device/*device*"
 
   smuggled-buffer-runtime-arg:
@@ -35,7 +41,17 @@ rules:
     suggest_fix: true
     model: null
     paths:
-      - "ttnn/cpp/ttnn/operations/**/device/*program_factory*"
+      # Host-side program construction uses several naming families beyond
+      # *program_factory*: *_factory.cpp (all_gather_multicast_factory,
+      # index_fill_multi_core_factory), *_program.cpp (reduce_to_root_program),
+      # *_device_operation.cpp, legacy *_op.cpp, and the *_fusion.cpp helpers.
+      # Kernel sources under device/kernels/ are deliberately not matched.
+      - "ttnn/cpp/ttnn/operations/**/device/*factory*"
+      - "ttnn/cpp/ttnn/operations/**/device/*program*"
+      - "ttnn/cpp/ttnn/operations/**/device/*device_operation*"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.cpp"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.hpp"
+      - "ttnn/cpp/ttnn/operations/**/device/*fusion*"
       - "tt_metal/impl/program/**"
       - "tt-train/sources/**/device/*program_factory*"
 
@@ -45,8 +61,14 @@ rules:
     suggest_fix: true
     model: null
     paths:
-      - "ttnn/cpp/ttnn/operations/**/device/*program_factory*"
+      # Same naming families as smuggled-buffer-runtime-arg: an
+      # override_runtime_arguments() lives wherever the factory lives.
+      - "ttnn/cpp/ttnn/operations/**/device/*factory*"
+      - "ttnn/cpp/ttnn/operations/**/device/*program*"
       - "ttnn/cpp/ttnn/operations/**/device/*device_operation*"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.cpp"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.hpp"
+      - "ttnn/cpp/ttnn/operations/**/device/*fusion*"
 
   llk-stale-hw-config-state:
     file: llk-stale-hw-config-state.md

--- a/.github/bug_checker/manifest.yaml
+++ b/.github/bug_checker/manifest.yaml
@@ -38,3 +38,36 @@ rules:
       - "ttnn/cpp/ttnn/operations/**/device/*program_factory*"
       - "tt_metal/impl/program/**"
       - "tt-train/sources/**/device/*program_factory*"
+
+  override-rebuild-in-cache-hit:
+    file: override-rebuild-in-cache-hit.md
+    severity: blocking
+    suggest_fix: true
+    model: null
+    paths:
+      - "ttnn/cpp/ttnn/operations/**/device/*program_factory*"
+      - "ttnn/cpp/ttnn/operations/**/device/*device_operation*"
+
+  llk-stale-hw-config-state:
+    file: llk-stale-hw-config-state.md
+    severity: blocking
+    suggest_fix: true
+    model: null
+    paths:
+      - "tt_metal/tt-llk/**/llk_lib/**"
+      - "tt_metal/tt-llk/**/common/inc/**"
+      - "tt_metal/hw/ckernels/**/llk_api/**"
+    labels:
+      - "area:llk"
+
+  op-shard-layout-validation:
+    file: op-shard-layout-validation.md
+    severity: warning
+    suggest_fix: true
+    model: null
+    paths:
+      - "ttnn/cpp/ttnn/operations/**/device/*device_operation*"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.cpp"
+      - "ttnn/cpp/ttnn/operations/**/device/*_op.hpp"
+    labels:
+      - "area:ops"

--- a/.github/bug_checker/manifest.yaml
+++ b/.github/bug_checker/manifest.yaml
@@ -19,3 +19,22 @@ rules:
       - "ttnn/cpp/ttnn/operations/data_movement/**"
     labels:
       - "area:ops"
+
+  program-cache-hash-collision:
+    file: program-cache-hash-collision.md
+    severity: blocking
+    suggest_fix: true
+    model: null
+    paths:
+      - "ttnn/cpp/ttnn/operations/**/device/*device_operation*"
+      - "tt-train/sources/**/device/*device*"
+
+  smuggled-buffer-runtime-arg:
+    file: smuggled-buffer-runtime-arg.md
+    severity: blocking
+    suggest_fix: true
+    model: null
+    paths:
+      - "ttnn/cpp/ttnn/operations/**/device/*program_factory*"
+      - "tt_metal/impl/program/**"
+      - "tt-train/sources/**/device/*program_factory*"

--- a/.github/bug_checker/rules/llk-stale-hw-config-state.md
+++ b/.github/bug_checker/rules/llk-stale-hw-config-state.md
@@ -1,0 +1,199 @@
+# LLK Stale Hardware Config State Across Kernel Calls
+
+## Description
+
+LLK compute kernels program the Tensix backend by writing *persistent* hardware
+configuration: unpacker tile descriptors and strides, packer output formats and
+L1 offsets, ALU format-spec / accumulate-control fields, ADDR_MOD slots, and the
+software-side trackers that mirror them. None of this state is reset between
+kernel invocations. Whatever the *previous* op left in a config register is what
+the *next* op starts with.
+
+A bug in this class appears when an op's `_init_` / `_reconfig_` / `_uninit_`
+path fails to fully re-establish the state it depends on, so behaviour becomes
+dependent on which op ran before it. The symptom is order-dependent: the op is
+correct in isolation and in its own unit test, and wrong only when preceded by
+some other op in a fused sequence or a program-cache-warmed second call. There
+is no crash — the packer emits subtly wrong datums, or the pipeline hangs.
+
+Four concrete shapes recur in tt-metal's history:
+
+- A **reconfig writes only some of the fields** it owns, leaving a sibling field
+  at the previous op's value.
+- A **full-word `WRCFG_32b` / `cfg[ADDR]=` write clobbers a neighbouring field**
+  that shares the same 32-bit config word but belongs to another thread or
+  another concern (the classic `STACC_RELU_*` vs
+  `ALU_ACC_CTRL_Zero_Flag_disabled_*` collision).
+- A **software state tracker goes stale**: code writes a config register
+  directly, bypassing the tracker that records what was last programmed, so the
+  tracker's skip-if-already-set fast path then suppresses a genuinely needed
+  re-apply.
+- An **`_init_` / `_uninit_` pair is asymmetric or mis-ordered**, so the op
+  leaves global state it never restores, breaking the *next* op rather than
+  itself.
+
+This is an actively-audited area: `tt_metal/tt-llk/.claude/skills/` carries
+dedicated `reconfig-stall-audit`, `cfg-word-overlap-audit`, and
+`srcreg-bank-sync-audit` skills, and the `llk::san::` sanitizer namespace
+enforces init/uninit contracts at runtime. Roughly thirty separate merged `fix`
+PRs share this root cause, many tagged `[LLK]` / `[SAN]`.
+
+## What to Look For
+
+1. **Partial field update in a reconfig**: a `_reconfig_` / `_init_` function
+   that writes some fields of a config register group but not others that the
+   same op depends on. Cross-check against the matching `_llk_*_hw_configure_`
+   for that unit — every field the full configure sets is a field a reconfig
+   must either set or provably not care about. Also diff the
+   `tt_llk_wormhole_b0` / `tt_llk_blackhole` / `tt_llk_quasar` siblings: a field
+   handled on one arch and missing on another is a strong signal.
+
+2. **Unmasked full-word write to a shared config word**: `TTI_WRCFG(...,
+   p_cfg::WRCFG_32b, X_ADDR32)` or a raw `cfg[X_ADDR32] = ...` targeting a word
+   that holds more than one named field. This zeroes every sibling field in the
+   word. The correct form is a masked read-modify-write —
+   `cfg_reg_rmw_tensix<X_RMW>(value)` — which is byte-atomic and touches only
+   its own bits.
+
+3. **Direct config write that bypasses a software state tracker**: writing
+   `ALU_ACC_CTRL_Zero_Flag_disabled_src` (or any tracked field) directly without
+   calling `_invalidate_src_zero_flag_state_()` afterwards. The tracker's
+   configurators (`_configure_default_zero_flag_state_`,
+   `_configure_unary_preserve_zero_flag_state_`,
+   `_configure_mov_ops_zero_flag_state_`) all early-return when
+   `src_zero_flag_state` already matches, so a stale tracker silently suppresses
+   the next re-apply.
+
+4. **Missing or mis-ordered `_uninit_`**: an `_init_` that installs an ADDR_MOD,
+   MOP program, or format override with no `_uninit_` restoring it, or an
+   `_uninit_` whose LLK calls run in an order that leaves the unit in a
+   half-configured state. Check that `llk::san::operation_init<...>()` is paired
+   with the matching `llk::san::operation_uninit<...>()`, and that the API-order
+   contract the sanitizer asserts is actually satisfied.
+
+5. **Config rewrite with no execution-unit drain**: config registers that the
+   hardware samples *during* an in-flight op must not be reprogrammed while that
+   unit is running. Packer config needs a preceding
+   `TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK)`, unpacker config needs
+   `p_stall::UNPACK0` / `UNPACK1`, and math config needs **both** engines:
+   `p_stall::MATH | p_stall::WAIT_SFPU`. A `p_stall::THCON`-only stall orders the
+   GPR-to-config write but drains no execution unit, and is the classic
+   insufficient guard.
+
+## Bad Code Examples
+
+```cpp
+// BUG: unmasked full-word write — STACC_RELU_ApplyRelu shares its 32-bit config
+// word with ALU_ACC_CTRL_Zero_Flag_disabled_src/dst, which the math thread owns.
+// This zeroes the math thread's zero-flag bits every time relu is configured.
+inline void _llk_pack_relu_config_(const std::uint32_t config)
+{
+    TTI_WRCFG(p_gpr::TMP0, p_cfg::WRCFG_32b, STACC_RELU_ApplyRelu_ADDR32);
+}
+```
+
+```cpp
+// BUG: writes the tracked zero-flag register directly, bypassing the tracker.
+// src_zero_flag_state still reads DEFAULT, so the next
+// _configure_default_zero_flag_state_() call early-returns and never restores
+// the flag — the following matmul runs with the wrong zero-substitution setting.
+inline void _llk_unpack_to_dest_32b_block_()
+{
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    // ... block body ...
+    // missing: _invalidate_src_zero_flag_state_();
+}
+```
+
+```cpp
+// BUG: math config reconfig drains only the FPU. The SFPU shares the math path
+// and also reads ALU_FORMAT_SPEC, so an in-flight SFPU op can sample the
+// half-updated format.
+inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_fmt, const std::uint32_t srcb_fmt)
+{
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH);   // missing | p_stall::WAIT_SFPU
+    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(srca_fmt);
+    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_RMW>(srcb_fmt);
+}
+```
+
+```cpp
+// BUG: reconfig updates the SrcA format but leaves the format-derived ch1 Z/Y
+// strides at the previous operand's values, so the unpacker walks the new tile
+// with the old stride and reads garbage after the first face.
+inline void _llk_unpack_reconfig_data_format_srca_impl_(
+    const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format, const std::uint32_t tile_size)
+{
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_RMW>(unpack_src_format);
+    TT_SETDMAREG(0, LOWER_HALFWORD(tile_size), 0, LO_16(p_gpr_unpack::TILE_SIZE_A));
+    // missing: reprogram the ch1 Z/Y strides that the new format implies
+}
+```
+
+```cpp
+// BUG: init installs a MOP program and an ADDR_MOD but the uninit only tears
+// down the sanitizer contract, leaving the ADDR_MOD slot owned by this op.
+// The next op that assumes the default ADDR_MOD silently mis-addresses.
+inline void _llk_pack_untilize_uninit_()
+{
+    llk::san::operation_uninit<llk::san::Operation::PackUntilize>();
+    // missing: restore the default packer addrmod / MOP state installed by _init_
+}
+```
+
+## Good Code Examples
+
+```cpp
+// GOOD: masked read-modify-write touches only the relu bits, so the math
+// thread's zero-flag bits in the same 32-bit word survive.
+inline void _llk_pack_relu_config_(const std::uint32_t config)
+{
+    cfg_reg_rmw_tensix<STACC_RELU_ApplyRelu_ADDR32, 0, hw_relu_mask>(config);
+}
+```
+
+```cpp
+// GOOD: the direct write is followed by an explicit tracker invalidation, so the
+// next configurator re-applies instead of taking its skip-if-already-set path.
+inline void _llk_unpack_to_dest_32b_block_()
+{
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    // ... block body ...
+    _invalidate_src_zero_flag_state_();
+}
+```
+
+```cpp
+// GOOD: both math engines are drained before the shared ALU config is rewritten.
+inline void _configure_src_zero_flag_(const bool disable)
+{
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable ? 1 : 0);
+}
+```
+
+```cpp
+// GOOD: the reconfig re-establishes every format-derived field it owns, so no
+// field carries over from the previously unpacked operand.
+inline void _llk_unpack_reconfig_data_format_srca_impl_(
+    const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format, const std::uint32_t tile_size)
+{
+    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::UNPACK0);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_RMW>(unpack_src_format);
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Out_data_format_RMW>(unpack_dst_format);
+    _llk_unpack_reconfig_tile_shape_srca_</*issue_stall=*/false>(tile_size);
+    _configure_default_zero_flag_state_(unpack_dst_format, src_zero_flag_srcb_fmt);
+}
+```
+
+```cpp
+// GOOD: the state the init installed is explicitly restored, and the sanitizer
+// contract is closed in the required order.
+inline void _llk_pack_untilize_uninit_(const std::uint32_t pack_dst_format)
+{
+    _llk_pack_configure_addrmod_();                       // restore default addrmod
+    _llk_pack_mop_config_<false>(pack_dst_format);        // restore default MOP
+    llk::san::operation_uninit<llk::san::Operation::PackUntilize>();
+}
+```

--- a/.github/bug_checker/rules/op-shard-layout-validation.md
+++ b/.github/bug_checker/rules/op-shard-layout-validation.md
@@ -1,0 +1,185 @@
+# Missing Shard and Layout Validation at Op Entry
+
+## Description
+
+A TTNN op's device operation is handed tensors whose `Layout` (`TILE` vs
+`ROW_MAJOR`) and `MemoryConfig` (interleaved vs height/width/block sharded) are
+chosen by the *caller*. The op's program factory, however, is usually written
+against one specific combination — it computes core ranges from a shard grid,
+sizes circular buffers from a shard shape, or indexes tiles assuming tile
+layout.
+
+When the validation hook does not reject the combinations the factory cannot
+handle, the factory runs anyway on an input it was never designed for. Because
+nothing asserts, the failure surfaces as **silently wrong output, or a hang**,
+far from the op that caused it — instead of a clean `TT_FATAL` naming the
+unsupported configuration. This was the single largest bug bucket in an audit of
+merged `fix` PRs: 74 of them were an op learning to reject, or correctly handle,
+a layout or memory-config combination it had previously accepted and mangled.
+
+The most common concrete failure is calling `.shard_spec().value()` on a tensor
+that is interleaved. `shard_spec()` returns an optional; dereferencing it on an
+interleaved tensor is undefined behaviour, and even when it happens not to
+crash, the derived core grid is meaningless. Across
+`ttnn/cpp/ttnn/operations/`, `.shard_spec().value()` outnumbers
+`.shard_spec().has_value()` by roughly eight to one, so the unchecked
+dereference is very much the default habit.
+
+**Scope — this rule is about presence of an entry-level compatibility check, not
+about shape arithmetic.** Reshape volume equality, ROW_MAJOR width-of-8
+alignment, TILE 32-divisibility, and MoE tile-distribution tables are covered by
+the separate `reshape-dim-check` rule; do not re-report those here. This rule
+fires on an op that *reads* layout, memory-config, or shard-spec fields to build
+its program without first *validating* that it supports what it was given.
+
+## What to Look For
+
+1. **`.shard_spec().value()` without a sharded guard**: any dereference of the
+   optional shard spec that is not dominated by `is_sharded()`,
+   `shard_spec().has_value()`, or an equivalent `TT_FATAL`. This includes
+   dereferences in the validation hook itself, and in helpers the hook calls.
+
+2. **Validation hook that never mentions layout or memory layout**: a
+   `validate_on_program_cache_miss()` / `validate()` that checks dtype, storage
+   type, and shapes but never constrains `layout()` or
+   `memory_config().memory_layout()`, while the corresponding program factory
+   branches on, or assumes, one of them. If the factory has a
+   `TILE`-only tile-indexing loop, the validator must require `Layout::TILE`.
+
+3. **Partial `TensorMemoryLayout` coverage**: an op that handles
+   `HEIGHT_SHARDED` and `INTERLEAVED` but silently falls through for
+   `WIDTH_SHARDED` / `BLOCK_SHARDED` — typically an `if/else if` chain or a
+   `switch` with no `default:` that raises. Every enumerator the op does not
+   support must be rejected explicitly.
+
+4. **Unvalidated input/output memory-config agreement**: ops that require input
+   and output to share a memory layout, shard shape, shard orientation, or core
+   grid, but only derive the output config from the input without asserting the
+   relationship — and multi-input ops that never check the operands' shard specs
+   are mutually compatible.
+
+5. **New op or new program factory with no layout/shard precondition at all**:
+   an added `DeviceOperation` whose validate hook is empty, trivial, or
+   dtype-only. Confirm the factory's actual assumptions and require them
+   upfront, rather than relying on callers to pass the right thing.
+
+## Bad Code Examples
+
+```cpp
+// BUG: shard_spec() is empty for an interleaved input — this dereferences a
+// disengaged optional. Nothing in validate() requires the input to be sharded.
+void MyOp::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    TT_FATAL(input.dtype() == DataType::BFLOAT16, "Input must be BFLOAT16");
+    const auto& shard_spec = input.shard_spec().value();
+    TT_FATAL(shard_spec.shape[0] % tt::constants::TILE_HEIGHT == 0, "Bad shard height");
+}
+```
+
+```cpp
+// BUG: the factory indexes the input tile-by-tile, but validate never requires
+// TILE layout — a ROW_MAJOR input produces silently wrong output.
+void MyOp::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input must be on device");
+    TT_FATAL(input.buffer() != nullptr, "Input must be allocated");
+    // no constraint on input.layout()
+}
+```
+
+```cpp
+// BUG: WIDTH_SHARDED and BLOCK_SHARDED fall through this chain with
+// num_cores left at 0, which later divides by zero or hangs the program.
+uint32_t num_cores = 0;
+if (input.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+    num_cores = input.shard_spec().value().num_cores();
+} else if (input.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED) {
+    num_cores = compute_grid.x * compute_grid.y;
+}
+```
+
+```cpp
+// BUG: output config is derived from the input without ever checking the two
+// operands are shard-compatible; mismatched grids produce garbage.
+void MyOp::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& a = tensor_args.input_a;
+    const auto& b = tensor_args.input_b;
+    TT_FATAL(a.padded_shape() == b.padded_shape(), "Shapes must match");
+    // a and b may have different memory layouts, shard grids, or orientations
+}
+```
+
+## Good Code Examples
+
+```cpp
+// GOOD: the sharded branch is guarded, so shard_spec() is only dereferenced
+// when it is engaged, and the interleaved case is handled explicitly.
+void MyOp::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    TT_FATAL(input.dtype() == DataType::BFLOAT16, "Input must be BFLOAT16");
+    if (input.is_sharded()) {
+        const auto& shard_spec = input.shard_spec().value();
+        TT_FATAL(
+            shard_spec.shape[0] % tt::constants::TILE_HEIGHT == 0,
+            "Shard height {} must be a multiple of the tile height",
+            shard_spec.shape[0]);
+    }
+}
+```
+
+```cpp
+// GOOD: the layout the factory actually requires is asserted at entry, with a
+// message that names the unsupported configuration.
+void MyOp::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input must be on device");
+    TT_FATAL(
+        input.layout() == Layout::TILE,
+        "my_op: only TILE layout is supported, got {}. Convert the input with "
+        "ttnn::to_layout before calling this op.",
+        input.layout());
+}
+```
+
+```cpp
+// GOOD: every TensorMemoryLayout enumerator is either handled or rejected.
+uint32_t num_cores = 0;
+switch (input.memory_config().memory_layout()) {
+    case TensorMemoryLayout::HEIGHT_SHARDED:
+        num_cores = input.shard_spec().value().num_cores();
+        break;
+    case TensorMemoryLayout::INTERLEAVED:
+        num_cores = compute_grid.x * compute_grid.y;
+        break;
+    default:
+        TT_THROW(
+            "my_op: unsupported memory layout {}. Only HEIGHT_SHARDED and "
+            "INTERLEAVED are supported.",
+            input.memory_config().memory_layout());
+}
+```
+
+```cpp
+// GOOD: the operands' shard compatibility is an explicit precondition.
+void MyOp::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& a = tensor_args.input_a;
+    const auto& b = tensor_args.input_b;
+    TT_FATAL(a.padded_shape() == b.padded_shape(), "Shapes must match");
+    TT_FATAL(
+        a.memory_config().memory_layout() == b.memory_config().memory_layout(),
+        "my_op: operands must share a memory layout, got {} and {}",
+        a.memory_config().memory_layout(),
+        b.memory_config().memory_layout());
+    if (a.is_sharded()) {
+        TT_FATAL(
+            a.shard_spec().value() == b.shard_spec().value(),
+            "my_op: sharded operands must have identical shard specs");
+    }
+}
+```

--- a/.github/bug_checker/rules/override-rebuild-in-cache-hit.md
+++ b/.github/bug_checker/rules/override-rebuild-in-cache-hit.md
@@ -1,0 +1,204 @@
+# Descriptor Rebuild Inside override_runtime_arguments
+
+## Description
+
+`override_runtime_arguments()` runs on **every program-cache hit**. Calling
+`create_descriptor()` (or `apply_descriptor_runtime_args()`) from inside it
+therefore pays the full cache-*miss* host cost on every *hit*:
+`split_work_to_cores`, `CoreRangeSet` construction, arch queries for the compute
+config, `TensorAccessorArgs`, kernel-source strings, compile-time-arg vectors, a
+freshly heap-allocated runtime-arg vector for every core, and then a walk over
+every kernel x core x arg and every CB — all to update two or three scalars.
+
+It is described internally as *the single most expensive mistake on the
+descriptor path*, and it is strictly slower than writing the changed slots in
+place. It is the same cliff that produced the ResNet50 (20x) and resnet-T3K
+(760%) performance regressions.
+
+It is tempting precisely because it looks *safe*: re-running the source of truth
+seems to guarantee the re-applied args cannot drift from the built layout. The
+correct way to get that guarantee for free is to single-source the work split —
+put the core split and per-core layout in one helper called by **both**
+`create_descriptor` and the override — so arg indices are structurally unable to
+drift, at zero host cost.
+
+There is a mechanical guard, `scripts/detect_override_rebuild.py`, run as the
+`detect-override-rebuild` pre-commit hook, with a grandfather list in
+`scripts/detect_override_rebuild_baseline.txt`. Seven ops remain on that
+baseline: `ccl/mesh_partition`, `data_movement/move`, `data_movement/slice`
+(rm_sharded), `data_movement/tilize`, `eltwise/unary`, `moreh/moreh_adam`, and
+`moreh/moreh_adamw`. Each baseline line is a live per-dispatch cost, and
+deleting a line is the fix.
+
+**Why this rule exists on top of that guard:** the script only scans text
+*inside* `override_runtime_arguments` bodies. Factoring the rebuild into a
+shared helper — `refresh_args(...)`, `rebuild_and_apply(...)`, a lambda, a
+base-class method — hides it completely from the textual scan while costing
+exactly the same at runtime. Detecting that requires following the call into the
+helper and recognising that the helper does full-rebuild work. That is the
+central job of this rule.
+
+## What to Look For
+
+1. **Rebuild hidden behind a helper call (the primary case)**: an
+   `override_runtime_arguments()` whose own body is short and clean, but which
+   calls a helper that itself invokes `create_descriptor()`,
+   `apply_descriptor_runtime_args()`, `split_work_to_cores()`, or otherwise
+   reconstructs the descriptor / core layout. Trace every function the override
+   calls — one level is rarely enough. The pre-commit guard cannot see through
+   this; you can. Treat "the override body looks fine" as the beginning of the
+   check, not the end.
+
+2. **Direct rebuild in the override body**: a literal
+   `create_descriptor(...)` / `apply_descriptor_runtime_args(...)` call inside
+   `override_runtime_arguments`. Only acceptable if the file+symbol is already
+   on `scripts/detect_override_rebuild_baseline.txt`, and even then a diff that
+   touches that op should be reducing the cost, not entrenching it.
+
+3. **Work-split logic duplicated instead of shared**: the override recomputing
+   `split_work_to_cores`, core ranges, or per-core tile counts — even inline
+   rather than via `create_descriptor`. This is both the host cost and a drift
+   risk. The fix is one shared helper called by the factory and the override.
+
+4. **The no-op early return trap**: an override that returns early when it has
+   no hash-excluded scalars to write (a prefill path, for example) also skips
+   the **address and CB patching**. `override_runtime_arguments` *supersedes*
+   the framework's own binding patching, so if the override returns, nothing
+   else refreshes those addresses and they freeze at the first miss. Gate only
+   the scalar writes; never gate the address and CB patching. This bit
+   `rotary_embedding`'s prefill path.
+
+5. **Matching CBs by position instead of by `CBIndex`**: refreshing a CB address
+   via `desc.cbs[7]` rather than by looking up its `CBIndex`. Positions shift
+   between descriptor variants — rotary's output CB is `cbs[7]` in the
+   single-tile variant and `cbs[8]` in the multi-tile one — so a positional
+   match silently patches the wrong buffer.
+
+6. **Incomplete refresh coverage**: because the override supersedes framework
+   patching, anything it forgets is frozen at the first miss. Enumerate every
+   bound buffer address, every globally-allocated CB base address, and every
+   hash-excluded scalar. Values derived purely from *hashed* inputs may be
+   skipped — a hit means they are identical — but trace each value to its
+   inputs rather than skipping on "looks static". Cover every core the
+   descriptor emplaced args for, including zero-work / no-op cores.
+
+7. **In-place and aliased tensors**: `resolve_bindings` bails to *empty*
+   bindings when the same buffer appears twice within the **input** region (the
+   `matmul(X, X)` ambiguity). An output aliasing an input is safe and keeps the
+   fast path — but an op that carries its output inside `tensor_args` as an
+   optional `output_tensor` lands in the input region and looks ambiguous,
+   silently losing all bindings. Check the
+   `allow_inplace_output_tensor_alias` handling before assuming the fast path
+   holds. This is the SDXL in-place silu / MorehAdamW class of bug.
+
+8. **Multi-factory ops whose override does not mirror `select_program_factory`**:
+   the selection logic must live in one shared helper too, or the override can
+   patch against the wrong factory's layout.
+
+## Bad Code Examples
+
+```cpp
+// BUG: the canonical anti-pattern — a full descriptor rebuild on every cache
+// hit, just to refresh a couple of addresses.
+void XDeviceOperation::override_runtime_arguments(
+    Program& program, const operation_attributes_t& attrs,
+    const tensor_args_t& tensor_args, tensor_return_value_t& out, MeshCoordinate coord) {
+    auto desc = XProgramFactory::create_descriptor(attrs, tensor_args, out);  // FULL REBUILD
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+}
+```
+
+```cpp
+// BUG: same cost, invisible to scripts/detect_override_rebuild.py because the
+// rebuild is one level down in a helper. The override body looks surgical.
+static void refresh_args(Program& program, const operation_attributes_t& attrs,
+                         const tensor_args_t& tensor_args, tensor_return_value_t& out) {
+    auto desc = XProgramFactory::create_descriptor(attrs, tensor_args, out);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+}
+
+void XDeviceOperation::override_runtime_arguments(
+    Program& program, const operation_attributes_t& attrs,
+    const tensor_args_t& tensor_args, tensor_return_value_t& out, MeshCoordinate coord) {
+    refresh_args(program, attrs, tensor_args, out);   // hidden full rebuild
+}
+```
+
+```cpp
+// BUG: no-op early return. The prefill path has no scalars to write, so the
+// override returns — and thereby also skips the address patching it alone is
+// responsible for. The addresses freeze at the first cache miss.
+void XDeviceOperation::override_runtime_arguments(...) {
+    if (!attrs.is_decode) {
+        return;   // also skipped every buffer address and CB refresh
+    }
+    write_update_idx(program, attrs.update_idx);
+    patch_addresses(program, tensor_args);
+}
+```
+
+```cpp
+// BUG: CB matched by position. desc.cbs[7] is the output CB in the
+// single-tile descriptor variant but cbs[8] in the multi-tile one, so this
+// patches an unrelated buffer half the time.
+desc.cbs[7].buffer = out.buffer();
+```
+
+```cpp
+// BUG: the override recomputes the work split itself. Cheaper than a full
+// create_descriptor, still the expensive part, and now the split logic exists
+// in two places that can drift apart.
+void XDeviceOperation::override_runtime_arguments(...) {
+    auto [num_cores, all_cores, core_group_1, core_group_2, tiles_per_core_1, tiles_per_core_2] =
+        tt::tt_metal::split_work_to_cores(compute_grid, num_tiles);
+    for (const auto& core : corerange_to_cores(all_cores)) { /* ... */ }
+}
+```
+
+## Good Code Examples
+
+```cpp
+// GOOD: the work split lives in ONE helper used by both create_descriptor and
+// the override, so arg indices cannot drift — and the override itself only
+// re-derives and writes per-dispatch state in place.
+static WorkSplit compute_work_split(const operation_attributes_t& attrs, const tensor_args_t& args);
+
+ProgramDescriptor XProgramFactory::create_descriptor(...) {
+    const auto split = compute_work_split(attrs, tensor_args);
+    // ... build kernels/CBs from `split` ...
+}
+
+void XDeviceOperation::override_runtime_arguments(
+    Program& program, const operation_attributes_t& attrs,
+    const tensor_args_t& tensor_args, tensor_return_value_t& out, MeshCoordinate coord) {
+    const auto split = compute_work_split(attrs, tensor_args);   // cheap, no descriptor build
+    auto& reader_args = GetRuntimeArgs(program, shared.reader_kernel_id);
+    for (const auto& core : split.cores) {
+        auto& args = reader_args[core.x][core.y];
+        args[shared.src_addr_idx] = tensor_args.input.buffer()->address();
+        args[shared.dst_addr_idx] = out.buffer()->address();
+        args[shared.update_idx_slot] = attrs.update_idx;
+    }
+}
+```
+
+```cpp
+// GOOD: only the scalar write is gated. Addresses and CBs are refreshed
+// unconditionally, because nothing else will do it.
+void XDeviceOperation::override_runtime_arguments(...) {
+    patch_addresses(program, tensor_args, out);   // always
+    patch_cb_addresses(program, tensor_args);     // always
+    if (attrs.is_decode) {
+        write_update_idx(program, attrs.update_idx);
+    }
+}
+```
+
+```cpp
+// GOOD: CB looked up by CBIndex, so it survives descriptor variants that
+// reorder the cbs vector.
+auto it = std::find_if(desc.cbs.begin(), desc.cbs.end(),
+                       [](const auto& cb) { return cb.index == CBIndex::c_16; });
+TT_FATAL(it != desc.cbs.end(), "output CB c_16 missing from descriptor");
+it->buffer = out.buffer();
+```

--- a/.github/bug_checker/rules/program-cache-hash-collision.md
+++ b/.github/bug_checker/rules/program-cache-hash-collision.md
@@ -2,26 +2,48 @@
 
 ## Description
 
-TTNN's program cache keys a compiled `Program` by a hash computed from a device
-operation's attributes and input tensor specs (`compute_program_hash()`, or the
-default hash for ops that don't override it). If two structurally different
-invocations of the same op hash to the same key, the program cache returns the
-*first* compiled program for the *second* call — the kernels, CBs, and static
-runtime args from call #1 are silently reused for call #2's shapes/dtypes/config.
-This does not crash; it produces wrong output or a downstream assert far from
-the actual bug.
+TTNN's program cache keys a compiled `Program` by a `ProgramCacheKey` that holds
+**both** a 64-bit hash **and** an exact canonical key. The two are not
+equivalent, and the difference is what this rule is about.
 
-Root cause is almost always the same shape: the hash implementation includes
-some but not all of the fields that actually change kernel generation. Common
-gaps are optional tensors (present vs. absent), broadcast/alignment flags that
-differ per operand, and shape fields hashed by rank or volume instead of the
-specific dims that affect tiling and padding.
+**The default path is protected.** An op that does not override
+`compute_program_hash()` gets the default reflection-based hash over
+`(operation_attributes, tensor_args)`. If two structurally different calls
+happen to produce the same 64-bit hash, the canonical key still differs, so the
+lookup **misses** and the op simply compiles a second program. A default-hash
+collision therefore costs a redundant rebuild — it does **not** produce a wrong
+result. Do not report fixed default-hash collision cases as correctness bugs.
 
-Tenstorrent hit this at scale: PR #45821 fixed a program-cache hashing bug in
-one CCL op, and thirteen more ops (all-gather, reduce-scatter, dropout, minimal
-matmul + strided reduce-scatter, neighbor pad, slice reshard, and others) each
-needed their own follow-up fix for the identical root cause, because their hash
-implementations had the same class of gap.
+**Custom hashes opt out of that safety net.** Overriding
+`compute_program_hash()` replaces the structural comparison with whatever the
+override returns (beyond the operation identity). There is no canonical key left
+to disambiguate, so two structurally different invocations that the override
+maps to the same value are a genuine **wrong cache hit**: the program cache
+returns the *first* compiled program for the *second* call, and the kernels, CBs,
+and static runtime args from call #1 are silently reused for call #2's
+shapes/dtypes/config. This does not crash; it produces wrong output or a
+downstream assert far from the actual bug.
+
+So the target of this rule is narrow and specific: **a custom
+`compute_program_hash()` that omits a structural field the program factory
+actually reads.** Common gaps are optional tensors (present vs. absent),
+broadcast/alignment flags that differ per operand, and shapes reduced to a
+single scalar (rank or volume) instead of the dims that drive tiling and
+padding.
+
+Two distinct pieces of history, which should not be conflated:
+
+- **Issue #45821** is the *default*-hash case: `PermuteDeviceOperation` has no
+  custom hash, and the boost-style combiner in `hash_objects` mapped the logical
+  shapes `[3, 17, 1, 1]` and `[1, 152, 1, 1]` to the same 64-bit value, causing a
+  wrong cache hit in `test_batch_norm`. The cause was a **weak hash combiner**,
+  not an omitted field, and the canonical-key comparison described above is what
+  now prevents that class from producing wrong results. It is background, not an
+  example of what this rule detects.
+- **The ~13 per-op fixes** (all-gather, reduce-scatter, dropout, minimal matmul +
+  strided reduce-scatter, neighbor pad, slice reshard, and others) are the real
+  evidence for this rule: each op had written its own `compute_program_hash()`
+  and each had omitted a field its factory depended on.
 
 ## What to Look For
 
@@ -40,10 +62,23 @@ implementations had the same class of gap.
    decision in the hash, not just the output shape (two operand pairs can
    alias to the same output shape via different broadcast paths).
 
-4. **Shape hashed by rank/volume instead of dims**: hashing
-   `shape.rank()` or `shape.volume()` instead of the actual per-dimension
-   values means different-rank shapes with identical padding, or same-volume
-   shapes with different tiling, collide.
+4. **Shape reduced to a single scalar instead of its dims**. Two separate and
+   independent failure modes, which should not be conflated:
+
+   - **Hashing `shape.rank()`**: rank is a *discriminator between different
+     ranks*, so it distinguishes `[32, 64]` from `[1, 32, 64]`. What it cannot
+     do is separate shapes of the **same rank but different dimensions** —
+     `[32, 64]`, `[64, 32]`, and `[128, 256]` all hash identically because only
+     the number `2` is folded in. That is the collision: same rank, different
+     dims.
+   - **Hashing `shape.volume()`**: volume separates different element counts,
+     but aliases shapes with the **same volume and different tiling** —
+     `[32, 64]` and `[64, 32]` both have volume 2048, yet tile into different
+     grids and generate different kernels.
+
+   In both cases the fix is the same — hash the actual per-dimension values —
+   but they are distinct aliasing conditions and a rule that describes only one
+   will miss the other.
 
 5. **New `DeviceOperation` with no explicit hash override**: silently
    inherits a default hash. Confirm the default is specific enough for this
@@ -73,12 +108,24 @@ implementations had the same class of gap.
 ## Bad Code Examples
 
 ```cpp
-// BUG: hash only accounts for rank, not the actual padded dims — a
-// different-rank shape with identical padding collides with this one
+// BUG: only the rank is hashed, so every shape with the SAME rank collides
+// regardless of its dimensions — [32, 64], [64, 32] and [128, 256] all fold
+// in as the single value 2 and share one cached program.
 size_t compute_program_hash() const {
     return tt::stl::hash::hash_objects_with_default_seed(
         operation_attributes.some_flag,
         input_tensor.padded_shape().rank());
+}
+```
+
+```cpp
+// BUG: a separate aliasing mode — volume distinguishes element counts but
+// not tiling, so [32, 64] and [64, 32] (both volume 2048) collide even
+// though they tile into different grids and need different kernels.
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        operation_attributes.some_flag,
+        input_tensor.padded_shape().volume());
 }
 ```
 
@@ -125,8 +172,9 @@ desc.custom_program_hash = tt::stl::hash::hash_objects_with_default_seed(attrs.m
 ## Good Code Examples
 
 ```cpp
-// GOOD: hashes the actual padded shape (not just rank), so
-// different-rank shapes with identical padding get distinct keys
+// GOOD: hashes the actual per-dimension padded shape, so same-rank shapes
+// with different dims — and same-volume shapes with different tiling — all
+// get distinct keys.
 size_t compute_program_hash() const {
     return tt::stl::hash::hash_objects_with_default_seed(
         operation_attributes.some_flag,

--- a/.github/bug_checker/rules/program-cache-hash-collision.md
+++ b/.github/bug_checker/rules/program-cache-hash-collision.md
@@ -49,6 +49,27 @@ implementations had the same class of gap.
    inherits a default hash. Confirm the default is specific enough for this
    op's actual configuration space before assuming it's fine.
 
+6. **Hashing a buffer address** — the inverse mistake: *including* a field that
+   must not be in the key. Folding `buffer()->address()` into the hash puts the
+   allocation itself into the cache key, so every reallocation produces a new
+   entry: unbounded cache growth, a fresh compile on essentially every call, and
+   the cache stops functioning as a cache. An address is never a structural
+   property. If a hash is reaching for one, the thing actually needed is a
+   per-dispatch refresh (a `BufferBinding`, or a re-apply in
+   `override_runtime_arguments`), not a key field.
+
+7. **`ProgramDescriptor::custom_program_hash` misuse**: this replaces the
+   descriptor's *structural* hash outright. It is **not** the op's
+   `compute_program_hash`, and setting it discards the structural keying the
+   framework would otherwise derive. You almost never want it — treat any new
+   use as needing explicit justification.
+
+8. **Excluding shape while the program bakes a per-core work distribution**: a
+   hash that omits shape or volume lets one cached program be shared across
+   different work splits, so per-core tile counts baked at the first miss are
+   wrong for later calls. Excluding a field is only safe if it is also
+   re-applied per dispatch — there is no third category.
+
 ## Bad Code Examples
 
 ```cpp
@@ -79,6 +100,26 @@ size_t compute_program_hash() const {
 size_t compute_program_hash() const {
     return tt::stl::hash::hash_objects_with_default_seed(output_shape);
 }
+```
+
+```cpp
+// BUG: hashing a buffer address puts the allocation in the cache key. Every
+// reallocation is a brand-new entry, so the cache grows without bound and
+// recompiles on essentially every call. The address needed a per-dispatch
+// refresh (a BufferBinding), not a key field.
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        input_tensor.padded_shape(),
+        input_tensor.buffer()->address());
+}
+```
+
+```cpp
+// BUG: custom_program_hash replaces the descriptor's STRUCTURAL hash. This
+// is not compute_program_hash — setting it here throws away the framework's
+// structural keying and silently narrows the key to one attribute.
+ProgramDescriptor desc = build_descriptor(...);
+desc.custom_program_hash = tt::stl::hash::hash_objects_with_default_seed(attrs.mode);
 ```
 
 ## Good Code Examples
@@ -112,5 +153,31 @@ size_t compute_program_hash() const {
         input_tensor_b.padded_shape(),
         broadcast_alignment_a,
         broadcast_alignment_b);
+}
+```
+
+```cpp
+// GOOD: only structural properties are hashed. The buffer address is handled
+// as a per-dispatch binding instead of a key field, so the cache stays small
+// and the address is refreshed on every hit.
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        input_tensor.padded_shape(),
+        input_tensor.dtype(),
+        input_tensor.memory_config());
+}
+
+// ... and in the factory:
+kernel.emplace_runtime_args(core, {input_tensor.buffer(), num_tiles});
+```
+
+```cpp
+// GOOD: the shape the work split is derived from is part of the key, so a
+// different split is a cache miss rather than a silently-reused program.
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        operation_attributes.mode,
+        input_tensor.padded_shape(),
+        input_tensor.memory_config());
 }
 ```

--- a/.github/bug_checker/rules/program-cache-hash-collision.md
+++ b/.github/bug_checker/rules/program-cache-hash-collision.md
@@ -1,0 +1,116 @@
+# Program Cache Hash Collision
+
+## Description
+
+TTNN's program cache keys a compiled `Program` by a hash computed from a device
+operation's attributes and input tensor specs (`compute_program_hash()`, or the
+default hash for ops that don't override it). If two structurally different
+invocations of the same op hash to the same key, the program cache returns the
+*first* compiled program for the *second* call — the kernels, CBs, and static
+runtime args from call #1 are silently reused for call #2's shapes/dtypes/config.
+This does not crash; it produces wrong output or a downstream assert far from
+the actual bug.
+
+Root cause is almost always the same shape: the hash implementation includes
+some but not all of the fields that actually change kernel generation. Common
+gaps are optional tensors (present vs. absent), broadcast/alignment flags that
+differ per operand, and shape fields hashed by rank or volume instead of the
+specific dims that affect tiling and padding.
+
+Tenstorrent hit this at scale: PR #45821 fixed a program-cache hashing bug in
+one CCL op, and thirteen more ops (all-gather, reduce-scatter, dropout, minimal
+matmul + strided reduce-scatter, neighbor pad, slice reshard, and others) each
+needed their own follow-up fix for the identical root cause, because their hash
+implementations had the same class of gap.
+
+## What to Look For
+
+1. **New or modified `compute_program_hash()`**: check every attribute and
+   input tensor field the op's `create()` / program factory actually reads to
+   decide kernel structure. If a field is read in `create()` but not folded
+   into the hash, two calls that differ only in that field collide.
+
+2. **Optional inputs/outputs**: ops with an optional bias, residual, mask, or
+   output tensor must hash "provided" vs. "not provided" as a distinct case —
+   not just hash the provided tensor's shape when present and skip the field
+   entirely when absent.
+
+3. **Per-operand broadcast/alignment flags**: binary/ternary ops where each
+   operand can independently broadcast must include each operand's broadcast
+   decision in the hash, not just the output shape (two operand pairs can
+   alias to the same output shape via different broadcast paths).
+
+4. **Shape hashed by rank/volume instead of dims**: hashing
+   `shape.rank()` or `shape.volume()` instead of the actual per-dimension
+   values means different-rank shapes with identical padding, or same-volume
+   shapes with different tiling, collide.
+
+5. **New `DeviceOperation` with no explicit hash override**: silently
+   inherits a default hash. Confirm the default is specific enough for this
+   op's actual configuration space before assuming it's fine.
+
+## Bad Code Examples
+
+```cpp
+// BUG: hash only accounts for rank, not the actual padded dims — a
+// different-rank shape with identical padding collides with this one
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        operation_attributes.some_flag,
+        input_tensor.padded_shape().rank());
+}
+```
+
+```cpp
+// BUG: optional bias tensor's presence isn't part of the hash — a call
+// with bias and a call without bias can hash identically if the other
+// fields happen to match
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        input_tensor_a.padded_shape(),
+        input_tensor_b.padded_shape());
+    // `bias` is read in create() but never enters the hash
+}
+```
+
+```cpp
+// BUG: only the output shape is hashed; two different per-operand
+// broadcast decisions that alias to the same output shape collide
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(output_shape);
+}
+```
+
+## Good Code Examples
+
+```cpp
+// GOOD: hashes the actual padded shape (not just rank), so
+// different-rank shapes with identical padding get distinct keys
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        operation_attributes.some_flag,
+        input_tensor.padded_shape());
+}
+```
+
+```cpp
+// GOOD: optional tensor's presence is an explicit part of the hash
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        input_tensor_a.padded_shape(),
+        input_tensor_b.padded_shape(),
+        bias.has_value(),
+        bias.has_value() ? bias->padded_shape() : ttnn::Shape{});
+}
+```
+
+```cpp
+// GOOD: each operand's broadcast alignment is folded in independently
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        input_tensor_a.padded_shape(),
+        input_tensor_b.padded_shape(),
+        broadcast_alignment_a,
+        broadcast_alignment_b);
+}
+```

--- a/.github/bug_checker/rules/smuggled-buffer-runtime-arg.md
+++ b/.github/bug_checker/rules/smuggled-buffer-runtime-arg.md
@@ -4,11 +4,12 @@
 
 When the program cache hits, TTNN does **not** rebuild the `Program` — it reuses
 the compiled program from the first call and only patches the specific runtime
-args that were registered as dynamic (e.g. via a `BufferBinding` /
-`get_dynamic_runtime_args`-style mechanism in `override_runtime_arguments()`).
-Any buffer address written into a kernel's runtime-arg vector *without* being
-registered that way is frozen at whatever value it had on the call that first
-populated the cache entry.
+args it knows are dynamic. There are three ways an arg becomes known-dynamic: a
+`BufferBinding` auto-registered by `KernelDescriptor::emplace_runtime_args()`,
+the op's `DeviceOperation::get_dynamic_runtime_args()` hook, or an explicit
+hand-written `override_runtime_arguments()`. Any buffer address written into a
+kernel's runtime-arg vector through *none* of those is frozen at whatever value
+it had on the call that first populated the cache entry.
 
 This is easy to introduce because the buggy and correct code look almost
 identical at the call site — `buffer->address()` compiles and runs fine on the
@@ -166,36 +167,51 @@ args.push_back((uint32_t)input_tensor.buffer()->address());  // smuggled-rta-ok:
 ## Good Code Examples
 
 ```cpp
-// GOOD: buffer address registered as a dynamic binding so the program
-// cache knows to patch it on every call, hit or miss
-tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
-shared_variables.buffer_bindings.push_back(
-    BufferBinding{reader_kernel_id, core, /*arg_index=*/0, src_buffer});
-
-void override_runtime_arguments(
-    cached_program_t& cached_program,
-    const operation_attributes_t&,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t&) {
-    for (auto& binding : cached_program.shared_variables.buffer_bindings) {
-        auto& rt_args = GetRuntimeArgs(cached_program.program, binding.kernel_id, binding.core);
-        rt_args[binding.arg_index] = tensor_args.input.buffer()->address();
-    }
-}
+// GOOD: the Buffer* overload of KernelDescriptor::emplace_runtime_args()
+// auto-registers a BufferBinding at that arg position, so the framework
+// resolves it to a RuntimeArgsData* on the cache miss and patches it
+// directly on every cache hit — no override_runtime_arguments needed, and
+// no create_descriptor() rebuild.
+KernelDescriptor reader_kernel{...};
+reader_kernel.emplace_runtime_args(core, {src_buffer, num_tiles, start_id});
+//                                        ^^^^^^^^^^ Buffer*, auto-bound
 ```
 
 ```cpp
-// GOOD: optional-output aliasing is re-resolved and re-patched every call,
-// not just baked in once at create() time
+// GOOD: same thing for a dynamically-built arg list — RTArgList accepts
+// uint32_t and Buffer* entries, and Buffer* entries auto-register.
+KernelDescriptor::RTArgList args;
+args.reserve(4);
+args.push_back(src_buffer);          // registers a BufferBinding
+args.push_back(dst_buffer);          // registers a BufferBinding
+args.push_back(num_tiles);           // plain value
+args.append(fused_op_signaler_args); // plain uint32_t range
+reader_kernel.emplace_runtime_args(core, args);
+```
+
+```cpp
+// GOOD: for common (non-per-core) runtime args, the equivalent call is
+// emplace_common_runtime_args(), which registers a CommonBufferBinding.
+writer_kernel.emplace_common_runtime_args({dst_buffer, page_size_u32});
+```
+
+```cpp
+// GOOD: on a legacy ProgramFactoryConcept op (no descriptor, so no
+// framework BufferBinding available), optional-output aliasing is
+// re-resolved and re-patched on every call rather than baked in at
+// create() time. `out_addr_slots` here is a field of this op's own
+// shared_variables_t recording which arg index holds the address — it is
+// NOT the framework's BufferBinding type.
 void override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t&,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     auto& out_tensor = output.has_value() ? output.value() : tensor_args.input;
-    for (auto& binding : cached_program.shared_variables.output_bindings) {
-        auto& rt_args = GetRuntimeArgs(cached_program.program, binding.kernel_id, binding.core);
-        rt_args[binding.arg_index] = out_tensor.buffer()->address();
+    const auto& shared = cached_program.shared_variables;
+    auto& rt_args = GetRuntimeArgs(cached_program.program, shared.writer_kernel_id);
+    for (const auto& core : shared.cores) {
+        rt_args[core.x][core.y][shared.out_addr_slot] = out_tensor.buffer()->address();
     }
 }
 ```

--- a/.github/bug_checker/rules/smuggled-buffer-runtime-arg.md
+++ b/.github/bug_checker/rules/smuggled-buffer-runtime-arg.md
@@ -16,14 +16,47 @@ very first call (cache miss), and only misbehaves on a subsequent cache-hit
 call with a different tensor at the same buffer-binding slot, which is often
 several calls or a different test entirely.
 
+The correct form is the declared binding: the *only* way the framework learns an
+arg slot holds an address is the `Buffer*` / `const MeshTensor&` overload of
+`emplace_runtime_args()` (or `emplace_common_runtime_args()` for common args),
+which records a `BufferBinding`. Smuggle the address instead and one of two
+things happens, both bad: the op must re-patch the slot by hand on every hit, or
+— with no binding and no override — the adapter falls back to a **full
+descriptor rebuild on every dispatch**, which is exactly the cost that blew the
+perf budget.
+
+```cpp
+// WRONG: smuggled
+reader_args.push_back(input_tensor.buffer()->address());
+kernel.runtime_args.emplace_back(core, reader_args);
+
+// RIGHT: declared binding
+kernel.emplace_runtime_args(core, {input_tensor.buffer(), num_tiles, start_id});
+```
+
 Tenstorrent has hit this repeatedly enough that a pre-commit guard was added,
 plus a nine-op-family sweep to backfill existing violations (moreh,
 moreh_adam, reduction, pool, normalization, eltwise, data-movement,
 experimental-matmul, examples) and several targeted point fixes
 (`point_to_point`, `all_to_all_combine`, `moreh_mean_backward`, `ttnn::pad`).
-The pre-commit guard only catches locally-run, changed files — it does not
-protect the whole tree, so this is worth checking on every diff that touches a
-program factory.
+The guard is `scripts/detect_smuggled_rta.py`, run as the `detect-smuggled-rta`
+pre-commit hook over `ttnn/**/device/**/*.{cpp,hpp}`; it flags `.address()`
+flowing into a descriptor sink. A deliberate exception is suppressed per line
+with a `// smuggled-rta-ok: <reason>` comment — the script accepts the bare
+marker, so the *reason* is unverified and is exactly the thing review must
+judge. Legitimate reasons look like a workload-scoped `GlobalSemaphore` address
+that is stable for the workload's lifetime, or a one-element metadata tensor
+whose address the kernel dereferences on device. "I couldn't get the overload to
+compile" is not one. The pre-commit guard only catches locally-run, changed
+files — it does not protect the whole tree, so this is worth checking on every
+diff that touches a program factory.
+
+**Critically, the fix is not always mechanical.** Adding a binding flips a
+descriptor op from rebuild-every-hit to fast-patch-only, and fast-patch
+refreshes *only* what is declared. So a binding alone is correct only if the
+address is the sole per-dispatch value — otherwise adding it *removes* a rebuild
+that was silently keeping other stale values correct, converting a slow-but-right
+op into a fast-and-wrong one.
 
 ## What to Look For
 
@@ -48,6 +81,29 @@ program factory.
    (including addresses) from `create()`, when it should instead store the
    *indices* of the address slots so `override_runtime_arguments()` can patch
    them.
+
+5. **Work-distribution trap — a binding added without re-keying the hash**: if
+   the op's custom hash drops shape or volume, one cached program is shared
+   across different work splits, and the per-core tile counts baked at the first
+   miss are wrong for the next call. The rebuild that a smuggled address forced
+   was silently covering this. When a diff *adds* a binding (or otherwise
+   removes a rebuild), check that shape/volume are actually in the hash;
+   otherwise the change trades a perf bug for a correctness bug.
+
+6. **Scalar trap — a hash-excluded scalar baked into runtime args**: values like
+   `update_idx`, `step`, `lr`, or a packed scalar that are deliberately excluded
+   from the program hash but written into rt-args at `create()` time freeze at
+   their first-miss value. Every hash-excluded scalar must be re-applied per
+   dispatch, not just the addresses.
+
+7. **Suppression comment without a real reason**: a `// smuggled-rta-ok` marker
+   whose stated justification is not a workload-scoped stable address. The
+   script does not validate the reason, so an unjustified suppression silently
+   reintroduces the bug.
+
+For each of items 5 and 6, the deliberate choices are: re-key the hash so the
+varying case becomes a cache miss, keep the rebuild, or cover everything in an
+override. Picking one implicitly is the bug.
 
 ## Bad Code Examples
 
@@ -78,6 +134,33 @@ void override_runtime_arguments(
 // result keeps writing to the first call's aliased buffer
 auto& out_tensor = output.has_value() ? output.value() : input_tensor;
 rt_args.push_back(out_tensor.buffer()->address());
+```
+
+```cpp
+// BUG: work-distribution trap. The binding is correct, but the custom hash
+// omits shape, so one cached program is reused across different work splits
+// and `num_tiles_per_core` — baked at the first miss — is wrong on the next
+// call. Adding the binding removed the rebuild that was hiding this.
+kernel.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, start_id});
+
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(operation_attributes.mode);
+    // shape/volume excluded, but the program bakes a per-core work split
+}
+```
+
+```cpp
+// BUG: scalar trap. `update_idx` is deliberately excluded from the hash so
+// successive decode steps hit the cache, but it is written once at
+// create() time and never re-applied — it freezes at its first-miss value.
+kernel.emplace_runtime_args(core, {cache.buffer(), input.buffer(), update_idx});
+// no override re-writes the update_idx slot
+```
+
+```cpp
+// BUG: suppression marker with a non-reason — this address is a per-dispatch
+// tensor buffer, not a workload-scoped semaphore, so it really is smuggled.
+args.push_back((uint32_t)input_tensor.buffer()->address());  // smuggled-rta-ok: overload wouldn't compile
 ```
 
 ## Good Code Examples
@@ -115,4 +198,36 @@ void override_runtime_arguments(
         rt_args[binding.arg_index] = out_tensor.buffer()->address();
     }
 }
+```
+
+```cpp
+// GOOD: declared binding via the Buffer* overload, and the work split is
+// re-keyed into the hash so a different split is a cache miss rather than a
+// silently-reused program.
+kernel.emplace_runtime_args(core, {input.buffer(), num_tiles_per_core, start_id});
+
+size_t compute_program_hash() const {
+    return tt::stl::hash::hash_objects_with_default_seed(
+        operation_attributes.mode,
+        input_tensor.padded_shape());   // work split is derived from shape
+}
+```
+
+```cpp
+// GOOD: the hash-excluded scalar is re-applied on every dispatch alongside
+// the bound addresses, so it never freezes at its first-miss value.
+void override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& attrs,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t&) {
+    auto& rt_args = GetRuntimeArgs(cached_program.program, cached_program.shared_variables.kernel_id, core);
+    rt_args[cached_program.shared_variables.update_idx_slot] = attrs.update_idx;
+}
+```
+
+```cpp
+// GOOD: a suppression whose reason is real — the semaphore is created once
+// for the whole workload, so its address is stable across dispatches.
+args.push_back((uint32_t)exit_semaphore.address());  // smuggled-rta-ok: persistent GlobalSemaphore, allocated once per workload
 ```

--- a/.github/bug_checker/rules/smuggled-buffer-runtime-arg.md
+++ b/.github/bug_checker/rules/smuggled-buffer-runtime-arg.md
@@ -1,0 +1,118 @@
+# Smuggled Buffer Address in Runtime Args
+
+## Description
+
+When the program cache hits, TTNN does **not** rebuild the `Program` — it reuses
+the compiled program from the first call and only patches the specific runtime
+args that were registered as dynamic (e.g. via a `BufferBinding` /
+`get_dynamic_runtime_args`-style mechanism in `override_runtime_arguments()`).
+Any buffer address written into a kernel's runtime-arg vector *without* being
+registered that way is frozen at whatever value it had on the call that first
+populated the cache entry.
+
+This is easy to introduce because the buggy and correct code look almost
+identical at the call site — `buffer->address()` compiles and runs fine on the
+very first call (cache miss), and only misbehaves on a subsequent cache-hit
+call with a different tensor at the same buffer-binding slot, which is often
+several calls or a different test entirely.
+
+Tenstorrent has hit this repeatedly enough that a pre-commit guard was added,
+plus a nine-op-family sweep to backfill existing violations (moreh,
+moreh_adam, reduction, pool, normalization, eltwise, data-movement,
+experimental-matmul, examples) and several targeted point fixes
+(`point_to_point`, `all_to_all_combine`, `moreh_mean_backward`, `ttnn::pad`).
+The pre-commit guard only catches locally-run, changed files — it does not
+protect the whole tree, so this is worth checking on every diff that touches a
+program factory.
+
+## What to Look For
+
+1. **Raw `buffer->address()` in `SetRuntimeArgs`**: a program factory's
+   `create()` calling `SetRuntimeArgs(program, kernel_id, core, {..., buffer->
+   address(), ...})` where `buffer` comes from an input/output `Tensor`, with
+   no matching registration in `override_runtime_arguments()`.
+
+2. **Incomplete `override_runtime_arguments()`**: an `override_runtime_arguments`
+   override that patches some but not all of the buffer addresses that
+   `create()` wrote into runtime args for the same kernel — check that every
+   buffer-derived RTA index has a corresponding patch.
+
+3. **Optional-output aliasing frozen at cache-miss time**: patterns like
+   `auto& out = output.has_value() ? output.value() : input;` where the
+   resulting buffer address is written into RTAs during `create()`, but the
+   aliasing decision isn't re-evaluated (or the new buffer isn't re-patched)
+   on a cache-hit call with a different optional-output choice.
+
+4. **Runtime-arg vectors captured by value in `shared_variables`**: a
+   `shared_variables_t` struct that stores a fully-built runtime-arg vector
+   (including addresses) from `create()`, when it should instead store the
+   *indices* of the address slots so `override_runtime_arguments()` can patch
+   them.
+
+## Bad Code Examples
+
+```cpp
+// BUG: buffer address baked directly into the runtime args at create()
+// time, with no BufferBinding registration — a cache-hit call with a
+// different tensor still reads this stale address
+std::vector<uint32_t> reader_rt_args = {
+    src_buffer->address(),
+    num_tiles,
+};
+tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
+
+// override_runtime_arguments() exists, but never touches reader_rt_args[0]
+void override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t&,
+    const tensor_args_t&,
+    tensor_return_value_t&) {
+    // only num_tiles-related state is patched here — address is never
+    // re-written, so it stays pinned to the first call's buffer
+}
+```
+
+```cpp
+// BUG: optional-output aliasing decided once at create() time and baked
+// into the RTAs; a later cache-hit call with a different has_value()
+// result keeps writing to the first call's aliased buffer
+auto& out_tensor = output.has_value() ? output.value() : input_tensor;
+rt_args.push_back(out_tensor.buffer()->address());
+```
+
+## Good Code Examples
+
+```cpp
+// GOOD: buffer address registered as a dynamic binding so the program
+// cache knows to patch it on every call, hit or miss
+tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_rt_args);
+shared_variables.buffer_bindings.push_back(
+    BufferBinding{reader_kernel_id, core, /*arg_index=*/0, src_buffer});
+
+void override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t&,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t&) {
+    for (auto& binding : cached_program.shared_variables.buffer_bindings) {
+        auto& rt_args = GetRuntimeArgs(cached_program.program, binding.kernel_id, binding.core);
+        rt_args[binding.arg_index] = tensor_args.input.buffer()->address();
+    }
+}
+```
+
+```cpp
+// GOOD: optional-output aliasing is re-resolved and re-patched every call,
+// not just baked in once at create() time
+void override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t&,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& out_tensor = output.has_value() ? output.value() : tensor_args.input;
+    for (auto& binding : cached_program.shared_variables.output_bindings) {
+        auto& rt_args = GetRuntimeArgs(cached_program.program, binding.kernel_id, binding.core);
+        rt_args[binding.arg_index] = out_tensor.buffer()->address();
+    }
+}
+```

--- a/.github/bug_checker/tests/test_rules.py
+++ b/.github/bug_checker/tests/test_rules.py
@@ -109,3 +109,84 @@ def test_select_rules_by_label():
     rules = load_rules()
     selected = select_rules(rules, changed_files=[], pr_labels=["area:ops"])
     assert any(r.id == "reshape-dim-check" for r in selected)
+
+
+# --- real-world path coverage regressions ---
+#
+# These pin the naming families that actually occur under
+# ttnn/cpp/ttnn/operations/**/device/. The blocking rules below were
+# originally scoped to only the modern *_device_operation.cpp /
+# *_program_factory.cpp names and silently skipped every op using a legacy
+# or one-off name. Each path here is a real file on main.
+
+
+def test_hash_rule_matches_legacy_op_filenames():
+    """program-cache-hash-collision must cover legacy *_op.{cpp,hpp} files.
+
+    These all implement a custom compute_program_hash() but do not match
+    the *device_operation* glob.
+    """
+    rules = load_rules()
+    for path in [
+        "ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp",
+        "ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.hpp",
+        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp",
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp",
+        # modern convention must keep working
+        "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp",
+    ]:
+        selected = select_rules(rules, changed_files=[path], pr_labels=[])
+        assert any(r.id == "program-cache-hash-collision" for r in selected), path
+
+
+def test_smuggled_rta_rule_matches_non_program_factory_filenames():
+    """smuggled-buffer-runtime-arg must cover every host-side factory family.
+
+    Each of these writes a tensor buffer address into runtime args but does
+    not match the original *program_factory* glob.
+    """
+    rules = load_rules()
+    for path in [
+        "ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_multicast_factory.cpp",
+        "ttnn/cpp/ttnn/operations/index_fill/device/index_fill_multi_core_factory.cpp",
+        "ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_program.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_1d_mm_fusion.cpp",
+        "ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp",
+        # modern convention must keep working
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp",
+    ]:
+        selected = select_rules(rules, changed_files=[path], pr_labels=[])
+        assert any(r.id == "smuggled-buffer-runtime-arg" for r in selected), path
+
+
+def test_host_rules_do_not_match_device_kernel_sources():
+    """Kernel sources under device/kernels/ are device-side code.
+
+    The host-side program-construction rules must not fire on them, or every
+    kernel-only PR pays for an irrelevant blocking LLM analysis.
+    """
+    rules = load_rules()
+    for path in [
+        "ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn.cpp",
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp",
+    ]:
+        ids = {r.id for r in select_rules(rules, changed_files=[path], pr_labels=[])}
+        assert "smuggled-buffer-runtime-arg" not in ids, path
+        assert "program-cache-hash-collision" not in ids, path
+        assert "override-rebuild-in-cache-hit" not in ids, path
+
+
+def test_llk_rule_matches_vendored_llk_tree():
+    """tt-llk is vendored in-tree (a plain directory, not a submodule)."""
+    rules = load_rules()
+    for path in [
+        "tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h",
+        "tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h",
+        "tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h",
+    ]:
+        selected = select_rules(rules, changed_files=[path], pr_labels=[])
+        assert any(r.id == "llk-stale-hw-config-state" for r in selected), path


### PR DESCRIPTION
Adds five new `bug_checker` rules, derived from an audit of ~1,398 merged `fix`-labelled tt-metal PRs (the MINFRA-1266 conventional-commit backfill), plus the internal engineering note *"Descriptors and Specs: how a TTNN op describes its program"* by @dgomezTT.

### Rules added

| Rule | Severity | Scope |
|---|---|---|
| `program-cache-hash-collision` | blocking | `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `*_op.cpp`, `*_op.hpp`, `tt-train/sources/**/device/*device*` |
| `smuggled-buffer-runtime-arg` | blocking | `ttnn/cpp/ttnn/operations/**/device/*factory*`, `*program*`, `*device_operation*`, `*_op.cpp`, `*_op.hpp`, `*fusion*`, `tt_metal/impl/program/**` |
| `override-rebuild-in-cache-hit` | blocking | `ttnn/cpp/ttnn/operations/**/device/*factory*`, `*program*`, `*device_operation*`, `*_op.cpp`, `*_op.hpp`, `*fusion*` |
| `llk-stale-hw-config-state` | blocking | `tt_metal/tt-llk/**/llk_lib/**`, `tt_metal/tt-llk/**/common/inc/**`, `tt_metal/hw/ckernels/**/llk_api/**` |
| `op-shard-layout-validation` | warning | `ttnn/cpp/ttnn/operations/**/device/*device_operation*`, `.../*_op.cpp`, `.../*_op.hpp` |

**`program-cache-hash-collision`** — a *custom* `compute_program_hash()` that omits a structural field the program factory reads, producing a wrong cache hit (the default reflection hash is protected by a canonical-key comparison, so it only costs a redundant rebuild, not a wrong result). Also flags `ProgramDescriptor::custom_program_hash` misuse, and separates two distinct shape-collision modes: hashing rank (collides same-rank/different-dims) vs. hashing volume (collides same-volume/different-tiling).

**`smuggled-buffer-runtime-arg`** — a buffer address written into a kernel's runtime-arg vector without going through `emplace_runtime_args`/`emplace_common_runtime_args` (or an explicit `override_runtime_arguments()`), so the program cache never re-patches it on a cache hit. Names the real guard (`scripts/detect_smuggled_rta.py`, `detect-smuggled-rta` hook) and its `// smuggled-rta-ok` suppression convention, plus the work-distribution and scalar traps where the fix isn't mechanical.

**`override-rebuild-in-cache-hit`** — calling `create_descriptor()` from `override_runtime_arguments()`, which pays the full cache-*miss* host cost on every cache *hit* (the ResNet50 20x / resnet-T3K 760% cliff). `scripts/detect_override_rebuild.py` already guards the literal form, but factoring the rebuild into a shared helper hides it from that textual scan while costing the same at runtime — catching that indirection is the centrepiece of this rule.

**`llk-stale-hw-config-state`** — unpacker/packer/SFPU hardware config carrying dirty state from a *previous* kernel invocation: a missing reconfig, a reconfig that updates only some fields of a shared 32-bit config word, a direct write bypassing a software state tracker, or a config rewrite with no execution-unit drain. Order-dependent by nature, so it passes in isolation and fails in a fused sequence. Backed by ~30 merged `fix` PRs, many tagged `[LLK]`/`[SAN]`.

**`op-shard-layout-validation`** — ops that read layout, memory config, or shard spec to build their program without validating up front that they support what they were given, producing wrong output or a hang instead of a clean `TT_FATAL`. The single largest bucket in the audit (74 PRs). Deliberately scoped away from `reshape-dim-check`: this is about the *presence of an entry-level compatibility check*, not shape arithmetic.

### Copilot review

Copilot flagged real gaps on the initial push, addressed in a follow-up commit: `program-cache-hash-collision`'s glob missed legacy `*_op.cpp/hpp` custom-hash implementations, and `smuggled-buffer-runtime-arg`/`override-rebuild-in-cache-hit` missed non-`*program_factory*` naming families (`*_factory.cpp`, `*_program.cpp`, `*_fusion.cpp`) — all three globs are now broadened, with 4 new regression tests pinning the real-world filenames that were previously missed. Also corrected an example in `smuggled-buffer-runtime-arg.md` that used a nonexistent `BufferBinding` constructor, and fixed a mischaracterization of issue #45821 in `program-cache-hash-collision.md` (it's a default-hash weak-combiner bug, not evidence for the custom-hash rule this PR adds).

### Validation

- `python -m pytest .github/bug_checker/tests/` — all passing, including the 4 new glob-coverage regression tests
- `run_bug_checker.py --subcommand list-rules` — all 7 rules load
- Path globs verified against the real tree, including the broadened hash-collision/runtime-arg/override-rebuild globs from the Copilot review pass

### Note for reviewers

`tt_metal/tt-llk` is a plain in-tree directory (mode `040000`, ~1,048 files on `main`), not a submodule — LLK was de-submoduled by vendoring, so these globs resolve inside this repo.

Not covered here: §4.3 of the note (copying the runtime-args grid by value) is fully mechanical and would be better served by a plain pre-commit script than an LLM rule — see the PR discussion.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bug-checker/program-cache-staleness-rules)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bug-checker/program-cache-staleness-rules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bug-checker/program-cache-staleness-rules)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bug-checker/program-cache-staleness-rules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bug-checker/program-cache-staleness-rules)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bug-checker/program-cache-staleness-rules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bug-checker/program-cache-staleness-rules)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bug-checker/program-cache-staleness-rules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bug-checker/program-cache-staleness-rules)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bug-checker/program-cache-staleness-rules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bug-checker/program-cache-staleness-rules)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bug-checker/program-cache-staleness-rules)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bug-checker/program-cache-staleness-rules)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bug-checker/program-cache-staleness-rules)
