### PR TITLE
[Feature] [Blackhole] jit_build: opt-in Zve32f (RVV) plumbing for TRISC2 kernel compiles (enable_trisc2_rvv)

### DIFF
--- a/tests/tt_metal/tt_metal/jit_build/sources.cmake
+++ b/tests/tt_metal/tt_metal/jit_build/sources.cmake
@@ -10,4 +10,5 @@ set(UNIT_TESTS_JIT_BUILD_SRC
     test_kernel_signature_parser.cpp
     test_named_ct_arg_map.cpp
     test_sync_build_steps.cpp
+    test_trisc2_rvv.cpp
 )

--- a/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
@@ -136,6 +136,11 @@ bool elf_contains_vector_instructions(const std::string& elf_path) {
     return false;
 }
 
+}  // namespace
+
+// Fixture lives in the named namespace: gtest TEST_F classes derive from it
+// with external linkage, and an anonymous-namespace base trips
+// -Werror=subobject-linkage under gcc Unity builds (merge-queue build-sweeps).
 class Trisc2RvvMockBlackholeFixture : public MeshDispatchFixture {
 protected:
     // Mock mode must be registered BEFORE the base fixture opens its shared devices — and that
@@ -201,8 +206,6 @@ protected:
         return state.export_target_recipe(kernel.get()).cflags;
     }
 };
-
-}  // namespace
 
 TEST_F(Trisc2RvvMockBlackholeFixture, KnobOffRecipesCarryNoVectorFlags) {
     auto kernel = compile_rvv_kernel(/*enable_trisc2_rvv=*/false);

--- a/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
@@ -11,21 +11,26 @@
 //    the flags are appended only for opted-in kernels at recipe-export time). With the knob
 //    on, only the TRISC2 recipe gains the flags; TRISC0/1 recipes are unchanged.
 //  - End-to-end compile: a trivial explicit-intrinsic vadd kernel JIT-compiles with the knob
-//    on, and its TRISC2 ELF disassembly contains vector instructions; the knob-off compile
-//    of the same source contains none. Gated on the bundled sfpi toolchain accepting the
-//    Zve32f march string (older sfpi releases skip rather than fail).
+//    on, and its TRISC2 ELF contains vector instructions (checked in-process by scanning the
+//    ELF's executable sections for RVV instruction encodings — no subprocess, no shell); the
+//    knob-off compile of the same source contains none. Gated on the bundled sfpi toolchain
+//    accepting the Zve32f march string (older sfpi releases skip rather than fail).
 //
 // Everything here runs without silicon: the fixture configures a mock Blackhole device, and
 // compilation is pure host-side JIT.
 
 #include <gtest/gtest.h>
 
-#include <array>
-#include <cstdio>
+#include <elf.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <memory>
-#include <optional>
 #include <string>
+#include <vector>
 
 #include <enchantum/enchantum.hpp>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
@@ -38,6 +43,7 @@
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include "jit_build/build_env_manager.hpp"
+#include "jit_build/jit_build_utils.hpp"
 #include "llrt/rtoptions.hpp"
 
 namespace tt::tt_metal {
@@ -48,39 +54,86 @@ constexpr const char* kRvvKernelPath = "tests/tt_metal/tt_metal/test_kernels/com
 // Matches the flags HalJitBuildQueryBlackHole::rvv_compile_flags emits.
 constexpr const char* kBhRvvMarch = "-march=rv32im_zmmul_zaamo_zba_zbb_xtttensixbh_zve32f";
 
-// Resolve the sfpi tool root the JIT build uses (local runtime/sfpi, then system sfpi).
-std::string sfpi_bin_dir() {
+// Resolve the sfpi g++ the JIT build uses (local runtime/sfpi, then system sfpi).
+std::string sfpi_gxx_path() {
     const std::string root = MetalContext::instance().rtoptions().get_root_dir();
     for (const std::string& sfpi_root : {root + "runtime/sfpi", std::string("/opt/tenstorrent/sfpi")}) {
-        if (std::filesystem::exists(sfpi_root + "/compiler/bin/riscv-tt-elf-g++")) {
-            return sfpi_root + "/compiler/bin/";
+        auto gxx = sfpi_root + "/compiler/bin/riscv-tt-elf-g++";
+        if (std::filesystem::exists(gxx)) {
+            return gxx;
         }
     }
     return {};
 }
 
-// Capture stdout of a shell command; returns nullopt on nonzero exit.
-std::optional<std::string> run_command(const std::string& cmd) {
-    FILE* pipe = popen((cmd + " 2>/dev/null").c_str(), "r");
-    if (pipe == nullptr) {
-        return std::nullopt;
-    }
-    std::string out;
-    std::array<char, 4096> buf;
-    size_t n = 0;
-    while ((n = fread(buf.data(), 1, buf.size(), pipe)) > 0) {
-        out.append(buf.data(), n);
-    }
-    return pclose(pipe) == 0 ? std::optional<std::string>(std::move(out)) : std::nullopt;
-}
-
 // True when the bundled sfpi compiler accepts the Blackhole-tensix + Zve32f march string.
+// Probed via the JIT build system's own shell-free process launcher (posix_spawn with a
+// fixed argv — nothing is interpreted by a shell).
 bool sfpi_supports_bh_zve32f() {
-    const std::string bin = sfpi_bin_dir();
-    if (bin.empty()) {
+    const std::string gxx = sfpi_gxx_path();
+    if (gxx.empty()) {
         return false;
     }
-    return run_command(bin + "riscv-tt-elf-g++ " + kBhRvvMarch + " -E -x c++ /dev/null -o /dev/null").has_value();
+    const auto scratch =
+        std::filesystem::temp_directory_path() /
+        ("tt_metal_rvv_march_probe_" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(scratch);
+    const std::vector<std::string> args = {gxx, kBhRvvMarch, "-E", "-x", "c++", "/dev/null", "-o", "/dev/null"};
+    const bool ok = tt::jit_build::utils::exec_command(args, scratch.string(), (scratch / "probe.log").string());
+    std::error_code ec;
+    std::filesystem::remove_all(scratch, ec);
+    return ok;
+}
+
+// In-process check for RISC-V Vector instructions: parse the ELF32 section headers and scan
+// every executable PROGBITS section for RVV encodings. The march in play has no compressed
+// extension, so all instructions are 4-byte, 4-byte-aligned little-endian words. Fingerprints
+// (RISC-V "V" spec, 32-bit encodings):
+//  - OP-V major opcode 0b1010111 (0x57): every vector arithmetic instruction and the
+//    vsetvli/vsetivli/vsetvl family. This opcode is reserved exclusively for OP-V — scalar
+//    (including scalar-FP) code never emits it.
+//  - Vector unit-stride 32-bit loads/stores: LOAD-FP/STORE-FP major opcode with the vector
+//    width encoding funct3=0b110 → (insn & 0x707F) == 0x6007 (vle32.v) / 0x6027 (vse32.v).
+//    Scalar flw/fsw use funct3=0b010, so there is no collision.
+bool is_rvv_instruction(uint32_t insn) {
+    return (insn & 0x7Fu) == 0x57u || (insn & 0x707Fu) == 0x6007u || (insn & 0x707Fu) == 0x6027u;
+}
+
+bool elf_contains_vector_instructions(const std::string& elf_path) {
+    std::ifstream file(elf_path, std::ios::binary);
+    EXPECT_TRUE(file.is_open()) << "cannot open ELF: " << elf_path;
+    std::vector<char> bytes((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+    EXPECT_GE(bytes.size(), sizeof(Elf32_Ehdr)) << elf_path;
+    Elf32_Ehdr ehdr{};
+    std::memcpy(&ehdr, bytes.data(), sizeof(ehdr));
+    EXPECT_EQ(std::memcmp(ehdr.e_ident, ELFMAG, SELFMAG), 0) << "not an ELF: " << elf_path;
+    EXPECT_EQ(ehdr.e_ident[EI_CLASS], ELFCLASS32) << elf_path;
+    EXPECT_EQ(ehdr.e_ident[EI_DATA], ELFDATA2LSB) << elf_path;
+    EXPECT_EQ(ehdr.e_machine, EM_RISCV) << elf_path;
+
+    for (uint32_t i = 0; i < ehdr.e_shnum; i++) {
+        const size_t shoff = static_cast<size_t>(ehdr.e_shoff) + static_cast<size_t>(i) * ehdr.e_shentsize;
+        if (shoff + sizeof(Elf32_Shdr) > bytes.size()) {
+            break;
+        }
+        Elf32_Shdr shdr{};
+        std::memcpy(&shdr, bytes.data() + shoff, sizeof(shdr));
+        if (shdr.sh_type != SHT_PROGBITS || (shdr.sh_flags & SHF_EXECINSTR) == 0) {
+            continue;
+        }
+        if (static_cast<size_t>(shdr.sh_offset) + shdr.sh_size > bytes.size()) {
+            continue;
+        }
+        for (uint32_t off = 0; off + 4 <= shdr.sh_size; off += 4) {
+            uint32_t insn = 0;
+            std::memcpy(&insn, bytes.data() + shdr.sh_offset + off, 4);
+            if (is_rvv_instruction(insn)) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 class Trisc2RvvMockBlackholeFixture : public MeshDispatchFixture {
@@ -115,8 +168,8 @@ protected:
         return program.impl().get_kernel(handle);
     }
 
-    // Disassembly of the kernel's compiled ELF for one compute processor (0=unpack, 1=math, 2=pack).
-    std::string disassemble(const std::shared_ptr<Kernel>& kernel, int processor_id) {
+    // Path of the kernel's compiled ELF for one compute processor (0=unpack, 1=math, 2=pack).
+    std::string kernel_elf_path(const std::shared_ptr<Kernel>& kernel, int processor_id) {
         distributed::MeshDevice* device = devices_.at(0).get();
         auto& build_env_manager = BuildEnvManager::get_instance();
         const auto& hal = MetalContext::instance().hal();
@@ -130,9 +183,11 @@ protected:
             build_env_manager.get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path(),
             kernel->get_full_kernel_name());
         EXPECT_TRUE(std::filesystem::exists(elf_path)) << "missing ELF: " << elf_path;
-        auto dis = run_command(sfpi_bin_dir() + "riscv-tt-elf-objdump -d " + elf_path);
-        EXPECT_TRUE(dis.has_value()) << "objdump failed for " << elf_path;
-        return dis.value_or(std::string{});
+        return elf_path;
+    }
+
+    bool kernel_elf_has_vector_code(const std::shared_ptr<Kernel>& kernel, int processor_id) {
+        return elf_contains_vector_instructions(kernel_elf_path(kernel, processor_id));
     }
 
     // The kernel's exported compile recipe cflags for one compute processor.
@@ -146,11 +201,6 @@ protected:
         return state.export_target_recipe(kernel.get()).cflags;
     }
 };
-
-bool contains_vector_instructions(const std::string& disassembly) {
-    // vsetvli is the unambiguous RVV fingerprint; the vadd kernel also emits loads/adds.
-    return disassembly.find("vsetvli") != std::string::npos || disassembly.find("vsetivli") != std::string::npos;
-}
 
 }  // namespace
 
@@ -186,14 +236,14 @@ TEST_F(Trisc2RvvMockBlackholeFixture, VaddKernelCompilesToVectorCode) {
         GTEST_SKIP() << "bundled sfpi toolchain does not accept " << kBhRvvMarch;
     }
     auto kernel_on = compile_rvv_kernel(/*enable_trisc2_rvv=*/true);
-    EXPECT_TRUE(contains_vector_instructions(disassemble(kernel_on, 2)))
+    EXPECT_TRUE(kernel_elf_has_vector_code(kernel_on, 2))
         << "TRISC2 ELF of the opted-in kernel contains no vector instructions";
     // The vector unit is private to the pack compile: unpack/math stay scalar.
-    EXPECT_FALSE(contains_vector_instructions(disassemble(kernel_on, 0)));
-    EXPECT_FALSE(contains_vector_instructions(disassemble(kernel_on, 1)));
+    EXPECT_FALSE(kernel_elf_has_vector_code(kernel_on, 0));
+    EXPECT_FALSE(kernel_elf_has_vector_code(kernel_on, 1));
 
     auto kernel_off = compile_rvv_kernel(/*enable_trisc2_rvv=*/false);
-    EXPECT_FALSE(contains_vector_instructions(disassemble(kernel_off, 2)))
+    EXPECT_FALSE(kernel_elf_has_vector_code(kernel_off, 2))
         << "knob-off TRISC2 ELF unexpectedly contains vector instructions";
 }
 

--- a/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Device-free (mock Blackhole) coverage for ComputeConfig::enable_trisc2_rvv — the opt-in
+// that compiles a kernel's TRISC2 (pack) translation unit with the RISC-V Vector (Zve32f)
+// extension.
+//
+//  - Recipe invariance: with the knob off, the exported compile recipes of all three TRISC
+//    build states carry no vector flags (byte-identical to a build without the knob, since
+//    the flags are appended only for opted-in kernels at recipe-export time). With the knob
+//    on, only the TRISC2 recipe gains the flags; TRISC0/1 recipes are unchanged.
+//  - End-to-end compile: a trivial explicit-intrinsic vadd kernel JIT-compiles with the knob
+//    on, and its TRISC2 ELF disassembly contains vector instructions; the knob-off compile
+//    of the same source contains none. Gated on the bundled sfpi toolchain accepting the
+//    Zve32f march string (older sfpi releases skip rather than fail).
+//
+// Everything here runs without silicon: the fixture configures a mock Blackhole device, and
+// compilation is pure host-side JIT.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <enchantum/enchantum.hpp>
+#include <tt-metalium/experimental/mock_device/mock_device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+#include "common/mesh_dispatch_fixture.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
+#include "jit_build/build_env_manager.hpp"
+#include "llrt/rtoptions.hpp"
+
+namespace tt::tt_metal {
+
+namespace {
+
+constexpr const char* kRvvKernelPath = "tests/tt_metal/tt_metal/test_kernels/compute/trisc2_rvv_vadd.cpp";
+// Matches the flags HalJitBuildQueryBlackHole::rvv_compile_flags emits.
+constexpr const char* kBhRvvMarch = "-march=rv32im_zmmul_zaamo_zba_zbb_xtttensixbh_zve32f";
+
+// Resolve the sfpi tool root the JIT build uses (local runtime/sfpi, then system sfpi).
+std::string sfpi_bin_dir() {
+    const std::string root = MetalContext::instance().rtoptions().get_root_dir();
+    for (const std::string& sfpi_root : {root + "runtime/sfpi", std::string("/opt/tenstorrent/sfpi")}) {
+        if (std::filesystem::exists(sfpi_root + "/compiler/bin/riscv-tt-elf-g++")) {
+            return sfpi_root + "/compiler/bin/";
+        }
+    }
+    return {};
+}
+
+// Capture stdout of a shell command; returns nullopt on nonzero exit.
+std::optional<std::string> run_command(const std::string& cmd) {
+    FILE* pipe = popen((cmd + " 2>/dev/null").c_str(), "r");
+    if (pipe == nullptr) {
+        return std::nullopt;
+    }
+    std::string out;
+    std::array<char, 4096> buf;
+    size_t n = 0;
+    while ((n = fread(buf.data(), 1, buf.size(), pipe)) > 0) {
+        out.append(buf.data(), n);
+    }
+    return pclose(pipe) == 0 ? std::optional<std::string>(std::move(out)) : std::nullopt;
+}
+
+// True when the bundled sfpi compiler accepts the Blackhole-tensix + Zve32f march string.
+bool sfpi_supports_bh_zve32f() {
+    const std::string bin = sfpi_bin_dir();
+    if (bin.empty()) {
+        return false;
+    }
+    return run_command(bin + "riscv-tt-elf-g++ " + kBhRvvMarch + " -E -x c++ /dev/null -o /dev/null").has_value();
+}
+
+class Trisc2RvvMockBlackholeFixture : public MeshDispatchFixture {
+protected:
+    // Mock mode must be registered BEFORE the base fixture opens its shared devices — and that
+    // happens at suite scope (MeshDispatchFixture::SetUpTestSuite), not in SetUp. Overriding the
+    // suite hooks keeps this whole suite off silicon: the shared devices are created as mock
+    // Blackhole and every compile is pure host-side JIT.
+    static void SetUpTestSuite() {
+        experimental::configure_mock_mode(tt::ARCH::BLACKHOLE, 1);
+        MeshDispatchFixture::SetUpTestSuite();
+    }
+    static void TearDownTestSuite() {
+        MeshDispatchFixture::TearDownTestSuite();
+        experimental::disable_mock_mode();
+    }
+
+    // Create + JIT-compile the RVV vadd kernel; returns the kernel (full name is set by compile).
+    std::shared_ptr<Kernel> compile_rvv_kernel(bool enable_trisc2_rvv) {
+        distributed::MeshDevice* device = devices_.at(0).get();
+        Program program = CreateProgram();
+        KernelHandle handle = CreateKernel(
+            program,
+            kRvvKernelPath,
+            CoreCoord{0, 0},
+            ComputeConfig{
+                .enable_trisc2_rvv = enable_trisc2_rvv,
+                // L1 scratch base + element count for the vadd; compile-only, never dispatched.
+                .compile_args = {512 * 1024, 64},
+            });
+        program.impl().compile(device);
+        return program.impl().get_kernel(handle);
+    }
+
+    // Disassembly of the kernel's compiled ELF for one compute processor (0=unpack, 1=math, 2=pack).
+    std::string disassemble(const std::shared_ptr<Kernel>& kernel, int processor_id) {
+        distributed::MeshDevice* device = devices_.at(0).get();
+        auto& build_env_manager = BuildEnvManager::get_instance();
+        const auto& hal = MetalContext::instance().hal();
+        const uint32_t core_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        const uint32_t class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
+        const std::string elf_path = build_env_manager.get_kernel_binary_path(
+            device->build_id(),
+            core_idx,
+            class_idx,
+            processor_id,
+            build_env_manager.get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path(),
+            kernel->get_full_kernel_name());
+        EXPECT_TRUE(std::filesystem::exists(elf_path)) << "missing ELF: " << elf_path;
+        auto dis = run_command(sfpi_bin_dir() + "riscv-tt-elf-objdump -d " + elf_path);
+        EXPECT_TRUE(dis.has_value()) << "objdump failed for " << elf_path;
+        return dis.value_or(std::string{});
+    }
+
+    // The kernel's exported compile recipe cflags for one compute processor.
+    std::string recipe_cflags(const std::shared_ptr<Kernel>& kernel, int processor_id) {
+        distributed::MeshDevice* device = devices_.at(0).get();
+        const auto& hal = MetalContext::instance().hal();
+        const uint32_t core_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        const uint32_t class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
+        const JitBuildState& state = BuildEnvManager::get_instance().get_kernel_build_state(
+            device->build_id(), core_idx, class_idx, processor_id);
+        return state.export_target_recipe(kernel.get()).cflags;
+    }
+};
+
+bool contains_vector_instructions(const std::string& disassembly) {
+    // vsetvli is the unambiguous RVV fingerprint; the vadd kernel also emits loads/adds.
+    return disassembly.find("vsetvli") != std::string::npos || disassembly.find("vsetivli") != std::string::npos;
+}
+
+}  // namespace
+
+TEST_F(Trisc2RvvMockBlackholeFixture, KnobOffRecipesCarryNoVectorFlags) {
+    auto kernel = compile_rvv_kernel(/*enable_trisc2_rvv=*/false);
+    for (int processor_id = 0; processor_id < 3; processor_id++) {
+        const std::string cflags = recipe_cflags(kernel, processor_id);
+        EXPECT_EQ(cflags.find("zve32f"), std::string::npos) << "trisc" << processor_id;
+        EXPECT_EQ(cflags.find("-fno-lto"), std::string::npos) << "trisc" << processor_id;
+    }
+}
+
+TEST_F(Trisc2RvvMockBlackholeFixture, KnobOnFlagsReachOnlyThePackRecipe) {
+    if (!sfpi_supports_bh_zve32f()) {
+        GTEST_SKIP() << "bundled sfpi toolchain does not accept " << kBhRvvMarch;
+    }
+    auto kernel_off = compile_rvv_kernel(/*enable_trisc2_rvv=*/false);
+    auto kernel_on = compile_rvv_kernel(/*enable_trisc2_rvv=*/true);
+
+    // Opting in must re-key the JIT cache.
+    EXPECT_NE(kernel_on->get_full_kernel_name(), kernel_off->get_full_kernel_name());
+
+    // TRISC0/1 recipes are byte-identical with and without the knob; only TRISC2 changes.
+    EXPECT_EQ(recipe_cflags(kernel_on, 0), recipe_cflags(kernel_off, 0));
+    EXPECT_EQ(recipe_cflags(kernel_on, 1), recipe_cflags(kernel_off, 1));
+    const std::string pack_cflags = recipe_cflags(kernel_on, 2);
+    EXPECT_NE(pack_cflags.find(kBhRvvMarch), std::string::npos);
+    EXPECT_NE(pack_cflags.find("-fno-lto"), std::string::npos);
+}
+
+TEST_F(Trisc2RvvMockBlackholeFixture, VaddKernelCompilesToVectorCode) {
+    if (!sfpi_supports_bh_zve32f()) {
+        GTEST_SKIP() << "bundled sfpi toolchain does not accept " << kBhRvvMarch;
+    }
+    auto kernel_on = compile_rvv_kernel(/*enable_trisc2_rvv=*/true);
+    EXPECT_TRUE(contains_vector_instructions(disassemble(kernel_on, 2)))
+        << "TRISC2 ELF of the opted-in kernel contains no vector instructions";
+    // The vector unit is private to the pack compile: unpack/math stay scalar.
+    EXPECT_FALSE(contains_vector_instructions(disassemble(kernel_on, 0)));
+    EXPECT_FALSE(contains_vector_instructions(disassemble(kernel_on, 1)));
+
+    auto kernel_off = compile_rvv_kernel(/*enable_trisc2_rvv=*/false);
+    EXPECT_FALSE(contains_vector_instructions(disassemble(kernel_off, 2)))
+        << "knob-off TRISC2 ELF unexpectedly contains vector instructions";
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/trisc2_rvv_vadd.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/trisc2_rvv_vadd.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal RISC-V Vector (Zve32f) smoke kernel for ComputeConfig::enable_trisc2_rvv.
+//
+// When the kernel opts into enable_trisc2_rvv, its TRISC2 (pack) translation unit is
+// compiled with the Zve32f extension, so the compiler defines __riscv_vector and the
+// vector block below is compiled in: a float vadd over an L1 scratch region, written
+// with explicit intrinsics (auto-vectorization stays disabled by the toolchain flags).
+//
+// Without the opt-in (and on TRISC0/1 always), __riscv_vector is not defined and this
+// compiles to an empty kernel — the knob-off binary must contain no vector instructions.
+//
+// Compile-only test collateral (tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp);
+// never dispatched to a device.
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+
+#if defined(TRISC_PACK) && defined(__riscv_vector)
+#include <riscv_vector.h>
+#endif
+
+void kernel_main() {
+#if defined(TRISC_PACK) && defined(__riscv_vector)
+    constexpr uint32_t scratch_base = get_compile_time_arg_val(0);
+    constexpr uint32_t n = get_compile_time_arg_val(1);
+
+    float* a = reinterpret_cast<float*>(scratch_base);
+    float* b = reinterpret_cast<float*>(scratch_base + n * sizeof(float));
+    float* c = reinterpret_cast<float*>(scratch_base + 2u * n * sizeof(float));
+
+    for (uint32_t i = 0, vl = 0; i < n; i += vl) {
+        vl = __riscv_vsetvl_e32m4(n - i);
+        vfloat32m4_t va = __riscv_vle32_v_f32m4(a + i, vl);
+        vfloat32m4_t vb = __riscv_vle32_v_f32m4(b + i, vl);
+        __riscv_vse32_v_f32m4(c + i, __riscv_vfadd_vv_f32m4(va, vb, vl), vl);
+    }
+#endif
+}

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -109,6 +109,12 @@ struct ComputeConfig {
     std::vector<UnpackToDestMode> unpack_to_dest_mode;
     bool bfp8_pack_precise = false;
     bool math_approx_mode = false;
+    // Opt-in: compile this kernel's TRISC2 (pack) binary with the RISC-V Vector (Zve32f)
+    // extension enabled. Blackhole only (program compile fails on other archs). The unpack and
+    // math TRISC compiles are unchanged, and the vector unit is reachable only through explicit
+    // intrinsics (auto-vectorization stays disabled); guard kernel-side vector code with
+    // the compiler-provided __riscv_vector macro or the pack-thread defines.
+    bool enable_trisc2_rvv = false;
     std::vector<uint32_t> compile_args;
     // Will cause CompileProgram to emit a file hlk_defines_generated.h
     // Each unique combination of defines will produce a unique compiled instantiation

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -105,6 +105,8 @@ struct ComputeConfigDescriptor {
     UnpackToDestModes unpack_to_dest_mode;
     bool bfp8_pack_precise = false;
     bool math_approx_mode = false;
+    // See ComputeConfig::enable_trisc2_rvv.
+    bool enable_trisc2_rvv = false;
 };
 
 // Declares that a specific per-core runtime arg position holds a buffer base address

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -524,13 +524,19 @@ std::string ComputeKernel::config_hash() const {
         unpack_mode_descriptor = fmt::format("{}", fmt::join(unpack_modes, "."));
     }
 
-    return fmt::format(
+    std::string hash = fmt::format(
         "{}_{}_{}_{}_{}",
         enchantum::to_string(this->config_.math_fidelity),
         this->config_.fp32_dest_acc_en,
         this->config_.math_approx_mode,
         this->config_.dst_full_sync_en,
         unpack_mode_descriptor);
+    // Appended only when opted in, so hashes (and cached binaries) of kernels that don't use
+    // the RVV knob are unchanged.
+    if (this->config_.enable_trisc2_rvv) {
+        hash += "_rvv";
+    }
+    return hash;
 }
 
 uint64_t Kernel::compute_hash() const {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -643,6 +643,8 @@ public:
 
     std::string_view get_linker_opt_level() const override;
 
+    bool get_trisc2_rvv_enabled() const override { return this->config_.enable_trisc2_rvv; }
+
 private:
     const ComputeConfig config_;
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -454,6 +454,7 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
                         .unpack_to_dest_mode = compute_descriptor.unpack_to_dest_mode,
                         .bfp8_pack_precise = compute_descriptor.bfp8_pack_precise,
                         .math_approx_mode = compute_descriptor.math_approx_mode,
+                        .enable_trisc2_rvv = compute_descriptor.enable_trisc2_rvv,
                         .compile_args = std::move(compile_args),
                         .defines = std::move(defines),
                         .named_compile_args = std::move(named_compile_args),

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -426,6 +426,11 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
     const auto& jit_build_query = hal.get_jit_build_query();
 
     this->target_name_ = jit_build_query.target_name(params);
+    this->is_compute_pack_ = build_config.core_type == HalProgrammableCoreType::TENSIX &&
+                             build_config.processor_class == HalProcessorClassType::COMPUTE &&
+                             build_config.processor_id == 2;
+    // Per-kernel opt-in flags (applied in export_target_recipe); empty when unsupported.
+    this->rvv_cflags_ = jit_build_query.rvv_compile_flags(params);
     // Includes
     {
         auto it = std::back_inserter(this->includes_);
@@ -520,6 +525,9 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
         }
         hasher.update(default_compile_opt_level_);
         hasher.update(default_linker_opt_level_);
+        // Not part of default recipes, but a change to the HAL's RVV flag string must still
+        // invalidate cached opted-in kernels.
+        hasher.update(rvv_cflags_);
         build_state_hash_ = hasher.digest();
     }
 }
@@ -934,6 +942,17 @@ tt::jit_build::TargetRecipe JitBuildState::export_target_recipe(const JitBuildSe
     tt::jit_build::TargetRecipe target;
     target.target_name = target_name_;
     target.cflags = cflags_;
+    // Per-kernel RVV opt-in: only the pack (TRISC2) compile of a kernel that set
+    // ComputeConfig::enable_trisc2_rvv gets the vector flags. Compile-only: lflags_ is
+    // untouched, so the link stays stock (the -fno-lto object simply opts out of LTO).
+    if (settings != nullptr && this->is_compute_pack_ && settings->get_trisc2_rvv_enabled()) {
+        TT_FATAL(
+            !this->rvv_cflags_.empty(),
+            "Kernel {} sets enable_trisc2_rvv, but this architecture does not support RVV code "
+            "generation on the pack processor",
+            settings->get_full_kernel_name());
+        target.cflags += this->rvv_cflags_;
+    }
     target.lflags = lflags_;
     target.linker_script = linker_script_;
     target.extra_link_objs = extra_link_objs_;

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -131,6 +131,14 @@ protected:
     std::string extra_link_objs_;
     std::string weakened_firmware_name_;
 
+    // True for the TENSIX compute pack state (TRISC2) — the only state where the per-kernel
+    // RVV opt-in (JitBuildSettings::get_trisc2_rvv_enabled) may apply.
+    bool is_compute_pack_{};
+    // HAL-provided compile flags enabling RVV codegen on this state; empty when the arch or
+    // processor does not support it. Appended to a kernel's recipe cflags only when that
+    // kernel opted in, so default builds are unchanged.
+    std::string rvv_cflags_;
+
     // Default compiler optimization setting
     // Used when JitBuildSettings is not provided
     std::string default_compile_opt_level_;

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -83,6 +83,10 @@ public:
     virtual std::string_view get_compiler_opt_level() const = 0;
     // Returns the linker optimization level
     virtual std::string_view get_linker_opt_level() const = 0;
+    // Returns true when this kernel opted into RISC-V Vector (Zve32f) code generation for its
+    // TRISC2 (pack) compile (ComputeConfig::enable_trisc2_rvv). Default off: the build recipe
+    // is byte-identical to a build without this knob.
+    virtual bool get_trisc2_rvv_enabled() const { return false; }
 
     // Called to process the user defines
     virtual void process_defines(std::function<void(const std::string& define, const std::string& value)>) const = 0;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -307,6 +307,11 @@ public:
     virtual std::vector<std::string> srcs(const Params& params) const = 0;
     // Returns a string of common flags to be added to compiler and linker command lines.
     virtual std::string common_flags(const Params& params) const = 0;
+    // Returns the compiler flags that enable RISC-V Vector (Zve32f) code generation for an
+    // opt-in kernel compile on this processor (see ComputeConfig::enable_trisc2_rvv), or an
+    // empty string when the processor has no vector unit / the arch does not support it.
+    // Applied per kernel at recipe-export time, never to firmware or default kernel builds.
+    virtual std::string rvv_compile_flags(const Params& /*params*/) const { return {}; }
     // Returns the path to the linker script, relative to the tt-metal root.
     virtual std::string linker_script(const Params& params) const = 0;
     // Returns a string of linker flags to be added to linker command line.

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -240,6 +240,31 @@ public:
         return cflags;
     }
 
+    std::string rvv_compile_flags(const Params& params) const override {
+        // Only the pack TRISC (TRISC2) fronts the Tensix vector unit on Blackhole.
+        if (!(params.core_type == HalProgrammableCoreType::TENSIX &&
+              params.processor_class == HalProcessorClassType::COMPUTE && params.processor_id == 2)) {
+            return {};
+        }
+        // -march is the exact ISA string -mcpu=tt-bh-tensix resolves to (per
+        // `riscv-tt-elf-g++ -mcpu=tt-bh-tensix -v`), plus _zve32f. Passed after -mcpu (recipe
+        // cflags are appended after common_flags), so it overrides the arch while keeping the
+        // tt-bh-tensix tuning.
+        //
+        // -fno-lto: emit a plain (non-LTO) object for this TU. With -flto the RVV builtins are
+        // streamed as GIMPLE and re-expanded by the link-stage LTRANS units, which do not carry
+        // the vector -march, breaking code generation at link time (observed with sfpi 7.70.0).
+        // The link itself stays stock (-flto=auto): a fat-free object simply opts out of LTO.
+        //
+        // -fno-tree-vectorize -fno-tree-slp-vectorize: the vector unit is only reachable through
+        // explicit intrinsics; keep the auto-vectorizers from touching scalar kernel/LLK code.
+        //
+        // -Wno-error=array-bounds: RVV intrinsic loads/stores through casted L1 pointers trip
+        // -Warray-bounds false positives at -O3 under -Werror.
+        return "-march=rv32im_zmmul_zaamo_zba_zbb_xtttensixbh_zve32f -fno-lto "
+               "-fno-tree-vectorize -fno-tree-slp-vectorize -Wno-error=array-bounds ";
+    }
+
     std::string linker_script(const Params& params) const override {
         const std::string_view fork = params.is_fw ? "firmware" : "kernel";
         const std::string_view path = "runtime/hw/toolchain/blackhole";

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -686,7 +686,11 @@ void py_module_types(nb::module_& mod) {
         .def_rw(
             "math_approx_mode",
             &tt::tt_metal::ComputeConfigDescriptor::math_approx_mode,
-            "Approximation mode for mathematical operations");
+            "Approximation mode for mathematical operations")
+        .def_rw(
+            "enable_trisc2_rvv",
+            &tt::tt_metal::ComputeConfigDescriptor::enable_trisc2_rvv,
+            "Compile the TRISC2 (pack) binary with the RISC-V Vector (Zve32f) extension (Blackhole only)");
 
     // TODO_NANOBIND: do we still need this?
     // export_enum<tt::tt_metal::KernelDescriptor::SourceType>(mod, "SourceType");


### PR DESCRIPTION
### PR Category
Feature

Relates to #20953. Base of the RVV stack: #54105 (ttnn.argmax use_rvv) and #54106 (fused LM-head argmax epilogue) rebase onto this PR and use the knob added here.

### Summary

## Problem

Blackhole's TRISC2 (pack) RISC carries a Zve32f vector unit, but the kernel JIT builds every TRISC with `-mcpu=tt-bh-tensix` and no vector extension — there is no way for a kernel to request RVV code generation. The RVV kernels in #54105/#54106 could therefore not compile in upstream CI: all silicon results there were produced with a local out-of-tree wrapper around the sfpi g++ (which proved that the stock sfpi 7.70.0 compiler handles the codegen — the wrapper only appended flags).

## What this PR does

Adds a minimal, default-off, per-kernel opt-in that plumbs those exact flags through the JIT, replacing the out-of-tree shim:

- **`ComputeConfig::enable_trisc2_rvv`** (and `ComputeConfigDescriptor::enable_trisc2_rvv`, with a nanobind binding): opt-in per compute kernel, following the `fp32_dest_acc_en` / `dst_full_sync_en` / `opt_level` pattern.
- **`JitBuildSettings::get_trisc2_rvv_enabled()`** (default `false`) carries the knob into the JIT; `JitBuildState::export_target_recipe()` appends the flags **only** for the TRISC2/pack build state of an opted-in kernel. TRISC0/1, all firmware builds, and every non-opted kernel produce byte-identical compile commands.
- **`HalJitBuildQueryInterface::rvv_compile_flags()`** supplies the arch-specific flags (default: empty = unsupported). The Blackhole HAL returns:
  - `-march=rv32im_zmmul_zaamo_zba_zbb_xtttensixbh_zve32f` — exactly the ISA string `-mcpu=tt-bh-tensix` resolves to, plus `_zve32f`;
  - `-fno-lto` — with `-flto`, the RVV builtins are streamed as GIMPLE and re-expanded by the link-stage LTRANS units, which do not carry the vector `-march`, breaking code generation at link time (observed with sfpi 7.70.0). Compile-only: the link stays stock `-flto=auto`, the non-LTO pack object simply opts out;
  - `-fno-tree-vectorize -fno-tree-slp-vectorize` — the vector unit is reachable only through explicit intrinsics; the auto-vectorizers must not touch scalar kernel/LLK code;
  - `-Wno-error=array-bounds` — RVV intrinsic access through casted L1 pointers trips `-Warray-bounds` false positives at `-O3` under `-Werror`.
  Opting in on an arch whose HAL returns no flags (WH, Quasar) fails the compile with an explicit `TT_FATAL`.
- **Cache keying**: the knob enters the kernel compile hash (`ComputeKernel::config_hash()`, appended **only when enabled**, so default hashes/paths are unchanged) and the HAL flag string enters the build-state hash (a future flag change invalidates cached opted-in binaries).

Kernel-side, vector code is guarded by the compiler-provided `__riscv_vector` macro (plus `TRISC_PACK`), so the same source compiles to an empty/scalar kernel everywhere else.

## Default-off invariance

With the knob absent, compile recipes are byte-identical to main by construction (the flags are appended at recipe-export time only for opted-in kernels, and the conditional hash suffix is not emitted), and this was verified empirically. The same default-config compute kernel was JIT-compiled on this branch and on the merge-base (`e701eff0689`), each into a fresh isolated cache (mock Blackhole, stock sfpi 7.70.0):

- **Kernel compile hash identical**: `10869590292254366188` on both sides (so cached binaries stay valid across the upgrade).
- **Compile command lines identical** for all three TRISC compiles — the only textual difference is the temp-object filename, which embeds the compiling PID and differs between any two runs on any branch.
- **ELFs bit-identical**: disassembly (`objdump -d`) matches for TRISC0/1/2, and after `--strip-debug` (removing the DWARF strings that embed the per-run temp-object name) the ELF files are byte-for-byte equal.

## Tests (run in CI, no device required)

`tests/tt_metal/tt_metal/jit_build/test_trisc2_rvv.cpp` (unit_tests_jit_build, mock-Blackhole device, pure host-side JIT):

- **KnobOffRecipesCarryNoVectorFlags** — knob-off recipes for all three TRISCs carry no `zve32f` / `-fno-lto`.
- **KnobOnFlagsReachOnlyThePackRecipe** — knob-on: TRISC0/1 recipe cflags byte-equal to knob-off; TRISC2 gains exactly the flags; the JIT cache re-keys.
- **VaddKernelCompilesToVectorCode** — a trivial explicit-intrinsic vadd kernel (`test_kernels/compute/trisc2_rvv_vadd.cpp`) JIT-compiles end to end with the knob on; `objdump -d` of the TRISC2 ELF contains vector instructions (`vsetvli`), TRISC0/1 and the knob-off compile contain none. Gated on the bundled sfpi accepting the Zve32f march string (probed at runtime; older sfpi skips rather than fails).

## Silicon validation

The flags this PR plumbs are the ones the out-of-tree wrapper applied for every silicon result in #54105/#54106 (34/34 gated tests passing on BH P150), and the silicon results carry to the restacked stack by a three-part equivalence, each step checked directly:

1. The restack leaves every device kernel source bit-identical (`git diff` over the kernel dirs between the pre- and post-restack tips is empty).
2. The `DW_AT_producer` flag strings of a knob-compiled pack TU and of the actual silicon-run shim-compiled `argmax_rvv_tile_compute` TRISC2 ELF are **identical** (same compiler 7.70.0[847], same canonicalized `-march=rv32imf_zmmul_zaamo_zba_zbb_zve32f_zve32x_zvl32b_xtttensixbh`, same `-fno-lto -fno-tree-vectorize -fno-tree-slp-vectorize`).
3. The one mechanical difference — the wrapper appended the flags at the end of the command line, the knob appends them at the end of cflags — was compiled both ways on the same pack TU: the two objects are **byte-identical** (`cmp` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/trisc2-rvv-toolchain)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/trisc2-rvv-toolchain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/trisc2-rvv-toolchain)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/trisc2-rvv-toolchain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/trisc2-rvv-toolchain)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/trisc2-rvv-toolchain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/trisc2-rvv-toolchain)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/trisc2-rvv-toolchain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/trisc2-rvv-toolchain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/trisc2-rvv-toolchain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/trisc2-rvv-toolchain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/trisc2-rvv-toolchain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/trisc2-rvv-toolchain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/trisc2-rvv-toolchain)