### PR TITLE
Blaze prefill: certify the three K3 TorusXY matrix rows

### DIFF
--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -127,6 +127,7 @@
   sp_config: sc1
 
 - name: "Kimi-K3-2.8T MLA chunked accuracy 55k@5k (vs golden trace)"
+  fabric_profile: torus_xy
   cmd: |
     export KIMI_K3_HF_MODEL=/mnt/models/blaze/moonshotai/Kimi-K3
 
@@ -402,6 +403,7 @@
   sp_config: sc1
 
 - name: "Kimi-K3-2.8T MoE accuracy 5k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
@@ -418,6 +420,7 @@
   sp_config: sc1
 
 - name: "Kimi-K3-2.8T MoE perf 5k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '


### PR DESCRIPTION
#53133 migrated three K3 rows' pytest selection to TorusXY but did not add `fabric_profile: torus_xy` to their matrix entries. Without it the impl workflow's "Configure TorusXY fabric profile" step never runs, so `PREFILL_TORUS_XY_CERTIFIED=1` / `TT_MESH_GRAPH_DESC_PATH` are unset and the conftest guard skips every torus-fabric item at collection. Each leg collected 1 test, skipped it, and reported green with zero coverage:

- Kimi-K3-2.8T MLA chunked accuracy 55k@5k (vs golden trace)
- Kimi-K3-2.8T MoE accuracy 5k
- Kimi-K3-2.8T MoE perf 5k

Observed in [run 32414437757](https://github.com/tenstorrent/tt-metal/actions/runs/32414437757). The sibling K3 rows edited in the same hunks did get the profile.

Validated on this branch with `test-type=k3_mla_trace,kimi_k3_moe,kimi_k3_moe_perf`: all three legs now execute and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/blaze-k3-torus-xy-profile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/blaze-k3-torus-xy-profile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/blaze-k3-torus-xy-profile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/blaze-k3-torus-xy-profile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/blaze-k3-torus-xy-profile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/blaze-k3-torus-xy-profile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/blaze-k3-torus-xy-profile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/blaze-k3-torus-xy-profile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/blaze-k3-torus-xy-profile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/blaze-k3-torus-xy-profile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/blaze-k3-torus-xy-profile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/blaze-k3-torus-xy-profile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/blaze-k3-torus-xy-profile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/blaze-k3-torus-xy-profile)