### PR TITLE
[Bug fix] binary_ng: hash the shard volumes on the tensor-scalar path

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -494,3 +494,38 @@ def test_ng_cache_correctness_broadcast_repeated(device, isolate_program_cache):
     for _ in range(3):
         torch_ref, tt_out = run_binary_ng_op(device, ttnn.add, shape_a, shape_b, dtype=ttnn.float32)
         assert_with_pcc(torch_ref, tt_out, 0.9999)
+
+
+def test_ng_cache_miss_sharded_evenness(device, isolate_program_cache):
+    """Same MemoryConfig, differing only in shard evenness -> different cache entries.
+
+    On the tensor-scalar path is_native_L1_sharding() reduces to !is_uneven(a), which reads
+    padded_shape -- and tensor_args_t::to_hash() carries no shape at all. The three shard-volume
+    attributes are the only ones expressing that decision: get_shard_specs() returns nullopt for the
+    uneven case, so they stay nullopt there and are set for the even one. Leaving them unset on both,
+    as the scalar overload of prim::binary_ng did, collides two calls that create_descriptor compiles
+    different reader/writer variants for.
+
+    Uneven runs first on purpose: the even-then-uneven order drives the cached SRC_SHARDED reader
+    with a_num_tiles == 0, which pushes no tiles and hangs the compute kernel in cb_wait_front.
+
+    On the unfixed build the second call fails its PCC check, having run the interleaved program
+    the first call compiled. The entry count is asserted as well because that corruption depends on
+    the shape pair, while the missing cache key does not.
+    """
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))}),
+        (64, 32),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    # 96 rows over a 64-row shard leaves a partial shard -> interleaved program.
+    torch_ref1, tt_out1 = run_scalar_ng_op(device, ttnn.add, [1, 1, 96, 32], 5.0, memory_config=mem_config)
+    assert_with_pcc(torch_ref1, tt_out1, 0.999)
+
+    # 128 rows divides evenly -> native L1 sharded program, with nothing else in the key changed.
+    torch_ref2, tt_out2 = run_scalar_ng_op(device, ttnn.add, [1, 1, 128, 32], 5.0, memory_config=mem_config)
+    assert_with_pcc(torch_ref2, tt_out2, 0.999)
+
+    assert device.cache_entries_counter.total == 2

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -736,6 +736,20 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         std::nullopt};
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
+    // The shard volumes are the only program-cache attributes carrying the sharded-vs-interleaved
+    // decision, and for the scalar path that decision reduces to is_uneven(a) -- a function of
+    // padded_shape, which tensor_args_t::to_hash() deliberately excludes. Leaving them nullopt lets
+    // an evenly-sharded and an unevenly-sharded call with the same MemoryConfig share one program,
+    // even though create_descriptor compiles SRC_SHARDED/DST_SHARDED from that decision.
+    const auto shard_volumes = ttnn::operations::binary_ng::get_shard_volumes(
+        input_tensor_a.tensor_spec(),
+        std::nullopt,
+        OperationType::compute_output_specs(operation_attributes, tensor_args));
+    if (shard_volumes.has_value()) {
+        operation_attributes.a_shard_volume = shard_volumes->a_shard_volume;
+        operation_attributes.b_shard_volume = shard_volumes->b_shard_volume;
+        operation_attributes.c_shard_volume = shard_volumes->c_shard_volume;
+    }
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 


### PR DESCRIPTION
### Ticket

Addresses item 2 of #51218. Deliberately no closing keyword — that issue tracks six defects and this covers one.

### What's wrong

The tensor-scalar overload of `prim::binary_ng` left `a_shard_volume`, `b_shard_volume` and `c_shard_volume` at `nullopt`, where the tensor-tensor overload immediately above it populates them from `get_shard_volumes()`.

Those three attributes are the only entries in `operation_attributes_t` that express the sharded-vs-interleaved decision. On the scalar path that decision is `!is_uneven(a)` (`binary_ng_utils.cpp:766`), and `is_uneven` reads `padded_shape` (`binary_ng_utils.cpp:742`) — which `tensor_args_t::to_hash()` does not carry at all: it hashes only the dtype and memory config of `a` and `b`, no shape (`binary_ng_device_operation.hpp:117`).

So two calls sharing one `MemoryConfig` and differing only in shard evenness produced the same program hash, while `create_descriptor` compiles `SRC_SHARDED`/`DST_SHARDED` and the globally-allocated CBs from that decision. The second call ran the reader/writer variant built for the first.

### What changed

The scalar overload now calls `get_shard_volumes()` and assigns the three attributes, mirroring the tensor-tensor path exactly — same call, same guard, same position between `tensor_args` and `launch`, differing only in passing `std::nullopt` for `b`.

Worth knowing when reading it: the two cases are not distinguished by *different* volume numbers. With one shard spec those would be identical. `get_shard_specs()` returns `nullopt` when `!is_native_L1_sharding` (`binary_ng_program_factory.cpp:103`), so the attributes stay `nullopt` for the uneven call and are set for the even one. The key differs on nullopt-vs-set.

### Test

`test_ng_cache_miss_sharded_evenness` in `test_binary_ng_program_cache.py`, alongside the existing `test_ng_cache_miss_different_*` family. Two `ttnn.add(tensor, 5.0)` calls on one `HEIGHT_SHARDED` L1 config with shard `(64, 32)`: 96 rows leaves a partial shard (uneven → interleaved program), 128 rows divides evenly (native L1 sharded). Per `is_uneven`'s formula, `96 % 64 = 32` and `128 % 64 = 0`.

Two details a reviewer may want to check:

- **Uneven runs first deliberately.** The even-then-uneven order drives the cached `SRC_SHARDED` reader with `a_num_tiles == 0`, which pushes no tiles and hangs the compute kernel in `cb_wait_front`. Not something to put in CI.
- **Both the output and the entry count are asserted.** On the unfixed build the second call fails its PCC check, having run the interleaved program the first call compiled. The count is asserted as well because that corruption depends on the shape pair while the missing cache key does not.

### Measured

Verified by reverting only `binary_ng_device_operation.cpp` to base, rebuilding, and re-running — not by inspection:

| | result |
|---|---|
| new test, fix reverted | fails, PCC on the second (even) call |
| new test, fix applied | passes |
| `test_binary_ng_program_cache.py` + `test_binary_scalar.py` + `test_add.py` | 232 passed, 1 skipped |



