### PR TITLE
fix sdpa attention mask docs

### DIFF
--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -392,7 +392,7 @@ An end-to-end example of the prefill attention module is in the [attention.py](.
      - `q`: Query tensor of shape `(1, n_q_heads, seqlen, head_dim)`.
      - `k`: Key tensor of shape `(1, n_kv_heads, cache_len, head_dim)`.
      - `v`: Value tensor of shape `(1, n_kv_heads, cache_len, head_dim)`.
-     - `attn_mask`: Defaults to `None`. Shape `(1, n_q_heads or 1, seqlen, cache_len)`. Dim 1 may be `1` to broadcast across heads; dims 2 and 3 must match Q's and K's sequence lengths exactly. Must be on device, `TILE_LAYOUT`, in DRAM, and `bfloat16`, `bfloat8_b` or `bfloat4_b`.
+     - `attn_mask`: Defaults to `None`. Shape `(bsz or 1, n_q_heads or 1, seqlen, cache_len)`, where a `1` in dim 0 or dim 1 broadcasts. Batch is `1` in this prefill flow, but the OP takes the full batch too. Dims 2 and 3 must match Q's and K's sequence lengths exactly. Must be on device, `TILE_LAYOUT`, in DRAM, and `bfloat16`, `bfloat8_b` or `bfloat4_b`.
      - `is_causal`: bool, defaults to `true`. Whether to apply causal masking. Mutually exclusive with `attn_mask` and with `sliding_window_size`. Since the default is `true`, passing `attn_mask` without also setting `is_causal=False` raises.
      - `scale`: float, defaults to `None`.
      - `sliding_window_size`: int, defaults to `None`. With `is_causal=True`, attends only to the last `sliding_window_size` tokens; with `is_causal=False`, to a window centred on the current position. Generated on device, so it cannot be combined with `attn_mask`.
@@ -475,7 +475,7 @@ An end-to-end example of the decode attention module is in the [attention.py](..
      - `k`: Key tensor of shape `(1, bsz, cache_len, head_dim)`.
      - `v`: Value tensor of shape `(1, bsz, cache_len, head_dim)`.
      - `is_causal`: Bool, defaults to `true`. Whether to apply causal masking.
-     - `attn_mask`: Defaults to `None`, and only valid with `is_causal=False`. Dim 2 must match `q`'s dim 2 — the padded per-device head count, not a sequence length — and dim 3 must match `k`'s `cache_len`. `cache_len` must also be a multiple of `k_chunk_size`, which defaults to the largest power-of-two divisor of the sequence length unless `program_config` overrides it. For a reference construction, see the `tt_xattn_mask` reshape in [models/tt_transformers/tt/multimodal/llama_vision_model.py](../../models/tt_transformers/tt/multimodal/llama_vision_model.py), which passes the head dim padded to 32.
+     - `attn_mask`: Defaults to `None`, and only valid with `is_causal=False`. Dim 2 must match `q`'s dim 2 — the padded per-device Q head count, not a sequence length — and dim 3 must match `k`'s `cache_len`. Dim 3 must also be a multiple of `k_chunk_size`: unpaged decode defaults it to `min(512, largest power-of-two divisor of cache_len)`, paged decode defaults it to `32` through `SDPAProgramConfig`, and paged non-causal attention requires an explicit positive `k_chunk_size`. For a reference construction, see the `tt_xattn_mask` reshape in [models/tt_transformers/tt/multimodal/llama_vision_model.py](../../models/tt_transformers/tt/multimodal/llama_vision_model.py), which pads the per-device head count (dim 2) to 32, not the head dimension.
      - `cur_pos`: (Required for is_causal=True) List of current positions in the sequence for each batch. Defaults to `None`. Must be provided if `cur_pos_tensor` is not provided.
      - `cur_pos_tensor`: (Required for is_causal=True) Optional current position tensor. Defaults to `None`. Must be provided if `cur_pos` is not provided.
      - `scale`: Optional scale factor. Defaults to `None`.
@@ -540,6 +540,8 @@ mask_4d = blocked.to(torch.bfloat16) * -1e3
 tt_mask = ttnn.from_torch(mask_4d, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
 ```
 
+This yields `[batch, 1, q_len, kv_len]`, which is the prefill and fused-softmax layout. Decode needs `[1, b, nh, s]` instead — see the table below.
+
 Dim 1 is left at `1` so the mask broadcasts across heads; expand it only if the OP requires an explicit head dimension. If you need the causal half alone, `AttentionMaskConverter(is_causal=True).to_causal_4d(...)` from `transformers.modeling_attn_mask_utils` produces it in one call, using `torch.finfo(dtype).min` as its fill value.
 
 #### Fill values
@@ -553,8 +555,8 @@ Mask shapes are enforced with hard asserts, so a mismatch is a crash rather than
 | OP | Mask shape | Constraint |
 | --- | --- | --- |
 | `scaled_dot_product_attention` | none, with `is_causal=True` | `attn_mask` and `is_causal` are mutually exclusive |
-| `scaled_dot_product_attention` | `(1, n_q_heads or 1, seqlen, cache_len)` | dims 2 and 3 must match Q and K exactly |
-| `scaled_dot_product_attention_decode` | `[1, b, nh, s]` | dim 2 is the padded head count; dim 3 is the KV length and must be a multiple of `k_chunk_size` |
+| `scaled_dot_product_attention` | `(bsz or 1, n_q_heads or 1, seqlen, cache_len)` | dims 2 and 3 must match Q and K exactly |
+| `scaled_dot_product_attention_decode` | `[1, b, nh, s]` | dim 2 is the padded Q head count; dim 3 is the KV length and must be a multiple of `k_chunk_size` |
 | `scale_mask_softmax`, interleaved | height (dim -2) `1` or the tile height (32) | intermediate dims must all be `1`; inner dim and batch must match the input |
 | `scale_mask_softmax`, sharded | equal to the input's padded shape | mask must be in `TILE` layout |
 | `ttnn.add` then `ttnn.softmax` | anything broadcastable | unfused, so slower |

--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -504,7 +504,66 @@ An end-to-end example of the decode attention module is in the [attention.py](..
      (1, bsz, n_q_heads, head_dim) -> (1, 1, bsz, hidden_dim) -> (1, 1, bsz, hidden_dim)
      ```
 
-### 2.4.3 Miscellaneous Facts
+### 2.4.3 Attention Masks
+
+The steps above take a mask as given, but a tokenizer does not produce one in a form any attention OP accepts.
+
+For purely causal attention you do not need this section: prefer `is_causal=True` as described in [2.4.1](#241-attention-prefill) and [2.4.2](#242-attention-decode), which builds causality on device with no mask tensor at all. What follows applies when you do need an explicit mask.
+
+#### Three kinds of mask
+
+| Kind | Origin | Shape |
+| --- | --- | --- |
+| Causal | Structural, derivable from shape alone | `[1, 1, q_len, kv_len]`, upper triangle blocked |
+| Padding | The tokenizer, when batching variable-length inputs | `[batch, seq]`, expanded to 4D |
+| Tile padding | KV length padded up to a multiple of 32 | the padded columns must be masked |
+
+The third is specific to tile-based hardware. Tensors are stored in 32x32 tiles, so a `kv_len` of 100 occupies 128 columns. Those 28 extra columns are part of the tensor the softmax sees; unless they are masked they contribute to its denominator, which raises no error and silently changes the result. Build the mask at the padded width and block the added columns — see the decode path in [models/demos/ttnn_falcon7b/tt/common.py](../../models/demos/ttnn_falcon7b/tt/common.py), which rounds `kv_len` up to a multiple of 32 and fills the added columns with the blocking value.
+
+#### Converting a 2D mask to a 4D additive mask
+
+A tokenizer returns `[batch, seq]`, where `1` marks a real token and `0` marks padding. Attention scores are `[batch, heads, q_len, kv_len]`. Two things must change: the mask gains two axes, and it becomes **additive** — `0` to attend, a large negative value to block — because it is added to the scores before the softmax.
+
+Combine the two halves as booleans first, then convert to additive **once**. Summing two masks that are already additive can overflow the dtype and produce `-inf`, which the fill-value rules below explain how to avoid.
+
+```python
+# Causal half: block j > i.                       -> [q_len, kv_len]
+causal_block = torch.ones(q_len, kv_len, dtype=torch.bool).triu(diagonal=1)
+
+# Padding half: block positions the tokenizer marked as padding.  -> [batch, 1, kv_len]
+padding_block = (attention_mask_2d == 0)[:, None, :]
+
+# Combine, then apply a single fill value.        -> [batch, 1, q_len, kv_len]
+blocked = causal_block[None, None, :, :] | padding_block[:, :, None, :]
+mask_4d = blocked.to(torch.bfloat16) * -1e3
+
+tt_mask = ttnn.from_torch(mask_4d, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+```
+
+Dim 1 is left at `1` so the mask broadcasts across heads; expand it only if the OP requires an explicit head dimension. If you need the causal half alone, `AttentionMaskConverter(is_causal=True).to_causal_4d(...)` from `transformers.modeling_attn_mask_utils` produces it in one call, using `torch.finfo(dtype).min` as its fill value.
+
+#### Fill values
+
+Use a large finite negative number. This codebase uses `-1e3`, and `-1e5` on the sharded softmax path. Avoid `float('-inf')`: a numerically stable softmax subtracts the row maximum, so a fully masked row computes `-inf - (-inf)` and yields `NaN`. Rows can become fully masked in ordinary situations — a padded-out batch entry, or a tile-padded block that falls entirely outside the real sequence. A large finite value keeps those rows well defined. HuggingFace applies the same reasoning, filling with `torch.finfo(dtype).min` rather than `-inf`.
+
+#### Which OP accepts which shape
+
+Mask shapes are enforced with hard asserts, so a mismatch is a crash rather than a silent error.
+
+| OP | Mask shape | Constraint |
+| --- | --- | --- |
+| `scaled_dot_product_attention` | none, with `is_causal=True` | `attn_mask` and `is_causal` are mutually exclusive |
+| `scaled_dot_product_attention` | `(1, n_q_heads or 1, seqlen, cache_len)` | dims 2 and 3 must match Q and K exactly |
+| `scaled_dot_product_attention_decode` | `[1, b, nh, s]` | dim 2 is the padded head count; dim 3 is the KV length and must be a multiple of `k_chunk_size` |
+| `scale_mask_softmax`, interleaved | height (dim -2) `1` or the tile height (32) | intermediate dims must all be `1`; inner dim and batch must match the input |
+| `scale_mask_softmax`, sharded | equal to the input's padded shape | mask must be in `TILE` layout |
+| `ttnn.add` then `ttnn.softmax` | anything broadcastable | unfused, so slower |
+
+Two consequences of the interleaved `scale_mask_softmax` row. A full causal mask of `[batch, 1, q_len, kv_len]` is rejected unless `q_len` is `1` or `32`, so callers on that path reshape to `(batch, 1, -1, 32)`. And since every intermediate dimension must be `1`, it accepts only **head-uniform** masks: a per-head bias — ALiBi, or any learned relative-position bias — needs a separate `ttnn.add` before `ttnn.softmax`, forgoing the fusion.
+
+These constraints are defined in [softmax_device_operation.cpp](../../ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp) and [sdpa_decode_device_operation.cpp](../../ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp); the [softmax OP documentation](../../ttnn/cpp/ttnn/operations/normalization/softmax/docs/Softmax.md) covers the full set of softmax variants.
+
+### 2.4.4 Miscellaneous Facts
 Flash attention and flash decode are the major OPs for attention. They are optimized for latency and throughput, and perform better than vanilla implementations. For more information see: [Flash Attention Tech Report](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/FlashAttention/FlashAttention.md).
 
 Here are some useful details regarding attention OPs for efficient and bug-free code writing:

--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -392,9 +392,11 @@ An end-to-end example of the prefill attention module is in the [attention.py](.
      - `q`: Query tensor of shape `(1, n_q_heads, seqlen, head_dim)`.
      - `k`: Key tensor of shape `(1, n_kv_heads, cache_len, head_dim)`.
      - `v`: Value tensor of shape `(1, n_kv_heads, cache_len, head_dim)`.
-     - `attn_mask`: Defaults to `None`. [b x 1 x cache_len x seqlen]. Head broadcasting is implied.
-     - `is_causal`: bool, defaults to `true`. Whether to apply causal masking.
+     - `attn_mask`: Defaults to `None`. Shape `(1, n_q_heads or 1, seqlen, cache_len)`. Dim 1 may be `1` to broadcast across heads; dims 2 and 3 must match Q's and K's sequence lengths exactly. Must be on device, `TILE_LAYOUT`, in DRAM, and `bfloat16`, `bfloat8_b` or `bfloat4_b`.
+     - `is_causal`: bool, defaults to `true`. Whether to apply causal masking. Mutually exclusive with `attn_mask` and with `sliding_window_size`. Since the default is `true`, passing `attn_mask` without also setting `is_causal=False` raises.
      - `scale`: float, defaults to `None`.
+     - `sliding_window_size`: int, defaults to `None`. With `is_causal=True`, attends only to the last `sliding_window_size` tokens; with `is_causal=False`, to a window centred on the current position. Generated on device, so it cannot be combined with `attn_mask`.
+     - `cu_window_seqlens`: Defaults to `None`. 1D `int32`/`uint32` ROW_MAJOR tensor of cumulative window boundaries, giving block-diagonal attention with the mask built on device. Non-causal, and mutually exclusive with `attn_mask`, `is_causal` and `sliding_window_size`.
      - `program_config`: Defaults to `None`.
      - `compute_kernel_config`: Defaults to `None`.
 
@@ -473,10 +475,11 @@ An end-to-end example of the decode attention module is in the [attention.py](..
      - `k`: Key tensor of shape `(1, bsz, cache_len, head_dim)`.
      - `v`: Value tensor of shape `(1, bsz, cache_len, head_dim)`.
      - `is_causal`: Bool, defaults to `true`. Whether to apply causal masking.
-     - `attn_mask`: Optional attention mask tensor. Defaults to `None` and only used if `is_causal=False`.
+     - `attn_mask`: Defaults to `None`, and only valid with `is_causal=False`. Dim 2 must match `q`'s dim 2 — the padded per-device head count, not a sequence length — and dim 3 must match `k`'s `cache_len`. `cache_len` must also be a multiple of `k_chunk_size`, which defaults to the largest power-of-two divisor of the sequence length unless `program_config` overrides it. For a reference construction, see the `tt_xattn_mask` reshape in [models/tt_transformers/tt/multimodal/llama_vision_model.py](../../models/tt_transformers/tt/multimodal/llama_vision_model.py), which passes the head dim padded to 32.
      - `cur_pos`: (Required for is_causal=True) List of current positions in the sequence for each batch. Defaults to `None`. Must be provided if `cur_pos_tensor` is not provided.
      - `cur_pos_tensor`: (Required for is_causal=True) Optional current position tensor. Defaults to `None`. Must be provided if `cur_pos` is not provided.
      - `scale`: Optional scale factor. Defaults to `None`.
+     - `sliding_window_size`: int, defaults to `None`. Restricts attention to the last `sliding_window_size` tokens, generated on device.
      - `program_config`: Optional program configuration. Defaults to `None`.
      - `compute_kernel_config`: Optional compute kernel configuration. Defaults to `None`.
      - `memory_config`: Optional memory configuration for output tensor. Defaults to `None`.
@@ -487,7 +490,7 @@ An end-to-end example of the decode attention module is in the [attention.py](..
      ```
    - For non-causal attention, `attn_mask` must be provided. An example is in the cross attention case in visual language models. For example:
      ```python
-     attn_output = ttnn.transformer.paged_scaled_dot_product_at tention_decode(Q, K, V, attn_mask=mask, is_causal=False)
+     attn_output = ttnn.transformer.paged_scaled_dot_product_attention_decode(Q, K, V, attn_mask=mask, is_causal=False)
      ```
 
 6. **Output Reshape and Output Matmul**

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa/sdpa_nanobind.cpp
@@ -119,7 +119,8 @@ ttnn::Tensor chunked_scaled_dot_product_attention_wrapper(
 void bind_sdpa(nb::module_& mod) {
     const auto* const doc =
         R"doc(
-        Causal scaled dot product attention. This API mimics the PyTorch API of the same name.
+        Causal scaled dot product attention. `is_causal` defaults to `true` and is mutually exclusive
+        with `attn_mask`, so pass `is_causal=False` when supplying a mask.
         The implementation is FlashAttention-2."
 
         Accepts a `SDPAProgramConfig` which specifies the grid size and chunk tiles in the Q and K sequence lengths. The op parallelizes over `b`, `nqh`, and Q's `s` dimension.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -110,7 +110,7 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
 
     if (!operation_attributes.is_causal) {
         if (tensor_args.attn_mask.has_value()) {
-            // Causal attention verification
+            // Non-causal: an explicit mask is permitted, so validate its shape and dtype
             const auto& mask_tensor = tensor_args.attn_mask.value();
             const auto mask_shape = mask_tensor.padded_shape();
             const auto mask_shape_unpadded = mask_tensor.logical_shape();
@@ -147,8 +147,10 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
                 mask_tensor.dtype());
         }
     } else {
-        // Uncausal attention verification
-        TT_FATAL(not tensor_args.attn_mask.has_value(), "Must not have attn_mask tensor for non-causal attention");
+        // Causal: causality is applied from cur_pos on device, so an explicit mask is rejected
+        TT_FATAL(
+            not tensor_args.attn_mask.has_value(),
+            "attn_mask must not be provided when is_causal=True. Pass is_causal=False to use an explicit mask.");
     }
 
     const auto& paged_geo = operation_attributes.paged_cache_geometry;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -28,6 +28,11 @@ void bind_sdpa_decode(nb::module_& mod) {
         Accepts a `SDPAMultiCoreProgramConfig` which specifies the grid size and chunk tiles in the K/V/Mask sequence lengths (Q chunk tiles is not used). The op parallelizes over `b` and K/V/Mask's `s` dimension.
 
 
+        Shape identifiers used below: `b` is the batch size, `nh` the number of Q heads on this device
+        (`pnh` the same count padded up to the tile height), `nkv` the number of KV heads, `s` the KV
+        sequence length and `dh` the head dimension.
+
+
         Args:
             input_tensor_q (ttnn.Tensor): the input tensor [1 x b x nh x dh]
             input_tensor_k (ttnn.Tensor): the input tensor [b x nkv x   s x dh]
@@ -36,7 +41,11 @@ void bind_sdpa_decode(nb::module_& mod) {
 
         Keyword args:
             is_causal (bool): whether the attention is is_causal. Defaults to `True`.
-            attn_mask (ttnn.Tensor, optional): the input tensor [b x 1 x s x s]. Defaults to `None`.
+            attn_mask (ttnn.Tensor, optional): the input tensor [1 x b x nh x s]; `nh` must match Q's.
+                `s` must be a multiple of `k_chunk_size`: unpaged decode defaults it to
+                `min(512, largest power-of-two divisor of s)`, paged decode defaults it to 32 through
+                `SDPAProgramConfig`, and paged non-causal attention requires an explicit positive
+                `k_chunk_size`. Only valid with `is_causal=False`. Defaults to `None`.
             cur_pos (List of int, optional): list of integers of length b. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             cur_pos_tensor (ttnn.Tensor, optional): [b] tensor of integers of length b. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -206,7 +206,12 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                 TT_FATAL(mask.padded_shape() == expected_shape, "Non-sharded mask shape must match expected shape");
             }
             for (uint32_t i = 1; i < tensors_args.input_tensor.padded_shape().rank() - 2; i++) {
-                TT_FATAL(mask.padded_shape()[i] == 1, "Non-sharded mask intermediate dimensions must be 1");
+                TT_FATAL(
+                    mask.padded_shape()[i] == 1,
+                    "Non-sharded mask intermediate dimensions must be 1, got {} at dimension {}. This path requires "
+                    "head-uniform masks; apply a per-head bias with a separate ttnn::add before ttnn::softmax.",
+                    mask.padded_shape()[i],
+                    i);
             }
             std::visit(
                 [&](const auto& program_config) {
@@ -503,12 +508,15 @@ Tensor scale_mask_softmax(
         TT_FATAL(
             mask.value().padded_shape()[-2] == 1 or
                 mask.value().padded_shape()[-2] == input_tensor.tensor_spec().tile().get_height(),
-            "Mask height must be 1 or input tensor tile height, got: {}",
+            "Mask height must be 1 or input tensor tile height ({}), got: {}. A full causal mask is not accepted "
+            "here; for causal attention use ttnn::transformer::scaled_dot_product_attention with is_causal=true.",
+            input_tensor.tensor_spec().tile().get_height(),
             mask.value().padded_shape()[-2]);
         for (uint32_t i = 1; i < input_tensor.padded_shape().rank() - 2; i++) {
             TT_FATAL(
                 mask.value().padded_shape()[i] == 1,
-                "Mask intermediate dimension {} must be 1, got: {}",
+                "Mask intermediate dimension {} must be 1, got: {}. This path requires head-uniform masks; apply a "
+                "per-head bias with a separate ttnn::add before ttnn::softmax.",
                 i,
                 mask.value().padded_shape()[i]);
         }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/docs/Softmax.md
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/docs/Softmax.md
@@ -461,12 +461,17 @@ result = ttnn.softmax(input_tensor, dim=-1)
 ### Attention with Scale and Mask
 ```python
 import math
+import torch
 
 # Attention scaling factor (1/√d_k)
 scale = 1.0 / math.sqrt(64)
 
-# Create attention mask
-mask = ttnn.rand((1, 1, 32, 64), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+# The mask is additive: it is added to the scores before the softmax, so 0 means
+# attend and a large negative value means ignore. Use a finite value, not -inf.
+mask_torch = torch.zeros((1, 1, 1, 64), dtype=torch.bfloat16)
+mask_torch[..., 48:] = -1e3  # ignore the last 16 key positions
+
+mask = ttnn.from_torch(mask_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
 # Fused scale-mask-softmax
 attention_weights = ttnn.scale_mask_softmax(
@@ -477,6 +482,11 @@ attention_weights = ttnn.scale_mask_softmax(
 )
 ```
 
+> **Mask shape.** The height (dim -2) must be `1` or the tile height, and intermediate dimensions
+> must be `1` — so a full causal mask and any per-head bias are both rejected here. Constructing a
+> mask from a tokenizer's output is covered in
+> [LLMs Tech Report §2.4.3](../../../../../../../tech_reports/LLMs/llms.md#243-attention-masks).
+
 ### Complete Transformer Attention Implementation
 ```python
 def transformer_attention(query, key, value, attention_mask=None, head_dim=64):
@@ -486,13 +496,15 @@ def transformer_attention(query, key, value, attention_mask=None, head_dim=64):
     key_transposed = ttnn.transpose(key, -2, -1)
     attention_scores = ttnn.matmul(query, key_transposed)
 
-    # Step 2: Apply fused scale + mask + softmax
+    # Step 2: Apply fused scale + mask + softmax.
+    # is_causal_mask describes a mask you supply; it does not generate one, and
+    # setting it true without passing a mask raises.
     scale_factor = 1.0 / math.sqrt(head_dim)
     attention_weights = ttnn.scale_mask_softmax(
         input_tensor=attention_scores,
         scale=scale_factor,
         mask=attention_mask,
-        is_causal_mask=True,  # For autoregressive models
+        is_causal_mask=False,
         numeric_stable=True   # For numerical stability
     )
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -305,7 +305,9 @@ void bind_sdpa(nb::module_& mod) {
 
     const auto* const doc =
         R"doc(
-        Causal scaled dot product attention. This API mimics the PyTorch API of the same name.
+        Causal scaled dot product attention. This API mirrors the PyTorch API of the same name, with one
+        difference: `is_causal` defaults to `true` here where PyTorch defaults to `false`, and `is_causal` and
+        `attn_mask` are mutually exclusive. Pass `is_causal=False` when supplying `attn_mask`.
         The implementation is FlashAttention-2."
 
         Accepts a `SDPAProgramConfig` which specifies the grid size and chunk tiles in the Q and K sequence lengths. The op parallelizes over `b`, `nqh`, and Q's `s` dimension.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -305,9 +305,8 @@ void bind_sdpa(nb::module_& mod) {
 
     const auto* const doc =
         R"doc(
-        Causal scaled dot product attention. This API mirrors the PyTorch API of the same name, with one
-        difference: `is_causal` defaults to `true` here where PyTorch defaults to `false`, and `is_causal` and
-        `attn_mask` are mutually exclusive. Pass `is_causal=False` when supplying `attn_mask`.
+        Causal scaled dot product attention. `is_causal` defaults to `true` and is mutually exclusive
+        with `attn_mask`, so pass `is_causal=False` when supplying a mask.
         The implementation is FlashAttention-2."
 
         Accepts a `SDPAProgramConfig` which specifies the grid size and chunk tiles in the Q and K sequence lengths. The op parallelizes over `b`, `nqh`, and Q's `s` dimension.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -110,7 +110,7 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
 
     if (!operation_attributes.is_causal) {
         if (tensor_args.attn_mask.has_value()) {
-            // Causal attention verification
+            // Non-causal: an explicit mask is permitted, so validate its shape and dtype
             const auto& mask_tensor = tensor_args.attn_mask.value();
             const auto mask_shape = mask_tensor.padded_shape();
             const auto mask_shape_unpadded = mask_tensor.logical_shape();
@@ -147,8 +147,10 @@ void SdpaDecodeDeviceOperation::validate_on_program_cache_miss(
                 mask_tensor.dtype());
         }
     } else {
-        // Uncausal attention verification
-        TT_FATAL(not tensor_args.attn_mask.has_value(), "Must not have attn_mask tensor for non-causal attention");
+        // Causal: causality is applied from cur_pos on device, so an explicit mask is rejected
+        TT_FATAL(
+            not tensor_args.attn_mask.has_value(),
+            "attn_mask must not be provided when is_causal=True. Pass is_causal=False to use an explicit mask.");
     }
 
     const auto& paged_geo = operation_attributes.paged_cache_geometry;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -28,6 +28,11 @@ void bind_sdpa_decode(nb::module_& mod) {
         Accepts a `SDPAMultiCoreProgramConfig` which specifies the grid size and chunk tiles in the K/V/Mask sequence lengths (Q chunk tiles is not used). The op parallelizes over `b` and K/V/Mask's `s` dimension.
 
 
+        Shape identifiers used below: `b` is the batch size, `nh` the number of Q heads on this device
+        (`pnh` the same count padded up to the tile height), `nkv` the number of KV heads, `s` the KV
+        sequence length and `dh` the head dimension.
+
+
         Args:
             input_tensor_q (ttnn.Tensor): the input tensor [1 x b x nh x dh]
             input_tensor_k (ttnn.Tensor): the input tensor [b x nkv x   s x dh]
@@ -36,11 +41,11 @@ void bind_sdpa_decode(nb::module_& mod) {
 
         Keyword args:
             is_causal (bool): whether the attention is is_causal. Defaults to `True`.
-            attn_mask (ttnn.Tensor, optional): the input tensor [1 x b x nh x s], where dim 2 is the padded
-                number of Q heads and dim 3 is the KV length. The KV length must be a multiple of
-                `k_chunk_size`, which defaults to the largest power-of-two divisor of the sequence
-                length unless `program_config` overrides it. Only valid with `is_causal=False`.
-                Defaults to `None`.
+            attn_mask (ttnn.Tensor, optional): the input tensor [1 x b x nh x s]; `nh` must match Q's.
+                `s` must be a multiple of `k_chunk_size`: unpaged decode defaults it to
+                `min(512, largest power-of-two divisor of s)`, paged decode defaults it to 32 through
+                `SDPAProgramConfig`, and paged non-causal attention requires an explicit positive
+                `k_chunk_size`. Only valid with `is_causal=False`. Defaults to `None`.
             cur_pos (List of int, optional): list of integers of length b. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             cur_pos_tensor (ttnn.Tensor, optional): [b] tensor of integers of length b. Defaults to `None`.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode_nanobind.cpp
@@ -36,7 +36,11 @@ void bind_sdpa_decode(nb::module_& mod) {
 
         Keyword args:
             is_causal (bool): whether the attention is is_causal. Defaults to `True`.
-            attn_mask (ttnn.Tensor, optional): the input tensor [b x 1 x s x s]. Defaults to `None`.
+            attn_mask (ttnn.Tensor, optional): the input tensor [1 x b x nh x s], where dim 2 is the padded
+                number of Q heads and dim 3 is the KV length. The KV length must be a multiple of
+                `k_chunk_size`, which defaults to the largest power-of-two divisor of the sequence
+                length unless `program_config` overrides it. Only valid with `is_causal=False`.
+                Defaults to `None`.
             cur_pos (List of int, optional): list of integers of length b. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
             cur_pos_tensor (ttnn.Tensor, optional): [b] tensor of integers of length b. Defaults to `None`.

--- a/ttnn/tutorials/basic_python/ttnn_multihead_attention.py
+++ b/ttnn/tutorials/basic_python/ttnn_multihead_attention.py
@@ -83,7 +83,9 @@ def main():
     hidden_size = num_heads * head_size
 
     torch_hidden_states = torch.randn((batch_size, sequence_size, hidden_size), dtype=torch.bfloat16)
-    torch_attention_mask = torch.randn((batch_size, 1, 1, sequence_size), dtype=torch.bfloat16)
+    # Additive padding mask: 0 to attend, a large negative value to ignore. Never -inf.
+    torch_attention_mask = torch.zeros((batch_size, 1, 1, sequence_size), dtype=torch.bfloat16)
+    torch_attention_mask[..., -32:] = -1e3
     torch_query_weight = torch.randn((hidden_size, hidden_size), dtype=torch.bfloat16)
     torch_query_bias = torch.randn((hidden_size,), dtype=torch.bfloat16)
     torch_key_weight = torch.randn((hidden_size, hidden_size), dtype=torch.bfloat16)

--- a/ttnn/tutorials/ttnn_multihead_attention.ipynb
+++ b/ttnn/tutorials/ttnn_multihead_attention.ipynb
@@ -149,7 +149,9 @@
       "metadata": {},
       "source": [
         "torch_hidden_states = torch.randn((batch_size, sequence_size, hidden_size), dtype=torch.bfloat16)\n",
-        "torch_attention_mask = torch.randn((batch_size, 1, 1, sequence_size), dtype=torch.bfloat16)\n",
+        "# Additive padding mask: 0 to attend, a large negative value to ignore. Never -inf.\n",
+        "torch_attention_mask = torch.zeros((batch_size, 1, 1, sequence_size), dtype=torch.bfloat16)\n",
+        "torch_attention_mask[..., -32:] = -1e3\n",
         "torch_query_weight = torch.randn((hidden_size, hidden_size), dtype=torch.bfloat16)\n",
         "torch_query_bias = torch.randn((hidden_size,), dtype=torch.bfloat16)\n",
         "torch_key_weight = torch.randn((hidden_size, hidden_size), dtype=torch.bfloat16)\n",


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Nothing documented how a tokenizer's `[batch, seq]` mask becomes a tensor the
attention ops accept, and two published examples used random tensors as
attention masks (`torch.randn` in the multi-head attention tutorial,
`ttnn.rand` in `Softmax.md`). `Softmax.md`'s transformer example also sets
`is_causal_mask=True` with no mask, which raises.

Two documented shapes were wrong: prefill `attn_mask` had its last two dims
transposed, and decode `attn_mask` was documented as `[b x 1 x s x s]` where
the op requires `[1 x b x nh x s]`.

- Correct both shapes; document `is_causal`/`attn_mask` exclusivity and the
  `k_chunk_size` default.
- Add `llms.md` 2.4.3: three kinds of mask (causal, padding, tile padding),
  2D→4D conversion, why the fill value is finite not `-inf`, and a table of
  which op accepts which shape.
- Replace the random-tensor masks; fix the example that would crash.
- Extend three softmax `TT_FATAL`s to name the remedy, not just the constraint.

Relates to #31129.

### Notes for reviewers
- Every constraint in the new table was triggered on a Wormhole card.
- The two intermediate-dim asserts guard different paths:
  `scale_mask_softmax` vs `validate_on_program_cache_miss` for
  `scale_mask_softmax_in_place`, which is what `attention_softmax_` calls.
- **I could not establish why this codebase uses `-1e3`/`-1e5` over `-inf`.**
  I documented the fully-masked-row `NaN` as the reason and verified that
  mechanism, but not that it's the historical one. Please correct if wrong.