### PR TITLE
[Metal 2.0] Per-width buffer sets for the tilize/tilize_with_val_padding block factories

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -906,10 +906,7 @@ def test_tilize_width_sharded_shapes(device, tensor_shape, num_cores, dtype):
     ["sharded_width_l1", "interleaved_dram_multicore", "single_core"],
 )
 def test_tilize_program_cache_addr_change(device, config):
-    """Program-cache hit path (override_runtime_arguments): re-running tilize on freshly
-    allocated inputs (different buffer addresses) must hit the same cached program and stay
-    correct. Guards the sharded CB-bound path (addresses ride on CBs) and the interleaved
-    buffer-address runtime args -- both re-derived from create_descriptor on every hit."""
+    """Program-cache hit path (override_runtime_arguments)"""
     torch.manual_seed(0)
 
     if config == "sharded_width_l1":
@@ -1206,3 +1203,57 @@ def test_tilize_uint8(device, shape):
     tt_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT)
     tt_output = ttnn.tilize(tt_input)
     assert_equal(torch_input, ttnn.to_torch(tt_output))
+
+
+@pytest.mark.parametrize("tensor_shape", [(1, 1, 32, 7328)])
+def test_tilize_block_two_pair_program_cache_addr_change(device, tensor_shape):
+    torch.manual_seed(0)
+    mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    keep_alive = []  # retain prior tensors so each iteration allocates at a NEW address
+    entries = None
+    for i in range(4):
+        torch_input = torch.rand(tensor_shape, dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(
+            torch_input, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_cfg
+        )
+        tt_output = ttnn.tilize(tt_input, memory_config=mem_cfg, use_multicore=True)
+        keep_alive += [tt_input, tt_output]
+        assert_equal(torch_input, ttnn.to_torch(tt_output))
+        if i == 0:
+            entries = device.num_program_cache_entries()
+        else:
+            assert device.num_program_cache_entries() == entries, "tilize must reuse the cached program on a hit"
+
+    assert entries == 1, "tilize should build exactly one program for a fixed config"
+    device.disable_and_clear_program_cache()
+
+
+# Blackhole sends non-sharded uint8 tilize to the block factory, the only way a 1-tile-wide tensor
+# reaches it. These get a single reader/writer pair: 2048/4096 rows build only full_set, 5120 rows
+# only cliffrow_set. Checks that lone pair is still re-pointed on a cache hit.
+@run_for_blackhole()
+@pytest.mark.parametrize("shape", [(1, 1, 2048, 32), (1, 1, 4096, 32), (1, 1, 5120, 32)])
+def test_tilize_uint8_tall_narrow_program_cache_addr_change(device, shape):
+    torch.manual_seed(0)
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    keep_alive = []  # retain prior tensors so each iteration allocates at a NEW address
+    entries = None
+    for i in range(4):
+        torch_input = torch.randint(0, 256, shape, dtype=torch.uint8)
+        tt_input = ttnn.from_torch(torch_input, device=device, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT)
+        tt_output = ttnn.tilize(tt_input)
+        keep_alive += [tt_input, tt_output]
+        assert_equal(torch_input, ttnn.to_torch(tt_output))
+        if i == 0:
+            entries = device.num_program_cache_entries()
+        else:
+            assert device.num_program_cache_entries() == entries, "tilize must reuse the cached program on a hit"
+
+    assert entries == 1, "tilize should build exactly one program for a fixed config"
+    device.disable_and_clear_program_cache()

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -940,7 +940,12 @@ def test_tilize_with_val_padding_block_per_node_cb_size(device, input_shape, pad
     )
     dram_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
-    for _ in range(2):
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    keep_alive = []  # retain prior tensors so each iteration allocates at a NEW address
+    entries = None
+    for i in range(2):
         torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
         tt_rm = ttnn.from_torch(
             torch_input,
@@ -951,7 +956,16 @@ def test_tilize_with_val_padding_block_per_node_cb_size(device, input_shape, pad
         )
 
         tt_tile = ttnn.tilize_with_val_padding(tt_rm, output_shape, pad_value, use_multicore=True)
+        keep_alive += [tt_rm, tt_tile]
 
         assert tt_tile.layout == ttnn.TILE_LAYOUT
         torch_golden = pytorch_tilize_with_val_padding(torch_input, output_shape, pad_value)
         assert_equal(torch_golden, tt_tile.cpu().to_torch_with_padded_shape())
+
+        if i == 0:
+            entries = device.num_program_cache_entries()
+            assert entries >= 1, "the first invocation should have populated the program cache"
+        else:
+            assert (
+                device.num_program_cache_entries() == entries
+            ), "tilize_with_val_padding must reuse the cached program on a cache hit"

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -910,3 +910,48 @@ def test_tilize_with_val_padding_program_cache_addr_change_interleaved_multicore
         out_mem_cfg=dram,
         use_multicore=True,
     )
+
+
+# TilizeWithValPaddingMultiCoreBlockInterleavedFactory gives cores one of two block widths, and a
+# block's width fixes the size of the buffers carrying it: the reader fills a block with one raw
+# linear write, and cb_push_back requires the producer to write contiguously, so a buffer whose
+# size is not an exact multiple of its block overruns the next one. Each width therefore gets its
+# own buffers (#51305). Widths here are indivisible by any plausible block size, so both widths are
+# live at once; 8192 is the single-width case. Each shape runs twice to cover the program-cache
+# hit, where every reader/writer pair has to be re-pointed at the new buffers.
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 1, 30, 7328),
+        (1, 1, 100, 7328),
+        (1, 1, 60, 8192),
+        (1, 1, 90, 7392),
+        (1, 1, 150, 6304),
+        (2, 1, 60, 7328),
+    ],
+)
+@pytest.mark.parametrize("pad_value", [1.0])
+def test_tilize_with_val_padding_block_per_node_cb_size(device, input_shape, pad_value):
+    output_shape = (
+        input_shape[0],
+        input_shape[1],
+        math.ceil(input_shape[2] / 32) * 32,
+        input_shape[3],
+    )
+    dram_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    for _ in range(2):
+        torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+        tt_rm = ttnn.from_torch(
+            torch_input,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=dram_cfg,
+            device=device,
+        )
+
+        tt_tile = ttnn.tilize_with_val_padding(tt_rm, output_shape, pad_value, use_multicore=True)
+
+        assert tt_tile.layout == ttnn.TILE_LAYOUT
+        torch_golden = pytorch_tilize_with_val_padding(torch_input, output_shape, pad_value)
+        assert_equal(torch_golden, tt_tile.cpu().to_torch_with_padded_shape())

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -13,6 +13,9 @@
 #include <numeric>
 #include <tt-metalium/tt_align.hpp>
 
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
 namespace ttnn::operations::data_movement {
 
 ttnn::Shape squeeze_shape_to_ND(const ttnn::Shape& shape, const uint32_t n) {
@@ -787,6 +790,142 @@ uint32_t per_shard_page_size_bytes(const ttnn::Tensor& t, uint32_t row_bytes) {
         return static_cast<uint32_t>(t.buffer()->aligned_page_size());
     }
     return row_bytes;
+}
+
+tt::tt_metal::CoreRangeSet union_of(const tt::tt_metal::CoreRangeSet& a, const tt::tt_metal::CoreRangeSet& b) {
+    if (a.empty()) {
+        return b;
+    }
+    if (b.empty()) {
+        return a;
+    }
+    return a.merge(b);
+}
+
+void push_buffer_set(
+    tt::tt_metal::ProgramDescriptor& desc,
+    const BlockBufferSet& set,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format,
+    uint32_t dram_alignment,
+    uint32_t tile_height,
+    const std::optional<tt::tt_metal::TileDescriptor>& tile) {
+    // The staging buffer is used by the reader when the DRAM source row and the L1 destination have
+    // different alignment offsets: the reader rounds the source address down to a dram_alignment
+    // boundary, issues one noc_async_read of (row_bytes + dram_alignment) into this buffer, then
+    // copies the correctly-offset slice into the input buffer.
+    //   row_bytes  = tile_width * elt_size * block_tiles  (one row of a block)
+    //              = input_single_tile_size / tile_height * block_tiles
+    //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
+    //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
+    //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
+    const uint32_t input_row_bytes = input_single_tile_size / tile_height;
+    const uint32_t temp_cb_size = input_row_bytes * set.block_tiles + 2 * dram_alignment;
+
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = temp_cb_size,
+        .core_ranges = set.core_ranges,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = set.staging_index,
+            .data_format = input_cb_data_format,
+            .page_size = temp_cb_size,
+        }}},
+    });
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = set.block_tiles * input_single_tile_size,
+        .core_ranges = set.core_ranges,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = set.input_index,
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+            .tile = tile,
+        }}},
+    });
+    desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+        .total_size = set.block_tiles * output_single_tile_size,
+        .core_ranges = set.core_ranges,
+        .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+            .buffer_index = set.output_index,
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+            .tile = tile,
+        }}},
+    });
+}
+
+BlockPlan make_block_plan(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    uint32_t tile_height,
+    uint32_t tile_width,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    const tt::tt_metal::CoreCoord grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    const tt::tt_metal::CoreRangeSet default_grid(tt::tt_metal::CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
+    tt::tt_metal::CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    const auto& padded = output_tensor.padded_shape();
+    const uint32_t num_tiles_per_col = padded[-2] / tile_height;
+    const uint32_t num_tiles_per_row = padded[-1] / tile_width;
+    const uint32_t num_blocks = (padded[-1] * padded[-2]) / (tile_height * tile_width);
+
+    // Fold the staging buffer (bytes/tile + fixed) into the limit or the region overruns L1.
+    const uint32_t max_l1_size = get_max_l1_space(input_tensor);
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    const uint32_t staging_bytes_per_tile = input_single_tile_size / tile_height;
+    const uint32_t fixed_staging_bytes = 2 * dram_alignment;
+    const uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
+    const uint32_t bytes_per_tile_pair = input_single_tile_size + output_single_tile_size + staging_bytes_per_tile;
+    const uint32_t cb_block_size_limit = (bytes_per_tile_pair == 0) ? 0 : budget_for_tiles / bytes_per_tile_pair;
+
+    BlockPlan plan;
+    plan.split = ttnn::split_blocks_for_tilize_wh(
+        available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col, cb_block_size_limit);
+
+    // The work split hands out exactly two block widths, so there are exactly two buffer sets:
+    //
+    //   full     - `single_sub_block_size` tiles wide: the full-block cores, plus the cliff-*column*
+    //              cores (a short column still processes full-width blocks).
+    //   cliffrow - `single_block_size_cliff_row` tiles wide: the cores holding the narrow block at
+    //              the end of a row, plus the corner core that is both cliff-row and cliff-column.
+    //
+    // Each set gets its own indices and its own sizes, so no index is ever re-used at two different
+    // sizes. Either set may be empty for a given shape.
+    plan.full = BlockBufferSet{
+        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+        .input_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+        .output_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+        .block_tiles = plan.split.single_sub_block_size,
+        .core_ranges = union_of(
+            plan.split.core_range,
+            plan.split.has_cliff_col ? plan.split.cliff_col_core_range : tt::tt_metal::CoreRangeSet{}),
+    };
+    plan.cliffrow = BlockBufferSet{
+        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+        .input_index = static_cast<uint8_t>(tt::CBIndex::c_2),
+        .output_index = static_cast<uint8_t>(tt::CBIndex::c_17),
+        .block_tiles = plan.split.single_block_size_cliff_row,
+        .core_ranges = plan.split.has_cliff_row ? union_of(
+                                                      plan.split.cliff_row_core_range,
+                                                      plan.split.has_cliff_col ? plan.split.cliff_col_row_core_range
+                                                                               : tt::tt_metal::CoreRangeSet{})
+                                                : tt::tt_metal::CoreRangeSet{},
+    };
+    return plan;
+}
+
+const BlockBufferSet& buffer_set_for_core(const BlockPlan& plan, const tt::tt_metal::CoreCoord& core) {
+    const bool in_full = !plan.full.empty() && plan.full.core_ranges.contains(core);
+    const bool in_cliffrow = !plan.cliffrow.empty() && plan.cliffrow.core_ranges.contains(core);
+    TT_FATAL(
+        in_full != in_cliffrow,
+        "Core {} is covered by {} buffer sets; the work split must place every core in exactly one",
+        core.str(),
+        (in_full && in_cliffrow) ? "both" : "neither");
+    return in_cliffrow ? plan.cliffrow : plan.full;
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
@@ -9,6 +9,12 @@
 
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
+namespace tt::tt_metal {
+struct ProgramDescriptor;
+struct TileDescriptor;
+}  // namespace tt::tt_metal
 
 namespace ttnn::operations::data_movement {
 
@@ -50,6 +56,93 @@ uint32_t get_estimated_size_of_cbs(
     uint32_t fixed_staging_bytes = 0);
 
 uint32_t get_max_l1_space(const Tensor& input_tensor_a);
+
+// One set of buffers, sized for a single block width.
+//
+// The `_multi_core_block[_interleaved]` tilize factories split work into blocks and hand cores one
+// of two block widths (the full width, and a narrower cliff-row width). A block's width fixes the
+// size of the buffers that carry it, and that size is a *correctness* property rather than a
+// performance one: the reader fills a whole block through one raw linear write starting at
+// `get_write_ptr()`, and `cb_push_back` requires the producer to write contiguously -- it only
+// wraps when the write pointer lands exactly on `fifo_limit` ("producer always writes into
+// contiguous memory, it cannot wrap"). A buffer whose size is not an exact multiple of the block
+// pushed into it therefore overruns into its neighbour rather than wrapping.
+//
+// So each block width gets its own set of buffers, with its own indices, sized for that width,
+// rather than one set of indices re-used at different sizes on disjoint cores (issue #51305). The
+// sets live on disjoint core ranges, so L1 usage is unchanged: a core allocates only the set
+// belonging to its own block width.
+//
+// This is shared rather than private to each factory because every factory using the model must
+// apply the *same* index and sizing rules -- a private copy can drift and reintroduce the
+// corruption the split prevents.
+struct BlockBufferSet {
+    uint8_t staging_index = 0;  // per-row DRAM-alignment staging buffer (reader-private scratchpad)
+    uint8_t input_index = 0;    // row-major block the reader fills and compute tilizes
+    uint8_t output_index = 0;   // tilized block compute produces and the writer drains
+    uint32_t block_tiles = 0;   // block width in tiles -- the page count of input/output
+    tt::tt_metal::CoreRangeSet core_ranges;
+
+    bool empty() const { return core_ranges.empty(); }
+};
+
+// The block work split plus the two buffer sets derived from it.
+//
+// Shared so both `_multi_core_block[_interleaved]` tilize factories apply one set of index and
+// sizing rules. A private copy per factory drifts, and a CB-index or sizing change landing in only
+// one of them silently reintroduces the overrun BlockBufferSet exists to prevent.
+//
+// Tile sizes are passed in rather than derived from a Tile: the factories compute them differently
+// (`Tile::get_tile_size`, which folds in runtime L1 alignment, versus the constexpr
+// `tt::tile_size`) and unifying that here would quietly change CB sizes.
+//
+// Call this only on a cache miss. It is **not** reproducible on a later cache hit: the block-size
+// limit folds in `get_max_l1_space`, which reads live L1 occupancy
+// (`lowest_occupied_compute_l1_address`), and the program cache does not key on that. Two calls
+// with identical attributes and tensor specs can therefore split differently, so anything the
+// cache-hit hook needs must be recorded in the program at miss time rather than recomputed.
+struct BlockPlan {
+    ttnn::BlockSplitWH split;
+    BlockBufferSet full;
+    BlockBufferSet cliffrow;
+
+    // Reader/writer kernels are emitted as one (reader, writer) pair per non-empty set, in
+    // full-then-cliffrow order, ahead of the compute kernels.
+    uint32_t num_dm_pairs() const { return (full.empty() ? 0u : 1u) + (cliffrow.empty() ? 0u : 1u); }
+};
+
+BlockPlan make_block_plan(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    uint32_t tile_height,
+    uint32_t tile_width,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids);
+
+// The buffer set whose block width this core was assigned. Asserts the core belongs to exactly one
+// set: an unmatched core silently defaulting to `full_set` would bind the wrong-width buffers, and
+// a downstream size check only catches that when the widths happen to differ numerically.
+const BlockBufferSet& buffer_set_for_core(const BlockPlan& plan, const tt::tt_metal::CoreCoord& core);
+
+// Union of two core ranges, either of which may be empty.
+tt::tt_metal::CoreRangeSet union_of(const tt::tt_metal::CoreRangeSet& a, const tt::tt_metal::CoreRangeSet& b);
+
+// Append the three CBDescriptors for one buffer set: staging, input, output.
+//
+// `tile` is the only factory-specific piece -- a factory that supports non-default tile shapes
+// passes its TileDescriptor so the input/output buffers carry it; one that is fixed to the
+// standard tile leaves it unset.
+void push_buffer_set(
+    tt::tt_metal::ProgramDescriptor& desc,
+    const BlockBufferSet& set,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format,
+    uint32_t dram_alignment,
+    uint32_t tile_height,
+    const std::optional<tt::tt_metal::TileDescriptor>& tile = std::nullopt);
 
 // reserved_l1_bytes_per_core: per-core L1 that is not yet allocated at the time of this
 // call but provably will be before the program's circular buffers are placed -- most
@@ -151,7 +244,7 @@ public:
             if (p2(args...)) {
                 *t2_required = true;
             }
-            return *t1_required or *t2_required;
+            return *t1_required or * t2_required;
         };
 
         auto merged_pre_transform = [t1 = this->pre_transform_,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp
@@ -13,17 +13,22 @@ void kernel_main() {
     constexpr uint32_t block_size_col = get_compile_time_arg_val(0);
     constexpr uint32_t block_size_row = get_compile_time_arg_val(1);
     constexpr uint32_t third_dim = get_compile_time_arg_val(2);
+    // Compile-time rather than fixed indices: a factory whose work split gives cores different
+    // block widths declares one correctly-sized buffer pair per width, and each instance of this
+    // kernel binds the pair matching the width its cores were given.
+    constexpr uint32_t dfb_id_in = get_compile_time_arg_val(3);
+    constexpr uint32_t dfb_id_out = get_compile_time_arg_val(4);
 
-    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    compute_kernel_hw_startup(dfb_id_in, dfb_id_out);
 
-    constexpr auto fp32_mode = compute_kernel_lib::is_fp32_input_format<tt::CBIndex::c_0>()
+    constexpr auto fp32_mode = compute_kernel_lib::is_fp32_input_format<dfb_id_in>()
                                    ? compute_kernel_lib::tilize_config::Fp32Mode::Lossless
                                    : compute_kernel_lib::tilize_config::Fp32Mode::Fast;
 
     compute_kernel_lib::tilize<
         block_size_row,
-        tt::CBIndex::c_0,
-        tt::CBIndex::c_16,
+        dfb_id_in,
+        dfb_id_out,
         compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
         compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
         compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -24,58 +24,175 @@ namespace ttnn::prim {
 
 namespace {
 
-// Helper: append a paired (input, output) CBDescriptor for a given core range.
-void push_cb_pair(
+// One set of buffers, sized for a single block width.
+//
+// The work split gives cores one of two block widths (the full width, and a narrower cliff-row
+// width), and a block's width fixes the size of the buffers that carry it. That size is a
+// *correctness* property, not a performance one: the reader fills a whole block through one raw
+// linear write starting at `get_write_ptr()`, and `cb_push_back` requires the producer to write
+// contiguously — it only wraps when the write pointer lands exactly on `fifo_limit`
+// ("producer always writes into contiguous memory, it cannot wrap"). A buffer whose size is not
+// an exact multiple of the block pushed into it therefore overruns into its neighbour rather than
+// wrapping. So each block width gets its **own** set of buffers, with its own indices, sized for
+// that width — rather than one set of indices re-used at different sizes on disjoint cores.
+//
+// The two sets live on disjoint core ranges, so L1 usage is unchanged: a core allocates only the
+// set belonging to its own block width.
+struct BlockBufferSet {
+    uint8_t staging_index;  // per-row DRAM-alignment staging buffer (reader-private scratchpad)
+    uint8_t input_index;    // row-major block the reader fills and compute tilizes
+    uint8_t output_index;   // tilized block compute produces and the writer drains
+    uint32_t block_tiles;   // block width in tiles — the page count of input/output
+    CoreRangeSet core_ranges;
+
+    bool empty() const { return core_ranges.empty(); }
+};
+
+// Append the three CBDescriptors for one buffer set.
+void push_buffer_set(
     ProgramDescriptor& desc,
-    const CoreRangeSet& core_ranges,
+    const BlockBufferSet& set,
     uint32_t input_single_tile_size,
     uint32_t output_single_tile_size,
-    uint32_t num_tiles,
     tt::DataFormat input_cb_data_format,
     tt::DataFormat output_cb_data_format,
     uint32_t dram_alignment,
     uint32_t tile_height,
     const TileDescriptor& tile_descriptor) {
-    // c_1 is a per-row staging buffer used by the reader when the DRAM source row and the
-    // L1 destination have different alignment offsets: the reader rounds the source address
-    // down to a dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment)
-    // into this buffer, then copies the correctly-offset slice into c_0.
-    //   row_bytes  = tile_width * elt_size * num_tiles  (one row of a sub-block)
-    //              = input_single_tile_size / tile_height * num_tiles
+    // The staging buffer is used by the reader when the DRAM source row and the L1 destination
+    // have different alignment offsets: the reader rounds the source address down to a
+    // dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment) into
+    // this buffer, then copies the correctly-offset slice into the input buffer.
+    //   row_bytes  = tile_width * elt_size * block_tiles  (one row of a block)
+    //              = input_single_tile_size / tile_height * block_tiles
     //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
     //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
     //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
     uint32_t input_row_bytes = input_single_tile_size / tile_height;
-    uint32_t temp_cb_size = input_row_bytes * num_tiles + 2 * dram_alignment;
+    uint32_t temp_cb_size = input_row_bytes * set.block_tiles + 2 * dram_alignment;
     desc.cbs.push_back(CBDescriptor{
         .total_size = temp_cb_size,
-        .core_ranges = core_ranges,
+        .core_ranges = set.core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+            .buffer_index = set.staging_index,
             .data_format = input_cb_data_format,
             .page_size = temp_cb_size,
         }}},
     });
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * input_single_tile_size,
-        .core_ranges = core_ranges,
+        .total_size = set.block_tiles * input_single_tile_size,
+        .core_ranges = set.core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .buffer_index = set.input_index,
             .data_format = input_cb_data_format,
             .page_size = input_single_tile_size,
             .tile = tile_descriptor,
         }}},
     });
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * output_single_tile_size,
-        .core_ranges = core_ranges,
+        .total_size = set.block_tiles * output_single_tile_size,
+        .core_ranges = set.core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .buffer_index = set.output_index,
             .data_format = output_cb_data_format,
             .page_size = output_single_tile_size,
             .tile = tile_descriptor,
         }}},
     });
+}
+
+// Union of two core ranges, either of which may be empty.
+CoreRangeSet union_of(const CoreRangeSet& a, const CoreRangeSet& b) {
+    if (a.empty()) {
+        return b;
+    }
+    if (b.empty()) {
+        return a;
+    }
+    return a.merge(b);
+}
+
+// The work split plus the two buffer sets derived from it.
+//
+// `create_descriptor` needs the whole split; the two buffer sets are derived from it here so the
+// sizes, the indices, and the core ranges they are built from all come from one place.
+//
+// Call this only on a cache miss. It is **not** reproducible on a later cache hit: the block-size
+// limit folds in `get_max_l1_space`, which reads live L1 occupancy
+// (`lowest_occupied_compute_l1_address`), and the program cache does not key on that. Two calls
+// with identical attributes and tensor specs can therefore split differently. Anything the
+// cache-hit hook needs must be recorded in the program at miss time, not recomputed.
+struct BlockPlan {
+    ttnn::BlockSplitWH split;
+    BlockBufferSet full;
+    BlockBufferSet cliffrow;
+
+    // Reader/writer kernels are emitted as one (reader, writer) pair per non-empty set, in
+    // full-then-cliffrow order, ahead of the compute kernels.
+    uint32_t num_dm_pairs() const { return (full.empty() ? 0u : 1u) + (cliffrow.empty() ? 0u : 1u); }
+};
+
+BlockPlan make_block_plan(const TilizeParams& operation_attributes, const Tensor& a, const Tensor& output) {
+    const uint32_t tile_width = operation_attributes.tile.get_width();
+    const uint32_t tile_height = operation_attributes.tile.get_height();
+    const uint32_t tile_hw = operation_attributes.tile.get_tile_hw();
+
+    const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
+    const uint32_t input_single_tile_size = operation_attributes.tile.get_tile_size(input_cb_data_format);
+    const tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t output_single_tile_size = operation_attributes.tile.get_tile_size(output_cb_data_format);
+
+    IDevice* device = a.device();
+    const CoreCoord grid_size = device->compute_with_storage_grid_size();
+    const CoreRangeSet default_grid(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
+    CoreRangeSet available_grid =
+        operation_attributes.sub_core_grids.has_value() ? operation_attributes.sub_core_grids.value() : default_grid;
+
+    const uint32_t max_l1_size = operations::data_movement::get_max_l1_space(a);
+    const uint32_t num_tiles_per_col = output.padded_shape()[-2] / tile_height;
+    const uint32_t num_tiles_per_row = output.padded_shape()[-1] / tile_width;
+    const uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / tile_hw;
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    // Fold the staging buffer (bytes/tile + fixed) into the limit or the region overruns L1.
+    const uint32_t staging_bytes_per_tile = input_single_tile_size / tile_height;
+    const uint32_t fixed_staging_bytes = 2 * dram_alignment;
+    const uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
+    const uint32_t bytes_per_tile_pair = input_single_tile_size + output_single_tile_size + staging_bytes_per_tile;
+    const uint32_t cb_block_size_limit = (bytes_per_tile_pair == 0) ? 0 : budget_for_tiles / bytes_per_tile_pair;
+
+    BlockPlan plan;
+    plan.split = ttnn::split_blocks_for_tilize_wh(
+        available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col, cb_block_size_limit);
+
+    // The work split hands out exactly two block widths, so the op needs exactly two buffer sets:
+    //
+    //   full     — `single_sub_block_size` tiles wide: the full-block cores, plus the cliff-*column*
+    //              cores (a short column still processes full-width blocks).
+    //   cliffrow — `single_block_size_cliff_row` tiles wide: the cores holding the narrow block at
+    //              the end of a row, plus the corner core that is both cliff-row and cliff-column.
+    //
+    // Each set gets its own indices and its own sizes, so no index is ever re-used at two
+    // different sizes. Either set may be empty for a given shape.
+    plan.full = BlockBufferSet{
+        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+        .input_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+        .output_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+        .block_tiles = plan.split.single_sub_block_size,
+        .core_ranges = union_of(
+            plan.split.core_range, plan.split.has_cliff_col ? plan.split.cliff_col_core_range : CoreRangeSet{}),
+    };
+    plan.cliffrow = BlockBufferSet{
+        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+        .input_index = static_cast<uint8_t>(tt::CBIndex::c_2),
+        .output_index = static_cast<uint8_t>(tt::CBIndex::c_17),
+        .block_tiles = plan.split.single_block_size_cliff_row,
+        .core_ranges = plan.split.has_cliff_row
+                           ? union_of(
+                                 plan.split.cliff_row_core_range,
+                                 plan.split.has_cliff_col ? plan.split.cliff_col_row_core_range : CoreRangeSet{})
+                           : CoreRangeSet{},
+    };
+    return plan;
 }
 
 }  // namespace
@@ -84,10 +201,8 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
     const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
-    const auto& sub_core_grids = operation_attributes.sub_core_grids;
     const uint32_t tile_width = operation_attributes.tile.get_width();
     const uint32_t tile_height = operation_attributes.tile.get_height();
-    const uint32_t tile_hw = operation_attributes.tile.get_tile_hw();
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = operation_attributes.tile.get_tile_size(input_cb_data_format);
@@ -100,43 +215,20 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
                         output.dtype() == DataType::FP8_E4M3 || output.dtype() == DataType::BFLOAT8_B ||
                         a.dtype() == DataType::UINT8;
 
-    IDevice* device = a.device();
-    CoreCoord grid_size = device->compute_with_storage_grid_size();
-    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-    CoreRangeSet default_grid(default_cores);
-    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
-
-    uint32_t max_l1_size = operations::data_movement::get_max_l1_space(a);
-    uint32_t num_tiles_per_col = output.padded_shape()[-2] / tile_height;
-    uint32_t num_tiles_per_row = output.padded_shape()[-1] / tile_width;
-
-    uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / tile_hw;
+    const uint32_t tile_hw = operation_attributes.tile.get_tile_hw();
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
-    // Fold push_cb_pair's c_1 staging (bytes/tile + fixed) into the limit or the region overruns L1.
-    uint32_t staging_bytes_per_tile = input_single_tile_size / tile_height;
-    uint32_t fixed_staging_bytes = 2 * dram_alignment;
-    uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
-    uint32_t bytes_per_tile_pair = input_single_tile_size + output_single_tile_size + staging_bytes_per_tile;
-    uint32_t cb_block_size_limit = (bytes_per_tile_pair == 0) ? 0 : budget_for_tiles / bytes_per_tile_pair;
 
-    auto
-        [ncores,
-         all_cores,
-         core_range,
-         cliff_row_core_range,
-         cliff_col_core_range,
-         cliff_col_row_core_range,
-         nblocks_per_core,
-         single_block_size,
-         single_block_size_cliff_row,
-         single_block_size_cliff_col,
-         has_cliff_row,
-         has_cliff_col,
-         full_cores_per_row,
-         full_cores_per_col,
-         single_sub_block_size] =
-            ttnn::split_blocks_for_tilize_wh(
-                available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col, cb_block_size_limit);
+    const BlockPlan plan = make_block_plan(operation_attributes, a, output);
+    const BlockBufferSet& full_set = plan.full;
+    const BlockBufferSet& cliffrow_set = plan.cliffrow;
+    const auto& [ncores, all_cores, core_range, cliff_row_core_range, cliff_col_core_range, cliff_col_row_core_range, nblocks_per_core, single_block_size, single_block_size_cliff_row, single_block_size_cliff_col, has_cliff_row, has_cliff_col, full_cores_per_row, full_cores_per_col, single_sub_block_size] =
+        plan.split;
+
+    // Same grid `make_block_plan` split over — the runtime-arg loop below walks it in core order.
+    const CoreCoord grid_size = a.device()->compute_with_storage_grid_size();
+    const CoreRangeSet available_grid = operation_attributes.sub_core_grids.has_value()
+                                            ? operation_attributes.sub_core_grids.value()
+                                            : CoreRangeSet(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
 
     if (single_sub_block_size > 0 && single_block_size % single_sub_block_size) {
         TT_FATAL(false, "single_block_size is not divided by single_sub_block_size");
@@ -155,52 +247,19 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
 
     ProgramDescriptor desc;
 
-    if (!core_range.empty()) {
-        push_cb_pair(
+    for (const BlockBufferSet* set : {&full_set, &cliffrow_set}) {
+        if (set->empty()) {
+            continue;
+        }
+        TT_FATAL(
+            set->block_tiles > 0,
+            "Buffer set on cores {} has a zero block width; its buffers would be empty",
+            set->core_ranges.str());
+        push_buffer_set(
             desc,
-            core_range,
+            *set,
             input_single_tile_size,
             output_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment,
-            tile_height,
-            tile_descriptor);
-    }
-    if (has_cliff_col && has_cliff_row) {
-        push_cb_pair(
-            desc,
-            cliff_col_row_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment,
-            tile_height,
-            tile_descriptor);
-    }
-    if (has_cliff_row) {
-        push_cb_pair(
-            desc,
-            cliff_row_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment,
-            tile_height,
-            tile_descriptor);
-    }
-    if (has_cliff_col) {
-        push_cb_pair(
-            desc,
-            cliff_col_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_sub_block_size,
             input_cb_data_format,
             output_cb_data_format,
             dram_alignment,
@@ -225,30 +284,51 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
         total_num_rows = output.padded_shape()[-2];
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        total_num_rows, third_dim, tile_height, a.element_size(), row_size_bytes, dram_alignment};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    // One reader and one writer per buffer set, each over that set's cores and bound to that
+    // set's indices. A set's cores are exactly the cores whose block width its buffers are sized
+    // for, so every instance's raw block write lands in a buffer that is an exact multiple of it.
+    auto make_reader_kernel = [&](const BlockBufferSet& set) {
+        std::vector<uint32_t> reader_compile_time_args = {
+            total_num_rows,
+            third_dim,
+            tile_height,
+            a.element_size(),
+            row_size_bytes,
+            dram_alignment,
+            set.input_index,
+            set.staging_index};
+        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_multicore_both_dims.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+        KernelDescriptor reader_desc;
+        reader_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
+            "reader_unary_pad_multicore_both_dims.cpp";
+        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader_desc.core_ranges = set.core_ranges;
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
+        reader_desc.config = ReaderConfigDescriptor{};
+        return reader_desc;
+    };
 
-    // writer
-    std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16, num_tiles_2d, third_dim, total_tiles_per_row};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    auto make_writer_kernel = [&](const BlockBufferSet& set) {
+        std::vector<uint32_t> writer_compile_time_args = {
+            set.output_index, num_tiles_2d, third_dim, total_tiles_per_row};
+        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = set.core_ranges;
+        writer_desc.compile_time_args = std::move(writer_compile_time_args);
+        writer_desc.config = WriterConfigDescriptor{};
+        return writer_desc;
+    };
+
+    KernelDescriptor full_reader_desc = make_reader_kernel(full_set);
+    KernelDescriptor full_writer_desc = make_writer_kernel(full_set);
+    KernelDescriptor cliffrow_reader_desc = make_reader_kernel(cliffrow_set);
+    KernelDescriptor cliffrow_writer_desc = make_writer_kernel(cliffrow_set);
 
     // compute
     uint32_t single_sub_block_wh = single_block_size * single_block_size / single_sub_block_size;
@@ -257,42 +337,54 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     // UInt8 uses 32-bit dest as integer (not float): do not enable FP32 unpack-to-dest mode.
     if (fp32_llk_acc && a.dtype() != DataType::UINT8) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[full_set.input_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[cliffrow_set.input_index] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp";
 
-    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
-        KernelDescriptor cd;
-        cd.kernel_source = compute_kernel_path;
-        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        cd.core_ranges = cores;
-        cd.compile_time_args = std::move(compile_args);
-        cd.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
+    // The compute kernel stays split per region — each region has its own block *count* — but each
+    // instance binds the buffer set matching its cores' block *width*. The region's block-width CTA
+    // (the second one) must equal that set's `block_tiles`, since it is the page count the kernel
+    // waits on and pops; the assertion below keeps the two from drifting apart.
+    auto make_compute_kernel =
+        [&](const CoreRangeSet& cores, const BlockBufferSet& set, uint32_t block_size_col, uint32_t block_size_row) {
+            TT_FATAL(
+                block_size_row == set.block_tiles,
+                "Compute on cores {} expects a block width of {} tiles but its buffers hold {}",
+                cores.str(),
+                block_size_row,
+                set.block_tiles);
+            KernelDescriptor cd;
+            cd.kernel_source = compute_kernel_path;
+            cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            cd.core_ranges = cores;
+            cd.compile_time_args = {block_size_col, block_size_row, third_dim, set.input_index, set.output_index};
+            cd.config = ComputeConfigDescriptor{
+                .fp32_dest_acc_en = fp32_llk_acc,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
+            };
+            return cd;
         };
-        return cd;
-    };
 
     std::vector<KernelDescriptor> compute_kernels;
     compute_kernels.reserve(4);
     if (!core_range.empty()) {
         compute_kernels.push_back(
-            make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));
+            make_compute_kernel(core_range, full_set, single_sub_block_wh, single_sub_block_size));
     }
     if (has_cliff_col && has_cliff_row) {
         compute_kernels.push_back(make_compute_kernel(
-            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
+            cliff_col_row_core_range, cliffrow_set, single_block_size_cliff_col, single_block_size_cliff_row));
     }
     if (has_cliff_row) {
         compute_kernels.push_back(
-            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
+            make_compute_kernel(cliff_row_core_range, cliffrow_set, single_block_size, single_block_size_cliff_row));
     }
     if (has_cliff_col) {
-        compute_kernels.push_back(make_compute_kernel(
-            cliff_col_core_range, {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}));
+        compute_kernels.push_back(
+            make_compute_kernel(cliff_col_core_range, full_set, single_sub_block_cliff_col_wh, single_sub_block_size));
     }
 
     // RUNTIME ARGS
@@ -332,6 +424,24 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
+        // Route this core's args to the reader/writer instance for its buffer set. Membership is
+        // read from the work split's own core assignment rather than re-derived from the branch
+        // above, so the args and the buffers they drive can never disagree about which set a core
+        // is in. The assertion then checks the one thing that must hold: the set's buffers are
+        // sized for exactly the sub-block width being passed here, which is what keeps the
+        // reader's raw block write inside its buffer.
+        const bool is_cliff_row_core = !cliffrow_set.empty() && cliffrow_set.core_ranges.contains(core);
+        const BlockBufferSet& set = is_cliff_row_core ? cliffrow_set : full_set;
+        KernelDescriptor& reader_desc = is_cliff_row_core ? cliffrow_reader_desc : full_reader_desc;
+        KernelDescriptor& writer_desc = is_cliff_row_core ? cliffrow_writer_desc : full_writer_desc;
+        TT_FATAL(
+            single_sub_block_size_row_arg == set.block_tiles,
+            "Core {} is fed a sub-block of {} tiles but the buffers on it hold {}. The work split "
+            "assigned this core a block width that disagrees with its runtime args",
+            core.str(),
+            single_sub_block_size_row_arg,
+            set.block_tiles);
+
         // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
         // framework patches addresses on cache hits.
         reader_desc.emplace_runtime_args(
@@ -364,8 +474,29 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
         }
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    // Push each non-empty set's reader before its writer. `TilizeDeviceOperation::override_runtime_arguments`
+    // re-points kernel 0 at the input buffer and kernel 1 at the output on a cache hit, so the first
+    // pair pushed must stay (reader, writer) in that order. The later pair, and every buffer slot in
+    // both, is refreshed anyway: slot 0 of each arg list is a `Buffer*`, which `emplace_runtime_args`
+    // registers as a per-kernel BufferBinding that the framework patches on every cache hit.
+    if (!full_set.empty()) {
+        desc.kernels.push_back(std::move(full_reader_desc));
+        desc.kernels.push_back(std::move(full_writer_desc));
+    }
+    if (!cliffrow_set.empty()) {
+        desc.kernels.push_back(std::move(cliffrow_reader_desc));
+        desc.kernels.push_back(std::move(cliffrow_writer_desc));
+    }
+
+    // Tell the cache-hit hook how many pairs it has to re-point, by riding on the first reader's
+    // common args. The hook cannot re-derive this: the block split depends on `get_max_l1_space`,
+    // which reads live L1 occupancy (`lowest_occupied_compute_l1_address`) — a value the program
+    // cache does not key on, so a fresh split on a later hit can disagree with the split baked
+    // into the cached program. Recording it keeps the fact with the program it describes.
+    // Host-side metadata only: the reader kernel reads no common args.
+    TT_FATAL(!desc.kernels.empty(), "Block tilize emitted no kernels");
+    desc.kernels.front().emplace_common_runtime_args({plan.num_dm_pairs()});
+
     for (auto& cd : compute_kernels) {
         desc.kernels.push_back(std::move(cd));
     }
@@ -380,9 +511,19 @@ void TilizeMultiCoreBlockProgramFactory::override_runtime_arguments(
     Tensor& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     // Every shape-derived arg is keyed, so only the reader/writer buffer addresses move on a hit.
-    // Reader is pushed first, writer second, each taking its buffer at slot 0.
-    patch_tilize_kernel_slot0(program, 0, tensor_args.input_tensor.buffer()->address());
-    patch_tilize_kernel_slot0(program, 1, tensor_return_value.buffer()->address());
+    //
+    // This factory emits one (reader, writer) pair *per buffer set*, so there may be two pairs to
+    // re-point rather than one. Both must be patched: an unpatched pair keeps the address from the
+    // call that populated the cache, which on a later hit with new tensor storage reads or writes
+    // the wrong buffer with nothing to flag it. The count comes from the program itself — see the
+    // note in create_descriptor for why it must not be re-derived here.
+    const uint32_t num_pairs = tt::tt_metal::GetCommonRuntimeArgs(program, 0)[0];
+    const uint32_t src_addr = tensor_args.input_tensor.buffer()->address();
+    const uint32_t dst_addr = tensor_return_value.buffer()->address();
+    for (uint32_t pair = 0; pair < num_pairs; ++pair) {
+        patch_tilize_kernel_slot0(program, 2 * pair, src_addr);      // reader
+        patch_tilize_kernel_slot0(program, 2 * pair + 1, dst_addr);  // writer
+    }
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -24,176 +24,17 @@ namespace ttnn::prim {
 
 namespace {
 
-// One set of buffers, sized for a single block width.
-//
-// The work split gives cores one of two block widths (the full width, and a narrower cliff-row
-// width), and a block's width fixes the size of the buffers that carry it. That size is a
-// *correctness* property, not a performance one: the reader fills a whole block through one raw
-// linear write starting at `get_write_ptr()`, and `cb_push_back` requires the producer to write
-// contiguously — it only wraps when the write pointer lands exactly on `fifo_limit`
-// ("producer always writes into contiguous memory, it cannot wrap"). A buffer whose size is not
-// an exact multiple of the block pushed into it therefore overruns into its neighbour rather than
-// wrapping. So each block width gets its **own** set of buffers, with its own indices, sized for
-// that width — rather than one set of indices re-used at different sizes on disjoint cores.
-//
-// The two sets live on disjoint core ranges, so L1 usage is unchanged: a core allocates only the
-// set belonging to its own block width.
-struct BlockBufferSet {
-    uint8_t staging_index;  // per-row DRAM-alignment staging buffer (reader-private scratchpad)
-    uint8_t input_index;    // row-major block the reader fills and compute tilizes
-    uint8_t output_index;   // tilized block compute produces and the writer drains
-    uint32_t block_tiles;   // block width in tiles — the page count of input/output
-    CoreRangeSet core_ranges;
+// Runtime-arg widths of this factory's DM kernels, used by the cache-hit hook to confirm it is
+// patching a reader/writer and not something else. Keep in step with the emplace_runtime_args
+// calls below.
+constexpr size_t kReaderRuntimeArgCount = 9;
+constexpr size_t kWriterRuntimeArgCount = 4;
 
-    bool empty() const { return core_ranges.empty(); }
-};
-
-// Append the three CBDescriptors for one buffer set.
-void push_buffer_set(
-    ProgramDescriptor& desc,
-    const BlockBufferSet& set,
-    uint32_t input_single_tile_size,
-    uint32_t output_single_tile_size,
-    tt::DataFormat input_cb_data_format,
-    tt::DataFormat output_cb_data_format,
-    uint32_t dram_alignment,
-    uint32_t tile_height,
-    const TileDescriptor& tile_descriptor) {
-    // The staging buffer is used by the reader when the DRAM source row and the L1 destination
-    // have different alignment offsets: the reader rounds the source address down to a
-    // dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment) into
-    // this buffer, then copies the correctly-offset slice into the input buffer.
-    //   row_bytes  = tile_width * elt_size * block_tiles  (one row of a block)
-    //              = input_single_tile_size / tile_height * block_tiles
-    //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
-    //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
-    //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
-    uint32_t input_row_bytes = input_single_tile_size / tile_height;
-    uint32_t temp_cb_size = input_row_bytes * set.block_tiles + 2 * dram_alignment;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = temp_cb_size,
-        .core_ranges = set.core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = set.staging_index,
-            .data_format = input_cb_data_format,
-            .page_size = temp_cb_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = set.block_tiles * input_single_tile_size,
-        .core_ranges = set.core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = set.input_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-            .tile = tile_descriptor,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = set.block_tiles * output_single_tile_size,
-        .core_ranges = set.core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = set.output_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-            .tile = tile_descriptor,
-        }}},
-    });
-}
-
-// Union of two core ranges, either of which may be empty.
-CoreRangeSet union_of(const CoreRangeSet& a, const CoreRangeSet& b) {
-    if (a.empty()) {
-        return b;
-    }
-    if (b.empty()) {
-        return a;
-    }
-    return a.merge(b);
-}
-
-// The work split plus the two buffer sets derived from it.
-//
-// `create_descriptor` needs the whole split; the two buffer sets are derived from it here so the
-// sizes, the indices, and the core ranges they are built from all come from one place.
-//
-// Call this only on a cache miss. It is **not** reproducible on a later cache hit: the block-size
-// limit folds in `get_max_l1_space`, which reads live L1 occupancy
-// (`lowest_occupied_compute_l1_address`), and the program cache does not key on that. Two calls
-// with identical attributes and tensor specs can therefore split differently. Anything the
-// cache-hit hook needs must be recorded in the program at miss time, not recomputed.
-struct BlockPlan {
-    ttnn::BlockSplitWH split;
-    BlockBufferSet full;
-    BlockBufferSet cliffrow;
-
-    // Reader/writer kernels are emitted as one (reader, writer) pair per non-empty set, in
-    // full-then-cliffrow order, ahead of the compute kernels.
-    uint32_t num_dm_pairs() const { return (full.empty() ? 0u : 1u) + (cliffrow.empty() ? 0u : 1u); }
-};
-
-BlockPlan make_block_plan(const TilizeParams& operation_attributes, const Tensor& a, const Tensor& output) {
-    const uint32_t tile_width = operation_attributes.tile.get_width();
-    const uint32_t tile_height = operation_attributes.tile.get_height();
-    const uint32_t tile_hw = operation_attributes.tile.get_tile_hw();
-
-    const tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
-    const uint32_t input_single_tile_size = operation_attributes.tile.get_tile_size(input_cb_data_format);
-    const tt::DataFormat output_cb_data_format = datatype_to_dataformat_converter(output.dtype());
-    const uint32_t output_single_tile_size = operation_attributes.tile.get_tile_size(output_cb_data_format);
-
-    IDevice* device = a.device();
-    const CoreCoord grid_size = device->compute_with_storage_grid_size();
-    const CoreRangeSet default_grid(CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
-    CoreRangeSet available_grid =
-        operation_attributes.sub_core_grids.has_value() ? operation_attributes.sub_core_grids.value() : default_grid;
-
-    const uint32_t max_l1_size = operations::data_movement::get_max_l1_space(a);
-    const uint32_t num_tiles_per_col = output.padded_shape()[-2] / tile_height;
-    const uint32_t num_tiles_per_row = output.padded_shape()[-1] / tile_width;
-    const uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / tile_hw;
-    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
-    // Fold the staging buffer (bytes/tile + fixed) into the limit or the region overruns L1.
-    const uint32_t staging_bytes_per_tile = input_single_tile_size / tile_height;
-    const uint32_t fixed_staging_bytes = 2 * dram_alignment;
-    const uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
-    const uint32_t bytes_per_tile_pair = input_single_tile_size + output_single_tile_size + staging_bytes_per_tile;
-    const uint32_t cb_block_size_limit = (bytes_per_tile_pair == 0) ? 0 : budget_for_tiles / bytes_per_tile_pair;
-
-    BlockPlan plan;
-    plan.split = ttnn::split_blocks_for_tilize_wh(
-        available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col, cb_block_size_limit);
-
-    // The work split hands out exactly two block widths, so the op needs exactly two buffer sets:
-    //
-    //   full     — `single_sub_block_size` tiles wide: the full-block cores, plus the cliff-*column*
-    //              cores (a short column still processes full-width blocks).
-    //   cliffrow — `single_block_size_cliff_row` tiles wide: the cores holding the narrow block at
-    //              the end of a row, plus the corner core that is both cliff-row and cliff-column.
-    //
-    // Each set gets its own indices and its own sizes, so no index is ever re-used at two
-    // different sizes. Either set may be empty for a given shape.
-    plan.full = BlockBufferSet{
-        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_1),
-        .input_index = static_cast<uint8_t>(tt::CBIndex::c_0),
-        .output_index = static_cast<uint8_t>(tt::CBIndex::c_16),
-        .block_tiles = plan.split.single_sub_block_size,
-        .core_ranges = union_of(
-            plan.split.core_range, plan.split.has_cliff_col ? plan.split.cliff_col_core_range : CoreRangeSet{}),
-    };
-    plan.cliffrow = BlockBufferSet{
-        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_3),
-        .input_index = static_cast<uint8_t>(tt::CBIndex::c_2),
-        .output_index = static_cast<uint8_t>(tt::CBIndex::c_17),
-        .block_tiles = plan.split.single_block_size_cliff_row,
-        .core_ranges = plan.split.has_cliff_row
-                           ? union_of(
-                                 plan.split.cliff_row_core_range,
-                                 plan.split.has_cliff_col ? plan.split.cliff_col_row_core_range : CoreRangeSet{})
-                           : CoreRangeSet{},
-    };
-    return plan;
-}
+using ttnn::operations::data_movement::BlockBufferSet;
+using ttnn::operations::data_movement::BlockPlan;
+using ttnn::operations::data_movement::buffer_set_for_core;
+using ttnn::operations::data_movement::make_block_plan;
+using ttnn::operations::data_movement::push_buffer_set;
 
 }  // namespace
 
@@ -218,7 +59,14 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
     const uint32_t tile_hw = operation_attributes.tile.get_tile_hw();
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
 
-    const BlockPlan plan = make_block_plan(operation_attributes, a, output);
+    const BlockPlan plan = make_block_plan(
+        a,
+        output,
+        input_single_tile_size,
+        output_single_tile_size,
+        tile_height,
+        tile_width,
+        operation_attributes.sub_core_grids);
     const BlockBufferSet& full_set = plan.full;
     const BlockBufferSet& cliffrow_set = plan.cliffrow;
     const auto& [ncores, all_cores, core_range, cliff_row_core_range, cliff_col_core_range, cliff_col_row_core_range, nblocks_per_core, single_block_size, single_block_size_cliff_row, single_block_size_cliff_col, has_cliff_row, has_cliff_col, full_cores_per_row, full_cores_per_col, single_sub_block_size] =
@@ -430,8 +278,8 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
         // is in. The assertion then checks the one thing that must hold: the set's buffers are
         // sized for exactly the sub-block width being passed here, which is what keeps the
         // reader's raw block write inside its buffer.
-        const bool is_cliff_row_core = !cliffrow_set.empty() && cliffrow_set.core_ranges.contains(core);
-        const BlockBufferSet& set = is_cliff_row_core ? cliffrow_set : full_set;
+        const BlockBufferSet& set = buffer_set_for_core(plan, core);
+        const bool is_cliff_row_core = &set == &cliffrow_set;
         KernelDescriptor& reader_desc = is_cliff_row_core ? cliffrow_reader_desc : full_reader_desc;
         KernelDescriptor& writer_desc = is_cliff_row_core ? cliffrow_writer_desc : full_writer_desc;
         TT_FATAL(
@@ -442,8 +290,10 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
             single_sub_block_size_row_arg,
             set.block_tiles);
 
-        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
-        // framework patches addresses on cache hits.
+        // reader runtime args — slot 0 carries the input buffer. Note the `Buffer*` here does NOT
+        // self-refresh: this factory defines override_runtime_arguments, and the adapter then skips
+        // automatic binding resolution entirely, so the explicit slot-0 patch in that hook is the
+        // only thing that re-points addresses on a cache hit.
         reader_desc.emplace_runtime_args(
             core,
             {src0_buffer,
@@ -474,28 +324,47 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
         }
     }
 
-    // Push each non-empty set's reader before its writer. `TilizeDeviceOperation::override_runtime_arguments`
-    // re-points kernel 0 at the input buffer and kernel 1 at the output on a cache hit, so the first
-    // pair pushed must stay (reader, writer) in that order. The later pair, and every buffer slot in
-    // both, is refreshed anyway: slot 0 of each arg list is a `Buffer*`, which `emplace_runtime_args`
-    // registers as a per-kernel BufferBinding that the framework patches on every cache hit.
+    // One (reader, writer) pair per non-empty buffer set. Every pair's slot 0 has to be re-pointed
+    // on a program-cache hit: because this factory defines override_runtime_arguments, the adapter
+    // skips automatic binding resolution, so the `Buffer*` in slot 0 does not refresh on its own
+    // and an unpatched pair keeps the address from the call that populated the cache — quietly
+    // reading or writing the wrong buffer.
+    //
+    // Collect the handles as they are assigned rather than letting the hook infer them from the
+    // push order. The hook cannot re-derive any of this: the block split folds in
+    // `get_max_l1_space`, which reads live L1 occupancy (`lowest_occupied_compute_l1_address`) — a
+    // value the program cache does not key on, so a fresh split on a later hit can disagree with
+    // the split baked into the cached program.
+    std::vector<uint32_t> dm_kernel_handles;
+    dm_kernel_handles.reserve(4);
+    const auto push_pair = [&desc, &dm_kernel_handles](KernelDescriptor&& reader, KernelDescriptor&& writer) {
+        dm_kernel_handles.push_back(static_cast<uint32_t>(desc.kernels.size()));
+        desc.kernels.push_back(std::move(reader));
+        dm_kernel_handles.push_back(static_cast<uint32_t>(desc.kernels.size()));
+        desc.kernels.push_back(std::move(writer));
+    };
     if (!full_set.empty()) {
-        desc.kernels.push_back(std::move(full_reader_desc));
-        desc.kernels.push_back(std::move(full_writer_desc));
+        push_pair(std::move(full_reader_desc), std::move(full_writer_desc));
     }
     if (!cliffrow_set.empty()) {
-        desc.kernels.push_back(std::move(cliffrow_reader_desc));
-        desc.kernels.push_back(std::move(cliffrow_writer_desc));
+        push_pair(std::move(cliffrow_reader_desc), std::move(cliffrow_writer_desc));
     }
 
-    // Tell the cache-hit hook how many pairs it has to re-point, by riding on the first reader's
-    // common args. The hook cannot re-derive this: the block split depends on `get_max_l1_space`,
-    // which reads live L1 occupancy (`lowest_occupied_compute_l1_address`) — a value the program
-    // cache does not key on, so a fresh split on a later hit can disagree with the split baked
-    // into the cached program. Recording it keeps the fact with the program it describes.
-    // Host-side metadata only: the reader kernel reads no common args.
+    // Hand the hook the handles it must patch, riding on the first reader's common args:
+    // {num_pairs, reader0, writer0, [reader1, writer1]}. Host-side metadata only — the reader
+    // kernel reads no common args — and it keeps the fact with the program it describes.
     TT_FATAL(!desc.kernels.empty(), "Block tilize emitted no kernels");
-    desc.kernels.front().emplace_common_runtime_args({plan.num_dm_pairs()});
+    TT_FATAL(
+        dm_kernel_handles.size() == 2 * plan.num_dm_pairs(),
+        "Recorded {} DM kernel handles for {} pairs",
+        dm_kernel_handles.size(),
+        plan.num_dm_pairs());
+    KernelDescriptor::RTArgList dm_kernel_metadata;
+    dm_kernel_metadata.push_back(plan.num_dm_pairs());
+    for (uint32_t handle : dm_kernel_handles) {
+        dm_kernel_metadata.push_back(handle);
+    }
+    desc.kernels.front().emplace_common_runtime_args(dm_kernel_metadata);
 
     for (auto& cd : compute_kernels) {
         desc.kernels.push_back(std::move(cd));
@@ -517,12 +386,54 @@ void TilizeMultiCoreBlockProgramFactory::override_runtime_arguments(
     // call that populated the cache, which on a later hit with new tensor storage reads or writes
     // the wrong buffer with nothing to flag it. The count comes from the program itself — see the
     // note in create_descriptor for why it must not be re-derived here.
-    const uint32_t num_pairs = tt::tt_metal::GetCommonRuntimeArgs(program, 0)[0];
+    // create_descriptor recorded {num_pairs, reader0, writer0, [reader1, writer1]} here, so the
+    // handles are read rather than inferred from the push order — nothing in this hook assumes the
+    // DM kernels come first or sit at consecutive indices.
+    auto& dm_kernel_metadata = tt::tt_metal::GetCommonRuntimeArgs(program, 0);
+    const uint32_t num_pairs = dm_kernel_metadata[0];
+    TT_FATAL(
+        num_pairs == 1 || num_pairs == 2,
+        "Block tilize recorded {} reader/writer pairs; the work split yields at most two block widths, "
+        "so this should be 1 or 2",
+        num_pairs);
+    TT_FATAL(
+        dm_kernel_metadata.size() == 1 + 2 * num_pairs,
+        "Block tilize recorded {} metadata args for {} pairs; expected {}",
+        dm_kernel_metadata.size(),
+        num_pairs,
+        1 + 2 * num_pairs);
+
     const uint32_t src_addr = tensor_args.input_tensor.buffer()->address();
     const uint32_t dst_addr = tensor_return_value.buffer()->address();
+
+    // Belt and braces on top of the recorded handles: confirm each one really is the reader or
+    // writer before writing an address into its slot 0. Putting a buffer address into a compute
+    // kernel's args would be exactly the silent corruption this hook exists to prevent. A reader
+    // carries kReaderRuntimeArgCount args and a writer kWriterRuntimeArgCount, while this
+    // factory's compute kernels carry none, so the arg width identifies the role.
+    const auto patch_dm_kernel = [&program](
+                                     uint32_t kernel_idx, uint32_t addr, size_t expected_args, const char* role) {
+        for (const auto& col : tt::tt_metal::GetRuntimeArgs(program, kernel_idx)) {
+            for (const auto& args : col) {
+                if (args.size() == 0) {
+                    continue;  // core outside this kernel's range
+                }
+                TT_FATAL(
+                    args.size() == expected_args,
+                    "Kernel {} should be the {} (buffer address at slot 0) but carries {} runtime args, "
+                    "not {}. The reader/writer-pairs-first kernel order this hook relies on has changed",
+                    kernel_idx,
+                    role,
+                    args.size(),
+                    expected_args);
+            }
+        }
+        patch_tilize_kernel_slot0(program, kernel_idx, addr);
+    };
+
     for (uint32_t pair = 0; pair < num_pairs; ++pair) {
-        patch_tilize_kernel_slot0(program, 2 * pair, src_addr);      // reader
-        patch_tilize_kernel_slot0(program, 2 * pair + 1, dst_addr);  // writer
+        patch_dm_kernel(dm_kernel_metadata[1 + 2 * pair], src_addr, kReaderRuntimeArgCount, "input reader");
+        patch_dm_kernel(dm_kernel_metadata[2 + 2 * pair], dst_addr, kWriterRuntimeArgCount, "output writer");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -25,89 +25,11 @@ namespace ttnn::prim {
 
 namespace {
 
-// One set of buffers, sized for a single block width.
-//
-// The work split gives cores one of two block widths (the full width, and a narrower cliff-row
-// width), and a block's width fixes the size of the buffers that carry it. That size is a
-// *correctness* property, not a performance one: the reader fills a whole block through one raw
-// linear write starting at `get_write_ptr()`, and `cb_push_back` requires the producer to write
-// contiguously — it only wraps when the write pointer lands exactly on `fifo_limit`
-// ("producer always writes into contiguous memory, it cannot wrap"). A buffer whose size is not
-// an exact multiple of the block pushed into it therefore overruns into its neighbour rather than
-// wrapping. So each block width gets its **own** set of buffers, with its own indices, sized for
-// that width — rather than one set of indices re-used at different sizes on disjoint cores.
-//
-// The two sets live on disjoint core ranges, so L1 usage is unchanged: a core allocates only the
-// set belonging to its own block width.
-struct BlockBufferSet {
-    uint8_t staging_index;  // per-row DRAM-alignment staging buffer (reader-private scratchpad)
-    uint8_t input_index;    // row-major block the reader fills and compute tilizes
-    uint8_t output_index;   // tilized block compute produces and the writer drains
-    uint32_t block_tiles;   // block width in tiles — the page count of input/output
-    CoreRangeSet core_ranges;
-
-    bool empty() const { return core_ranges.empty(); }
-};
-
-// Union of two core ranges, either of which may be empty.
-CoreRangeSet union_of(const CoreRangeSet& a, const CoreRangeSet& b) {
-    if (a.empty()) {
-        return b;
-    }
-    if (b.empty()) {
-        return a;
-    }
-    return a.merge(b);
-}
-
-// Append the three CBDescriptors for one buffer set.
-void push_buffer_set(
-    ProgramDescriptor& desc,
-    const BlockBufferSet& set,
-    uint32_t input_single_tile_size,
-    uint32_t output_single_tile_size,
-    tt::DataFormat input_cb_data_format,
-    tt::DataFormat output_cb_data_format,
-    uint32_t dram_alignment) {
-    // c_1 is a per-row staging buffer used by the reader when the DRAM source row and the
-    // L1 destination have different alignment offsets: the reader rounds the source address
-    // down to a dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment)
-    // into this buffer, then copies the correctly-offset slice into the input buffer.
-    //   row_bytes  = TILE_WIDTH * elt_size * block_tiles  (one row of a block)
-    //              = input_single_tile_size / TILE_HEIGHT * block_tiles
-    //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
-    //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
-    //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
-    uint32_t input_row_bytes = input_single_tile_size / TILE_HEIGHT;
-    uint32_t temp_cb_size = input_row_bytes * set.block_tiles + 2 * dram_alignment;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = temp_cb_size,
-        .core_ranges = set.core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = set.staging_index,
-            .data_format = input_cb_data_format,
-            .page_size = temp_cb_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = set.block_tiles * input_single_tile_size,
-        .core_ranges = set.core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = set.input_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = set.block_tiles * output_single_tile_size,
-        .core_ranges = set.core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = set.output_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-}
+using ttnn::operations::data_movement::BlockBufferSet;
+using ttnn::operations::data_movement::BlockPlan;
+using ttnn::operations::data_movement::buffer_set_for_core;
+using ttnn::operations::data_movement::make_block_plan;
+using ttnn::operations::data_movement::push_buffer_set;
 
 }  // namespace
 
@@ -131,36 +53,14 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
     CoreRangeSet default_grid(default_cores);
     CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
 
-    uint32_t max_l1_size = operations::data_movement::get_max_l1_space(a);
-    uint32_t num_tiles_per_col = output.padded_shape()[-2] / TILE_HEIGHT;
-    uint32_t num_tiles_per_row = output.padded_shape()[-1] / TILE_WIDTH;
-    uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
-    // Fold the staging buffer (bytes/tile + fixed) into the limit or the region overruns L1.
-    uint32_t staging_bytes_per_tile = input_single_tile_size / TILE_HEIGHT;
-    uint32_t fixed_staging_bytes = 2 * dram_alignment;
-    uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
-    uint32_t bytes_per_tile_pair = input_single_tile_size + output_single_tile_size + staging_bytes_per_tile;
-    uint32_t cb_block_size_limit = (bytes_per_tile_pair == 0) ? 0 : budget_for_tiles / bytes_per_tile_pair;
 
-    auto
-        [ncores,
-         all_cores,
-         core_range,
-         cliff_row_core_range,
-         cliff_col_core_range,
-         cliff_col_row_core_range,
-         nblocks_per_core,
-         single_block_size,
-         single_block_size_cliff_row,
-         single_block_size_cliff_col,
-         has_cliff_row,
-         has_cliff_col,
-         full_cores_per_row,
-         full_cores_per_col,
-         single_sub_block_size] =
-            ttnn::split_blocks_for_tilize_wh(
-                available_grid, num_blocks, num_tiles_per_row, num_tiles_per_col, cb_block_size_limit);
+    const BlockPlan plan = make_block_plan(
+        a, output, input_single_tile_size, output_single_tile_size, TILE_HEIGHT, TILE_WIDTH, sub_core_grids);
+    const BlockBufferSet& full_set = plan.full;
+    const BlockBufferSet& cliffrow_set = plan.cliffrow;
+    const auto& [ncores, all_cores, core_range, cliff_row_core_range, cliff_col_core_range, cliff_col_row_core_range, nblocks_per_core, single_block_size, single_block_size_cliff_row, single_block_size_cliff_col, has_cliff_row, has_cliff_col, full_cores_per_row, full_cores_per_col, single_sub_block_size] =
+        plan.split;
 
     if (single_sub_block_size > 0 && single_block_size % single_sub_block_size) {
         TT_FATAL(false, "single_block_size is not divided by single_sub_block_size");
@@ -178,32 +78,6 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
 
     ProgramDescriptor desc;
 
-    // The work split hands out exactly two block widths, so the op needs exactly two buffer sets:
-    //
-    //   full     — `single_sub_block_size` tiles wide: the full-block cores, plus the cliff-*column*
-    //              cores (a short column still processes full-width blocks).
-    //   cliffrow — `single_block_size_cliff_row` tiles wide: the cores holding the narrow block at
-    //              the end of a row, plus the corner core that is both cliff-row and cliff-column.
-    //
-    // Each set gets its own indices and its own sizes, so no index is ever re-used at two
-    // different sizes. Either set may be empty for a given shape.
-    const BlockBufferSet full_set{
-        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_1),
-        .input_index = static_cast<uint8_t>(tt::CBIndex::c_0),
-        .output_index = static_cast<uint8_t>(tt::CBIndex::c_16),
-        .block_tiles = single_sub_block_size,
-        .core_ranges = union_of(core_range, has_cliff_col ? cliff_col_core_range : CoreRangeSet{}),
-    };
-    const BlockBufferSet cliffrow_set{
-        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_3),
-        .input_index = static_cast<uint8_t>(tt::CBIndex::c_2),
-        .output_index = static_cast<uint8_t>(tt::CBIndex::c_17),
-        .block_tiles = single_block_size_cliff_row,
-        .core_ranges = has_cliff_row
-                           ? union_of(cliff_row_core_range, has_cliff_col ? cliff_col_row_core_range : CoreRangeSet{})
-                           : CoreRangeSet{},
-    };
-
     for (const BlockBufferSet* set : {&full_set, &cliffrow_set}) {
         if (set->empty()) {
             continue;
@@ -219,7 +93,8 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
             output_single_tile_size,
             input_cb_data_format,
             output_cb_data_format,
-            dram_alignment);
+            dram_alignment,
+            TILE_HEIGHT);
     }
 
     // reader
@@ -389,8 +264,8 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
         // is in. The assertion then checks the one thing that must hold: the set's buffers are
         // sized for exactly the sub-block width being passed here, which is what keeps the
         // reader's raw block write inside its buffer.
-        const bool is_cliff_row_core = !cliffrow_set.empty() && cliffrow_set.core_ranges.contains(core);
-        const BlockBufferSet& set = is_cliff_row_core ? cliffrow_set : full_set;
+        const BlockBufferSet& set = buffer_set_for_core(plan, core);
+        const bool is_cliff_row_core = &set == &cliffrow_set;
         KernelDescriptor& reader_desc = is_cliff_row_core ? cliffrow_reader_desc : full_reader_desc;
         KernelDescriptor& writer_desc = is_cliff_row_core ? cliffrow_writer_desc : full_writer_desc;
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -25,50 +25,84 @@ namespace ttnn::prim {
 
 namespace {
 
-// Helper: append a paired (input, output) CBDescriptor for a given core range.
-void push_padded_cb_pair(
+// One set of buffers, sized for a single block width.
+//
+// The work split gives cores one of two block widths (the full width, and a narrower cliff-row
+// width), and a block's width fixes the size of the buffers that carry it. That size is a
+// *correctness* property, not a performance one: the reader fills a whole block through one raw
+// linear write starting at `get_write_ptr()`, and `cb_push_back` requires the producer to write
+// contiguously — it only wraps when the write pointer lands exactly on `fifo_limit`
+// ("producer always writes into contiguous memory, it cannot wrap"). A buffer whose size is not
+// an exact multiple of the block pushed into it therefore overruns into its neighbour rather than
+// wrapping. So each block width gets its **own** set of buffers, with its own indices, sized for
+// that width — rather than one set of indices re-used at different sizes on disjoint cores.
+//
+// The two sets live on disjoint core ranges, so L1 usage is unchanged: a core allocates only the
+// set belonging to its own block width.
+struct BlockBufferSet {
+    uint8_t staging_index;  // per-row DRAM-alignment staging buffer (reader-private scratchpad)
+    uint8_t input_index;    // row-major block the reader fills and compute tilizes
+    uint8_t output_index;   // tilized block compute produces and the writer drains
+    uint32_t block_tiles;   // block width in tiles — the page count of input/output
+    CoreRangeSet core_ranges;
+
+    bool empty() const { return core_ranges.empty(); }
+};
+
+// Union of two core ranges, either of which may be empty.
+CoreRangeSet union_of(const CoreRangeSet& a, const CoreRangeSet& b) {
+    if (a.empty()) {
+        return b;
+    }
+    if (b.empty()) {
+        return a;
+    }
+    return a.merge(b);
+}
+
+// Append the three CBDescriptors for one buffer set.
+void push_buffer_set(
     ProgramDescriptor& desc,
-    const CoreRangeSet& core_ranges,
+    const BlockBufferSet& set,
     uint32_t input_single_tile_size,
     uint32_t output_single_tile_size,
-    uint32_t num_tiles,
     tt::DataFormat input_cb_data_format,
     tt::DataFormat output_cb_data_format,
     uint32_t dram_alignment) {
     // c_1 is a per-row staging buffer used by the reader when the DRAM source row and the
     // L1 destination have different alignment offsets: the reader rounds the source address
     // down to a dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment)
-    // into this buffer, then copies the correctly-offset slice into c_0.
-    //   row_bytes  = TILE_WIDTH * elt_size * num_tiles  (one row of a sub-block)
-    //              = input_single_tile_size / TILE_HEIGHT * num_tiles
+    // into this buffer, then copies the correctly-offset slice into the input buffer.
+    //   row_bytes  = TILE_WIDTH * elt_size * block_tiles  (one row of a block)
+    //              = input_single_tile_size / TILE_HEIGHT * block_tiles
     //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
     //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
     //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
     uint32_t input_row_bytes = input_single_tile_size / TILE_HEIGHT;
-    uint32_t temp_cb_size = input_row_bytes * num_tiles + 2 * dram_alignment;
+    uint32_t temp_cb_size = input_row_bytes * set.block_tiles + 2 * dram_alignment;
     desc.cbs.push_back(CBDescriptor{
         .total_size = temp_cb_size,
-        .core_ranges = core_ranges,
+        .core_ranges = set.core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+            .buffer_index = set.staging_index,
             .data_format = input_cb_data_format,
             .page_size = temp_cb_size,
         }}},
     });
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * input_single_tile_size,
-        .core_ranges = core_ranges,
+        .total_size = set.block_tiles * input_single_tile_size,
+        .core_ranges = set.core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .buffer_index = set.input_index,
             .data_format = input_cb_data_format,
             .page_size = input_single_tile_size,
         }}},
     });
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * output_single_tile_size,
-        .core_ranges = core_ranges,
+        .total_size = set.block_tiles * output_single_tile_size,
+        .core_ranges = set.core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .buffer_index = set.output_index,
             .data_format = output_cb_data_format,
             .page_size = output_single_tile_size,
         }}},
@@ -102,7 +136,7 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
     uint32_t num_tiles_per_row = output.padded_shape()[-1] / TILE_WIDTH;
     uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
-    // Fold push_padded_cb_pair's c_1 staging (bytes/tile + fixed) into the limit or the region overruns L1.
+    // Fold the staging buffer (bytes/tile + fixed) into the limit or the region overruns L1.
     uint32_t staging_bytes_per_tile = input_single_tile_size / TILE_HEIGHT;
     uint32_t fixed_staging_bytes = 2 * dram_alignment;
     uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
@@ -144,46 +178,45 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
 
     ProgramDescriptor desc;
 
-    if (!core_range.empty()) {
-        push_padded_cb_pair(
+    // The work split hands out exactly two block widths, so the op needs exactly two buffer sets:
+    //
+    //   full     — `single_sub_block_size` tiles wide: the full-block cores, plus the cliff-*column*
+    //              cores (a short column still processes full-width blocks).
+    //   cliffrow — `single_block_size_cliff_row` tiles wide: the cores holding the narrow block at
+    //              the end of a row, plus the corner core that is both cliff-row and cliff-column.
+    //
+    // Each set gets its own indices and its own sizes, so no index is ever re-used at two
+    // different sizes. Either set may be empty for a given shape.
+    const BlockBufferSet full_set{
+        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+        .input_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+        .output_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+        .block_tiles = single_sub_block_size,
+        .core_ranges = union_of(core_range, has_cliff_col ? cliff_col_core_range : CoreRangeSet{}),
+    };
+    const BlockBufferSet cliffrow_set{
+        .staging_index = static_cast<uint8_t>(tt::CBIndex::c_3),
+        .input_index = static_cast<uint8_t>(tt::CBIndex::c_2),
+        .output_index = static_cast<uint8_t>(tt::CBIndex::c_17),
+        .block_tiles = single_block_size_cliff_row,
+        .core_ranges = has_cliff_row
+                           ? union_of(cliff_row_core_range, has_cliff_col ? cliff_col_row_core_range : CoreRangeSet{})
+                           : CoreRangeSet{},
+    };
+
+    for (const BlockBufferSet* set : {&full_set, &cliffrow_set}) {
+        if (set->empty()) {
+            continue;
+        }
+        TT_FATAL(
+            set->block_tiles > 0,
+            "Buffer set on cores {} has a zero block width; its buffers would be empty",
+            set->core_ranges.str());
+        push_buffer_set(
             desc,
-            core_range,
+            *set,
             input_single_tile_size,
             output_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment);
-    }
-    if (has_cliff_col && has_cliff_row) {
-        push_padded_cb_pair(
-            desc,
-            cliff_col_row_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment);
-    }
-    if (has_cliff_row) {
-        push_padded_cb_pair(
-            desc,
-            cliff_row_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment);
-    }
-    if (has_cliff_col) {
-        push_padded_cb_pair(
-            desc,
-            cliff_col_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_sub_block_size,
             input_cb_data_format,
             output_cb_data_format,
             dram_alignment);
@@ -211,37 +244,51 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
         total_num_rows = output.padded_shape()[-2];
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        total_num_rows,
-        third_dim,
-        tile_height,
-        a.element_size(),
-        unpadded_row_size_bytes,
-        dram_alignment,
-        tt::CBIndex::c_0,
-        tt::CBIndex::c_1};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    // One reader and one writer per buffer set, each over that set's cores and bound to that
+    // set's indices. A set's cores are exactly the cores whose block width its buffers are sized
+    // for, so every instance's raw block write lands in a buffer that is an exact multiple of it.
+    auto make_reader_kernel = [&](const BlockBufferSet& set) {
+        std::vector<uint32_t> reader_compile_time_args = {
+            total_num_rows,
+            third_dim,
+            tile_height,
+            a.element_size(),
+            unpadded_row_size_bytes,
+            dram_alignment,
+            set.input_index,
+            set.staging_index};
+        TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_multicore_both_dims.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+        KernelDescriptor reader_desc;
+        reader_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
+            "reader_unary_pad_multicore_both_dims.cpp";
+        reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        reader_desc.core_ranges = set.core_ranges;
+        reader_desc.compile_time_args = std::move(reader_compile_time_args);
+        reader_desc.config = ReaderConfigDescriptor{};
+        return reader_desc;
+    };
 
-    // writer
-    std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16, num_tiles_2d, third_dim, total_tiles_per_row};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    auto make_writer_kernel = [&](const BlockBufferSet& set) {
+        std::vector<uint32_t> writer_compile_time_args = {
+            set.output_index, num_tiles_2d, third_dim, total_tiles_per_row};
+        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
+        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer_desc.core_ranges = set.core_ranges;
+        writer_desc.compile_time_args = std::move(writer_compile_time_args);
+        writer_desc.config = WriterConfigDescriptor{};
+        return writer_desc;
+    };
+
+    KernelDescriptor full_reader_desc = make_reader_kernel(full_set);
+    KernelDescriptor full_writer_desc = make_writer_kernel(full_set);
+    KernelDescriptor cliffrow_reader_desc = make_reader_kernel(cliffrow_set);
+    KernelDescriptor cliffrow_writer_desc = make_writer_kernel(cliffrow_set);
 
     // compute
     uint32_t single_sub_block_wh = single_block_size * single_block_size / single_sub_block_size;
@@ -249,45 +296,54 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
 
     std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[full_set.input_index] = UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[cliffrow_set.input_index] = UnpackToDestMode::UnpackToDestFp32;
     }
 
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp";
 
-    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
-        // This factory uses one buffer pair for every core, so every instance binds c_0 / c_16.
-        compile_args.push_back(tt::CBIndex::c_0);
-        compile_args.push_back(tt::CBIndex::c_16);
-        KernelDescriptor cd;
-        cd.kernel_source = compute_kernel_path;
-        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        cd.core_ranges = cores;
-        cd.compile_time_args = std::move(compile_args);
-        cd.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
+    // The compute kernel stays split per region — each region has its own block *count* — but each
+    // instance binds the buffer set matching its cores' block *width*. The region's block-width CTA
+    // (the second one) must equal that set's `block_tiles`, since it is the page count the kernel
+    // waits on and pops; the assertion below keeps the two from drifting apart.
+    auto make_compute_kernel =
+        [&](const CoreRangeSet& cores, const BlockBufferSet& set, uint32_t block_size_col, uint32_t block_size_row) {
+            TT_FATAL(
+                block_size_row == set.block_tiles,
+                "Compute on cores {} expects a block width of {} tiles but its buffers hold {}",
+                cores.str(),
+                block_size_row,
+                set.block_tiles);
+            KernelDescriptor cd;
+            cd.kernel_source = compute_kernel_path;
+            cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+            cd.core_ranges = cores;
+            cd.compile_time_args = {block_size_col, block_size_row, third_dim, set.input_index, set.output_index};
+            cd.config = ComputeConfigDescriptor{
+                .fp32_dest_acc_en = fp32_llk_acc,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
+            };
+            return cd;
         };
-        return cd;
-    };
 
     std::vector<KernelDescriptor> compute_kernels;
     compute_kernels.reserve(4);
     if (!core_range.empty()) {
         compute_kernels.push_back(
-            make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));
+            make_compute_kernel(core_range, full_set, single_sub_block_wh, single_sub_block_size));
     }
     if (has_cliff_col && has_cliff_row) {
         compute_kernels.push_back(make_compute_kernel(
-            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
+            cliff_col_row_core_range, cliffrow_set, single_block_size_cliff_col, single_block_size_cliff_row));
     }
     if (has_cliff_row) {
         compute_kernels.push_back(
-            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
+            make_compute_kernel(cliff_row_core_range, cliffrow_set, single_block_size, single_block_size_cliff_row));
     }
     if (has_cliff_col) {
-        compute_kernels.push_back(make_compute_kernel(
-            cliff_col_core_range, {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}));
+        compute_kernels.push_back(
+            make_compute_kernel(cliff_col_core_range, full_set, single_sub_block_cliff_col_wh, single_sub_block_size));
     }
 
     // RUNTIME ARGS
@@ -327,8 +383,27 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
-        // framework patches addresses on cache hits.
+        // Route this core's args to the reader/writer instance for its buffer set. Membership is
+        // read from the work split's own core assignment rather than re-derived from the branch
+        // above, so the args and the buffers they drive can never disagree about which set a core
+        // is in. The assertion then checks the one thing that must hold: the set's buffers are
+        // sized for exactly the sub-block width being passed here, which is what keeps the
+        // reader's raw block write inside its buffer.
+        const bool is_cliff_row_core = !cliffrow_set.empty() && cliffrow_set.core_ranges.contains(core);
+        const BlockBufferSet& set = is_cliff_row_core ? cliffrow_set : full_set;
+        KernelDescriptor& reader_desc = is_cliff_row_core ? cliffrow_reader_desc : full_reader_desc;
+        KernelDescriptor& writer_desc = is_cliff_row_core ? cliffrow_writer_desc : full_writer_desc;
+        TT_FATAL(
+            single_sub_block_size_row_arg == set.block_tiles,
+            "Core {} is fed a sub-block of {} tiles but the buffers on it hold {}. The work split "
+            "assigned this core a block width that disagrees with its runtime args",
+            core.str(),
+            single_sub_block_size_row_arg,
+            set.block_tiles);
+
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding, which is what
+        // refreshes addresses on a cache hit (this factory declares no override_runtime_arguments,
+        // so `resolve_bindings` walks every kernel's bindings, extra pairs included).
         reader_desc.emplace_runtime_args(
             core,
             {src0_buffer,
@@ -359,8 +434,15 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
         }
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    // One (reader, writer) pair per non-empty set, ahead of the compute kernels.
+    if (!full_set.empty()) {
+        desc.kernels.push_back(std::move(full_reader_desc));
+        desc.kernels.push_back(std::move(full_writer_desc));
+    }
+    if (!cliffrow_set.empty()) {
+        desc.kernels.push_back(std::move(cliffrow_reader_desc));
+        desc.kernels.push_back(std::move(cliffrow_writer_desc));
+    }
     for (auto& cd : compute_kernels) {
         desc.kernels.push_back(std::move(cd));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -212,7 +212,14 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
     }
 
     std::vector<uint32_t> reader_compile_time_args = {
-        total_num_rows, third_dim, tile_height, a.element_size(), unpadded_row_size_bytes, dram_alignment};
+        total_num_rows,
+        third_dim,
+        tile_height,
+        a.element_size(),
+        unpadded_row_size_bytes,
+        dram_alignment,
+        tt::CBIndex::c_0,
+        tt::CBIndex::c_1};
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
     KernelDescriptor reader_desc;
@@ -249,6 +256,9 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
         "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp";
 
     auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
+        // This factory uses one buffer pair for every core, so every instance binds c_0 / c_16.
+        compile_args.push_back(tt::CBIndex::c_0);
+        compile_args.push_back(tt::CBIndex::c_16);
         KernelDescriptor cd;
         cd.kernel_source = compute_kernel_path;
         cd.source_type = KernelDescriptor::SourceType::FILE_PATH;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
@@ -15,18 +15,21 @@
 using tt::data_movement::common::tt_memmove;
 
 void kernel_main() {
-    constexpr uint32_t dfb_id_in0 = 0;
-    constexpr uint32_t dfb_id_in1 = 1;
-
     constexpr uint32_t total_num_rows = get_compile_time_arg_val(0);
     constexpr uint32_t third_dim = get_compile_time_arg_val(1);
     constexpr uint32_t tile_height = get_compile_time_arg_val(2);
     constexpr uint32_t element_size = get_compile_time_arg_val(3);
     constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(4);
     constexpr uint32_t dram_alignment = get_compile_time_arg_val(5);
+    // The buffer this instance fills, and its staging buffer. These are compile-time args rather
+    // than fixed indices because a factory whose work split gives cores different block widths
+    // must give each width its own correctly-sized pair of buffers: the raw block write below
+    // cannot wrap, so a buffer's size must stay an exact multiple of the block pushed into it.
+    constexpr uint32_t dfb_id_in0 = get_compile_time_arg_val(6);
+    constexpr uint32_t dfb_id_in1 = get_compile_time_arg_val(7);
     constexpr uint64_t dram_align_mask = ~static_cast<uint64_t>(dram_alignment - 1);
     constexpr uint64_t dram_align_offset = static_cast<uint64_t>(dram_alignment - 1);
-    constexpr auto src_args = TensorAccessorArgs<6>();
+    constexpr auto src_args = TensorAccessorArgs<8>();
 
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t pad_value = get_arg_val<uint32_t>(1);


### PR DESCRIPTION
### Ticket
#51305 

### Summary
Prereq refactor for #51305, so the multi-core block factories of `tilize` and
`tilize_with_val_padding` can be ported to Metal 2.0.

Both factories were allocating up to four `(staging, input, output)` CB triples that reused the
same three buffer indices on disjoint core ranges at different sizes. Named DFBs can't express
per-node sizing. And the size isn't just a perf knob here: the reader fills a whole block with one
raw linear write from `get_write_ptr()`, and `cb_push_back` only wraps when the write pointer lands
exactly on `fifo_limit`, so a buffer whose size isn't an exact multiple of its block overruns the
next one instead of wrapping. That's why sizing every region to the max doesn't work.

The work split only ever hands out two block widths, so each factory now declares two buffer sets
instead of four colliding triples: `full` (`c_0`/`c_1`/`c_16`, sized `single_sub_block_size`) and
`cliffrow` (`c_2`/`c_3`/`c_17`, sized `single_block_size_cliff_row`). Each non-empty set gets its
own reader/writer pair over its own cores; compute stays split per region but binds the set
matching its block width. A core's set comes from the work split's own core assignment, and a
couple of TT_FATALs assert that a set's buffers are sized for exactly the width its cores are fed.
L1 usage is unchanged, since the two sets sit on disjoint core ranges.

`tilize_wh.cpp` and `reader_unary_pad_multicore_both_dims.cpp` now take their buffer indices as
compile-time args instead of hardcoding `c_0`/`c_1`/`c_16`. Both are only used by these two
factories and both call sites are updated.

### Notes for reviewers
The two ops refresh buffer addresses on a program-cache hit differently, which is why the diffs
aren't symmetric. tilize's factories define `override_runtime_arguments`, and per the adapter that
means `resolve_bindings` is skipped entirely, so the hook is the only thing that repoints
addresses. Emitting a second reader/writer pair meant extending it past kernel 0/1, otherwise the
extra pair keeps its cache-miss address and quietly reads the wrong buffer. tilize_with_val_padding
has no such hook, so `resolve_bindings` walks every kernel's bindings and the extra pair refreshes
on its own.



**Heads-up: this changes `ttnn.to_layout` semantics on the height-sharded path.** That path now
returns the unpadded logical shape, matching what `tilize_with_val_padding` already produces on the
interleaved path; before, it returned the tile-padded shape. It's the right fix and it's what the
`test_tilize_height_sharded_shapes` uneven cases cover, but anything downstream reading `.shape`
off a height-sharded `to_layout` result changes behaviour, so it deserves model-CI attention rather
than being waved through with the CB-sizing refactor. The `to_layout_op.cpp` change is otherwise
unrelated to #51305 and can be split out if you'd rather review it separately.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/tilize-val-padding-per-node-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/tilize-val-padding-per-node-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/tilize-val-padding-per-node-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/tilize-val-padding-per-node-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/tilize-val-padding-per-node-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/tilize-val-padding-per-node-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/tilize-val-padding-per-node-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/tilize-val-padding-per-node-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/tilize-val-padding-per-node-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/tilize-val-padding-per-node-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/tilize-val-padding-per-node-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/tilize-val-padding-per-node-cb-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/tilize-val-padding-per-node-cb-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/tilize-val-padding-per-node-cb-size)

