### PR TITLE
fix(remainder): bidirectional 2-pass correction for large-ratio resid…

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_binary_remainder.h"
+#include "ckernel_sfpu_exp.h"  // For _sfpu_round_to_nearest_int32_
 #include "ckernel_sfpu_recip.h"
 #include "cmath_common.h"
 #include "sfpu/ckernel_sfpu_converter.h"
@@ -168,24 +169,49 @@ inline void calculate_remainder() {
         sfpi::vFloat val = dst_reg[0];
         sfpi::vFloat v = sfpi::abs(val);
 
-        sfpi::vFloat quotient;
-        vInt exp = sfpi::exexp(v * recip_val);
-        v_if(exp < 0) { quotient = 0.0f; }
-        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
-        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
-        // shifting it back using (0 - (exp - 23)).
-        v_elseif(exp < 23) {
-            quotient = sfpi::as<sfpi::vFloat>(
-                shft((shft(sfpi::as<sfpi::vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
+        // Magnitude computation (issue #54048 fix): 2-pass reciprocal-quotient
+        // refine + bidirectional mop-up loop.
+        //
+        // The original single-pass version (truncated quotient estimate, one
+        // -1 overshoot correction, then a SUBTRACT-ONLY 10x loop) is exact only
+        // while `quotient * s` stays within FP32's exact-integer-product range.
+        // Once |dividend/divisor| exceeds roughly 2^24/s, `quotient * s` itself
+        // can no longer be represented exactly in FP32 -- no amount of
+        // quotient-estimate refinement fixes that (verified empirically: 3 and
+        // 4 refinement passes gave identical results to 2). Beyond that
+        // threshold the old subtract-only loop, unable to correct a residual
+        // that came out negative (quotient over-estimated), let errors grow
+        // UNBOUNDED with ratio -- up to -19x/-11x the divisor observed at
+        // ratio~2^26 in dense sweep validation (see the #54048 correction
+        // comment on the issue and sfpu_audit/fix_remainder/dense_sweep.py).
+        //
+        // Fix: (1) two refinement passes -- each computes round(v/s), subtracts
+        // q*s, and re-estimates on the (much smaller) residual, which recovers
+        // exactness for the full range where FP32 can represent it; (2) the
+        // mop-up loop now corrects in BOTH directions (the refine passes above
+        // can leave v<0 when the quotient was over-estimated at extreme
+        // ratios; the old loop only ever subtracted). Beyond the exact-product
+        // threshold, the
+        // result is bounded to at most one divisor-width from the true
+        // remainder (never unbounded) -- validated across positive/negative
+        // dividend and divisor, ratios up to 2^33, multiple divisor magnitudes
+        // (sfpu_audit/fix_remainder/sim_fixed.py). A third/fourth pass does not
+        // improve this further -- it's an FP32 precision floor, not an
+        // under-provisioned iteration count.
+        sfpi::vInt discard_k;
+#pragma GCC unroll 2
+        for (int refine = 0; refine < 2; refine++) {
+            sfpi::vFloat q = _sfpu_round_to_nearest_int32_(v * recip_val, discard_k);
+            v = v - q * s;
         }
-        v_else { quotient = v * recip_val; }
-        v_endif
 
-        v_if(quotient > v * recip_val) {
-            quotient = quotient - 1;
+        constexpr auto iter = 10;
+        for (int l = 0; l < iter; l++) {
+            v_if(v >= s) { v = v - s; }
+            v_endif;
+            v_if(v < 0.0f) { v = v + s; }
+            v_endif;
         }
-        v_endif;
-        v = v - quotient * s;
 
         v_if(val < 0 && v != 0) { v = s - v; }
         v_endif;
@@ -196,11 +222,6 @@ inline void calculate_remainder() {
         v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
 
-        constexpr auto iter = 10;
-        for (int l = 0; l < iter; l++) {
-            v_if(v >= s) { v = v - s; }
-            v_endif;
-        }
         v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }
         v_endif;
         sfpi::dst_reg[0] = v;


### PR DESCRIPTION
Fixes #54048 ($2,500 community bounty).

## Problem (corrected characterization — see the correction comment on the issue)

My original issue write-up understated this: it was based on isolating just the
quotient-estimation logic, not the complete `calculate_remainder()`. Running the full
function through a dense sweep (20,000 random inputs per ratio bucket, all 4 sign
quadrants) shows:

- Failures start around ratio ≈2^11 (~2,048), not 2^23.
- By ratio ≈2^22, over 50% of random inputs in every sign quadrant are wrong.
- Errors are **unbounded** in the direction the original loop can't correct — up to
  **−19× and −11× the divisor** observed at ratio ≈2^26.

Root cause: the original single-pass quotient estimate + subtract-only 10-iteration
correction loop (`for l in 0..9: v_if(v >= s) v -= s;`) is exact only while `quotient * s`
stays within FP32's exact-integer-product range — roughly `ratio < 2^24 / divisor`. Beyond
that, `quotient * s` itself can't be represented exactly in FP32 (confirmed: adding a 3rd
or 4th refinement pass to the fix below gives identical results to 2 passes — this is a
representable-precision floor, not an under-provisioned estimate). The old loop only ever
subtracts, so whenever the quotient estimate comes out too *high* (increasingly likely as
ratio grows, since `v * recip_val` loses precision), the residual goes negative and the
loop can't recover — errors accumulate without bound.

## Fix

- **Two refinement passes** instead of one: each computes `q = round(v * recip_val)`,
  subtracts `q*s`, and the *next* pass re-estimates on the much-smaller residual. This
  recovers exact correctness for the entire range where FP32 can represent `quotient*s`
  exactly.
- **Bidirectional mop-up loop**: the existing 10-iteration loop now also handles `v < 0`
  (adds `s`), not just `v >= s` (subtracts `s`) — the missing half of the original loop,
  and the direct cause of the unbounded-error class of failures.
- Left the existing sign-combination logic (`v = s - v` for negative dividend, `v = v +
  value_tmp` for negative divisor, `copysgn`) **untouched** — verified algebraically it's
  correct given a properly-bounded magnitude input in `[0, s)`, which it wasn't reliably
  getting before. The bug was in the magnitude computation, not the sign logic.

## Validation

Completed:
- Full bit-accurate FP32 model of both the original (confirming the corrected severity
  numbers above) and fixed function, swept across all 4 sign quadrants, ratios 2^0 to
  2^33, and multiple divisor magnitudes (3.0, 7.0, 0.5, 123.456) —
  `sfpu_audit/fix_remainder/sim_fixed.py` / `dense_sweep.py`.
- **Exact** (matches `numpy`'s `mod` to within FP32 rounding) for the full range where
  FP32 can represent `quotient*s` exactly (up to ratio ≈2^24/divisor).
- **Bounded** beyond that threshold: worst observed error is at most one divisor-width
  from truth (never more), across every quadrant and ratio tested up to 2^33 — down from
  unbounded growth (−19×/−11× divisor) in the original.
- Regression check: 100,000 random small-ratio inputs across 4 divisor values, 0 failures
  — confirms the previously-working range is unaffected.
- Confirmed empirically that 3–4 refinement passes give identical results to 2 (ruling out
  "just needs more passes" as a path to full exactness beyond the FP32 product-precision
  floor).

Limitations (disclosed, not glossed over):
- Source-level FP32 arithmetic model (Python), not a real on-device SFPU run — no hardware
  access to validate this kernel change directly this session.
- The hardware's `_sfpu_round_to_nearest_int32_` bit-trick is documented (Hacker's Delight,
  same technique already used elsewhere in this file family) as correct for `|z| < 2^22`.
  The *second* refinement pass always operates on a small residual, comfortably within that
  range. The *first* pass, at the most extreme ratios (beyond ~2^22), may not round
  identically to the plain `round()` used in the Python validation model — the second pass
  is specifically designed to absorb whatever error that leaves, so the qualitative
  conclusion (bounded to ≤1 divisor-width) should hold regardless, but exact numeric parity
  with the Python model at the extreme tail (ratio > ~2^28) hasn't been hardware-verified.
- Blackhole's copy of this file was confirmed byte-identical to Wormhole's during the
  original investigation, so the same fix likely applies there too — not included in this
  PR to keep it scoped; happy to open a follow-up.

## Acceptance criteria

- [x] Exact correctness restored for the full FP32-representable range (up to ratio
      ≈2^24/divisor), across all 4 sign quadrants.
- [x] Beyond that range: bounded to at most 1 divisor-width error (down from unbounded,
      up to −19×/−11× divisor previously).
- [x] Existing small-ratio behavior unaffected (100k-sample regression check, 0 failures).
- [ ] On-device hardware validation (requesting maintainer/CI run — no local hardware
      access this session).
