### PR TITLE
[Bug fix] Fix active-ERISC kernel link: define and initialize __global_pointer$

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisc-crt0.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisc-crt0.cc
@@ -20,6 +20,18 @@ static void return_to_base_fw();
 extern "C" void wzerorange(uint32_t* start, uint32_t* end);
 
 extern "C" [[gnu::section(".start"), gnu::optimize("Os")]] void _start(void) {
+    // Initialize the global pointer.  This core is launched by base firmware and so
+    // does not link tmu-crt0.o, which is where every other processor sets gp up.
+    // Must come first: once __global_pointer$ is defined, the linker relaxes nearby
+    // loads to gp-relative addressing, and those would read from a garbage base until
+    // gp holds its intended value.  norelax keeps this sequence itself absolute.
+    __asm__ volatile(
+        ".option push\n"
+        ".option norelax\n"
+        "la gp, __global_pointer$\n"
+        ".option pop" ::
+            : "memory");
+
     extern uint32_t __ldm_bss_start[];
     extern uint32_t __ldm_bss_end[];
     wzerorange(__ldm_bss_start, __ldm_bss_end);

--- a/tt_metal/hw/toolchain/main.ld
+++ b/tt_metal/hw/toolchain/main.ld
@@ -198,7 +198,11 @@ SECTIONS
 
 /* Begin the data area.  */
 #if defined(TYPE_FIRMWARE)
-  PROVIDE(__global_pointer$ = DATA_START + 0x7f0);
+  /* kernels get __global_pointer$ from the firmware ELF via --just-symbols, so it must be in the firmware's symbol
+     table even when the firmware itself never references it.  Every processor must initialize gp in its startup
+     code (tmu-crt0.S, or active_erisc-crt0.cc for the BH erisc0 that skips it) -- defining the symbol lets the
+     linker relax to gp-relative addressing, which reads garbage if gp was never set up.  */
+  __global_pointer$ = DATA_START + 0x7f0;
   .data DATA_START :
 #define SECTION(NEW, PREV) NEW :
 #else


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Cold-cache active-ERISC kernel links on Blackhole fail with:

    undefined reference to `__global_pointer$'

main.ld declared the symbol with PROVIDE(), which emits it only when something in the link references it. The reference comes from tmu-crt0.S, and bh_hal.cpp deliberately omits tmu-crt0.o for ACTIVE_ETH processor_id 0 in 2-erisc mode, since erisc0 is launched by base firmware. So active_erisc firmware links with nothing referencing __global_pointer$, PROVIDE emits nothing, and the symbol never reaches active_erisc.elf.

Kernel linker scripts do not define __global_pointer$; they import it from the firmware ELF via --just-symbols. weaken() already lists it in strong_names, but cannot preserve a symbol that was never emitted. Kernel links do pull in tmu-crt0.o, so the reference goes unresolved.

Defining the symbol is necessary but not sufficient. Once it exists the linker relaxes nearby loads to gp-relative addressing, and BH erisc0 never initialized gp: it skips tmu-crt0.o and active_erisc-crt0.cc:_start did not set it up. A previous attempt (#53968, reverted) changed only the linker script, which turned the link error into a silent runtime failure -- the relaxed load of eth_chan_to_noc_xy in notify_master_router() read from a garbage base, so the local-handshake atomic landed at the wrong NoC address and fabric stalled at REMOTE_HANDSHAKE_COMPLETE on BH + 2-erisc + fabric.

Fix both halves together: define __global_pointer$ unconditionally for TYPE_FIRMWARE, and initialize gp at the top of active_erisc-crt0.cc:_start, mirroring tmu-crt0.S. The setup sequence uses .option norelax so it does not depend on the register it is establishing. All ten Blackhole targets now both define and initialize gp; active_erisc is no longer an outlier.

Addresses are unchanged (brisc stays ffb007f0; active_erisc is ffb00ef0, reflecting its 0x700 mailbox offset). Verified in the generated firmware that gp is loaded at _start+0x8, ahead of the first gp-relative access, and that a kernel linked against the weakened ELF resolves eth_chan_to_noc_xy gp-relative to the correct address.

Wormhole is unaffected: WH ACTIVE_ETH also skips tmu-crt0.o and its erisc-crt0.cc does not set gp, but wh_hal.cpp routes it to erisc-b0-app*.ld rather than the main.ld-generated script, so it keeps PROVIDE and stays on absolute addressing. WH would need the same crt0 change before those scripts could be made unconditional.

Mainly affects silicon: rtoptions force-disables 2-erisc mode under the simulator, so simulator runs largely bypass the affected path while Blackhole silicon, where 2-erisc is the default, hits it on any cold-cache active-eth kernel build. Cached kernels skip the link and so masked it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/gp-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/gp-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/gp-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/gp-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/gp-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/gp-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/gp-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/gp-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/gp-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/gp-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/gp-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/gp-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/gp-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/gp-fix)