### PR TITLE
prefill - Enable SiTU for shared expert and FFN for Kimi K3

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -103,11 +103,16 @@ class KimiK3Config:
     ATTN_RES_BLOCK_SIZE = 12
 
     LATENT_MOE_USE_NORM = True
-    # The routed experts run the checkpoint's SiTU-GLU on device (#51351). Spelled as a string
-    # because this config is torch-only; ROUTED_EXPERT_ACTIVATION_BY_NAME maps it onto the kernel
-    # enum. Routed only: the shared expert and the dense FFN have no SiTU kernel and stay on SiLU.
+    # All three FFN sites run the checkpoint's SiTU-GLU on device: routed experts (#51351), and the
+    # shared expert / layer-0 dense FFN (#53625). Spelled as strings because this config is
+    # torch-only -- ROUTED_EXPERT_ACTIVATION_BY_NAME maps the routed one onto the fused kernel's
+    # enum, while the other two are consumed as-is by TtSharedExpert / TtFfn, which compose SiTU
+    # from Python-level ttnn ops (there is no fused kernel at 6144 / 33792 wide).
     ROUTED_EXPERT_ACTIVATION = "situ"
-    # Must match SituGluConfigKimi, which the fused routed-expert kernel bakes in.
+    SHARED_EXPERT_ACTIVATION = "situ"
+    DENSE_FFN_ACTIVATION = "situ"
+    # Must match SituGluConfigKimi, which the fused routed-expert kernel bakes in; the two composed
+    # sites read these directly, so all three activations stay on one pair of betas.
     ACTIVATION_SITU_BETA = 4.0
     ACTIVATION_SITU_LINEAR_BETA = 25.0
 
@@ -195,7 +200,9 @@ def kimi_k3_hf_config(max_seq: int = 8192):
         routed_expert_hidden_size=KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
         latent_moe_use_norm=KimiK3Config.LATENT_MOE_USE_NORM,
         # The checkpoint says "situ", but consumers of this field index ACT2FN with it, which has
-        # no "situ" entry. The routed expert selects SiTU through RoutedExpertActivation instead.
+        # no "situ" entry. The device path selects SiTU out of band instead: the routed expert
+        # through RoutedExpertActivation, the shared expert and dense FFN through
+        # SHARED_EXPERT_ACTIVATION / DENSE_FFN_ACTIVATION.
         hidden_act="silu",
         activation_situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
         activation_situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -199,11 +199,11 @@ def kimi_k3_hf_config(max_seq: int = 8192):
         # LatentMoE: the routed experts' reduced hidden dim, and the latent RMSNorm flag.
         routed_expert_hidden_size=KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
         latent_moe_use_norm=KimiK3Config.LATENT_MOE_USE_NORM,
-        # The checkpoint says "situ", but consumers of this field index ACT2FN with it, which has
-        # no "situ" entry. The device path selects SiTU out of band instead: the routed expert
-        # through RoutedExpertActivation, the shared expert and dense FFN through
-        # SHARED_EXPERT_ACTIVATION / DENSE_FFN_ACTIVATION.
-        hidden_act="silu",
+        # What the checkpoint actually uses, so a consumer that reads only this field still builds
+        # the right model. Reading it means branching on "situ" rather than indexing ACT2FN, which
+        # has no such entry -- KimiMLP, KimiBlockSparseMLP and the tests' _build_act_fn all do.
+        # ACT2FN is deliberately left unmutated: it is shared with every other model here.
+        hidden_act="situ",
         activation_situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
         activation_situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,
     )

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/expert.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/expert.py
@@ -40,11 +40,11 @@ def apply_glu_activation(
     separate arguments avoids a concat the device path would not do either. Computed in fp32 to match
     upstream, which casts both halves up before the tanh/sigmoid.
 
-    NOTE: on Blackhole every K3 FFN site now runs SiTU -- the routed experts through the fused
-    kernel (``ttnn.RoutedExpertActivation.SituGlu``, issue #51351), the shared expert and the
-    layer-0 dense FFN through the Python-composed path in ``TtSharedExpert`` / ``TtFfn``
-    (issue #53625). Wormhole has no ``ttnn.softcap`` and so no SiTU at all; K3 comparisons there
-    must run ``silu`` on both sides.
+    NOTE: every K3 FFN site runs SiTU on device -- the routed experts through the fused kernel
+    (``ttnn.RoutedExpertActivation.SituGlu``), the shared expert and the layer-0 dense FFN through
+    the composed path in ``TtSharedExpert`` / ``TtFfn``. All three are Blackhole-only, and K3 names
+    SiTU unconditionally, so there is no Wormhole configuration of K3 to compare against; ``silu``
+    here serves the other models.
     """
     if activation == ACTIVATION_SILU:
         return F.silu(gate_out) * up_out

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/expert.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/expert.py
@@ -40,10 +40,11 @@ def apply_glu_activation(
     separate arguments avoids a concat the device path would not do either. Computed in fp32 to match
     upstream, which casts both halves up before the tanh/sigmoid.
 
-    NOTE: the fused routed-expert kernel implements SiTU on Blackhole
-    (``ttnn.RoutedExpertActivation.SituGlu``, issue #51351); everywhere else -- shared expert,
-    dense FFN, Wormhole -- the device path still runs SiLU, so those comparisons must run
-    ``silu`` on both sides.
+    NOTE: on Blackhole every K3 FFN site now runs SiTU -- the routed experts through the fused
+    kernel (``ttnn.RoutedExpertActivation.SituGlu``, issue #51351), the shared expert and the
+    layer-0 dense FFN through the Python-composed path in ``TtSharedExpert`` / ``TtFfn``
+    (issue #53625). Wormhole has no ``ttnn.softcap`` and so no SiTU at all; K3 comparisons there
+    must run ``silu`` on both sides.
     """
     if activation == ACTIVATION_SILU:
         return F.silu(gate_out) * up_out

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/moe.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/moe.py
@@ -216,9 +216,9 @@ class TorchMoe(nn.Module):
             activation / situ_beta / situ_linear_beta: GLU activation for the ROUTED experts, and
                 for the shared expert unless shared_activation overrides it. Defaults to "silu".
                 Kimi-K3's routed experts run "situ" on device (RoutedExpertActivation.SituGlu).
-            shared_activation: GLU activation for the SHARED expert; defaults to activation. K3 needs
-                the split because its checkpoint uses SiTU for both but the device has a SiTU kernel
-                for the routed expert only, so the shared side must stay on SiLU to compare.
+            shared_activation: GLU activation for the SHARED expert; defaults to activation. K3 runs
+                SiTU on both sides now (#53625), so it needs no override -- the knob stays for the
+                Wormhole case, where the shared expert has no SiTU and must compare against SiLU.
         """
         super().__init__()
 

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/moe.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/moe.py
@@ -216,9 +216,9 @@ class TorchMoe(nn.Module):
             activation / situ_beta / situ_linear_beta: GLU activation for the ROUTED experts, and
                 for the shared expert unless shared_activation overrides it. Defaults to "silu".
                 Kimi-K3's routed experts run "situ" on device (RoutedExpertActivation.SituGlu).
-            shared_activation: GLU activation for the SHARED expert; defaults to activation. K3 runs
-                SiTU on both sides now (#53625), so it needs no override -- the knob stays for the
-                Wormhole case, where the shared expert has no SiTU and must compare against SiLU.
+            shared_activation: GLU activation for the SHARED expert; defaults to activation. The
+                two sites are configured independently on device -- a fused kernel vs composed ttnn
+                ops -- so the reference mirrors them independently. No model splits them today.
         """
         super().__init__()
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
@@ -161,12 +161,12 @@ def test_ffn_pcc(
     # dim 0 stacks mesh_shape[0] copies of the same result. Tile the reference to match rather than
     # slicing off one copy: a row that diverged would then still show up in the PCC. No-op on a
     # single-row mesh, which is what every non-Galaxy param here is.
+    #
+    # Tile once and only once -- at K3's 3200x7168 each fp32 copy is ~92 MB, ~734 MB tiled across a
+    # Galaxy's 8 rows, in a test that is already multi-gigabyte on the host.
     torch_reference = torch_output.repeat(mesh_shape[0], 1)
 
     logger.debug("Comparing outputs with PCC")
-    # The 2x4 Fabric2D profile replicates this TP-only FFN across both SP rows. The composer concatenates
-    # those replicas on the sequence dimension, so validate each replica against the same Torch output.
-    torch_output = torch_output.repeat(mesh_shape[0], 1)
     pcc_passed, pcc_message = assert_with_pcc(
         torch_reference.to(torch.float32),
         tt_output_torch.to(torch.float32),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
@@ -15,15 +15,29 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import ACTIVATION_SILU, ACTIVATION_SITU
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import EMB_DIM, HIDDEN_DIM, TtFfn
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@pytest.mark.parametrize("batch_seq_len", [4096, 3200], ids=["4K", "3.2K"])
+@pytest.mark.parametrize(
+    "batch_seq_len, hidden_dim, activation",
+    [
+        (4096, HIDDEN_DIM, ACTIVATION_SILU),
+        (3200, HIDDEN_DIM, ACTIVATION_SILU),
+        # Kimi-K3's layer-0 dense FFN: 33792 wide, on the checkpoint's SiTU-GLU (#53625). Both the
+        # width and the activation are new here — 33792 is 1.8x DSv3's 18432, and it is far past
+        # ttnn.situ_glu's 3072 L1 cutoff, so every intermediate is a full-size DRAM tensor.
+        (3200, KimiK3Config.INTERMEDIATE_SIZE, ACTIVATION_SITU),
+    ],
+    ids=["4K", "3.2K", "3.2K-k3-33792-situ"],
+)
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links",
     [
@@ -34,6 +48,15 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
+        # BH Galaxy. A Blackhole box accepts no mesh smaller than all 32 devices, so this is the
+        # only param where the SiTU case can run at all -- SiTU needs ttnn.softcap, Blackhole-only.
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
+            2,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -41,6 +64,8 @@ def test_ffn_pcc(
     mesh_device,
     device_params,
     batch_seq_len: int,
+    hidden_dim: int,
+    activation: str,
     num_links: int,
 ):
     """
@@ -51,18 +76,28 @@ def test_ffn_pcc(
         - hidden_dim: 18432
         - activations: bfloat16
         - weights bfloat8_b (explore bfp4 in future)
+
+    ``hidden_dim`` / ``activation`` are parametrized so Kimi-K3's dense layer 0 (33792 wide, SiTU)
+    is covered alongside the DeepSeek default.
     """
+    if activation == ACTIVATION_SITU and not is_blackhole():
+        pytest.skip("SiTU-GLU needs ttnn.softcap, which is Blackhole-only")
 
     activations_dtype = ttnn.bfloat16
     weights_dtype = ttnn.bfloat8_b
+    # Only read on the SiTU path; reference and device must share one pair of betas.
+    situ_betas = dict(
+        situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
+        situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,
+    )
 
     topology = per_axis_topology(device_params["fabric_config"])[1]
     num_devices = mesh_device.get_num_devices()
     mesh_shape = mesh_device.shape
     logger.debug(f"Testing with mesh_shape={mesh_shape}, num_devices={num_devices}")
-    logger.debug(f"batch_seq_len={batch_seq_len}, emb_dim={EMB_DIM}, hidden_dim={HIDDEN_DIM}")
+    logger.debug(f"batch_seq_len={batch_seq_len}, emb_dim={EMB_DIM}, hidden_dim={hidden_dim}, {activation=}")
 
-    signpost(f"FFN PCC test - {mesh_shape=} {batch_seq_len=} {num_links=} {topology=}")
+    signpost(f"FFN PCC test - {mesh_shape=} {batch_seq_len=} {hidden_dim=} {activation=} {num_links=} {topology=}")
 
     actual_num_links = get_num_links(mesh_device, cluster_axis=1)
     logger.debug(f"Available ethernet links along mesh columns: {actual_num_links}")
@@ -70,7 +105,7 @@ def test_ffn_pcc(
 
     # Create PyTorch reference model with FFN dimensions
     logger.debug("Creating TorchExpert reference with FFN dimensions")
-    torch_model = TorchExpert(EMB_DIM, HIDDEN_DIM)
+    torch_model = TorchExpert(EMB_DIM, hidden_dim, activation=activation, **situ_betas)
 
     torch_weights = {
         "gate_proj": torch_model.gate_proj.data,
@@ -83,10 +118,13 @@ def test_ffn_pcc(
     tt_model = TtFfn(
         mesh_device=mesh_device,
         torch_weights=torch_weights,
+        hidden_dim=hidden_dim,
         num_links=num_links,
         topology=topology,
         activations_dtype=activations_dtype,
         weights_dtype=weights_dtype,
+        activation=activation,
+        **situ_betas,
     )
 
     # Create input tensor (replicated across all devices)
@@ -119,12 +157,18 @@ def test_ffn_pcc(
     )
     logger.debug(f"TTNN output converted to torch: {tt_output_torch.shape}")
 
+    # The input is replicated across mesh ROWS (only the TP axis, dim 1, is sharded), so composing
+    # dim 0 stacks mesh_shape[0] copies of the same result. Tile the reference to match rather than
+    # slicing off one copy: a row that diverged would then still show up in the PCC. No-op on a
+    # single-row mesh, which is what every non-Galaxy param here is.
+    torch_reference = torch_output.repeat(mesh_shape[0], 1)
+
     logger.debug("Comparing outputs with PCC")
     # The 2x4 Fabric2D profile replicates this TP-only FFN across both SP rows. The composer concatenates
     # those replicas on the sequence dimension, so validate each replica against the same Torch output.
     torch_output = torch_output.repeat(mesh_shape[0], 1)
     pcc_passed, pcc_message = assert_with_pcc(
-        torch_output.to(torch.float32),
+        torch_reference.to(torch.float32),
         tt_output_torch.to(torch.float32),
         pcc=0.97,
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -39,8 +39,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         # the shared intermediate coincided and 6144 was never exercised here.
         (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SILU),
         # ...and the same shape on the activation the K3 checkpoint actually uses. This builds
-        # TtSharedExpert without a sub-device, so it covers the ttnn.situ_glu delegate; the
-        # hand-composed sub_core_grids branch is only reachable through the MoE (test_ttnn_moe).
+        # TtSharedExpert without a sub-device, so ttnn.situ_glu runs here on the full grid; its
+        # sub_core_grids form is only reachable through the MoE (test_ttnn_moe).
         (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SITU),
     ],
     # Ids label seq_len_per_chip first, so the K3 cases keep the "3.2K" prefix they share with the

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -38,9 +38,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         # Worth its own case because every prior model has num_shared_experts == 1, so hidden_dim and
         # the shared intermediate coincided and 6144 was never exercised here.
         (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SILU),
-        # ...and the same shape on the activation the K3 checkpoint actually uses (#53625). SiTU is
-        # the interesting case here precisely because 6144 is past ttnn.situ_glu's 3072 L1 cutoff,
-        # so this is the composed DRAM path, not the tuned one.
+        # ...and the same shape on the activation the K3 checkpoint actually uses. This builds
+        # TtSharedExpert without a sub-device, so it covers the ttnn.situ_glu delegate; the
+        # hand-composed sub_core_grids branch is only reachable through the MoE (test_ttnn_moe).
         (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SITU),
     ],
     # Ids label seq_len_per_chip first, so the K3 cases keep the "3.2K" prefix they share with the

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -15,28 +15,37 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
-from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import ACTIVATION_SILU, ACTIVATION_SITU, TtSharedExpert
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize(
-    "seq_len_per_chip, emb_dim, hidden_dim",
+    "seq_len_per_chip, emb_dim, hidden_dim, activation",
     [
-        (4096, 7 * 1024, 2 * 1024),
-        (3200, 7 * 1024, 2 * 1024),
+        (4096, 7 * 1024, 2 * 1024, ACTIVATION_SILU),
+        (3200, 7 * 1024, 2 * 1024, ACTIVATION_SILU),
         # Kimi-K3: one shared-expert MLP at moe_intermediate_size * num_shared_experts = 3072 * 2.
         # Worth its own case because every prior model has num_shared_experts == 1, so hidden_dim and
         # the shared intermediate coincided and 6144 was never exercised here.
-        (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE),
+        (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SILU),
+        # ...and the same shape on the activation the K3 checkpoint actually uses (#53625). SiTU is
+        # the interesting case here precisely because 6144 is past ttnn.situ_glu's 3072 L1 cutoff,
+        # so this is the composed DRAM path, not the tuned one.
+        (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SITU),
     ],
-    # Ids label seq_len_per_chip first, so the K3 case keeps the "3.2K" prefix it shares with the
-    # case above and adds what actually differs (the 6144 shared intermediate).
-    ids=["4K", "3.2K", "3.2K-k3-6144"],
+    # Ids label seq_len_per_chip first, so the K3 cases keep the "3.2K" prefix they share with the
+    # case above and add what actually differs (the 6144 shared intermediate, the activation).
+    ids=["4K", "3.2K", "3.2K-k3-6144", "3.2K-k3-6144-situ"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links",
@@ -55,6 +64,15 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
         ),
+        # BH Galaxy. A Blackhole box accepts no mesh smaller than all 32 devices, so this is the
+        # only param where the SiTU cases can run at all -- SiTU needs ttnn.softcap, Blackhole-only.
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
+            2,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -64,6 +82,7 @@ def test_shared_expert_pcc(
     seq_len_per_chip: int,
     emb_dim: int,
     hidden_dim: int,
+    activation: str,
     num_links: int,
 ):
     """
@@ -72,22 +91,30 @@ def test_shared_expert_pcc(
     This test verifies:
     1. Correct weight sharding (gate_proj/up_proj on -1, down_proj on -2)
     2. Proper all-gather before matmuls
-    3. SiLU activation fusion
+    3. The GLU activation — SiLU fused into the gate matmul, or SiTU-GLU over both raw accumulators
     4. Proper reduce-scatter after final matmul
     5. Output matches torch reference with PCC > 0.97
     """
+    if activation == ACTIVATION_SITU and not is_blackhole():
+        pytest.skip("SiTU-GLU needs ttnn.softcap, which is Blackhole-only")
 
     activations_dtype = ttnn.bfloat16
     weights_dtype = ttnn.bfloat8_b
     topology = per_axis_topology(device_params["fabric_config"])[1]
+    # Only read on the SiTU path; TorchExpert and TtSharedExpert must be given the same pair or the
+    # comparison silently measures two different activations.
+    situ_betas = dict(
+        situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
+        situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,
+    )
 
     num_devices = mesh_device.get_num_devices()
     mesh_shape = mesh_device.shape
     logger.debug(f"Testing with mesh_shape={mesh_shape}, num_devices={num_devices}")
-    logger.debug(f"seq_len_per_chip={seq_len_per_chip}, emb_dim={emb_dim}, hidden_dim={hidden_dim}")
+    logger.debug(f"{seq_len_per_chip=} {emb_dim=} {hidden_dim=} {activation=}")
 
     # Add Tracy signpost for profiling
-    signpost(f"SharedExpert PCC test - {mesh_shape=} {seq_len_per_chip=} {num_links=} {topology=}")
+    signpost(f"SharedExpert PCC test - {mesh_shape=} {seq_len_per_chip=} {activation=} {num_links=} {topology=}")
 
     # Query available ethernet links
     actual_num_links = get_num_links(mesh_device, cluster_axis=1)  # Query along mesh columns
@@ -98,7 +125,7 @@ def test_shared_expert_pcc(
     # Step 1: Create PyTorch reference model
     # ========================================
     logger.debug("Creating TorchExpert reference")
-    torch_model = TorchExpert(emb_dim, hidden_dim)
+    torch_model = TorchExpert(emb_dim, hidden_dim, activation=activation, **situ_betas)
 
     # Extract weights for TTNN model
     torch_weights = {
@@ -120,6 +147,8 @@ def test_shared_expert_pcc(
         topology=topology,
         activations_dtype=activations_dtype,
         weights_dtype=weights_dtype,
+        activation=activation,
+        **situ_betas,
     )
 
     # ========================================

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -32,20 +32,21 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, hidden_dim, activation",
     [
-        (4096, 7 * 1024, 2 * 1024, ACTIVATION_SILU),
-        (3200, 7 * 1024, 2 * 1024, ACTIVATION_SILU),
+        # 640 is the per-chip prefill chunk: 5120 tokens over sp_factor 8. Every case here runs that
+        # depth, which pins the matmul program configs to per_core_M=1 -- the blocking prefill uses.
+        (640, 7 * 1024, 2 * 1024, ACTIVATION_SILU),
         # Kimi-K3: one shared-expert MLP at moe_intermediate_size * num_shared_experts = 3072 * 2.
         # Worth its own case because every prior model has num_shared_experts == 1, so hidden_dim and
         # the shared intermediate coincided and 6144 was never exercised here.
-        (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SILU),
+        (640, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SILU),
         # ...and the same shape on the activation the K3 checkpoint actually uses. This builds
         # TtSharedExpert without a sub-device, so ttnn.situ_glu runs here on the full grid; its
         # sub_core_grids form is only reachable through the MoE (test_ttnn_moe).
-        (3200, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SITU),
+        (640, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SITU),
     ],
-    # Ids label seq_len_per_chip first, so the K3 cases keep the "3.2K" prefix they share with the
-    # case above and add what actually differs (the 6144 shared intermediate, the activation).
-    ids=["4K", "3.2K", "3.2K-k3-6144", "3.2K-k3-6144-situ"],
+    # Ids label seq_len_per_chip first, then what differs from the case above it (the 6144 shared
+    # intermediate, the activation).
+    ids=["640", "640-k3-6144", "640-k3-6144-situ"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -115,6 +115,7 @@ def run_model(
     rms_norm_eps=1e-5,
     final_output_pcc=0.982,
     routed_activation=ttnn.RoutedExpertActivation.Silu,
+    shared_activation=ACTIVATION_SILU,
     measure=None,
 ):
     """TtMoe PCC body — shared between `test_ds_moe` / `test_kimi_moe`.
@@ -130,9 +131,10 @@ def run_model(
     dedicated grouped_topk / routing_setup tests. HOST_ALL gates ignore padding entirely
     (TtMoe falls back to padding_config=None for non-DEVICE_FP32 gates).
 
-    ``routed_activation`` selects the fused routed-expert kernel's activation and the matching
-    torch reference. The shared expert always runs SiLU: no SiTU kernel exists outside the
-    routed-expert op, so both sides must stay on SiLU there for the comparison to mean anything.
+    ``routed_activation`` selects the fused routed-expert kernel's activation and ``shared_activation``
+    the shared expert's; each is mirrored onto the matching torch reference. They are separate knobs
+    because the two sites run different implementations -- a fused kernel vs the Python-composed
+    ttnn ops in TtSharedExpert -- even where Kimi-K3 sets both to SiTU (#53625).
 
     ``measure`` wraps the forward for a perf caller: it is called as ``measure(forward)``,
     must invoke the thunk and return its result, and owns the device sync. The perf gates use
@@ -144,6 +146,8 @@ def run_model(
         raise ValueError(f"no torch reference for {routed_activation}; supported: {list(_TORCH_ROUTED_ACTIVATION)}")
     torch_routed_activation = _TORCH_ROUTED_ACTIVATION[routed_activation]
     upstream_activation = _UPSTREAM_ACT[routed_activation]
+    if shared_activation not in (ACTIVATION_SILU, ACTIVATION_SITU):
+        raise ValueError(f"unknown shared_activation {shared_activation!r}")
 
     profiler.clear()
     profiler.start("test_ttnn_moe")
@@ -362,12 +366,11 @@ def run_model(
             latent_weights=latent_weights,
             latent_use_norm=latent_use_norm,
             rms_norm_eps=rms_norm_eps,
-            # Routed side matches whatever the fused kernel runs; the shared expert stays on SiLU
-            # (no SiTU kernel outside the routed-expert op).
+            # Each side matches whatever the device runs there.
             activation=torch_routed_activation,
             situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
             situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,
-            shared_activation=ACTIVATION_SILU,
+            shared_activation=shared_activation,
         )
         profiler.end("torch_moe_creation")
 
@@ -402,6 +405,9 @@ def run_model(
         routed_expert_activation=routed_activation,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
+        shared_expert_activation=shared_activation,
+        shared_expert_situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
+        shared_expert_situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,
         gate_weights=gate_weights,
         gate_fallback_mode=gate_fallback_mode,
         weight_cache_path=moe_cache_dir,
@@ -657,9 +663,9 @@ def run_model(
         shared_expert_weights=shared_expert_weights,
         latent_weights=latent_weights,
         x=x,
-        # Same routed/shared split the device runs; see run_reference_moe.
+        # Same per-site activations the device runs; see run_reference_moe.
         hidden_act=upstream_activation,
-        shared_hidden_act="silu" if upstream_activation is not None else None,
+        shared_hidden_act=shared_activation if upstream_activation is not None else None,
     )
     if ref_out is not None and tt_output is not None:
         logger.info("Running upstream MoE reference")
@@ -971,4 +977,5 @@ def test_kimi_k3_moe(
         rms_norm_eps=KimiK3Config.RMS_NORM_EPS,
         final_output_pcc=0.965,
         routed_activation=ROUTED_EXPERT_ACTIVATION_BY_NAME[KimiK3Config.ROUTED_EXPERT_ACTIVATION],
+        shared_activation=KimiK3Config.SHARED_EXPERT_ACTIVATION,
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -934,11 +934,11 @@ def test_kimi_k3_moe(
 ):
     """Kimi-K3 MoE: 896 experts / top-16 with the LatentMoE projections around the routed side.
 
-    The routed experts run the checkpoint's SiTU-GLU on device
-    (``RoutedExpertActivation.SituGlu``, #51351), matched by a SiTU torch reference. The SHARED
-    expert stays on SiLU on both sides: the SiTU kernel is the routed-expert op's, and nothing
-    implements it at the shared expert's 6144 width, so holding both sides to SiLU there keeps
-    this a test of the dataflow rather than of a gap the device cannot close.
+    Both expert kinds run the checkpoint's SiTU-GLU on device, each matched by a SiTU torch
+    reference: the routed side through the fused kernel (``RoutedExpertActivation.SituGlu``), the
+    shared side through TtSharedExpert's composed softcap/sigmoid/multiply. This is also the only
+    test that reaches that composed path's sub_core_grids branch -- the shared expert runs on a
+    sub-device here, overlapped with the dispatch, which test_shared_expert does not set up.
 
     One deliberate limit remains from the bring-up scope:
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
@@ -29,10 +29,11 @@ What the number excludes, verified on an 8x4 galaxy (warm caches, 58 programs x 
 Recalibrating: set ``_EXPECTED_NS = None`` and the test measures and logs without gating, printing
 the value to set it back to. Do that on any box whose baseline you need to re-cut.
 
-Two limits carried over from the tracy version:
+One limit carried over from the tracy version:
 
-  * Measures the SiLU path, not the checkpoint's SiTU-GLU (#51335), so this baseline moves when
-    that kernel lands.
+  * ``_EXPECTED_NS`` was cut before the shared expert moved off SiLU. It now measures the
+    checkpoint's SiTU-GLU on every FFN site, where the shared expert's single fused multiply
+    becomes a softcap/sigmoid/multiply chain, so the baseline is stale until re-cut.
 """
 
 import os
@@ -148,6 +149,7 @@ def test_kimi_k3_moe_perf_galaxy(variant, config_only, mesh_device, device_param
         shared_hidden_dim=KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE,
         latent_use_norm=KimiK3Config.LATENT_MOE_USE_NORM,
         rms_norm_eps=KimiK3Config.RMS_NORM_EPS,
+        shared_activation=KimiK3Config.SHARED_EXPERT_ACTIVATION,
         measure=measure,
     )
 

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -53,9 +53,9 @@ def run_reference_moe(
 
     ``hidden_act`` overrides the config's GLU activation; ``shared_hidden_act`` overrides it for the
     shared expert alone. The upstream block picks one activation for routed and shared alike, but a
-    device may implement the two halves differently (Kimi-K3: SiTU-GLU in the fused routed-expert
-    kernel, SiLU for the shared expert), and this reference is only a fair cross-check if it splits
-    the same way.
+    device may implement the two halves differently, and this reference is only a fair cross-check
+    if it splits the same way. Kimi-K3 on Blackhole runs SiTU-GLU on both halves (#53625) and so
+    passes the same value twice; the split still matters on Wormhole, which has no SiTU at all.
     """
     if variant.reference_moe_cls is None:
         return None

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -52,10 +52,10 @@ def run_reference_moe(
     """Forward the variant's upstream MoE reference on CPU.
 
     ``hidden_act`` overrides the config's GLU activation; ``shared_hidden_act`` overrides it for the
-    shared expert alone. The upstream block picks one activation for routed and shared alike, but a
-    device may implement the two halves differently, and this reference is only a fair cross-check
-    if it splits the same way. Kimi-K3 on Blackhole runs SiTU-GLU on both halves (#53625) and so
-    passes the same value twice; the split still matters on Wormhole, which has no SiTU at all.
+    shared expert alone. The upstream block picks one activation for routed and shared alike, but the
+    device configures the two halves independently, and this reference is only a fair cross-check if
+    it splits the same way. Every variant passes the same value twice today; the parameter exists so
+    that a device-side split does not silently go unmirrored here.
     """
     if variant.reference_moe_cls is None:
         return None

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
@@ -488,7 +488,8 @@ def _tt_moe_from_kimi_block(blk, cfg, *, seq_len, dispatch_group_size, capacity_
     [
         # The checkpoint's real combination, and what every K3 FFN site runs on Blackhole.
         ("situ", True),
-        # Every other model's activation, and K3's fallback on Wormhole (no ttnn.softcap there).
+        # Every other model's activation. K3 never runs it, but it keeps the SiLU branch of this
+        # comparison validated against upstream.
         ("silu", True),
         # Upstream's own default, even though K3's checkpoint sets it true.
         ("situ", False),
@@ -509,9 +510,9 @@ def test_kimi_k3_latent_moe_reference_pcc(activation, latent_use_norm):
     device-side gate tests.
 
     Both activations are exercised: ``situ`` is what the checkpoint does and what the whole K3 MoE
-    now runs on Blackhole -- routed experts through the fused kernel (#51351), shared expert through
-    the composed ttnn path (#53625) -- while ``silu`` is every other model's activation and K3's
-    only option on Wormhole. Testing both keeps the SiLU path validated against upstream too.
+    runs on device -- routed experts through the fused kernel, shared expert through the composed
+    ttnn path -- while ``silu`` is every other model's. Testing both keeps the SiLU path validated
+    against upstream too.
     """
     torch.manual_seed(42)
 

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
@@ -486,9 +486,9 @@ def _tt_moe_from_kimi_block(blk, cfg, *, seq_len, dispatch_group_size, capacity_
 @pytest.mark.parametrize(
     "activation, latent_use_norm",
     [
-        # The checkpoint's real combination.
+        # The checkpoint's real combination, and what every K3 FFN site runs on Blackhole.
         ("situ", True),
-        # What the device still runs outside the routed experts (shared expert, dense FFN).
+        # Every other model's activation, and K3's fallback on Wormhole (no ttnn.softcap there).
         ("silu", True),
         # Upstream's own default, even though K3's checkpoint sets it true.
         ("situ", False),
@@ -508,10 +508,10 @@ def test_kimi_k3_latent_moe_reference_pcc(activation, latent_use_norm):
     the dataflow under test from any gate-implementation difference -- gate parity is covered by the
     device-side gate tests.
 
-    Both activations are exercised: ``situ`` is what the checkpoint does and what the routed experts
-    now run on device (#51351), and ``silu`` is what the shared expert and the dense FFN still run,
-    having no SiTU kernel at their widths. Testing both means each half of that split is validated
-    against upstream rather than assumed.
+    Both activations are exercised: ``situ`` is what the checkpoint does and what the whole K3 MoE
+    now runs on Blackhole -- routed experts through the fused kernel (#51351), shared expert through
+    the composed ttnn path (#53625) -- while ``silu`` is every other model's activation and K3's
+    only option on Wormhole. Testing both keeps the SiLU path validated against upstream too.
     """
     torch.manual_seed(42)
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -33,7 +33,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_intermediates import TtMoEInterm
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_routing_setup import TtMoERoutingSetup
 from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
-from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
+from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import ACTIVATION_SILU, TtSharedExpert
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
 # Four similarly-named dimensions, shown for Kimi-K3, the only variant where all four differ:
@@ -202,6 +202,9 @@ class TtMoe(LightweightModule):
         routed_expert_activation=ttnn.RoutedExpertActivation.Silu,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
+        shared_expert_activation: str = ACTIVATION_SILU,
+        shared_expert_situ_beta: float | None = None,
+        shared_expert_situ_linear_beta: float | None = None,
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
         weight_cache_path: Optional[Path] = None,
         layer_idx: int = 0,
@@ -245,6 +248,11 @@ class TtMoe(LightweightModule):
             routed_expert_weights_dtype: Data type for routed expert weights
             shared_expert_activations_dtype: Data type for shared expert activations
             shared_expert_weights_dtype: Data type for shared expert weights
+            shared_expert_activation: GLU activation the shared expert runs -- "silu" (default) or
+                "situ" for Kimi-K3's SiTU-GLU. Independent of routed_expert_activation: the two
+                sites run different ops (Python-composed vs fused kernel) at different widths.
+            shared_expert_situ_beta / shared_expert_situ_linear_beta: SiTU softcap betas, required
+                when shared_expert_activation == "situ".
             gate_weights: Dict with "weight" and "e_score_correction_bias" keys for gate
             gate_fallback_mode: Fallback mode for gate (default: HOST_ALL)
             overlap_shared_expert_with_dispatch: If True, run the shared expert and dispatch
@@ -504,6 +512,9 @@ class TtMoe(LightweightModule):
             cache_name_prefix=f"layer_{layer_idx}.shared_expert",
             subdevice_id=self.shared_sd_id,
             subdevice_cores=self.shared_sd_cores,
+            activation=shared_expert_activation,
+            situ_beta=shared_expert_situ_beta,
+            situ_linear_beta=shared_expert_situ_linear_beta,
         )
 
         self.latent_projections = (

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -277,8 +277,8 @@ class TtMoe(LightweightModule):
             rms_norm_eps: eps for that latent norm. Passed explicitly because
                 TtDistributedRmsNorm defaults to 1e-6 while K3's config says 1e-5.
             routed_expert_activation: GLU activation the fused routed-expert kernel runs.
-                Defaults to SiLU (DeepSeek / K2.6 / GLM). Kimi-K3 passes SituGlu. Routed only:
-                the shared expert and the dense FFN have no SiTU kernel and stay on SiLU.
+                Defaults to SiLU (DeepSeek / K2.6 / GLM). Kimi-K3 passes SituGlu. Routed only --
+                the shared expert takes shared_expert_activation, which is a separate knob.
         """
         super().__init__()
         self.mesh_device = mesh_device

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -8,7 +8,7 @@ TTNN implementation of Shared Expert module with multi-chip sharding and CCL.
 This module demonstrates:
 - Multi-chip tensor parallelism with proper weight sharding
 - Collective communication operations (all-gather, reduce-scatter)
-- SiLU activation fusion
+- SiLU activation fusion, or Kimi-K3's SiTU-GLU (see ``situ_glu``)
 """
 
 from pathlib import Path
@@ -22,6 +22,54 @@ from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
+# GLU activations this module can run over its gate/up pair. Spelled as the HF ``hidden_act``
+# and as the torch reference (reference/tt/moe/expert.py), so a model config's string maps across
+# without translation -- unlike the routed expert, whose fused kernel needs an enum.
+ACTIVATION_SILU = "silu"
+ACTIVATION_SITU = "situ"
+SUPPORTED_ACTIVATIONS = (ACTIVATION_SILU, ACTIVATION_SITU)
+
+
+def situ_glu(
+    gate_out: ttnn.Tensor,
+    up_out: ttnn.Tensor,
+    situ_beta: float,
+    situ_linear_beta: float,
+    sub_core_grids: Optional[ttnn.CoreRangeSet] = None,
+) -> ttnn.Tensor:
+    """Kimi-K3's SiTU-GLU over a raw gate/up matmul pair, consuming (deallocating) both.
+
+        softcap(gate, situ_beta) * sigmoid(gate) * softcap(up, situ_linear_beta)
+
+    Identical math to ``ttnn.situ_glu``, which this delegates to when the caller has no sub-device
+    to respect. The hand-composed form exists only for the shared expert: it runs on a sub-device
+    (it overlaps with the MoE dispatch) and ``ttnn.situ_glu`` takes no ``sub_core_grids``, while
+    softcap / sigmoid / multiply each do. sigmoid's ttnn defaults (ACCURATE, vector_mode RC) are
+    the ones ``ttnn.situ_glu`` passes explicitly, so the two paths agree bit-for-bit.
+
+    Blackhole only, since ``ttnn.softcap`` is. Both inputs are freed as soon as they are dead:
+    ``ttnn.situ_glu``'s L1 fast path covers hidden <= 3072 only, so at the shared expert's 6144
+    and the dense FFN's 33792 every intermediate here is a full-size DRAM tensor.
+    """
+    if sub_core_grids is None:
+        activated = ttnn.situ_glu(gate_out, up_out, situ_beta, situ_linear_beta)
+        ttnn.deallocate(gate_out)
+        ttnn.deallocate(up_out)
+        return activated
+
+    situ_a = ttnn.softcap(gate_out, situ_beta, sub_core_grids=sub_core_grids)
+    gate_sigmoid = ttnn.sigmoid(gate_out, sub_core_grids=sub_core_grids)
+    ttnn.deallocate(gate_out)
+    ttnn.multiply_(situ_a, gate_sigmoid, sub_core_grids=sub_core_grids)
+    ttnn.deallocate(gate_sigmoid)
+
+    up_half = ttnn.softcap(up_out, situ_linear_beta, sub_core_grids=sub_core_grids)
+    ttnn.deallocate(up_out)
+    ttnn.multiply_(situ_a, up_half, sub_core_grids=sub_core_grids)
+    ttnn.deallocate(up_half)
+    return situ_a
+
+
 COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
     math_fidelity=ttnn.MathFidelity.HiFi2,
     math_approx_mode=False,
@@ -30,8 +78,12 @@ COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
 )
 
 
-def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
-    """Program configs for the gate / up / down matmuls on Blackhole."""
+def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int, fuse_silu: bool = True):
+    """Program configs for the gate / up / down matmuls on Blackhole.
+
+    ``fuse_silu=False`` leaves the gate matmul's accumulator raw, for a GLU activation that is
+    binary over (gate, up) and so has no ``UnaryOpType`` to fuse -- SiTU-GLU.
+    """
     grid = ttnn.CoreCoord(11, 9)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
@@ -42,7 +94,7 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
         per_core_N=gate_n_tiles,
         fuse_batch=False,
         mcast_in0=False,
-        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU) if fuse_silu else None,
     )
     up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
@@ -67,8 +119,12 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
     return gate, up, down
 
 
-def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
-    """Program configs for the gate / up / down matmuls on Wormhole."""
+def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int, fuse_silu: bool = True):
+    """Program configs for the gate / up / down matmuls on Wormhole.
+
+    ``fuse_silu=False`` leaves the gate matmul's accumulator raw, for a GLU activation that is
+    binary over (gate, up) and so has no ``UnaryOpType`` to fuse -- SiTU-GLU.
+    """
     grid = ttnn.CoreCoord(8, 7)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
@@ -79,7 +135,7 @@ def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
         per_core_N=gate_n_tiles,
         fuse_batch=False,
         mcast_in0=False,
-        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU) if fuse_silu else None,
     )
     up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
@@ -114,7 +170,8 @@ class TtSharedExpert(LightweightModule):
         Input: x [batch, seq_len, emb_dim] (replicated across mesh columns)
         1. gate_out = x @ gate_proj → [batch, seq_len, hidden_dim / num_devices]
         2. up_out = x @ up_proj → [batch, seq_len, hidden_dim / num_devices]
-        3. activated = silu(gate_out) * up_out → [batch, seq_len, hidden_dim / num_devices]
+        3. activated = glu_activation(gate_out, up_out) → [batch, seq_len, hidden_dim / num_devices]
+           (SiLU fused into the gate matmul, or SiTU-GLU over both raw accumulators)
         4. output_full = activated @ down_proj → [batch, seq_len, emb_dim]
         5. Reduce-scatter output across mesh columns → [batch, seq_len, emb_dim / num_devices]
 
@@ -239,6 +296,9 @@ class TtSharedExpert(LightweightModule):
         cache_name_prefix: Optional[str] = None,
         subdevice_id: Optional[ttnn.SubDeviceId] = None,
         subdevice_cores: Optional[ttnn.CoreRangeSet] = None,
+        activation: str = ACTIVATION_SILU,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None,
     ):
         """
         Initialize TtSharedExpert module.
@@ -255,6 +315,11 @@ class TtSharedExpert(LightweightModule):
             compute_kernel_config: Compute kernel configuration
             weight_cache_path: Optional path for caching TTNN weight tensors
             cache_name_prefix: Optional prefix for cache file names
+            activation: GLU activation over the gate/up pair -- "silu" (default, every model but
+                Kimi-K3) or "situ" for K3's SiTU-GLU. Unlike the routed expert this is a plain
+                string: both paths are composed from Python-level ttnn ops, not a fused kernel.
+            situ_beta / situ_linear_beta: SiTU softcap betas (K3: 4.0 / 25.0). Required, and
+                non-zero, when activation == "situ"; ignored otherwise.
         """
         super().__init__()
         self.mesh_device = mesh_device
@@ -269,6 +334,24 @@ class TtSharedExpert(LightweightModule):
         self.subdevice_id = subdevice_id
         self.subdevice_cores = subdevice_cores
         self.weight_cache_path = weight_cache_path
+
+        if activation not in SUPPORTED_ACTIVATIONS:
+            raise ValueError(f"unknown activation {activation!r}; expected one of {SUPPORTED_ACTIVATIONS}")
+        if activation == ACTIVATION_SITU:
+            # ttnn.softcap, which both SiTU halves go through, is Blackhole-only. Raise rather than
+            # fall back to SiLU: a silently different activation is a wrong model, not a slow one.
+            if not is_blackhole():
+                raise ValueError(f"activation {activation!r} needs ttnn.softcap, which is Blackhole-only")
+            # softcap precomputes 1/beta, so a zero (or missing) beta would emit inf.
+            if not situ_beta or not situ_linear_beta:
+                raise ValueError(
+                    f"activation {activation!r} requires non-zero situ_beta / situ_linear_beta, "
+                    f"got {situ_beta} / {situ_linear_beta}"
+                )
+        self.activation = activation
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
+
         # Shared per-mesh CCL handle. Drives reduce_scatter_minimal_async and owns the shared,
         # stable-address reduce_scatter INTERMEDIATE buffer (one per mesh, reused by all layers'
         # shared experts) — see forward() and TT_CCL.get_shared_rs_intermediate.
@@ -430,13 +513,16 @@ class TtSharedExpert(LightweightModule):
 
         gate_n_tiles = self.gate_proj.padded_shape[-1] // TILE
         down_n_tiles = self.down_proj.padded_shape[-1] // TILE
+        # SiTU-GLU is binary over (gate, up), so it cannot ride along as the gate matmul's fused
+        # unary; the gate accumulator has to come out raw and be combined below.
+        fuse_silu = self.activation == ACTIVATION_SILU
         if is_blackhole():
             gate_program_config, up_program_config, down_program_config = get_bh_program_configs(
-                per_core_M, gate_n_tiles, down_n_tiles
+                per_core_M, gate_n_tiles, down_n_tiles, fuse_silu=fuse_silu
             )
         else:
             gate_program_config, up_program_config, down_program_config = get_wh_program_configs(
-                per_core_M, gate_n_tiles, down_n_tiles
+                per_core_M, gate_n_tiles, down_n_tiles, fuse_silu=fuse_silu
             )
 
         # 1) Compute gate and up projections
@@ -455,19 +541,30 @@ class TtSharedExpert(LightweightModule):
             sub_device_id=self.subdevice_id,
         )
 
-        # 2) Multiply gate and up projection
-        ttnn.multiply_(gate_out, up_out, sub_core_grids=self.subdevice_cores)
-        ttnn.deallocate(up_out)
+        # 2) Combine the gate and up projections through the GLU activation
+        if self.activation == ACTIVATION_SITU:
+            activated = situ_glu(
+                gate_out,
+                up_out,
+                self.situ_beta,
+                self.situ_linear_beta,
+                sub_core_grids=self.subdevice_cores,
+            )
+        else:
+            # gate_out already carries the matmul-fused SiLU.
+            ttnn.multiply_(gate_out, up_out, sub_core_grids=self.subdevice_cores)
+            ttnn.deallocate(up_out)
+            activated = gate_out
 
         # 3) Compute down projection
         output_full = ttnn.matmul(
-            gate_out,
+            activated,
             self.down_proj,
             program_config=down_program_config,
             compute_kernel_config=self.compute_kernel_config,
             sub_device_id=self.subdevice_id,
         )
-        ttnn.deallocate(gate_out)
+        ttnn.deallocate(activated)
 
         # 4) Reduce-scatter across mesh columns when TP > 1.
         if self.mesh_device.shape[1] > 1:

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -47,9 +47,15 @@ def situ_glu(
     softcap / sigmoid / multiply each do. sigmoid's ttnn defaults (ACCURATE, vector_mode RC) are
     the ones ``ttnn.situ_glu`` passes explicitly, so the two paths agree bit-for-bit.
 
-    Blackhole only, since ``ttnn.softcap`` is. Both inputs are freed as soon as they are dead:
-    ``ttnn.situ_glu``'s L1 fast path covers hidden <= 3072 only, so at the shared expert's 6144
-    and the dense FFN's 33792 every intermediate here is a full-size DRAM tensor.
+    Blackhole only, since ``ttnn.softcap`` is. Both inputs are freed as soon as they are dead.
+
+    The hand-composed branch leaves its three intermediates wherever ``gate_out`` lives, i.e. DRAM.
+    ``ttnn.situ_glu`` would place them in L1 instead below a 3072 hidden -- a bound on the per-chip
+    width, ``hidden_dim // TP``, not the model's, so the shared expert's 1536 at TP=4 clears it and
+    the width is not what keeps them in DRAM. What does is that these ops take ``sub_core_grids``
+    but no ``sub_device_id``: an interleaved-L1 tensor would come from the global allocator and
+    span banks the concurrently-dispatched MoE's sub-device is allocating from. Whether it can be
+    made safe is the open perf question here.
     """
     if sub_core_grids is None:
         activated = ttnn.situ_glu(gate_out, up_out, situ_beta, situ_linear_beta)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -41,39 +41,19 @@ def situ_glu(
 
         softcap(gate, situ_beta) * sigmoid(gate) * softcap(up, situ_linear_beta)
 
-    Identical math to ``ttnn.situ_glu``, which this delegates to when the caller has no sub-device
-    to respect. The hand-composed form exists only for the shared expert: it runs on a sub-device
-    (it overlaps with the MoE dispatch) and ``ttnn.situ_glu`` takes no ``sub_core_grids``, while
-    softcap / sigmoid / multiply each do. sigmoid's ttnn defaults (ACCURATE, vector_mode RC) are
-    the ones ``ttnn.situ_glu`` passes explicitly, so the two paths agree bit-for-bit.
+    ``ttnn.situ_glu`` is the math; this wrapper exists only to free the two matmul accumulators,
+    which an op may not do to its own inputs.
 
-    Blackhole only, since ``ttnn.softcap`` is. Both inputs are freed as soon as they are dead.
+    Blackhole only, since ``ttnn.softcap`` is.
 
-    The hand-composed branch leaves its three intermediates wherever ``gate_out`` lives, i.e. DRAM.
-    ``ttnn.situ_glu`` would place them in L1 instead below a 3072 hidden -- a bound on the per-chip
-    width, ``hidden_dim // TP``, not the model's, so the shared expert's 1536 at TP=4 clears it and
-    the width is not what keeps them in DRAM. What does is that these ops take ``sub_core_grids``
-    but no ``sub_device_id``: an interleaved-L1 tensor would come from the global allocator and
-    span banks the concurrently-dispatched MoE's sub-device is allocating from. Whether it can be
-    made safe is the open perf question here.
+    ``sub_core_grids`` confines every composed step to the shared expert's sub-device, so this can
+    run overlapped with the MoE dispatch. It also keeps the intermediates in DRAM: the op's L1 fast
+    path allocates interleaved, i.e. on the dispatch sub-device's cores as well.
     """
-    if sub_core_grids is None:
-        activated = ttnn.situ_glu(gate_out, up_out, situ_beta, situ_linear_beta)
-        ttnn.deallocate(gate_out)
-        ttnn.deallocate(up_out)
-        return activated
-
-    situ_a = ttnn.softcap(gate_out, situ_beta, sub_core_grids=sub_core_grids)
-    gate_sigmoid = ttnn.sigmoid(gate_out, sub_core_grids=sub_core_grids)
+    activated = ttnn.situ_glu(gate_out, up_out, situ_beta, situ_linear_beta, sub_core_grids=sub_core_grids)
     ttnn.deallocate(gate_out)
-    ttnn.multiply_(situ_a, gate_sigmoid, sub_core_grids=sub_core_grids)
-    ttnn.deallocate(gate_sigmoid)
-
-    up_half = ttnn.softcap(up_out, situ_linear_beta, sub_core_grids=sub_core_grids)
     ttnn.deallocate(up_out)
-    ttnn.multiply_(situ_a, up_half, sub_core_grids=sub_core_grids)
-    ttnn.deallocate(up_half)
-    return situ_a
+    return activated
 
 
 COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -18,9 +18,10 @@ and ``allocate_kv_cache`` are inherited but would size the KV cache to ``params.
 is wrong for 24-of-93; they are overridden to fail loudly rather than mislead.
 
 MoE scope (issue #51336): the latent-MoE structure -- routed experts at the reduced 3584 hidden,
-896 experts / top-16, a latent RMSNorm, and one shared expert at 6144. The routed experts run the
-checkpoint's **SiTU-GLU** on device (#51351); the shared expert and the dense FFN still run SiLU,
-having no SiTU kernel at their widths. One deliberate limit remains:
+896 experts / top-16, a latent RMSNorm, and one shared expert at 6144. Every FFN site runs the
+checkpoint's **SiTU-GLU** on device: the routed experts through the fused kernel (#51351), the
+shared expert and the layer-0 dense FFN through ttnn-level softcap/sigmoid/multiply (#53625), which
+is correct but not yet tuned at their 6144 / 33792 widths. One deliberate limit remains:
   * only the **gate** uses real checkpoint weights. Experts, shared expert and the latent
     projections use seeded random weights, because everything routed is MXFP4 and no dequantizer
     exists yet. Device PCC is therefore TT-vs-torch on identical seeded weights.
@@ -99,10 +100,9 @@ class KimiK3Adapter(MLAPrefillAdapter):
     def reference_moe_cls(self):
         """K3's MoE block: DeepSeek-V3's, wrapped in the shared low-rank latent projection pair.
 
-        The block applies one activation to routed and shared experts alike, while the device has a
-        SiTU-GLU kernel for the routed expert only (#51351). ``run_reference_moe`` therefore builds
-        it with hidden_act="situ" and pins the shared half back to SiLU, so both sides of a device
-        comparison split the same way.
+        The block applies one activation to routed and shared experts alike, which now matches the
+        device: ``run_reference_moe`` builds it with hidden_act="situ" for both halves (#51351,
+        #53625). Its ``shared_hidden_act`` override stays for Wormhole, which has no SiTU at all.
         """
         from models.demos.deepseek_v3_d_p.reference.kimi_k3.modeling_kimi_moe import KimiSparseMoeBlock
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -100,9 +100,8 @@ class KimiK3Adapter(MLAPrefillAdapter):
     def reference_moe_cls(self):
         """K3's MoE block: DeepSeek-V3's, wrapped in the shared low-rank latent projection pair.
 
-        The block applies one activation to routed and shared experts alike, which now matches the
-        device: ``run_reference_moe`` builds it with hidden_act="situ" for both halves (#51351,
-        #53625). Its ``shared_hidden_act`` override stays for Wormhole, which has no SiTU at all.
+        The block applies one activation to routed and shared experts alike, which matches the
+        device: ``run_reference_moe`` builds it with hidden_act="situ" for both halves.
         """
         from models.demos.deepseek_v3_d_p.reference.kimi_k3.modeling_kimi_moe import KimiSparseMoeBlock
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ffn.py
@@ -145,9 +145,9 @@ class TtFfn(TtSharedExpert):
 
         # Step 3: GLU activation and element-wise multiplication
         if self.activation == ACTIVATION_SITU:
-            # No sub-device here, so the helper reduces to a plain ttnn.situ_glu call. That op's
-            # L1 fast path is bounded on the per-chip width: K3's 33792 is 8448 at TP=4, past the
-            # 3072 bound, so its intermediates land in DRAM. Correctness first; #53625 tracks perf.
+            # No sub-device here, so ttnn.situ_glu's L1 fast path is in play -- but it is bounded on
+            # the per-chip width, and K3's 33792 is 8448 at TP=4, past the 3072 bound. So the
+            # intermediates land in DRAM anyway. Correctness first; #53625 tracks perf.
             activated = situ_glu(gate_out, up_out, self.situ_beta, self.situ_linear_beta)
         else:
             activated = ttnn.mul(

--- a/models/demos/deepseek_v3_d_p/tt/tt_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ffn.py
@@ -145,9 +145,9 @@ class TtFfn(TtSharedExpert):
 
         # Step 3: GLU activation and element-wise multiplication
         if self.activation == ACTIVATION_SITU:
-            # No sub-device here, so the helper reduces to a plain ttnn.situ_glu call. At K3's
-            # 33792 hidden dim that op's intermediates land in DRAM (its L1 path stops at 3072) —
-            # correctness first, see issue #53625 for the perf follow-up.
+            # No sub-device here, so the helper reduces to a plain ttnn.situ_glu call. That op's
+            # L1 fast path is bounded on the per-chip width: K3's 33792 is 8448 at TP=4, past the
+            # 3072 bound, so its intermediates land in DRAM. Correctness first; #53625 tracks perf.
             activated = situ_glu(gate_out, up_out, self.situ_beta, self.situ_linear_beta)
         else:
             activated = ttnn.mul(

--- a/models/demos/deepseek_v3_d_p/tt/tt_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ffn.py
@@ -17,7 +17,13 @@ from typing import Optional
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import COMPUTE_KERNEL_CONFIG_HIFI2, TtSharedExpert
+from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import (
+    ACTIVATION_SILU,
+    ACTIVATION_SITU,
+    COMPUTE_KERNEL_CONFIG_HIFI2,
+    TtSharedExpert,
+    situ_glu,
+)
 
 # DeepSeek 671B FFN dimensions
 EMB_DIM = 7168
@@ -35,6 +41,7 @@ class TtFfn(TtSharedExpert):
         gate_out = x @ gate_proj
         up_out   = x @ up_proj
         activated = silu(gate_out) * up_out          (fused via ttnn.mul)
+                    -- or SiTU-GLU (ttnn.situ_glu) when activation == "situ"
         output_full = activated @ down_proj
         output = reduce_scatter(output_full)         (only when TP > 1)
     """
@@ -52,8 +59,11 @@ class TtFfn(TtSharedExpert):
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_HIFI2,
         weight_cache_path: Optional[Path] = None,
         cache_name_prefix: Optional[str] = None,
+        activation: str = ACTIVATION_SILU,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None,
     ):
-        """Initialize TtFfn — same signature as before, no sub-device parameters."""
+        """Initialize TtFfn — same signature as before plus the GLU activation, no sub-device parameters."""
         super().__init__(
             mesh_device=mesh_device,
             emb_dim=emb_dim,
@@ -66,6 +76,9 @@ class TtFfn(TtSharedExpert):
             compute_kernel_config=compute_kernel_config,
             weight_cache_path=weight_cache_path,
             cache_name_prefix=cache_name_prefix,
+            activation=activation,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
             # subdevice_id / subdevice_cores intentionally left as defaults (None) —
             # TtFfn's overridden forward() does not use them.
         )
@@ -130,13 +143,19 @@ class TtFfn(TtSharedExpert):
         up_out = ttnn.matmul(x, self.up_proj, compute_kernel_config=self.compute_kernel_config)
         logger.debug(f"After up_proj matmul: {up_out.shape}")
 
-        # Step 3: SiLU activation and element-wise multiplication (fused)
-        activated = ttnn.mul(
-            gate_out,
-            up_out,
-            input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
-        )
-        logger.debug(f"After SiLU fusion: {activated.shape}")
+        # Step 3: GLU activation and element-wise multiplication
+        if self.activation == ACTIVATION_SITU:
+            # No sub-device here, so the helper reduces to a plain ttnn.situ_glu call. At K3's
+            # 33792 hidden dim that op's intermediates land in DRAM (its L1 path stops at 3072) —
+            # correctness first, see issue #53625 for the perf follow-up.
+            activated = situ_glu(gate_out, up_out, self.situ_beta, self.situ_linear_beta)
+        else:
+            activated = ttnn.mul(
+                gate_out,
+                up_out,
+                input_tensor_a_activations=[ttnn.UnaryOpType.SILU],
+            )
+        logger.debug(f"After {self.activation} activation: {activated.shape}")
 
         # Step 4: Down projection
         output_full = ttnn.matmul(activated, self.down_proj, compute_kernel_config=self.compute_kernel_config)

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -17,6 +17,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import compute_constants, 
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
+from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import ACTIVATION_SILU
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
@@ -385,6 +386,11 @@ class TtPrefillBlock(LightweightModule):
                 topology=tp_topology,  # dense FFN all-gather/reduce-scatter run on the TP axis
                 weight_cache_path=weight_cache_path,
                 cache_name_prefix=f"layer_{layer_idx}.ffn",
+                # Same rule as the MoE shared expert in _build_moe: only Kimi-K3 names a
+                # non-SiLU activation here (#53625).
+                activation=getattr(model_cfg, "DENSE_FFN_ACTIVATION", ACTIVATION_SILU),
+                situ_beta=getattr(model_cfg, "ACTIVATION_SITU_BETA", None),
+                situ_linear_beta=getattr(model_cfg, "ACTIVATION_SITU_LINEAR_BETA", None),
                 **_dense_ffn_kwargs,
             )
 
@@ -462,6 +468,11 @@ class TtPrefillBlock(LightweightModule):
             ],
             shared_expert_activations_dtype=shared_expert_activations_dtype,
             shared_expert_weights_dtype=shared_expert_weights_dtype,
+            # Kimi-K3 names "situ" here too (#53625); every other config defaults to SiLU. The
+            # betas are only read on the SiTU path, so getattr(None) is fine for everyone else.
+            shared_expert_activation=getattr(model_cfg, "SHARED_EXPERT_ACTIVATION", ACTIVATION_SILU),
+            shared_expert_situ_beta=getattr(model_cfg, "ACTIVATION_SITU_BETA", None),
+            shared_expert_situ_linear_beta=getattr(model_cfg, "ACTIVATION_SITU_LINEAR_BETA", None),
             gate_weights=state_dict.get("gate_weights"),  # None if cache exists
             gate_fallback_mode=gate_fallback_mode,
             n_expert_groups=model_cfg.NUM_EXPERT_GROUPS,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -1046,6 +1046,34 @@ def test_situ_glu_sub_core_grids_conflict(device, expect_error):
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
+@pytest.mark.parametrize("via", ["memory_config", "input_placement"])
+def test_situ_glu_sub_core_grids_rejects_interleaved_l1(device, expect_error, via):
+    shape = torch.Size([1, 1, 32, 32])
+    cores = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))])
+
+    # An interleaved-L1 buffer takes L1 on every worker core, including the ones a core restriction
+    # exists to stay off. It reaches the output placement two ways -- asked for, or inherited from an
+    # interleaved-L1 input when memory_config is omitted -- so both have to be rejected.
+    l1 = ttnn.L1_MEMORY_CONFIG
+    gate = ttnn.zeros(
+        shape,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=l1 if via == "input_placement" else ttnn.DRAM_MEMORY_CONFIG,
+    )
+    with expect_error(RuntimeError, "core restriction cannot be combined with an interleaved-L1 output"):
+        ttnn.situ_glu(
+            gate,
+            gate,
+            SITU_GLU_BETA1,
+            SITU_GLU_BETA2,
+            memory_config=l1 if via == "memory_config" else None,
+            sub_core_grids=cores,
+        )
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
 def test_situ_glu_zero_beta_guard(device, expect_error):
     shape = torch.Size([1, 1, 32, 32])
     gate = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -1074,6 +1074,25 @@ def test_situ_glu_sub_core_grids_rejects_interleaved_l1(device, expect_error, vi
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
+def test_situ_glu_requires_cores_when_sub_devices_loaded(device, expect_error):
+    shape = torch.Size([1, 1, 32, 32])
+    grid = device.compute_with_storage_grid_size()
+    first = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, 0))})
+    rest = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 1), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    manager = device.create_sub_device_manager([ttnn.SubDevice([first]), ttnn.SubDevice([rest])], 0)
+    device.load_sub_device_manager(manager)
+    try:
+        gate = ttnn.zeros(shape, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        # Unrestricted, the composed ops would take sub-device 0 -- the first strip -- instead of the
+        # full grid, with no error to show it. Make the caller name the cores once the grid is split.
+        with expect_error(RuntimeError, "sub-devices are loaded"):
+            ttnn.situ_glu(gate, gate, SITU_GLU_BETA1, SITU_GLU_BETA2)
+    finally:
+        device.clear_loaded_sub_device_manager()
+        device.remove_sub_device_manager(manager)
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
 def test_situ_glu_zero_beta_guard(device, expect_error):
     shape = torch.Size([1, 1, 32, 32])
     gate = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -993,6 +993,59 @@ def test_situ_glu_l1_intermediates_fall_back(device):
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
+@pytest.mark.parametrize(
+    "sub_core_grid",
+    [
+        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))]),
+        ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 4)),
+                ttnn.CoreRange(ttnn.CoreCoord(3, 2), ttnn.CoreCoord(4, 3)),
+            ]
+        ),
+    ],
+    ids=["contiguous", "disjoint"],
+)
+def test_situ_glu_sub_core_grids(device, sub_core_grid):
+    torch.manual_seed(0)
+    # A width under the 3072 L1 cutoff, so this also pins the core restriction's other effect: it
+    # holds the intermediates in the output's memory space instead of taking interleaved L1 on
+    # every core, the restricted-away ones included.
+    shape = torch.Size([1, 1, 512, 3072])
+    gate = torch.empty(shape, dtype=torch.bfloat16).uniform_(-30.0, 30.0)
+    up = torch.empty(shape, dtype=torch.bfloat16).uniform_(-30.0, 30.0)
+
+    gate_tt = ttnn.from_torch(gate, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    up_tt = ttnn.from_torch(up, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    out = ttnn.situ_glu(gate_tt, up_tt, SITU_GLU_BETA1, SITU_GLU_BETA2, sub_core_grids=sub_core_grid)
+
+    assert out.memory_config().buffer_type == gate_tt.memory_config().buffer_type
+    tt_res = ttnn.to_torch(out)
+    golden = ttnn.get_golden_function(ttnn.situ_glu)(gate, up, beta1=SITU_GLU_BETA1, beta2=SITU_GLU_BETA2)
+    assert_with_ulp(golden, tt_res, ulp_threshold=SITU_GLU_ULP)
+    assert_with_pcc(golden, tt_res, pcc=SITU_GLU_BF16_PCC)
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
+def test_situ_glu_sub_core_grids_conflict(device, expect_error):
+    shape = torch.Size([1, 1, 32, 32])
+    gate = ttnn.zeros(shape, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # The composed unaries take only sub_core_grids, so situ_glu resolves sub_device_id into it and
+    # cannot honour both.
+    with expect_error(RuntimeError, "Cannot specify both sub_core_grids and sub_device_id"):
+        ttnn.situ_glu(
+            gate,
+            gate,
+            SITU_GLU_BETA1,
+            SITU_GLU_BETA2,
+            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+            sub_device_id=ttnn.SubDeviceId(0),
+        )
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
 def test_situ_glu_zero_beta_guard(device, expect_error):
     shape = torch.Size([1, 1, 32, 32])
     gate = ttnn.from_torch(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -281,6 +281,8 @@ Tensor situ_glu(
     const Tensor& up,
     float beta1,
     float beta2,
-    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -890,8 +890,12 @@ void bind_situ_glu(nb::module_& mod, const std::string& description, const std::
 
             Implemented for Blackhole only.
 
-            Restricting the cores also forces the intermediates to the output's memory space: the L1
-            placement this picks on a full grid is unsafe next to a concurrently running op.
+            Restricting the cores forces the intermediates to the output's memory space, because the
+            L1 placement this picks on a full grid is unsafe next to a concurrently running op. For
+            the same reason a core restriction rejects an interleaved-L1 output, whether asked for
+            through :attr:`memory_config` or inherited from an interleaved-L1 :attr:`input_tensor_a`:
+            such a buffer takes L1 on the cores restricted away. Sharded L1 is accepted -- its shard
+            spec confines it.
         )doc",
         std::string(Name),
         "ttnn." + std::string(Name),

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_nanobind.cpp
@@ -870,6 +870,9 @@ void bind_situ_glu(nb::module_& mod, const std::string& description, const std::
 
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            sub_core_grids (ttnn.CoreRangeSet, optional): the cores every composed step runs on. Defaults to `None`.
+            sub_device_id (ttnn.SubDeviceId, optional): sub-device whose worker cores to run on, as an alternative to
+                spelling them out in :attr:`sub_core_grids`. Mutually exclusive with it. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -886,6 +889,9 @@ void bind_situ_glu(nb::module_& mod, const std::string& description, const std::
                  - TILE
 
             Implemented for Blackhole only.
+
+            Restricting the cores also forces the intermediates to the output's memory space: the L1
+            placement this picks on a full grid is unsafe next to a concurrently running op.
         )doc",
         std::string(Name),
         "ttnn." + std::string(Name),
@@ -901,7 +907,9 @@ void bind_situ_glu(nb::module_& mod, const std::string& description, const std::
         nb::arg("beta1"),
         nb::arg("beta2"),
         nb::kw_only(),
-        nb::arg("memory_config") = nb::none());
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("sub_device_id") = nb::none());
 }
 
 template <ttnn::unique_string Name, typename Fn>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -937,29 +937,54 @@ Tensor situ_glu(
     const Tensor& up,
     float beta1,
     float beta2,
-    const std::optional<MemoryConfig>& output_mem_config) {
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
     using namespace operations::unary;
 
     // softcap precomputes 1/beta, so zero would emit inf.
     TT_FATAL(beta1 != 0.0f && beta2 != 0.0f, "situ_glu: beta1 and beta2 must be non-zero");
 
+    // The composed unaries take sub_core_grids but no sub_device_id, so resolve here and let every
+    // step share one core restriction.
+    auto cores = sub_core_grids;
+    if (sub_device_id.has_value()) {
+        TT_FATAL(!sub_core_grids.has_value(), "Cannot specify both sub_core_grids and sub_device_id");
+        cores = gate.device()->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+    }
+
     // Sharded inputs keep the ops' own placement: interleaved-L1 intermediates against a sharded
     // input would add an unshard/reshard round-trip, which is the opposite of the point here.
-    const bool use_l1 =
-        !gate.is_sharded() && gate.logical_shape()[-1] <= SITU_GLU_L1_MAX_HIDDEN && situ_glu_intermediates_fit_l1(gate);
+    //
+    // A core restriction also rules L1 out. It means another op is running concurrently on the
+    // complementary cores, and an interleaved-L1 buffer comes from the global allocator: it takes
+    // L1 on every worker core, the other op's included, growing down toward that op's circular
+    // buffers. A program only re-checks its CB region against live L1 buffers when it is enqueued,
+    // and the concurrent op is already in flight by then, so an overlap here is silent corruption
+    // rather than a throw.
+    const bool use_l1 = !gate.is_sharded() && !cores.has_value() &&
+                        gate.logical_shape()[-1] <= SITU_GLU_L1_MAX_HIDDEN && situ_glu_intermediates_fit_l1(gate);
     const std::optional<MemoryConfig> interm_mem =
         use_l1 ? std::optional<MemoryConfig>(ttnn::L1_MEMORY_CONFIG) : output_mem_config;
 
-    Tensor situ_a = ttnn::multiply(
-        ttnn::softcap(gate, beta1, interm_mem),
-        ttnn::sigmoid(gate, static_cast<int>(VecMode::RC), SigmoidMode::ACCURATE, interm_mem),
-        std::nullopt,
-        interm_mem);
-    Tensor up_half = ttnn::softcap(up, beta2, interm_mem);
-    // Pin the output placement, or multiply would inherit situ_a's possibly-L1 config and
-    // make placement depend on the hidden dim.
-    const MemoryConfig out_mem = output_mem_config.value_or(gate.memory_config());
-    return ttnn::multiply(situ_a, up_half, std::nullopt, out_mem);
+    Tensor situ_a = ttnn::softcap(gate, beta1, interm_mem, std::nullopt, cores);
+    {
+        Tensor gate_sigmoid =
+            ttnn::sigmoid(gate, static_cast<int>(VecMode::RC), SigmoidMode::ACCURATE, interm_mem, std::nullopt, cores);
+        ttnn::multiply_(situ_a, gate_sigmoid, {}, {}, {}, std::nullopt, cores);
+    }
+    Tensor up_half = ttnn::softcap(up, beta2, interm_mem, std::nullopt, cores);
+
+    // Without L1 the intermediates already sit at the output placement, so the last multiply can
+    // accumulate in place -- one buffer fewer to allocate and free, which matters when this runs
+    // overlapped with an op that is handed whatever DRAM is freed here.
+    if (!use_l1) {
+        ttnn::multiply_(situ_a, up_half, {}, {}, {}, std::nullopt, cores);
+        return situ_a;
+    }
+    // Pin the output placement, or multiply would inherit situ_a's L1 config and make placement
+    // depend on the hidden dim.
+    return ttnn::multiply(situ_a, up_half, std::nullopt, output_mem_config.value_or(gate.memory_config()));
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -952,6 +952,18 @@ Tensor situ_glu(
         TT_FATAL(!sub_core_grids.has_value(), "Cannot specify both sub_core_grids and sub_device_id");
         cores = gate.device()->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
     }
+    if (!cores.has_value()) {
+        // Unrestricted, the composed ops fall back to the worker cores of get_sub_device_ids().front().
+        // That is the whole grid only while the device is unpartitioned: the default manager holds one
+        // sub-device spanning it. Once a custom manager is loaded, front() is sub-device 0 -- some
+        // arbitrary strip -- and silently landing there is never what a caller means.
+        const auto& loaded_sub_devices = gate.device()->get_sub_device_ids();
+        TT_FATAL(
+            loaded_sub_devices.size() == 1,
+            "situ_glu: {} sub-devices are loaded, so leaving the cores unrestricted would run on "
+            "sub-device 0 rather than the full grid. Pass sub_core_grids or sub_device_id.",
+            loaded_sub_devices.size());
+    }
 
     // A core restriction means another op is running concurrently on the complementary cores, and an
     // interleaved-L1 buffer comes from the global allocator: it takes L1 on every worker core, the

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -953,15 +953,24 @@ Tensor situ_glu(
         cores = gate.device()->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
     }
 
+    // A core restriction means another op is running concurrently on the complementary cores, and an
+    // interleaved-L1 buffer comes from the global allocator: it takes L1 on every worker core, the
+    // other op's included, growing down toward that op's circular buffers. A program only re-checks
+    // its CB region against live L1 buffers when it is enqueued, and the concurrent op is already in
+    // flight by then, so an overlap is silent corruption rather than a throw.
+    //
+    // Declining the L1 fast path below is not enough to rule that out: the intermediates then follow
+    // the output placement, which is interleaved L1 whenever the caller asks for it or hands in an
+    // interleaved-L1 gate with no output_mem_config. Sharded L1 stays safe -- its shard spec confines
+    // it to named cores -- so only the interleaved case is rejected.
+    const MemoryConfig effective_out = output_mem_config.value_or(gate.memory_config());
+    TT_FATAL(
+        !(cores.has_value() && effective_out.is_l1() && !effective_out.is_sharded()),
+        "situ_glu: a core restriction cannot be combined with an interleaved-L1 output, which would "
+        "take L1 on the cores restricted away. Use DRAM or a sharded L1 memory config.");
+
     // Sharded inputs keep the ops' own placement: interleaved-L1 intermediates against a sharded
     // input would add an unshard/reshard round-trip, which is the opposite of the point here.
-    //
-    // A core restriction also rules L1 out. It means another op is running concurrently on the
-    // complementary cores, and an interleaved-L1 buffer comes from the global allocator: it takes
-    // L1 on every worker core, the other op's included, growing down toward that op's circular
-    // buffers. A program only re-checks its CB region against live L1 buffers when it is enqueued,
-    // and the concurrent op is already in flight by then, so an overlap here is silent corruption
-    // rather than a throw.
     const bool use_l1 = !gate.is_sharded() && !cores.has_value() &&
                         gate.logical_shape()[-1] <= SITU_GLU_L1_MAX_HIDDEN && situ_glu_intermediates_fit_l1(gate);
     const std::optional<MemoryConfig> interm_mem =
@@ -984,7 +993,7 @@ Tensor situ_glu(
     }
     // Pin the output placement, or multiply would inherit situ_a's L1 config and make placement
     // depend on the hidden dim.
-    return ttnn::multiply(situ_a, up_half, std::nullopt, output_mem_config.value_or(gate.memory_config()));
+    return ttnn::multiply(situ_a, up_half, std::nullopt, effective_out);
 }
 
 }  // namespace ttnn


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/53625


### Problem description

Currently Kimi K3 uses SiTU only for routed expert, while it should be also used for shared expert and FFN dense layers.

### What's changed
- Applied `ttnn.situ_glu `call inside shared expert and FFN dense layers only on Python level (for now)
- Added sub_core grid support for `ttnn.situ_glu` call
- Changed shapes for `test_shared_expert.py` to be suitable for 5K input size chunk

### Util and DRAM bandwidth for shared expert
<img width="1678" height="328" alt="image" src="https://github.com/user-attachments/assets/886e7364-908d-4247-a4bc-f4da229e76a1" />



### DeepSeek CI

- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)
- [x] [![(Galaxy) Blaze Models Prefill tests ](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/53625-k3-shared-expert-dense-situ)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/53625-k3-shared-expert-dense-situ)