### PR TITLE
Fix job log downloads broken by gh 2.97 escape-sequence guard

### DIFF
--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -97,7 +97,10 @@ download_logs_for_all_jobs() {
         # https://github.com/tenstorrent/tt-metal/issues/12966
         # We bypass any log download that returned a non-zero exit code so the downloader doesn't crash midway.
         # williamly: We may want to check http status code for robustness in the future again but it may be costly in terms of api calls used.
-        gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || true
+        # We output escape sequences, gh cli >= 2.97.0 requires --allow-escape-sequences else it fails. Fall back to regular call for older images.
+        gh api --allow-escape-sequences /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log 
+            gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log
+            || true
 
         # Download annotations for failed jobs (failure reason) and for CIv2 runner jobs.
         # CIv2 runners emit node-name and card-serial notice annotations at job start

--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -98,9 +98,8 @@ download_logs_for_all_jobs() {
         # We bypass any log download that returned a non-zero exit code so the downloader doesn't crash midway.
         # williamly: We may want to check http status code for robustness in the future again but it may be costly in terms of api calls used.
         # We output escape sequences, gh cli >= 2.97.0 requires --allow-escape-sequences else it fails. Fall back to regular call for older images.
-        gh api --allow-escape-sequences /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log 
-            gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log
-            || true
+        gh api --allow-escape-sequences /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || \
+            gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || true
 
         # Download annotations for failed jobs (failure reason) and for CIv2 runner jobs.
         # CIv2 runners emit node-name and card-serial notice annotations at job start


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
All tt-metal test rows stopped landing in `sw_test.cicd_test` on Aug 14 (job and
pipeline rows kept working). Root cause is the `ubuntu-latest` runner image bump
`ubuntu24/20260720.247` → `20260810.271`, which took GitHub CLI from 2.96.0 to
2.97.0. gh 2.97 refuses to print any response containing terminal escape
sequences, and job logs are full of them because GitHub colorizes the echoed
`run:` lines.

Example job: https://github.com/tenstorrent/tt-metal/actions/runs/32733499699/job/97450878430

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezicTT-patch-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezicTT-patch-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezicTT-patch-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezicTT-patch-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezicTT-patch-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezicTT-patch-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezicTT-patch-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezicTT-patch-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezicTT-patch-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezicTT-patch-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezicTT-patch-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezicTT-patch-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezicTT-patch-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezicTT-patch-3)