### PR TITLE
port(metal_2.0): reduction/argmax ArgMaxDeviceOperation → ProgramSpecFactoryConcept (6 gtests / 66 / 937 passed)

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PORT_BRIEF.md
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PORT_BRIEF.md
@@ -1,0 +1,203 @@
+# Metal 2.0 Port Brief — `ttnn/cpp/ttnn/operations/reduction/argmax`
+
+> **Scope: `ArgMaxDeviceOperation` only** — its `ArgMaxSingleCoreProgramFactory` and
+> `ArgMaxMultiCoreProgramFactory`, and the four kernels they instantiate. This DeviceOperation
+> cleared every gate.
+>
+> **`ArgMaxNCDeviceOperation` / `ArgMaxNCProgramFactory` is OUT OF SCOPE and must not be
+> touched.** It is still on the legacy imperative `host_api.hpp` builder (`legacy device-op`
+> concept), so it is blocked pending its `ProgramDescriptor` migration. Leave
+> `argmax_nc_device_operation.*`, `argmax_nc_program_factory.cpp`, `kernels/reader_argmax_nc.cpp`,
+> `kernels/writer_argmax_nc.cpp`, and `kernels/argmax_nc_compute.cpp` exactly as they are. The
+> user-facing `ttnn::argmax` facade will dispatch to a ported device-op and a legacy one
+> side by side; that is expected.
+>
+> Full record — including the gated half — is in `METAL2_PREPORT_AUDIT.md`.
+
+**Gates cleared:** Device 2.0 ✓ · Features ✓ · TTNN factory concept ✓ (both in-scope factories)
+· Offset base pointers ✓ · TensorAccessor 3rd arg ✓
+
+**Recipe docs:** `b73b958088a 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources` *(carry this line into the port report's Provenance section)*
+
+## TTNN factory analysis
+
+These facts feed the port's TTNN ProgramFactory wiring (→ `ttnn_factory.md`); the op ports to
+`ProgramSpecFactoryConcept`. Carry them forward:
+
+- **Current concept:** `descriptor` — `create_descriptor()` returning a `ProgramDescriptor`,
+  declared at `device/argmax_device_operation.hpp:17` (single-core) and `:22` (multi-core).
+- **Op-owned tensors:** none.
+- **Target concept:** **`ProgramSpecFactoryConcept`** (the base concept — no
+  `override_runtime_arguments` exists on either in-scope factory, so the framework refreshes the
+  tensor bindings on a cache hit and each factory writes one method).
+- **`program_factory_t` variant:** `std::variant<ArgMaxSingleCoreProgramFactory,
+  ArgMaxMultiCoreProgramFactory>` @ `device/argmax_device_operation.hpp:31`. Both factories are
+  selected at runtime by `select_program_factory` (`argmax_device_operation.cpp:76`) via
+  `uses_multicore_path`, so **both must be ported together** — the variant admits no half state.
+- **No pybound `create_descriptor`** to delete: `argmax_nanobind.cpp` binds only the user-facing
+  `ttnn::argmax`, so this port carries **no user-visible API change**.
+- **Gate-cleared, confirmed absent** (each would have blocked the brief): a non-`none`
+  `TensorParameter relaxation` (the sheet reads `none`) · `get_dynamic_runtime_args` (the
+  deprecated hook — absent from both device-ops). This op *also* happens to carry no custom
+  `compute_program_hash`, no `override_runtime_arguments`, and no pybound `create_descriptor` —
+  but note none of those three would have gated anyway.
+
+## Construct — to do
+
+**Tensor bindings** (per binding — identical in both factories, and in all three of the
+single-core factory's kernel configs):
+
+- `input` — **Case 1** (via `TensorAccessor`) → express as `TensorParameter` / `TensorBinding`;
+  the kernel builds `TensorAccessor(tensor::<name>)` instead.
+- `output` — **Case 1** (via `TensorAccessor`) → same.
+
+Today both arrive through the `Buffer*`-binding form in its MeshTensor spelling —
+`reader_desc.emplace_runtime_args(core, {input, output})` at
+`device/argmax_single_core_program_factory.cpp:205` and
+`device/argmax_multi_core_program_factory.cpp:394` / `:424`. The framework auto-registers those as
+`BufferBinding`s and patches them on cache hits, so this is **routine port work, not a correctness
+hazard** — it is already correct today, and the typed binding supersedes the mechanism.
+
+Both of these disappear on the host side when you bind the tensors:
+
+- `TensorAccessorArgs(input).append_to(ctime_args)` / `TensorAccessorArgs(output).append_to(...)`
+  @ `argmax_single_core_program_factory.cpp:182,183` and
+  `argmax_multi_core_program_factory.cpp:373,374`.
+- Kernel-side, the paired `TensorAccessorArgs<N>()` /
+  `next_compile_time_args_offset()` plumbing: `reader_argmax_interleaved.cpp:41,42`;
+  `reader_argmax_interleaved_multicore.cpp:299,300`; `reader_argmax_tile_layout.cpp:49,50`;
+  `reader_argmax_tile_layout_h.cpp:44,45`. Note the two TILE readers hardcode the accessor's
+  starting CTA offset as `num_c_time_args` (`= 13` @ `reader_argmax_tile_layout.cpp:40`, `= 11` @
+  `reader_argmax_tile_layout_h.cpp:39`) — those constants go away with the accessor args, and the
+  remaining CTAs become named.
+
+**TensorParameter relaxation:** none.
+
+**TensorAccessor 3rd arg:** none — no accessor in the op passes a 3rd argument. All ten
+construction sites are the 2-arg form, so there is nothing to drop and no
+`dynamic_tensor_shape` to set.
+
+**CB endpoints:** **self-loop on all six**, i.e. bind the single touching kernel as *both*
+PRODUCER and CONSUMER. Every CB in scope has exactly **one** toucher per node, and that toucher
+is **sync-free** — a raw `get_write_ptr()` peek with no FIFO ops anywhere in these four kernels
+(no `reserve_back` / `push_back` / `wait_front` / `pop_front`). No 1P+1C assignment, no
+multi-binding advanced option, no dead-CB drop, no conditional DFB.
+
+| Factory | `(CB, config)` | Disposition |
+|---|---|---|
+| single-core | `(c_0 src, RM)` · `(c_1 dst, RM)` | self-loop |
+| single-core | `(c_0 src, TILE-W)` · `(c_1 dst, TILE-W)` | self-loop |
+| single-core | `(c_0 src, TILE-H)` · `(c_1 dst, TILE-H)` | self-loop |
+| multi-core | `(c_0 src)` · `(c_1 dst)` · `(c_2 red_idxs)` · `(c_3 red_vals)` | self-loop |
+
+**`get_dataformat(<cb_idx>)` → move onto the bound object.** Five sites query the buffer's data
+format through the CB-index free function; the port moves them to the DFB member, which is
+`constexpr` and so survives the NTTP uses:
+
+| File | Line |
+|---|---|
+| `device/kernels/reader_argmax_interleaved.cpp` | `54` |
+| `device/kernels/reader_argmax_interleaved_multicore.cpp` | `317`, `334` |
+| `device/kernels/reader_argmax_tile_layout.cpp` | `63` |
+| `device/kernels/reader_argmax_tile_layout_h.cpp` | `53` |
+
+Each result must stay a compile-time constant — they feed `get_default_value<fmt>()`,
+`compare_values<fmt>(…)`, `process_input_tile<T, fmt>(…)`,
+`find_argmax_from_intermediate_outputs<n, fmt>(…)`, and a `static_assert` @
+`reader_argmax_interleaved_multicore.cpp:341`. `DataflowBuffer::get_dataformat()` is `constexpr`
+(`tt_metal/hw/inc/api/dataflow/dataflow_buffer.h:279`), so this works; the `CircularBuffer`
+member is **not** `constexpr`, which is why this move belongs to the port and not to Device 2.0.
+
+**Two DFB specs share one buffer index, over disjoint core ranges — reproduce this faithfully.**
+The multi-core factory declares `c_0` **twice**:
+`argmax_multi_core_program_factory.cpp:218` over `cores0` sized
+`round_up_to_mul32(red_dim_units0 * input_unit_size)`, and `:231` over `cores1` sized from
+`red_dim_units1` — **guarded by `if (num_cores1 > 0)`**. On the default (no `sub_core_grids`) path
+those two sizes genuinely **differ**, because `split_work_to_cores` gives the two groups different
+per-core block counts. Keep both specs, keep the size difference, and keep the second one
+conditional.
+
+**Two `KernelDescriptor`s share one `kernel_source` — this is the disjoint-node shape, not a
+work-split.** `argmax_multi_core_program_factory.cpp:376` and `:408` both instantiate
+`reader_argmax_interleaved_multicore.cpp`, but over `cores0` and `cores1` respectively — disjoint
+sets, so each node sees exactly **one** instance. Do not read this as a dual-instance work-split
+and do not reach for the multi-binding option; the per-node census really is 1. The second
+`KernelSpec`, like the second `c_0` spec, is conditional on `num_cores1 > 0`.
+
+## Watch for
+
+- **CB endpoints (multi-binding):** none — no CB reaches two touchers on a node. Nothing to hunt.
+- **The multi-core kernel requires `c_2` / `c_3` to land at the *same* L1 address on every node.**
+  A worker computes the reducer's destination from its **own** base pointer —
+  `red_idx_cb.get_write_ptr() + core_id * red_idx_size_per_core`, then writes to
+  `{.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_idx_cb_local_addr}`
+  (`reader_argmax_interleaved_multicore.cpp:326-339`, `:416-427`, `:467-478`). Legacy honours
+  that: `ProgramImpl::allocate_circular_buffers` assigns **one** address per CB object, taken as
+  the max region-end across every core range it spans
+  (`tt_metal/impl/program/program.cpp:1719-1751`), so a CB over `all_cores` is uniform even
+  though the two `c_0` specs differ in size between the groups. **Confirm the DFB allocator keeps
+  the same property** rather than assuming it — if a DFB were placed per-core-range, these
+  cross-core writes would silently land at the wrong offset. Wrong numerics, no assertion. Worth
+  an explicit numerical check on the multi-core path with an odd `red_dim` (so the two groups get
+  different sizes) plus `sub_core_grids` unset.
+- **Cross-op / shared kernels:** **no borrowed kernel files** — this op owns all four in-scope
+  kernels, and no other *op* instantiates any of them. But `reader_argmax_interleaved.cpp` has one
+  out-of-directory **consumer**: `tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126`
+  file-path-instantiates it from a hand-built `ProgramDescriptor`, with the CTA layout (indices
+  0-7 plus two `TensorAccessorArgs` blocks) and the RTA pair
+  (`src_buffer->address()`, `dst_buffer->address()`) hardcoded at `:105-121`. Rewriting the kernel
+  changes exactly that contract, and `generic_op` / `ProgramDescriptor` **cannot** supply Metal
+  2.0 named bindings — so the test cannot simply be re-pointed. **No `_metal2` fork exists beside
+  any argmax kernel today.** Confirm the chosen resolution with the user before you touch that
+  kernel (audit *Questions* #1): either fork to `reader_argmax_interleaved_metal2.cpp` and leave
+  the test on the legacy copy (then it is a **sunset** item, not authorization to convert in
+  place), or rewrite in place and migrate the test off `generic_op`. Either way, run that gtest.
+- **RTA varargs:** none — prefer named RTAs throughout. Every in-scope kernel reads a fixed set of
+  args at constant indices: 2 for each single-core reader (`src_base_addr`, `dst_base_addr`), and
+  7 for the multi-core reader (`src_base_addr`, `dst_base_addr`, `core_id`, `src_offset`,
+  `red_dim_offset`, `src_read_size`, `red_dim_units_this_core` @
+  `reader_argmax_interleaved_multicore.cpp:219-233`). No counted loop, no in-loop `arg_index++`,
+  no data-selected index. **No CTA varargs either** — every `get_compile_time_arg_val` call in
+  the op uses a literal index, so every CTA gets a name.
+- **The four kernels are at *different* modernization levels — the work is asymmetric.**
+  `reader_argmax_tile_layout.cpp:58,59` and `reader_argmax_tile_layout_h.cpp:51,54` already hold
+  **`DataflowBuffer`**, so for those two the port is a binding-layer change (name the DFB, drop
+  the CTA index) rather than an object rewrite. `reader_argmax_interleaved.cpp:49,50` and
+  `reader_argmax_interleaved_multicore.cpp:311-314` are still on **`CircularBuffer`** and need the
+  full CB→DFB swap — including the `use<CircularBuffer::AddrSelector::WRITE_PTR>(cb)` views
+  (`reader_argmax_interleaved.cpp:87,100`; `reader_argmax_interleaved_multicore.cpp:417,423,451,
+  468,474,499`) and dropping `#include "api/dataflow/circular_buffer.h"`
+  (`reader_argmax_interleaved.cpp:7`, `reader_argmax_interleaved_multicore.cpp:8`). That include
+  is legitimate today — the kernels really do use the wrapper — so it goes away as part of the
+  CB→DFB swap, not as a stray cleanup.
+- **`constexpr`-vs-`const` decides token form site by site.** Every DFB in these kernels comes
+  from a `constexpr uint32_t` CTA feeding a **non**-`constexpr` wrapper object (e.g.
+  `constexpr uint32_t src_dfb_idx = get_compile_time_arg_val(0);` then
+  `DataflowBuffer src_dfb(src_dfb_idx);` @ `reader_argmax_tile_layout.cpp:18,58`), while the
+  `get_dataformat` results must remain compile-time constants. Decide per site, not uniformly.
+- **The dst DFB is reached by raw pointer, not by the object, in the two TILE readers.** They take
+  `dst_dfb.get_write_ptr()` (`reader_argmax_tile_layout.cpp:66`,
+  `reader_argmax_tile_layout_h.cpp:55`), hand it to `OutputContext`, and the actual NoC write goes
+  through a `CoreLocalMem<uint32_t>` built on that address inside `write_to_output`
+  (`kernels/argmax_tile_layout.hpp:329-345`). The binding is still required — the kernel touches
+  the DFB — but you will not find the DFB object at the write site, so bind from the
+  `get_write_ptr()` peek and leave the `CoreLocalMem` walk alone.
+- **`c_1` in the multi-core factory looks per-core-conditional and is not.** Its comment says
+  *"This CB is only used in the reduction core"* (`reader_argmax_interleaved_multicore.cpp:239`),
+  but `dst_cb.get_write_ptr()` @ `:322` executes unconditionally on every node. It is live
+  everywhere — do **not** drop it or make its DFB spec conditional.
+- **`experimental/quasar/reduction/` exists. Stay out of it.** There is a quasar copy of the
+  reduction family. It is a deliberately hacky shortcut port — not a precedent, not a naming
+  source, not a fork to reuse, and its kernels carry idioms this recipe forbids. Do not read it,
+  and do not let anything from it into the diff.
+- **Baseline before the first kernel edit.** Kernels are JIT-compiled from the working tree at
+  test time, so capture the pre-port numerical baseline (all four configs: RM last-dim,
+  RM reduce-all, TILE dim=W, TILE dim=H — plus the multi-core path with and without
+  `sub_core_grids`) **before** editing any kernel file.
+- **Known latent issues in these files that are NOT yours to fix** (they route to the ops team;
+  see the audit's *Misc anomalies*): dead CTA index 4 in the multi-core reader; dead CTA index 3
+  in both TILE readers; the `(bool)`-narrowed `reduce_core_id` @
+  `reader_argmax_interleaved_multicore.cpp:273`; the dummy `(0,0)` core-range CTAs for the
+  single-group case. **Do not scoop these up** — but do notice that the two dead CTAs will show
+  up as CTAs with no kernel-side reader when you convert to named args. Leave them present and
+  named (or raise them), rather than silently deleting them as part of the port.

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PORT_PLAN.md
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PORT_PLAN.md
@@ -1,0 +1,450 @@
+# Port Plan — `reduction/argmax` (`ArgMaxDeviceOperation`)
+
+Port plan for `ttnn/cpp/ttnn/operations/reduction/argmax`, ported from the legacy
+`ProgramDescriptor` API to Metal 2.0.
+Written during the inventory and planning steps; committed alongside the port for review.
+
+**Scope: `ArgMaxDeviceOperation` only** — `ArgMaxSingleCoreProgramFactory` +
+`ArgMaxMultiCoreProgramFactory` and the four kernels they bind.
+`ArgMaxNCDeviceOperation` / `ArgMaxNCProgramFactory` (and its three kernels) are **out of
+scope and untouched** — still on the legacy imperative `host_api.hpp` builder, blocked pending
+its `ProgramDescriptor` migration (audit gate).
+
+---
+
+## Legacy Inventory
+
+### Legacy factory shape
+
+- **Concept:** `ProgramDescriptorFactoryConcept` — `create_descriptor()` returning
+  `tt::tt_metal::ProgramDescriptor`, declared at `device/argmax_device_operation.hpp:17`
+  (single-core) and `:22` (multi-core).
+- **Variants:** two factories in a `program_factory_t` variant
+  (`std::variant<ArgMaxSingleCoreProgramFactory, ArgMaxMultiCoreProgramFactory>` @
+  `device/argmax_device_operation.hpp:31`), selected at runtime by `select_program_factory`
+  (`argmax_device_operation.cpp:76`) via `uses_multicore_path`. **Both port together** — see
+  *Flags*.
+- **Factory methods live in factory structs**, not on the device-operation. So
+  [`ttnn_factory.md` exception 3](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/ttnn_factory.md)
+  (direct-descriptor shape) does **not** apply — the port is a method swap inside the
+  existing structs.
+- **Custom `compute_program_hash`:** none — default reflection-based hash. No backdoor
+  `attribute_values` / `to_hash` either. Nothing to leave alone.
+- **`override_runtime_arguments`:** absent on both factories → base
+  `ProgramSpecFactoryConcept`.
+
+---
+
+### Variant: `ArgMaxSingleCoreProgramFactory`
+
+The factory selects **one of three kernel sources at runtime**
+(`argmax_single_core_program_factory.cpp:185-193`), and the CTA list differs per source
+(`get_ctime_args_single_core`, `:48`). All three convert together.
+
+#### Kernels
+
+| unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | CRTAs | defines | opt_level | config |
+|---|---|---|---|---|---|---|---|---|---|
+| reader (RM) | `kernels/reader_argmax_interleaved.cpp` | `all_cores` (1 node) | 0 `src_cb_index`, 1 `dst_cb_index`, 2 `src_page_size`, 3 `dst_page_size`, 4 `outer_dim_units`, 5 `inner_dim_units`, 6 `red_dim_units`, 7 `reduce_all`, then `TensorAccessorArgs(input)` @ 8, `TensorAccessorArgs(output)` chained | none | per node: `{input, output}` (MeshTensor bindings) @ `:205` | none | none | unset → **O2** (DM) | `ReaderConfigDescriptor{}` |
+| reader (TILE-W) | `kernels/reader_argmax_tile_layout.cpp` | `all_cores` (1 node) | 0 `src_cb_index`, 1 `dst_cb_index`, 2 `src_page_size`, 3 `dst_page_size` *(dead — kernel skips 3)*, 4 `tile_height`, 5 `tile_width`, 6 `h_tiles`, 7 `w_tiles`, 8 `h_logical`, 9 `w_logical`, 10 `outer_dim_units`, 11 `reduce_all`, 12 `keepdim`, then TA args @ 13 | none | same | none | none | unset → **O2** (DM) | `ReaderConfigDescriptor{}` |
+| reader (TILE-H) | `kernels/reader_argmax_tile_layout_h.cpp` | `all_cores` (1 node) | as TILE-W but **without** 11/12; TA args @ 11 | none | same | none | none | unset → **O2** (DM) | `ReaderConfigDescriptor{}` |
+
+`opt_level` confirmed mechanically: `grep -n opt_level` over both factory `.cpp`s returns
+nothing → `std::nullopt` → resolves to `O2` on a reader/DM descriptor. Both factories build
+**only DM kernels**, so [Compiler options](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/port/metal2_port.md)
+rule 2 (compute → explicit `O3`) does not fire anywhere in this port; Metal 2.0's `O2` default
+already reproduces legacy.
+
+#### CBs
+
+| index | total_size | core_ranges | data_format | page_size | tile (if set) |
+|---|---|---|---|---|---|
+| `c_0` (src) | `src_page_size` | `all_cores` | `input_data_format` | `src_page_size` | not set |
+| `c_1` (dst) | `dst_page_size` | `all_cores` | `output_data_format` | `dst_page_size` | not set |
+
+`total_size == page_size` on both → **one entry each**. No `GlobalCircularBuffer`, no
+`address_offset`, no multi-element `format_descriptors` (no aliasing).
+
+#### Semaphores
+
+none.
+
+#### Tensor accessors
+
+| host site (file:line) | originating Tensor | RTA slot (host) |
+|---|---|---|
+| `argmax_single_core_program_factory.cpp:182` (`TensorAccessorArgs(input).append_to`) | `tensor_args.input` | RTA 0 (`input`) @ `:205` |
+| `argmax_single_core_program_factory.cpp:183` (`TensorAccessorArgs(output).append_to`) | `tensor_return_value` | RTA 1 (`output`) @ `:205` |
+
+Kernel-side pairs: `reader_argmax_interleaved.cpp:41,42`;
+`reader_argmax_tile_layout.cpp:49,50`; `reader_argmax_tile_layout_h.cpp:44,45`.
+Both bindings are **Case 1** (consumed via `TensorAccessor`, never as a raw base pointer).
+
+#### Work split
+
+- Driver: `split_work_to_cores(grid_size, /*num_units=*/1)` @ `:133`.
+- num_cores: 1 · all_cores: the single resulting node · groups 2-6 discarded (`unused_1..4`).
+- `cores = grid_to_cores(num_cores, grid_size.x, grid_size.y, false)` @ `:203` → one node.
+
+---
+
+### Variant: `ArgMaxMultiCoreProgramFactory`
+
+One kernel source, instantiated **once or twice** over disjoint core groups.
+
+#### Kernels
+
+| unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | CRTAs | defines | opt_level | config |
+|---|---|---|---|---|---|---|---|---|---|
+| reader_desc0 | `kernels/reader_argmax_interleaved_multicore.cpp` | `cores0` | 0-27 (below) + TA(input) @ 28 + TA(output) | none | per node: `{input, output, core_id, src_offset, red_dim_offset, src_read_size, red_dim_units_this_core}` @ `:394` | none | none | unset → **O2** (DM) | `DataMovementConfigDescriptor{RISCV_1, NOC::RISCV_1_default, DM_DEDICATED_NOC}` |
+| reader_desc1 *(only if `num_cores1 > 0`)* | same source | `cores1` | identical CTA vector | none | same shape, different offsets @ `:424` | none | none | unset → **O2** (DM) | identical |
+
+Positional CTA list (`argmax_multi_core_program_factory.cpp:342-372`), with the **kernel's**
+name for each slot (`reader_argmax_interleaved_multicore.cpp:237-297`):
+
+| # | host value | kernel name |
+|---|---|---|
+| 0 | `src_cb_idx` | `src_cb_idx` |
+| 1 | `dst_cb_idx` | `dst_cb_idx` |
+| 2 | `red_idxs_cb_idx` | `red_idxs_cb_idx` |
+| 3 | `red_vals_cb_idx` | `red_vals_cb_idx` |
+| 4 | `src_page_size` | *(never read — dead CTA)* |
+| 5 | `dst_page_size` | `dst_page_size` |
+| 6 | `red_idxs_page_size / num_total_cores` | `red_idx_size_per_core` |
+| 7 | `red_vals_page_size / num_total_cores` | `red_val_size_per_core` |
+| 8 | `outer_dim_units` | `outer_dim_units` |
+| 9 | `inner_dim_units` | `inner_dim_units` |
+| 10 | `red_dim_units` | `red_dim_units` |
+| 11 | `reduce_all` | `reduce_all` |
+| 12 | `num_total_cores` | `num_cores` |
+| 13 | `reduce_core_id` | `reduce_core_id` |
+| 14 | `reduce_core.x` | `reduce_core_x` |
+| 15 | `reduce_core.y` | `reduce_core_y` |
+| 16 | **`end_core0.x`** | `start_core_x0` |
+| 17 | **`end_core0.y`** | `start_core_y0` |
+| 18 | **`start_core0.x`** | `end_core_x0` |
+| 19 | **`start_core0.y`** | `end_core_y0` |
+| 20 | **`end_core1.x`** | `start_core_x1` |
+| 21 | **`end_core1.y`** | `start_core_y1` |
+| 22 | **`start_core1.x`** | `end_core_x1` |
+| 23 | **`start_core1.y`** | `end_core_y1` |
+| 24 | `num_cores_range0` | `num_cores0` |
+| 25 | `num_cores_range1` | `num_cores1` |
+| 26 | `start_sem_idx` | `start_sem_idx` |
+| 27 | `done_sem_idx` | `done_sem_idx` |
+
+> **Slots 16-23 carry a deliberate start/end swap** — the host comments it
+> `// end comes before start for NOC1` (`:359`). The kernel's `start_core_*0` receives the
+> group's **end** coordinate and its `end_core_*0` receives the **start**, because the NOC_1
+> multicast rectangle is addressed end-corner-first. The named port **preserves the value
+> mapping, not the label**: `{"start_core_x0", end_core0.x}`. Renaming the kernel's variables
+> instead would be kernel-logic surgery outside the whitelist.
+
+#### CBs
+
+| index | total_size | core_ranges | data_format | page_size | tile (if set) |
+|---|---|---|---|---|---|
+| `c_0` (src, group 0) @ `:218` | `round_up_to_mul32(red_dim_units0 * input_unit_size)` | `cores0` | `input_cb_data_format` | same | not set |
+| `c_0` (src, group 1) @ `:231`, **`if (num_cores1 > 0)`** | `round_up_to_mul32(red_dim_units1 * input_unit_size)` | `cores1` | `input_cb_data_format` | same | not set |
+| `c_1` (dst) @ `:244` | `dst_page_size` | `all_cores` | `output_cb_data_format` | same | not set |
+| `c_2` (red_idxs) @ `:257` | `round_up_to_mul32(output_last_dim*output_unit_size) * num_total_cores` | `all_cores` | `output_cb_data_format` | same | not set |
+| `c_3` (red_vals) @ `:270` | `round_up_to_mul32(output_last_dim*input_unit_size) * num_total_cores` | `all_cores` | `input_cb_data_format` | same | not set |
+
+All five have `total_size == page_size` → **one entry each**. No GlobalCircularBuffer, no
+`address_offset`, no aliasing.
+
+#### Semaphores
+
+| id | core_type | core_ranges | initial_value |
+|---|---|---|---|
+| 0 (`start_sem_idx`) @ `:303` | `WORKER` | `all_cores` | 0 |
+| 1 (`done_sem_idx`) @ `:309` | `WORKER` | `all_cores` | 0 |
+
+#### Tensor accessors
+
+| host site (file:line) | originating Tensor | RTA slot (host) |
+|---|---|---|
+| `argmax_multi_core_program_factory.cpp:373` | `tensor_args.input` | RTA 0 @ `:394` / `:424` |
+| `argmax_multi_core_program_factory.cpp:374` | `tensor_return_value` | RTA 1 @ `:394` / `:424` |
+
+Kernel-side pair: `reader_argmax_interleaved_multicore.cpp:299,300`. Both **Case 1**.
+
+#### Work split
+
+- Driver: `distribute_work_to_cores(...)` @ `:195`, which either honours `sub_core_grids`
+  or calls `tt::tt_metal::split_work_to_cores(core_grid, div_up(red_dim_units, min_red_dim_units_per_core))`.
+- Returns `(all_cores, cores0, cores1, red_dim_units0, red_dim_units1)`;
+  `num_cores0 = cores0.num_cores()`, `num_cores1 = cores1.num_cores()`,
+  `num_total_cores = num_cores0 + num_cores1`.
+- Per-node coords: `corerange_to_cores(cores0, num_cores0, true)` / `(cores1, num_cores1, true)`.
+
+---
+
+### Shared kernels
+
+| kernel | class | other consumers | `_metal2` fork present? | rung |
+|---|---|---|---|---|
+| `kernels/reader_argmax_interleaved.cpp` | **lent** (out-of-directory *test* consumer) | `tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126` (`TestGenericOpArgmaxSingleCore`) file-path-instantiates it from a hand-built `ProgramDescriptor`, CTA/RTA contract hardcoded at `:105-121` | **no** | **rung 2 — create the fork** |
+| `kernels/reader_argmax_interleaved_multicore.cpp` | private | none | n/a | convert in place |
+| `kernels/reader_argmax_tile_layout.cpp` | private | none | n/a | convert in place |
+| `kernels/reader_argmax_tile_layout_h.cpp` | private | none | n/a | convert in place |
+
+Census run as `grep -rl <filename> ttnn/cpp/ttnn/operations/ tests/`; the only non-factory,
+non-`METAL2_*.md` hit in the whole set is the gtest above.
+
+**Resolution (confirmed with the invoker; audit *Questions* #1, option (a)):** create
+`kernels/reader_argmax_interleaved_metal2.cpp` beside the original, point the single-core
+factory's RM branch at it, add the pointer comment to the legacy original, and leave
+`test_generic_op.cpp` untouched on the legacy copy. `generic_op` / `ProgramDescriptor` cannot
+supply Metal 2.0 named bindings, so the test could not be re-pointed even in principle. The
+legacy copy is a **sunset** item recorded in `METAL2_PORT_REPORT.md`, not authorization to
+convert it in place.
+
+### In-directory kernel headers (not shared outside the op)
+
+`kernels/argmax_common.hpp`, `kernels/argmax_tile_layout.hpp`, `kernels/argmax_tile_h_col.hpp`
+are included only by the four in-scope readers (and, for `argmax_common.hpp`, by the retained
+legacy fork). They take **raw `uint32_t` L1 addresses and `DataFormat` NTTPs** — no CB object,
+no CB id, no FIFO call — so they need no API change. They do carry `cb`-flavoured *identifier*
+names for the buffer whose address they hold (`InputContext::cb_addr`,
+`OutputContext::output_cb_addr`, `compare_values(src_cb_addr, …)`, `dst_cb_mem`); those follow
+the `cb_* → dfb_*` rename with the rest of the port. Renames are positional-parameter /
+member renames, invisible to the retained legacy fork.
+
+### Flags
+
+- **Both factories must convert in the same change.** They live in one `program_factory_t`
+  variant selected at runtime; the variant itself tolerates mixed concepts, but leaving one on
+  `create_descriptor` while the header declares only `create_program_artifacts` for the other
+  is not the shape here — the brief instructs both, and both are tractable in one pass.
+- **Dead CTAs (known, *not* the port's to fix — routed to the ops team via the report):**
+  index 4 (`src_page_size`) in the multi-core reader; index 3 (`dst_page_size`) in both TILE
+  readers. They become **named CTAs with no kernel-side reader**. Kept and named, per the
+  brief — not silently deleted.
+- **`reduce_core_id` narrowed through `(bool)`** @ `reader_argmax_interleaved_multicore.cpp:273`.
+  Latent, inert today (value 0). Left exactly as-is; reported.
+- **Dummy `(0,0)` core-range CTAs for the single-group case** @
+  `argmax_multi_core_program_factory.cpp:290`. Left as-is.
+- No unreferenced kernel file in the in-scope set. No descriptor type outside the audit's
+  Appendix A scan.
+
+---
+
+## TTNN ProgramFactory
+
+- **Concept (inherited from audit):** `ProgramSpecFactoryConcept` (base) — neither in-scope
+  factory has an `override_runtime_arguments`, so the framework refreshes tensor bindings on a
+  cache hit and each factory writes exactly one method.
+- **Custom `compute_program_hash`:** none — default reflection-based hash. Untouched.
+- **Pybind:** `argmax_nanobind.cpp` binds only the user-facing `ttnn::argmax`; there is no
+  pybound `create_descriptor`, so **no pybind deletion and no user-visible API change**
+  (`ttnn_factory.md` exceptions 1 and 2 do not fire).
+- **Implementation notes:** resource-name constants (`KernelSpecName` / `DFBSpecName` /
+  `SemaphoreSpecName` / `TensorParamName`) are declared **function-locally inside
+  `create_program_artifacts`**, not at namespace scope. Namespace-scope `const` objects have
+  internal linkage, and the two factory `.cpp`s share a unity-build translation unit, so
+  identically-named constants in both would collide
+  ([Unity-build hygiene](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md)).
+  Function-local declarations sidestep it without prefixing.
+
+---
+
+## Planned Spec Shape
+
+### Variant: `ArgMaxSingleCoreProgramFactory`
+
+- **KernelSpecs:** 1 — `READER{"reader"}`, source selected by the same runtime branch as
+  legacy (RM → the new `_metal2` fork; TILE-H → `reader_argmax_tile_layout_h.cpp`;
+  TILE-W → `reader_argmax_tile_layout.cpp`). `hw_config =
+  ttnn::create_reader_datamovement_config(device->arch())` — the legacy
+  `ReaderConfigDescriptor{}` resolves to exactly the reader default triple
+  (`RISCV_1`, `NOC_0`, `DM_DEDICATED_NOC`).
+- **DataflowBufferSpecs:** 2 — `SRC{"src"}`, `DST{"dst"}`, each `entry_size = <page_size>`,
+  `num_entries = 1`, `data_format_metadata` copied from the legacy CB.
+  `tile_format_metadata` left `nullopt` (legacy `.tile` unset).
+- **SemaphoreSpecs:** none.
+- **TensorParameters:** 2 — `INPUT{"input"}`, `OUTPUT{"output"}`, from
+  `input.tensor_spec()` / `output.tensor_spec()`. `relaxations` left at the strict default
+  (audit: relaxation `none`).
+- **WorkUnitSpecs:** 1 — `{"main", {READER}, all_cores}`.
+- **Op-owned tensors:** none.
+- **KernelRunArgs:** **none** — after the two address RTAs become `TensorBinding`s the reader
+  has zero RTAs and zero CRTAs, so its `KernelRunArgs` entry is omitted entirely (permitted:
+  "except for kernels that have no runtime or common runtime arguments").
+  `ProgramRunArgs` carries only `tensor_args`.
+
+Kernel-side accessor names (all three sources): `dfb::src`, `dfb::dst`, `tensor::src`,
+`tensor::dst` — taken from the kernels' own vocabulary (`src_cb_idx`/`src_dfb_idx`,
+`src_base_addr`, `s_src`).
+
+### Variant: `ArgMaxMultiCoreProgramFactory`
+
+- **KernelSpecs:** 1 or 2 — `READER0{"reader0"}` over `cores0`, and `READER1{"reader1"}` over
+  `cores1` **only when `num_cores1 > 0`**. Same source. `hw_config` is a **custom** Gen1
+  triple, replicated verbatim (see *Applied Patterns*).
+- **DataflowBufferSpecs:** 4 or 5 — `SRC0{"src0"}`, `SRC1{"src1"}` *(conditional)*,
+  `DST{"dst"}`, `RED_IDXS{"red_idxs"}`, `RED_VALS{"red_vals"}`; each `num_entries = 1` with
+  `entry_size` = the legacy per-CB page size, `data_format_metadata` copied.
+  **Declaration order is `SRC0, SRC1, DST, RED_IDXS, RED_VALS`** — matching the legacy
+  `desc.cbs.push_back` order, because the DFB allocator walks
+  `ProgramSpec::dataflow_buffers` in user order.
+- **SemaphoreSpecs:** 2 — `START{"start"}`, `DONE{"done"}`, `target_nodes = all_cores`.
+  (Metal 2.0 semaphores are zero-initialised; legacy `initial_value` was 0 on both.)
+- **TensorParameters:** 2 — `INPUT{"input"}`, `OUTPUT{"output"}`; strict matching.
+- **WorkUnitSpecs:** 1 or 2 — `{"group0", {READER0}, cores0}` and, conditionally,
+  `{"group1", {READER1}, cores1}`.
+- **Op-owned tensors:** none.
+- **KernelRunArgs:** one per instantiated reader, built with `AddRuntimeArgsForNode` from the
+  existing node-first loop (loop nesting left as-is; no name-first restructure).
+
+Kernel-side accessor names: `dfb::src` (READER0→SRC0, READER1→SRC1 — one name, two specs,
+one per KernelSpec), `dfb::dst`, `dfb::red_idxs`, `dfb::red_vals`, `sem::start`, `sem::done`,
+`tensor::src`, `tensor::dst`.
+
+#### `c_0` declared twice at one buffer index, over disjoint core ranges
+
+Legacy declares `c_0` twice with **genuinely different sizes** on the default (no
+`sub_core_grids`) path. Metal 2.0 has no buffer index, so this becomes **two
+`DataflowBufferSpec`s** (`SRC0`, `SRC1`) with the two legacy sizes, each bound by exactly one
+reader, each placed (derived) on that reader's disjoint node set. The second spec stays
+conditional on `num_cores1 > 0`, matching legacy.
+
+#### Address-uniformity requirement — **checked, holds**
+
+The kernel computes the reducer's destination from its **own** `c_2`/`c_3` base pointer
+(`red_idx_cb.get_write_ptr() + core_id * red_idx_size_per_core`, then writes to
+`{reduce_core_x, reduce_core_y, that address}` — `reader_argmax_interleaved_multicore.cpp:326-339,
+416-427, 467-478`). That is only correct if `c_2`/`c_3` land at the **same L1 address on every
+node**, even though `SRC0`/`SRC1` differ in size between the two groups.
+
+Verified against the Metal 2.0 allocator rather than assumed:
+`ProgramImpl::allocate_dataflow_buffers` (`tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp:2505-2571`)
+computes **one** `alloc_addr` per DFB as the max `get_cb_region_end()` across every core range
+the DFB spans, then writes that single address into every core's entry — the code says so
+explicitly: *"All cores of a DFB get the same alloc_addr so the L1 buffer is at a uniform
+absolute address on every physical core."* This is a byte-for-byte analog of the legacy
+`ProgramImpl::allocate_circular_buffers` behaviour the audit cited
+(`tt_metal/impl/program/program.cpp:1719-1751`). Since `RED_IDXS` / `RED_VALS` span
+`all_cores`, their address clears the larger of the two `SRC` sizes on every node. Preserving
+the legacy declaration order keeps the resulting addresses identical to legacy as well.
+
+---
+
+## Preserved Multiplicity
+
+| legacy KernelDescriptors | same-source KernelSpecs | WorkUnitSpecs | shared DFBs (endpoint role each binds) |
+|---|---|---|---|
+| `reader_desc0` @ `argmax_multi_core_program_factory.cpp:376` (over `cores0`) and `reader_desc1` @ `:408` (over `cores1`, `if num_cores1 > 0`), both of `reader_argmax_interleaved_multicore.cpp` | `READER0`, `READER1` | `group0` (`cores0`), `group1` (`cores1`) | `DST`, `RED_IDXS`, `RED_VALS`: **each reader binds PRODUCER + CONSUMER (self-loop)**. `SRC0` bound only by `READER0`; `SRC1` only by `READER1`. |
+
+This is the **disjoint-node** shape, *not* a dual-instance work-split: `cores0` and `cores1`
+never overlap, so every node sees exactly one reader instance and every DFB's per-node
+toucher census is **1**. Multiple `KernelSpec`s on one endpoint of `DST` / `RED_IDXS` /
+`RED_VALS` are legal precisely because their node coverage is non-overlapping, the kernel kind
+is the same (DM) and the binding-site parameters are identical (`STRIDED`, `num_threads = 1`)
+— the `dataflow_buffer_spec.hpp` invariant. **No `allow_instance_multi_binding` anywhere.**
+
+The single-core factory has no work-split multiplicity: one `KernelDescriptor` on one node.
+
+---
+
+## Dropped Plumbing
+
+### Single-core factory
+
+| legacy location (file:line) | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `argmax_single_core_program_factory.cpp:205` RTA slot 0 | `emplace_runtime_args(core, {input, …})` — MeshTensor `BufferBinding` | `TensorParameter INPUT` + `TensorBinding{INPUT, "src"}` + `TensorArgument` |
+| `argmax_single_core_program_factory.cpp:205` RTA slot 1 | `… {…, output})` | `TensorParameter OUTPUT` + `TensorBinding{OUTPUT, "dst"}` + `TensorArgument` |
+| `get_ctime_args_single_core` CTA slot 0 (`:68`, `:89`) | `src_cb_index` (`tt::CBIndex::c_0`) | `DFBBinding{SRC, "src", …}` |
+| `get_ctime_args_single_core` CTA slot 1 (`:69`, `:90`) | `dst_cb_index` (`tt::CBIndex::c_1`) | `DFBBinding{DST, "dst", …}` |
+| `argmax_single_core_program_factory.cpp:182` | `TensorAccessorArgs(input).append_to(ctime_args)` | binding mechanism (host-side CTA payload emitted by the framework) |
+| `argmax_single_core_program_factory.cpp:183` | `TensorAccessorArgs(output).append_to(ctime_args)` | same |
+| `reader_argmax_interleaved.cpp:41,42` | `TensorAccessorArgs<8>()` / `next_compile_time_args_offset()` | `TensorAccessor(tensor::src)` / `(tensor::dst)` |
+| `reader_argmax_tile_layout.cpp:40,49,50` | `num_c_time_args = 13` + the `TensorAccessorArgs<…>` chain | same — and the `num_c_time_args` constant disappears with it |
+| `reader_argmax_tile_layout_h.cpp:39,44,45` | `num_c_time_args = 11` + the chain | same |
+| `reader_argmax_interleaved.cpp:15,16` RTA reads | `get_arg_val<uint32_t>(0/1)` for the two base addresses | gone — binding auto-injects the address |
+| `reader_argmax_tile_layout.cpp:44,45`; `_h.cpp:41,42` | same | gone |
+| all remaining positional CTAs | `get_compile_time_arg_val(N)` | named: `get_arg(args::<name>)` (names in *Planned Spec Shape*) |
+
+**Page-size 3rd argument:** none — all accessor constructions are the 2-arg form (audit).
+Note `src_page_size` / `dst_page_size` are **not** third-argument page sizes: they are the
+kernel's own NoC transfer sizes (`noc.async_read(..., src_page_size, ...)`), so they stay as
+named CTAs.
+
+### Multi-core factory
+
+| legacy location (file:line) | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `argmax_multi_core_program_factory.cpp:394,424` RTA slots 0,1 | `{input, output, …}` MeshTensor bindings | `TensorParameter`/`TensorBinding`/`TensorArgument` ×2 |
+| CTA slot 0 (`:343`) | `src_cb_idx` | `DFBBinding{SRC0 or SRC1, "src", …}` |
+| CTA slot 1 (`:344`) | `dst_cb_idx` | `DFBBinding{DST, "dst", …}` |
+| CTA slot 2 (`:345`) | `red_idxs_cb_idx` | `DFBBinding{RED_IDXS, "red_idxs", …}` |
+| CTA slot 3 (`:346`) | `red_vals_cb_idx` | `DFBBinding{RED_VALS, "red_vals", …}` |
+| CTA slot 26 (`:370`) | `start_sem_idx` | `SemaphoreBinding{START, "start"}` |
+| CTA slot 27 (`:371`) | `done_sem_idx` | `SemaphoreBinding{DONE, "done"}` |
+| `argmax_multi_core_program_factory.cpp:373,374` | the two `TensorAccessorArgs(...).append_to` calls | binding mechanism |
+| `reader_argmax_interleaved_multicore.cpp:299,300` | `TensorAccessorArgs<28>()` / chain | `TensorAccessor(tensor::src)` / `(tensor::dst)` |
+| `reader_argmax_interleaved_multicore.cpp:219,220` | `get_arg_val<uint32_t>(0/1)` base addresses | gone — binding auto-injects |
+| RTA slots 2-6 | `get_arg_val<uint32_t>(2..6)` | named RTAs `core_id`, `src_offset`, `red_dim_offset`, `src_read_size`, `red_dim_units_this_core` |
+| CTA slots 4-25 | `get_compile_time_arg_val(N)` | named CTAs (kernel-side names; slots 16-23 keep the legacy value↔name swap) |
+
+**Retained varargs:** none. Every argument in every in-scope kernel is a distinct field read a
+fixed number of times at a literal index — no counted loop, no data-selected index, no
+sentinel scan. All become named.
+
+---
+
+## Applied Patterns
+
+- **[Sync-free CB → self-loop DFB](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md):**
+  all six single-core `(CB, config)` pairs and all five multi-core DFBs. Re-derived from the
+  kernel-touch census rather than transcribed from the brief: every DFB in scope is touched by
+  **exactly one** kernel per node, and that touch is a bare `get_write_ptr()` peek — there is
+  no `reserve_back` / `push_back` / `wait_front` / `pop_front` and no `evil_set_*` cursor
+  surgery anywhere in the four kernels. One toucher ⇒ self-loop (bind PRODUCER **and**
+  CONSUMER under one accessor name). Census agrees with the brief on all ten.
+  The multi-core cross-core NoC writes do not add touchers: the destination is a bare
+  `{noc_x, noc_y, addr}` on the reducer, not a DFB binding.
+- **[Multi-variant factory](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md):**
+  the single-core factory's runtime source selection (RM / TILE-W / TILE-H) stays a branch
+  inside `create_program_artifacts`; all three sources convert together.
+- **[Porting a shared kernel — rung 2](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md):**
+  `reader_argmax_interleaved_metal2.cpp` created beside the original; pointer comment added to
+  the legacy file; nothing else in it changed.
+- **[Pass DFB handles directly](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md)
+  / CB→DFB whitelist §A `constexpr` carve-out:** the five `get_dataformat(<cb_idx>)` sites keep
+  the **free-function** form with the binding token — `get_dataformat(dfb::src)` — because each
+  is a `constexpr DataFormat` feeding non-type template parameters, and a `DataflowBuffer`
+  object can never be a constant expression (`DataflowBuffer(uint16_t)` is a non-`constexpr`
+  out-of-line constructor, `dataflow_buffer.h:113`). **This contradicts the brief**, which
+  directs these onto the member getter; see the report's Friction section.
+- **Custom DM hardware config (multi-core):** the legacy triple is
+  `(RISCV_1, NOC::RISCV_1_default, DM_DEDICATED_NOC)`, and `NOC::RISCV_1_default == NOC_1`.
+  That matches **neither** default — reader is `(RISCV_1, NOC_0)`, writer is `(RISCV_0, NOC_1)`
+  — so it is replicated field-by-field as
+  `DataMovementGen1Config{.processor = RISCV_1, .noc = NOC_1, .noc_mode = DM_DEDICATED_NOC}`,
+  **not** routed through a "close" helper.
+- **Not applied, deliberately:** no `allow_instance_multi_binding`, no `alias_with`, no
+  conditional DFB `#ifdef` gating (the conditional `SRC1` / `READER1` pair is a whole extra
+  `KernelSpec` with its own generated bindings, so no kernel-side `#ifdef` is needed — the
+  same source compiles twice, and both builds bind exactly one `dfb::src`), no borrowed-memory
+  DFB, no varargs, no op-owned tensors.
+
+---
+
+## Deferred / Flagged
+
+- **Brief vs. CB→DFB whitelist disagreement on `get_dataformat`** — planning-step finding.
+  The brief instructs "move onto the DFB member, which is `constexpr` and so survives the NTTP
+  uses"; the whitelist §A and recipe rule 7 say the opposite for a legacy-`constexpr` site.
+  The whitelist is right (the *getter* is `constexpr`, the *object* can never be), and it is
+  authoritative. Following the whitelist. → report.
+- **Conditional `KernelRunArgs` for `READER1`** — the multi-core `ProgramRunArgs` must not
+  carry a `KernelRunArgs` entry for a `READER1` that was never added to the spec.
+- **`argmax_common.hpp` is shared with the retained legacy fork** — only positional-parameter
+  renames there; no signature or behaviour change.
+- **Anti-pattern sweep denominator caveat:** the `cb`-name sweep over the op directory will
+  legitimately report hits from the two retained legacy files
+  (`reader_argmax_interleaved.cpp` and the whole out-of-scope NC half). The sweep is therefore
+  reported both op-wide *and* scoped to the ported file set, with the residue enumerated.
+- Nothing found during planning that the audit missed structurally. No stop signal.

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PORT_REPORT.md
@@ -1,0 +1,286 @@
+# Metal 2.0 Port Report — `reduction/argmax` (`ArgMaxDeviceOperation`)
+
+## Outcome
+
+**`PORTED`** — both in-scope factories converted to `ProgramSpecFactoryConcept` and their tests
+pass: `ArgMaxSingleCoreProgramFactory` (all three runtime-selected kernel sources) and
+`ArgMaxMultiCoreProgramFactory`.
+
+`ArgMaxNCDeviceOperation` / `ArgMaxNCProgramFactory` remains on the legacy imperative API, out of
+scope by the audit gate, and is **untouched**. `ttnn::argmax` now dispatches to a Metal 2.0
+device-op and a legacy one side by side, which is expected.
+
+Verification (all with the host-side legality checks forced on and *proven* live — see Successes):
+
+| Layer | Result |
+|---|---|
+| `./build_metal.sh --build-tests` | SUCCESS, 0 errors; `_ttnncpp.so` relinked; `nm` confirms both factories export `create_program_artifacts` and no longer export `create_descriptor` |
+| `unit_tests_ttnn --gtest_filter='*Argmax*:*ArgMax*:*argmax*'` | **6/6 passed** (incl. `TestGenericOpArgmaxSingleCore`, the out-of-directory consumer of the retained legacy kernel) |
+| `tests/ttnn/unit_tests/operations/reduce/test_argmax.py` | **66 passed**, 0 failed |
+| `tests/ttnn/nightly/.../reduction/test_reduction_op_corners.py` + `test_generic_ops.py` | **937 passed, 8 skipped**, 0 failed |
+
+The 8 skips are argmax cases the tests skip by their own capability guards (`dim=None` with TILE
+layout; non-last-dim reduction) — conditions evaluated before the op is called, so they are
+unrelated to the port.
+
+## Provenance
+
+- **Recipe docs (this port):** `b73b958088a 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources`
+- **Audit docs (inherited):** `b73b958088a 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources`
+
+## TTNN ProgramFactory
+
+### Concept realized
+
+`ProgramSpecFactoryConcept` (base), as the audit chose. Neither factory had an
+`override_runtime_arguments`, so the framework refreshes the tensor bindings on a cache hit and
+each factory writes exactly one method. Nothing about the concept choice was revisited.
+
+Both factories already lived in a `program_factory_t` variant
+(`argmax_device_operation.hpp:31`), so the direct-descriptor exception did not apply — the port
+was a method swap inside the existing structs.
+
+### Device-op-class edits
+
+- **Pybind entry points removed:** none. `argmax_nanobind.cpp` binds only the user-facing
+  `ttnn::argmax`; there was no pybound `create_descriptor`, so this port carries **no
+  user-visible API change**.
+- **Custom `compute_program_hash`:** none — the op uses the default reflection-based hash, and
+  no backdoor `attribute_values` / `to_hash`. Nothing to leave alone, nothing touched.
+- The only device-op-class edit is the two factory-method declarations in
+  `argmax_device_operation.hpp` (`create_descriptor` → `create_program_artifacts`) and the
+  matching include swap. That is the port itself, not one of the three sanctioned exceptions.
+
+### Open items
+
+- **Relaxation candidates:** none identified. Both `TensorParameter`s are left strict, matching
+  the audit's `relaxation: none`. The two TILE readers do reason explicitly about padded-vs-
+  logical shape, but they take both as compile-time arguments and bake them into the spec, so a
+  `dynamic_tensor_shape` relaxation would be actively wrong here, not merely unexercised.
+- **Concept fit:** no friction. The single-core factory ends up with **zero** runtime arguments
+  once the two address RTAs become `TensorBinding`s, so its `ProgramRunArgs` carries only
+  `tensor_args` and it declares no `KernelRunArgs` entry at all. That is a nice demonstration of
+  the binding model paying for itself, and it worked exactly as the header documents.
+
+## Handoff points
+
+**No capitulation, no boundary-rule violation, no kernel-lib gap, no framework gap.** No call
+site required a `sem::` or `tensor::` handle outside the op directory; no compute kernel is
+involved (both factories build DM kernels only), so the Case-2 / compute-`TensorBinding` block
+never came up.
+
+One item worth routing, though it is environmental rather than API:
+
+- **[Environment / invoker] The checkout could not build as handed over.**
+  `tt_metal/third_party/umd` was checked out ~85 commits behind the commit this branch records
+  (`4ed96fb3` vs. the recorded `0b263b2c400`), which is the `M tt_metal/third_party/umd` present
+  in the session's opening `git status`. `tt_metal/llrt/tt_cluster.cpp:363,365,372` call
+  `umd::restore_default_tdp_limit`, `umd::set_tdp_limit`, and
+  `FirmwareInfoProvider::get_tdp_limit`, none of which exist at that older commit, so every build
+  failed in `llrt` long before reaching any TTNN op. The submodule had no local edits and the
+  recorded commit was already in its object store, so `git submodule update --init
+  tt_metal/third_party/umd` restored it cleanly and reversibly (it now matches HEAD and does not
+  appear in the diff at all). Flagging it because it is invisible from the port diff and because
+  anyone else picking up this branch will hit the same wall.
+
+## Successes
+
+- **[Compiler options](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/port/metal2_port.md) — the "answer it mechanically" instruction did its job.**
+  The section insists on `grep -n opt_level` rather than reading `config`. Doing that returned
+  nothing across both factories, which — combined with the section's table — resolves to `O2` on
+  a reader/DM descriptor and therefore needs no action, since Metal 2.0 also defaults to `O2`.
+  The compute-kernel `O3` trap the section is really aimed at cannot fire here: both factories
+  build DM kernels only. Worth recording that the mechanical check produced a confident *"nothing
+  to do"* rather than a guess.
+
+- **[Hardware configuration](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/port/metal2_port.md) — "match on the *values*, not the constructor spelling" caught a real trap.**
+  The multi-core factory's legacy config reads
+  `DataMovementConfigDescriptor{.processor = RISCV_1, .noc = NOC::RISCV_1_default}`. The name
+  `RISCV_1_default` reads like "the default for the RISCV_1 kernel", i.e. the reader default —
+  and `create_reader_datamovement_config()` was the obvious reach. But `NOC::RISCV_1_default == NOC_1`
+  (`kernel_types.hpp:33-38`), and the *reader* default is `NOC_0`. Routing this through the reader
+  helper would have flipped the NOC on every multi-core dispatch: no build error, no test
+  failure, a silent bandwidth regression. Replicated verbatim instead as a raw
+  `DataMovementGen1Config` at `argmax_multi_core_program_factory.cpp:428`. This is precisely the
+  failure mode the section says it exists to prevent, and the section is what stopped it.
+
+- **[CB→DFB whitelist §A](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/cb_dfb_api_whitelist.md) — the `constexpr` carve-out outranked the brief, correctly.**
+  See the Friction entry below; the whitelist's rule is stated precisely enough that the
+  disagreement was resolvable by reading one constructor declaration.
+
+- **[Two-toucher / endpoint-assignment procedure](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md) — "re-derive, don't transcribe" confirmed the brief rather than correcting it.**
+  Running the census independently over all four kernels found what the brief said: every DFB has
+  exactly one toucher per node, and every touch is a bare `get_write_ptr()` peek with no FIFO op
+  and no `evil_set_*` cursor surgery anywhere. Ten self-loops, no `allow_instance_multi_binding`.
+  The procedure's explicit warning that *cursor surgery is not a peek* is what made the sweep
+  conclusive rather than approximate — it named the one thing that would have changed the answer.
+
+- **The `_metal2` fork convention held up under a case it was not written for.**
+  The shared-kernel Caution is written around *factories* that will not co-migrate. Here the
+  stranded consumer is a **gtest** (`test_generic_op.cpp:126`) that file-path-instantiates
+  `reader_argmax_interleaved.cpp` from a hand-built `ProgramDescriptor` — a shape that cannot be
+  re-pointed, because `generic_op` cannot supply named bindings at all. Rung 2 applied unchanged
+  and worked: the gtest still passes, untouched, on the legacy copy.
+
+## Friction
+
+### Gaps
+
+- **The brief and the CB→DFB whitelist give opposite instructions for `get_dataformat`, and the
+  brief is wrong.** `METAL2_PORT_BRIEF.md` says to move all five sites onto the DFB member
+  getter, reasoning that "`DataflowBuffer::get_dataformat()` is `constexpr`
+  (`dataflow_buffer.h:279`), so this works" for the NTTP uses. It does not.
+  [Whitelist §A](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/cb_dfb_api_whitelist.md)
+  and [recipe kernel-side rule 7](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/port/metal2_port.md)
+  state the actual rule: a member getter cannot produce a constant expression, because the
+  *getter* being `constexpr` is irrelevant when no `DataflowBuffer` object can be — its only
+  usable constructor, `DataflowBuffer(uint16_t)` at `dataflow_buffer.h:113`, is a non-`constexpr`
+  out-of-line declaration. So a legacy-`constexpr` metadata read keeps the free-function form
+  with the binding token. Followed the whitelist; all five sites are
+  `constexpr DataFormat … = get_dataformat(dfb::…)` at
+  `reader_argmax_interleaved_metal2.cpp:49`, `reader_argmax_interleaved_multicore.cpp:299,316`,
+  `reader_argmax_tile_layout.cpp:51`, `reader_argmax_tile_layout_h.cpp:44`. That is also the form
+  landed ports on `main` already use (e.g. `data_movement/scatter`,
+  `experimental/reduction/integral_image`).
+
+  *Suggested fix:* the audit's own *Recipe notes* #1 asked for `get_dataformat` to be added to a
+  sanctioned list, and the resulting brief text over-corrected into a member-getter instruction.
+  The audit template should route a `constexpr`-site metadata read to the whitelist's carve-out
+  by name rather than restating the reasoning, since restating it is where the error entered.
+  These are **Gen1-only token-form sites** (the token's `uint32_t` conversion is documented as
+  such), so they are Quasar-uplift debt, recorded here as §A asks.
+
+- **The anti-pattern self-audit's `cb`-name sweep has no defined answer when the port creates a
+  `_metal2` fork.** The checklist says to run the sweep over `<op-dir>` and expect **zero** hits,
+  on the reasoning that "post-port the op has no CBs". That reasoning does not survive rung 2:
+  the whole point of a fork is that the legacy copy *stays in the directory*, still full of
+  `CircularBuffer` and `cb_*`, and (here) so does an entirely out-of-scope second DeviceOperation
+  the audit gated. Reported both ways instead — **0 hits over the 10 ported files**, with the
+  residue enumerated as exactly `reader_argmax_interleaved.cpp` (the retained fork) plus the four
+  NC-half files. *Suggested fix:* have the checklist define the sweep's denominator as the ported
+  file set, and require the residue to be enumerated and attributed, rather than asking for a
+  zero that a correct rung-2 port cannot produce.
+
+- **`ProgramRunArgs` has no worked example of a kernel with no runtime arguments.** The
+  single-core factory ends with zero RTAs and zero CRTAs. The `program_run_args.hpp` comment does
+  cover it ("except for kernels that have no runtime or common runtime arguments"), but every
+  example in the migration guide and the recipe shows a populated `kernel_run_args`, so it took a
+  header read to be confident that omitting the entry entirely — rather than pushing an empty
+  `KernelRunArgs{.kernel = READER}` — was the intended shape. One sentence in the migration
+  guide's `ProgramRunArgs` section would settle it.
+
+### Confusion
+
+- **"Preserve the value mapping, not the label" is the right rule for named CTAs, but no doc
+  states it.** The multi-core factory deliberately swaps start/end coordinates — the host comment
+  reads `// end comes before start for NOC1` — so the kernel's `start_core_x0` has always
+  received `end_core0.x`. Under positional CTAs that is invisible; under *named* CTAs it produces
+  `{"start_core_x0", static_cast<uint32_t>(end_core0.x)}`
+  (`argmax_multi_core_program_factory.cpp:353`), which reads like a transcription bug and is the
+  faithful port. The alternative — renaming the kernel's variables so the names line up — would
+  be kernel-logic surgery outside the whitelist and would obscure the NOC1 convention the
+  original comment documents. Recorded the reasoning at the emission site so the next reader does
+  not "fix" it. A line in the recipe's *Dropped Plumbing* / naming guidance saying that naming a
+  CTA never licenses re-pairing name to value would have made this a non-decision.
+
+- **The recipe's "build in the background, read the log with a subagent" pattern silently
+  tolerates a broken exit code.** Piping `build_metal.sh` into `tail` to bound the log makes `$?`
+  report `tail`, so the harness reported the first build as exit 0 when ninja had in fact stopped.
+  What actually caught it was the memory-driven habit of checking `nm` on the relinked library —
+  the `.so` was still dated a month earlier and still exported `create_descriptor`. The recipe
+  already warns that `build_metal.sh` can return 0 over a failed unity build; the pipeline
+  variant is a second, independent way to manufacture the same false green. *Suggested fix:*
+  show the redirect form (`> log 2>&1`) explicitly rather than a pipeline, and add "confirm the
+  library was relinked" to the build step.
+
+## Open items for downstream
+
+### Shared kernel touches
+
+- **`ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp`** —
+  *lent* (an out-of-directory consumer binds it).
+  - **(a) Kernel path:** as above.
+  - **(b) Rung taken: 2 — created the fork.** New file:
+    `ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_metal2.cpp`.
+    The pointer comment landed at the top of the legacy original and is that file's **only**
+    change. Resolution confirmed with the invoker before any kernel edit (audit *Questions* #1,
+    option (a)).
+  - **(c) Remaining unmigrated consumer:** `tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126`
+    (`TTNNFixtureWithDevice.TestGenericOpArgmaxSingleCore`), which builds a `ProgramDescriptor`
+    around the kernel with the CTA layout (indices 0-7 plus two `TensorAccessorArgs` blocks) and
+    the RTA pair (`src_buffer->address()`, `dst_buffer->address()`) hardcoded at `:105-121`.
+    **Sunset condition:** the legacy copy can be deleted once that gtest is retired or moved off
+    `ttnn::generic_op`. It cannot simply be re-pointed at the fork — `generic_op` /
+    `ProgramDescriptor` has no way to supply Metal 2.0 named bindings.
+
+  Note this is a **test**, not an op, so it is invisible to the borrowed-kernel inventory (which
+  only looks outward, at what *this* op binds). The audit's *Recipe notes* #4 already proposes
+  adding a "who else instantiates my kernels" grep to that step; this port is a concrete instance
+  of why. Nothing else in the repo binds any of the other three in-scope kernels, so those three
+  were converted in place.
+
+### Findings routed to the ops team (observed, deliberately **not** fixed)
+
+The audit already listed items 1-4 under *Misc anomalies*; they are repeated here with their
+**post-port** locations, because the port changed how two of them present.
+
+1. **Dead CTA — `src_page_size` in the multi-core reader.** The factory emits it
+   (`argmax_multi_core_program_factory.cpp:341`) and the kernel never reads it; reads are sized
+   from the `src_read_size` runtime argument instead. **This is now visible in a way it was not
+   before:** under positional CTAs it was a silent hole at index 4, and it is now a *named* CTA
+   with no kernel-side reader, which a reader of the factory can spot directly. Kept and named
+   rather than deleted, per the brief.
+2. **Dead CTA — `dst_page_size` in both TILE readers.** Same shape: emitted at
+   `argmax_single_core_program_factory.cpp:76` (RM branch, where it *is* read) and `:98` (TILE
+   branch, where neither TILE reader reads it — both derive the write size from
+   `output_page_elements` in `write_to_output`). One shared argument builder serving two reader
+   families is what leaves the hole. Kept and named.
+3. **A core index narrowed through `bool`.**
+   `reader_argmax_interleaved_multicore.cpp:260` reads
+   `constexpr uint32_t reduce_core_id = (bool)get_arg(args::reduce_core_id);`. CTA
+   `reduce_core_id` is the reducer's **core index**, not a flag. It is 0 today so the cast is
+   inert, but the factory explicitly anticipates changing it — *"We can do perf optimization by
+   tuning this in the future"* (`argmax_multi_core_program_factory.cpp:283`). The first non-zero
+   value collapses to 1 and both the `is_reduce_core` test and the worker-skip test silently pick
+   the wrong core. Carried across verbatim, cast included.
+4. **Dummy `(0,0)` core-range arguments for the single-group case.**
+   `argmax_multi_core_program_factory.cpp:292` substitutes
+   `CoreRange(CoreCoord(0,0), CoreCoord(0,0))` for the absent second group, so
+   `start_core_*1` / `end_core_*1` describe core (0,0) rather than "no group". Inert, because
+   every use is guarded by `num_cores1 > 0`, but it hands the kernel plausible-looking
+   coordinates for a group that does not exist. Preserved.
+5. **The NOC1 start/end argument swap is undocumented at the kernel.** The host knows why
+   (`// end comes before start for NOC1`); the kernel just declares `start_core_x0` and feeds it
+   to `set_multicast` as a start coordinate. The swap is correct but is stated only on the host
+   side, and only in the factory the arguments happen to come from. The port added an explanatory
+   comment at the emission site; a matching note at the kernel's declaration would be a real
+   improvement, but writing one is an edit to kernel documentation that the port did not need,
+   so it is left here.
+
+### Other notes
+
+- **Test-coverage note.** `test_argmax.py` plus the two nightly reduction files cover all four
+  kernel configurations (RM last-dim, RM reduce-all, TILE dim=W, TILE dim=H) and both multi-core
+  paths. The brief asked specifically for a multi-core check with an odd `red_dim` and
+  `sub_core_grids` unset, to exercise the two core groups at *different* `SRC` sizes and confirm
+  the shared `RED_IDXS` / `RED_VALS` still land at one uniform L1 address; the suites include such
+  shapes and pass. The underlying property was also confirmed by reading the allocator rather
+  than inferred from the green run — `ProgramImpl::allocate_dataflow_buffers`
+  (`tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp:2505-2571`) assigns one address per DFB,
+  taken as the max region-end across every core range it spans, and writes that same address to
+  every core, mirroring the legacy `allocate_circular_buffers` behaviour. The port also preserves
+  the legacy DFB declaration order, since the allocator walks `ProgramSpec::dataflow_buffers` in
+  user order.
+- **Pre-port baseline — a deviation worth disclosing.** The recipe asks for the numerical
+  baseline *before* the first kernel edit. Build and test commands were unavailable at the start
+  of this session (blocked by the environment's permission layer), so the kernels were converted
+  first and the baseline was left recoverable via `git stash` rather than captured up front. It
+  was never needed: the post-port run is green across every suite, which rules out a regression
+  without a comparison point. Had anything failed, the baseline would have been taken by stashing
+  the port. Noting it because the recipe's rule is sound and the ordering here was forced, not
+  chosen.
+- **Per-op carry-over.** `ArgMaxNCDeviceOperation` is the obvious next port for this directory and
+  is blocked only on its `ProgramDescriptor` migration (audit gate; every other gate is already
+  clear for it). When that lands, its two CBs are a textbook plain 1:1 and the re-audit should be
+  short. Whoever takes it should re-derive the CB census rather than trusting the audit's
+  provisional one, since the migration rewrites the very factory it describes.

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PREPORT_AUDIT.md
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/METAL2_PREPORT_AUDIT.md
@@ -1,0 +1,554 @@
+# Metal 2.0 Audit Findings — `ttnn/cpp/ttnn/operations/reduction/argmax`
+
+The directory holds **two** DeviceOperations, both reachable from the single user-facing
+`ttnn::argmax` facade (`argmax.cpp`), which routes between them by dim/dtype/layout:
+
+- **`ArgMaxDeviceOperation`** (`device/argmax_device_operation.{hpp,cpp}`) — `descriptor` concept
+  - `ArgMaxSingleCoreProgramFactory` (`device/argmax_single_core_program_factory.cpp`)
+    - RM input → `kernels/reader_argmax_interleaved.cpp`
+    - TILE input, dim == W → `kernels/reader_argmax_tile_layout.cpp`
+    - TILE input, dim == H → `kernels/reader_argmax_tile_layout_h.cpp`
+  - `ArgMaxMultiCoreProgramFactory` (`device/argmax_multi_core_program_factory.cpp`)
+    - `kernels/reader_argmax_interleaved_multicore.cpp`
+- **`ArgMaxNCDeviceOperation`** (`device/argmax_nc_device_operation.{hpp,cpp}`) — **`legacy device-op`** concept
+  - `ArgMaxNCProgramFactory` (`device/argmax_nc_program_factory.cpp`)
+    - `kernels/reader_argmax_nc.cpp`, `kernels/argmax_nc_compute.cpp`, `kernels/writer_argmax_nc.cpp`
+
+**Bundling rationale.** The two DeviceOperations share **no** factories and **no** kernels
+(the NC kernels include none of `argmax_common.hpp` / `argmax_tile_layout.hpp` /
+`argmax_tile_h_col.hpp`), so on the recipe's shared-code test they are *independent* and the
+recipe would have them audited separately. They are reported together anyway because the audit's
+output filename is **op-directory-scoped** — two independent DeviceOperations in one directory
+cannot each own a `METAL2_PREPORT_AUDIT.md`. Findings are attributed per DeviceOperation
+throughout, and a *Per-DeviceOperation attribution* section is provided. See *Recipe notes*.
+
+**Kernel-file census.** All seven kernel `.cpp` files in `device/kernels/` are referenced by a
+factory; none are dead. The three `.hpp` files in that directory are headers included by the
+`ArgMaxDeviceOperation` readers only.
+
+**Scope:** TTNN op, Gen1 (WH/BH) target — within scope of `audit/metal2_audit.md`.
+
+**Recipe docs:** `b73b958088a 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources`
+
+## Status summary
+
+| Field | Value |
+|---|---|
+| **Op directory** | `ttnn/cpp/ttnn/operations/reduction/argmax` |
+| **Overall** | **RED at op level; subset `ArgMaxDeviceOperation` (single-core + multi-core factories) is clear** |
+| **DOps / Factories** | `ArgMaxDeviceOperation` → `ArgMaxSingleCoreProgramFactory`, `ArgMaxMultiCoreProgramFactory` · `ArgMaxNCDeviceOperation` → `ArgMaxNCProgramFactory` |
+| *Prereqs* — Device 2.0 (every kernel used) | **Yes** — all 7 kernels structurally Device 2.0 (`Noc`, `CircularBuffer` / `DataflowBuffer`, `Semaphore<>`, `UnicastEndpoint`, `TensorAccessor`). One judgment call recorded below (`get_dataformat(cb_id)`) |
+| *Prereqs* — Cross-op escapes | **Ok** — every kernel `#include` resolves to `tt_metal/*` (`api/…`, `tt-metalium/constants.hpp`) or an in-directory header. Zero borrowed kernel files. One *reverse* coupling reported (a gtest consumer) |
+| *Feature Support* — overall | **GREEN** — no Appendix A entry fires |
+| *Feature Support* — Variadic-CTA | Ok (no variable-index compile-time-arg reads anywhere) |
+| *TTNN Readiness* — `Is able to port?` (the gate) | **Per-factory split.** `ArgMaxSingleCoreProgramFactory` = `yes` · `ArgMaxMultiCoreProgramFactory` = `yes` · **`ArgMaxNCProgramFactory` = `no`**, attributed to `Concept` == `legacy device-op` |
+| *TTNN Readiness* — Concept (current) | `descriptor` (both `ArgMaxDeviceOperation` factories) · **`legacy device-op`** (`ArgMaxNCProgramFactory`) |
+| *TTNN Readiness* — Secretly SPMD (WorkloadDescriptor only) | N/A — no factory is `WorkloadDescriptor` |
+| *TTNN Readiness* — Custom hash | **No** — sheet `no` on all three rows; `grep` for `compute_program_hash` / `attribute_values` / `to_hash` over the op directory returns nothing |
+| *TTNN Readiness* — `get_dynamic_runtime_args` | **No** — sheet `no` on all three rows; no hook on either device-op |
+| *TTNN Readiness* — `override_runtime_arguments` | **No** on the two `descriptor` factories. `ArgMaxNCProgramFactory` defines one (`argmax_nc_program_factory.cpp:218`) but as part of the **legacy** concept signature — the sheet correctly records that column as `n/a` there, and it gates via `Concept`, not via this column |
+| *TTNN Readiness* — Pybind `create_descriptor` | **No** — `argmax_nanobind.cpp` binds only the user-facing `ttnn::argmax`; no `create_descriptor` binding, no `nb::class_` of a device op |
+| *TTNN Readiness* — Op-owned tensors | **No** (`no` / blank on all rows; no `WorkloadDescriptor`, no `buffers` vector) |
+| *TTNN Readiness* — Target concept | **`ProgramSpecFactoryConcept`** (for the clean `ArgMaxDeviceOperation` subset) |
+| *Port work* — Offset base pointer | **none** — every address argument is a clean base; the multi-core factory already passes its byte offset as a *separate* RTA |
+| *Port work* — Tensor bindings (per binding) | `input` **Case 1**, `output` **Case 1** — in both clean factories, all three single-core configs |
+| *TTNN Readiness* — TensorParameter relaxation | **`none`** on all three rows → clears |
+| *Port work* — TensorAccessor 3rd arg | **none — no accessor in the op passes a 3rd argument** (all 10 construction sites are 2-arg) |
+| *Port work* — CB endpoints | **self-loop** on all 6 CBs of the clean subset (every CB has exactly one, sync-free, toucher per node). `ArgMaxNCProgramFactory`'s 2 CBs are plain 1:1 — recorded but deferred, see below |
+
+**CB endpoints** are dispositions, not gates: every out-of-window CB has a port-time resolution
+— a **self-loop** (one toucher: single-ended / sync-free), a **1P+1C assignment** (two touchers),
+the **multi-binding advanced-option flag** (genuine ≥2 of a role on a node the census cannot
+relabel), or a **dead-CB drop** (zero endpoints). Dispositions are recorded per `(CB, config)`.
+
+## Result
+
+**RED at op level; subset `ArgMaxDeviceOperation` (both factories) is clear.**
+
+The single blocker is the **TTNN factory concept** gate on `ArgMaxNCProgramFactory`: that factory
+is still on the legacy imperative `host_api.hpp` builder (`Program`, `CreateCircularBuffer`,
+`CreateKernel`, `SetRuntimeArgs`, `CachedProgram` + `override_runtime_arguments`), so its concept
+is `legacy device-op` and the readiness sheet's `Is able to port?` cell reads `no`. This is the
+**expected** outcome for an op still on the legacy API, not an alarm — it unblocks when
+`ArgMaxNCDeviceOperation`'s `ProgramDescriptor` migration lands, a separate ongoing effort owned by
+the **TTNN / PD-migration team**. Routed there.
+
+**Every other gate is clear, for both DeviceOperations** — Device 2.0 (all 7 kernels, including
+the NC ones), feature compatibility (no Appendix A entry fires), offset base pointers (no
+host-folded offset anywhere), and the `TensorAccessor` 3rd argument (no site exists). So when the
+PD migration lands, `ArgMaxNCProgramFactory` should re-audit to GREEN with nothing else to clear.
+
+Because a clean factory subset survives, a **porter brief is issued** — scoped to
+`ArgMaxDeviceOperation`'s two factories only (`METAL2_PORT_BRIEF.md`).
+
+## Gate detail
+
+- **TTNN factory concept (`Is able to port?`):** **per-factory split.**
+
+  | Factory | `Concept` | `Is able to port?` | Verdict |
+  |---|---|---|---|
+  | `ArgMaxSingleCoreProgramFactory` | `descriptor` | `yes` | **cleared** |
+  | `ArgMaxMultiCoreProgramFactory` | `descriptor` | `yes` | **cleared** |
+  | `ArgMaxNCProgramFactory` | `legacy device-op` | **`no`** | **GATE** |
+
+  The `no` is **fully attributed**: the blocking column is `Concept`, value `legacy device-op`.
+  Route: **TTNN / PD-migration team**. This is a separate ongoing effort and the expected outcome
+  for a legacy op; the Metal 2.0 gate lifts when that op's `ProgramDescriptor` migration lands.
+  Every other blocking column on that row is benign — `Runtime-args update
+  (get_dynamic_runtime_args)` = `no`, `Smuggled pointer` = `no`, `TensorParameter relaxation` =
+  `none`, `Known op issues` = *(empty)*, `Op-owned tensors?` = `no`.
+
+  **Cross-check (trust, but verify) — clean on every checkable column:**
+
+  | Column | Sheet | Code evidence | Match |
+  |---|---|---|---|
+  | `Concept` (ArgMax ×2) | `descriptor` | `create_descriptor()` returning `ProgramDescriptor` @ `argmax_device_operation.hpp:17,22`; bodies @ `argmax_single_core_program_factory.cpp:116`, `argmax_multi_core_program_factory.cpp:159` | ✓ |
+  | `Concept` (NC) | `legacy device-op` | `create()` + `override_runtime_arguments()` on a `CachedProgram` @ `argmax_nc_device_operation.hpp:41-50`; imperative body @ `argmax_nc_program_factory.cpp:47,218` | ✓ |
+  | `Custom hash` / `Backdoor custom hash` | `no` / `no` | no `compute_program_hash`, `attribute_values`, or `to_hash` in the op directory | ✓ |
+  | `Runtime-args update (get_dynamic_runtime_args)` | `no` (all 3) | no such hook on either DeviceOperation | ✓ |
+  | `Override runtime args method?` | `no`, `no`, `n/a` | absent on both `descriptor` factories; present on `ArgMaxNCProgramFactory` @ `argmax_nc_program_factory.cpp:218` — the *legacy*-concept signature, so `n/a` is the correct value per the recipe's name-collision rule | ✓ |
+  | `Pybind descriptor` | `no` | `argmax_nanobind.cpp` binds only the user-facing op; no `create_descriptor` | ✓ |
+  | `Smuggled pointer` | `no` | the `descriptor` factories pass tensors via the framework-registered `emplace_runtime_args(core, {input, output})` MeshTensor form, not a raw `->address()` (see *Tensor bindings*) | ✓ |
+  | `Op-owned tensors?` | `no` / blank | no `WorkloadDescriptor`, no `buffers` vector | ✓ |
+  | **Factory-set match** | 3 rows | 3 factories in code, one-to-one, no phantom and no missing row | ✓ |
+
+  **Cross-column invariants:** `get_dynamic_runtime_args` == `no` everywhere (so the
+  "`yes` only on `descriptor`/`WorkloadDescriptor`" invariant is vacuously held);
+  `Op-owned tensors?` is never `yes`, so the "`yes` only on `WorkloadDescriptor`" invariant holds.
+  No conflict, no violated invariant → **the sheet is sound for this op.**
+
+  *Informational, non-gating, worth carrying:* `Op Classification` reads
+  `PD Op (pointer-patching)` for the two `descriptor` rows with `Pointer patching perf issue?` =
+  `OK` — consistent with the `emplace_runtime_args(core, {input, output})` binding form these
+  factories use, which the Metal 2.0 typed binding supersedes.
+
+- **Device 2.0 (every kernel used): GREEN — all 7 kernels.**
+
+  Every data-movement kernel is on the Device 2.0 object surface: `Noc` for all NoC traffic,
+  `CircularBuffer` / `DataflowBuffer` wrappers for CB access, `Semaphore<>` +
+  `UnicastEndpoint` for the multi-core handshake, `TensorAccessor` for tensor addressing. Zero
+  Device 1.0 idioms across the directory: no `noc_async_read` / `noc_async_write`, no
+  `cb_reserve_back` / `cb_push_back` / `cb_wait_front` / `cb_pop_front` free functions, no
+  `get_write_ptr(cb)` / `get_read_ptr(cb)` free functions, no `InterleavedAddrGen` /
+  `ShardedAddrGen` / `InterleavedAddrGenFast` / `InterleavedPow2AddrGen*`, no raw semaphore
+  addresses, no `get_noc_addr_from_bank_id`, no `evil_set_*_ptr`. Confirmed for the NC kernels too,
+  even though that factory is gated elsewhere.
+
+  **The one judgment call — `get_dataformat(<cb_idx>)`, and why it is *not* scored a holdover.**
+  Four kernels query the buffer's data format through the CB-index free function, at a
+  `constexpr` site whose value is then used as a template argument:
+
+  | File | Line | Call | Wrapper in scope |
+  |---|---|---|---|
+  | `device/kernels/reader_argmax_interleaved.cpp` | `54` | `get_dataformat(src_cb_idx)` | `CircularBuffer src_cb` |
+  | `device/kernels/reader_argmax_interleaved_multicore.cpp` | `317` | `get_dataformat(src_cb_idx)` | `CircularBuffer src_cb` |
+  | `device/kernels/reader_argmax_interleaved_multicore.cpp` | `334` | `get_dataformat(red_vals_cb_idx)` | `CircularBuffer red_val_cb` |
+  | `device/kernels/reader_argmax_tile_layout.cpp` | `63` | `get_dataformat(src_dfb_idx)` | `DataflowBuffer src_dfb` |
+  | `device/kernels/reader_argmax_tile_layout_h.cpp` | `53` | `get_dataformat(src_dfb_idx)` | `DataflowBuffer src_dfb` |
+
+  `get_dataformat` is **not** on the recipe's sanctioned list (which names only
+  `get_tile_size(cb_id)` and `get_local_cb_interface(cb_id)`), and a wrapper object *is* in scope
+  at each site — so it matches the holdover *shape*. It is nonetheless **not** a holdover, because
+  the second half of the recipe's own holdover criterion is unmet: **no usable wrapper-method
+  replacement exists.** `CircularBuffer::get_dataformat()` is a plain `const` member
+  (`tt_metal/hw/inc/api/dataflow/circular_buffer.h:113`), *not* `constexpr`, and the
+  `CircularBuffer` object is not a constant expression either — while the free function *is*
+  `constexpr` (`tt_metal/hw/inc/api/dataflow/dataflow_api.h:300`) and every one of these five sites
+  feeds a `constexpr DataFormat` that is consumed as a non-type template parameter
+  (`get_default_value<fmt>()`, `compare_values<fmt>(…)`, `process_input_tile<T, fmt>(…)`,
+  `find_argmax_from_intermediate_outputs<n, fmt>(…)`, plus a `static_assert` @
+  `reader_argmax_interleaved_multicore.cpp:341`). Substituting the member would not compile. The
+  lookup is also the same *class* of thing as the sanctioned `get_tile_size(cb_id)` — a
+  compile-time CB metadata query, not a data-movement operation — and the recipe's own breadcrumb
+  states these metadata lookups move onto the object at **port** time, which is exactly the
+  resolution path here: `DataflowBuffer::get_dataformat()` **is** `constexpr`
+  (`tt_metal/hw/inc/api/dataflow/dataflow_buffer.h:279`), so the Metal 2.0 port can move them
+  where Device 2.0 could not. Recorded as PORT WORK in the brief, not as a Device 2.0 gate.
+  Flagged in *Recipe notes* as a sanctioned-list gap.
+
+  The two kernels that still `#include "api/dataflow/circular_buffer.h"`
+  (`reader_argmax_interleaved.cpp:7`, `reader_argmax_interleaved_multicore.cpp:8`) do so
+  legitimately — they genuinely use the `CircularBuffer` wrapper and its
+  `use<CircularBuffer::AddrSelector::WRITE_PTR>` view. This is *not* the stale-include idiom;
+  the include goes away as part of the Metal 2.0 CB→DFB swap, not as a Device 2.0 fix.
+
+- **Feature compatibility:** every Appendix A entry, in order. A clean scan is all-`N/A`.
+
+  | Feature | Status | Notes |
+  |---|---|---|
+  | GlobalCircularBuffer | **N/A** | No `GlobalCircularBuffer` type, no `CreateGlobalCircularBuffer`, no `global_circular_buffer.hpp` include, no `CBDescriptor::global_circular_buffer` field set, no `experimental::CreateCircularBuffer(…, global_cb)` 4-arg form, no `CircularBufferConfig::remote_index()`, no `remote_cb_*` identifiers, no `remote_circular_buffer.h`. The multi-core factory's cross-core traffic is *not* a remote CB — it is a plain `noc.async_write` to an explicit `{.noc_x, .noc_y, .addr}` on the reducer core through a `UnicastEndpoint` (`reader_argmax_interleaved_multicore.cpp:416-427, 467-478`), using ordinary per-core CBs at both ends. |
+  | CBDescriptor `address_offset` (non-zero) | **N/A** | No `.address_offset` on any `CBDescriptor`, no `set_address_offset`, no 4-arg `UpdateDynamicCircularBufferAddress`, no `cb_descriptor_from_sharded_tensor`. All five `CBDescriptor` literals (`argmax_single_core_program_factory.cpp:145,156`; `argmax_multi_core_program_factory.cpp:218,231,244,257,270`) leave the field at its default zero. |
+  | GlobalSemaphore | **N/A** | No `GlobalSemaphore` type, no `CreateGlobalSemaphore`, no `global_semaphore.hpp` include. The multi-core factory's two semaphores are plain `SemaphoreDescriptor`s (`argmax_multi_core_program_factory.cpp:303,309`), consumed kernel-side as `Semaphore<>` (`reader_argmax_interleaved_multicore.cpp:347-348`) — the regular path, supported as `SemaphoreSpec`. |
+
+- **CB endpoints (GATE-free):** census per `(CB, config)`, per node. **Every CB in the clean
+  subset has exactly one toucher per node, and that toucher is sync-free (raw
+  `get_write_ptr()` peek, no FIFO ops at all) → self-loop across the board.**
+
+  `ArgMaxSingleCoreProgramFactory` — one reader kernel on the single node in every config:
+
+  | CB | Config | Touchers on a node | Verdict | Disposition |
+  |---|---|---|---|---|
+  | `c_0` src | RM (`reader_argmax_interleaved.cpp`) | 1 — reader, raw `src_cb.get_write_ptr()` @ `:53` + `noc.async_read` destination @ `:67`; no FIFO ops | single-ended / sync-free | **self-loop** |
+  | `c_1` dst | RM | 1 — reader, raw `dst_cb.get_write_ptr()` @ `:57`, written via `out_idxs[]` and drained by `noc.async_write(use<WRITE_PTR>(dst_cb), …)` @ `:86,99` | single-ended / sync-free | **self-loop** |
+  | `c_0` src | TILE-W (`reader_argmax_tile_layout.cpp`) | 1 — raw `src_dfb.get_write_ptr()` @ `:62` + `noc.async_read` destination @ `:136` | single-ended / sync-free | **self-loop** |
+  | `c_1` dst | TILE-W | 1 — raw `dst_dfb.get_write_ptr()` @ `:66`, then written/read through `CoreLocalMem<uint32_t>` in `write_to_output` (`argmax_tile_layout.hpp:329`) | single-ended / sync-free | **self-loop** |
+  | `c_0` src | TILE-H (`reader_argmax_tile_layout_h.cpp`) | 1 — raw `src_dfb.get_write_ptr()` @ `:52` + `noc.async_read` @ `:104` | single-ended / sync-free | **self-loop** |
+  | `c_1` dst | TILE-H | 1 — raw `dst_dfb.get_write_ptr()` @ `:55`, same `CoreLocalMem` path | single-ended / sync-free | **self-loop** |
+
+  `ArgMaxMultiCoreProgramFactory` — `reader_argmax_interleaved_multicore.cpp`, one instance per
+  node (see the note below on the two same-source `KernelDescriptor`s):
+
+  | CB | Config | Touchers on a node | Verdict | Disposition |
+  |---|---|---|---|---|
+  | `c_0` src | both (cores0 spec; cores1 spec when `num_cores1 > 0`) | 1 — raw `src_cb.get_write_ptr()` @ `:318` + `noc.async_read` destination @ `:58` | single-ended / sync-free | **self-loop** |
+  | `c_1` dst | both | 1 — raw `dst_cb.get_write_ptr()` @ `:322` + `noc.async_write(use<WRITE_PTR>(dst_cb), …)` @ `:450,498`. *Functionally* only the reducer core fills it, but the binding is taken unconditionally on every node | single-ended / sync-free | **self-loop** |
+  | `c_2` red_idxs | both | 1 — raw `red_idx_cb.get_write_ptr()` @ `:326`, written locally @ `:116` and drained @ `:416,467` | single-ended / sync-free | **self-loop** |
+  | `c_3` red_vals | both | 1 — raw `red_val_cb.get_write_ptr()` @ `:333`, written locally @ `:117` and drained @ `:422,473` | single-ended / sync-free | **self-loop** |
+
+  **The remote NoC writes do not add touchers.** In the multi-core kernel a worker writes its
+  partials into the *reducer's* L1 (`{.noc_x = reduce_core_x, .noc_y = reduce_core_y,
+  .addr = red_idx_cb_local_addr}`). That destination is a bare NoC address, not a DFB binding —
+  the writing kernel binds only its **own** node's `c_2` / `c_3` (as the `use<WRITE_PTR>` source).
+  So each node's census stays at 1, and there is no hidden second writer on any CB. Actively
+  scanned for face (a): no kernel writes another kernel's CB via `get_write_ptr()` /
+  `fifo_wr_ptr` on the same node, and the two semaphores gate core-to-core ordering, not an
+  intra-node co-fill.
+
+  **The two same-source `KernelDescriptor`s are the disjoint-node shape, not a dual-instance
+  work-split.** `argmax_multi_core_program_factory.cpp:376` and `:408` push the same
+  `kernel_source` twice, but over **`cores0`** and **`cores1`** respectively — disjoint core sets,
+  so each node sees exactly one instance and every CB stays at 1 toucher. This is the
+  demoting-per-group-CTA shape, not the both-instances-on-every-node split that produces
+  two touchers.
+
+  **No dead CB.** Every allocated `buffer_index` is referenced by its bound kernel in every config
+  — verified by resolving each index through its CTA to a wrapper construction and at least one
+  access. Note the near-miss: `c_1` in the multi-core factory is *documented* as
+  "only used in the reduction core" (`reader_argmax_interleaved_multicore.cpp:239`), but
+  `dst_cb.get_write_ptr()` @ `:322` runs unconditionally on every node, so it is live everywhere
+  and **must not** be dropped or made conditional.
+
+  **`ArgMaxNCProgramFactory` (gated — recorded, then deferred).** Its two CBs are textbook plain
+  1:1 and need no action if that factory ever ports as-is: `c_0` — reader is a locked producer
+  (`dfb.reserve_back`/`push_back` @ `reader_argmax_nc.cpp:57,60`), compute is a locked consumer
+  (`dfb_val_obj.wait_front`/`pop_front` @ `argmax_nc_compute.cpp:82,84,92,94`); `c_16` — compute
+  is a locked producer (`:112,116`), writer a locked consumer (`writer_argmax_nc.cpp:97,100`).
+  This census is **provisional**: the `ProgramDescriptor` migration will rewrite that factory, so
+  re-derive it at re-audit rather than trusting these rows.
+
+- **Offset base pointers:** **GREEN — no address argument folds a host-side offset into its base,
+  in any factory.** Every address site resolved to its host computation:
+
+  | Site | Host expression | Kernel consumption | Verdict |
+  |---|---|---|---|
+  | `argmax_single_core_program_factory.cpp:205` | `emplace_runtime_args(core, {input, output})` — MeshTensor bindings, base only, **no arithmetic** | fed to `TensorAccessor(args, base)` @ `reader_argmax_interleaved.cpp:45,46` / `reader_argmax_tile_layout.cpp:52,53` / `reader_argmax_tile_layout_h.cpp:47,48` | clean base |
+  | `argmax_multi_core_program_factory.cpp:394,424` | `{input, output, …}` — MeshTensor bindings, base only | `TensorAccessor(args, base)` @ `reader_argmax_interleaved_multicore.cpp:306,307` | clean base |
+  | `argmax_nc_program_factory.cpp:199` | bare `input.buffer()->address()`, **no arithmetic** | `TensorAccessor(args, addr)` @ `reader_argmax_nc.cpp:46` | clean base |
+  | `argmax_nc_program_factory.cpp:207` | bare `output.buffer()->address()`, **no arithmetic** | `TensorAccessor(args, addr)` @ `writer_argmax_nc.cpp:89` | clean base |
+
+  **The multi-core factory is the case worth stating explicitly, because it looks like a Type 1
+  and is not.** It *does* compute a per-core byte offset — `i * src_read_size0` and
+  `src_offset1 + (i * src_read_size1)` (`argmax_multi_core_program_factory.cpp:399,429`) — but
+  passes it as a **separate RTA at index 3**, never folded into the base. The kernel consumes it
+  as the accessor's per-read `{.offset_bytes = src_offset}` argument
+  (`reader_argmax_interleaved_multicore.cpp:62`) on top of a clean-base accessor. That is exactly
+  the already-split-out shape the recipe calls GREEN, and it drops straight into ordinary
+  tensor-binding port work. Likewise `red_dim_offset` (RTA 4) is an element index, not an address.
+
+  Type 3 (`address_offset`) is absent — see the Appendix A row. Type 4 (`ttnn::narrow` /
+  interior-base `MeshBuffer::create`) is absent. `reduction/argmax` appears in **neither** table
+  of `2026-07-19_offset_base_pointers.md`, which agrees with this scan (the "no fold, not in the
+  tables → clean" outcome).
+
+- **TensorAccessor 3rd argument:** **N/A — no accessor in the op passes a 3rd argument.** All ten
+  construction sites are the 2-arg `TensorAccessor(args, base_addr)` form
+  (`reader_argmax_interleaved.cpp:45,46`; `reader_argmax_interleaved_multicore.cpp:306,307`;
+  `reader_argmax_tile_layout.cpp:52,53`; `reader_argmax_tile_layout_h.cpp:47,48`;
+  `reader_argmax_nc.cpp:46`; `writer_argmax_nc.cpp:89`). The subject never fires, so there is
+  nothing to classify — this is *no sites*, not *sites found and judged redundant*. Consistent
+  with `reduction/argmax` being absent from `2026-07-06_tensor_accessor_3rd_arg_triage.md`.
+
+## Port-work summary  *(mirrors the brief)*
+
+Scoped to the clean subset — `ArgMaxDeviceOperation`'s two factories.
+
+- **Tensor bindings** (per binding, both factories, all three single-core configs):
+  - `input` — **Case 1** (via `TensorAccessor`).
+  - `output` — **Case 1** (via `TensorAccessor`).
+
+  Delivery today is the `Buffer*`-binding form in its MeshTensor spelling —
+  `emplace_runtime_args(core, {input, output})` (`argmax_single_core_program_factory.cpp:205`;
+  `argmax_multi_core_program_factory.cpp:394,424`) — which the framework auto-registers as
+  `BufferBinding`s and patches on cache hits. So this is **routine port work, not a correctness
+  hazard**: it is already correct-on-cache-hit today, and the Metal 2.0 typed binding supersedes
+  the mechanism. The kernel side then loses both `TensorAccessorArgs(...).append_to(...)` calls
+  (`argmax_single_core_program_factory.cpp:182,183`;
+  `argmax_multi_core_program_factory.cpp:373,374`) and the paired
+  `TensorAccessorArgs<N>()` / `next_compile_time_args_offset()` CTA plumbing.
+
+- **TensorParameter relaxation:** **none** (sheet `none` on both clean rows).
+- **TensorAccessor 3rd arg:** none — no site exists.
+- **CB endpoints:** **self-loop** on all six: `(c_0, RM)`, `(c_1, RM)`, `(c_0, TILE-W)`,
+  `(c_1, TILE-W)`, `(c_0, TILE-H)`, `(c_1, TILE-H)` for the single-core factory; and
+  `(c_0, multicore)`, `(c_1, multicore)`, `(c_2, multicore)`, `(c_3, multicore)`. No 1P+1C
+  assignment, no multi-binding flag, no dead-CB drop, no conditional DFB.
+- **`get_dataformat(<cb_idx>)` → DFB member:** move the five sites listed in the Device 2.0
+  block onto the bound object (`DataflowBuffer::get_dataformat()` is `constexpr`, so the NTTP
+  uses survive). Port work by the recipe's own breadcrumb, not a Device 2.0 fix.
+
+## Heads-ups  *(mirrors the brief)*
+
+- **CB endpoints (multi-binding shapes to watch):** **none.** No CB in the clean subset reaches
+  two touchers on a node, so nothing needs the multi-binding advanced option. The two
+  same-source `KernelDescriptor`s in the multi-core factory are the *disjoint-node* shape
+  (`cores0` / `cores1`), not the dual-instance work-split — do not read them as two touchers.
+- **Two DFB specs sharing one buffer index over disjoint core ranges.** The multi-core factory
+  declares `c_0` **twice** — `argmax_multi_core_program_factory.cpp:218` over `cores0` with
+  `total_size = round_up_to_mul32(red_dim_units0 * input_unit_size)`, and `:231` over `cores1`
+  with the `red_dim_units1` size — and on the default (no `sub_core_grids`) path those two sizes
+  genuinely **differ**, because `split_work_to_cores` hands the two groups different per-core
+  block counts. The port must reproduce this as two `DataflowBufferSpec`s at the same index over
+  disjoint core ranges, keeping the second one conditional on `num_cores1 > 0`.
+- **The multi-core kernel requires `c_2` / `c_3` to land at the *same* L1 address on every
+  node.** A worker computes the reducer's destination address from its **own** base pointer —
+  `red_idx_cb_local_addr = red_idx_cb.get_write_ptr() + core_id * red_idx_size_per_core`, then
+  sends to `{.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_idx_cb_local_addr}`
+  (`reader_argmax_interleaved_multicore.cpp:326-339, 416-427, 467-478`). Legacy honours that
+  assumption: `ProgramImpl::allocate_circular_buffers` assigns **one** address per CB object,
+  taken as the max region-end across all the core ranges it spans
+  (`tt_metal/impl/program/program.cpp:1719-1751`), so a CB over `all_cores` is uniform even
+  though the `c_0` specs differ in size between the groups. Confirm the Metal 2.0 DFB allocator
+  keeps the same property — if a DFB were placed per-core-range instead, the cross-core writes
+  would silently land at the wrong offset. Numerically wrong, with nothing to flag it.
+- **Cross-op / shared kernels:** **no borrowed kernel files** — the op owns all seven, and no
+  other *op* instantiates any of them. But there is one **reverse** coupling the port must not
+  trip over: `tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126` file-path-instantiates
+  `device/kernels/reader_argmax_interleaved.cpp` from a **hand-built `ProgramDescriptor`**, with
+  the CTA layout (indices 0-7 plus two `TensorAccessorArgs` blocks) and the RTA pair
+  (`src_buffer->address()`, `dst_buffer->address()`) hardcoded in the test at `:105-121`. A
+  Metal 2.0 rewrite of that kernel changes exactly that contract, and the `generic_op` /
+  `ProgramDescriptor` entry point cannot supply Metal 2.0 named bindings — so the test breaks.
+  No `_metal2` fork exists beside any argmax kernel today. Resolve deliberately (fork the kernel,
+  or update the test) — see *Questions*.
+- **RTA varargs:** **none.** Every kernel reads a fixed set of args at constant indices — 2
+  (single-core readers), 7 (multi-core reader), 7 / 3 (NC reader / writer) — with no counted
+  loop, no `arg_index++` inside a loop, and no data-selected index. Ordinary named-arg port work.
+  **No CTA varargs either:** every `get_compile_time_arg_val` call in the directory uses a literal
+  constant index; there is no variable-index compile-time-arg read anywhere.
+- **`experimental/quasar/reduction/` exists — stay out of it.** There is a quasar copy of the
+  reduction family. It is a deliberately hacky shortcut port, not a precedent, not a naming
+  source, and not a fork to reuse. Do not read it and do not let it into the port diff.
+- **Two kernels are already partly on the Metal 2.0-era object.**
+  `reader_argmax_tile_layout.cpp` and `reader_argmax_tile_layout_h.cpp` already hold
+  `DataflowBuffer` (not `CircularBuffer`) at `:58,59` and `:51,54`, while
+  `reader_argmax_interleaved.cpp` and `reader_argmax_interleaved_multicore.cpp` are still on
+  `CircularBuffer` + the `use<CircularBuffer::AddrSelector::WRITE_PTR>` view. So the port's
+  kernel work is asymmetric: for the two TILE readers it is a binding-layer change
+  (name the DFB, drop the CTA index) rather than an object swap; for the two RM readers it is
+  the full CB→DFB swap, including replacing the `use<…>` views and dropping
+  `#include "api/dataflow/circular_buffer.h"`.
+- **`constexpr`-vs-`const` decides token form at every DFB site.** All four kernels take their
+  buffer index from a `constexpr uint32_t` CTA and then build a *non*-`constexpr` wrapper object
+  (e.g. `constexpr uint32_t src_dfb_idx = get_compile_time_arg_val(0);` then
+  `DataflowBuffer src_dfb(src_dfb_idx);`). The `get_dataformat` results, by contrast, must stay
+  compile-time constants (they are NTTPs). Decide token-form vs member-getter per site rather
+  than uniformly.
+
+## Team-only
+
+- **Out-of-directory coupling & donor shape:** **roll-up ✓ clean.** No per-call detail table is
+  owed — there are no ⚠ / ✗ / ⭐ entries.
+
+  | Op kernel | Donor file | Class | Status |
+  |---|---|---|---|
+  | all 7 | `tt_metal/hw/inc/api/**` (`dataflow_api.h`, `noc.h`, `circular_buffer.h`, `dataflow_buffer.h`, `noc_semaphore.h`, `endpoints.h`, `core_local_mem.h`, `tensor/tensor_accessor.h`, `tensor/noc_traits.h`, `numeric/*`, `debug/*`, `compute/*`) | 1 — `tt_metal/*` LLK/HAL | ✓ no concern |
+  | `argmax_tile_layout.hpp` | `tt-metalium/constants.hpp` | 1 — `tt_metal/*` | ✓ no concern |
+  | 4 readers | `argmax_common.hpp`, `argmax_tile_layout.hpp`, `argmax_tile_h_col.hpp` | in-directory (not an escape) | ✓ |
+
+  No include resolves into `ttnn/cpp/ttnn/kernel_lib/`, `ttnn/cpp/ttnn/kernel/`,
+  `ttnn/cpp/ttnn/operations/kernel_helper_functions/`, another op family, or another op in
+  `reduction/`. **Borrowed kernel files: none** — every `kernel_source` string in all three
+  factories points inside `reduction/argmax/device/kernels/`. Host-side, the two `descriptor`
+  factories include the in-family `ttnn/operations/reduction/reduce_op_validation.hpp` for
+  `validate_reduce_op_program_grid` / `validate_reduce_op_tensor` — host validation, outside the
+  kernel-coupling model and unaffected by the port.
+
+  **Reverse (consumer-side) coupling — the recipe has no slot for this, so it is recorded here
+  as well as in the brief:** `tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126` is an
+  out-of-directory consumer that file-path-instantiates `reader_argmax_interleaved.cpp` against a
+  hardcoded CTA/RTA contract. Not a donor problem and not a gate, but it is coupling the port
+  will break, and it is invisible to a borrowed-kernel inventory that only looks outward.
+
+- **Relaxation candidates:** none to mine — the op declares no custom `compute_program_hash` and
+  no backdoor `attribute_values` / `to_hash`, so there is no hash to read dependencies out of.
+  `TensorParameter relaxation` is `none` on all three rows.
+
+- **TTNN factory analysis:** op-owned tensors — none (no `WorkloadDescriptor`, no `buffers`
+  vector). MeshWorkload need — none; `Execution Model` is `SPMD` on all three rows and neither
+  device-op builds a workload. Pybind `create_descriptor` — absent; `argmax_nanobind.cpp` binds
+  only the user-facing `ttnn::argmax` (no `nb::class_` of a device op, so **no user-visible API
+  deletion** falls out of this port). Other risky pybind — none. Custom hash — absent, so the
+  default attribute hash applies (see *Misc anomalies* for one forced attribute that still feeds
+  it). `get_dynamic_runtime_args` — absent on both device-ops. `override_runtime_arguments` —
+  only on `ArgMaxNCProgramFactory` (`argmax_nc_program_factory.cpp:218`), as the legacy-concept
+  signature, so the clean subset targets the **base** `ProgramSpecFactoryConcept`, not the custom
+  one. Target concept for the clean subset: **`ProgramSpecFactoryConcept`**, matching the sheet's
+  `Porting Target` cell.
+
+## Misc anomalies  *(team-only, non-gating; route to the ops team — the port does not act on these)*
+
+1. **Dead CTA — `src_page_size` in the multi-core reader.** The factory passes `src_page_size`
+   at compile-time index 4 (`argmax_multi_core_program_factory.cpp:346`), but the kernel reads
+   indices 0,1,2,3 then jumps to 5 (`reader_argmax_interleaved_multicore.cpp:249`) — index 4 is
+   never read. The kernel sizes its reads from the `src_read_size` RTA instead. Harmless; it does
+   cost a CTA slot and misleads anyone counting offsets by hand.
+2. **Dead CTA — `dst_page_size` in both TILE readers.** `get_ctime_args_single_core` emits
+   `dst_page_size` at index 3 for the TILE branch too
+   (`argmax_single_core_program_factory.cpp:91`), but `reader_argmax_tile_layout.cpp` and
+   `reader_argmax_tile_layout_h.cpp` both skip index 3 (they read 0,1,2 then 4…) and derive the
+   write size from `output_page_elements * sizeof(uint32_t)` in `write_to_output`
+   (`argmax_tile_layout.hpp:344`). Live only on the RM branch, where
+   `reader_argmax_interleaved.cpp:23` does read it. Sharing one CTA builder across two kernel
+   families is what leaves the hole.
+3. **A core index narrowed through `bool` — latent, currently inert.**
+   `reader_argmax_interleaved_multicore.cpp:273` reads
+   `constexpr uint32_t reduce_core_id = (bool)get_compile_time_arg_val(13);`. CTA 13 is the
+   reducer's **core index**, not a flag. It is 0 today, so the cast is a no-op — but the factory
+   explicitly anticipates changing it: *"We can do perf optimization by tuning this in the
+   future"* (`argmax_multi_core_program_factory.cpp:284`). The moment anyone sets it to a
+   non-zero index the `bool` cast collapses it to 1, and both the `is_reduce_core` test
+   (`:304`) and the worker-skip test (`:415`) silently pick the wrong core. Cheap to fix now,
+   expensive to debug later.
+4. **Dummy core-range CTAs for the single-group case.** When `all_cores.size() == 1`,
+   `argmax_multi_core_program_factory.cpp:290` substitutes
+   `CoreRange(CoreCoord(0,0), CoreCoord(0,0))` for the absent second group, so CTAs 20-23
+   (`start_core_[xy]1` / `end_core_[xy]1`) describe core (0,0) rather than "no group". Inert
+   because every use is guarded by `num_cores1 > 0` (`reader_argmax_interleaved_multicore.cpp:378,
+   522`), but it hands the kernel plausible-looking coordinates for a group that does not exist.
+5. **A forced attribute that still participates in the hash.** `ArgmaxParams::output_dtype` is
+   validated to be exactly `UINT32` (`argmax_device_operation.cpp:125`) and the facade only ever
+   passes `DataType::UINT32` (`argmax.cpp`, both `prim::argmax` call sites). It is therefore a
+   constant that still rides the default attribute hash and the pybind surface. Not a
+   portability question — the port leaves hashing alone — but it is dead configurability.
+6. **`ArgMaxNCProgramFactory` reads `input.device()` rather than the output's.**
+   `argmax_nc_program_factory.cpp:49` takes the device from the input tensor while the two
+   `descriptor` factories use `&output.mutable_device()`
+   (`argmax_single_core_program_factory.cpp:124`, `argmax_multi_core_program_factory.cpp:184`).
+   Equivalent in practice; noted only because the PD migration of that factory will have to pick
+   one, and the `descriptor` siblings set the house style.
+
+## Per-DeviceOperation attribution
+
+| Field | `ArgMaxDeviceOperation` | `ArgMaxNCDeviceOperation` |
+|---|---|---|
+| **Factories** | `ArgMaxSingleCoreProgramFactory`, `ArgMaxMultiCoreProgramFactory` | `ArgMaxNCProgramFactory` |
+| **Overall** | **GREEN** — every gate cleared | **RED** |
+| *Prereqs* — Device 2.0 | Yes (4 kernels) | **Yes** (3 kernels) — not the blocker |
+| *Prereqs* — Cross-op escapes | Ok — no borrowed kernels; one reverse coupling (a gtest consumer of `reader_argmax_interleaved.cpp`) | Ok — no borrowed kernels, no external consumer |
+| *Feature Support* | GREEN (all Appendix A `N/A`) | GREEN (all Appendix A `N/A`) |
+| *TTNN Readiness* — `Is able to port?` | `yes` (both rows) | **`no`** — `Concept` == `legacy device-op` → **TTNN / PD-migration team** |
+| *TTNN Readiness* — Concept (current) | `descriptor` | `legacy device-op` |
+| *TTNN Readiness* — Custom hash / `get_dynamic_runtime_args` / Pybind descriptor / Op-owned tensors | No / No / No / No | No / No / No / No |
+| *TTNN Readiness* — `override_runtime_arguments` | No | Yes @ `argmax_nc_program_factory.cpp:218` — the *legacy* signature, so it does not select the custom concept |
+| *TTNN Readiness* — relaxation | `none` | `none` |
+| *TTNN Readiness* — Target concept | `ProgramSpecFactoryConcept` | `ProgramSpecFactoryConcept` (per the sheet's `Porting Target`), reachable only after the PD migration |
+| *Port work* — Offset base pointer | none | none |
+| *Port work* — Tensor bindings | `input` Case 1, `output` Case 1 | *(informational subject skipped — see below)* |
+| *Port work* — TensorAccessor 3rd arg | none (no site) | none (no site) |
+| *Port work* — CB endpoints | self-loop ×6 | *(informational subject skipped; a provisional 1:1 census is noted in Gate detail for context only)* |
+| **Brief issued?** | **Yes** — `METAL2_PORT_BRIEF.md` covers this DeviceOperation only | No |
+
+**Skipped informational subjects for `ArgMaxNCDeviceOperation`** — recorded so the omission is
+never mistaken for a clean result. The blocker clears on the **op-code side** (a
+`ProgramDescriptor` migration rewrites the very factory these subjects would describe), so the
+**Red** outcome scoping rule says defer them to the re-audit:
+
+- **TTNN porting shape** — `skipped — whole-DeviceOperation RED, no portable subset; re-audit on unblock`
+- **TensorParameter relaxations** — *(read anyway from the sheet: `none`)*; candidate mining `skipped — no custom hash to mine`
+- **TensorParameter analysis** — `skipped — whole-DeviceOperation RED, no portable subset; re-audit on unblock`
+- **CB endpoints** — `skipped — whole-DeviceOperation RED, no portable subset; re-audit on unblock` (a provisional census appears in Gate detail as context, not as a finding)
+- **RTA varargs** — `skipped as a finding — whole-DeviceOperation RED`; scanned incidentally while checking the gates and clean (fixed indices only)
+- **Out-of-directory coupling** — `skipped as a full inventory — whole-DeviceOperation RED`; the Device 2.0 gate confirmed no donor kernels exist, so nothing gate-relevant is deferred
+- **Incidental anomalies** — opportunistic only; item 6 above was noticed while working the gates
+
+The four **gate-bearing** subjects were run in full for this DeviceOperation, and all four are
+clear — so the PD migration is the *only* thing standing between it and a GREEN re-audit.
+
+## Questions for the user
+
+1. **How should the port handle the gtest that consumes `reader_argmax_interleaved.cpp`?**
+   `tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126` builds its own `ProgramDescriptor`
+   around that kernel with the CTA/RTA contract hardcoded at `:105-121`. A Metal 2.0 rewrite
+   changes that contract, and the `generic_op` / `ProgramDescriptor` entry point cannot supply
+   Metal 2.0 named bindings, so the test cannot simply be re-pointed. Two paths: **(a)** create
+   `reader_argmax_interleaved_metal2.cpp` beside the original per the shared-kernel fork
+   convention and leave the test on the legacy copy (the copy is then sunset when the test is
+   retired or reworked), or **(b)** rewrite the kernel in place and migrate the test off
+   `generic_op`. (a) keeps the port's blast radius inside the op; (b) avoids a duplicated kernel
+   but pulls a test rewrite into the port diff. Which do you want?
+2. **Is `ArgMaxNCDeviceOperation`'s `ProgramDescriptor` migration scheduled?** It is the sole
+   blocker, and every other gate is already clear for it — so it should re-audit to GREEN with
+   nothing further to fix. Worth confirming with the PD-migration team whether it is queued, so
+   the two halves of `ttnn::argmax` can converge rather than one shipping ported and the other
+   waiting indefinitely.
+3. **Should the clean subset be ported now, or held until the whole op can go together?**
+   `ArgMaxDeviceOperation` (both factories) is portable today. Porting it alone leaves
+   `ttnn::argmax` split across a Metal 2.0 device-op and a legacy one, which is functionally fine
+   but means two rounds of review on one user-facing op.
+
+## Recipe notes
+
+1. **`get_dataformat(cb_id)` should join the sanctioned free-function list — or the list should
+   say what to do with a near-miss.** The Device 2.0 Green bullet sanctions exactly
+   `get_tile_size(cb_id)` and `get_local_cb_interface(cb_id)`, and insists *"the list is the whole
+   test."* `get_dataformat(cb_id)` is the same *kind* of thing — a compile-time CB metadata query,
+   not a data-movement operation — appears in five places in this op, and its
+   `CircularBuffer::get_dataformat()` counterpart **cannot substitute** at any of them, because
+   the member is not `constexpr` (`circular_buffer.h:113`) while the free function is
+   (`dataflow_api.h:300`) and every site feeds an NTTP. I read the Red bullet's own conjunct
+   (*"**and** a wrapper-method replacement exists"*) as unmet and scored it GREEN, but that is a
+   judgment the auditor should not have to make on a hard prereq gate. Please either add
+   `get_dataformat` (and plausibly `get_tile_hw`) to the sanctioned list, or add a sentence saying
+   that a free function whose only wrapper counterpart is non-`constexpr` is not a holdover at a
+   `constexpr` site. Note the asymmetry that makes this specifically a *port*-stage fix:
+   `DataflowBuffer::get_dataformat()` **is** `constexpr` (`dataflow_buffer.h:279`), so the Metal
+   2.0 port can move these lookups onto the object where Device 2.0 could not — which is exactly
+   what the Green bullet's breadcrumb already implies for the two sanctioned names.
+
+2. **Two *independent* DeviceOperations in one op directory have nowhere to go.** The Scope rule
+   says to audit device-operations together when they share factories or kernels and *"audit each
+   separately"* when they are independent. `ArgMaxDeviceOperation` and `ArgMaxNCDeviceOperation`
+   share neither — but `METAL2_PREPORT_AUDIT.md` is **op-directory-scoped**, so "separately"
+   has no filename to land in. I bundled them and leaned on *Per-DeviceOperation attribution*,
+   which worked well, but the recipe should say so explicitly: either name a filename convention
+   for the independent case (`METAL2_PREPORT_AUDIT_<DeviceOperation>.md`?) or state that
+   co-directory device-ops are always bundled with per-DOp attribution regardless of the
+   shared-code test. (Here the shared *facade* — one `ttnn::argmax` dispatching to both — is
+   arguably the stronger reason to bundle than the shared-code test the rule actually asks about.)
+
+3. **"Clean factory subset" is written as if the subset is always within one DeviceOperation.**
+   The Code-path scope rule and the `RED at op level; subset <X> is clear` formula read
+   factory-scoped (*"a single factory's `if (use_width_sharding)` branch"*). Here the clean subset
+   is a **whole DeviceOperation** and the gated remainder is a *different* DeviceOperation. The
+   rule generalizes fine and I applied it that way — brief issued, scoped to the clean
+   DeviceOperation — but one clause acknowledging the DeviceOperation-granular subset would save
+   the next auditor the inference, especially since the brief-vs-no-brief decision hangs on it.
+
+4. **Out-of-directory coupling has no slot for a *consumer* of the op's own kernel.** The subject
+   inventories what the op borrows — outward escapes and borrowed kernel files. It has no place
+   for the mirror case found here: an out-of-directory consumer that file-path-instantiates one of
+   *this* op's kernels against a hardcoded CTA/RTA contract
+   (`tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126`). That is real, port-breaking coupling
+   with exactly the same shape as the shared-kernel problem the `_metal2` fork convention exists
+   to solve, and it is invisible to an inventory that only looks outward. It also cannot be
+   re-pointed the usual way, since `generic_op`/`ProgramDescriptor` cannot feed a Metal 2.0
+   `KernelSpec`. Suggest adding a "who else instantiates *my* kernels" grep to the borrowed-kernel
+   step — it is one `grep` for the kernel paths — and saying whether a **test** consumer justifies
+   a fork or a test rewrite.
+
+5. **Minor: the *Red* scoping rule's clear-side question is easy to answer per-subject but is
+   asked per-op.** For `ArgMaxNCDeviceOperation` the blocker clears on the op-code side (skip the
+   seven), while for the bundled report the clean subset needs all seven *for the other
+   DeviceOperation*. So the same audit both skips and runs the informational subjects, which the
+   one-line disclosure format does not quite anticipate. I disclosed per-subject inside the
+   *Per-DeviceOperation attribution* section; a sentence blessing that placement would help.

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
@@ -8,18 +8,18 @@
 
 #include <optional>
 #include <variant>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn::prim {
 
 struct ArgMaxSingleCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value);
 };
 
 struct ArgMaxMultiCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value);
 };
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
@@ -5,17 +5,20 @@
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/math.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/work_split.hpp>
+
+#include <utility>
 
 namespace ttnn::prim {
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 /**
  * @brief Distributes work across cores for argmax reduction operations
@@ -89,20 +92,20 @@ static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uin
  * The argmax operation is split across multiple cores to handle large tensors efficiently.
  * Each core processes a portion of the reduction dimension, finding local maxima and their indices.
  *
- * Circular Buffers (CBs):
- * 1. Input CB:
+ * Dataflow Buffers (DFBs):
+ * 1. Input DFB:
  *    - Size depends on input tensor shape and number of cores
  *    - Used for reading input tensor data
  *
- * 2. Worker Output CB (indices):
+ * 2. Worker Output DFB (indices):
  *    - Size depends on final output shape and number of worker cores
  *    - Used by worker cores to store local maxima indices
  *
- * 3. Worker Output CB (values):
+ * 3. Worker Output DFB (values):
  *    - Size depends on final output shape and number of worker cores
  *    - Used by worker cores to store local maxima values
  *
- * 4. Final Output CB:
+ * 4. Final Output DFB:
  *    - Size depends on final output tensor shape
  *    - Used only by reduce core to write final global argmax results
  *
@@ -110,7 +113,7 @@ static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uin
  * 1. Worker Cores:
  *    - Process assigned portion of reduction dimension
  *    - Find local maxima and their indices
- *    - Write results to output CB
+ *    - Write results to output DFB
  *
  * 2. Reduce Core:
  *    - Collects results from all worker cores
@@ -118,12 +121,12 @@ static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uin
  *    - Writes final results to DRAM
  *
  * Semaphore Usage:
- * 1. Semaphore 1:
+ * 1. Semaphore 1 (start):
  *    - Controls output buffer availability for writing results
  *    - Worker cores wait before writing results
  *    - Set by reduce core (multicast)
  *
- * 2. Semaphore 2:
+ * 2. Semaphore 2 (done):
  *    - Controls output buffer availability for reading results
  *    - Worker cores signal completion (increment)
  *    - Reduce core waits for all workers
@@ -156,7 +159,7 @@ static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uin
  *
  *    Refer to the kernel code for info on compile time args and runtime args
  */
-ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts ArgMaxMultiCoreProgramFactory::create_program_artifacts(
     const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input.mesh_tensor();
     const auto& output = tensor_return_value.mesh_tensor();
@@ -164,11 +167,23 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
     const bool keepdim = operation_attributes.keepdim;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
 
-    ProgramDescriptor desc;
+    // Resource names. Declared function-locally: both argmax factories share a unity-build
+    // translation unit, and namespace-scope `const` objects would collide by name there.
+    const KernelSpecName READER0{"reader0"};
+    const KernelSpecName READER1{"reader1"};
+    const DFBSpecName SRC0{"src0"};
+    const DFBSpecName SRC1{"src1"};
+    const DFBSpecName DST{"dst"};
+    const DFBSpecName RED_IDXS{"red_idxs"};
+    const DFBSpecName RED_VALS{"red_vals"};
+    const SemaphoreSpecName START{"start"};
+    const SemaphoreSpecName DONE{"done"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
 
-    const auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const auto input_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     const auto input_unit_size = input.element_size();
-    const auto output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const auto output_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     const auto output_unit_size = output.element_size();
 
     const auto& input_shape = input.padded_shape();
@@ -212,69 +227,56 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
     const auto src_page_size = round_up_to_mul32(red_dim_units * input_unit_size);
     const auto dst_page_size = round_up_to_mul32(output_last_dim * output_unit_size);
 
-    // Create input CB to read reduction dim worth of data at once (split across all cores)
-    const uint32_t src_cb_idx = tt::CBIndex::c_0;
-    const auto src_cb_page_size0 = round_up_to_mul32(red_dim_units0 * input_unit_size);
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = src_cb_page_size0,
-        .core_ranges = cores0,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src_cb_idx),
-            .data_format = input_cb_data_format,
-            .page_size = src_cb_page_size0,
-        }}},
+    // DFBs are declared in the order the pre-Metal-2.0 factory declared its circular buffers. The
+    // allocator walks this list in order and gives each DFB one L1 address across every node it
+    // spans, so preserving the order preserves the resulting addresses.
+    Group<DataflowBufferSpec> dataflow_buffers;
+
+    // Input DFB to read reduction dim worth of data at once (split across all cores). The two core
+    // groups get different per-core block counts, so group 1 needs its own (differently sized) DFB.
+    const auto src_dfb_entry_size0 = round_up_to_mul32(red_dim_units0 * input_unit_size);
+    dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = SRC0,
+        .entry_size = src_dfb_entry_size0,
+        .num_entries = 1,
+        .data_format_metadata = input_dfb_data_format,
     });
 
-    // We only create the second CB if there are some cores assigned to the second group
+    // We only create the second input DFB if there are some cores assigned to the second group
     if (num_cores1 > 0) {
-        const auto src_cb_page_size1 = round_up_to_mul32(red_dim_units1 * input_unit_size);
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = src_cb_page_size1,
-            .core_ranges = cores1,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(src_cb_idx),
-                .data_format = input_cb_data_format,
-                .page_size = src_cb_page_size1,
-            }}},
+        const auto src_dfb_entry_size1 = round_up_to_mul32(red_dim_units1 * input_unit_size);
+        dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = SRC1,
+            .entry_size = src_dfb_entry_size1,
+            .num_entries = 1,
+            .data_format_metadata = input_dfb_data_format,
         });
     }
 
-    // Create output CB based on the output shape's last dimension
-    const uint32_t dst_cb_idx = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = dst_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(dst_cb_idx),
-            .data_format = output_cb_data_format,
-            .page_size = dst_page_size,
-        }}},
+    // Create output DFB based on the output shape's last dimension
+    dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = DST,
+        .entry_size = dst_page_size,
+        .num_entries = 1,
+        .data_format_metadata = output_dfb_data_format,
     });
 
-    // Create intermediate CB for indices based on number of cores and output shape's last dimension
-    const uint32_t red_idxs_cb_idx = tt::CBIndex::c_2;
+    // Create intermediate DFB for indices based on number of cores and output shape's last dimension
     const auto red_idxs_page_size = round_up_to_mul32(output_last_dim * output_unit_size) * num_total_cores;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = red_idxs_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(red_idxs_cb_idx),
-            .data_format = output_cb_data_format,
-            .page_size = red_idxs_page_size,
-        }}},
+    dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = RED_IDXS,
+        .entry_size = red_idxs_page_size,
+        .num_entries = 1,
+        .data_format_metadata = output_dfb_data_format,
     });
 
-    // Create intermediate CB for values based on number of cores and output shape's last dimension
-    const uint32_t red_vals_cb_idx = tt::CBIndex::c_3;
+    // Create intermediate DFB for values based on number of cores and output shape's last dimension
     const auto red_vals_page_size = round_up_to_mul32(output_last_dim * input_unit_size) * num_total_cores;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = red_vals_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(red_vals_cb_idx),
-            .data_format = input_cb_data_format,
-            .page_size = red_vals_page_size,
-        }}},
+    dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = RED_VALS,
+        .entry_size = red_vals_page_size,
+        .num_entries = 1,
+        .data_format_metadata = input_dfb_data_format,
     });
 
     const auto inner_dim_units = output_last_dim;
@@ -297,23 +299,12 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
     const auto num_cores_range0 = group0.size();
     const auto num_cores_range1 = all_cores.size() > 1 ? group1.size() : 0;
 
-    // Allocate two semaphores for synchronization (cores -> reducer core) and (reducer core -> cores)
-    const uint32_t start_sem_idx = 0;
-    const uint32_t done_sem_idx = 1;
-    desc.semaphores.push_back(SemaphoreDescriptor{
-        .id = start_sem_idx,
-        .core_type = tt::CoreType::WORKER,
-        .core_ranges = all_cores,
-        .initial_value = 0,
-    });
-    desc.semaphores.push_back(SemaphoreDescriptor{
-        .id = done_sem_idx,
-        .core_type = tt::CoreType::WORKER,
-        .core_ranges = all_cores,
-        .initial_value = 0,
-    });
+    // Two semaphores for synchronization (cores -> reducer core) and (reducer core -> cores).
+    // Semaphores are zero-initialized, which is the initial value the kernel handshake assumes.
+    SemaphoreSpec start_sem{.unique_id = START, .target_nodes = all_cores};
+    SemaphoreSpec done_sem{.unique_id = DONE, .target_nodes = all_cores};
 
-    // Byte size of the data to read from the input CB for each core
+    // Byte size of the data to read from the input DFB for each core
     const auto src_read_size0 = red_dim_units0 * input_unit_size;
     const auto src_read_size1 = red_dim_units1 * input_unit_size;
 
@@ -337,105 +328,176 @@ ProgramDescriptor ArgMaxMultiCoreProgramFactory::create_descriptor(
     const auto src_read_size_last0 = red_dim_units_last0 * input_unit_size;
     const auto src_read_size_last1 = red_dim_units_last1 * input_unit_size;
 
-    // Common compile time args for all cores
-    // Refer to the kernel code for explanation of the args
-    std::vector<uint32_t> reader_compile_args = {
-        src_cb_idx,
-        dst_cb_idx,
-        red_idxs_cb_idx,
-        red_vals_cb_idx,
-        src_page_size,
-        dst_page_size,
-        red_idxs_page_size / num_total_cores,
-        red_vals_page_size / num_total_cores,
-        outer_dim_units,
-        inner_dim_units,
-        red_dim_units,
-        static_cast<uint32_t>(reduce_all),
-        num_total_cores,
-        reduce_core_id,
-        static_cast<uint32_t>(reduce_core.x),
-        static_cast<uint32_t>(reduce_core.y),
-        // end comes before start for NOC1
-        static_cast<uint32_t>(end_core0.x),
-        static_cast<uint32_t>(end_core0.y),
-        static_cast<uint32_t>(start_core0.x),
-        static_cast<uint32_t>(start_core0.y),
-        static_cast<uint32_t>(end_core1.x),
-        static_cast<uint32_t>(end_core1.y),
-        static_cast<uint32_t>(start_core1.x),
-        static_cast<uint32_t>(start_core1.y),
-        static_cast<uint32_t>(num_cores_range0),
-        static_cast<uint32_t>(num_cores_range1),
-        start_sem_idx,
-        done_sem_idx,
+    // Common compile time args for all cores.
+    // Names are the reader kernel's own variable names; refer to the kernel code for what each means.
+    //
+    // start_core_*/end_core_* carry the NOC1 multicast convention: a NOC1 multicast rectangle is
+    // addressed end-corner first, so the kernel's "start" arguments receive the group's *end*
+    // coordinate and its "end" arguments receive the *start* one. The swap is deliberate; the
+    // kernel feeds these straight to set_multicast().
+    const KernelSpec::CompileTimeArgs reader_compile_args = {
+        // The reader sizes its transfers from the src_read_size runtime argument, so it never reads
+        // src_page_size. Emitted anyway, unchanged from the pre-Metal-2.0 argument list.
+        {"src_page_size", src_page_size},
+        {"dst_page_size", dst_page_size},
+        {"red_idx_size_per_core", red_idxs_page_size / num_total_cores},
+        {"red_val_size_per_core", red_vals_page_size / num_total_cores},
+        {"outer_dim_units", outer_dim_units},
+        {"inner_dim_units", inner_dim_units},
+        {"red_dim_units", red_dim_units},
+        {"reduce_all", static_cast<uint32_t>(reduce_all)},
+        {"num_cores", num_total_cores},
+        {"reduce_core_id", reduce_core_id},
+        {"reduce_core_x", static_cast<uint32_t>(reduce_core.x)},
+        {"reduce_core_y", static_cast<uint32_t>(reduce_core.y)},
+        {"start_core_x0", static_cast<uint32_t>(end_core0.x)},
+        {"start_core_y0", static_cast<uint32_t>(end_core0.y)},
+        {"end_core_x0", static_cast<uint32_t>(start_core0.x)},
+        {"end_core_y0", static_cast<uint32_t>(start_core0.y)},
+        {"start_core_x1", static_cast<uint32_t>(end_core1.x)},
+        {"start_core_y1", static_cast<uint32_t>(end_core1.y)},
+        {"end_core_x1", static_cast<uint32_t>(start_core1.x)},
+        {"end_core_y1", static_cast<uint32_t>(start_core1.y)},
+        {"num_cores0", static_cast<uint32_t>(num_cores_range0)},
+        {"num_cores1", static_cast<uint32_t>(num_cores_range1)},
     };
-    tt::tt_metal::TensorAccessorArgs(input).append_to(reader_compile_args);
-    tt::tt_metal::TensorAccessorArgs(output).append_to(reader_compile_args);
 
-    KernelDescriptor reader_desc0;
-    reader_desc0.kernel_source =
+    const std::filesystem::path reader_source =
         "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp";
-    reader_desc0.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc0.core_ranges = cores0;
-    reader_desc0.compile_time_args = reader_compile_args;
-    reader_desc0.config = DataMovementConfigDescriptor{
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-        .noc = tt::tt_metal::NOC::RISCV_1_default,
+
+    // Every DFB this reader binds is touched by the reader alone, through a raw write pointer, with
+    // no FIFO operation anywhere in the kernel — so each is bound self-loop (the one toucher is both
+    // producer and consumer). The two readers cover disjoint node sets, so a DFB they both bind
+    // still sees exactly one instance of each endpoint per node.
+    //
+    // The cross-core writes into the reducer's L1 do not add an endpoint: their destination is a
+    // bare NoC address, not a binding.
+    auto make_reader = [&](const KernelSpecName& unique_id, const DFBSpecName& src_dfb) {
+        return KernelSpec{
+            .unique_id = unique_id,
+            .source = reader_source,
+            .dfb_bindings =
+                {
+                    DFBBinding{
+                        .dfb_spec_name = src_dfb, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER},
+                    DFBBinding{
+                        .dfb_spec_name = src_dfb, .accessor_name = "src", .endpoint_type = DFBEndpointType::CONSUMER},
+                    DFBBinding{
+                        .dfb_spec_name = DST, .accessor_name = "dst", .endpoint_type = DFBEndpointType::PRODUCER},
+                    DFBBinding{
+                        .dfb_spec_name = DST, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER},
+                    DFBBinding{
+                        .dfb_spec_name = RED_IDXS,
+                        .accessor_name = "red_idxs",
+                        .endpoint_type = DFBEndpointType::PRODUCER},
+                    DFBBinding{
+                        .dfb_spec_name = RED_IDXS,
+                        .accessor_name = "red_idxs",
+                        .endpoint_type = DFBEndpointType::CONSUMER},
+                    DFBBinding{
+                        .dfb_spec_name = RED_VALS,
+                        .accessor_name = "red_vals",
+                        .endpoint_type = DFBEndpointType::PRODUCER},
+                    DFBBinding{
+                        .dfb_spec_name = RED_VALS,
+                        .accessor_name = "red_vals",
+                        .endpoint_type = DFBEndpointType::CONSUMER},
+                },
+            .semaphore_bindings =
+                {
+                    SemaphoreBinding{.semaphore_spec_name = START, .accessor_name = "start"},
+                    SemaphoreBinding{.semaphore_spec_name = DONE, .accessor_name = "done"},
+                },
+            .tensor_bindings =
+                {
+                    TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"},
+                    TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"},
+                },
+            .compile_time_args = reader_compile_args,
+            .runtime_arg_schema =
+                {
+                    .runtime_arg_names =
+                        {"core_id", "src_offset", "red_dim_offset", "src_read_size", "red_dim_units_this_core"},
+                },
+            // Not the reader default placement (that is NOC_0): this kernel is pinned to RISCV_1 on
+            // NOC_1, reproduced field-by-field from the pre-Metal-2.0 config.
+            .hw_config = DataMovementHardwareConfig{DataMovementGen1Config{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = tt::tt_metal::NOC::NOC_1,
+                .noc_mode = tt::tt_metal::NOC_MODE::DM_DEDICATED_NOC,
+            }},
+        };
     };
+
+    Group<KernelSpec> kernels;
+    Group<WorkUnitSpec> work_units;
+    Group<KernelRunArgs> kernel_run_args;
+
+    kernels.push_back(make_reader(READER0, SRC0));
+    work_units.push_back(WorkUnitSpec{.name = "group0", .kernels = {READER0}, .target_nodes = cores0});
 
     const auto cores_coords0 = corerange_to_cores(cores0, num_cores0, true);
     const auto cores_coords1 = corerange_to_cores(cores1, num_cores1, true);
 
     // Set runtime args for cores0 and cores1, only offsets (src and red_dim_units) are different
     // Refer to the kernel code for explanation of the args
+    KernelRunArgs reader_run_args0{.kernel = READER0};
     for (uint32_t i = 0; i < num_cores0; ++i) {
         const CoreCoord& core = cores_coords0.at(i);
-        reader_desc0.emplace_runtime_args(
+        AddRuntimeArgsForNode(
+            reader_run_args0.runtime_arg_values,
             core,
-            {input,
-             output,
-             i,
-             static_cast<uint32_t>(i * src_read_size0),
-             i * red_dim_units0,
-             static_cast<uint32_t>((i == num_cores0 - 1) ? src_read_size_last0 : src_read_size0),
-             (i == num_cores0 - 1) ? red_dim_units_last0 : red_dim_units0});
+            {{"core_id", i},
+             {"src_offset", static_cast<uint32_t>(i * src_read_size0)},
+             {"red_dim_offset", i * red_dim_units0},
+             {"src_read_size", static_cast<uint32_t>((i == num_cores0 - 1) ? src_read_size_last0 : src_read_size0)},
+             {"red_dim_units_this_core", (i == num_cores0 - 1) ? red_dim_units_last0 : red_dim_units0}});
     }
-
-    desc.kernels.push_back(std::move(reader_desc0));
+    kernel_run_args.push_back(std::move(reader_run_args0));
 
     if (num_cores1 > 0) {
-        KernelDescriptor reader_desc1;
-        reader_desc1.kernel_source =
-            "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp";
-        reader_desc1.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        reader_desc1.core_ranges = cores1;
-        reader_desc1.compile_time_args = std::move(reader_compile_args);
-        reader_desc1.config = DataMovementConfigDescriptor{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::NOC::RISCV_1_default,
-        };
+        kernels.push_back(make_reader(READER1, SRC1));
+        work_units.push_back(WorkUnitSpec{.name = "group1", .kernels = {READER1}, .target_nodes = cores1});
 
         const uint32_t src_offset1 = static_cast<uint32_t>(src_read_size0 * num_cores0);
         const uint32_t red_dim_offset1 = static_cast<uint32_t>(red_dim_units0 * num_cores0);
 
+        KernelRunArgs reader_run_args1{.kernel = READER1};
         for (uint32_t i = 0; i < num_cores1; ++i) {
             const CoreCoord& core = cores_coords1.at(i);
-            reader_desc1.emplace_runtime_args(
+            AddRuntimeArgsForNode(
+                reader_run_args1.runtime_arg_values,
                 core,
-                {input,
-                 output,
-                 static_cast<uint32_t>(num_cores0 + i),
-                 static_cast<uint32_t>(src_offset1 + (i * src_read_size1)),
-                 red_dim_offset1 + (i * red_dim_units1),
-                 static_cast<uint32_t>((i == num_cores1 - 1) ? src_read_size_last1 : src_read_size1),
-                 (i == num_cores1 - 1) ? red_dim_units_last1 : red_dim_units1});
+                {{"core_id", static_cast<uint32_t>(num_cores0 + i)},
+                 {"src_offset", static_cast<uint32_t>(src_offset1 + (i * src_read_size1))},
+                 {"red_dim_offset", red_dim_offset1 + (i * red_dim_units1)},
+                 {"src_read_size", static_cast<uint32_t>((i == num_cores1 - 1) ? src_read_size_last1 : src_read_size1)},
+                 {"red_dim_units_this_core", (i == num_cores1 - 1) ? red_dim_units_last1 : red_dim_units1}});
         }
-
-        desc.kernels.push_back(std::move(reader_desc1));
+        kernel_run_args.push_back(std::move(reader_run_args1));
     }
 
-    return desc;
+    ProgramSpec spec{
+        .name = "argmax_multi_core",
+        .kernels = std::move(kernels),
+        .dataflow_buffers = std::move(dataflow_buffers),
+        .semaphores = {std::move(start_sem), std::move(done_sem)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()},
+                TensorParameter{.unique_id = OUTPUT, .spec = output.tensor_spec()},
+            },
+        .work_units = std::move(work_units),
+    };
+
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = std::move(kernel_run_args);
+    run_args.tensor_args = {
+        {INPUT, input},
+        {OUTPUT, output},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_single_core_program_factory.cpp
@@ -4,16 +4,20 @@
 #include "argmax_device_operation.hpp"
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
 
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
-#include <vector>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
+
+#include <string>
+#include <utility>
 
 namespace ttnn::prim {
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 static std::tuple<uint32_t, uint32_t> get_page_sizes_single_core(
     const MeshTensor& input, const MeshTensor& output, bool keepdim, bool reduce_all) {
@@ -45,12 +49,15 @@ static std::tuple<uint32_t, uint32_t> get_page_sizes_single_core(
     }
 }
 
-static std::vector<uint32_t> get_ctime_args_single_core(
+// Named compile-time arguments for the selected reader.
+//
+// The argument names are the reader kernels' own variable names, so a reader reads each one as
+// `get_arg(args::<name>)`. The ROW_MAJOR and TILE readers take different argument sets, matching
+// the branch that selects the kernel source.
+static KernelSpec::CompileTimeArgs get_ctime_args_single_core(
     const MeshTensor& input,
     uint32_t src_page_size,
     uint32_t dst_page_size,
-    uint32_t src_cb_index,
-    uint32_t dst_cb_index,
     bool keepdim,
     bool reduce_all,
     bool tile_reader_omit_reduce_all_keepdim) {
@@ -65,14 +72,12 @@ static std::vector<uint32_t> get_ctime_args_single_core(
             const uint32_t outer_dim_units = input.logical_volume() / inner_dim_units / red_dim_units;
 
             return {
-                src_cb_index,
-                dst_cb_index,
-                src_page_size,
-                dst_page_size,
-                outer_dim_units,
-                inner_dim_units,
-                red_dim_units,
-                static_cast<uint32_t>(reduce_all),
+                {"src_page_size", src_page_size},
+                {"dst_page_size", dst_page_size},
+                {"outer_dim_units", outer_dim_units},
+                {"inner_dim_units", inner_dim_units},
+                {"red_dim_units", red_dim_units},
+                {"reduce_all", static_cast<uint32_t>(reduce_all)},
             };
         }
         case Layout::TILE: {
@@ -85,23 +90,24 @@ static std::vector<uint32_t> get_ctime_args_single_core(
             const uint32_t h_logical = logical_rank > 1 ? input.logical_shape()[logical_rank - 2] : 1;
             const uint32_t outer_dim_units = input.logical_volume() / (h_logical * w_logical);
 
-            std::vector<uint32_t> cta = {
-                src_cb_index,
-                dst_cb_index,
-                src_page_size,
-                dst_page_size,
-                tile_height,
-                tile_width,
-                h_tiles,
-                w_tiles,
-                h_logical,
-                w_logical,
-                outer_dim_units,
+            KernelSpec::CompileTimeArgs cta = {
+                {"src_page_size", src_page_size},
+                // Neither TILE reader reads dst_page_size: both derive the write size from
+                // output_page_elements instead. Emitted anyway so the two reader families keep a
+                // single argument builder, exactly as the pre-Metal-2.0 factory did.
+                {"dst_page_size", dst_page_size},
+                {"tile_height", tile_height},
+                {"tile_width", tile_width},
+                {"input_height", h_tiles},
+                {"input_width", w_tiles},
+                {"logical_height", h_logical},
+                {"logical_width", w_logical},
+                {"outer_dim_size", outer_dim_units},
             };
             // Width-reduction reader uses reduce_all/keepdim; height-reduction reader does not.
             if (!tile_reader_omit_reduce_all_keepdim) {
-                cta.push_back(static_cast<uint32_t>(reduce_all));
-                cta.push_back(static_cast<uint32_t>(keepdim));
+                cta.emplace("reduce_all", static_cast<uint32_t>(reduce_all));
+                cta.emplace("keepdim", static_cast<uint32_t>(keepdim));
             }
             return cta;
         }
@@ -113,20 +119,23 @@ static std::vector<uint32_t> get_ctime_args_single_core(
     }
 }
 
-ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts ArgMaxSingleCoreProgramFactory::create_program_artifacts(
     const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input.mesh_tensor();
     const auto& output = tensor_return_value.mesh_tensor();
     const auto& dim = operation_attributes.dim;
     const bool keepdim = operation_attributes.keepdim;
 
-    ProgramDescriptor desc;
     const tt::tt_metal::IDevice* device = &output.mutable_device();
     const bool reduce_all = not dim.has_value();
 
-    // Circular buffers
-    const auto src_cb_index = tt::CBIndex::c_0;
-    const auto dst_cb_index = tt::CBIndex::c_1;
+    // Resource names. Declared function-locally: both argmax factories share a unity-build
+    // translation unit, and namespace-scope `const` objects would collide by name there.
+    const KernelSpecName READER{"reader"};
+    const DFBSpecName SRC{"src"};
+    const DFBSpecName DST{"dst"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
 
     const auto grid_size = device->compute_with_storage_grid_size();
     const uint32_t num_units = 1;  // single-core
@@ -141,27 +150,21 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
     const tt::DataFormat output_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     const auto [src_page_size, dst_page_size] = get_page_sizes_single_core(input, output, keepdim, reduce_all);
 
-    // Create input CB
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = src_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src_cb_index),
-            .data_format = input_data_format,
-            .page_size = src_page_size,
-        }}},
-    });
+    // Input DFB: one entry holding a whole input page.
+    DataflowBufferSpec dfb_src{
+        .unique_id = SRC,
+        .entry_size = src_page_size,
+        .num_entries = 1,
+        .data_format_metadata = input_data_format,
+    };
 
-    // Create output CB
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = dst_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(dst_cb_index),
-            .data_format = output_data_format,
-            .page_size = dst_page_size,
-        }}},
-    });
+    // Output DFB: one entry holding a whole output page.
+    DataflowBufferSpec dfb_dst{
+        .unique_id = DST,
+        .entry_size = dst_page_size,
+        .num_entries = 1,
+        .data_format_metadata = output_data_format,
+    };
 
     const int32_t rank_i = static_cast<int32_t>(input.logical_shape().size());
     const int32_t nd = dim.has_value() ? (dim.value() < 0 ? dim.value() + rank_i : dim.value()) : -1;
@@ -169,22 +172,14 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
 
     // Compile-time args
     const bool tile_reader_omit_reduce_all_keepdim = input.layout() == Layout::TILE && dim_is_h;
-    std::vector<uint32_t> ctime_args = get_ctime_args_single_core(
-        input,
-        src_page_size,
-        dst_page_size,
-        src_cb_index,
-        dst_cb_index,
-        keepdim,
-        reduce_all,
-        tile_reader_omit_reduce_all_keepdim);
-
-    tt::tt_metal::TensorAccessorArgs(input).append_to(ctime_args);
-    tt::tt_metal::TensorAccessorArgs(output).append_to(ctime_args);
+    KernelSpec::CompileTimeArgs ctime_args = get_ctime_args_single_core(
+        input, src_page_size, dst_page_size, keepdim, reduce_all, tile_reader_omit_reduce_all_keepdim);
 
     std::string kernel_path;
     if (input.layout() == Layout::ROW_MAJOR) {
-        kernel_path = "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp";
+        // The Metal 2.0 fork; the legacy source beside it still serves a ProgramDescriptor
+        // consumer that cannot supply named bindings.
+        kernel_path = "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_metal2.cpp";
     } else {
         // TILE: reduction on H (rank-2) uses the height reader
         kernel_path = dim_is_h
@@ -192,22 +187,53 @@ ProgramDescriptor ArgMaxSingleCoreProgramFactory::create_descriptor(
                           : "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout.cpp";
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source = kernel_path;
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(ctime_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // Both DFBs are touched by this one reader and by nothing else: it takes a raw write pointer
+    // into each and never runs a FIFO operation on either. A single toucher cannot present a
+    // producer and a consumer on distinct kernels, so the reader is bound as both.
+    KernelSpec reader{
+        .unique_id = READER,
+        .source = kernel_path,
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = SRC, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER},
+                DFBBinding{.dfb_spec_name = SRC, .accessor_name = "src", .endpoint_type = DFBEndpointType::CONSUMER},
+                DFBBinding{.dfb_spec_name = DST, .accessor_name = "dst", .endpoint_type = DFBEndpointType::PRODUCER},
+                DFBBinding{.dfb_spec_name = DST, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"},
+                TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"},
+            },
+        .compile_time_args = std::move(ctime_args),
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+    };
 
-    // Runtime args
-    const auto cores = grid_to_cores(num_cores, grid_size.x, grid_size.y, false);
-    for (const auto& core : cores) {
-        reader_desc.emplace_runtime_args(core, {input, output});
-    }
+    ProgramSpec spec{
+        .name = "argmax_single_core",
+        .kernels = {std::move(reader)},
+        .dataflow_buffers = {std::move(dfb_src), std::move(dfb_dst)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()},
+                TensorParameter{.unique_id = OUTPUT, .spec = output.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{.name = "main", .kernels = {READER}, .target_nodes = all_cores},
+            },
+    };
 
-    desc.kernels.push_back(std::move(reader_desc));
+    // The reader declares no runtime or common runtime arguments — the two tensor base addresses
+    // it used to read as runtime args now arrive through its tensor bindings — so it needs no
+    // KernelRunArgs entry.
+    ProgramRunArgs run_args;
+    run_args.tensor_args = {
+        {INPUT, input},
+        {OUTPUT, output},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
@@ -137,16 +137,16 @@ inline void update_max_if_greater(
 }
 
 /**
- * @brief Compares values from a circular buffer and updates the maximum value and its index for argmax operation.
+ * @brief Compares values from a dataflow buffer and updates the maximum value and its index for argmax operation.
  *
- * This template function reads a value from the specified circular buffer address and compares it with the current
+ * This template function reads a value from the specified dataflow buffer address and compares it with the current
  * maximum value. If the new value is greater, it updates both the maximum value and its corresponding index.
  * The comparison logic is specialized for different data formats using compile-time branching.
  *
  * @tparam data_format The data format type (Float16_b, Float32, UInt16, Int32, UInt32) that determines
  *                     the value type and comparison method to use
  *
- * @param src_cb_addr Address of the source circular buffer containing the input values
+ * @param src_dfb_addr Address of the source dataflow buffer containing the input values
  * @param max_val Reference to the current maximum value that may be updated if a larger value is found
  * @param max_idx Reference to the index of the current maximum value that may be updated
  * @param i Index within the reduction dimension (inner-most index)
@@ -163,7 +163,7 @@ inline void update_max_if_greater(
  */
 template <DataFormat data_format>
 void compare_values(
-    const uint32_t src_cb_addr,
+    const uint32_t src_dfb_addr,
     decltype(get_default_value<data_format>())& max_val,
     uint32_t& max_idx,
     const uint32_t i,
@@ -172,7 +172,7 @@ void compare_values(
     const uint32_t red_dim_units,
     bool reduce_all,
     uint32_t inner_dim_units) {
-    auto in_vals = get_tt_l1_ptr_based_on_data_format<data_format>(src_cb_addr);
+    auto in_vals = get_tt_l1_ptr_based_on_data_format<data_format>(src_dfb_addr);
     auto val = in_vals[i];
     const uint32_t index = calculate_argmax_index(reduce_all, k, j, i, inner_dim_units, red_dim_units);
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_common.hpp
@@ -137,16 +137,17 @@ inline void update_max_if_greater(
 }
 
 /**
- * @brief Compares values from a dataflow buffer and updates the maximum value and its index for argmax operation.
+ * @brief Compares values from a source L1 buffer and updates the maximum value and its index for argmax operation.
  *
- * This template function reads a value from the specified dataflow buffer address and compares it with the current
+ * This template function reads a value from the specified source L1 buffer address and compares it with the current
  * maximum value. If the new value is greater, it updates both the maximum value and its corresponding index.
  * The comparison logic is specialized for different data formats using compile-time branching.
  *
  * @tparam data_format The data format type (Float16_b, Float32, UInt16, Int32, UInt32) that determines
  *                     the value type and comparison method to use
  *
- * @param src_dfb_addr Address of the source dataflow buffer containing the input values
+ * @param src_l1_addr L1 address of the source buffer holding the input values. Callers pass either a
+ *                    DataflowBuffer or a legacy CircularBuffer pointer, so this stays buffer-neutral.
  * @param max_val Reference to the current maximum value that may be updated if a larger value is found
  * @param max_idx Reference to the index of the current maximum value that may be updated
  * @param i Index within the reduction dimension (inner-most index)
@@ -163,7 +164,7 @@ inline void update_max_if_greater(
  */
 template <DataFormat data_format>
 void compare_values(
-    const uint32_t src_dfb_addr,
+    const uint32_t src_l1_addr,
     decltype(get_default_value<data_format>())& max_val,
     uint32_t& max_idx,
     const uint32_t i,
@@ -172,7 +173,7 @@ void compare_values(
     const uint32_t red_dim_units,
     bool reduce_all,
     uint32_t inner_dim_units) {
-    auto in_vals = get_tt_l1_ptr_based_on_data_format<data_format>(src_dfb_addr);
+    auto in_vals = get_tt_l1_ptr_based_on_data_format<data_format>(src_l1_addr);
     auto val = in_vals[i];
     const uint32_t index = calculate_argmax_index(reduce_all, k, j, i, inner_dim_units, red_dim_units);
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_h_col.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_h_col.hpp
@@ -12,7 +12,7 @@
 #include <cstdint>
 
 /**
- * One pass over the tile already in the CB: for each in-tile column `in_tile_w`, update
+ * One pass over the tile already in the DFB: for each in-tile column `in_tile_w`, update
  * max_vals[in_tile_w] / arg_maxs[in_tile_w] (argmax along global H for that global_w column).
  * Matches face indexing and padding handling of process_input_tile (W reader).
  *
@@ -24,7 +24,7 @@
 template <typename DTYPE, DataFormat format>
 void process_loaded_tile_all_h_columns(
     const InputContext& ctx, uint32_t w_tile, uint32_t h_tile, DTYPE max_vals[], uint32_t arg_maxs[]) {
-    auto src_ptr = get_tt_l1_ptr_based_on_data_format<format>(ctx.cb_addr);
+    auto src_ptr = get_tt_l1_ptr_based_on_data_format<format>(ctx.dfb_addr);
 
     constexpr uint32_t faces_per_tile = 4;
     for (uint32_t face_id = 0; face_id < faces_per_tile; face_id++) {

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_tile_layout.hpp
@@ -34,7 +34,7 @@ struct InputContext {
     const uint32_t logical_width;
 
     const DataFormat data_format;
-    const uint32_t cb_addr;
+    const uint32_t dfb_addr;
 
     // Reminders for calculating padding offsets
     const uint32_t tile_h_rem;
@@ -61,7 +61,7 @@ struct InputContext {
         uint32_t f_h_rem,
         uint32_t f_w_rem,
         DataFormat format,
-        uint32_t l1_cb_addr) :
+        uint32_t l1_dfb_addr) :
         tile_height(tile_h),
         tile_width(tile_w),
         input_height(tiles_h),
@@ -69,7 +69,7 @@ struct InputContext {
         logical_height(data_h),
         logical_width(data_w),
         data_format(format),
-        cb_addr(l1_cb_addr),
+        dfb_addr(l1_dfb_addr),
         tile_h_rem(t_h_rem),
         tile_w_rem(t_w_rem),
         face_h_rem(f_h_rem),
@@ -87,18 +87,18 @@ struct OutputContext {
     uint32_t* const stack_ptr;
     const uint32_t stack_buffer_size;
 
-    const uint32_t output_cb_addr;
+    const uint32_t output_dfb_addr;
     const uint32_t write_out_count;
 
     OutputContext() = delete;
     OutputContext(const OutputContext&) = delete;
 
-    OutputContext(uint32_t* ptr, uint32_t size, uint32_t dst_cb_addr, uint32_t out_count) :
+    OutputContext(uint32_t* ptr, uint32_t size, uint32_t dst_dfb_addr, uint32_t out_count) :
         collected_count(0),
         output_page_id(0),
         stack_ptr(ptr),
         stack_buffer_size(size),
-        output_cb_addr(dst_cb_addr),
+        output_dfb_addr(dst_dfb_addr),
         write_out_count(out_count) {}
 };
 
@@ -210,7 +210,7 @@ void process_input_tile(
     uint32_t& rows_processed) {
     const bool has_padding = ctx.has_padding;
     const DataFormat src_data_format = ctx.data_format;
-    auto src_ptr = get_tt_l1_ptr_based_on_data_format<format>(ctx.cb_addr);
+    auto src_ptr = get_tt_l1_ptr_based_on_data_format<format>(ctx.dfb_addr);
 
     rows_processed = 0;
 
@@ -300,7 +300,7 @@ void collect_row_major_output(uint32_t new_values[], uint32_t count, OutputConte
     }
 
     auto* stack_ptr = ctx.stack_ptr;
-    auto* cb_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ctx.output_cb_addr);
+    auto* dfb_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ctx.output_dfb_addr);
 
     for (uint32_t idx = 0; idx < count; idx++) {
         uint32_t write_index = curr_collected + idx;
@@ -308,8 +308,8 @@ void collect_row_major_output(uint32_t new_values[], uint32_t count, OutputConte
             // Accumulate into the on stack array
             stack_ptr[write_index] = new_values[idx];
         } else {
-            // Write directly into the output CB
-            cb_ptr[write_index] = new_values[idx];
+            // Write directly into the output DFB
+            dfb_ptr[write_index] = new_values[idx];
         }
     }
 
@@ -331,24 +331,24 @@ void write_to_output(const Noc& noc, AccessorType& output_accessor, OutputContex
     uint32_t collected_count = output_ctx.collected_count;
     uint32_t output_page_id = output_ctx.output_page_id;
 
-    auto dst_cb_addr = output_ctx.output_cb_addr;
-    CoreLocalMem<uint32_t> dst_cb_mem(dst_cb_addr);
+    auto dst_dfb_addr = output_ctx.output_dfb_addr;
+    CoreLocalMem<uint32_t> dst_dfb_mem(dst_dfb_addr);
 
     uint32_t sent_count = 0;
     while (collected_count > 0) {
         // When keepdim is true, argmax values are accumulated in an on-stack buffer.
-        // Otherwise, argmax values are accumulated directly in the output CB.
+        // Otherwise, argmax values are accumulated directly in the output DFB.
         if constexpr (keepdim) {
             auto* stack_ptr = output_ctx.stack_ptr;
-            auto* dst_cb_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_cb_addr);
-            // Copy one page of output data into the output CB.
+            auto* dst_dfb_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_dfb_addr);
+            // Copy one page of output data into the output DFB.
             for (uint32_t idx = 0; idx < output_page_elements; idx++) {
-                dst_cb_ptr[idx] = stack_ptr[sent_count + idx];
+                dst_dfb_ptr[idx] = stack_ptr[sent_count + idx];
             }
         }
 
         const uint32_t write_size = output_page_elements * sizeof(uint32_t);
-        noc.async_write(dst_cb_mem, output_accessor, write_size, {.offset_bytes = 0}, {.page_id = output_page_id});
+        noc.async_write(dst_dfb_mem, output_accessor, write_size, {.offset_bytes = 0}, {.page_id = output_page_id});
 
         sent_count += output_page_elements;
         collected_count -= output_page_elements;

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved.cpp
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: A Metal 2.0 fork of this kernel lives beside it, as
+// reader_argmax_interleaved_metal2.cpp. Ops ported to Metal 2.0 bind the fork; this file serves
+// the consumers still on the legacy API. Until the last of them migrates and this file is
+// retired, changes here likely belong in the fork too.
+
 #include "argmax_common.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_metal2.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of reader_argmax_interleaved.cpp, which lives beside this file and still serves
+// consumers on the legacy ProgramDescriptor API. Keep the two in sync until the legacy copy is
+// retired; the only differences should be the named arguments and the named resource bindings.
+
+#include "argmax_common.hpp"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+#include <stdint.h>
+
+void kernel_main() {
+    // Compile time args
+    // -----------------
+    constexpr auto src_page_size = get_arg(args::src_page_size);
+    constexpr auto dst_page_size = get_arg(args::dst_page_size);
+
+    // This is the number of elements in the output, excluding the last two dimensions.
+    // i.e. for an input tensor of shape (.., N, C, H, W), this is (.. * N * C)
+    // It also depends on the `keepdim`
+    constexpr auto outer_dim_units = get_arg(args::outer_dim_units);
+
+    // This is the number of elements in the last dimension of the output
+    // i.e. for an input tensor of shape (.., N, C, H, W), this is H.
+    // This dictates the page size in the output dfb
+    constexpr auto inner_dim_units = get_arg(args::inner_dim_units);
+
+    // This is the number of elements in the input tensor along the reduction dim (W)
+    constexpr auto red_dim_units = get_arg(args::red_dim_units);
+
+    // Boolean to indicate if we reduce across _all_ dimensions or just on the reduction dim (last dim)
+    constexpr bool reduce_all = (bool)get_arg(args::reduce_all);
+
+    //-------------------------------------------------------------------------
+    const auto s_src = TensorAccessor(tensor::src);
+    const auto s_dst = TensorAccessor(tensor::dst);
+
+    Noc noc;
+    DataflowBuffer src_dfb(dfb::src);
+    DataflowBuffer dst_dfb(dfb::dst);
+
+    // DFB in L1 memory for storing input
+    const uint32_t src_dfb_addr = src_dfb.get_write_ptr();
+    constexpr DataFormat src_dfb_addr_data_format = get_dataformat(dfb::src);
+
+    // DFB in L1 memory for storing output
+    const uint32_t dst_dfb_addr = dst_dfb.get_write_ptr();
+    volatile tt_l1_ptr uint32_t* out_idxs = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_dfb_addr);
+
+    uint32_t max_idx = 0;
+    auto max_val = get_default_value<src_dfb_addr_data_format>();
+
+    //-------------------------------------------------------------------------
+    // Main loop - run by all cores
+    for (uint32_t k = 0; k < outer_dim_units; ++k) {
+        for (uint32_t j = 0; j < inner_dim_units; ++j) {
+            noc.async_read(s_src, src_dfb, src_page_size, {.page_id = k * inner_dim_units + j}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+
+            // Reset max_val for each new output
+            if constexpr (not reduce_all) {
+                max_idx = 0;
+                max_val = get_default_value<src_dfb_addr_data_format>();
+            }
+
+            for (uint32_t i = 0; i < red_dim_units; ++i) {
+                compare_values<src_dfb_addr_data_format>(
+                    src_dfb_addr, max_val, max_idx, i, j, k, red_dim_units, reduce_all, inner_dim_units);
+            }
+            if constexpr (not reduce_all) {
+                out_idxs[j] = max_idx;
+            }
+        }
+
+        // The results were written at dst_dfb's write pointer, and that is the address this send
+        // reads from: nothing on this DFB ever calls reserve_back/push_back/wait_front/pop_front, so
+        // its read and write pointers both stay at the buffer base for the whole kernel.
+        if constexpr (not reduce_all) {
+            noc.async_write(dst_dfb, s_dst, dst_page_size, {.offset_bytes = 0}, {.page_id = k});
+            noc.async_write_barrier();
+        }
+    }
+
+    // TODO: Generalize write for argmax for other dims
+    if constexpr (reduce_all) {
+        out_idxs[0] = max_idx;
+        noc.async_write(dst_dfb, s_dst, dst_page_size, {.offset_bytes = 0}, {.page_id = 0});
+        noc.async_write_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -264,6 +264,13 @@ void kernel_main() {
 
     // start and end coordinates of the cores that will be used to compute the intermediate outputs
     // At maximum, there can be two groups of cores (suffix 0 and 1)
+    //
+    // These four names are the operands of a NOC1 multicast rectangle, which is addressed
+    // end-corner first. The host therefore sends the group's *end* coordinate in the "start"
+    // argument and its *start* coordinate in the "end" argument, and set_multicast() below
+    // consumes them in that order. The inversion is deliberate and load-bearing: swapping these
+    // to make the names read naturally would address the wrong rectangle, and multicast has no
+    // check that would catch it.
     constexpr auto start_core_x0 = get_arg(args::start_core_x0);
     constexpr auto start_core_y0 = get_arg(args::start_core_y0);
     constexpr auto end_core_x0 = get_arg(args::end_core_x0);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -5,11 +5,12 @@
 #include "api/numeric/bfloat16.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 #include <cstdint>
 
@@ -30,21 +31,21 @@
  * @param outer_idx Index of the current outer dimension being processed
  * @param src_offset Offset into the source data buffer
  * @param s_src Interleaved address generator for source data access
- * @param src_cb_addr Address of the source circular buffer
+ * @param src_dfb Dataflow buffer holding the source data
  * @param src_read_size Size of data to read from source in bytes
  * @param red_dim_offset Offset along the reduction dimension
  * @param red_dim_units_this_core Number of reduction dimension units assigned to this core
  * @param in_vals Pointer to L1 memory containing input values with data type determined by data_format template
  * parameter
  */
-template <bool reduce_all, DataFormat data_format, typename AddrGen, typename SrcCb>
+template <bool reduce_all, DataFormat data_format, typename AddrGen, typename SrcDfb>
 inline void find_argmax_for_core(
     const Noc& noc,
     const uint32_t inner_dim_units,
     const uint32_t outer_idx,
     const uint32_t src_offset,
     const AddrGen& s_src,
-    const SrcCb& src_cb,
+    const SrcDfb& src_dfb,
     const uint32_t src_read_size,
     const uint32_t red_dim_offset,
     const uint32_t red_dim_units_this_core,
@@ -57,7 +58,7 @@ inline void find_argmax_for_core(
     for (uint32_t j = 0; j < inner_dim_units; ++j) {
         noc.async_read(
             s_src,
-            src_cb,
+            src_dfb,
             src_read_size,
             {.page_id = outer_idx * inner_dim_units + j, .offset_bytes = src_offset},
             {.offset_bytes = 0});
@@ -135,8 +136,8 @@ inline void find_argmax_for_core(
  *                     - DataFormat::UInt32: 32-bit unsigned integer
  *
  * @param inner_idx Index within each core's output buffer to compare
- * @param red_val_cb_local_base_addr Base address of the circular buffer containing reduction values
- * @param red_idx_cb_local_base_addr Base address of the circular buffer containing reduction indices
+ * @param red_val_dfb_local_base_addr Base address of the dataflow buffer containing reduction values
+ * @param red_idx_dfb_local_base_addr Base address of the dataflow buffer containing reduction indices
  * @param red_val_size_per_core Size in bytes of reduction values buffer per core
  * @param red_idx_size_per_core Size in bytes of reduction indices buffer per core
  *
@@ -149,8 +150,8 @@ inline void find_argmax_for_core(
 template <uint32_t num_cores, DataFormat data_format>
 inline uint32_t find_argmax_from_intermediate_outputs(
     const uint32_t inner_idx,
-    const uint32_t red_val_cb_local_base_addr,
-    const uint32_t red_idx_cb_local_base_addr,
+    const uint32_t red_val_dfb_local_base_addr,
+    const uint32_t red_idx_dfb_local_base_addr,
     const uint32_t red_val_size_per_core,
     const uint32_t red_idx_size_per_core) {
     // Reset max_val for each new output
@@ -159,11 +160,11 @@ inline uint32_t find_argmax_from_intermediate_outputs(
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         volatile tt_l1_ptr auto i_red_idxs =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_idx_cb_local_base_addr + i * red_idx_size_per_core);
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_idx_dfb_local_base_addr + i * red_idx_size_per_core);
 
         if constexpr (data_format == DataFormat::Float16_b) {
             volatile tt_l1_ptr auto i_red_vals =
-                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(red_val_cb_local_base_addr + i * red_val_size_per_core);
+                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(red_val_dfb_local_base_addr + i * red_val_size_per_core);
 
             process_core_data<data_format>(
                 inner_idx, i_red_vals, i_red_idxs, max_val, max_idx, [](uint16_t a, uint16_t b) {
@@ -172,14 +173,14 @@ inline uint32_t find_argmax_from_intermediate_outputs(
 
         } else if constexpr (data_format == DataFormat::UInt16) {
             volatile tt_l1_ptr auto i_red_vals =
-                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(red_val_cb_local_base_addr + i * red_val_size_per_core);
+                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(red_val_dfb_local_base_addr + i * red_val_size_per_core);
 
             process_core_data<data_format>(
                 inner_idx, i_red_vals, i_red_idxs, max_val, max_idx, [](uint16_t a, uint16_t b) { return a > b; });
 
         } else if constexpr (data_format == DataFormat::Float32) {
             volatile tt_l1_ptr auto i_red_vals =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_val_cb_local_base_addr + i * red_val_size_per_core);
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_val_dfb_local_base_addr + i * red_val_size_per_core);
 
             process_core_data<data_format>(
                 inner_idx, i_red_vals, i_red_idxs, max_val, max_idx, [](uint32_t a, uint32_t b) {
@@ -188,7 +189,7 @@ inline uint32_t find_argmax_from_intermediate_outputs(
 
         } else if constexpr (data_format == DataFormat::Int32) {
             volatile tt_l1_ptr auto i_red_vals =
-                reinterpret_cast<volatile tt_l1_ptr int32_t*>(red_val_cb_local_base_addr + i * red_val_size_per_core);
+                reinterpret_cast<volatile tt_l1_ptr int32_t*>(red_val_dfb_local_base_addr + i * red_val_size_per_core);
 
             process_core_data<data_format>(
                 inner_idx, i_red_vals, i_red_idxs, max_val, max_idx, [](int32_t a, int32_t b) {
@@ -197,7 +198,7 @@ inline uint32_t find_argmax_from_intermediate_outputs(
 
         } else if constexpr (data_format == DataFormat::UInt32) {
             volatile tt_l1_ptr auto i_red_vals =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_val_cb_local_base_addr + i * red_val_size_per_core);
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_val_dfb_local_base_addr + i * red_val_size_per_core);
 
             process_core_data<data_format>(
                 inner_idx, i_red_vals, i_red_idxs, max_val, max_idx, [](uint32_t a, uint32_t b) { return a > b; });
@@ -216,139 +217,120 @@ inline uint32_t find_argmax_from_intermediate_outputs(
 void kernel_main() {
     // Runtime args
     // ------------
-    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
-    const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
-    const uint32_t core_id = get_arg_val<uint32_t>(2);
+    const auto core_id = get_arg(args::core_id);
 
-    // The offset of the input CB in the input tensor
-    const uint32_t src_offset = get_arg_val<uint32_t>(3);
+    // The offset of the input DFB in the input tensor
+    const auto src_offset = get_arg(args::src_offset);
 
-    // The offset of the reduction dim in the input CB
-    const uint32_t red_dim_offset = get_arg_val<uint32_t>(4);
+    // The offset of the reduction dim in the input DFB
+    const auto red_dim_offset = get_arg(args::red_dim_offset);
 
-    // The bytes to read from the input CB for this core
-    const uint32_t src_read_size = get_arg_val<uint32_t>(5);
+    // The bytes to read from the input DFB for this core
+    const auto src_read_size = get_arg(args::src_read_size);
 
     // This is the number of elements in the reduction dim processed by this core
-    const uint32_t red_dim_units_this_core = get_arg_val<uint32_t>(6);
+    const auto red_dim_units_this_core = get_arg(args::red_dim_units_this_core);
 
     // Compile time args
     // -----------------
-    constexpr uint32_t src_cb_idx = get_compile_time_arg_val(0);
-
-    // This CB is only used in the reduction core. It is used to store
-    // final outputs (indices) after reduction of intermediate outputs.
-    constexpr uint32_t dst_cb_idx = get_compile_time_arg_val(1);
-
-    // This CB holds intermediate outputs (indices) in each core
-    constexpr uint32_t red_idxs_cb_idx = get_compile_time_arg_val(2);
-
-    // This CB holds intermediate outputs (values) in each core
-    constexpr uint32_t red_vals_cb_idx = get_compile_time_arg_val(3);
-
-    constexpr uint32_t dst_page_size = get_compile_time_arg_val(5);
-    constexpr uint32_t red_idx_size_per_core = get_compile_time_arg_val(6);
-    constexpr uint32_t red_val_size_per_core = get_compile_time_arg_val(7);
+    constexpr auto dst_page_size = get_arg(args::dst_page_size);
+    constexpr auto red_idx_size_per_core = get_arg(args::red_idx_size_per_core);
+    constexpr auto red_val_size_per_core = get_arg(args::red_val_size_per_core);
 
     // This is the number of elements in the output, excluding the last two dimensions.
     // i.e. for an input tensor of shape (.., N, C, H, W), this is (.. * N * C)
     // It also depends on the `keepdim`
-    constexpr uint32_t outer_dim_units = get_compile_time_arg_val(8);
+    constexpr auto outer_dim_units = get_arg(args::outer_dim_units);
 
     // This is the number of elements in the last dimension of the output
     // i.e. for an input tensor of shape (.., N, C, H, W), this is H.
-    // This dictates the page size in the output cb
-    constexpr uint32_t inner_dim_units = get_compile_time_arg_val(9);
+    // This dictates the page size in the output dfb
+    constexpr auto inner_dim_units = get_arg(args::inner_dim_units);
 
     // This is the number of elements in the input tensor along the reduction dim (W)
-    constexpr uint32_t red_dim_units = get_compile_time_arg_val(10);
+    constexpr auto red_dim_units = get_arg(args::red_dim_units);
 
     // Boolean to indicate if we reduce across _all_ dimensions or just on the reduction dim (last dim)
-    constexpr bool reduce_all = (bool)get_compile_time_arg_val(11);
+    constexpr bool reduce_all = (bool)get_arg(args::reduce_all);
 
     // Total number of cores participating in this op
-    constexpr uint32_t num_cores = get_compile_time_arg_val(12);
+    constexpr auto num_cores = get_arg(args::num_cores);
 
     // Pick the core that will collate the intermediate outputs
-    constexpr uint32_t reduce_core_id = (bool)get_compile_time_arg_val(13);
+    constexpr uint32_t reduce_core_id = (bool)get_arg(args::reduce_core_id);
 
-    constexpr uint32_t reduce_core_x = get_compile_time_arg_val(14);
-    constexpr uint32_t reduce_core_y = get_compile_time_arg_val(15);
+    constexpr auto reduce_core_x = get_arg(args::reduce_core_x);
+    constexpr auto reduce_core_y = get_arg(args::reduce_core_y);
 
     // start and end coordinates of the cores that will be used to compute the intermediate outputs
     // At maximum, there can be two groups of cores (suffix 0 and 1)
-    constexpr uint32_t start_core_x0 = get_compile_time_arg_val(16);
-    constexpr uint32_t start_core_y0 = get_compile_time_arg_val(17);
-    constexpr uint32_t end_core_x0 = get_compile_time_arg_val(18);
-    constexpr uint32_t end_core_y0 = get_compile_time_arg_val(19);
+    constexpr auto start_core_x0 = get_arg(args::start_core_x0);
+    constexpr auto start_core_y0 = get_arg(args::start_core_y0);
+    constexpr auto end_core_x0 = get_arg(args::end_core_x0);
+    constexpr auto end_core_y0 = get_arg(args::end_core_y0);
 
-    constexpr uint32_t start_core_x1 = get_compile_time_arg_val(20);
-    constexpr uint32_t start_core_y1 = get_compile_time_arg_val(21);
-    constexpr uint32_t end_core_x1 = get_compile_time_arg_val(22);
-    constexpr uint32_t end_core_y1 = get_compile_time_arg_val(23);
+    constexpr auto start_core_x1 = get_arg(args::start_core_x1);
+    constexpr auto start_core_y1 = get_arg(args::start_core_y1);
+    constexpr auto end_core_x1 = get_arg(args::end_core_x1);
+    constexpr auto end_core_y1 = get_arg(args::end_core_y1);
 
-    constexpr uint32_t num_cores0 = get_compile_time_arg_val(24);  // Number of cores in group 0
-    constexpr uint32_t num_cores1 = get_compile_time_arg_val(25);  // Number of cores in group 1
-
-    // Semaphore to fire when intermediate outputs can be started to compute
-    constexpr uint32_t start_sem_idx = get_compile_time_arg_val(26);
-
-    // Semaphore to fire when intermediate outputs for one page are ready
-    constexpr uint32_t done_sem_idx = get_compile_time_arg_val(27);
-
-    constexpr auto s_src_args = TensorAccessorArgs<28>();
-    constexpr auto s_dst_args = TensorAccessorArgs<s_src_args.next_compile_time_args_offset()>();
+    constexpr auto num_cores0 = get_arg(args::num_cores0);  // Number of cores in group 0
+    constexpr auto num_cores1 = get_arg(args::num_cores1);  // Number of cores in group 1
 
     //-------------------------------------------------------------------------
     // Flag to identify if this core will collate intermediate outputs
     const bool is_reduce_core = (core_id == reduce_core_id);
 
-    const auto s_src = TensorAccessor(s_src_args, src_base_addr);
-    const auto s_dst = TensorAccessor(s_dst_args, dst_base_addr);
+    const auto s_src = TensorAccessor(tensor::src);
+    const auto s_dst = TensorAccessor(tensor::dst);
 
     Noc noc;
     UnicastEndpoint remote;
-    CircularBuffer src_cb(src_cb_idx);
-    CircularBuffer dst_cb(dst_cb_idx);
-    CircularBuffer red_idx_cb(red_idxs_cb_idx);
-    CircularBuffer red_val_cb(red_vals_cb_idx);
+    DataflowBuffer src_dfb(dfb::src);
+    // This DFB is only used in the reduction core. It is used to store
+    // final outputs (indices) after reduction of intermediate outputs.
+    DataflowBuffer dst_dfb(dfb::dst);
+    // This DFB holds intermediate outputs (indices) in each core
+    DataflowBuffer red_idx_dfb(dfb::red_idxs);
+    // This DFB holds intermediate outputs (values) in each core
+    DataflowBuffer red_val_dfb(dfb::red_vals);
 
-    // CB in L1 memory for storing input
-    constexpr DataFormat src_cb_addr_data_format = get_dataformat(src_cb_idx);
-    const uint32_t src_cb_addr = src_cb.get_write_ptr();
-    volatile tt_l1_ptr auto* in_vals = get_tt_l1_ptr_based_on_data_format<src_cb_addr_data_format>(src_cb_addr);
+    // DFB in L1 memory for storing input
+    constexpr DataFormat src_dfb_addr_data_format = get_dataformat(dfb::src);
+    const uint32_t src_dfb_addr = src_dfb.get_write_ptr();
+    volatile tt_l1_ptr auto* in_vals = get_tt_l1_ptr_based_on_data_format<src_dfb_addr_data_format>(src_dfb_addr);
 
-    // CB in L1 memory of reducer core for storing output
-    const uint32_t dst_cb_addr = dst_cb.get_write_ptr();
-    volatile tt_l1_ptr uint32_t* out_idxs = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_cb_addr);
+    // DFB in L1 memory of reducer core for storing output
+    const uint32_t dst_dfb_addr = dst_dfb.get_write_ptr();
+    volatile tt_l1_ptr uint32_t* out_idxs = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_dfb_addr);
 
-    // CB in L1 memory for storing partial idx output
-    const uint32_t red_idx_cb_local_base_addr = red_idx_cb.get_write_ptr();
+    // DFB in L1 memory for storing partial idx output
+    const uint32_t red_idx_dfb_local_base_addr = red_idx_dfb.get_write_ptr();
     const uint32_t red_idx_offset = core_id * red_idx_size_per_core;
 
-    const uint32_t red_idx_cb_local_addr = red_idx_cb_local_base_addr + red_idx_offset;
-    volatile tt_l1_ptr uint32_t* red_idxs = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_idx_cb_local_addr);
+    const uint32_t red_idx_dfb_local_addr = red_idx_dfb_local_base_addr + red_idx_offset;
+    volatile tt_l1_ptr uint32_t* red_idxs = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_idx_dfb_local_addr);
 
-    // CB in L1 memory for storing partial val output
-    const uint32_t red_val_cb_local_base_addr = red_val_cb.get_write_ptr();
-    constexpr DataFormat red_val_cb_local_addr_data_format = get_dataformat(red_vals_cb_idx);
+    // DFB in L1 memory for storing partial val output
+    const uint32_t red_val_dfb_local_base_addr = red_val_dfb.get_write_ptr();
+    constexpr DataFormat red_val_dfb_local_addr_data_format = get_dataformat(dfb::red_vals);
     const uint32_t red_val_offset = core_id * red_val_size_per_core;
 
-    const uint32_t red_val_cb_local_addr = red_val_cb_local_base_addr + red_val_offset;
+    const uint32_t red_val_dfb_local_addr = red_val_dfb_local_base_addr + red_val_offset;
     volatile tt_l1_ptr auto* red_vals =
-        get_tt_l1_ptr_based_on_data_format<red_val_cb_local_addr_data_format>(red_val_cb_local_addr);
+        get_tt_l1_ptr_based_on_data_format<red_val_dfb_local_addr_data_format>(red_val_dfb_local_addr);
 
     static_assert(
-        red_val_cb_local_addr_data_format == src_cb_addr_data_format,
+        red_val_dfb_local_addr_data_format == src_dfb_addr_data_format,
         "Program logic error. "
         "Partial result buffer must use the same data format as values.");
 
     // Semaphores
-    Semaphore<> start_sem(start_sem_idx);
-    Semaphore<> done_sem(done_sem_idx);
+    Semaphore<> start_sem(sem::start);
+    Semaphore<> done_sem(sem::done);
 
     uint32_t max_idx = 0;
-    auto max_val = get_default_value<src_cb_addr_data_format>();
+    auto max_val = get_default_value<src_dfb_addr_data_format>();
 
     // -------------------------------------------------------------------------
     // Main loop - run by all cores
@@ -393,13 +375,13 @@ void kernel_main() {
             start_sem.wait_min(k + 1);
         }
 
-        find_argmax_for_core<reduce_all, src_cb_addr_data_format>(
+        find_argmax_for_core<reduce_all, src_dfb_addr_data_format>(
             noc,
             inner_dim_units,
             k,
             src_offset,
             s_src,
-            src_cb,
+            src_dfb,
             src_read_size,
             red_dim_offset,
             red_dim_units_this_core,
@@ -411,20 +393,25 @@ void kernel_main() {
             red_vals);
 
         if constexpr (not reduce_all) {
-            // We now write these local values to the equivalent position in the reduction core
+            // We now write these local values to the equivalent position in the reduction core.
+            //
+            // A DFB handed to async_write as the source is read at its read pointer. That is the
+            // address the partials were written to as well: no DFB in this kernel ever calls
+            // reserve_back/push_back/wait_front/pop_front, so every one of them keeps its read and
+            // write pointers at the buffer base for the whole kernel.
             if (core_id != reduce_core_id) {
                 noc.async_write(
-                    use<CircularBuffer::AddrSelector::WRITE_PTR>(red_idx_cb),
+                    red_idx_dfb,
                     remote,
                     red_idx_size_per_core,
                     {.offset_bytes = red_idx_offset},
-                    {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_idx_cb_local_addr});
+                    {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_idx_dfb_local_addr});
                 noc.async_write(
-                    use<CircularBuffer::AddrSelector::WRITE_PTR>(red_val_cb),
+                    red_val_dfb,
                     remote,
                     red_val_size_per_core,
                     {.offset_bytes = red_val_offset},
-                    {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_val_cb_local_addr});
+                    {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_val_dfb_local_addr});
                 noc.async_write_barrier();
             }
 
@@ -439,20 +426,15 @@ void kernel_main() {
 
                 // Find argmax from intermediate outputs and write to output
                 for (uint32_t j = 0; j < inner_dim_units; ++j) {
-                    out_idxs[j] = find_argmax_from_intermediate_outputs<num_cores, src_cb_addr_data_format>(
+                    out_idxs[j] = find_argmax_from_intermediate_outputs<num_cores, src_dfb_addr_data_format>(
                         j,
-                        red_val_cb_local_base_addr,
-                        red_idx_cb_local_base_addr,
+                        red_val_dfb_local_base_addr,
+                        red_idx_dfb_local_base_addr,
                         red_val_size_per_core,
                         red_idx_size_per_core);
                 }
 
-                noc.async_write(
-                    use<CircularBuffer::AddrSelector::WRITE_PTR>(dst_cb),
-                    s_dst,
-                    dst_page_size,
-                    {.offset_bytes = 0},
-                    {.page_id = k});
+                noc.async_write(dst_dfb, s_dst, dst_page_size, {.offset_bytes = 0}, {.page_id = k});
                 noc.async_write_barrier();
             }
         }
@@ -465,17 +447,17 @@ void kernel_main() {
         // We now write these local values to the equivalent position in the reduction core
         if (core_id != reduce_core_id) {
             noc.async_write(
-                use<CircularBuffer::AddrSelector::WRITE_PTR>(red_idx_cb),
+                red_idx_dfb,
                 remote,
                 red_idx_size_per_core,
                 {.offset_bytes = red_idx_offset},
-                {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_idx_cb_local_addr});
+                {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_idx_dfb_local_addr});
             noc.async_write(
-                use<CircularBuffer::AddrSelector::WRITE_PTR>(red_val_cb),
+                red_val_dfb,
                 remote,
                 red_val_size_per_core,
                 {.offset_bytes = red_val_offset},
-                {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_val_cb_local_addr});
+                {.noc_x = reduce_core_x, .noc_y = reduce_core_y, .addr = red_val_dfb_local_addr});
             noc.async_write_barrier();
         }
 
@@ -488,19 +470,14 @@ void kernel_main() {
                 done_sem.wait(num_cores);
             }
 
-            out_idxs[0] = find_argmax_from_intermediate_outputs<num_cores, src_cb_addr_data_format>(
+            out_idxs[0] = find_argmax_from_intermediate_outputs<num_cores, src_dfb_addr_data_format>(
                 0,  // For reduce_all, we only have one inner_dim_unit
-                red_val_cb_local_base_addr,
-                red_idx_cb_local_base_addr,
+                red_val_dfb_local_base_addr,
+                red_idx_dfb_local_base_addr,
                 red_val_size_per_core,
                 red_idx_size_per_core);
 
-            noc.async_write(
-                use<CircularBuffer::AddrSelector::WRITE_PTR>(dst_cb),
-                s_dst,
-                dst_page_size,
-                {.offset_bytes = 0},
-                {.page_id = 0});
+            noc.async_write(dst_dfb, s_dst, dst_page_size, {.offset_bytes = 0}, {.page_id = 0});
             noc.async_write_barrier();
         }
     }  // if constexpr (reduce_all)

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout.cpp
@@ -9,60 +9,48 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 #include <stdint.h>
 
 void kernel_main() {
     // Compile time args
     // -----------------
-    constexpr uint32_t src_dfb_idx = get_compile_time_arg_val(0);
-    constexpr uint32_t dst_dfb_idx = get_compile_time_arg_val(1);
+    constexpr auto src_page_size = get_arg(args::src_page_size);
 
-    constexpr uint32_t src_page_size = get_compile_time_arg_val(2);
-
-    constexpr uint32_t tile_height = get_compile_time_arg_val(4);
-    constexpr uint32_t tile_width = get_compile_time_arg_val(5);
+    constexpr auto tile_height = get_arg(args::tile_height);
+    constexpr auto tile_width = get_arg(args::tile_width);
 
     // Input padded size (last two dims) in tiles
-    constexpr uint32_t input_height = get_compile_time_arg_val(6);
-    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr auto input_height = get_arg(args::input_height);
+    constexpr auto input_width = get_arg(args::input_width);
 
     // Input logical size (last two dims) in data elements
-    constexpr uint32_t logical_height = get_compile_time_arg_val(8);
-    constexpr uint32_t logical_width = get_compile_time_arg_val(9);
+    constexpr auto logical_height = get_arg(args::logical_height);
+    constexpr auto logical_width = get_arg(args::logical_width);
 
     // Size of all dims combined, excluding the last two dims.
-    constexpr uint32_t outer_dim_size = get_compile_time_arg_val(10);
+    constexpr auto outer_dim_size = get_arg(args::outer_dim_size);
 
-    constexpr bool reduce_all = (bool)get_compile_time_arg_val(11);
-    constexpr bool keepdim = (bool)get_compile_time_arg_val(12);
-
-    constexpr uint32_t num_c_time_args = 13;
-
-    // Runtime args
-    // ------------
-    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
-    const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
+    constexpr bool reduce_all = (bool)get_arg(args::reduce_all);
+    constexpr bool keepdim = (bool)get_arg(args::keepdim);
 
     // Tensor Accessors
     // ----------------
-    constexpr auto s_src_args = TensorAccessorArgs<num_c_time_args>();
-    constexpr auto s_dst_args = TensorAccessorArgs<s_src_args.next_compile_time_args_offset()>();
-
-    auto s_src = TensorAccessor(s_src_args, src_base_addr);
-    auto s_dst = TensorAccessor(s_dst_args, dst_base_addr);
+    auto s_src = TensorAccessor(tensor::src);
+    auto s_dst = TensorAccessor(tensor::dst);
 
     using dst_accessor_type = decltype(s_dst);
 
     Noc noc;
-    DataflowBuffer src_dfb(src_dfb_idx);
-    DataflowBuffer dst_dfb(dst_dfb_idx);
+    DataflowBuffer src_dfb(dfb::src);
+    DataflowBuffer dst_dfb(dfb::dst);
 
-    // CB for input data.
+    // DFB for input data.
     const uint32_t src_dfb_addr = src_dfb.get_write_ptr();
-    constexpr DataFormat src_data_format = get_dataformat(src_dfb_idx);
+    constexpr DataFormat src_data_format = get_dataformat(dfb::src);
 
-    // CB for output data.
+    // DFB for output data.
     const uint32_t dst_dfb_addr = dst_dfb.get_write_ptr();
 
     auto default_val = get_default_value<src_data_format>();

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout_h.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/tensor/tensor_accessor.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
 
 #include <stdint.h>
 
@@ -19,45 +20,35 @@
  */
 
 void kernel_main() {
-    constexpr uint32_t src_dfb_idx = get_compile_time_arg_val(0);
-    constexpr uint32_t dst_dfb_idx = get_compile_time_arg_val(1);
+    constexpr auto src_page_size = get_arg(args::src_page_size);
 
-    constexpr uint32_t src_page_size = get_compile_time_arg_val(2);
+    constexpr auto tile_height = get_arg(args::tile_height);
+    constexpr auto tile_width = get_arg(args::tile_width);
 
-    constexpr uint32_t tile_height = get_compile_time_arg_val(4);
-    constexpr uint32_t tile_width = get_compile_time_arg_val(5);
+    constexpr auto input_height = get_arg(args::input_height);
+    constexpr auto input_width = get_arg(args::input_width);
 
-    constexpr uint32_t input_height = get_compile_time_arg_val(6);
-    constexpr uint32_t input_width = get_compile_time_arg_val(7);
+    constexpr auto logical_height = get_arg(args::logical_height);
+    constexpr auto logical_width = get_arg(args::logical_width);
 
-    constexpr uint32_t logical_height = get_compile_time_arg_val(8);
-    constexpr uint32_t logical_width = get_compile_time_arg_val(9);
+    constexpr auto outer_dim_size = get_arg(args::outer_dim_size);
 
-    constexpr uint32_t outer_dim_size = get_compile_time_arg_val(10);
+    // This reader takes no reduce_all/keepdim arguments; the width reader adds those.
 
-    // TensorAccessor follows the kernel-specific compile-time args (no reduce_all/keepdim; width reader adds those).
-    constexpr uint32_t num_c_time_args = 11;
-
-    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
-    const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
-
-    constexpr auto s_src_args = TensorAccessorArgs<num_c_time_args>();
-    constexpr auto s_dst_args = TensorAccessorArgs<s_src_args.next_compile_time_args_offset()>();
-
-    auto s_src = TensorAccessor(s_src_args, src_base_addr);
-    auto s_dst = TensorAccessor(s_dst_args, dst_base_addr);
+    auto s_src = TensorAccessor(tensor::src);
+    auto s_dst = TensorAccessor(tensor::dst);
     using dst_accessor_type = decltype(s_dst);
 
-    DataflowBuffer src_dfb(src_dfb_idx);
+    DataflowBuffer src_dfb(dfb::src);
     const uint32_t src_dfb_addr = src_dfb.get_write_ptr();
-    constexpr DataFormat src_data_format = get_dataformat(src_dfb_idx);
-    DataflowBuffer dst_dfb(dst_dfb_idx);
+    constexpr DataFormat src_data_format = get_dataformat(dfb::src);
+    DataflowBuffer dst_dfb(dfb::dst);
     const uint32_t dst_dfb_addr = dst_dfb.get_write_ptr();
 
     auto default_val = get_default_value<src_data_format>();
     using src_element_type = decltype(default_val);
 
-    // Required by OutputContext; unused with collect_row_major_output<false> (values go to output CB).
+    // Required by OutputContext; unused with collect_row_major_output<false> (values go to output DFB).
     uint32_t stack_unused[1] = {0};
 
     // Batching must match the output buffer page size. Do not use keepdim ? 1 : width (one uint32


### PR DESCRIPTION
Metal 2.0 port of `reduction/argmax` — **`ArgMaxDeviceOperation` only**: both its factories (`ArgMaxSingleCoreProgramFactory`, `ArgMaxMultiCoreProgramFactory`) and the four kernels they bind, converted together because the two factories share one `program_factory_t` variant selected at runtime. The single-core factory runtime-selects among three kernel sources (RM / TILE-W / TILE-H), so all three convert as one unit. `ArgMaxNCDeviceOperation` is **out of scope and untouched** — still on the legacy imperative `host_api.hpp` builder and blocked pending its `ProgramDescriptor` migration, so `ttnn::argmax` now dispatches to a Metal 2.0 device-op and a legacy one side by side.

`reader_argmax_interleaved.cpp` has an out-of-directory consumer — `tests/ttnn/unit_tests/gtests/test_generic_op.cpp:126` file-path-instantiates it from a hand-built `ProgramDescriptor` with the CTA/RTA contract hardcoded, and `generic_op` cannot supply Metal 2.0 named bindings, so it cannot be re-pointed. It gets a `_metal2` fork beside the original plus a pointer comment (rung 2); the original is otherwise unchanged and the gtest still passes on it. The other three kernels convert in place. **No intra-op forks, no borrowed kernels.**

Behaviour-preserving. Two things are restated explicitly rather than inferred: the multi-core reader's DM config is rebuilt field-by-field as a raw `DataMovementGen1Config`, because its legacy triple `(RISCV_1, NOC::RISCV_1_default)` resolves to `(RISCV_1, NOC_1)` — neither the reader default (`NOC_0`) nor the writer one, so routing it through `create_reader_datamovement_config` would have silently flipped the NOC; and the five `constexpr` `get_dataformat` sites keep the free-function + token form `get_dataformat(dfb::src)`, since no `DataflowBuffer` object can be a constant expression and every site feeds a non-type template parameter. Both factories build DM kernels only, so no compute `opt_level`/`unpack_modes` work applies. Ten sync-free single-toucher DFBs, all self-looped. No custom hash, no pybind change, no op-owned tensors, no multi-binding flag, no varargs, no relaxations.

The multi-core factory's two differently sized input DFBs over disjoint core groups are reproduced as two specs in the legacy declaration order, because the kernel requires the shared `red_idxs`/`red_vals` DFBs to land at one uniform L1 address on every node. Confirmed against `ProgramImpl::allocate_dataflow_buffers` rather than assumed: it assigns one address per DFB, taken as the max region-end across every core range it spans — the same property legacy `allocate_circular_buffers` had.

**Verified on-device, with the Metal 2.0 host-side legality checks forced on and proven live** (both `METAL2_CHECKS_FORCED` markers present, from `program_spec.cpp` *and* `program_run_args.cpp`): gtests `--gtest_filter='*Argmax*:*ArgMax*:*argmax*'` **6 passed** (including `TestGenericOpArgmaxSingleCore` on the retained legacy kernel); `tests/ttnn/unit_tests/operations/reduce/test_argmax.py` **66 passed / 0 failed**; `tests/ttnn/nightly/.../reduction/{test_reduction_op_corners,test_generic_ops}.py` **937 passed / 8 skipped / 0 failed**. The 8 skips are argmax cases the tests skip on their own capability guards (`dim=None` with TILE, non-last-dim). Audit + brief + plan + report are committed here for review and are **not** intended for main — delete before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2_port_reduction_argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2_port_reduction_argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2_port_reduction_argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2_port_reduction_argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2_port_reduction_argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2_port_reduction_argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2_port_reduction_argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2_port_reduction_argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2_port_reduction_argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2_port_reduction_argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2_port_reduction_argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2_port_reduction_argmax)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2_port_reduction_argmax)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2_port_reduction_argmax)
