### PR TITLE
Revert "[Bug fix] Fix active-ERISC kernel link: define __global_point…

### DIFF
--- a/tt_metal/hw/toolchain/main.ld
+++ b/tt_metal/hw/toolchain/main.ld
@@ -198,9 +198,7 @@ SECTIONS
 
 /* Begin the data area.  */
 #if defined(TYPE_FIRMWARE)
-  /* kernels get __global_pointer$ from the firmware ELF via --just-symbols, so it must be in the firmware's symbol
-     table even when the firmware itself never references it.  */
-  __global_pointer$ = DATA_START + 0x7f0;
+  PROVIDE(__global_pointer$ = DATA_START + 0x7f0);
   .data DATA_START :
 #define SECTION(NEW, PREV) NEW :
 #else


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/54151

### Summary

This reverts commit 570b68fa1c62dab5cf93500ffe47612185fbb300, that caused failing of CI on device opening on main branch.

### CI

Main:

Blackhole E2E: https://github.com/tenstorrent/tt-metal/actions/runs/32675425907
Blaze: https://github.com/tenstorrent/tt-metal/actions/runs/32692702300


Reverted:

L2 nightly: https://github.com/tenstorrent/tt-metal/actions/runs/32666696123
Blackhole E2E: https://github.com/tenstorrent/tt-metal/actions/runs/32635750827
Blaze Prefill: https://github.com/tenstorrent/tt-metal/actions/runs/32666670314


