### PR TITLE
[Bug fix] ttnn.topk: honour optional indices_tensor and its index width

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -504,6 +504,48 @@ def test_topk_indices_tensor_too_narrow_raises(device, expect_error):
         ttnn.topk(ttnn_input, k, dim=-1, indices_tensor=indices_tensor)
 
 
+@pytest.mark.parametrize("tensor_under_test", ("indices_tensor", "output_tensor"))
+def test_topk_row_major_tensor_raises(tensor_under_test, device, expect_error):
+    # topk is tile-only: the compute kernel sorts tiles and compute_output_specs hardcodes TILE.
+    k = 32
+    W = 64
+    shape = [1, 1, 32, W]
+
+    ttnn_input = ttnn.from_torch(
+        torch.randn(shape, dtype=torch.bfloat16), ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device
+    )
+
+    if tensor_under_test == "indices_tensor":
+        kwargs = {
+            "indices_tensor": ttnn.from_torch(
+                torch.arange(W, dtype=torch.int32).expand(shape).contiguous(),
+                ttnn.uint16,
+                layout=ttnn.Layout.ROW_MAJOR,
+                device=device,
+            )
+        }
+    else:
+        kwargs = {
+            "output_tensor": (
+                ttnn.from_torch(
+                    torch.zeros([1, 1, 32, k], dtype=torch.bfloat16),
+                    ttnn.bfloat16,
+                    layout=ttnn.Layout.ROW_MAJOR,
+                    device=device,
+                ),
+                ttnn.from_torch(
+                    torch.zeros([1, 1, 32, k], dtype=torch.bfloat16),
+                    ttnn.uint16,
+                    layout=ttnn.Layout.ROW_MAJOR,
+                    device=device,
+                ),
+            )
+        }
+
+    with expect_error(RuntimeError, "must be in tiled format"):
+        ttnn.topk(ttnn_input, k, dim=-1, **kwargs)
+
+
 @pytest.mark.parametrize("largest", [True, False])
 def test_topk_multicore_local_write_correctness(largest, device):
     """

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -463,6 +463,47 @@ def test_topk_indices_tensor_payload_is_used(W, device):
     assert torch.all(returned == payload), "indices_tensor was ignored; the op generated its own iota"
 
 
+@pytest.mark.parametrize("W", (64, 16384), ids=["single_core", "multi_core"])
+@pytest.mark.parametrize("index_dtype", (ttnn.uint16, ttnn.uint32), ids=["uint16", "uint32"])
+def test_topk_indices_tensor_dtype(W, index_dtype, device):
+    torch.manual_seed(0)
+
+    k = 32
+    shape = [1, 1, 32, W]
+
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    iota = torch.arange(W, dtype=torch.int32).expand(shape).contiguous()
+
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    indices_tensor = ttnn.from_torch(iota, index_dtype, layout=ttnn.Layout.TILE, device=device)
+
+    values, indices = ttnn.topk(ttnn_input, k, dim=-1, indices_tensor=indices_tensor)
+
+    assert indices.dtype == index_dtype
+    indices = ttnn.to_torch(indices).to(torch.int64)
+
+    # Indices are the iota, so gathering from the input must reproduce the returned values.
+    assert_equal(torch.gather(torch_input, -1, indices), ttnn.to_torch(values))
+
+
+def test_topk_indices_tensor_too_narrow_raises(device, expect_error):
+    # W is past 65535, so the op resolves the index dtype to UINT32 and sizes the index CB 32-bit,
+    # but the payload here is UINT16. Reject rather than read a 16-bit tensor at a 32-bit stride.
+    k = 32
+    W = 2 * UINT16_MAX + 1
+    shape = [1, 1, 32, W]
+
+    ttnn_input = ttnn.from_torch(
+        torch.randn(shape, dtype=torch.bfloat16), ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device
+    )
+    indices_tensor = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch.int32), ttnn.uint16, layout=ttnn.Layout.TILE, device=device
+    )
+
+    with expect_error(RuntimeError, "must be the same width as the output indices dtype"):
+        ttnn.topk(ttnn_input, k, dim=-1, indices_tensor=indices_tensor)
+
+
 @pytest.mark.parametrize("largest", [True, False])
 def test_topk_multicore_local_write_correctness(largest, device):
     """

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -448,25 +448,26 @@ def test_topk_indices_tensor_on_non_last_dim_raise(device, expect_error):
 
 @pytest.mark.parametrize("W", (64, 16384), ids=["single_core", "multi_core"])
 def test_topk_indices_tensor_payload_is_used(W, device):
-    # The payload is the constant 777 in every column, so the outcome is unambiguous: honoured means
-    # every returned index is 777, ignored means the op generated its own iota instead.
+    # Column i is labelled i + label_offset. A label below the offset means the payload was ignored;
+    # subtracting it recovers the column, so a wrong column is caught too.
     # W=64 takes the single-core factory, W=16384 the multi-core one.
     torch.manual_seed(0)
     k = 32
-    payload = 777
+    label_offset = 20000
     shape = [1, 1, 32, W]
 
-    ttnn_input = ttnn.from_torch(
-        torch.randn(shape, dtype=torch.bfloat16), ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device
-    )
-    indices_tensor = ttnn.from_torch(
-        torch.full(shape, payload, dtype=torch.uint16), ttnn.uint16, layout=ttnn.Layout.TILE, device=device
-    )
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    labels = (torch.arange(W, dtype=torch.int32) + label_offset).expand(shape)
 
-    _, ttnn_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=True, sorted=True, indices_tensor=indices_tensor)
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    indices_tensor = ttnn.from_torch(labels, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
 
-    returned = ttnn.to_torch(ttnn_indices, dtype=torch.uint16)
-    assert torch.all(returned == payload), "indices_tensor was ignored; the op generated its own iota"
+    values, ttnn_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=True, sorted=True, indices_tensor=indices_tensor)
+
+    returned = ttnn.to_torch(ttnn_indices, dtype=torch.uint16).to(torch.int64)
+    assert torch.all(returned >= label_offset), "indices_tensor was ignored; the op generated its own iota"
+    # Each label must name the column whose value was selected.
+    assert_equal(torch.gather(torch_input, -1, returned - label_offset), ttnn.to_torch(values))
 
 
 @pytest.mark.parametrize("W", (64, 16384), ids=["single_core", "multi_core"])
@@ -514,7 +515,7 @@ def test_topk_indices_tensor_too_narrow_raises(device, expect_error):
     # W is past 65535, so the op resolves the index dtype to UINT32 and sizes the index CB 32-bit,
     # but the payload here is UINT16. Reject rather than read a 16-bit tensor at a 32-bit stride.
     k = 32
-    W = 2 * UINT16_MAX + 1
+    W = UINT16_MAX + 1  # smallest width that forces UINT32
     shape = [1, 1, 32, W]
 
     ttnn_input = ttnn.from_torch(
@@ -558,7 +559,7 @@ def test_topk_row_major_tensor_raises(tensor_under_test, device, expect_error):
                     device=device,
                 ),
                 ttnn.from_torch(
-                    torch.zeros([1, 1, 32, k], dtype=torch.bfloat16),
+                    torch.zeros([1, 1, 32, k], dtype=torch.int32),
                     ttnn.uint16,
                     layout=ttnn.Layout.ROW_MAJOR,
                     device=device,

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -486,6 +486,24 @@ def test_topk_indices_tensor_dtype(W, index_dtype, device):
     assert_equal(torch.gather(torch_input, -1, indices), ttnn.to_torch(values))
 
 
+def test_topk_indices_tensor_labels_above_uint16_max(device):
+    k, W = 32, 16384
+    offset = 100_000
+    shape = [1, 1, 32, W]
+
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    labels = (torch.arange(W, dtype=torch.int64) + offset).expand(shape).contiguous()
+
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    indices_tensor = ttnn.from_torch(labels, ttnn.uint32, layout=ttnn.Layout.TILE, device=device)
+
+    values, indices = ttnn.topk(ttnn_input, k, dim=-1, indices_tensor=indices_tensor)
+    indices = ttnn.to_torch(indices).to(torch.int64)
+
+    assert torch.all(indices > UINT16_MAX), "labels were truncated to 16 bits"
+    assert_equal(torch.gather(torch_input, -1, indices - offset), ttnn.to_torch(values))
+
+
 def test_topk_indices_tensor_too_narrow_raises(device, expect_error):
     # W is past 65535, so the op resolves the index dtype to UINT32 and sizes the index CB 32-bit,
     # but the payload here is UINT16. Reject rather than read a 16-bit tensor at a 32-bit stride.

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -40,9 +40,9 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
 
     if pass_indices_tensor:
-        indices_tensor_torch = torch.zeros(shape, dtype=torch_indices_dtype)
-        for i in range(W):
-            indices_tensor_torch[:, :, :, i] = i
+        # The payload must differ from the iota topk generates on its own, or the gather below
+        # cannot tell a read from a regeneration. Column i is labelled W - 1 - i.
+        indices_tensor_torch = (W - 1 - torch.arange(W)).expand(shape).to(torch_indices_dtype)
         indices_tensor = ttnn.from_torch(
             indices_tensor_torch, ttnn_indices_dtype, layout=ttnn.Layout.TILE, device=device
         )
@@ -89,7 +89,13 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     # rounding may also cause more ties than expected
     # the bigger we get, the tighter the distribution of the top K elements, so the pcc will be worse as stability/rounding will cause more ties
     # use cosine similarity on the gathered indices as this will show the top elements are all about the same
-    ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_indices.to(torch.int64))
+    # topk returns the labels it is given, so turn each label back into the column it names.
+    # The labelling above is its own inverse: label L names column W - 1 - L.
+    # Without a payload the op generates plain column indices, so no conversion is needed.
+    ttnn_torch_columns = ttnn_torch_indices.to(torch.int64)
+    if pass_indices_tensor:
+        ttnn_torch_columns = W - 1 - ttnn_torch_columns
+    ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_columns)
     cosine = torch.nn.CosineSimilarity(dim=dim)
     ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
 
@@ -464,7 +470,7 @@ def test_topk_indices_tensor_payload_is_used(W, device):
 
 
 @pytest.mark.parametrize("W", (64, 16384), ids=["single_core", "multi_core"])
-@pytest.mark.parametrize("index_dtype", (ttnn.uint16, ttnn.uint32), ids=["uint16", "uint32"])
+@pytest.mark.parametrize("index_dtype", (ttnn.uint16, ttnn.uint32, ttnn.int32), ids=["uint16", "uint32", "int32"])
 def test_topk_indices_tensor_dtype(W, index_dtype, device):
     torch.manual_seed(0)
 
@@ -472,7 +478,7 @@ def test_topk_indices_tensor_dtype(W, index_dtype, device):
     shape = [1, 1, 32, W]
 
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
-    iota = torch.arange(W, dtype=torch.int32).expand(shape).contiguous()
+    iota = torch.arange(W, dtype=torch.int32).expand(shape)
 
     ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
     indices_tensor = ttnn.from_torch(iota, index_dtype, layout=ttnn.Layout.TILE, device=device)
@@ -492,7 +498,7 @@ def test_topk_indices_tensor_labels_above_uint16_max(device):
     shape = [1, 1, 32, W]
 
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
-    labels = (torch.arange(W, dtype=torch.int64) + offset).expand(shape).contiguous()
+    labels = (torch.arange(W, dtype=torch.int64) + offset).expand(shape)
 
     ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
     indices_tensor = ttnn.from_torch(labels, ttnn.uint32, layout=ttnn.Layout.TILE, device=device)
@@ -536,7 +542,7 @@ def test_topk_row_major_tensor_raises(tensor_under_test, device, expect_error):
     if tensor_under_test == "indices_tensor":
         kwargs = {
             "indices_tensor": ttnn.from_torch(
-                torch.arange(W, dtype=torch.int32).expand(shape).contiguous(),
+                torch.arange(W, dtype=torch.int32).expand(shape),
                 ttnn.uint16,
                 layout=ttnn.Layout.ROW_MAJOR,
                 device=device,

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -440,6 +440,29 @@ def test_topk_indices_tensor_on_non_last_dim_raise(device, expect_error):
         ttnn.topk(ttnn_input, k=k, dim=2, largest=True, sorted=True, indices_tensor=indices_tensor)
 
 
+@pytest.mark.parametrize("W", (64, 16384), ids=["single_core", "multi_core"])
+def test_topk_indices_tensor_payload_is_used(W, device):
+    # The payload is the constant 777 in every column, so the outcome is unambiguous: honoured means
+    # every returned index is 777, ignored means the op generated its own iota instead.
+    # W=64 takes the single-core factory, W=16384 the multi-core one.
+    torch.manual_seed(0)
+    k = 32
+    payload = 777
+    shape = [1, 1, 32, W]
+
+    ttnn_input = ttnn.from_torch(
+        torch.randn(shape, dtype=torch.bfloat16), ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device
+    )
+    indices_tensor = ttnn.from_torch(
+        torch.full(shape, payload, dtype=torch.uint16), ttnn.uint16, layout=ttnn.Layout.TILE, device=device
+    )
+
+    _, ttnn_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=True, sorted=True, indices_tensor=indices_tensor)
+
+    returned = ttnn.to_torch(ttnn_indices, dtype=torch.uint16)
+    assert torch.all(returned == payload), "indices_tensor was ignored; the op generated its own iota"
+
+
 @pytest.mark.parametrize("largest", [True, False])
 def test_topk_multicore_local_write_correctness(largest, device):
     """

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -24,8 +24,8 @@ namespace ttnn::prim {
 
 namespace {
 // The index dtype the op runs at: index CB, generated iota and output tensor all follow it.
-// A preallocated indices output pins it; a 32-bit indices_tensor widens it. UINT16 must not
-// narrow it, or the width check in validate would compare UINT16 with itself and pass.
+// A preallocated indices output pins it; a 32-bit indices_tensor widens it. A UINT16
+// indices_tensor never narrows it -- validate rejects one narrower than the input requires.
 DataType resolve_index_dtype(
     const TopKDeviceOperation::operation_attributes_t& args, const TopKDeviceOperation::tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_outputs.has_value()) {
@@ -227,7 +227,7 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             indices_tensor_dtype == DataType::UINT16 || indices_tensor_dtype == DataType::UINT32 ||
                 indices_tensor_dtype == DataType::INT32,
-            "Optional input tensor must be UINT16, UINT32, or INT32, got: {}",
+            "Optional indices tensor must be UINT16, UINT32, or INT32, got: {}",
             indices_tensor_dtype);
         // fp32 input forces UINT32 index CBs (see compute_output_specs); UINT16 indices would be wrong.
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -219,6 +219,10 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
 
     // Optional indices tensor validation (for pre-allocated indices)
     if (indices_tensor.has_value()) {
+        TT_FATAL(
+            indices_tensor->layout() == Layout::TILE,
+            "Optional indices tensor must be in tiled format, got: {}",
+            indices_tensor->layout());
         const auto indices_tensor_dtype = indices_tensor->dtype();
         TT_FATAL(
             indices_tensor_dtype == DataType::UINT16 || indices_tensor_dtype == DataType::UINT32 ||
@@ -254,8 +258,18 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
 
     // Preallocated output tensor validation
     if (preallocated_outputs.has_value()) {
-        const auto output_tensor0_dtype = std::get<0>(preallocated_outputs.value()).dtype();  // Values tensor
-        const auto output_tensor1_dtype = std::get<1>(preallocated_outputs.value()).dtype();  // Indices tensor
+        const auto& output_tensor0 = std::get<0>(preallocated_outputs.value());  // Values tensor
+        const auto& output_tensor1 = std::get<1>(preallocated_outputs.value());  // Indices tensor
+        TT_FATAL(
+            output_tensor0.layout() == Layout::TILE,
+            "Preallocated output tensor must be in tiled format, got: {}",
+            output_tensor0.layout());
+        TT_FATAL(
+            output_tensor1.layout() == Layout::TILE,
+            "Preallocated indices tensor must be in tiled format, got: {}",
+            output_tensor1.layout());
+        const auto output_tensor0_dtype = output_tensor0.dtype();
+        const auto output_tensor1_dtype = output_tensor1.dtype();
         TT_FATAL(
             output_tensor0_dtype == DataType::BFLOAT16 || output_tensor0_dtype == DataType::BFLOAT8_B ||
                 output_tensor0_dtype == DataType::FLOAT32,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -23,20 +23,21 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
-// Resolves the data type that will be used for the output index tensor: the preallocated indices dtype when
-// provided, otherwise the auto-selected width (UINT16 when the reduced dimension fits in 16 bits, else UINT32).
+// The index dtype the op runs at: index CB, generated iota and output tensor all follow it.
+// A preallocated indices output pins it; a 32-bit indices_tensor widens it. UINT16 must not
+// narrow it, or the width check in validate would compare UINT16 with itself and pass.
 DataType resolve_index_dtype(
     const TopKDeviceOperation::operation_attributes_t& args, const TopKDeviceOperation::tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_outputs.has_value()) {
         return std::get<1>(tensor_args.preallocated_outputs.value()).dtype();
     }
-    const auto input_shape = tensor_args.input.padded_shape();
-    // fp32 input sorts with fp32 dest accumulation, which loads indices as INT32, so it requires
-    // 32-bit indices regardless of dimension size. This must agree with compute_output_specs, or the
-    // index CB format and the single-core cost model describe UInt16 while the output tensor is UINT32.
-    const bool uint16_indices = (input_shape[args.dim] <= std::numeric_limits<uint16_t>::max()) &&
-                                (tensor_args.input.dtype() != DataType::FLOAT32);
-    return uint16_indices ? DataType::UINT16 : DataType::UINT32;
+    if (tensor_args.indices.has_value()) {
+        const auto indices_dtype = tensor_args.indices->dtype();
+        if (indices_dtype == DataType::UINT32 || indices_dtype == DataType::INT32) {
+            return indices_dtype;
+        }
+    }
+    return required_index_dtype(tensor_args.input, args.dim);
 }
 
 // Maps the resolved index dtype onto the circular-buffer data format used by the sort datapath. 16-bit indices
@@ -228,6 +229,14 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             !(input_tensor_dtype == DataType::FLOAT32 && indices_tensor_dtype == DataType::UINT16),
             "Optional indices tensor must be UINT32 when input tensor is FLOAT32, got UINT16");
+        // The reader reads this tensor into the index CB one entry at a time, so the widths must match.
+        // UINT16 is the only 16-bit index dtype; UINT32 and INT32 are both 32-bit and interchangeable.
+        const DataType resolved_index_dtype = resolve_index_dtype(args, tensor_args);
+        TT_FATAL(
+            (indices_tensor_dtype == DataType::UINT16) == (resolved_index_dtype == DataType::UINT16),
+            "Optional indices tensor must be the same width as the output indices dtype {}, got: {}",
+            resolved_index_dtype,
+            indices_tensor_dtype);
         // The reader kernels page a caller-supplied indices tensor with the input's page index
         // (page_id = i * Wt + j), so the two must describe the same tile grid: same padded width
         // and same total number of tiles. A narrower indices tensor is read past the end of its
@@ -348,19 +357,11 @@ TopKDeviceOperation::spec_return_value_t TopKDeviceOperation::compute_output_spe
     auto output_shape = input_tensor.logical_shape();
     output_shape[-1] = args.k;  // Set last dimension to K (number of top elements)
 
-    ttnn::Shape input_shape = input_tensor.padded_shape();
-    // Choose index data type based on dimension size (16-bit vs 32-bit indices).
-    // fp32 input sorts with fp32 dest accumulation, which loads indices as INT32, so it
-    // requires 32-bit (UINT32) indices regardless of dimension size.
-    const bool uint16_output = (input_shape[args.dim] <= std::numeric_limits<uint16_t>::max()) &&
-                               (input_tensor.dtype() != DataType::FLOAT32);  // 65535
-
     // Create values tensor specification (same data type as input)
     const auto values_spec = tt::tt_metal::TensorSpec(
         output_shape, TensorLayout(input_tensor.dtype(), PageConfig(Layout::TILE), args.output_memory_config));
 
-    // Create indices tensor specification (integer type based on dimension size)
-    const DataType index_dtype = uint16_output ? DataType::UINT16 : DataType::UINT32;
+    const DataType index_dtype = resolve_index_dtype(args, tensor_args);
     const auto index_spec = tt::tt_metal::TensorSpec(
         output_shape, TensorLayout(index_dtype, PageConfig(Layout::TILE), args.output_memory_config));
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -190,12 +190,6 @@ ttnn::device_operation::ProgramArtifacts TopKDeviceOperation::TopKSingleCoreProg
     });
 
     // Tensor Parameter Declarations:
-    // The optional input indices tensor is declared only when the caller supplies one, but no build
-    // reads it today: the reader's sole use sits behind `#if not GENERATE_INDICES` and that define is
-    // pinned on (GH issue #36329), so the host condition and the kernel condition do not track each
-    // other. The parameter, its binding and its run arg are provisioned for the fix rather than
-    // consumed, and the declared spec is still re-checked against the supplied tensor every
-    // dispatch.
     spec.tensor_parameters.push_back(TensorParameter{.unique_id = INPUT_TENSOR, .spec = input_tensor.tensor_spec()});
     if (tensor_args.indices.has_value()) {
         spec.tensor_parameters.push_back(TensorParameter{
@@ -217,8 +211,7 @@ ttnn::device_operation::ProgramArtifacts TopKDeviceOperation::TopKSingleCoreProg
         .source = "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp",
         .compiler_options =
             {
-                .defines = {{"GENERATE_INDICES", "1"}},  // tensor_args.indices.has_value() ? "0" : "1" - GH issue:
-                                                         // #36329
+                .defines = {{"GENERATE_INDICES", tensor_args.indices.has_value() ? "0" : "1"}},
             },
         .dfb_bindings =
             {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -6,8 +6,6 @@
 #include "ttnn/operations/reduction/topk/device/topk_constants.hpp"
 #include "ttnn/operations/reduction/topk/device/topk_utils.hpp"
 
-#include <limits>
-
 namespace ttnn::prim {
 
 /**

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -6,6 +6,8 @@
 #include "ttnn/operations/reduction/topk/device/topk_constants.hpp"
 #include "ttnn/operations/reduction/topk/device/topk_utils.hpp"
 
+#include <limits>
+
 namespace ttnn::prim {
 
 /**
@@ -336,6 +338,12 @@ bool verify_single_core_cost(const ttnn::Tensor& input_tensor, uint32_t k, bool 
 
     // Verify that total memory requirement fits within single core's L1 cache
     return memory_cost_local < device->l1_size_per_core();
+}
+
+tt::tt_metal::DataType required_index_dtype(const ttnn::Tensor& input_tensor, int8_t dim) {
+    const bool dim_fits_uint16 = input_tensor.padded_shape()[dim] <= std::numeric_limits<uint16_t>::max();
+    const bool is_fp32 = input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32;
+    return (dim_fits_uint16 && !is_fp32) ? tt::tt_metal::DataType::UINT16 : tt::tt_metal::DataType::UINT32;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.hpp
@@ -56,4 +56,9 @@ bool verify_multi_core_cost(
     uint32_t tile_width = 32);
 
 bool verify_single_core_cost(const ttnn::Tensor& input_tensor, uint32_t k, bool uint16_output);
+
+// The index dtype the op picks on its own: UINT16 if the padded reduced dim fits in 16 bits, else
+// UINT32. fp32 input also forces UINT32 -- it sorts with fp32 dest accumulation, which loads
+// indices as INT32.
+tt::tt_metal::DataType required_index_dtype(const ttnn::Tensor& input_tensor, int8_t dim);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/topk/docs/TopK.md
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/docs/TopK.md
@@ -28,7 +28,7 @@ The operation returns both:
 
 ### Usage Limitations
 
-- Supported index tensor types: `uint16`, `uint32` (a user-provided `indices_tensor` must be `uint32` when the input tensor is `float32`, since fp32 forces UINT32 index CBs)
+- Supported index tensor types: `uint16`, `uint32`, `int32` (a user-provided `indices_tensor` must be `uint32` when the input tensor is `float32`, since fp32 forces UINT32 index CBs)
 - Supported value tensor types: `bfloat16`, `bfloat8_b`, `float32`
 - Input tensor must be in **TILE** layout
 - Input shape must be 4D (after internal transformations)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
@@ -45,7 +45,7 @@ void bind_reduction_topk_operation(nb::module_& mod) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 output_tensor (tuple[ttnn.Tensor, ttnn.Tensor], optional): A tuple with preallocated output tensors for the values and indices. If specified, must be on the same device as :attr:`input_tensor`. Defaults to (`None`, `None`).
                 sub_core_grids (ttnn.CoreRangeSet, optional): Core range set to run the operation on. Defaults to `None`.
-                indices_tensor (ttnn.Tensor, optional): Input tensor containing pre-computed index values. When provided, the operation reads indices from this tensor instead of generating them. Defaults to `None`.
+                indices_tensor (ttnn.Tensor, optional): Input tensor containing pre-computed index values. When provided, the operation returns the labels held in this tensor for the selected elements instead of generating positional indices. It must have the same logical shape as :attr:`input_tensor`, be in TILE layout, and be UINT16, UINT32, or INT32. Its width must match the resolved output index dtype: a UINT16 tensor is rejected when 32-bit indices are required (reduced dimension above 65535, or a `float32` :attr:`input_tensor`), and a UINT32/INT32 tensor widens the output indices to 32-bit. Defaults to `None`.
                 stable (bool, optional): EXPERIMENTAL, best effort only -- do not rely on this for correctness. Asks the LLK's stable bitonic network to break exact-value ties by lowest index rather than by array position. The stable network is an open issue (tenstorrent/tt-metal#33492): it can still return incorrect indices for tied values, and every stable case in the LLK test suite is currently skipped, so a caller passing `True` may get either tie-break. Only Wormhole B0 and Blackhole implement it at all; other architectures raise. Off by default. Defaults to `False`.
 
             Returns:
@@ -72,7 +72,8 @@ void bind_reduction_topk_operation(nb::module_& mod) {
 
                 The :attr:`output_value_tensor` will have the same data type as :attr:`input_tensor` and will be in TILE layout.
                 The :attr:`output_index_tensor` will be in TILE layout. Its data type is UINT16 or UINT32 by default (chosen
-                based on the reduced dimension size), or matches the preallocated index tensor dtype (UINT16, UINT32, or INT32) when one is provided.
+                based on the reduced dimension size), widened to 32-bit by a UINT32 or INT32 :attr:`indices_tensor`, or
+                matching the preallocated index tensor dtype (UINT16, UINT32, or INT32) when one is provided.
 
             Memory Support:
                 - Interleaved: DRAM and L1


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

- Closes #51921
- Fixes #36329

`ttnn.topk` accepted an `indices_tensor` and then ignored it on the single-core path, returning its own generated iota instead of the caller's labels. No error was raised, so callers got indices that did not correspond to the values they were handed. Three further gaps around the same parameter — index width, layout validation, and output dtype — are fixed alongside it.

### Root causes

**Defect 1** — the single-core reader pinned `GENERATE_INDICES` to `"1"`, so the kernel always took the generate branch and the supplied payload was never read. Only the multi-core factory honoured it.

**Defect 2** — the index circular buffer took its width from the output dtype alone. A 32-bit payload read into a 16-bit CB is paged at the wrong stride, so indices came back corrupted with no validation to catch it.

Defects 5–7 are independent validation and documentation gaps on the same parameter.

### Solutions by defect

| Defect | Change |
| --- | --- |
| 1 | `GENERATE_INDICES` is derived from `tensor_args.indices.has_value()`, matching the multi-core factory. |
| 2 | New `required_index_dtype()` holds the auto-width rule; the existing `resolve_index_dtype()` gains payload-driven widening; a `TT_FATAL` rejects a payload whose width does not match the resolved index dtype. |
| 5 | `Layout::TILE` is now required on `indices_tensor` and on both preallocated outputs, not just on the value input. |
| 6 | The output index dtype is derived from the payload, so labels above 65535 survive instead of being truncated. |
| 7 | The `indices_tensor` docstring documents the full contract; `TopK.md` drops the stale "multi-core is uint16-only" claim; error messages corrected; test payloads no longer alias the generated iota. |

Defects 3 (shape validation) and 4 (input transformations) were already fixed on main before this branch — `topk.cpp:434-452` requires the indices tensor to share the input's logical shape and rejects non-last-dim reductions, and `topk.cpp:587-598` pads it in lockstep with the input. No commit here.

### Tests

New:

- `test_topk_indices_tensor_payload_is_used` — a constant payload proves the labels are returned rather than regenerated, on both the single-core and multi-core factories.
- `test_topk_indices_tensor_dtype` — uint16 / uint32 / int32 payloads across both factories; asserts the output dtype and that gathering by the returned indices reproduces the values.
- `test_topk_indices_tensor_labels_above_uint16_max` — labels offset past 65535 survive.
- `test_topk_indices_tensor_too_narrow_raises` — a UINT16 payload is rejected when the input requires 32-bit indices.
- `test_topk_row_major_tensor_raises` — ROW_MAJOR `indices_tensor` and `output_tensor` rejected.

Changed:

- `run_topk_test` labels column `i` as `W - 1 - i` instead of `i`. The old payload was byte-identical to the iota the op generates on its own, so every existing parametrization passed whether or not the payload was read. With the reversed labelling those cases now fail if the payload is ignored.

### Notes for reviewers

- **Contract change:** a UINT32/INT32 `indices_tensor` now produces 32-bit output indices where the op would previously have auto-selected UINT16. Every in-repo caller passes uint16, so nothing downstream changes, but this is user-visible.
- The width check compares bit widths, not dtype names — UINT32 and INT32 are interchangeable for the non-negative positions topk produces.
- `resolve_index_dtype()` returns the payload dtype only when it is 32-bit; a UINT16 payload never narrows the resolved width.
- `required_index_dtype()` is new. It puts the auto-width rule in one place, though only one caller uses it so far.

### Follow-up

Preallocated output index dtype is still not validated against the required width — a UINT16 `output_tensor` indices buffer silently wraps when the input needs 32-bit indices. Tracked in #51959, will be a follow-up PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-51921-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-51921-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-51921-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-51921-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-51921-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-51921-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-51921-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-51921-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-51921-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-51921-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-51921-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-51921-topk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-51921-topk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-51921-topk)