### PR TITLE
[Bug fix] ternary: restore pack data format after LLK row broadcast

### DIFF
--- a/tech_reports/data_formats/reconfig_data_format.md
+++ b/tech_reports/data_formats/reconfig_data_format.md
@@ -60,6 +60,8 @@ The following DataFormat reconfigurations are currently supported:
 - `reconfig_data_format` API should be used to reconfigure the hardware between calls to operations that use CBs of different DataFormats.
 - `pack_reconfig_data_format` API is called independently of `reconfig_data_format`, when the output CB changes DataFormats
 - Programmers should always use the API calls providing both the old and the new operand CB index, as this enables faster reconfiguration and dynamic checks for eligible conversions.
+- Both configurations are sticky hardware state, not scoped to the call that follows. A kernel that retargets the packer at an intermediate CB — an LLK broadcast destination, an activation staging buffer — must hand it back to the output CB before packing its result, or the result is packed in the intermediate CB's format. Where those formats happen to agree the corruption is invisible, so it surfaces only once a caller changes the output dtype.
+- When passing both operands, the old index must be the CB the hardware is actually configured for. The two-operand calls skip the reconfiguration when the two formats match, so a stale or guessed old index silently does nothing.
 
 ## Examples:
 TO DO

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -489,3 +489,174 @@ def test_ternary_addcmul_cache_hit_refreshes_operand_addresses(device):
     assert_with_pcc(reference(2), ttnn.to_torch(out1).float(), 0.99)
 
     device.disable_and_clear_program_cache()
+
+
+# Same width, at least one operand with H==1 -> ROW_BCAST. One case per broadcast position so each of
+# the kernels' three per-operand LLK-broadcast blocks is exercised; one case with two operands
+# broadcast, which is the only multi-block configuration the dispatch admits (all three H==1
+# classifies as OUTER_BCAST instead) and the only one where a block's restore has to hold for the
+# block after it.
+ROW_BCAST_SHAPES = [
+    pytest.param((1, 1, 1, 128), (1, 1, 64, 128), (1, 1, 64, 128), id="bcast_a"),
+    pytest.param((1, 1, 64, 128), (1, 1, 1, 128), (1, 1, 64, 128), id="bcast_b"),
+    pytest.param((1, 1, 64, 128), (1, 1, 64, 128), (1, 1, 1, 128), id="bcast_c"),
+    pytest.param((1, 1, 1, 128), (1, 1, 1, 128), (1, 1, 64, 128), id="bcast_ab"),
+]
+
+ROW_BCAST_OUT_DTYPES = [ttnn.bfloat16, ttnn.float32]
+
+
+def _uniform_bf16(shape, lo, hi):
+    return torch.empty(shape, dtype=torch.bfloat16).uniform_(lo, hi)
+
+
+def _check_row_bcast_output(torch_output, out, out_dtype, computes_new_values):
+    """Assert a row-broadcast result, given a reference computed in fp32.
+
+    bfloat16 output is the control: same kernel, formats happen to agree. Packing in a broadcast CB's
+    bfloat16 format would write half-length tiles into a wider output buffer, so a format regression
+    collapses PCC rather than merely degrading it. `computes_new_values` additionally pins that a
+    FLOAT32 output really carries fp32 precision -- a result packed as bfloat16 would be exactly
+    bfloat16-representable everywhere. That check is meaningless for ops that only select among their
+    inputs, since bfloat16 inputs make bfloat16-representable outputs the correct answer.
+    """
+    assert out.dtype == out_dtype, f"expected {out_dtype} output, got {out.dtype}"
+    result = ttnn.to_torch(out).float()
+    assert_with_pcc(torch_output, result, 0.999)
+    if out_dtype == ttnn.float32 and computes_new_values:
+        assert not torch.equal(
+            result, result.bfloat16().float()
+        ), "FLOAT32 output holds only bfloat16-representable values -- packed in the broadcast CB's format?"
+
+
+@pytest.mark.parametrize("a_shape, b_shape, c_shape", ROW_BCAST_SHAPES)
+@pytest.mark.parametrize("out_dtype", ROW_BCAST_OUT_DTYPES)
+@pytest.mark.parametrize("ttnn_op", [ttnn.addcmul, ttnn.addcdiv])
+def test_addc_row_bcast_preallocated_output_dtype(device, ttnn_op, out_dtype, a_shape, b_shape, c_shape):
+    """Guards the packer restore in the FPU addc row-broadcast compute kernel.
+
+    All-BFLOAT16 inputs on ROW_BCAST shapes select the LLK broadcast path, whose blocks retarget the
+    packer at a broadcast CB carrying the input dtype; the result must still be packed in the output
+    CB's format, which differs whenever a preallocated output tensor changes the dtype.
+    """
+    torch.manual_seed(0)
+
+    torch_a = _uniform_bf16(a_shape, -100, 100)
+    torch_b = _uniform_bf16(b_shape, -100, 100)
+    # Keep the addcdiv denominator away from zero so the reference stays finite.
+    torch_c = _uniform_bf16(c_shape, 1, 100)
+    value = 2.0
+
+    golden_fn = ttnn.get_golden_function(ttnn_op)
+    torch_output = golden_fn(torch_a.float(), torch_b.float(), torch_c.float(), value=value)
+
+    a = ttnn.from_torch(torch_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    c = ttnn.from_torch(torch_c, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.from_torch(torch.zeros(torch_output.shape), dtype=out_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_op(a, b, c, value=value, output_tensor=out)
+
+    _check_row_bcast_output(torch_output, out, out_dtype, computes_new_values=True)
+
+
+def _lerp_operands(a_shape, b_shape, c_shape):
+    return _uniform_bf16(a_shape, -100, 100), _uniform_bf16(b_shape, -100, 100), _uniform_bf16(c_shape, 0, 1)
+
+
+def _lerp_reference(a, b, c):
+    return torch.lerp(a, b, c)
+
+
+def _where_operands(a_shape, b_shape, c_shape):
+    predicate = torch.randint(0, 2, a_shape).to(torch.bfloat16)
+    return predicate, _uniform_bf16(b_shape, -100, 100), _uniform_bf16(c_shape, -100, 100)
+
+
+def _where_reference(a, b, c):
+    return torch.where(a.bool(), b, c)
+
+
+def _snake_beta_reference(a, b, c):
+    s = torch.sin(b * a)
+    return a + (s * s) / c
+
+
+# Every TTT ternary op other than addcmul/addcdiv routes to the same SFPU row-broadcast kernel, so
+# each of them reached the same defect. `where` only selects among its inputs, so an fp32 output of a
+# bfloat16 selection is legitimately bfloat16-representable. snake_beta needs its own shapes and has
+# its own test below.
+#
+# The op and output dtype are one axis so that `where`'s FLOAT32 cases can carry a strict xfail: they
+# fail for a defect unrelated to the pack format restore -- identically so with the kernels reverted --
+# and the mark keeps the body running, so an XPASS means that defect is fixed and the mark must go.
+ROW_BCAST_TTT_CASES = [
+    pytest.param(ttnn.lerp, _lerp_operands, _lerp_reference, True, ttnn.bfloat16, id="lerp-bf16"),
+    pytest.param(ttnn.lerp, _lerp_operands, _lerp_reference, True, ttnn.float32, id="lerp-fp32"),
+    pytest.param(ttnn.where, _where_operands, _where_reference, False, ttnn.bfloat16, id="where-bf16"),
+    pytest.param(
+        ttnn.where,
+        _where_operands,
+        _where_reference,
+        False,
+        ttnn.float32,
+        id="where-fp32",
+        marks=pytest.mark.xfail(
+            strict=True,
+            reason="where with a FLOAT32 preallocated output is broken independently of the pack format restore",
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("a_shape, b_shape, c_shape", ROW_BCAST_SHAPES)
+@pytest.mark.parametrize("ttnn_op, make_operands, reference, computes_new_values, out_dtype", ROW_BCAST_TTT_CASES)
+def test_ttt_row_bcast_preallocated_output_dtype(
+    device, ttnn_op, make_operands, reference, computes_new_values, out_dtype, a_shape, b_shape, c_shape
+):
+    """Guards the packer restore in the TTT SFPU row-broadcast compute kernel.
+
+    Same defect as test_addc_row_bcast_preallocated_output_dtype in the kernel shared by every
+    non-addc TTT ternary op. is_llk_bcast() inspects only the input dtypes, so a FLOAT32 output on
+    BFLOAT16 inputs still selects the broadcast path.
+    """
+    torch.manual_seed(0)
+
+    torch_a, torch_b, torch_c = make_operands(a_shape, b_shape, c_shape)
+    torch_output = reference(torch_a.float(), torch_b.float(), torch_c.float())
+
+    a = ttnn.from_torch(torch_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    c = ttnn.from_torch(torch_c, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.from_torch(torch.zeros(torch_output.shape), dtype=out_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn_op(a, b, c, output_tensor=out)
+
+    _check_row_bcast_output(torch_output, out, out_dtype, computes_new_values)
+
+
+@pytest.mark.parametrize("out_dtype", ROW_BCAST_OUT_DTYPES)
+def test_snake_beta_row_bcast_preallocated_output_dtype(device, out_dtype):
+    """Guards the packer restore for snake_beta, which shares the TTT SFPU row-broadcast kernel.
+
+    snake_beta requires alpha.shape == beta.shape with a non-1 extent only on the last dim, so the
+    only ROW_BCAST configuration it admits broadcasts alpha and beta together -- two blocks, where one
+    block's restore has to hold for the next.
+    """
+    torch.manual_seed(0)
+
+    torch_x = _uniform_bf16((1, 1, 64, 128), -10, 10)
+    torch_alpha = _uniform_bf16((1, 1, 1, 128), -2, 2)
+    # Keep beta away from zero so the reference stays finite.
+    torch_beta = _uniform_bf16((1, 1, 1, 128), 1, 10)
+
+    torch_output = _snake_beta_reference(torch_x.float(), torch_alpha.float(), torch_beta.float())
+
+    x = ttnn.from_torch(torch_x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    alpha = ttnn.from_torch(torch_alpha, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    beta = ttnn.from_torch(torch_beta, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    out = ttnn.from_torch(torch.zeros(torch_output.shape), dtype=out_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn.snake_beta(x, alpha, beta, output_tensor=out)
+
+    _check_row_bcast_output(torch_output, out, out_dtype, computes_new_values=True)

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_rowbcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addc_ops_fpu_rowbcast.cpp
@@ -51,6 +51,11 @@ void kernel_main() {
     compute_kernel_hw_startup(dfb_eff_b.get_id(), dfb_eff_c.get_id(), dfb_out.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        // Each broadcast block below retargets the packer at its broadcast CB and must hand it back
+        // to dfb_out: pack data format is sticky packer state, and the broadcast CBs carry the input
+        // dtypes while dfb_out carries the output dtype, which differ whenever a preallocated output
+        // tensor changes it. The unpack formats need no matching restore -- is_llk_bcast() admits
+        // this path only when all three inputs share one dtype, so every unpack source agrees.
 // 1) Prepare B and C (broadcast if required), then compute mul(B, C) -> DST[0]
 // Perform LLK row broadcast for B if requested
 #if BCAST_B
@@ -67,6 +72,10 @@ void kernel_main() {
         dfb_llk_b.push_back(num_tiles_per_cycle);
         tile_regs_release();
         dfb_in1.pop_front(num_tiles_per_cycle);
+        pack_reconfig_data_format(/*old*/ dfb_llk_b.get_id(), /*new*/ dfb_out.get_id());
+#ifdef ARCH_BLACKHOLE
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out.get_id())));
+#endif
 #endif
 
 // Perform LLK row broadcast for C if requested
@@ -84,6 +93,10 @@ void kernel_main() {
         dfb_llk_c.push_back(num_tiles_per_cycle);
         tile_regs_release();
         dfb_in2.pop_front(num_tiles_per_cycle);
+        pack_reconfig_data_format(/*old*/ dfb_llk_c.get_id(), /*new*/ dfb_out.get_id());
+#ifdef ARCH_BLACKHOLE
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out.get_id())));
+#endif
 #endif
 
 // Perform LLK row broadcast for A if requested (do this before compute regs session)
@@ -101,6 +114,10 @@ void kernel_main() {
         dfb_llk_a.push_back(num_tiles_per_cycle);
         tile_regs_release();
         dfb_in0.pop_front(num_tiles_per_cycle);
+        pack_reconfig_data_format(/*old*/ dfb_llk_a.get_id(), /*new*/ dfb_out.get_id());
+#ifdef ARCH_BLACKHOLE
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out.get_id())));
+#endif
 #endif
 
         // Ensure sources available

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
@@ -58,6 +58,11 @@ void kernel_main() {
     copy_init(dfb_eff_a.get_id());
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        // Each broadcast block below retargets the packer at its broadcast CB and must hand it back
+        // to dfb_out: pack data format is sticky packer state, and the broadcast CBs carry the input
+        // dtypes while dfb_out carries the output dtype, which differ whenever a preallocated output
+        // tensor changes it. The unpack formats need no matching restore -- is_llk_bcast() admits
+        // this path only when all three inputs share one dtype, so every unpack source agrees.
 #if BCAST_A
         {
             dfb_pre_a.wait_front(num_tiles_per_cycle);
@@ -76,6 +81,8 @@ void kernel_main() {
             tile_regs_release();
 
             dfb_pre_a.pop_front(num_tiles_per_cycle);
+            pack_reconfig_data_format(/*old*/ dfb_bcast_a.get_id(), /*new*/ dfb_out.get_id());
+            PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out.get_id())));
         }
 #endif
 
@@ -97,6 +104,8 @@ void kernel_main() {
             tile_regs_release();
 
             dfb_pre_b.pop_front(num_tiles_per_cycle);
+            pack_reconfig_data_format(/*old*/ dfb_bcast_b.get_id(), /*new*/ dfb_out.get_id());
+            PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out.get_id())));
         }
 #endif
 
@@ -118,6 +127,8 @@ void kernel_main() {
             tile_regs_release();
 
             dfb_pre_c.pop_front(num_tiles_per_cycle);
+            pack_reconfig_data_format(/*old*/ dfb_bcast_c.get_id(), /*new*/ dfb_out.get_id());
+            PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out.get_id())));
         }
 #endif
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -204,6 +204,8 @@ void bind_ternary_addcmul(
                  - TILE
 
             Only TTT (tensor-tensor-tensor) variant is supported.
+
+            A preallocated output_tensor may use a different dtype than the inputs; FLOAT32 output with BFLOAT16 inputs is supported.
         )doc",
         "addcmul",
         "ttnn.addcmul",
@@ -261,6 +263,8 @@ void bind_ternary_addcdiv(
                  - TILE
 
             Only TTT (tensor-tensor-tensor) variant is supported.
+
+            A preallocated output_tensor may use a different dtype than the inputs; FLOAT32 output with BFLOAT16 inputs is supported.
         )doc",
         "addcdiv",
         "ttnn.addcdiv",


### PR DESCRIPTION
### Ticket

Addresses items 3 and 4 of #51218 — one defect, present in two kernels.

### What's wrong

Each per-operand LLK row-broadcast block reconfigured the packer to its broadcast CB and never restored it. Pack data format is sticky packer state, so the result computed below the block was packed into `c_3` using the *broadcast* CB's format.

The broadcast CBs (`c_4`/`c_5`/`c_6`) carry the input dtypes while `c_3` carries the output dtype, and those differ whenever a preallocated output tensor changes it. `is_llk_bcast()` inspects only the input dtypes, so a FLOAT32 output on BFLOAT16 inputs still selects the broadcast path. The result is bf16-formatted, half-length tiles written into a wider buffer.

### What changed

Purely additive — six call sites across `ternary_addc_ops_fpu_rowbcast.cpp` and `ternary_sfpu_row_bcast_ttt.cpp`, each broadcast block gaining a restore on the way out:

```cpp
   dfb_in1.pop_front(num_tiles_per_cycle);
+  pack_reconfig_data_format(/*old*/ dfb_llk_b.get_id(), /*new*/ dfb_out.get_id());
+#ifdef ARCH_BLACKHOLE
+  PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(dfb_out.get_id())));
+#endif
```

`llk_pack_hw_configure` pairs with the restore in all ten binary_ng broadcast siblings — arch-gated in the FPU kernels (`eltwise_binary_row_bcast.cpp:67-70`), unconditional in the SFPU ones (`eltwise_binary_sfpu_row_bcast.cpp:94-95`). Each kernel here mirrors its own sibling class. It is not redundant with `compute_kernel_hw_startup`: `eltwise_binary_row_bcast.cpp:44` performs the identical startup and still issues it.

The unpack formats get no matching restore, matching the siblings. That is safe only while `is_llk_bcast()` admits a single input dtype, so the requirement is now stated on `is_llk_bcast()` itself and at the top of each loop rather than left implicit.

Two documentation gaps closed alongside: `addcmul`/`addcdiv`/`where` never mentioned that a preallocated `output_tensor` may carry a different dtype than the inputs (only `lerp` did), and the `reconfig_data_format` tech report never recorded that these configurations are sticky state a temporary retarget must hand back.

### Tests

`test_addc_row_bcast_preallocated_output_dtype` (addcmul/addcdiv) and `test_ttt_row_bcast_preallocated_output_dtype`, in `test_ternary.py`.

- **All three ops sharing the SFPU kernel.** `overwrite_compute_kernel_name_and_defines` routes every non-addc TTT ROW_BCAST op to `ComputeRowBcastTTT`, so `where` and `snake_beta` carried the same defect as `lerp`. `where` is the heaviest consumer of that kernel and had no coverage here — the existing preallocated-output `where` test uses all-FLOAT32 inputs, so `is_llk_bcast()` returns false and it never reaches the kernel.
- **Four shapes.** One per broadcast position, plus one with two operands broadcast. That last is the only multi-block configuration the dispatch admits (all three `H==1` classifies as OUTER_BCAST instead) and the only one where one block's restore has to hold for the block after it.
- **BFLOAT16 output as the control** — same kernel, formats happen to agree.
- **Reference computed in fp32**, not from the bfloat16 operands, and the FLOAT32 cases additionally assert the result is not exactly bfloat16-representable everywhere. PCC against a bf16-rounded reference cannot tell an fp32 result from a bf16-precision one; that check can. It is skipped for `where`, which only selects among its inputs, so bf16-representable output is correct there.

Pre-existing coverage never passed a preallocated output whose dtype differed from the inputs', which is why this survived.

### A second, unrelated defect this exposed

`where` with a FLOAT32 preallocated output on a ROW_BCAST shape returns garbage (PCC ≈ -0.03 to 0.003) **both before and after this change** — verified by running it with the kernel reverted to `main` and with the fix applied, identical failures either way. It is not the pack format restore, and it is not fixed here. Those four cases are `xfail`ed with that reason so the suite records the defect instead of hiding it. `where`'s BFLOAT16 output passes, so this is specific to the differing-dtype path.

### Sibling audit

`unary_bcast_init` appears in exactly two ternary compute kernels — the two fixed here. All ten binary_ng broadcast kernels already restore the pack format. Outside those trees, thirteen more kernels call it: the ten `experimental/quasar/binary_ng` copies all restore, and the three `experimental/bcast_to` kernels never touch `pack_reconfig_data_format`. No third offender.

The ternary column and scalar broadcast kernels are **not applicable** rather than unaudited: they pack exclusively into `dfb_out` and never retarget the packer (`ternary_sfpu_col_scalar_bcast_ttt.cpp:74`, `ternary_addc_ops_fpu_bcast.cpp:88`), relying on reader-side fill instead of an LLK broadcast into an intermediate CB. The defect cannot occur there.

### Follow-ups, not in this PR

- `bfloat8_b` as a preallocated output dtype reaches these kernels with no validation and no coverage — a third distinct pack format. Nothing in `validate_on_program_cache_miss` accepts or rejects it deliberately.
- The three broadcast CBs (`c_4`/`c_5`/`c_6`) are allocated for every TTT ROW_BCAST program, including when `is_llk_bcast()` rejected the LLK path and they are dead, and regardless of which operands actually broadcast. Up to three tile-sized CBs of L1 per core, which also tightens `num_tiles_per_cb` on that path.
- `ternary_sfpu_row_bcast_ttt.cpp` has no program-cache-hit coverage at all, while `override_runtime_arguments` patches output addresses by slot.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iklemenskiTT/51218/ternary-rowbcast-packer-restore)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iklemenskiTT/51218/ternary-rowbcast-packer-restore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iklemenskiTT/51218/ternary-rowbcast-packer-restore)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iklemenskiTT/51218/ternary-rowbcast-packer-restore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iklemenskiTT/51218/ternary-rowbcast-packer-restore)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iklemenskiTT/51218/ternary-rowbcast-packer-restore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iklemenskiTT/51218/ternary-rowbcast-packer-restore)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iklemenskiTT/51218/ternary-rowbcast-packer-restore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iklemenskiTT/51218/ternary-rowbcast-packer-restore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iklemenskiTT/51218/ternary-rowbcast-packer-restore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iklemenskiTT/51218/ternary-rowbcast-packer-restore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iklemenskiTT/51218/ternary-rowbcast-packer-restore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iklemenskiTT/51218/ternary-rowbcast-packer-restore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iklemenskiTT/51218/ternary-rowbcast-packer-restore)