### PR TITLE
[Infrastructure] Run L2 nightly matmul/fused/reduction/moreh unit tests in package-and-release

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -91,8 +91,8 @@ ttnn:
     wh_galaxy: 120
     bh_galaxy: 40
     bh_p100: 805
-    bh_p150b_civ2: 1045
-    wh_n150_civ2: 1215
+    bh_p150b_civ2: 840
+    wh_n150_civ2: 1010
     wh_n300_civ2: 1180
     bh_p150b_civ2_viommu: 115
     bh_p300: 60

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -97,6 +97,9 @@ ttnn:
     bh_p150b_civ2_viommu: 115
     bh_p300: 60
     bh_quietbox_2: 60
+  package_and_release:
+    wh_n150_civ2: 205
+    bh_p150b_civ2: 205
   e2e:
     wh_llmbox: 90
     wh_galaxy: 0

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -21,6 +21,18 @@ on:
         type: string
         default: ''
         description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
+      tests-yaml-path:
+        required: false
+        type: string
+        default: ./tests/pipeline_reorg/ops_unit_tests.yaml
+        description: "Test list to load. Pipelines that own a disjoint slice of the ops suites pass their own yaml."
+      budget-subheading:
+        required: false
+        type: string
+        default: "unit"
+        description: "Key under each team in .github/time_budget.yaml to verify against.
+          Pipelines that run this workflow at different frequencies pass different keys so
+          their budgets are tracked separately (e.g. package_and_release vs the nightly unit)."
       enable-llk-asserts:
         required: false
         type: boolean
@@ -41,7 +53,7 @@ jobs:
     outputs:
       matrix: ${{ steps.filter-categories.outputs.matrix }}
     env:
-      TESTS_YAML_PATH: ./tests/pipeline_reorg/ops_unit_tests.yaml
+      TESTS_YAML_PATH: ${{ inputs.tests-yaml-path }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,7 +71,7 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "unit"
+            "${{ inputs.budget-subheading }}"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -84,6 +84,8 @@ jobs:
         run: |
           matrix='${{ steps.build-matrix.outputs.matrix }}'
           categories='${{ inputs.additional_test_categories }}'
+          # The comparison is exact between commas, strip whitespace first.
+          categories="${categories//[[:space:]]/}"
           filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
           {
             echo "matrix<<EOF"

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -27,6 +27,11 @@ on:
         required: false
         default: ""
         type: string
+      ops-test-categories:
+        description: "Categories from ops_pnr_tests.yaml to run (comma-separated)."
+        required: false
+        default: ""
+        type: string
 
   schedule:
     # Create dev every day at EOD of PST Mon-Fri + night of Sunday to kick off
@@ -53,6 +58,12 @@ env:
   #     SHA3
   DEFAULT_IGNORE_COMMITS: >-
     72e9419a1be562889e1f008cf3e2db495f9e0aa9
+  # Ops unit-test categories every release runs; the ops-test-categories dispatch UI input
+  # overrides this when set, and falls back here when left empty. Keep this value itself
+  # non-empty: the filter matches category names exactly, so an empty list would match
+  # nothing and skip the job. A new category also needs a timeout in ops_pnr_tests.yaml.
+  DEFAULT_OPS_TEST_CATEGORIES: >-
+    matmul,fused,reduction,moreh
 
 # Some explanation:
 # is-release-candidate is always true, unless the workflow is manually dispatched on a tag
@@ -67,6 +78,7 @@ jobs:
       is-release-candidate: ${{ steps.get-is-release-candidate-and-tag-type.outputs.is-release-candidate }}
       tag-type: ${{ steps.get-is-release-candidate-and-tag-type.outputs.tag-type }}
       default-ignore-commits: ${{ steps.set-defaults.outputs.ignore-commits }}
+      default-ops-test-categories: ${{ steps.set-defaults.outputs.ops-test-categories }}
     steps:
       - name: Set default values
         id: set-defaults
@@ -74,6 +86,7 @@ jobs:
         # (i.e., in `uses:` with `with:`), so we must expose env values via job outputs.
         run: |
           echo "ignore-commits=${{ env.DEFAULT_IGNORE_COMMITS }}" >> "$GITHUB_OUTPUT"
+          echo "ops-test-categories=${{ env.DEFAULT_OPS_TEST_CATEGORIES }}" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
@@ -161,6 +174,7 @@ jobs:
       tag-version: ${{ needs.create-tag.outputs.version }}
       is-release-candidate: ${{ needs.release-precheck.outputs.is-release-candidate }}
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
+      ops-test-categories: ${{ inputs.ops-test-categories || needs.release-precheck.outputs.default-ops-test-categories }}
 
   publish-to-pypi:
     needs: [build-test-publish, create-tag]
@@ -654,7 +668,8 @@ jobs:
             {
               "release-type": "rc",
               "dry-run": "${{ inputs.dry-run || 'false' }}",
-              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}"
+              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}",
+              "ops-test-categories": "${{ inputs.ops-test-categories || '' }}"
             }
       - name: Log no action needed
         if: ${{ steps.check-new-commits.outputs.has-new-commits == 'false' }}
@@ -682,5 +697,6 @@ jobs:
             {
               "release-type": "prod",
               "dry-run": "${{ inputs.dry-run || 'false' }}",
-              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}"
+              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}",
+              "ops-test-categories": "${{ inputs.ops-test-categories || '' }}"
             }

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -145,7 +145,7 @@ jobs:
 
   ttnn-ops-unit-tests:
     needs: [build-artifact]
-    if: ${{ inputs.tag-version != '' }}
+    if: ${{ inputs.tag-version != '' && inputs.platform == inputs.main-platform }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -32,6 +32,11 @@ on:
         required: false
         default: ""
         type: string
+      ops-test-categories:
+        description: "Categories to run from ops_pnr_tests.yaml (comma-separated)."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -137,6 +142,23 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: wh_n150,bh_p150
+
+  ttnn-ops-unit-tests:
+    needs: [build-artifact]
+    if: ${{ inputs.tag-version != '' }}
+    permissions:
+      contents: read
+      packages: read
+    secrets: inherit
+    uses: ./.github/workflows/ops-unit-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enabled-skus: wh_n150_civ2,bh_p150b_civ2
+      additional_test_categories: ${{ inputs.ops-test-categories }}
+      tests-yaml-path: ./tests/pipeline_reorg/ops_pnr_tests.yaml
+      budget-subheading: package_and_release
 
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
   # expected-jobs is the union of single-host and exabox multihost legs so a

--- a/tests/pipeline_reorg/ops_pnr_tests.yaml
+++ b/tests/pipeline_reorg/ops_pnr_tests.yaml
@@ -5,7 +5,7 @@
 # ops_unit_tests.yaml; in consequence each (test, sku) leg has exactly
 # one owning pipeline and one time budget.
 
-- name: ttnn nightly matmul tests
+- name: ttnn release matmul tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
     wh_n150_civ2:
@@ -16,7 +16,7 @@
   team: ttnn
   category: matmul
 
-- name: ttnn nightly fused tests
+- name: ttnn release fused tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
     wh_n150_civ2:
@@ -27,7 +27,7 @@
   team: ttnn
   category: fused
 
-- name: ttnn nightly reduction tests
+- name: ttnn release reduction tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/reduction -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
     wh_n150_civ2:
@@ -38,7 +38,7 @@
   team: ttnn
   category: reduction
 
-- name: ttnn nightly moreh tests
+- name: ttnn release moreh tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
     wh_n150_civ2:

--- a/tests/pipeline_reorg/ops_pnr_tests.yaml
+++ b/tests/pipeline_reorg/ops_pnr_tests.yaml
@@ -1,0 +1,50 @@
+# This file defines the test matrix for the ops unit tests that run in
+# package-and-release.
+#
+# Same schema and same impl workflow (ops-unit-tests-impl.yaml) as
+# ops_unit_tests.yaml; in consequence each (test, sku) leg has exactly
+# one owning pipeline and one time budget.
+
+- name: ttnn nightly matmul tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 50
+    bh_p150b_civ2:
+      timeout: 50
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: matmul
+
+- name: ttnn nightly fused tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 65
+    bh_p150b_civ2:
+      timeout: 65
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: fused
+
+- name: ttnn nightly reduction tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/reduction -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 45
+    bh_p150b_civ2:
+      timeout: 45
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: reduction
+
+- name: ttnn nightly moreh tests
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  skus:
+    wh_n150_civ2:
+      timeout: 45
+    bh_p150b_civ2:
+      timeout: 45
+  owner_id: U084B1CES7M # Borys Bradel
+  team: ttnn
+  category: moreh

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -39,13 +39,9 @@
   ai_summary:
     authoritative_job_status: true
   skus:
-    wh_n150_civ2:
-      timeout: 50
     wh_n300_civ2:
       timeout: 50
     bh_p100:
-      timeout: 50
-    bh_p150b_civ2:
       timeout: 50
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
@@ -54,13 +50,9 @@
 - name: ttnn nightly fused tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
-    wh_n150_civ2:
-      timeout: 65
     wh_n300_civ2:
       timeout: 65
     bh_p100:
-      timeout: 65
-    bh_p150b_civ2:
       timeout: 65
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
@@ -71,13 +63,9 @@
   ai_summary:
     authoritative_job_status: true
   skus:
-    wh_n150_civ2:
-      timeout: 45
     wh_n300_civ2:
       timeout: 45
     bh_p100:
-      timeout: 45
-    bh_p150b_civ2:
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn
@@ -234,13 +222,9 @@
 - name: ttnn nightly moreh tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/moreh -xv -m "not disable_fast_runtime_mode" --timeout=600'
   skus:
-    wh_n150_civ2:
-      timeout: 45
     wh_n300_civ2:
       timeout: 45
     bh_p100:
-      timeout: 45
-    bh_p150b_civ2:
       timeout: 45
   owner_id: U084B1CES7M # Borys Bradel
   team: ttnn


### PR DESCRIPTION
### PR Category
CI/Infrastructure

### Summary

Implements #54005: moves the matmul / fused / reduction / moreh nightly op suites off the release SKUs in L2 nightly and into package-and-release. Each of the four platforms stays covered exactly once, and the total test count is unchanged:

| pipeline | SKUs |
|---|---|
| l2-nightly | `wh_n300_civ2`, `bh_p100` |
| package-and-release | `wh_n150_civ2`, `bh_p150b_civ2` |

The split is implemented with a new test list: `ops_pnr_tests.yaml`

### What's changed

- `tests/pipeline_reorg/ops_pnr_tests.yaml` (new file) — the four suites on `wh_n150_civ2` and `bh_p150b_civ2`.
- `tests/pipeline_reorg/ops_unit_tests.yaml` — those two SKUs removed from the same four suites.
- `.github/workflows/ops-unit-tests-impl.yaml` — new `tests-yaml-path` and `budget-subheading` inputs. Both default to today's values.
- `.github/workflows/release-build-test-publish.yaml` — added new `ttnn-ops-unit-tests` job
- `.github/time_budget.yaml` — 205 min per SKU moved from `ttnn.unit` to a new `ttnn.package_and_release` key. Per-SKU totals are unchanged.

One unrelated improvement: the test category filter on input like `conv, pool` silently dropped `pool`, which is now fixed.

### Notes for reviewers

- Note that on merge, the PnR job's first run is also the only coverage WH N150 and BH P150 have for matmul / fused / reduction / moreh.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/54005-move-l2-ops-to-pnr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/54005-move-l2-ops-to-pnr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/54005-move-l2-ops-to-pnr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/54005-move-l2-ops-to-pnr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/54005-move-l2-ops-to-pnr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/54005-move-l2-ops-to-pnr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/54005-move-l2-ops-to-pnr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/54005-move-l2-ops-to-pnr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/54005-move-l2-ops-to-pnr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/54005-move-l2-ops-to-pnr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/54005-move-l2-ops-to-pnr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/54005-move-l2-ops-to-pnr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/54005-move-l2-ops-to-pnr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/54005-move-l2-ops-to-pnr)
