### PR TITLE
Add category picker to package-and-release + ops_pnr scaffold

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -125,6 +125,14 @@ ttnn:
     wh_n150_civ2: 60
     bh_p100: 30
     bh_p150b_civ2_viommu: 30
+  pnr:
+    # Mirrors ttnn's L2 `integration` budget as a starting point; ops_pnr.yaml has no
+    # entries yet — retune once real ops PnR tests land.
+    wh_llmbox: 30
+    wh_galaxy: 100
+    wh_n150_civ2: 60
+    bh_p100: 30
+    bh_p150b_civ2_viommu: 30
   profiler:
     wh_llmbox: 30
     wh_n150_civ2: 8

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -126,8 +126,6 @@ ttnn:
     bh_p100: 30
     bh_p150b_civ2_viommu: 30
   pnr:
-    # Mirrors ttnn's L2 `integration` budget as a starting point; ops_pnr.yaml has no
-    # entries yet — retune once real ops PnR tests land.
     wh_llmbox: 30
     wh_galaxy: 100
     wh_n150_civ2: 60

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -129,6 +129,7 @@ ttnn:
     wh_llmbox: 30
     wh_galaxy: 100
     wh_n150_civ2: 60
+    wh_n150: 5
     bh_p100: 30
     bh_p150b_civ2_viommu: 30
   profiler:

--- a/.github/workflows/ops-pnr-tests-impl.yaml
+++ b/.github/workflows/ops-pnr-tests-impl.yaml
@@ -1,7 +1,7 @@
 name: "[internal] ttnn ops PnR tests impl"
 
 # Team: ttnn
-# test list: ops_pnr.yaml (currently empty)
+# test list: ops_pnr.yaml (currently a single no-op placeholder entry)
 #
 # Reusable workflow for the ops PnR (package-and-release) test track. Mirrors
 # ops-integration-tests-impl.yaml / ops-unit-tests-impl.yaml's structure so this

--- a/.github/workflows/ops-pnr-tests-impl.yaml
+++ b/.github/workflows/ops-pnr-tests-impl.yaml
@@ -1,0 +1,128 @@
+name: "[internal] ttnn ops PnR tests impl"
+
+# Team: ttnn
+# test list: ops_pnr.yaml (currently empty)
+#
+# Reusable workflow for the ops PnR (package-and-release) test track. Mirrors
+# ops-integration-tests-impl.yaml / ops-unit-tests-impl.yaml's structure so this
+# is ready to run real tests as soon as ops_pnr.yaml gains entries.
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      enabled-skus:
+        required: true
+        type: string
+        description: "Comma-separated SKUs (see .github/sku_config.yaml)."
+      additional_test_categories:
+        required: false
+        type: string
+        default: ''
+        description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
+      enable-llk-asserts:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  load-test-matrix:
+    runs-on: ubuntu-slim
+    outputs:
+      matrix: ${{ steps.filter-categories.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/ops_pnr.yaml
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
+      - name: Install dependencies
+        run: pip3 install PyYAML
+      - name: Verify test timeouts against budget
+        run: |
+          set -e
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "pnr"
+      - name: Build test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "${{ inputs.enabled-skus }}" \
+            ./.github/sku_config.yaml
+      - name: Filter matrix by additional_test_categories
+        id: filter-categories
+        run: |
+          matrix='${{ steps.build-matrix.outputs.matrix }}'
+          categories='${{ inputs.additional_test_categories }}'
+          filtered=$(echo "$matrix" | jq -c --arg cats ",$categories," '[.[] | .category as $c | select($cats | contains(",\($c),"))]')
+          {
+            echo "matrix<<EOF"
+            echo "$filtered"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  ops-pnr-tests:
+    needs: load-test-matrix
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
+    name: ${{ matrix.test-group.name }}
+    runs-on: ${{ matrix.test-group.runs_on }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️  Setup Job
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
+      - name: ${{ matrix.test-group.name }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
+        run: |
+          ${{ matrix.test-group.cmd }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -29,8 +29,10 @@ on:
         type: string
       additional_test_categories:
         description: >
-          Additional test categories to run (comma-separated). Currently only consumed by
-          the ops PnR test track (tests/pipeline_reorg/ops_pnr.yaml), which has no entries yet.
+          Additional test categories to run (comma-separated). Applied to both the ops PnR
+          test track (tests/pipeline_reorg/ops_pnr.yaml, filtered by its `category` field)
+          and the models e2e suite (tests/pipeline_reorg/models_e2e_tests.yaml, filtered
+          by `model_family` as an interim measure — see release-demo-tests-impl.yaml).
         required: false
         type: string
         default: ""

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -27,6 +27,13 @@ on:
         required: false
         default: ""
         type: string
+      additional_test_categories:
+        description: >
+          Additional test categories to run (comma-separated). Currently only consumed by
+          the ops PnR test track (tests/pipeline_reorg/ops_pnr.yaml), which has no entries yet.
+        required: false
+        type: string
+        default: ""
 
   schedule:
     # Create dev every day at EOD of PST Mon-Fri + night of Sunday to kick off
@@ -161,6 +168,7 @@ jobs:
       tag-version: ${{ needs.create-tag.outputs.version }}
       is-release-candidate: ${{ needs.release-precheck.outputs.is-release-candidate }}
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
+      additional_test_categories: ${{ inputs.additional_test_categories }}
 
   publish-to-pypi:
     needs: [build-test-publish, create-tag]
@@ -654,7 +662,8 @@ jobs:
             {
               "release-type": "rc",
               "dry-run": "${{ inputs.dry-run || 'false' }}",
-              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}"
+              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}",
+              "additional_test_categories": "${{ inputs.additional_test_categories || '' }}"
             }
       - name: Log no action needed
         if: ${{ steps.check-new-commits.outputs.has-new-commits == 'false' }}
@@ -682,5 +691,6 @@ jobs:
             {
               "release-type": "prod",
               "dry-run": "${{ inputs.dry-run || 'false' }}",
-              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}"
+              "tests-yaml-gist-url": "${{ inputs.tests-yaml-gist-url || '' }}",
+              "additional_test_categories": "${{ inputs.additional_test_categories || '' }}"
             }

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -34,8 +34,10 @@ on:
         type: string
       additional_test_categories:
         description: >
-          Additional test categories to run (comma-separated). Currently only consumed by
-          the ops PnR test track (tests/pipeline_reorg/ops_pnr.yaml), which has no entries yet.
+          Additional test categories to run (comma-separated). Applied to both the ops PnR
+          test track (tests/pipeline_reorg/ops_pnr.yaml, filtered by its `category` field)
+          and the models e2e suite (tests/pipeline_reorg/models_e2e_tests.yaml, filtered
+          by `model_family` as an interim measure — see release-demo-tests-impl.yaml).
         required: false
         type: string
         default: ""
@@ -129,6 +131,7 @@ jobs:
       mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
       tier: "1"
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
+      additional_test_categories: ${{ inputs.additional_test_categories }}
       summary-scope: ${{ inputs.platform }}
 
   # Run-level aggregate of per-job AI summaries from release-demo-tests-impl.
@@ -185,7 +188,14 @@ jobs:
 
   # ===========================================================================
   # Team: ttnn
-  # test list: ops_pnr.yaml (currently empty)
+  # test list: ops_pnr.yaml (currently a single no-op placeholder entry)
+  #
+  # additional_test_categories is filtered here against ops_pnr.yaml's own
+  # `category` field, but against `model_family` for the models e2e suite
+  # below in release-demo-tests (see release-demo-tests-impl.yaml) — two
+  # different fields serving the same input as an interim measure. Plan is
+  # to unify these into a single `category` field/filter shared by every
+  # PnR test track once the models e2e taxonomy is settled.
   # ===========================================================================
   ops-pnr-tests:
     needs: [build-artifact, determine-test-skus]

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -32,6 +32,13 @@ on:
         required: false
         default: ""
         type: string
+      additional_test_categories:
+        description: >
+          Additional test categories to run (comma-separated). Currently only consumed by
+          the ops PnR test track (tests/pipeline_reorg/ops_pnr.yaml), which has no entries yet.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -175,6 +182,22 @@ jobs:
           else
             echo "::warning::Report file not found: $REPORT_FILE"
           fi
+
+  # ===========================================================================
+  # Team: ttnn
+  # test list: ops_pnr.yaml (currently empty)
+  # ===========================================================================
+  ops-pnr-tests:
+    needs: [build-artifact, determine-test-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
+    secrets: inherit
+    uses: ./.github/workflows/ops-pnr-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enabled-skus: ${{ needs.determine-test-skus.outputs.enabled-skus }}
+      additional_test_categories: ${{ inputs.additional_test_categories }}
 
   # Polls the "RTL Sim CI test" GitHub check on stable HEAD (posted by the
   # tt-umd-simulators polling agent -- GitLab issue #71). Runs in parallel

--- a/.github/workflows/release-demo-tests-impl.yaml
+++ b/.github/workflows/release-demo-tests-impl.yaml
@@ -1,8 +1,10 @@
 name: "[internal] Release demo tests impl"
 
 # Package-and-release entry for models e2e: download optional gist, filter to
-# release_ready, then pass the combined matrix to models-e2e-tests-impl.yaml
-# which splits single-host vs exabox multihost and runs the tests.
+# release_ready (and, optionally, additional_test_categories via model_family —
+# see the apply-filters step), then pass the combined matrix to
+# models-e2e-tests-impl.yaml which splits single-host vs exabox multihost and
+# runs the tests.
 
 on:
   workflow_call:
@@ -38,6 +40,16 @@ on:
         type: string
         default: ""
         description: "URL to gist containing models_e2e_tests.yaml (optional, falls back to local file if not provided). Security: Only GitHub gist/raw URLs allowed, validated before download."
+      additional_test_categories:
+        required: false
+        type: string
+        default: ""
+        description: >
+          Comma-separated category filter, matched against each test's `model_family`
+          (case-insensitive; models_e2e_tests.yaml has no dedicated `category` field yet
+          — see release-build-test-publish.yaml's ops-pnr-tests section for the plan to
+          unify this with ops_pnr.yaml's `category` field). Empty = no narrowing (today's
+          tier/release_ready behavior).
       summary-scope:
         required: false
         type: string
@@ -110,7 +122,7 @@ jobs:
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml
-      - name: Apply tier, release_ready, and model filters
+      - name: Apply tier, release_ready, model, and category filters
         id: apply-filters
         # Pass values via env rather than inline ${{ }} so arbitrary cmd content in the matrix
         # (apostrophes, parentheses, etc.) cannot break the shell quoting of the assignment.
@@ -118,6 +130,7 @@ jobs:
           MATRIX: ${{ steps.build-matrix.outputs.matrix }}
           TIER: ${{ inputs.tier }}
           MODEL: ${{ inputs.model }}
+          CATEGORIES: ${{ inputs.additional_test_categories }}
         run: |
           # Filter by tier
           FILTERED=$(echo "$MATRIX" | jq -c --argjson tier "$TIER" '[.[] | select(.tier == $tier)]')
@@ -129,8 +142,16 @@ jobs:
               ($m | ascii_downcase | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $toks
               | [ .[] | select((.model | ascii_downcase) as $mm | any($toks[]; . as $t | $mm | contains($t))) ]')
           fi
+          # Filter by additional_test_categories (interim: matched against model_family
+          # since models_e2e_tests.yaml has no dedicated category field yet — exact
+          # match, case-insensitive; empty input = no narrowing).
+          if [ -n "$CATEGORIES" ]; then
+            FILTERED=$(echo "$FILTERED" | jq -c --arg c "$CATEGORIES" '
+              ($c | ascii_downcase | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $toks
+              | [ .[] | select((.model_family // "" | ascii_downcase) as $mf | any($toks[]; . == $mf)) ]')
+          fi
           if [ "$FILTERED" = "[]" ]; then
-            echo "::warning::No tests found for tier=${TIER}, release_ready=true, model=${MODEL}. Pipeline will be skipped."
+            echo "::warning::No tests found for tier=${TIER}, release_ready=true, model=${MODEL}, additional_test_categories=${CATEGORIES}. Pipeline will be skipped."
             echo "matrix=[]" >> $GITHUB_OUTPUT
           else
             echo "matrix<<EOF" >> $GITHUB_OUTPUT

--- a/tests/pipeline_reorg/ops_pnr.yaml
+++ b/tests/pipeline_reorg/ops_pnr.yaml
@@ -1,9 +1,9 @@
 # This file defines the test matrix for the ops PnR (package-and-release) tests pipeline.
 #
 # Team: ttnn
-# Currently empty — scaffolding in preparation for ops PnR tests. Consumed by
-# ops-pnr-tests-impl.yaml, which is wired into release-build-test-publish.yaml's
-# package-and-release pipeline.
+# Scaffolding in preparation for ops PnR tests — only a no-op placeholder entry
+# so far. Consumed by ops-pnr-tests-impl.yaml, which is wired into
+# release-build-test-publish.yaml's package-and-release pipeline.
 
 # Each entry represents a parallel job with the following keys:
 #   name: The display name for the job in GitHub Actions.
@@ -19,4 +19,13 @@
 
 # For max allowed timeout refer to .github/time_budget.yaml (ttnn -> pnr)
 
-[]
+- name: ops PnR no-op smoke test
+  # Placeholder entry to verify the category-filter/dispatch wiring end-to-end.
+  # Replace with real ops PnR tests as they come online.
+  cmd: 'echo "ops PnR no-op smoke test"'
+  skus:
+    wh_n150:
+      timeout: 5
+  owner_id: U08DEGUJY3H # Rose Li
+  team: ttnn
+  category: matmul

--- a/tests/pipeline_reorg/ops_pnr.yaml
+++ b/tests/pipeline_reorg/ops_pnr.yaml
@@ -1,0 +1,22 @@
+# This file defines the test matrix for the ops PnR (package-and-release) tests pipeline.
+#
+# Team: ttnn
+# Currently empty — scaffolding in preparation for ops PnR tests. Consumed by
+# ops-pnr-tests-impl.yaml, which is wired into release-build-test-publish.yaml's
+# package-and-release pipeline.
+
+# Each entry represents a parallel job with the following keys:
+#   name: The display name for the job in GitHub Actions.
+#   cmd: The exact command to run for the test.
+#   skus: A mapping of SKU names to their configuration.
+#     Each SKU entry contains:
+#       timeout: The maximum allowed runtime for this job in minutes on that SKU.
+#   owner_id: The Slack user ID to notify on failure.
+#   team: The team that owns the test.
+#   category: Selector used by package-and-release.yaml's additional_test_categories
+#     dispatch input. On dispatch the impl filters this matrix to entries whose
+#     category appears in the comma-separated list.
+
+# For max allowed timeout refer to .github/time_budget.yaml (ttnn -> pnr)
+
+[]


### PR DESCRIPTION
## Summary
- Mirrors `tt-metal-l2-nightly.yaml`'s `additional_test_categories` dispatch input into `package-and-release.yaml`, threaded through `release-build-test-publish.yaml`, so a manual release dispatch can pick a category of tests to run from the GUI — **applied across the whole PnR pipeline**, not just the new ops track (see "Implementation choice" below).
- Establishes an ops PnR test track for the ttnn team, in preparation for future ops tests:
  - `tests/pipeline_reorg/ops_pnr.yaml` — test-definitions yaml, same schema/header style as `ops_integration_tests.yaml`, with a single no-op placeholder entry (`category: matmul`) to exercise the wiring end-to-end.
  - `.github/workflows/ops-pnr-tests-impl.yaml` — reusable workflow, structurally identical to `ops-integration-tests-impl.yaml`, wired into `release-build-test-publish.yaml` under a `# Team: ttnn` comment block (same convention as `merge-gate.yaml`'s team sections).
  - `.github/time_budget.yaml` — added a `ttnn.pnr` budget as a starting point to retune once real tests land.
- Wires the same `additional_test_categories` input into `release-demo-tests-impl.yaml` so it also filters the models e2e suite (`tests/pipeline_reorg/models_e2e_tests.yaml`), layered on top of the existing tier/release_ready/model filters. Empty input = today's behavior, unchanged.

## Implementation choice: category selection for the models e2e track
`models_e2e_tests.yaml` has no dedicated `category` field (unlike `ops_pnr.yaml`/the L2 ops files). Rather than backfill one across all 82 entries, this PR **reuses the existing `model_family` field** (Llama, Gemma, Qwen, ...) as an interim category selector for that track.

**Pros:**
- Zero backfill — `model_family` already exists on ~84/82 entries; ships now instead of blocking on a taxonomy design + data-authoring pass.
- No new taxonomy to invent/maintain.
- Same filter mechanism/input (`additional_test_categories`) covers both tracks from the GUI.

**Cons:**
- Mixes two vocabularies in one input: ops feature-tags (`matmul`, `conv`, ...) vs. model family names (`Llama`, `Qwen`, ...).
- Overlaps with the existing `model:` dispatch input on the same workflow, which already filters by model substring — two different ways to select "just Llama tests."
- `model_family` is optional and 2/82 entries omit it; those become silently unreachable by category.
- Coarser than a real category system — selects by model identity only, not by test *kind* (no cross-family grouping like "all perf tests").
- Reusing a display-oriented field as a stable filter contract means renaming a `model_family` value later is a breaking change for saved dispatch inputs/automation.

**Promise:** this is intentionally an interim measure, not the final design. `ops_pnr.yaml` keeps its own dedicated `category` field. Once the models e2e taxonomy is settled, unify both tracks onto a single shared `category` field/filter mechanism (see the comment block above the `ops-pnr-tests` job in `release-build-test-publish.yaml`, which cross-references this).

## Notes for reviewers
- The `ttnn.pnr` entry added to `.github/time_budget.yaml` is copied verbatim from `ttnn.integration` (the closest existing L2 analog), plus a `wh_n150: 5` line for the no-op smoke test. Retune once real ops PnR tests land.
- `ops_pnr.yaml` currently has one no-op placeholder entry ("ops PnR no-op smoke test", `category: matmul`, owned by me) added to validate the category-filter/dispatch path with a real dispatch. Remove/replace once real ops PnR tests land.
- The `model_family`-based filter in `release-demo-tests-impl.yaml` was validated locally (YAML parses, jq expression hand-traced against sample entries) but not yet exercised end-to-end via a real dispatch — a prior dry-run dispatch validated the ops_pnr side (`ops-pnr-tests` passed) but was cancelled before this models-track change landed. Happy to launch another dry-run dispatch on request.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all changed files — all parse cleanly.
- [x] `verify_time_budget.py tests/pipeline_reorg/ops_pnr.yaml .github/time_budget.yaml pnr` — passes.
- [x] `prepare_test_matrix.py tests/pipeline_reorg/ops_pnr.yaml ALL_SKUS_IN_TESTS .github/sku_config.yaml` — resolves the no-op entry correctly.
- [x] Dry-run dispatch of `package-and-release.yaml` with `additional_test_categories: matmul` — `ops-pnr-tests` job passed (Ubuntu 22.04 leg): https://github.com/tenstorrent/tt-metal/actions/runs/32774251730/job/97585674877 (run was cancelled afterward, before the models-track change below).
- [ ] Re-run the dry-run dispatch to validate the `model_family` filter against `release-demo-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)