### PR TITLE
[tt-llk] TDMA guard: per-TRISC thread_local armed_mask (TEN-4746)

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -64,6 +64,13 @@ thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((use
 // returns immediately for any DFB math TRISC is not a participant in (expected_signal == 0).
 thread_local uintptr_t g_dfb_config_base_addr __attribute__((used));
 
+namespace llk_tdma_guard {
+// TEN-4746 tile-counter guard mask (Quasar). thread_local so each TRISC gets its own mask in the
+// host-threaded emulation (tt-llk#1678); declared extern thread_local in llk_tdma_guard.h. Defined
+// unconditionally (like bfd_state) -- a zero-init 4-byte .tbss slot when the guard is compiled out.
+thread_local std::uint32_t tdma_guard_armed_mask __attribute__((used)) = 0;
+}  // namespace llk_tdma_guard
+
 namespace ckernel {
 
 // Transition shim

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_tdma_guard.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/llk_tdma_guard.h
@@ -28,11 +28,28 @@ namespace llk_tdma_guard
 {
 // One mask per TRISC (the unpack TRISC owns the unpack copy, the pack TRISC owns the pack copy).
 // Bit d set  => a WAIT armed dfb d and no TDMA has touched dfb d since.
+//
+// The compute TRISCs run as separate threads in the host-threaded emulation. A single shared mask
+// races the arm/disarm read-modify-writes (|= / &=) and lets one TRISC's WAIT/POP see another's bits
+// -- the same shared-mutable-global-across-Neos bug tt-llk#1678 fixed for bfd_state. Give the mask
+// per-TRISC thread_local storage. It is zero-initialized, so it stays in .tbss (no load image) and
+// adds no .tdata/LMA firmware footprint. Mirrors trisc::bfd_state / dest_register_offset: ENV_LLK_INFRA
+// (standalone LLK infra, no firmware TU) uses a plain static; the metal build declares it extern
+// thread_local and defines it in firmware (tt_metal/hw/firmware/src/tt-2xx/trisc.cc).
+#ifdef ENV_LLK_INFRA
 inline std::uint32_t& armed_mask()
 {
     static std::uint32_t mask = 0;
     return mask;
 }
+#else
+extern thread_local std::uint32_t tdma_guard_armed_mask; // defined in tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+
+inline std::uint32_t& armed_mask()
+{
+    return tdma_guard_armed_mask;
+}
+#endif
 
 inline void note_wait(const std::uint32_t dfb)
 {


### PR DESCRIPTION
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

The TEN-4746 tile-counter guard's armed_mask() used a function-local static uint32_t shared across a core's compute TRISC host-threads in the host-threaded emulation, so the arm/disarm read-modify-writes (|= / &=) race -- the same shared-mutable-global-across-Neos bug tt-llk#1678 fixed for bfd_state.

Give the mask per-TRISC thread_local storage, mirroring trisc::bfd_state / dest_register_offset: ENV_LLK_INFRA keeps the plain function-local static; the metal build declares it extern thread_local in the header and defines it in firmware (trisc.cc). It is zero-initialized, so it stays in .tbss with no .tdata / firmware multicast-load footprint.

Add a validation test (QuasarTdmaGuardWaitPopNoUnpack) driving a new DFB consumer kernel that does wait_front -> pop_front with no unpack (UNPACR) between; the guard trips in llk_pop_tiles (llk_io_unpack.h) on every executed run, both before and after the change (100% trip rate; single-TRISC deterministic regression check).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

https://github.com/tenstorrent/tt-llk/issues/1678


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdma-guard-thread-local)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdma-guard-thread-local)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdma-guard-thread-local)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdma-guard-thread-local)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdma-guard-thread-local)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdma-guard-thread-local)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdma-guard-thread-local)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdma-guard-thread-local)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdma-guard-thread-local)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdma-guard-thread-local)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdma-guard-thread-local)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdma-guard-thread-local)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdma-guard-thread-local)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdma-guard-thread-local)