### PR TITLE
[Models CI] Migrate DeepSeek-V3 unit and module tests to tier 1 Models unit CI

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -353,10 +353,10 @@ models:
     bh_p300: 8
     bh_quietbox_2: 42
   unit:
-    wh_llmbox: 45
+    wh_llmbox: 25
     wh_galaxy_perf: 10
   unit_tier1:
-    wh_llmbox: 86
+    wh_llmbox: 100
     wh_n150: 110
     wh_galaxy: 235
     wh_galaxy_perf: 45
@@ -383,7 +383,7 @@ models:
     bh_p300: 30
     bh_quietbox_2: 21
   integration:
-    wh_llmbox: 30
+    wh_llmbox: 0
   perf:
     wh_galaxy_perf: 55
   device_perf:

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -18,6 +18,7 @@ on:
           - qwen3.6-27b
           - gpt-oss-120b
           - minimax-m3
+          - deepseek-v3
           - whisper
           - gemma-4-12b
           - gemma-4-26b-a4b

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -45,7 +45,6 @@ on:
           - tteager
           - ethernet
           - trace stress
-          - deepseek-modules
       t3000-e2e:
         required: false
         type: boolean

--- a/.github/workflows/t3000-integration-tests.yaml
+++ b/.github/workflows/t3000-integration-tests.yaml
@@ -12,7 +12,6 @@ on:
           - all
           - tteager
           - trace stress
-          - deepseek-modules
       platform:
         required: false
         type: choice

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -11,7 +11,6 @@ on:
         options:
           - all
           - dits
-          - deepseek
           - tttv2 modules
           - qwen3_vl
       platform:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -738,6 +738,42 @@
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
 
+- name: DeepSeek-V3 unit tests
+  cmd: |
+    unset TT_METAL_WATCHER  # tests self-skip under watcher: #36312, #36314
+    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
+    export DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
+    export MESH_DEVICE=T3K
+    fail=0
+    pytest --timeout 60 --durations=0 models/demos/deepseek_v3/tests/unit || fail=1
+    pytest --durations=0 models/demos/deepseek_v3/tests/test_rms_norm.py || fail=1
+    exit $fail
+  model: deepseek-v3
+  model_family: DeepSeek
+  skus:
+    wh_llmbox:
+      timeout: 22
+      tier: 1
+  owner_id: U03HY7MK4BT # Mark O'Connor
+  team: models
+
+- name: DeepSeek-V3 module unit tests (host-side)
+  cmd: |
+    unset TT_METAL_WATCHER
+    export MESH_DEVICE=N150
+    pytest --durations=0 models/demos/deepseek_v3/tests -m t3k_compat \
+      --ignore=models/demos/deepseek_v3/tests/test_rms_norm.py \
+      --ignore=models/demos/deepseek_v3/tests/test_cache_specs_harness.py
+  model: deepseek-v3
+  model_family: DeepSeek
+  skus:
+    wh_n150:
+      timeout: 8
+      tier: 1
+  owner_id: U04N3GWH8F9 # Kartik Paigwar
+  team: models
+
 - name: GPT-OSS-120B (disaggregated prefill) unit tests
   # Single-card PCC units for the gpt_oss_d_p prefill package (standalone: random weights +
   # a self-contained torch reference, no HF_MODEL). Directory glob so the kv-cache / MoE tests

--- a/tests/pipeline_reorg/t3k_integration_tests.yaml
+++ b/tests/pipeline_reorg/t3k_integration_tests.yaml
@@ -45,15 +45,3 @@
 #   owner_id: U06UEFWB4P9 # Colman Glagovich
 #   team: models
 #   model-name: n300 mesh llama3.2-vision
-
-- name: t3k_deepseek_module_tests
-  cmd: |
-    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=T3K
-    pytest models/demos/deepseek_v3/tests -m t3k_compat --durations=0
-  skus:
-    wh_llmbox:
-      timeout: 20
-  owner_id: U04N3GWH8F9 # Kartik Paigwar
-  team: models
-  model-name: deepseek-modules

--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -52,15 +52,6 @@
   team: models
   model-name: dits
 
-- name: t3k_deepseek_tests
-  cmd: run_t3000_deepseek_tests
-  skus:
-    wh_llmbox:
-      timeout: 10
-  owner_id: U03HY7MK4BT # Mark O'Connor
-  team: models
-  model-name: deepseek
-
 - name: t3k_ttnn_multiprocess_slow_tests
   cmd: run_t3000_ttnn_multiprocess_slow_tests
   skus:

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -189,14 +189,6 @@ run_t3000_ttnn_multiprocess_slow_tests() {
   tt-run --mpi-args "$mpi_args" --rank-binding "$mesh2x4_rank_binding" build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4_to_string
 }
 
-run_t3000_deepseek_tests() {
-  uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-
-  export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-dequantized-stacked
-  export DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI
-  MESH_DEVICE=T3K pytest models/demos/deepseek_v3/tests/unit --timeout 60 --durations=0
-}
-
 run_t3000_ccl_tests() {
   # Record the start time
   fail=0


### PR DESCRIPTION
**CI run:** [(Tier 1) Models Unit Tests — `model: deepseek-v3`, all SKUs](https://github.com/tenstorrent/tt-metal/actions/runs/32754817526)

Earlier run [32750904035](https://github.com/tenstorrent/tt-metal/actions/runs/32750904035) had the host-side entry on `cpu_medium`: the T3K leg passed, the CPU leg went 91 passed / 5 failed / 1 error because six of those tests do open the device driver. Entry moved to `wh_n150`; see *Six "host-side" tests are not host-side* below.

---

### Ticket

N/A — CI pipeline migration, continuation of #53911.

### Problem description

Two DeepSeek suites were the last `team: models` entries in T3K pipelines that run no DeepSeek model end to end.

| Job | Pipeline | Runs |
|---|---|---|
| `t3k_deepseek_tests` | `(T3K) T3000 unit tests` | `pytest models/demos/deepseek_v3/tests/unit` — 21 files of ttnn op reference tests pinned to DeepSeek-V3 shapes, dtypes, memory configs and core grids, each driven through trace and no-trace by `utils.run_test` |
| `t3k_deepseek_module_tests` | `(T3K) T3000 integration tests` | `pytest models/demos/deepseek_v3/tests -m t3k_compat` — 8 files, 87 test functions: checkpoint/weight-config plumbing plus `DistributedRMSNorm` / `RMSNorm` forward PCC |

Neither pipeline is where these belong. The T3K unit pipeline's other five jobs are tt-metal, ttnn, multiprocess and UDM suites owned by `scaleout` and `ttnn`; the T3K integration pipeline's remaining two are `tteager` (ttnn) and `trace stress` (scaleout).

### The two suites are disjoint, not nested

Worth stating explicitly, because the paths suggest otherwise — `models/demos/deepseek_v3/tests` is a strict superset of `models/demos/deepseek_v3/tests/unit` on disk.

`-m t3k_compat` selects by marker, and the marker is set as a module-level `pytestmark` in exactly eight files, all at the root of `tests/`:

```
test_cache_specs_harness.py   test_get_weight_config.py   test_rms_norm.py
test_config_helpers.py        test_hf_model_utils.py      test_row_batched_model.py
test_generator_vllm.py        test_lazy_state_dict.py
```

No file under `tests/unit/` carries it (`grep -rn t3k_compat models/demos/deepseek_v3/tests/unit/` is empty), so the module job collects zero op tests and the unit job collects zero module tests. Neither set subsumes the other, so both are kept.

### 85 of the 87 module tests never open a device

The module suite was using a whole LLMBox for 20 minutes to run tests that mostly do not touch hardware:

| File | Tests | Device | Notes |
|---|---|---|---|
| `test_rms_norm.py` | 2 (16 cases) | **T3K mesh** | the only real device test — `DistributedRMSNorm` / `RMSNorm` vs the `DeepseekV3RMSNorm` reference, real layernorm weights, pcc 0.98 |
| `test_cache_specs_harness.py` | 1 | requests a mesh | opt-in: skips unless `DEEPSEEK_V3_CACHE_SPECS_JSONL` is set, which CI never sets |
| `test_get_weight_config.py` | 35 | none | `_FakeMeshDevice` dataclass + `tmp_path` |
| `test_lazy_state_dict.py` | 22 | none | ″ |
| `test_hf_model_utils.py` | 20 | none | ″ |
| `test_generator_vllm.py` | 4 | none | ″ |
| `test_config_helpers.py` | 2 | none | pure functions |
| `test_row_batched_model.py` | 1 | none | `_FakeMeshDevice` + monkeypatch |

So the migration splits by what each set actually needs, rather than carrying the LLMBox requirement across wholesale.

### What changed

| | Was | Now |
|---|---|---|
| Op suite | `t3k_unit_tests.yaml`, `cmd: run_t3000_deepseek_tests`, `wh_llmbox` 10 min | `models_unit_tests.yaml`, **tier 1**, `wh_llmbox` 22 min, joined by `test_rms_norm.py` |
| Module suite | `t3k_integration_tests.yaml`, inlined, `wh_llmbox` 20 min | its one device test folded into the entry above; the rest of the module suite to **tier 1** `wh_n150` 8 min |

Two entries:

- **`DeepSeek-V3 unit tests`** — `wh_llmbox`, 22 min, Mark O'Connor. The op suite plus `test_rms_norm.py`, the only module test that needs the mesh.
- **`DeepSeek-V3 module unit tests (host-side)`** — `wh_n150`, 8 min, Kartik Paigwar. `-m t3k_compat` with `test_rms_norm.py` and `test_cache_specs_harness.py` excluded by `--ignore`.

The two pytest calls in the T3K entry accumulate through `|| fail=1` and `exit $fail`, so a red op test cannot mask a red RMSNorm test — the isolation #53911 wanted, without a second LLMBox job for a single file.

The host-side entry excludes by path rather than by a new marker, so a future device-requiring `t3k_compat` file lands on N150 and fails loudly instead of silently running against a 1x1 mesh. Adding `requires_device` markers to the test files would be tidier but would also have to name every Galaxy system, since `galaxy-deepseek-tests.yaml` runs `-m t3k_compat` too — left to the DeepSeek team.

Both share `model: deepseek-v3` / `model_family: DeepSeek`, so one `workflow_dispatch` filter runs the set — the same shared-identifier pattern as `tt-transformers-common` and `gpt-oss-120b`. `deepseek-v3` added to the tier-1 workflow's `model` enum.

### Six "host-side" tests are not host-side

The first attempt put this entry on `cpu_medium`, on the reading that 85 of the 87 module tests use a `_FakeMeshDevice` dataclass and `tmp_path` and therefore need no accelerator. The CPU leg proved that reading almost right and materially wrong: **91 passed, 5 failed, 1 error in 30.6 s**, every failure the same

```
RuntimeError: TT_FATAL @ tt_metal/llrt/tt_cluster.cpp:123: num_chips > 0
info: No chips detected in the cluster
```

preceded by `Device | Opening user mode device driver (tt_cluster.cpp:227)`. Six tests reach through the fake mesh into the runtime and open the cluster for real:

| Test | File |
|---|---|
| `test_get_weight_config_emit_weight_cache_streams_saved_weights_from_shard_and_save` | `test_get_weight_config.py` |
| `test_get_weight_config_use_weight_cache_rejects_invalid_cache` | ″ |
| `test_get_weight_config_emit_weight_cache_writes_manifest_for_saved_weights` | ″ |
| `test_validate_weight_config_paths_missing_file` | ″ |
| `test_validate_weight_config_paths_error_path_prefix` | ″ |
| `test_initialize_vllm_model_passes_cache_dir_without_enabling_weight_cache` (setup error) | `test_generator_vllm.py` |

They are the `shard_and_save` / cache-validation paths, where saving a real `ttnn` tensor needs the cluster, plus one vllm fixture. So the entry is on `wh_n150` — the smallest SKU that satisfies `num_chips > 0` — and the `cpu_medium` wiring is reverted out of this PR.

Worth recording for whoever picks this up: the CPU runner itself was never the problem. `cpu_medium` scheduled on `f11-ci-cpu-03`, the container started, and 91 tests passed in half a minute. A CPU-only leg is reachable once those six tests stop opening a device, and it needs exactly three things in the pipeline, all no-ops for non-`cpu_*` entries: drop `--device /dev/tenstorrent --privileged -v /sys:/sys` for `cpu_*` SKUs, point the hugepages and MLPerf bind mounts elsewhere there, and add `cpu_medium` to the tier-1 workflow's `ALL_SKUS` and `sku` choices. `setup-job` and `cleanup` are already device-agnostic and need no change.

### Watcher

Both entries `unset TT_METAL_WATCHER`. Neither T3K impl passes `enable-watcher` to `setup-job`, so both suites run watcher-free today; `models-unit-tests-impl.yaml` does pass it, and `setup-job` then exports `TT_METAL_WATCHER=2`. Left alone that would flip `is_watcher_enabled()` and the `@skip_with_watcher` guard in `test_all_gather` / `test_matmul` (#36312, #36314), silently dropping op coverage on arrival — a green job testing less than the one it replaced. Same reason `dit-common` and the TTTv2 entries already unset it.

### Env is trimmed to what each entry consumes

`MESH_DEVICE` is **mandatory** for every pytest run under `models/demos/deepseek_v3/`, not incidental: the package conftest defines its own `mesh_device` fixture that raises `ValueError` when it is unset, and `pytest_collection_modifyitems` calls `get_current_device_type()` and `pytest.exit`s on failure. Each entry therefore sets a value — `T3K` (1x8) on the LLMBox, `N150` (1x1) on the CPU entry, where it is only a name lookup in `SYSTEM_NAME_TO_MESH_SHAPE` because nothing there opens a device.

The rest was verified per suite:

- **T3K entry** keeps the `uv pip install` of the reference requirements (`triton==3.5.1`) and both `DEEPSEEK_V3_*` vars, because `test_rms_norm.py` needs them: `conftest.py`'s `model_path` / `cache_path` / `state_dict` fixtures read the vars, and the test imports `models.demos.deepseek_v3.reference.modeling_deepseek`. Nothing under `tests/unit/` reads either, so folding RMSNorm in is what keeps them in this job at all.
- **Host-side entry** needs neither: the two excluded files are the only consumers.

The op-suite call keeps `--timeout 60`; the RMSNorm and host-side calls pass no `--timeout` so they inherit `pytest.ini`'s `timeout = 300`, exactly as the old integration job did.

`/mnt/MLPerf` is mounted `:ro` in both the old and the new pipeline, so cache behaviour is unchanged; `mlperf-write-access` is the knob if the DeepSeek tensor cache ever needs regenerating.

### Budget moves with the tests

| Team / pipeline / SKU | Was | Now | Used | Why |
|---|---|---|---|---|
| `models.unit_tier1.wh_llmbox` | 86 | 100 | 92 | +22 arriving (10 op + 12 RMSNorm, one job) |
| `models.unit_tier1.wh_n150` | 110 | 110 | 108 | +8 arriving, fits as-is |
| `models.unit.wh_llmbox` | 45 | 25 | 20 | only `t3k_dits_tests` left in the T3K unit registry |
| `models.integration.wh_llmbox` | 30 | 0 | 0 | no `team: models` entry left in any integration registry |

Splitting the module suite is what keeps the LLMBox ask to +22 instead of +30, and puts the other 8 minutes on an N150 instead of a second LLMBox slot.

Verified with the CI check itself across every affected registry and tier:

```
models_unit_tests.yaml     unit tier 1/2/3 → Verification successful
t3k_unit_tests.yaml        unit            → models 20/25 OK
t3k_integration_tests.yaml integration     → Verification successful
```

`prepare_test_matrix.py` also confirmed to emit both entries onto the right runners (`config-t3000`, `N150`), and `bash -n` on the edited shell script passes.

### Dispatch options cleaned up

`deepseek` removed from `t3000-unit-tests.yaml`, `deepseek-modules` from `t3000-integration-tests.yaml` and from `pipeline-select-t3k.yaml`. Left as-is: `silencer.lock.yml` embeds a snapshot of these enums but is gh-aw-generated with a frontmatter hash and marked DO NOT EDIT — it regenerates on its own.

### Not in this PR

- **`t3k_dits_tests`** stays for now. Cross-referenced against the tier-1 `dit-common` job and there is **no overlap**: `dit-common` runs `models/tt_dit/tests/unit/` (conv2d/3d, fused rmsnorm, feedforward, linear, normalization, ring joint attention, solvers), while the T3K job runs `tests/encoders/t5`, `tests/encoders/umt5`, `tests/encoders/clip` and `tests/models/flux1`. The SD3.5 T5 and CLIP encoders, the Wan2.2 UMT5 encoder, and the Flux1 `2x4sp0tp1` transformer case are covered **nowhere** in the tiered registries — the only encoder test anywhere in them is Qwen-Image's `qwen25vl_encoder_pair`. Migrating it needs a further `models.unit_tier1.wh_llmbox` bump (+20 against 8 min of headroom) and a decision on `test_transformer_flux1.py`, which ignores `DIT_UNIT_TEST` and is marked `# TODO: DELETE!`.
- **A CPU-only leg for the module suite.** Blocked on the six tests above opening the device driver, not on infrastructure — the `cpu_medium` run proved the runner and container work. Worth a ticket against the DeepSeek team.
- **`t3k_trace_stress_tests`** is not model related — `test_multi_device_trace.py` imports nothing from `models/`, captures synthetic eltwise/matmul chains on a 1x8 mesh and replays them 15x across 2 command queues. It belongs to `scaleout` where it is.
- **`fail+=$?`** in `run_t3000_unit_tests.sh` is string concatenation, so `fail` accumulates as `"0000"` and is then parsed as octal by `[[ $fail -ne 0 ]]`; an exit code of 8 or 9 raises `value too great for base` instead of failing the job. Not touched here because the migrated entries no longer go through that function, but it still affects `run_t3000_tt_dit_tests` and `run_t3000_trace_stress_tests`.

### Checklist

- [x] (Tier 1) Models Unit Tests — `model: deepseek-v3`, `sku: wh_llmbox (T3000)` — green in [32754817526](https://github.com/tenstorrent/tt-metal/actions/runs/32754817526)
- [x] (Tier 1) Models Unit Tests — `model: deepseek-v3`, `sku: wh_n150 (N150)` — green in [32754817526](https://github.com/tenstorrent/tt-metal/actions/runs/32754817526)
- [ ] (T3K) T3000 unit tests — confirm remaining matrix still builds and runs
- [ ] (T3K) T3000 integration tests — confirm remaining matrix still builds and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
