### PR TITLE
Respect CPU affinity when sizing the global executor

### DIFF
--- a/tests/tt_metal/tt_metal/misc/test_executor.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_executor.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#if defined(__linux__)
+#include <sched.h>
+#endif
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
@@ -10,6 +13,35 @@
 #include "common/executor.hpp"
 
 namespace tt::tt_metal {
+
+TEST(ExecutorTest, ThreadCountRespectsCpuAffinity) {
+#if defined(__linux__)
+    cpu_set_t original_affinity;
+    ASSERT_EQ(sched_getaffinity(0, sizeof(original_affinity), &original_affinity), 0);
+
+    int selected_cpu = -1;
+    for (int cpu_index = 0; cpu_index < CPU_SETSIZE; ++cpu_index) {
+        if (CPU_ISSET(cpu_index, &original_affinity)) {
+            selected_cpu = cpu_index;
+            break;
+        }
+    }
+    ASSERT_NE(selected_cpu, -1);
+
+    cpu_set_t restricted_affinity;
+    CPU_ZERO(&restricted_affinity);
+    CPU_SET(selected_cpu, &restricted_affinity);
+    ASSERT_EQ(sched_setaffinity(0, sizeof(restricted_affinity), &restricted_affinity), 0);
+
+    const size_t detected_thread_count = detail::get_executor_thread_count();
+    const int restore_result = sched_setaffinity(0, sizeof(original_affinity), &original_affinity);
+
+    EXPECT_EQ(detected_thread_count, 1);
+    ASSERT_EQ(restore_result, 0);
+#else
+    GTEST_SKIP() << "CPU affinity detection is Linux-specific";
+#endif
+}
 
 TEST(ExecutorTest, AsyncRunsInline) {
     std::atomic<int> value{0};

--- a/tt_metal/common/executor.hpp
+++ b/tt_metal/common/executor.hpp
@@ -8,6 +8,9 @@
 #include <pthread.h>
 #include <unistd.h>
 #endif
+#if defined(__linux__)
+#include <sched.h>
+#endif
 // Include LSan interface only when present
 // __has_feature(leak_sanitizer) / __has_feature(address_sanitizer) for clang
 // compile-time predicates; __SANITIZE_ADDRESS__ / __SANITIZE_LEAK__ for gcc.
@@ -27,7 +30,24 @@
 #include <thread>
 
 namespace tt::tt_metal::detail {
-inline static const size_t EXECUTOR_NTHREADS = std::thread::hardware_concurrency() ? std::thread::hardware_concurrency() : 1;
+inline size_t get_executor_thread_count() {
+#if defined(__linux__)
+    cpu_set_t allowed_cpus;
+    CPU_ZERO(&allowed_cpus);
+    if (sched_getaffinity(0, sizeof(allowed_cpus), &allowed_cpus) == 0) {
+        const int allowed_cpu_count = CPU_COUNT(&allowed_cpus);
+        if (allowed_cpu_count > 0) {
+            return static_cast<size_t>(allowed_cpu_count);
+        }
+    }
+#endif
+    const size_t hardware_thread_count = std::thread::hardware_concurrency();
+    return hardware_thread_count > 0 ? hardware_thread_count : 1;
+}
+
+// hardware_concurrency() can ignore Linux CPU affinity. Respect the effective
+// CPU set to avoid oversubscribing restricted processes.
+inline static const size_t EXECUTOR_NTHREADS = get_executor_thread_count();
 
 using Executor = tf::Executor;
 using ExecTask = tf::Task;


### PR DESCRIPTION
## Summary

- size the global Taskflow executor from the Linux CPU affinity set
- retain `std::thread::hardware_concurrency()` as the fallback
- test detection under a one-CPU affinity

## Motivation

`std::thread::hardware_concurrency()` can report the physical host CPU count inside a CPU-restricted container. The global executor then creates excessive workers. Concurrent JIT compiler subprocesses can exhaust the container process limit and fail with `posix_spawn: Resource temporarily unavailable`.

## Testing

`unit_tests_misc` builds and `ExecutorTest.ThreadCountRespectsCpuAffinity` passes, together with the pre-existing `AsyncRunsInline` and `ForkSafety` cases in that suite. The new test restricts the process to a single CPU with `sched_setaffinity`, checks that `get_executor_thread_count()` reports 1, and restores the original affinity before asserting so a failure cannot leave the process pinned.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bnorris/executor-affinity-20260824)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bnorris/executor-affinity-20260824)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bnorris/executor-affinity-20260824)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bnorris/executor-affinity-20260824)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bnorris/executor-affinity-20260824)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bnorris/executor-affinity-20260824)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bnorris/executor-affinity-20260824)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bnorris/executor-affinity-20260824)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bnorris/executor-affinity-20260824)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bnorris/executor-affinity-20260824)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bnorris/executor-affinity-20260824)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bnorris/executor-affinity-20260824)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bnorris/executor-affinity-20260824)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bnorris/executor-affinity-20260824)
