### PR TITLE
[Bug fix] unary: take the output dtype from the preallocated output tensor

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
@@ -440,3 +440,42 @@ def test_unary_inplace_cache_hit_interleaved_readdresses(device):
 
     # One shared program reused across all four differently-addressed in-place hits.
     assert device.cache_entries_counter.total == 1
+
+
+def test_unary_cache_miss_preallocated_output_dtype(device):
+    """A preallocated output's dtype must reach the cache key.
+
+    output_dtype is part of the hashed UnaryParams, but unary_impl derived it from the INPUT while
+    taking only the memory config from the preallocated output. The program factory takes the output
+    CB's data format and page size from the output tensor, and that page size is what the writer
+    reads as page_bytes -- so two calls differing solely in the preallocated output dtype collided
+    and the second ran the first's page size against the other's buffer.
+
+    validate_on_program_cache_miss checks only the shape and layout of the preallocated output, and
+    does not run at all on a hit, so nothing else catches this.
+
+    bfloat16 runs first because its 2048 B pages are the narrower of the two: a collision then
+    leaves an fp32 tile half written, rather than overrunning a 2048 B page.
+    """
+    device.cache_entries_counter.reset()
+
+    shape = [1, 1, 32, 32]
+    torch_a = torch.rand(shape, dtype=torch.bfloat16) - 0.5  # straddle zero so relu does something
+    torch_ref = torch.relu(torch_a)
+
+    input_tensor = ttnn.from_torch(torch_a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    def relu_into(out_dtype):
+        out = ttnn.from_torch(torch.zeros(shape), dtype=out_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        with device.cache_entries_counter.measure():
+            ttnn.relu(input_tensor, output_tensor=out)
+        return ttnn.to_torch(out)
+
+    got_bf16 = relu_into(ttnn.bfloat16)
+    got_fp32 = relu_into(ttnn.float32)
+
+    # relu is exact in both dtypes, so equality rather than a tolerance.
+    assert_equal(torch_ref, got_bf16)
+    assert_equal(torch_ref.float(), got_fp32)
+
+    assert device.cache_entries_counter.total == 2

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -19,7 +19,13 @@ Tensor unary_impl(
     const std::optional<CoreRangeSet>& sub_core_grids) {
     TT_FATAL(!op_chain.empty(), "Op chain cannot be empty");
     DataType input_dtype = input_tensor.dtype();
-    DataType output_dtype = input_dtype;
+    // A preallocated output decides the dtype, the same way it already decides the memory config
+    // below: the program factory takes the output CB's data format and page size from that tensor,
+    // while compute_program_hash sees only this attribute. Defaulting to the input's dtype instead
+    // let two calls differing solely in the preallocated output dtype collide, and the second then
+    // ran the first's page size against the other's buffer. A trailing TYPECAST or BITCAST still
+    // wins below -- both entry points already require the two to agree.
+    DataType output_dtype = optional_output_tensor.has_value() ? optional_output_tensor->dtype() : input_dtype;
     if (op_chain.back().type() == unary::UnaryOpType::TYPECAST ||
         op_chain.back().type() == unary::UnaryOpType::BITCAST) {
         output_dtype = static_cast<DataType>(*op_chain.back().get_param_if<float>(1));


### PR DESCRIPTION
### Ticket

Addresses item 5 of #51218. Deliberately no closing keyword; that issue tracks six defects.

### What's wrong

`unary_impl` derived `output_dtype` from the **input** tensor, while already taking `output_memory_config` from the preallocated output a few lines below.

`output_dtype` is part of the hashed `UnaryParams`, but the program factory derives the output CB's data format and page size from the output **tensor** — and that page size is what the writer kernel reads out of the CB interface as `page_bytes`. So two calls differing solely in the preallocated output's dtype produced the same program hash, and the second ran the first's page size against the other's buffer: half of each fp32 tile written, or a 4096 B write into a 2048 B bfloat16 page.

`validate_on_program_cache_miss` compares only the shape and layout of the preallocated output, and does not run at all on a cache hit, so nothing else catches it.

### What changed

One line: `output_dtype` now starts from the preallocated output's dtype when one is supplied, falling back to the input's dtype otherwise.

A trailing `TYPECAST` or `BITCAST` still takes precedence, exactly as before — the branch that reads the op's target dtype is unchanged and still runs after. That ordering is deliberate rather than incidental: both public entry points already `TT_FATAL` that their target dtype matches the preallocated output (`typecast.cpp:68` and `:86`, `unary.cpp:436`), so the two can never disagree, and no in-repo caller reaches `unary_impl` with a TYPECAST-terminated chain at all — the only other `UnaryOpType::TYPECAST` chain constructions are in the binary_ng program factories, which do not route here.

Deriving the dtype rather than rejecting a mismatch is the issue's first suggested option, and it is the right one: `bfloat16`-in/`FLOAT32`-out is **already correct on a cache miss** — `compute_output_specs` returns the preallocated spec verbatim, the output CB is 4096 B, and the writer's page size matches the fp32 buffer. Only the collision corrupts. A `TT_FATAL` would have regressed a configuration that works on first call in order to fix the second.

The change also brings `fp32_dest_acc_en` and `preserve_fp32_precision` in line with the real output dtype, since both are computed from `output_dtype` below.

### Test

`test_unary_cache_miss_preallocated_output_dtype` in `test_unary_program_cache.py`, alongside the existing `test_unary_cache_miss_*` family and using that file's `cache_entries_counter` convention.

Two `ttnn.relu` calls on one input with a bfloat16 then a FLOAT32 preallocated output. bfloat16 runs first deliberately: its 2048 B pages are the narrower of the two, so a collision leaves an fp32 tile half written rather than overrunning a 2048 B page. `relu` is exact in both dtypes, so the comparison is equality rather than a tolerance.

### Measured

Verified by reverting only `unary.cpp` to base, rebuilding, and re-running — not by inspection:

| | result |
|---|---|
| new test, fix reverted | fails on `assert_equal` for the **FLOAT32** output — real data corruption, not merely a cache-count discrepancy |
| new test, fix applied | passes |
| `test_unary_program_cache.py` + `test_typecast_program_cache.py` + `test_unary.py` + `test_unary_sharding.py` | 1043 passed, 3 xfailed |

The bfloat16 call passes on the unfixed build and the FLOAT32 call fails, which is what binds the test to this defect: the first call compiles its own program, the second reuses it.

Blackhole p100a only (`ARCH_BLACKHOLE`); I have no Wormhole to hand. The defect is in host-side attribute derivation, so it is not architecture-specific, but the numbers above are one architecture.

### Related, not addressed

`tensor_args_t::to_hash()` for binary_ng does not hash the preallocated output tensor either. That is a different op and out of scope here, but worth a look by someone who owns it.

