### PR TITLE
chore: Update ccache to 4.14

### DIFF
--- a/dockerfile/Dockerfile.tools
+++ b/dockerfile/Dockerfile.tools
@@ -15,8 +15,8 @@
 # These must match the versions in the main Dockerfile
 #############################################################
 
-ARG CCACHE_VERSION=4.13.6
-ARG CCACHE_SHA256=508b2a1217dc6e04a23e967c7b95a0fb45d8a7e16fde9e180919698f2e2be060
+ARG CCACHE_VERSION=4.14
+ARG CCACHE_SHA256=45a91165db7092e67c6208ada03f54700e684c4cd3735f9031de95669ed9272c
 
 ARG MOLD_VERSION=2.42.0
 ARG MOLD_SHA256=f5ed2f6e31d1ada4f07fe766fe0de7a73104d1c5cdc59086fcecc16a43720b6d

--- a/dockerfile/Dockerfile.tools
+++ b/dockerfile/Dockerfile.tools
@@ -4,11 +4,11 @@
 # to /install, which can then be used as a source for COPY --from.
 #
 # Usage:
-#   docker build -f dockerfile/Dockerfile.tools --target ccache -t ghcr.io/.../tool-ccache:v4.13.6 .
+#   docker build -f dockerfile/Dockerfile.tools --target ccache -t ghcr.io/.../tool-ccache:v4.14 .
 #   docker build -f dockerfile/Dockerfile.tools --target mold -t ghcr.io/.../tool-mold:v2.42.0 .
 #
 # The main Dockerfile can then use:
-#   FROM ghcr.io/.../tool-ccache:v4.13.6 AS ccache-layer
+#   FROM ghcr.io/.../tool-ccache:v4.14 AS ccache-layer
 
 #############################################################
 # Version and hash configuration

--- a/dockerfile/scripts/install-ccache.sh
+++ b/dockerfile/scripts/install-ccache.sh
@@ -3,11 +3,11 @@
 # Apt's version for 20.04 predates remote_storage support
 set -euo pipefail
 
-CCACHE_VERSION="${CCACHE_VERSION:-4.13.6}"
+CCACHE_VERSION="${CCACHE_VERSION:-4.14}"
 # SHA256 for ccache-4.13.6-linux-x86_64-glibc.tar.xz
 # Note: starting v4.11, upstream renamed the tarball to include -glibc suffix
 # Verified by downloading and computing hash with compute-hashes.sh
-CCACHE_SHA256="${CCACHE_SHA256:-508b2a1217dc6e04a23e967c7b95a0fb45d8a7e16fde9e180919698f2e2be060}"
+CCACHE_SHA256="${CCACHE_SHA256:-45a91165db7092e67c6208ada03f54700e684c4cd3735f9031de95669ed9272c}"
 
 # Remote storage helper for S3-backed ccache (crsh: custom storage protocol).
 # ccache derives the helper name (ccache-storage-s3) from the s3:// URL scheme

--- a/dockerfile/scripts/install-ccache.sh
+++ b/dockerfile/scripts/install-ccache.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 CCACHE_VERSION="${CCACHE_VERSION:-4.14}"
-# SHA256 for ccache-4.13.6-linux-x86_64-glibc.tar.xz
+# SHA256 for ccache-4.14-linux-x86_64-glibc.tar.xz
 # Note: starting v4.11, upstream renamed the tarball to include -glibc suffix
 # Verified by downloading and computing hash with compute-hashes.sh
 CCACHE_SHA256="${CCACHE_SHA256:-45a91165db7092e67c6208ada03f54700e684c4cd3735f9031de95669ed9272c}"


### PR DESCRIPTION
https://ccache.dev/releasenotes.html#_ccache_4_14

Patches driving upgrade:

* Added support for @layout=local in the file storage backend, allowing a copy or read-only mount of a local cache to be used as remote storage.
* Extended the remote storage helper protocol with an exists operation, avoiding transfer of already stored values in reshare mode, and an info operation for reporting the helper’s identity and diagnostics.
* Added support for rewriting absolute profile data file paths to relative, improving cache sharing between different directory trees.
* Fixed a remote storage configuration with read_only=false being treated as read-only.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-ccache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-upgrade-ccache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-ccache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/0-upgrade-ccache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-upgrade-ccache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-upgrade-ccache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-upgrade-ccache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-upgrade-ccache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-upgrade-ccache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-upgrade-ccache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-upgrade-ccache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-upgrade-ccache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-upgrade-ccache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-upgrade-ccache)