### PR TITLE
[Bug fix] tanh_bw: drop the custom program hash that omitted the output tensor

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_tanh.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_tanh.py
@@ -30,6 +30,58 @@ def test_bw_tanh(input_shapes, device):
     assert status
 
 
+@pytest.fixture
+def isolate_program_cache(device):
+    """Ensure the test starts with an empty program cache and cleans up after."""
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def test_bw_tanh_preallocated_output_buffer_type_not_cached(device, isolate_program_cache):
+    """The preallocated input_grad's buffer type must take part in the program-cache key.
+
+    The writer kernel bakes the output buffer's TensorAccessorArgs -- IsDram included -- into its
+    compile-time args, and the host wrapper takes output_memory_config from the INPUT
+    (unary_backward.cpp, output_mem_config.value_or(input.memory_config())), so operation_attributes
+    say DRAM even when the real buffer is L1. validate compares only memory_layout, INTERLEAVED both
+    ways, so the L1 input_grad is accepted. When the two calls collided, the second ran a DRAM
+    accessor against an L1 address and the L1 tensor kept stale data.
+    """
+    torch.manual_seed(0)
+    shape = torch.Size([1, 1, 32, 32])
+
+    in_data, input_tensor = data_gen_with_range(shape, -1.45, 1.45, device, True)
+    grad_data, grad_tensor = data_gen_with_range(shape, -1e4, 1e4, device)
+
+    golden_function = ttnn.get_golden_function(ttnn.tanh_bw)
+    golden_tensor = golden_function(grad_data, in_data)
+
+    # Call 1: no preallocated output -> created interleaved DRAM, writer compiled for DRAM.
+    dram_result = ttnn.tanh_bw(grad_tensor, input_tensor)
+    entries_after_dram = device.num_program_cache_entries()
+
+    # Call 2: identical inputs, preallocated output in L1. Same operation_attributes, so this must
+    # miss the cache on the buffer type alone.
+    l1_input_grad = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    ttnn.tanh_bw(grad_tensor, input_tensor, input_grad=l1_input_grad)
+
+    assert compare_pcc(dram_result, golden_tensor, 0.95)
+    assert compare_pcc([l1_input_grad], golden_tensor, 0.95)
+
+    assert device.num_program_cache_entries() > entries_after_dram, (
+        "L1 preallocated output reused the DRAM program: the output buffer type is missing from "
+        "the program-cache key"
+    )
+
+
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.cpp
@@ -101,22 +101,6 @@ Tensor TanhBwDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t TanhBwDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& grad_output = tensor_args.grad_output;
-    const auto& input_shape = input_tensor.padded_shape();
-    operation::Hash hash = operation::hash_operation<TanhBwDeviceOperation>(
-        args,
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        grad_output.dtype(),
-        grad_output.memory_config(),
-        input_shape.volume());
-
-    return hash;
-}
-
 Tensor launch_tanh_bw(
     const Tensor& grad_output,
     const Tensor& input,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/tanh_bw/device/tanh_bw_device_operation.hpp
@@ -29,7 +29,11 @@ struct TanhBwDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    // No compute_program_hash: the default hashes tensor_args, which is what covers
+    // preallocated_input_grad. The program factory bakes the output buffer's TensorAccessorArgs
+    // (IsDram among them) into the writer's compile-time args, and the host wrapper derives
+    // output_memory_config from the input, so a custom hash omitting that tensor collides across
+    // DRAM and L1 outputs. GeluBwDeviceOperation relies on the default for the same reason.
 };
 
 Tensor launch_tanh_bw(


### PR DESCRIPTION
### Ticket

Addresses item 6 of #51218. 

### What's wrong

`TanhBwDeviceOperation::compute_program_hash` enumerated the input and grad_output dtypes and memory configs plus `padded_shape().volume()` — but never the output tensor.

Two things combine to make that a collision rather than a cosmetic omission:

1. The writer bakes the output buffer's `TensorAccessorArgs` — `IsDram` among them — into its compile-time args (`tanh_bw_program_factory.cpp:90`).
2. The host wrapper derives `output_memory_config` from the **input**: `output_mem_config.value_or(input.memory_config())` (`unary_backward.cpp:300`). Pass a preallocated `input_grad` in L1 without an explicit memory config and the attribute still says DRAM.

So `operation_attributes` cannot distinguish a DRAM output from an L1 one, and the omitted tensor was the only remaining candidate. `validate_on_program_cache_miss` compares only `memory_layout()` (`:45`), which is INTERLEAVED either way — buffer type is never compared — so the L1 output is accepted.

The second call then ran a DRAM accessor against an L1 address. Measured: the L1 tensor comes back holding the zeros it was constructed with, i.e. never written.

### What changed

The override is deleted. `TanhBwInputs` has no custom `to_hash`, so the default hashing reflects over all three of its members — `grad_output`, `input`, and `preallocated_input_grad` — which is exactly what was missing.

### Does the default hash thrash the cache on buffer addresses?

No, and this is the obvious objection to deleting a custom hash, so it is worth stating explicitly. `Tensor::attribute_names` is `("storage", "tensor_spec")` (`ttnn/api/ttnn/tensor/tensor.hpp:252`) and `DeviceStorage`'s attribute tuple is **empty** (`ttnn/api/ttnn/tensor/storage.hpp:187`), so no buffer address enters the key. Granularity moves from `volume()` to the full `TensorSpec` — marginally finer, strictly safer, and `padded_shape` is still covered because it is part of the spec.

`GeluBwDeviceOperation` already relies on the default hash for the same reason, so this brings tanh_bw in line with its sibling rather than inventing a new convention.

A comment on the declaration records why there is deliberately no override, so it does not get helpfully re-added.

### Test

`test_bw_tanh_preallocated_output_buffer_type_not_cached` in `test_backward_tanh.py`. `ttnn.tanh_bw` with no preallocated output (interleaved DRAM), then identical inputs with an L1 `input_grad`. Asserts the output first and the cache-entry count second.

### Measured

Verified by reverting only the two `tanh_bw` device-operation files, rebuilding, and re-running — not by inspection:

| | result |
|---|---|
| new test, fix reverted | fails on the **L1 output's** PCC — the tensor is all zeros, never written |
| new test, fix applied | passes |
| `test_backward_tanh.py` | 7 passed |
| + `test_backward_gelu.py`, `test_tanh_bw_ulp.py`, `test_gelu_bw_ulp.py` | 118 passed |

gelu_bw is included in the regression set deliberately, since it is the sibling whose reliance on the default hash this change appeals to.

Blackhole p100a only (`ARCH_BLACKHOLE`); I have no Wormhole to hand. The defect is in host-side hash construction, so it is not architecture-specific, but the numbers above are one architecture.

### One thing for a reviewer to decide

This test lives in `tests/ttnn/nightly/`, because that is where `test_backward_tanh.py` is. A regression guard for a program-cache-key omission arguably belongs on a faster cadence — if someone re-adds a custom hash, nightly is up to a day of delay. There is no program-cache test file in the backward tree to move it to, and relocating a test between the nightly and main pipelines is a CI-ownership call rather than mine, so I left it in place.

### Related, not addressed

`output_memory_config` in `TanhBwParams` describes the input's memory config rather than the actual output's whenever a preallocated output is supplied. That is harmless for `compute_output_specs`, which returns the preallocated spec verbatim (`:78`), and this change makes it harmless for hashing too — but the attribute is still misleading to read. `unary_impl` and `typecast_impl` both take that value from the preallocated output instead; aligning tanh_bw would be a separate, larger change.

