### PR TITLE
[sweeps] Classify PCIe enumeration failure as infrastructure

### DIFF
--- a/tests/sweep_framework/sweeps_runner.py
+++ b/tests/sweep_framework/sweeps_runner.py
@@ -862,6 +862,19 @@ _FABRIC_INFRA_SIGNATURES = (
     # for a fault that happens before any op kernel runs.
     # Matched on the invariant phrase -- the ASIC ID, the core and enabled/disabled all vary.
     "routing firmware for device asic id",
+    # The kernel driver cannot enumerate a PCI device, so Cluster construction never completes. UMD
+    # raises it from pci_device.cpp:442 with the strerror text appended, e.g.
+    #   Query mappings failed on device 17: No such device
+    #   Location: .../umd/device/pcie/pci_device.cpp:442
+    #    1. TTDevice::create -> 2. TopologyDiscovery::get_connected_devices ->
+    #    3. create_ethernet_map -> 4. discover -> 5. Cluster::Cluster
+    # Same discovery path as the two signatures above, and equally sticky: a device that is not
+    # enumerable does not reappear mid-job. Seen escalating on consecutive scheduled lead-models runs
+    # -- 32612848099 booked 2 such failures, 32683040586 booked 84, all against add_model_traced on a
+    # single host each time, for a fault that happens before any op kernel runs.
+    # Matched on the invariant phrase: the device number and the strerror string both vary
+    # ("No such device" is ENODEV, but the same call reports other errno values).
+    "query mappings failed on device",
     # The host came up with fewer chips than the traced topology needs, so mesh open fails
     # before any kernel runs. Seen on main run 30681057227 job 91319472767 (runner g03glx03):
     #   TT_FATAL @ tt_metal/distributed/system_mesh.cpp:159: requested_size <= system_size


### PR DESCRIPTION
### Problem

Two consecutive scheduled lead-models runs booked failures against `add_model_traced` for a fault that happens **before any op kernel runs** — and it's escalating:

| run | date | failures | host |
|---|---|---|---|
| [32612848099](https://github.com/tenstorrent/tt-metal/actions/runs/32612848099) | 08-23 | 2 | one host |
| [32683040586](https://github.com/tenstorrent/tt-metal/actions/runs/32683040586) | 08-24 | **84** | one host |

All with the same message and callstack:

```
Query mappings failed on device 17: No such device
Location: .../umd/device/pcie/pci_device.cpp:442
 1. TTDevice::create
 2. TopologyDiscovery::get_connected_devices()
 3. TopologyDiscovery::create_ethernet_map()
 4. TopologyDiscovery::discover(...)
 5. Cluster::Cluster(ClusterOptions)
```

The kernel driver cannot enumerate a PCI device (ENODEV), so `Cluster` construction never completes. This is the **same `TopologyDiscovery` path** as the ETH-heartbeat and routing-firmware signatures already in `_FABRIC_INFRA_SIGNATURES`, and equally sticky — a device that isn't enumerable doesn't reappear mid-job.

### Change

One entry added to `_FABRIC_INFRA_SIGNATURES`, matched on the invariant phrase `query mappings failed on device`. The device number varies, and so does the `strerror` text — the same call reports other errno values, so keying on `"No such device"` would miss them.

### Verification

- **All 86** real failing messages from both runs classify as infra
- An ENOMEM variant of the same message (`Cannot allocate memory`) classifies too
- The three sibling signatures still match (heartbeat, routing firmware, TLB window)
- Failures that must **not** be swallowed still aren't: PCC `0.0`, the `split` chunk PCC failure, `pytensor.cpp:300 buffers.size() == 1`, and the `all_gather` exact-equality failure

### Impact

Run 32683040586: **1174 pass / 84 fail (93.32% of executed) → 1174 pass / 0 fail (100.00%)**, with the 84 reported as `NOT_RUN` so the lost coverage stays visible rather than being hidden.

Note this is orthogonal to #54027: that PR fixes the *denominator* (NOT_RUN shouldn't count against the rate), while these 84 are currently *failures* — only a signature moves them.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/infra-pcie-enumeration-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/infra-pcie-enumeration-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/infra-pcie-enumeration-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/infra-pcie-enumeration-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/infra-pcie-enumeration-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/infra-pcie-enumeration-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/infra-pcie-enumeration-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/infra-pcie-enumeration-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/infra-pcie-enumeration-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/infra-pcie-enumeration-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/infra-pcie-enumeration-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/infra-pcie-enumeration-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/infra-pcie-enumeration-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/infra-pcie-enumeration-signature)