### PR TITLE
[Cleanup] Route NoC address construction through an arch-selected backend

### DIFF
--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
@@ -60,7 +60,7 @@ namespace noc_address_backend {
 [[maybe_unused]] static bool is_local(uint64_t noc_addr, uint8_t noc) {
     return NOC_UNICAST_ADDR_X(noc_addr) == my_x[noc] && NOC_UNICAST_ADDR_Y(noc_addr) == my_y[noc];
 }
-[[maybe_unused]] static uint64_t worker(uint32_t x, uint32_t y, uint32_t addr, [[maybe_unused]] uint8_t noc) {
+[[maybe_unused]] static uint64_t worker_address(uint32_t x, uint32_t y, uint32_t addr, [[maybe_unused]] uint8_t noc) {
     return NOC_XY_ADDR(DYNAMIC_NOC_X(noc, x), DYNAMIC_NOC_Y(noc, y), addr);
 }
 }  // namespace noc_address_backend

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
@@ -54,6 +54,16 @@ static void host_assert(bool condition, const char* expression) {
 #define DYNAMIC_NOC_X(noc, x) (x)
 #define DYNAMIC_NOC_Y(noc, y) (y)
 #define NOC_XY_ADDR(x, y, addr) (static_cast<uint64_t>(x) << 32 | static_cast<uint64_t>(y) << 16 | static_cast<uint64_t>(addr))
+// Host mock of the device NoC address backend (see internal/dataflow/noc_address_backend_xy.h),
+// mirroring the macro stubs above.
+namespace noc_address_backend {
+[[maybe_unused]] static bool is_local(uint64_t noc_addr, uint8_t noc) {
+    return NOC_UNICAST_ADDR_X(noc_addr) == my_x[noc] && NOC_UNICAST_ADDR_Y(noc_addr) == my_y[noc];
+}
+[[maybe_unused]] static uint64_t worker(uint32_t x, uint32_t y, uint32_t addr, uint8_t noc) {
+    return NOC_XY_ADDR(DYNAMIC_NOC_X(noc, x), DYNAMIC_NOC_Y(noc, y), addr);
+}
+}  // namespace noc_address_backend
 #endif
 
 #include "api/tensor/tensor_accessor.h"

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
@@ -55,7 +55,8 @@ static void host_assert(bool condition, const char* expression) {
 #define DYNAMIC_NOC_Y(noc, y) (y)
 #define NOC_XY_ADDR(x, y, addr) (static_cast<uint64_t>(x) << 32 | static_cast<uint64_t>(y) << 16 | static_cast<uint64_t>(addr))
 // Host mock of the device NoC address backend (see internal/dataflow/noc_address_backend_xy.h),
-// mirroring the macro stubs above.
+// mirroring the macro stubs above. Required even when no test calls these paths: qualified
+// names in TensorAccessor's member bodies are looked up when the template is parsed.
 namespace noc_address_backend {
 [[maybe_unused]] static bool is_local(uint64_t noc_addr, uint8_t noc) {
     return NOC_UNICAST_ADDR_X(noc_addr) == my_x[noc] && NOC_UNICAST_ADDR_Y(noc_addr) == my_y[noc];

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor.cpp
@@ -60,7 +60,7 @@ namespace noc_address_backend {
 [[maybe_unused]] static bool is_local(uint64_t noc_addr, uint8_t noc) {
     return NOC_UNICAST_ADDR_X(noc_addr) == my_x[noc] && NOC_UNICAST_ADDR_Y(noc_addr) == my_y[noc];
 }
-[[maybe_unused]] static uint64_t worker(uint32_t x, uint32_t y, uint32_t addr, uint8_t noc) {
+[[maybe_unused]] static uint64_t worker(uint32_t x, uint32_t y, uint32_t addr, [[maybe_unused]] uint8_t noc) {
     return NOC_XY_ADDR(DYNAMIC_NOC_X(noc, x), DYNAMIC_NOC_Y(noc, y), addr);
 }
 }  // namespace noc_address_backend

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -6,7 +6,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "internal/debug/noc_zero_guard.h"
-// Arch-specific (resolved by the HAL's per-arch include roots).
 #include "noc_address_backend.h"
 template <typename DSpecT>
 class TensorAccessor;

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -6,6 +6,8 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "internal/debug/noc_zero_guard.h"
+// Arch-specific (resolved by the HAL's per-arch include roots).
+#include "noc_address_backend.h"
 template <typename DSpecT>
 class TensorAccessor;
 

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -151,11 +151,7 @@ public:
         return virtual_x == my_x[noc_id_] && virtual_y == my_y[noc_id_];
     }
 
-    bool is_local_addr(const uint64_t noc_addr) const {
-        uint32_t x = NOC_UNICAST_ADDR_X(noc_addr);
-        uint32_t y = NOC_UNICAST_ADDR_Y(noc_addr);
-        return is_local_bank(x, y);
-    }
+    bool is_local_addr(const uint64_t noc_addr) const { return noc_address_backend::is_local(noc_addr, noc_id_); }
 
     /**
      * @brief Initiates an asynchronous read from a specified source.

--- a/tt_metal/hw/inc/api/tensor/noc_traits.h
+++ b/tt_metal/hw/inc/api/tensor/noc_traits.h
@@ -6,6 +6,8 @@
 
 #include "api/dataflow/noc.h"
 #include "api/tensor/tensor_accessor.h"
+// Arch-specific (resolved by the HAL's per-arch include roots).
+#include "noc_address_backend.h"
 
 // TODO(#29597): The traits classes for TensorAccessor and related classes could be moved to tensor_accessor.h
 // (need to break the include dependency dataflow_api.h -> tensor_accessor.h.).

--- a/tt_metal/hw/inc/api/tensor/noc_traits.h
+++ b/tt_metal/hw/inc/api/tensor/noc_traits.h
@@ -25,7 +25,7 @@ struct noc_traits_t<TensorAccessor<DSpecT>> {
         uint64_t noc_addr = src.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -35,7 +35,7 @@ struct noc_traits_t<TensorAccessor<DSpecT>> {
         uint64_t noc_addr = dst.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -57,7 +57,7 @@ struct noc_traits_t<PageView<Accessor>> {
         uint64_t noc_addr = src.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -67,7 +67,7 @@ struct noc_traits_t<PageView<Accessor>> {
         uint64_t noc_addr = dst.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -90,7 +90,7 @@ struct noc_traits_t<ShardView<Accessor>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(src.is_local_shard(args.shard_id, noc.get_noc_id()));
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -101,7 +101,7 @@ struct noc_traits_t<ShardView<Accessor>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(dst.is_local_shard(args.shard_id, noc.get_noc_id()));
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -121,7 +121,7 @@ struct noc_traits_t<tensor_accessor::Page> {
         uint64_t noc_addr = src.noc_addr() + args.offset_bytes;
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -131,7 +131,7 @@ struct noc_traits_t<tensor_accessor::Page> {
         uint64_t noc_addr = dst.noc_addr() + args.offset_bytes;
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -154,7 +154,7 @@ struct noc_traits_t<AbstractTensorAccessorWrapper> {
         uint64_t noc_addr = src.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -165,7 +165,7 @@ struct noc_traits_t<AbstractTensorAccessorWrapper> {
         uint64_t noc_addr = dst.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return noc_address_backend::local_address(noc_addr);
+            return noc_address_backend::extract_local_address(noc_addr);
         }
         return noc_addr;
     }

--- a/tt_metal/hw/inc/api/tensor/noc_traits.h
+++ b/tt_metal/hw/inc/api/tensor/noc_traits.h
@@ -6,7 +6,6 @@
 
 #include "api/dataflow/noc.h"
 #include "api/tensor/tensor_accessor.h"
-// Arch-specific (resolved by the HAL's per-arch include roots).
 #include "noc_address_backend.h"
 
 // TODO(#29597): The traits classes for TensorAccessor and related classes could be moved to tensor_accessor.h

--- a/tt_metal/hw/inc/api/tensor/noc_traits.h
+++ b/tt_metal/hw/inc/api/tensor/noc_traits.h
@@ -25,7 +25,7 @@ struct noc_traits_t<TensorAccessor<DSpecT>> {
         uint64_t noc_addr = src.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -35,7 +35,7 @@ struct noc_traits_t<TensorAccessor<DSpecT>> {
         uint64_t noc_addr = dst.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -57,7 +57,7 @@ struct noc_traits_t<PageView<Accessor>> {
         uint64_t noc_addr = src.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -67,7 +67,7 @@ struct noc_traits_t<PageView<Accessor>> {
         uint64_t noc_addr = dst.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -90,7 +90,7 @@ struct noc_traits_t<ShardView<Accessor>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(src.is_local_shard(args.shard_id, noc.get_noc_id()));
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -101,7 +101,7 @@ struct noc_traits_t<ShardView<Accessor>> {
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(dst.is_local_shard(args.shard_id, noc.get_noc_id()));
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -121,7 +121,7 @@ struct noc_traits_t<tensor_accessor::Page> {
         uint64_t noc_addr = src.noc_addr() + args.offset_bytes;
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -131,7 +131,7 @@ struct noc_traits_t<tensor_accessor::Page> {
         uint64_t noc_addr = dst.noc_addr() + args.offset_bytes;
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -154,7 +154,7 @@ struct noc_traits_t<AbstractTensorAccessorWrapper> {
         uint64_t noc_addr = src.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }
@@ -165,7 +165,7 @@ struct noc_traits_t<AbstractTensorAccessorWrapper> {
         uint64_t noc_addr = dst.get_noc_addr(args.page_id, args.offset_bytes, noc.get_noc_id());
         if constexpr (address_type == Noc::AddressType::LOCAL_L1) {
             ASSERT(noc.is_local_addr(noc_addr));
-            return static_cast<uint32_t>(noc_addr);
+            return noc_address_backend::local_address(noc_addr);
         }
         return noc_addr;
     }

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -17,8 +17,6 @@
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 #include "internal/dataflow/dataflow_api_addrgen.h"
-// Arch-specific (resolved by the HAL's per-arch include roots); host builds
-// (e.g. the accessor unit tests) provide a mock instead.
 #include "noc_address_backend.h"
 #endif
 
@@ -38,7 +36,7 @@ uint64_t get_dram_bank_base_offset(uint32_t bank_id, uint8_t noc) {
     uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<true>(bank_id);
     uint32_t bank_index = interleaved_addr_gen::get_bank_index<true>(bank_id, bank_offset_index);
     uint32_t bank_offset = interleaved_addr_gen::get_bank_offset<true>(bank_index);
-    return interleaved_addr_gen::get_bank_noc_addr<true>(bank_index, bank_offset, noc);
+    return noc_address_backend::bank_address<true>(bank_index, bank_offset, noc);
 }
 #endif
 }  // namespace tensor_accessor

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -302,7 +302,7 @@ private:
         auto bank_x = get_bank_x(packed_xy_coords[page_mapping.bank_id]);
         auto bank_y = get_bank_y(packed_xy_coords[page_mapping.bank_id]);
         auto bank_start = DSpec::is_dram ? tensor_accessor::get_dram_bank_base_offset(bank_x, noc)
-                                         : noc_address_backend::worker(bank_x, bank_y, 0, noc);
+                                         : noc_address_backend::worker_address(bank_x, bank_y, 0, noc);
         return bank_start + bank_base_address + (page_mapping.bank_page_offset * aligned_page_size) + offset;
     }
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -35,9 +35,7 @@ uint64_t get_dram_bank_base_offset(uint32_t bank_id, uint8_t noc) {
     uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<true>(bank_id);
     uint32_t bank_index = interleaved_addr_gen::get_bank_index<true>(bank_id, bank_offset_index);
     uint32_t bank_offset = interleaved_addr_gen::get_bank_offset<true>(bank_index);
-    uint32_t noc_xy = interleaved_addr_gen::get_noc_xy<true>(bank_index, noc);
-    uint64_t noc_addr = get_noc_addr_helper(noc_xy, bank_offset);
-    return noc_addr;
+    return interleaved_addr_gen::get_bank_noc_addr<true>(bank_index, bank_offset, noc);
 }
 #endif
 }  // namespace tensor_accessor
@@ -227,9 +225,7 @@ public:
 
     FORCE_INLINE
     bool is_local_addr(const uint64_t noc_addr, uint8_t noc = noc_index) const {
-        uint32_t x = NOC_UNICAST_ADDR_X(noc_addr);
-        uint32_t y = NOC_UNICAST_ADDR_Y(noc_addr);
-        return is_local_bank(x, y, noc);
+        return noc_address_backend::is_local(noc_addr, noc);
     }
 
     FORCE_INLINE
@@ -306,7 +302,7 @@ private:
         auto bank_x = get_bank_x(packed_xy_coords[page_mapping.bank_id]);
         auto bank_y = get_bank_y(packed_xy_coords[page_mapping.bank_id]);
         auto bank_start = DSpec::is_dram ? tensor_accessor::get_dram_bank_base_offset(bank_x, noc)
-                                         : NOC_XY_ADDR(DYNAMIC_NOC_X(noc, bank_x), DYNAMIC_NOC_Y(noc, bank_y), 0);
+                                         : noc_address_backend::worker(bank_x, bank_y, 0, noc);
         return bank_start + bank_base_address + (page_mapping.bank_page_offset * aligned_page_size) + offset;
     }
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -17,6 +17,9 @@
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 #include "internal/dataflow/dataflow_api_addrgen.h"
+// Arch-specific (resolved by the HAL's per-arch include roots); host builds
+// (e.g. the accessor unit tests) provide a mock instead.
+#include "noc_address_backend.h"
 #endif
 
 // NOLINTBEGIN(misc-unused-parameters)

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
@@ -208,7 +208,7 @@ uint64_t get_noc_multicast_addr(
 // clang-format on
 FORCE_INLINE
 uint64_t get_noc_addr(uint32_t noc_x, uint32_t noc_y, uint32_t addr, uint8_t noc = noc_index) {
-    return noc_address_backend::worker(noc_x, noc_y, addr, noc);
+    return noc_address_backend::worker_address(noc_x, noc_y, addr, noc);
 }
 
 /*
@@ -221,7 +221,7 @@ std::uint64_t get_noc_addr_helper(std::uint32_t noc_xy, std::uint32_t addr) {
         Get an encoding which contains tensix core and address you want to
         write to via the noc multicast
     */
-    return noc_address_backend::packed_worker(noc_xy, addr);
+    return noc_address_backend::packed_worker_address(noc_xy, addr);
 }
 
 namespace interleaved_addr_gen {
@@ -231,7 +231,7 @@ namespace interleaved_addr_gen {
 // generators below.
 template <bool DRAM>
 FORCE_INLINE uint64_t get_bank_noc_addr(uint32_t bank_index, uint32_t addr, uint8_t noc = noc_index) {
-    return noc_address_backend::bank<DRAM>(bank_index, addr, noc);
+    return noc_address_backend::bank_address<DRAM>(bank_index, addr, noc);
 }
 
 }  // namespace interleaved_addr_gen
@@ -271,7 +271,7 @@ uint64_t get_system_memory_noc_addr(
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
     uint32_t addr = base_addr + page_size * id + offset;
-    return noc_address_backend::system_memory(addr, noc);
+    return noc_address_backend::system_memory_address(addr, noc);
 }
 
 FORCE_INLINE
@@ -280,7 +280,7 @@ std::uint64_t get_noc_addr(std::uint32_t addr, uint8_t noc = noc_index) {
         Get an encoding which contains the address in L1 on the current core that you want to
         read from/write to via the noc
     */
-    return noc_address_backend::local(addr, noc);
+    return noc_address_backend::self_address(addr, noc);
 }
 
 template <bool DRAM>
@@ -526,7 +526,7 @@ get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_
     if constexpr (DRAM) {
         bank_address_offset += bank_to_dram_offset[bank_id];
     }
-    return noc_address_backend::packed_worker(packed_xy, bank_address_offset);
+    return noc_address_backend::packed_worker_address(packed_xy, bank_address_offset);
 }
 
 template <bool DRAM, uint32_t page_size>

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
@@ -6,7 +6,6 @@
 
 #include "internal/dataflow/dataflow_api_common.h"
 #include "internal/dataflow/dataflow_cmd_bufs.h"
-// Arch-specific (resolved by the HAL's per-arch include roots, like noc_parameters.h).
 #include "noc_address_backend.h"
 #include "api/debug/assert.h"
 #include "internal/debug/sanitize.h"
@@ -224,18 +223,6 @@ std::uint64_t get_noc_addr_helper(std::uint32_t noc_xy, std::uint32_t addr) {
     return noc_address_backend::packed_worker_address(noc_xy, addr);
 }
 
-namespace interleaved_addr_gen {
-
-// Full NOC address for `addr` inside bank `bank_index`. This is the single
-// place the bank -> NOC destination mapping happens for the address
-// generators below.
-template <bool DRAM>
-FORCE_INLINE uint64_t get_bank_noc_addr(uint32_t bank_index, uint32_t addr, uint8_t noc = noc_index) {
-    return noc_address_backend::bank_address<DRAM>(bank_index, addr, noc);
-}
-
-}  // namespace interleaved_addr_gen
-
 uint64_t get_dram_noc_addr(
     const uint32_t id,
     const uint32_t page_size,
@@ -247,7 +234,7 @@ uint64_t get_dram_noc_addr(
     uint32_t addr =
         (bank_offset_index * align_power_of_2(page_size, interleaved_addr_gen::get_allocator_alignment<true>())) +
         bank_base_address + offset + bank_to_dram_offset[bank_index];
-    return interleaved_addr_gen::get_bank_noc_addr<true>(bank_index, addr, noc);
+    return noc_address_backend::bank_address<true>(bank_index, addr, noc);
 }
 
 uint64_t get_l1_noc_addr(
@@ -261,7 +248,7 @@ uint64_t get_l1_noc_addr(
     uint32_t addr =
         (bank_offset_index * align_power_of_2(page_size, interleaved_addr_gen::get_allocator_alignment<false>())) +
         bank_base_address + offset + bank_to_dram_offset[bank_index];
-    return interleaved_addr_gen::get_bank_noc_addr<false>(bank_index, addr, noc);
+    return noc_address_backend::bank_address<false>(bank_index, addr, noc);
 }
 
 uint64_t get_system_memory_noc_addr(
@@ -306,7 +293,7 @@ struct InterleavedAddrGen {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
+        return noc_address_backend::bank_address<DRAM>(bank_index, addr, noc);
     }
 };
 
@@ -337,7 +324,7 @@ struct InterleavedPow2AddrGen {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
+        return noc_address_backend::bank_address<DRAM>(bank_index, addr, noc);
     }
 };
 
@@ -364,7 +351,7 @@ struct InterleavedAddrGenFast {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
+        return noc_address_backend::bank_address<DRAM>(bank_index, addr, noc);
     }
 };
 
@@ -395,7 +382,7 @@ struct InterleavedPow2AddrGenFast {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
+        return noc_address_backend::bank_address<DRAM>(bank_index, addr, noc);
     }
 };
 

--- a/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h
@@ -6,6 +6,8 @@
 
 #include "internal/dataflow/dataflow_api_common.h"
 #include "internal/dataflow/dataflow_cmd_bufs.h"
+// Arch-specific (resolved by the HAL's per-arch include roots, like noc_parameters.h).
+#include "noc_address_backend.h"
 #include "api/debug/assert.h"
 #include "internal/debug/sanitize.h"
 #include "api/debug/waypoint.h"
@@ -187,12 +189,7 @@ uint64_t get_noc_multicast_addr(
     uint32_t noc_y_end,
     uint32_t addr,
     uint8_t noc = noc_index) {
-    return NOC_MULTICAST_ADDR(
-        DYNAMIC_NOC_X(noc, noc_x_start),
-        DYNAMIC_NOC_Y(noc, noc_y_start),
-        DYNAMIC_NOC_X(noc, noc_x_end),
-        DYNAMIC_NOC_Y(noc, noc_y_end),
-        addr);
+    return noc_address_backend::multicast_descriptor(noc_x_start, noc_y_start, noc_x_end, noc_y_end, addr, noc);
 }
 
 // clang-format off
@@ -211,7 +208,7 @@ uint64_t get_noc_multicast_addr(
 // clang-format on
 FORCE_INLINE
 uint64_t get_noc_addr(uint32_t noc_x, uint32_t noc_y, uint32_t addr, uint8_t noc = noc_index) {
-    return NOC_XY_ADDR(DYNAMIC_NOC_X(noc, noc_x), DYNAMIC_NOC_Y(noc, noc_y), addr);
+    return noc_address_backend::worker(noc_x, noc_y, addr, noc);
 }
 
 /*
@@ -224,8 +221,20 @@ std::uint64_t get_noc_addr_helper(std::uint32_t noc_xy, std::uint32_t addr) {
         Get an encoding which contains tensix core and address you want to
         write to via the noc multicast
     */
-    return ((uint64_t)(noc_xy) << NOC_ADDR_COORD_SHIFT) | addr;
+    return noc_address_backend::packed_worker(noc_xy, addr);
 }
+
+namespace interleaved_addr_gen {
+
+// Full NOC address for `addr` inside bank `bank_index`. This is the single
+// place the bank -> NOC destination mapping happens for the address
+// generators below.
+template <bool DRAM>
+FORCE_INLINE uint64_t get_bank_noc_addr(uint32_t bank_index, uint32_t addr, uint8_t noc = noc_index) {
+    return noc_address_backend::bank<DRAM>(bank_index, addr, noc);
+}
+
+}  // namespace interleaved_addr_gen
 
 uint64_t get_dram_noc_addr(
     const uint32_t id,
@@ -238,9 +247,7 @@ uint64_t get_dram_noc_addr(
     uint32_t addr =
         (bank_offset_index * align_power_of_2(page_size, interleaved_addr_gen::get_allocator_alignment<true>())) +
         bank_base_address + offset + bank_to_dram_offset[bank_index];
-    uint32_t noc_xy = interleaved_addr_gen::get_noc_xy<true>(bank_index, noc);
-    uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
-    return noc_addr;
+    return interleaved_addr_gen::get_bank_noc_addr<true>(bank_index, addr, noc);
 }
 
 uint64_t get_l1_noc_addr(
@@ -254,9 +261,7 @@ uint64_t get_l1_noc_addr(
     uint32_t addr =
         (bank_offset_index * align_power_of_2(page_size, interleaved_addr_gen::get_allocator_alignment<false>())) +
         bank_base_address + offset + bank_to_dram_offset[bank_index];
-    uint32_t noc_xy = interleaved_addr_gen::get_noc_xy<false>(bank_index, noc);
-    uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
-    return noc_addr;
+    return interleaved_addr_gen::get_bank_noc_addr<false>(bank_index, addr, noc);
 }
 
 uint64_t get_system_memory_noc_addr(
@@ -265,11 +270,8 @@ uint64_t get_system_memory_noc_addr(
     const uint32_t base_addr,
     const uint32_t offset = 0,
     uint8_t noc = noc_index) {
-    uint64_t pcie_core_noc_encoding =
-        uint64_t(NOC_XY_PCIE_ENCODING(DYNAMIC_NOC_X(noc, PCIE_NOC_X), DYNAMIC_NOC_Y(noc, PCIE_NOC_Y)));
     uint32_t addr = base_addr + page_size * id + offset;
-    uint64_t noc_addr = pcie_core_noc_encoding | addr;
-    return noc_addr;
+    return noc_address_backend::system_memory(addr, noc);
 }
 
 FORCE_INLINE
@@ -278,7 +280,7 @@ std::uint64_t get_noc_addr(std::uint32_t addr, uint8_t noc = noc_index) {
         Get an encoding which contains the address in L1 on the current core that you want to
         read from/write to via the noc
     */
-    return NOC_XY_ADDR(my_x[noc], my_y[noc], addr);
+    return noc_address_backend::local(addr, noc);
 }
 
 template <bool DRAM>
@@ -304,10 +306,7 @@ struct InterleavedAddrGen {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
-        return noc_addr;
+        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
     }
 };
 
@@ -338,10 +337,7 @@ struct InterleavedPow2AddrGen {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
-        return noc_addr;
+        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
     }
 };
 
@@ -368,10 +364,7 @@ struct InterleavedAddrGenFast {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
-        return noc_addr;
+        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
     }
 };
 
@@ -402,10 +395,7 @@ struct InterleavedPow2AddrGenFast {
         uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
         uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
         uint32_t addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
-        return noc_addr;
+        return interleaved_addr_gen::get_bank_noc_addr<DRAM>(bank_index, addr, noc);
     }
 };
 
@@ -530,14 +520,13 @@ FORCE_INLINE uint64_t get_noc_addr(
 template <bool DRAM>
 FORCE_INLINE uint64_t
 get_noc_addr_from_bank_id(uint32_t bank_id, uint32_t bank_address_offset, uint8_t noc = noc_index) {
-    uint64_t noc_addr = 0;
+    // Look up the bank destination before the DRAM offset add, matching the
+    // load order (and object code) of the pre-backend implementation.
+    const uint32_t packed_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_id, noc);
     if constexpr (DRAM) {
-        noc_addr = dram_bank_to_noc_xy[noc][bank_id];
         bank_address_offset += bank_to_dram_offset[bank_id];
-    } else {
-        noc_addr = l1_bank_to_noc_xy[noc][bank_id];
     }
-    return (noc_addr << NOC_ADDR_COORD_SHIFT) | (bank_address_offset);
+    return noc_address_backend::packed_worker(packed_xy, bank_address_offset);
 }
 
 template <bool DRAM, uint32_t page_size>

--- a/tt_metal/hw/inc/internal/dataflow/noc_address_backend_xy.h
+++ b/tt_metal/hw/inc/internal/dataflow/noc_address_backend_xy.h
@@ -20,15 +20,15 @@
 
 namespace noc_address_backend_xy {
 
-FORCE_INLINE uint64_t worker(uint32_t x, uint32_t y, uint32_t local_address, uint8_t noc) {
+FORCE_INLINE uint64_t worker_address(uint32_t x, uint32_t y, uint32_t local_address, uint8_t noc) {
     return NOC_XY_ADDR(DYNAMIC_NOC_X(noc, x), DYNAMIC_NOC_Y(noc, y), local_address);
 }
 
-FORCE_INLINE uint64_t local(uint32_t local_address, uint8_t noc) {
+FORCE_INLINE uint64_t self_address(uint32_t local_address, uint8_t noc) {
     return NOC_XY_ADDR(my_x[noc], my_y[noc], local_address);
 }
 
-FORCE_INLINE uint64_t packed_worker(uint32_t packed_xy, uint32_t local_address) {
+FORCE_INLINE uint64_t packed_worker_address(uint32_t packed_xy, uint32_t local_address) {
     return ((uint64_t)(packed_xy) << NOC_ADDR_COORD_SHIFT) | local_address;
 }
 
@@ -48,17 +48,17 @@ FORCE_INLINE uint64_t multicast_descriptor(
 }
 
 template <bool DRAM>
-FORCE_INLINE uint64_t bank(uint32_t bank_index, uint32_t local_address, uint8_t noc) {
+FORCE_INLINE uint64_t bank_address(uint32_t bank_index, uint32_t local_address, uint8_t noc) {
     uint32_t packed_xy;
     if constexpr (DRAM) {
         packed_xy = dram_bank_to_noc_xy[noc][bank_index];
     } else {
         packed_xy = l1_bank_to_noc_xy[noc][bank_index];
     }
-    return packed_worker(packed_xy, local_address);
+    return packed_worker_address(packed_xy, local_address);
 }
 
-FORCE_INLINE uint32_t local_address(uint64_t address) { return static_cast<uint32_t>(address); }
+FORCE_INLINE uint32_t extract_local_address(uint64_t address) { return static_cast<uint32_t>(address); }
 
 FORCE_INLINE bool is_local(uint64_t address, uint8_t noc) {
     uint32_t x = NOC_UNICAST_ADDR_X(address);
@@ -67,11 +67,11 @@ FORCE_INLINE bool is_local(uint64_t address, uint8_t noc) {
 }
 
 // Dispatch go-message coordinates arrive as the raw uint8_t fields of go_msg_t.
-FORCE_INLINE uint64_t dispatch(uint8_t x, uint8_t y, uint32_t local_address) {
+FORCE_INLINE uint64_t dispatch_address(uint8_t x, uint8_t y, uint32_t local_address) {
     return NOC_XY_ADDR(NOC_X(x), NOC_Y(y), local_address);
 }
 
-FORCE_INLINE uint64_t system_memory(uint32_t local_address, uint8_t noc) {
+FORCE_INLINE uint64_t system_memory_address(uint32_t local_address, uint8_t noc) {
     uint64_t pcie_core_noc_encoding =
         uint64_t(NOC_XY_PCIE_ENCODING(DYNAMIC_NOC_X(noc, PCIE_NOC_X), DYNAMIC_NOC_Y(noc, PCIE_NOC_Y)));
     return pcie_core_noc_encoding | local_address;

--- a/tt_metal/hw/inc/internal/dataflow/noc_address_backend_xy.h
+++ b/tt_metal/hw/inc/internal/dataflow/noc_address_backend_xy.h
@@ -7,19 +7,24 @@
 // Legacy XY NoC address backend: addresses carry raw (x, y) coordinates in the
 // bits above NOC_ADDR_COORD_SHIFT. Each function expands to exactly the
 // expression it replaced at its call sites (verified by object-code
-// comparison). Include through internal/dataflow/noc_address_backend.h, which
-// selects the active backend; call sites use the backend-neutral
-// noc_address_backend alias, never this namespace directly.
+// comparison). Include through the arch-selected "noc_address_backend.h"
+// wrapper (internal/tt-1xx/ or internal/tt-2xx/quasar/), which sets the
+// backend-neutral noc_address_backend alias call sites use; never include or
+// name this namespace directly.
+//
+// No defaulted noc parameter here on purpose: callers always pass it, and a
+// noc_index default would break translation units where the global is not
+// declared at this point (e.g. DRISC firmware).
 
 #include <cstdint>
 
 namespace noc_address_backend_xy {
 
-FORCE_INLINE uint64_t worker(uint32_t x, uint32_t y, uint32_t local_address, uint8_t noc = noc_index) {
+FORCE_INLINE uint64_t worker(uint32_t x, uint32_t y, uint32_t local_address, uint8_t noc) {
     return NOC_XY_ADDR(DYNAMIC_NOC_X(noc, x), DYNAMIC_NOC_Y(noc, y), local_address);
 }
 
-FORCE_INLINE uint64_t local(uint32_t local_address, uint8_t noc = noc_index) {
+FORCE_INLINE uint64_t local(uint32_t local_address, uint8_t noc) {
     return NOC_XY_ADDR(my_x[noc], my_y[noc], local_address);
 }
 
@@ -33,7 +38,7 @@ FORCE_INLINE uint64_t multicast_descriptor(
     uint32_t end_x,
     uint32_t end_y,
     uint32_t local_address,
-    uint8_t noc = noc_index) {
+    uint8_t noc) {
     return NOC_MULTICAST_ADDR(
         DYNAMIC_NOC_X(noc, start_x),
         DYNAMIC_NOC_Y(noc, start_y),
@@ -43,7 +48,7 @@ FORCE_INLINE uint64_t multicast_descriptor(
 }
 
 template <bool DRAM>
-FORCE_INLINE uint64_t bank(uint32_t bank_index, uint32_t local_address, uint8_t noc = noc_index) {
+FORCE_INLINE uint64_t bank(uint32_t bank_index, uint32_t local_address, uint8_t noc) {
     uint32_t packed_xy;
     if constexpr (DRAM) {
         packed_xy = dram_bank_to_noc_xy[noc][bank_index];
@@ -53,13 +58,9 @@ FORCE_INLINE uint64_t bank(uint32_t bank_index, uint32_t local_address, uint8_t 
     return packed_worker(packed_xy, local_address);
 }
 
-FORCE_INLINE uint64_t dram_bank(uint32_t bank_index, uint32_t local_address, uint8_t noc = noc_index) {
-    return bank<true>(bank_index, local_address, noc);
-}
-
 FORCE_INLINE uint32_t local_address(uint64_t address) { return static_cast<uint32_t>(address); }
 
-FORCE_INLINE bool is_local(uint64_t address, uint8_t noc = noc_index) {
+FORCE_INLINE bool is_local(uint64_t address, uint8_t noc) {
     uint32_t x = NOC_UNICAST_ADDR_X(address);
     uint32_t y = NOC_UNICAST_ADDR_Y(address);
     return x == my_x[noc] && y == my_y[noc];
@@ -70,7 +71,7 @@ FORCE_INLINE uint64_t dispatch(uint8_t x, uint8_t y, uint32_t local_address) {
     return NOC_XY_ADDR(NOC_X(x), NOC_Y(y), local_address);
 }
 
-FORCE_INLINE uint64_t system_memory(uint32_t local_address, uint8_t noc = noc_index) {
+FORCE_INLINE uint64_t system_memory(uint32_t local_address, uint8_t noc) {
     uint64_t pcie_core_noc_encoding =
         uint64_t(NOC_XY_PCIE_ENCODING(DYNAMIC_NOC_X(noc, PCIE_NOC_X), DYNAMIC_NOC_Y(noc, PCIE_NOC_Y)));
     return pcie_core_noc_encoding | local_address;

--- a/tt_metal/hw/inc/internal/dataflow/noc_address_backend_xy.h
+++ b/tt_metal/hw/inc/internal/dataflow/noc_address_backend_xy.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Legacy XY NoC address backend: addresses carry raw (x, y) coordinates in the
+// bits above NOC_ADDR_COORD_SHIFT. Each function expands to exactly the
+// expression it replaced at its call sites (verified by object-code
+// comparison). Include through internal/dataflow/noc_address_backend.h, which
+// selects the active backend; call sites use the backend-neutral
+// noc_address_backend alias, never this namespace directly.
+
+#include <cstdint>
+
+namespace noc_address_backend_xy {
+
+FORCE_INLINE uint64_t worker(uint32_t x, uint32_t y, uint32_t local_address, uint8_t noc = noc_index) {
+    return NOC_XY_ADDR(DYNAMIC_NOC_X(noc, x), DYNAMIC_NOC_Y(noc, y), local_address);
+}
+
+FORCE_INLINE uint64_t local(uint32_t local_address, uint8_t noc = noc_index) {
+    return NOC_XY_ADDR(my_x[noc], my_y[noc], local_address);
+}
+
+FORCE_INLINE uint64_t packed_worker(uint32_t packed_xy, uint32_t local_address) {
+    return ((uint64_t)(packed_xy) << NOC_ADDR_COORD_SHIFT) | local_address;
+}
+
+FORCE_INLINE uint64_t multicast_descriptor(
+    uint32_t start_x,
+    uint32_t start_y,
+    uint32_t end_x,
+    uint32_t end_y,
+    uint32_t local_address,
+    uint8_t noc = noc_index) {
+    return NOC_MULTICAST_ADDR(
+        DYNAMIC_NOC_X(noc, start_x),
+        DYNAMIC_NOC_Y(noc, start_y),
+        DYNAMIC_NOC_X(noc, end_x),
+        DYNAMIC_NOC_Y(noc, end_y),
+        local_address);
+}
+
+template <bool DRAM>
+FORCE_INLINE uint64_t bank(uint32_t bank_index, uint32_t local_address, uint8_t noc = noc_index) {
+    uint32_t packed_xy;
+    if constexpr (DRAM) {
+        packed_xy = dram_bank_to_noc_xy[noc][bank_index];
+    } else {
+        packed_xy = l1_bank_to_noc_xy[noc][bank_index];
+    }
+    return packed_worker(packed_xy, local_address);
+}
+
+FORCE_INLINE uint64_t dram_bank(uint32_t bank_index, uint32_t local_address, uint8_t noc = noc_index) {
+    return bank<true>(bank_index, local_address, noc);
+}
+
+FORCE_INLINE uint32_t local_address(uint64_t address) { return static_cast<uint32_t>(address); }
+
+FORCE_INLINE bool is_local(uint64_t address, uint8_t noc = noc_index) {
+    uint32_t x = NOC_UNICAST_ADDR_X(address);
+    uint32_t y = NOC_UNICAST_ADDR_Y(address);
+    return x == my_x[noc] && y == my_y[noc];
+}
+
+// Dispatch go-message coordinates arrive as the raw uint8_t fields of go_msg_t.
+FORCE_INLINE uint64_t dispatch(uint8_t x, uint8_t y, uint32_t local_address) {
+    return NOC_XY_ADDR(NOC_X(x), NOC_Y(y), local_address);
+}
+
+FORCE_INLINE uint64_t system_memory(uint32_t local_address, uint8_t noc = noc_index) {
+    uint64_t pcie_core_noc_encoding =
+        uint64_t(NOC_XY_PCIE_ENCODING(DYNAMIC_NOC_X(noc, PCIE_NOC_X), DYNAMIC_NOC_Y(noc, PCIE_NOC_Y)));
+    return pcie_core_noc_encoding | local_address;
+}
+
+}  // namespace noc_address_backend_xy

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -206,6 +206,10 @@ void wait_for_go_message() {
 }
 
 #if !defined(COMPILE_FOR_TRISC)
+// TRISCs are not NoC initiators; the address backend is data-movement-only.
+// Arch-specific (resolved by the HAL's per-arch include roots, like noc_parameters.h).
+#include "noc_address_backend.h"
+
 FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) {
     go_msg_t go_message;
     go_message.all = go_message_in->all;
@@ -214,11 +218,8 @@ FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) 
 #else
     constexpr uint32_t dispatch_message_stride = NOC_STREAM_REG_SPACE_SIZE;
 #endif
-    uint64_t addr = NOC_XY_ADDR(
-        NOC_X(go_message.master_x),
-        NOC_Y(go_message.master_y),
-        DISPATCH_MESSAGE_ADDR + dispatch_message_stride * go_message.dispatch_message_offset);
-    return addr;
+    const uint32_t local_addr = DISPATCH_MESSAGE_ADDR + dispatch_message_stride * go_message.dispatch_message_offset;
+    return noc_address_backend::dispatch(go_message.master_x, go_message.master_y, local_addr);
 }
 
 FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_index) {

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -206,8 +206,6 @@ void wait_for_go_message() {
 }
 
 #if !defined(COMPILE_FOR_TRISC)
-// TRISCs are not NoC initiators; the address backend is data-movement-only.
-// Arch-specific (resolved by the HAL's per-arch include roots, like noc_parameters.h).
 #include "noc_address_backend.h"
 
 FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) {

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -219,7 +219,7 @@ FORCE_INLINE uint64_t calculate_dispatch_addr(volatile go_msg_t* go_message_in) 
     constexpr uint32_t dispatch_message_stride = NOC_STREAM_REG_SPACE_SIZE;
 #endif
     const uint32_t local_addr = DISPATCH_MESSAGE_ADDR + dispatch_message_stride * go_message.dispatch_message_offset;
-    return noc_address_backend::dispatch(go_message.master_x, go_message.master_y, local_addr);
+    return noc_address_backend::dispatch_address(go_message.master_x, go_message.master_y, local_addr);
 }
 
 FORCE_INLINE void notify_dispatch_core_done(uint64_t dispatch_addr, uint8_t noc_index) {

--- a/tt_metal/hw/inc/internal/tt-1xx/noc_address_backend.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/noc_address_backend.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// NoC address backend for Wormhole and Blackhole, selected by include path the
+// same way as noc_parameters.h. Both architectures encode addresses with raw
+// (x, y) coordinates; call sites use the backend-neutral noc_address_backend
+// alias and never name a concrete backend directly.
+
+#include "internal/dataflow/noc_address_backend_xy.h"
+
+namespace noc_address_backend = noc_address_backend_xy;

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_address_backend.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_address_backend.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// NoC address backend for Quasar, selected by include path the same way as
+// noc_parameters.h. Call sites use the backend-neutral noc_address_backend
+// alias and never name a concrete backend directly.
+//
+// Quasar NoC V1/V2 use the legacy XY encoding. NoC V3 will select between the
+// XY encoding and the ATT (Address Translation Table) encoding
+// (noc_address_backend_att) here.
+
+#include "internal/dataflow/noc_address_backend_xy.h"
+
+namespace noc_address_backend = noc_address_backend_xy;

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -186,6 +186,7 @@ set(HW_JIT_API_HEADERS
     inc/internal/dataflow/dataflow_api_addrgen.h
     inc/internal/dataflow/dataflow_api_common.h
     inc/internal/dataflow/dataflow_cmd_bufs.h
+    inc/internal/dataflow/noc_address_backend_xy.h
     inc/internal/debug/dprint_buffer.h
     inc/internal/debug/fw_debug.h
     inc/internal/debug/noc_zero_guard.h
@@ -238,12 +239,14 @@ set(HW_JIT_API_HEADERS
     inc/internal/tt-2xx/quasar/noc/noc.h
     inc/internal/tt-2xx/quasar/noc/noc_overlay_parameters.h
     inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+    inc/internal/tt-2xx/quasar/noc_address_backend.h
     inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
     inc/internal/tt-2xx/quasar/stream_interface.h
     inc/internal/tt-2xx/quasar/stream_io_map.h
     inc/internal/tt-2xx/quasar/tdma_xmov.h
     inc/internal/tt-2xx/quasar/tensix.h
     inc/internal/tt-2xx/quasar/tensix_types.h
+    inc/internal/tt-1xx/noc_address_backend.h
     inc/internal/tt-1xx/risc_common.h
     inc/internal/tt-1xx/wormhole/c_tensix_core.h
     inc/internal/tt-1xx/wormhole/core_config.h


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Introduces a single seam through which the shared device-side NoC address construction flows: a backend-neutral `noc_address_backend` namespace alias, resolved per architecture by include path (the same mechanism as `noc_parameters.h`). Both tt-1xx (WH/BH) and Quasar alias the legacy XY encoding (`noc_address_backend_xy`) today, so behavior is unchanged everywhere.

Rerouted call sites: the `get_noc_addr` family, the interleaved address generators (via one new `interleaved_addr_gen::get_bank_noc_addr<DRAM>`), `get_noc_addr_from_bank_id`, `get_system_memory_noc_addr`, the `is_local_addr` predicates, the `noc_traits` local-pointer extraction, and `calculate_dispatch_addr`.

Not yet rerouted (deliberately — no behavior may change in this PR): the dispatch kernels' direct PCIe compositions (`cq_prefetch.cpp`/`cq_dispatch.cpp`, which use the physical-coordinate frame via `NOC_X_PHYS_COORD`) and `mem_bench_kernel.cpp`. These are tracked for the dispatch-conversion PR later in the stack.


**This is the first preparation PR for enabling ATT on Quasar, which completelly changes how we construct addresses for NOC, for WH/BH this PR must not change the binaries and this was verified by comparing binaries with and without the chagne**

### Notes for reviewers
- Review contract: every `noc_address_backend_xy` function body is exactly the expression it replaced at its call sites.
- Verified by object-code comparison, not just inspection: kernels and firmware were compiled against main and this branch with the SFPI cross-compiler (kernels built the way JIT builds them: `brisck.cc`/`ncrisck.cc`/`dmk.cc` wrapper + generated `kernel_includes.hpp`), and the object files compared with `cmp`. Corpus: all 236 kernels under `tests/tt_metal/tt_metal/test_kernels/{dataflow,misc}` and `tt_metal/impl/dispatch/kernels`, plus a probe TU calling every rerouted entry point and firmware TUs. Kernels that need host-generated bindings don't compile standalone on main either and are excluded on both sides; every kernel that compiles on main compiles on this branch.

| Pass | Corpus | Identical | Mismatch |
|---|---|---|---|
| WH brisc `-Os`/`-O3` + ncrisc `-Os` | 236 kernels x 3 | 332/332 | 0 |
| BH brisc `-Os`/`-O3` + ncrisc `-Os` | 236 kernels x 3 | 335/335 | 0 |
| Quasar dm `-Os`/`-O3` | 236 kernels x 2 | 206/207 | 1 |
| Probe TU + firmware TUs, all arches, `-Os` and `-O3` | 12 configs | 12/12 | 0 |

- The single non-identical build (`dram_copy_to_noc_coord.cpp`, Quasar): the entire object diff is 4 instructions in inlined `calculate_dispatch_addr` where two registers swap which of `(v>>8)<<36` / `(v>>16)<<42` they carry before a commutative `or` combines them — same instruction multiset, provably the same result (GCC scheduling of two independent bitfield loads across the new function boundary; not pinnable from source, verified by experiment).
- TRISC compilation was additionally checked on WH and Quasar to confirm the backend header stays data-movement-only.
- Byte-identity dictated three signature details worth knowing: `dispatch()` takes `uint8_t` coordinates (preserves the `go_msg_t` bitfield integer promotions on RV64), `packed_worker()`/`dispatch()` take no unused `noc` parameter, and `system_memory()` only encodes (the bank-space arithmetic stays at the call site).
- `jit_build/fake_kernels_target/CMakeLists.txt` still uses the pre-`tt-1xx` include layout, so it cannot resolve any arch-selected header (pre-existing; unaffected here).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/att-pr1-noc-address-backend)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/att-pr1-noc-address-backend)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/att-pr1-noc-address-backend)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/att-pr1-noc-address-backend)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/att-pr1-noc-address-backend)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/att-pr1-noc-address-backend)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/att-pr1-noc-address-backend)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/att-pr1-noc-address-backend)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/att-pr1-noc-address-backend)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/att-pr1-noc-address-backend)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/att-pr1-noc-address-backend)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/att-pr1-noc-address-backend)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/att-pr1-noc-address-backend)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/att-pr1-noc-address-backend)


