### PR TITLE
[LLK] Don't clear the LLK artifact tree on a collect-only pytest pass

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_pytest_plugin.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_pytest_plugin.py
@@ -416,6 +416,7 @@ def pytest_configure(config):
         config.getoption("--compile-producer", default=False),
         config.getoption("--stimuli-only"),
         config.getoption("--use-stimuli"),
+        collect_only=bool(config.option.collectonly),
     )
 
     # Create directories from all processes - lock in create_directories handles race

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -838,11 +838,10 @@ class TestConfig:
             )
             golden_generators_module.get_golden_generator = get_golden_proxied
 
-        # Always have a fresh build when compiling. Under xdist, only the
-        # controller may remove the shared artifact tree; workers can already
-        # be compiling variants under it. Never on a collect-only pass either —
-        # setup_mode still runs while pytest is only counting tests, so this
-        # would wipe a build that a following consumer run is about to read.
+        # Start compilation from a clean artifact directory. With xdist, only
+        # the controller can safely remove shared artifacts because workers may
+        # already be writing to them. Skip cleanup during test collection so a
+        # subsequent consumer run can reuse the existing build.
         if (
             TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]
             and worker_id == "master"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -779,6 +779,7 @@ class TestConfig:
         compile_producer: bool,
         stimuli_only: str = None,
         use_stimuli: str = None,
+        collect_only: bool = False,
     ):
         TestConfig.WORKER_ID = worker_id
 
@@ -839,10 +840,13 @@ class TestConfig:
 
         # Always have a fresh build when compiling. Under xdist, only the
         # controller may remove the shared artifact tree; workers can already
-        # be compiling variants under it.
+        # be compiling variants under it. Never on a collect-only pass either —
+        # setup_mode still runs while pytest is only counting tests, so this
+        # would wipe a build that a following consumer run is about to read.
         if (
             TestConfig.BUILD_MODE in [BuildMode.PRODUCE, BuildMode.DEFAULT]
             and worker_id == "master"
+            and not collect_only
         ):
             shutil.rmtree(TestConfig.ARTEFACTS_DIR.absolute(), ignore_errors=True)
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Keep LLK artifacts intact during `pytest --collect-only`.

### Notes for reviewers
The existing cleanup behavior is unchanged for normal runs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/llk-collect-only-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/llk-collect-only-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/llk-collect-only-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/llk-collect-only-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/llk-collect-only-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/llk-collect-only-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/llk-collect-only-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/llk-collect-only-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/llk-collect-only-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/llk-collect-only-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/llk-collect-only-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/llk-collect-only-artifacts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/llk-collect-only-artifacts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/llk-collect-only-artifacts)