### PR TITLE
Metal 2.0 port: `data_movement/pad`

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -621,6 +621,47 @@ def test_pad_op(device, in_dtype, shape, padshape, use_multicore, layout, mem_co
         assert torch.equal(output_tt, output_torch)
 
 
+# test_pad_op above parametrizes TILE x use_multicore=False, but its shapes are already tile-aligned,
+# so invoke_tile() returns through the view() fast path and never reaches prim::pad.  Crossing a tile
+# boundary is what actually selects PadTileCoreProgramFactory, the single-core tiled factory.
+@pytest.mark.parametrize(
+    "in_dtype", [ttnn.bfloat16, ttnn.float32, ttnn.int32, ttnn.uint32, ttnn.uint16, ttnn.bfloat8_b]
+)
+@pytest.mark.parametrize(
+    "shape, padshape",
+    [
+        ([1, 1, 32, 32], [1, 1, 64, 64]),  # grow both tile dims
+        ([1, 1, 32, 64], [2, 3, 64, 96]),  # grow the batch/channel dims too
+        ([2, 1, 64, 32], [2, 2, 96, 64]),
+    ],
+)
+@pytest.mark.parametrize("pad_value", [0.0, 7.0])
+@pytest.mark.parametrize("mem_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+def test_pad_tile_single_core(device, in_dtype, shape, padshape, pad_value, mem_config):
+    if in_dtype == ttnn.bfloat8_b and pad_value != 0.0:
+        pytest.skip("bfloat8_b compares approximately; the exact-fill check below does not apply")
+    if in_dtype == ttnn.float32 and pad_value != 0.0:
+        pytest.xfail("#54223: FLOAT32 pad value is packed as two bfloat16s in the single-core TILE factory")
+
+    torch_input = random_torch_tensor(in_dtype, shape)
+    ttnn_input = ttnn.from_torch(
+        torch_input, device=device, memory_config=mem_config, dtype=in_dtype, layout=ttnn.TILE_LAYOUT
+    )
+
+    # Repeat so the second and third dispatches land on a program-cache hit, which is where a
+    # stale tensor binding would show up.
+    for _ in range(3):
+        output_tt = ttnn.to_torch(ttnn.pad(ttnn_input, padshape, [0, 0, 0, 0], value=pad_value, use_multicore=False))
+        assert output_tt.shape == torch.Size(padshape)
+
+        output_torch = torch.full(padshape, pad_value).to(output_tt.dtype)
+        output_torch[: shape[0], : shape[1], : shape[2], : shape[3]] = torch_input.to(output_tt.dtype)
+        if in_dtype == ttnn.bfloat8_b:
+            assert_allclose(output_torch, output_tt, rtol=0.05, atol=0.025)
+        else:
+            assert torch.equal(output_tt, output_torch)
+
+
 @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("use_multicore", [True])
 def test_pad_op_row_major_unevernly_sharded(device, in_dtype, use_multicore):

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_BRIEF.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_BRIEF.md
@@ -1,0 +1,308 @@
+# Metal 2.0 Port Brief — `ttnn/cpp/ttnn/operations/data_movement/pad`
+
+> Audit cleared all gates. This is your actionable input; the full record is in
+> `METAL2_PREPORT_AUDIT.md`.
+
+**In scope — all seven factories:**
+
+- `PadRmReaderWriterProgramFactory` — `pad_rm_reader_writer_program_factory.cpp`
+- `PadRmReaderWriterMultiCoreProgramFactory` — `pad_rm_reader_writer_multi_core_program_factory.cpp` *(unreachable from `select_program_factory` — raise before porting, see Watch-for)*
+- `PadRmReaderWriterMultiCoreDefaultProgramFactory` — `pad_rm_reader_writer_multi_core_default_program_factory.cpp`
+- `PadRmShardedHeightOnlyProgramFactory` — `pad_rm_sharded_height_only_program_factory.cpp` *(the only `CustomProgramSpecFactoryConcept` target — see below)*
+- `PadRmShardedWidthOnlyProgramFactory` — `pad_rm_sharded_width_only_program_factory.cpp`
+- `PadTileCoreProgramFactory` — `pad_tile_program_factory.cpp`
+- `PadTileMulticoreProgramFactory` — `pad_tile_multicore_program_factory.cpp`
+
+> **Note on `PadRmShardedHeightOnlyProgramFactory`.** Its readiness-sheet row still reads
+> `Is able to port? = no`, derived from a `get_dynamic_runtime_args` cell that PR #52556
+> (`90ec10f4bf4`, on `main` 2026-08-19) made obsolete — the hook is gone and an
+> `override_runtime_arguments` replaced it. **The sheet is outdated; the audit overrode it on code
+> evidence** and the factory is in scope. Don't be alarmed if you look the row up yourself and see a
+> `no`. Every gate the audit checks directly clears for it.
+
+`ttnn/cpp/ttnn/operations/experimental/quasar/pad/` is out of bounds. It holds a shortcut copy of this
+op; its `_metal2` kernels are **not** forks to reuse and its idioms are not precedent. Don't read it.
+
+**Gates cleared:** Device 2.0 ✓ · Features ✓ · TTNN factory concept ✓ · Offset base pointers ✓ ·
+TensorAccessor 3rd arg ✓
+
+**Recipe docs:** `64668f470e4 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources`
+*(carry this line into the port report's Provenance section)*
+
+## TTNN factory analysis
+
+These facts feed the port's TTNN ProgramFactory wiring (→ `ttnn_factory.md`). Carry them forward:
+
+- **Current concept:** `descriptor` for `PadRmReaderWriterMultiCoreDefaultProgramFactory`,
+  `PadRmShardedHeightOnlyProgramFactory`, `PadRmShardedWidthOnlyProgramFactory`,
+  `PadTileCoreProgramFactory`, `PadTileMulticoreProgramFactory` · `WorkloadDescriptor` (secretly
+  SPMD — collapses to single-program) for `PadRmReaderWriterProgramFactory` and
+  `PadRmReaderWriterMultiCoreProgramFactory`.
+- **Op-owned tensors:** yes, on the two `WorkloadDescriptor` factories only — the pad-value const
+  tensor pushed onto `WorkloadDescriptor::buffers` at
+  `pad_rm_reader_writer_program_factory.cpp:200` and
+  `pad_rm_reader_writer_multi_core_program_factory.cpp:419`. `ProgramSpecFactoryConcept` carries
+  these natively, so the `WorkloadDescriptor` wrapper goes away — it only ever existed to unlock the
+  feature. **Keep holding the source `Tensor`, not just the `shared_ptr<MeshBuffer>`**: `~Tensor`
+  force-deallocates the device memory through `DeviceStorage::deallocate` regardless of external
+  `MeshBuffer` owners (issue #44565, and both factory headers say so).
+- **Target concept:** `ProgramSpecFactoryConcept` for six factories (two of them carrying op-owned
+  tensors) · **`CustomProgramSpecFactoryConcept` for `PadRmShardedHeightOnlyProgramFactory`** — the
+  only factory defining `override_runtime_arguments`
+  (`pad_rm_sharded_height_only_program_factory.cpp:412`, declared `.hpp:22`). Translate that method
+  into one returning a `ProgramRunArgs` rather than deleting it; details and an open question about
+  it in *Construct*.
+- **Gate-cleared, confirmed absent** (each would have blocked the brief): a non-`none`
+  `TensorParameter relaxation` (all seven sheet rows read `none`) · `get_dynamic_runtime_args` (the
+  deprecated hook — absent from the whole op). Also absent, though none of them gate: a custom
+  `compute_program_hash`, a backdoor `attribute_values` / `to_hash`, and a pybound
+  `create_descriptor` (`pad_nanobind.cpp` binds only the public `ttnn::pad` overloads, so the port
+  removes no user-visible API).
+- **No compute kernels.** Every `KernelDescriptor` in all seven factories carries a
+  `ReaderConfigDescriptor` or `WriterConfigDescriptor`. The compute `opt_level` question does not
+  arise for this op.
+
+## Construct — to do
+
+**Tensor bindings** (per binding, per factory) — twelve Case 1, four clean, **no Case 2**:
+
+- `PadRmReaderWriterProgramFactory` and `PadRmReaderWriterMultiCoreProgramFactory` (identical shape,
+  same two kernels):
+  - `input` — **Case 1** → `TensorParameter` / `TensorBinding`; kernel builds
+    `TensorAccessor(tensor::…)`. Legacy: `Buffer*` at reader/writer RTA slot 0
+    (`..._program_factory.cpp:143`, `..._multi_core_...:348`) → `TensorAccessor(src_args, src_addr)`
+    at `reader_pad_dims_rm_interleaved.cpp:75`.
+  - `output` — **Case 1**. Legacy: `Buffer*` at slot 1 (`:144` / `:349`) →
+    `TensorAccessor(dst_args, dst_addr)` at `writer_pad_dims_rm_interleaved.cpp:32`.
+  - `pad_value_const` *(op-owned)* — **Case 1**. Legacy: `Buffer*` at slot 13 (`:156` / `:361`) →
+    `TensorAccessor(pad_tensor_args, pad_value_const_buffer_addr)` at
+    `reader_pad_dims_rm_interleaved.cpp:77`.
+- `PadRmReaderWriterMultiCoreDefaultProgramFactory`:
+  - `input` — **Case 1**. `Buffer*` reader slot 0 (`:221`) →
+    `TensorAccessor(src_args, src_addr, accessor_page_size)` at
+    `reader_pad_dims_rm_interleaved_v2.cpp:95`.
+  - `output` — **Case 1**. `Buffer*` writer slot 0 (`:222`) →
+    `TensorAccessor(dst_args, dst_addr, accessor_page_size)` at
+    `writer_pad_dims_rm_interleaved_v2.cpp:25`.
+- `PadRmShardedHeightOnlyProgramFactory`:
+  - `input` — **clean** (borrowed-memory DFB): CB `c_0` is globally allocated to the input buffer
+    (`cb_src0.buffer = src_buffer`, `..._height_only_program_factory.cpp:294`) → express as
+    `DataflowBufferSpec::borrowed_from` the input tensor parameter.
+  - `output` — **clean** (borrowed-memory DFB): CB `c_16` ← output buffer (`:309`) →
+    `borrowed_from` the output.
+  - This factory passes **no buffer address to any kernel at all** — the comment at
+    `..._height_only_program_factory.cpp:380-382` says so explicitly, and its reader/writer contain no
+    `TensorAccessor`. Both bindings exist purely as `borrowed_from` sources.
+- `PadRmShardedWidthOnlyProgramFactory`:
+  - `input` — **clean** (borrowed-memory DFB): CB `c_0` is globally allocated to the input buffer
+    (`cb_input.buffer = input_buffer`, `..._width_only_program_factory.cpp:75`) → express as
+    `DataflowBufferSpec::borrowed_from` the input tensor parameter. No accessor, no address arg.
+  - `output` — **clean** (borrowed-memory DFB): CB `c_16` ← output buffer (`:91`) →
+    `borrowed_from` the output.
+- `PadTileCoreProgramFactory`:
+  - `input` — **Case 1**. `Buffer*` reader slot 0 (`:122`) → donor's
+    `TensorAccessor(src_args, src_addr)` at `reader_unary_interleaved_start_id.cpp:30`. *(The donor's
+    `_metal2` fork already expresses this as `tensor::src` — see Watch-for.)*
+  - `output` — **Case 1**. `Buffer*` writer slot 0 (`:126`) →
+    `TensorAccessor(dst_args, dst_addr)` at `writer_unary_pad_dims_interleaved.cpp:30`.
+- `PadTileMulticoreProgramFactory`:
+  - `input` — **Case 1**. `Buffer*` reader slot 0 (`:222`) →
+    `TensorAccessor(dst_args, input_addr)` at `reader_pad_tiled.cpp:29`.
+  - `output` — **Case 1**. `Buffer*` writer slot 0 (`:223`) →
+    `TensorAccessor(dst_args, output_addr)` at `writer_pad_tiled.cpp:42`.
+
+Every Case-1 binding today arrives as a `Buffer*` pushed into `KernelDescriptor::RTArgList`, i.e. the
+framework's `BufferBinding` form — **not** a raw `->address()` RTA. So none of these is the
+silently-wrong-on-cache-hit hazard; they are correct today and the port simply replaces the mechanism
+with the typed binding.
+
+**TensorParameter relaxation:** none — the only value that reaches a brief.
+
+**TensorAccessor 3rd arg:** drop the redundant page-size argument at **two sites**, both in
+`PadRmReaderWriterMultiCoreDefaultProgramFactory`:
+
+- `reader_pad_dims_rm_interleaved_v2.cpp:95` — drop `accessor_page_size`, leaving
+  `TensorAccessor(tensor::…)`.
+- `writer_pad_dims_rm_interleaved_v2.cpp:25` — same.
+
+Also drop what feeds them on the host: CTA slot 21 (`input_accessor_page_size`,
+`..._default_program_factory.cpp:163`), CTA slot 4 (`output_accessor_page_size`, `:171`), and the
+`:57-73` computation of both. Both sites are **Class 2 (redundant)** — the sharded branch passes
+`buffer->aligned_page_size()` verbatim (exactly what Metal 2.0 supplies) and the interleaved branch
+passes the true logical page, which the interleaved accessor realigns to the same value. **Do not set
+`dynamic_tensor_shape`** — despite being interleaved row-major, these are *compile-time* args, so the
+page size cannot vary across shapes sharing one compiled program.
+
+Note that dropping the reader's CTA 21 shifts `TensorAccessorArgs<22>` at
+`reader_pad_dims_rm_interleaved_v2.cpp:81` — but that whole args block disappears with the binding
+anyway. Same for `TensorAccessorArgs<5>` at `writer_pad_dims_rm_interleaved_v2.cpp:23`.
+
+**CB endpoints:**
+
+- **Self-loop** (one toucher: single-ended / sync-free — bind the same kernel PRODUCER *and*
+  CONSUMER):
+  - `c_1` (`cb_pad`) in `PadRmReaderWriterMultiCoreDefaultProgramFactory` — reader-only
+    (`reader_pad_dims_rm_interleaved_v2.cpp:19,98`).
+  - `c_0` and `c_1` in `PadRmShardedHeightOnlyProgramFactory` — `c_0` is a reader-only raw peek
+    (`reader_pad_dims_rm_sharded.cpp:32`, also `borrowed_from` the input); `c_1` (`cb_pad`) is
+    writer-only (`writer_pad_dims_rm_sharded.cpp:16,22,43,82`).
+  - `c_0` and `c_1` in `PadRmShardedWidthOnlyProgramFactory` — `c_0` is a reader-only raw peek
+    (`reader_pad_dims_rm_sharded_stickwise.cpp:29`, also `borrowed_from` the input); `c_1`
+    (`padding_value_cb`) is writer-only (`writer_pad_dims_rm_sharded_stickwise.cpp:24,60`).
+  - `c_1` in `PadTileCoreProgramFactory` — writer-only; it `reserve_back(1)`s and takes
+    `get_write_ptr()` but never pushes (`writer_unary_pad_dims_interleaved.cpp:35,37`).
+  - `c_2` (`pad_val`) in `PadTileMulticoreProgramFactory` — writer-only
+    (`writer_pad_tiled.cpp:48,49,57`).
+- **1P+1C assignment — `c_16` in `PadRmShardedHeightOnlyProgramFactory`.** Two touchers on every
+  node: the reader is a locked producer (`reserve_back` / `push_back` at
+  `reader_pad_dims_rm_sharded.cpp:31,69`, plus `get_write_ptr` at `:33`), and the **writer raw-peeks
+  the same buffer** via `dfb_out0_exp.get_write_ptr()` at `writer_pad_dims_rm_sharded.cpp:90` with no
+  FIFO ops. The peek is role-free, so bind **reader PRODUCER, writer CONSUMER** — cosmetic on Gen1,
+  no runtime effect. **This is not multi-binding; do not set the advanced option.** The writer *must*
+  still be bound: in Metal 2.0 it cannot touch a DFB it hasn't bound, and this raw peek is easy to
+  miss because a FIFO-sync trace doesn't show it. `c_16` is also `borrowed_from` the output.
+- **Conditional DFB — `c_2` in `PadRmReaderWriterMultiCoreDefaultProgramFactory`. Do NOT drop it.**
+  Dead under `stick_size_padded_front == 0 && !unaligned`, live otherwise: the host allocates it only
+  under that condition (`..._default_program_factory.cpp:127-139`). Make the `DataflowBufferSpec`
+  conditional on the same predicate — **and gate the kernel too.** The kernel constructs the buffer
+  unconditionally (`reader_pad_dims_rm_interleaved_v2.cpp:90-93`) and calls
+  `dfb_pad_align_exp.get_read_ptr()` unconditionally at `:99`; only the *uses* at `:134/:139/:142` sit
+  behind `if constexpr`. Under Metal 2.0 a kernel may not reference a DFB it hasn't bound, so `:99`
+  must move behind a real preprocessor `#ifdef` fed by a host-side define — **`if constexpr` will not
+  work**, because it does not suppress `dfb::` name lookup, and the resulting failure is a build-time
+  unbound-DFB reference rather than anything the tests would catch.
+- **Dead-CB drop — `c_1` in `PadTileMulticoreProgramFactory`.** Confirmed dead in every config: no
+  kernel touches it. Drop the `CBDescriptor` at `pad_tile_multicore_program_factory.cpp:70-78`, and
+  drop the dead CTA carrying its index — `output_cb_index` is pushed as writer CTA 1 at
+  `pad_tile_multicore_program_factory.cpp:125` and unpacked-then-never-used at
+  `writer_pad_tiled.cpp:23`. Removing both changes L1 footprint and nothing else. **Record both
+  `file:line` prominently in the port report.** (Dropping the CTA renumbers the writer's remaining
+  compile-time args and shifts `TensorAccessorArgs<7>` at `writer_pad_tiled.cpp:40` — though that
+  block disappears with the output binding regardless.)
+- **All other CBs are legal 1:1** and need no action: `c_0` in both v1 RM factories, `c_0` in the
+  default RM factory, `c_16` in the width-only sharded factory (reader consumes, writer produces),
+  `c_0` in both tile factories. **No CB anywhere in this op needs the multi-binding advanced
+  option** — no node reaches three touchers and no two kernels lock the same FIFO role. The
+  hidden-second-writer hunt found exactly one cross-kernel raw touch (`c_16` above), and the op
+  declares no semaphores at all, so the semaphore-gated co-fill shape cannot be present.
+- **Four borrowed-memory CBs**, all binding at base with no `address_offset`: `c_0` / `c_16` in
+  `PadRmShardedHeightOnlyProgramFactory` (`cb_src0.buffer` / `cb_output.buffer` at
+  `..._height_only_program_factory.cpp:294,309`) and `c_0` / `c_16` in
+  `PadRmShardedWidthOnlyProgramFactory` (`..._width_only_program_factory.cpp:75,91`) →
+  `DataflowBufferSpec::borrowed_from`.
+
+**Translating `override_runtime_arguments`** (`PadRmShardedHeightOnlyProgramFactory` only — the one
+`CustomProgramSpecFactoryConcept` target). The method at
+`pad_rm_sharded_height_only_program_factory.cpp:412-424` owns the whole cache-hit refresh. Its body
+builds a two-entry CB-address-only `ProgramDescriptor` and calls `apply_descriptor_runtime_args`,
+mirroring `create_descriptor`'s CB push order **positionally** — input CB, output CB, then the
+pad-value CB it deliberately omits. That positional contract is fragile; carry it into the
+translation as an explicit comment so a later CB reorder in `create_descriptor` can't silently
+mis-target.
+
+> **Open question — raise it, don't decide it silently.** The method exists *solely* to re-point the
+> two borrowed CB base addresses. In Metal 2.0 that is exactly what
+> `DataflowBufferSpec::borrowed_from` plus the `TensorBinding` refresh does natively, so the body may
+> be wholly subsumed — in which case the factory drops to the plain `ProgramSpecFactoryConcept` and
+> the override disappears entirely. The evidence that it may already be unnecessary:
+> `PadRmShardedWidthOnlyProgramFactory` has the same two borrowed CBs, defines **no** override, and
+> relies on the framework's `cb.buffer` patching (see its comment at
+> `..._width_only_program_factory.cpp:170-173`). One of the two factories is doing redundant work.
+> Dropping the override is a **concept change**, so surface it rather than taking it on your own
+> judgement.
+
+## Watch for
+
+- **CB endpoints (multi-binding):** none. Nothing in this op needs the flag. But **do** bind the
+  writer on `c_16` in `PadRmShardedHeightOnlyProgramFactory` — its raw peek at
+  `writer_pad_dims_rm_sharded.cpp:90` is invisible to a FIFO-sync trace and is the one cross-kernel
+  toucher in the whole op (see *Construct* → 1P+1C).
+- **Cross-op / shared kernels:** `PadTileCoreProgramFactory` file-path-instantiates
+  `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp`
+  (`pad_tile_program_factory.cpp:104-105`).
+  - **A `_metal2` fork already exists beside it** — `reader_unary_interleaved_start_id_metal2.cpp`,
+    same directory. **Bind it; do not re-fork and do not convert the legacy file in place.**
+  - **The fork owns the vocabulary — conform the factory to it, never rename the kernel.** Its
+    bindings are `dfb::in`, `tensor::src`, and named args `args::num_pages`, `args::start_id`. Its
+    header states these are its interface and are not renamed once a consumer exists. Note it is
+    `tensor::src` — *not* `tensor::input`.
+  - The fork has already replaced `get_local_cb_interface(cb_id_in0).fifo_page_size` with
+    `dfb.get_entry_size()`, so you inherit that move rather than making it.
+  - **Trap:** a second, differently-named fork of the same kernel lives at
+    `ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_unary_interleaved_start_id_metal2.cpp`
+    (vocabulary `tensor::input`). It is an op-local fork, not the one beside the original. Do not bind
+    it.
+  - Other ops still binding the legacy file — a **sunset list, not authorization to convert the
+    kernel in place**: `data_movement/untilize_with_unpadding` (2 factories), `examples/example` (2),
+    `examples/example_multiple_return`, `experimental/transformer/nlp_create_qkv_heads_falcon7b`,
+    `reduction/topk` (`topk_route_prep`), plus `tests/.../test_generic_op.cpp` and
+    `tests/.../test_generic_op.py`. The legacy copy can be deleted only when the last of them
+    migrates.
+- **RTA varargs — two genuine sites.**
+  **(1) `reader_pad_dims_rm_sharded.cpp:17-22`** (`PadRmShardedHeightOnlyProgramFactory`). The arg
+  block is `num_cores`, then `2·num_cores` NoC x/y values, then `num_cores` chunk counts, then
+  `2·Σchunks` `(start_id, length)` pairs — read through `get_arg_addr()` at **runtime-computed**
+  offsets (`get_arg_addr(1 + num_cores_read * 2)`, `… * 3`), with per-core counts driving the loops
+  at `:38,44`. Host side at `pad_rm_sharded_height_only_program_factory.cpp:158-186`. No
+  per-argument names exist to infer — use the RTA vararg mechanism.
+  **(2) `reader_pad_tiled.cpp:22-25` and `writer_pad_tiled.cpp:35-38`** (`PadTileMulticoreProgramFactory`).
+  Four consecutive `num_dims`-long blocks (`input_page_shape`, `output_page_shape`,
+  `input_id_per_dim`, `output_id_per_dim`) are reached via `get_arg_addr(rt_ind)` plus `+ num_dims`
+  pointer strides and consumed in `for (d < num_dims)` loops (`:46`, `:66`, and
+  `device/kernels/dataflow/common.hpp:12`); `num_dims` is CTA 2 = `output_padded_shape.rank()`. Host
+  side at `pad_tile_multicore_program_factory.cpp:236-253`. Reach for the RTA vararg mechanism rather
+  than naming each element. *(Rank is in fact pinned to 4 upstream — `pad.cpp:193` and
+  `pad_device_operation.cpp:121` — so naming the 16 values would also be defensible if you'd rather
+  keep the kernel's rank-generic loops intact. Either is fine; the vararg route is the safer default.)*
+  - **These two look like varargs and are not — name them.**
+    `reader_pad_dims_rm_interleaved_v2.cpp:59` (`start_dim_offset = get_arg_addr(7)`, read at `:112`)
+    and `writer_pad_dims_rm_sharded.cpp:53` (`get_arg_addr(5)`, read at `:93`) both index the array at
+    **fixed** positions `[1]`, `[2]`, `[3]` only. Each is three distinct nameable fields (`start_h`,
+    `start_c`, `start_n`) reached through legacy pointer arithmetic, not a data-directed pick. Don't
+    let them ride a vararg block — note the second one sits in the *same kernel pair* as genuine
+    vararg site (1), so keep them apart.
+  - **No CTA varargs anywhere.** The `kernel_compile_time_args[13]` read at
+    `reader_pad_dims_rm_interleaved_v2.cpp:85` and `[10..12]` at
+    `writer_pad_dims_rm_sharded.cpp:70-72` use *constant* indices inside
+    `if constexpr (not_pad_by_zero)`, and the host emits those slots unconditionally
+    (`..._default_program_factory.cpp:141-163`, `..._height_only_program_factory.cpp:337-350`) — fixed
+    named CTAs on both branches, not variable-count blocks. Don't reach for `compile_time_varargs`.
+    (Because the host emits them unconditionally, no `#ifdef` gymnastics are needed here either —
+    unlike the `c_2` DFB above.)
+- **`PadRmReaderWriterMultiCoreProgramFactory` is unreachable — raise it before you port it.** It is
+  declared in the `program_factory_t` variant (`pad_device_operation.hpp:33`) but
+  `select_program_factory` never returns it: the RM multicore path returns
+  `PadRmReaderWriterMultiCoreDefaultProgramFactory` instead (`pad_device_operation.cpp:99-101`). No
+  test can exercise it, so a port of its 433 lines — including an op-owned-tensor allocation and a
+  hardcoded resnet core split — is unverifiable by construction. The audit asked the user whether it
+  should be deleted rather than ported; check the answer before spending effort here. If it stays,
+  note it must remain in the `program_factory_t` variant: a `create_program_artifacts` outside the
+  variant builds green and fails on device.
+- **Idle-core `0u` sentinel disappears by itself.** Two factories push a literal `0u` instead of the
+  `Buffer*` on cores with no work (`..._default_program_factory.cpp:224-225`,
+  `pad_tile_multicore_program_factory.cpp:225-226`) to skip `BufferBinding` registration. Under
+  Metal 2.0 the tensor base rides a broadcast CRTA, so there is nothing to skip and the branch has no
+  translation — drop it. Both kernels already short-circuit on `num_sticks_per_core == 0` /
+  `num_pages_per_core == 0`, and in practice `split_work_to_cores` returns
+  `all_cores == group_1 ∪ group_2`, so no idle core exists today anyway.
+- **The v1 RM kernels are handed identical 27-slot arg lists.** `writer_rt_args = reader_rt_args`
+  (`pad_rm_reader_writer_program_factory.cpp:172`,
+  `pad_rm_reader_writer_multi_core_program_factory.cpp:385`), so each kernel receives roughly half
+  the slots it never reads, and slot indices are shared across the two. When you convert to named
+  args, give each kernel only the args it actually reads — don't preserve the shared layout. Slots
+  each kernel unpacks but never uses (safe to drop entirely): reader `num_total_W`(3),
+  `num_total_Y`(7), `start_src_stick_wi`(18), `full_unpadded_X_nbytes`(23); writer `num_total_W`(3),
+  `num_total_Y`(7), `num_total_X`(9), `num_local_unpadded_Y`(22), `full_padded_X_nbytes`(24),
+  `start_dst_stick_wi`(19). The writer's compile-time args likewise copy in the pad-value tensor's
+  `TensorAccessorArgs` (`:85`) that it never instantiates.
+- **`pad_value_const_buffer_nbytes` (slot 14) is a live arg the kernel ignores.**
+  `reader_pad_dims_rm_interleaved.cpp:52` hardcodes `64` with a *"fails on BH when > 64"* comment
+  (issue #21978) while the host still computes and passes the real value
+  (`pad_rm_reader_writer_program_factory.cpp:157`). Port the kernel's behavior as-is — the hardcode
+  stays. Just don't create a named arg for a value nothing reads.
+- **The two `WorkloadDescriptor` factories replicate one descriptor across ranges.** Each builds a
+  single `ProgramDescriptor` above the loop and pushes it once per range in `tensor_coords`
+  (`pad_rm_reader_writer_program_factory.cpp:202-211`,
+  `..._multi_core_program_factory.cpp:421-429`). Nothing is per-mesh-coordinate, so this collapses
+  cleanly onto the single-program `ProgramSpecFactoryConcept` — you are removing a wrapper, not
+  losing per-coordinate behavior.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_PLAN.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_PLAN.md
@@ -1,0 +1,611 @@
+# Port Plan — `ttnn/cpp/ttnn/operations/data_movement/pad`
+
+Port plan for `data_movement/pad`, ported from `ProgramDescriptor` / `WorkloadDescriptor` to Metal 2.0.
+Written during the inventory and planning steps; committed alongside the port for review.
+
+**Scope: all seven factories**, converted in one change. Every kernel source in the op directory is
+bound only by pad's own factories (census below), so there is no *lent* kernel; the single *borrowed*
+kernel already has a `_metal2` fork beside it (rung 1 — reuse).
+
+**Invoker decisions taken before construction** (both raised by the audit / brief):
+
+1. **`PadRmReaderWriterMultiCoreProgramFactory` is ported, not deleted.** It is unreachable from
+   `select_program_factory` (`pad_device_operation.cpp:99-101`), so **its port is build-verified
+   only** — no test can exercise it. Recorded again in the report.
+2. **`PadRmShardedHeightOnlyProgramFactory` lands on the base `ProgramSpecFactoryConcept`**, dropping
+   its `override_runtime_arguments`. Rationale in [TTNN ProgramFactory](#ttnn-programfactory).
+
+---
+
+## Legacy Inventory
+
+### Legacy factory shape
+
+| Factory | Concept | Entry point | Op-owned tensors |
+|---|---|---|---|
+| `PadRmReaderWriterProgramFactory` | `MeshWorkloadFactoryConcept` (`WorkloadDescriptor`) | `create_workload_descriptor` @ `pad_rm_reader_writer_program_factory.cpp:185` | yes — pad-value const tensor @ `:200` |
+| `PadRmReaderWriterMultiCoreProgramFactory` | `MeshWorkloadFactoryConcept` (`WorkloadDescriptor`) | `create_workload_descriptor` @ `pad_rm_reader_writer_multi_core_program_factory.cpp:404` | yes — pad-value const tensor @ `:419` |
+| `PadRmReaderWriterMultiCoreDefaultProgramFactory` | `ProgramDescriptorFactoryConcept` | `create_descriptor` @ `pad_rm_reader_writer_multi_core_default_program_factory.cpp:32` | none |
+| `PadRmShardedHeightOnlyProgramFactory` | `ProgramDescriptorFactoryConcept` + `override_runtime_arguments` | `create_descriptor` @ `pad_rm_sharded_height_only_program_factory.cpp:195`; override @ `:412` | none |
+| `PadRmShardedWidthOnlyProgramFactory` | `ProgramDescriptorFactoryConcept` | `create_descriptor` @ `pad_rm_sharded_width_only_program_factory.cpp:20` | none |
+| `PadTileCoreProgramFactory` | `ProgramDescriptorFactoryConcept` | `create_descriptor` @ `pad_tile_program_factory.cpp:18` | none |
+| `PadTileMulticoreProgramFactory` | `ProgramDescriptorFactoryConcept` | `create_descriptor` @ `pad_tile_multicore_program_factory.cpp:31` | none |
+
+- **Variants**: seven factories in one `program_factory_t` variant (`pad_device_operation.hpp:32-39`).
+  All factory methods live in factory structs — **no direct-descriptor shape**, so
+  `ttnn_factory.md` exception 3 does not apply.
+- **Custom `compute_program_hash`**: **none** — no `compute_program_hash`, no backdoor
+  `attribute_values` / `to_hash` anywhere in the op. Default reflection hash applies. Nothing to
+  leave alone.
+- **`opt_level`**: `grep -n opt_level` over the op directory returns **zero hits in code** — no
+  `KernelDescriptor::opt_level` is set anywhere. Every kernel is a reader/writer DM kernel
+  (`ReaderConfigDescriptor` / `WriterConfigDescriptor`), so the resolved legacy level is `O2` on all
+  22 kernel descriptors, which is exactly Metal 2.0's `CompilerOptions` default. **No `opt_level`
+  line is required on any `KernelSpec`.** (The op owns no compute kernels, so the `O3` rule never
+  fires.)
+- **Semaphores**: **none** — the op declares no semaphores of any kind.
+
+### Kernels
+
+#### `PadRmReaderWriterProgramFactory` (single core) and `PadRmReaderWriterMultiCoreProgramFactory`
+
+Identical kernel pair and identical 27-slot RTA layout; the multicore version differs only in the
+per-core work split. `writer_rt_args = reader_rt_args` (`:172` / `:385`), so each kernel is handed
+roughly half the slots it never reads.
+
+| unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | CRTAs | defines | opt_level | config |
+|---|---|---|---|---|---|---|---|---|---|
+| reader | `device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp` | sc: `CoreRange({0,0},{0,0})`; mc: `all_cores` from `split_across_cores` | `{unpadded_row_size_nbytes, padded_row_size_nbytes}` + `TensorAccessorArgs(src)` + `(dst)` + `(pad_value_const)` | none | 27 slots (see below) | none | none | `O2` (unset) | `ReaderConfigDescriptor{}` |
+| writer | `device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp` | same | `= reader_ct_args` (a verbatim copy) | none | same 27 slots | none | none | `O2` (unset) | `WriterConfigDescriptor{}` |
+
+RTA slot map (host emission order, `:141-169` / `:346-374`) and per-kernel liveness:
+
+| slot | value | reader | writer |
+|---|---|---|---|
+| 0 | `src0_buffer` (`Buffer*`) | **addr** | — |
+| 1 | `dst_buffer` (`Buffer*`) | — | **addr** |
+| 2 | `a.padded_shape()[0]` → `num_unpadded_W` | live | — |
+| 3 | `output_shape[0]` → `num_total_W` | **dead** (declared, unused) | **dead** |
+| 4 | `a.padded_shape()[1]` → `num_unpadded_Z` | live | — |
+| 5 | `output_shape[1]` → `num_total_Z` | live | live |
+| 6 | `a.padded_shape()[2]` → `num_unpadded_Y` | **dead** (declared, unused) | — |
+| 7 | `output_shape[2]` → `num_total_Y` | **dead** | **dead** |
+| 8 | `a.padded_shape()[3]` | — | — |
+| 9 | `output_shape[3]` → `num_total_X` | — | **dead** |
+| 10 | `unpadded_row_size_nbytes` → `unpadded_X_nbytes` | live | — |
+| 11 | `padded_row_size_nbytes` → `padded_X_nbytes` | live | live |
+| 12 | `padded_row_diff_size_nbytes` | live | — |
+| 13 | `pad_value_const_buffer` (`Buffer*`) | **addr** | — |
+| 14 | `pad_value_const_buffer_nbytes` | **never read** (kernel hardcodes 64, `reader…:52`) | — |
+| 15 | `packed_pad_value` | live | — |
+| 16 | `start_src_stick_id` | live | — |
+| 17 | `start_dst_stick_id` | — | live |
+| 18 | `start_src_stick_wi` | **dead** | — |
+| 19 | `start_dst_stick_wi` | — | **dead** (assigned to `dst_stick_wi`, never advanced) |
+| 20 | `start_src_stick_offset` | live | — |
+| 21 | `num_local_Y` | live | live |
+| 22 | `num_local_unpadded_Y` | live | **dead** |
+| 23 | `full_unpadded_X_nbytes` | **dead** | — |
+| 24 | `full_padded_X_nbytes` | — | **dead** |
+| 25 | `dst_stick_offset` | — | live |
+| 26 | `num_local_W` | live | live |
+
+> The brief lists the reader's dead set as slots 3, 7, 18, 23. The census adds **slot 6
+> (`num_unpadded_Y`)** — declared at `reader_pad_dims_rm_interleaved.cpp:46`, never referenced
+> (the loop at `:87` tests `num_local_unpadded_Y`, slot 22). Recorded in the port report.
+
+Both kernels' **positional CTAs 0 and 1 are never read** — the kernels contain no
+`get_compile_time_arg_val` call at all. Slots 0/1 exist only to offset the `TensorAccessorArgs<2>()`
+chain, and the writer's copy of the pad-value tensor's accessor args (`:85`) is never instantiated.
+
+#### `PadRmReaderWriterMultiCoreDefaultProgramFactory`
+
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | opt_level | config |
+|---|---|---|---|---|---|---|
+| reader | `…/reader_pad_dims_rm_interleaved_v2.cpp` | `all_cores` (`split_work_to_cores` over `NCH_padded`) | 22 values @ `:141-163` + `TensorAccessorArgs(src)` @ `:164` | `src_buffer`, `num_sticks_per_core`, `num_sticks_per_barrier`, `curr_sticks_read*num_input_pages_in_row`, `front_pad_n/c/h`, then `num_dims` × `start_dim_offset` | `O2` (unset) | `ReaderConfigDescriptor{}` |
+| writer | `…/writer_pad_dims_rm_interleaved_v2.cpp` | `all_cores` | 5 values @ `:166-171` + `TensorAccessorArgs(dst)` @ `:172` | `dst_buffer`, `num_sticks_per_core`, `num_sticks_per_barrier`, `curr_sticks_write*num_output_pages_in_row` | `O2` (unset) | `WriterConfigDescriptor{}` |
+
+Reader CTA slot map, with kernel liveness:
+
+| slot | host value | kernel name | live |
+|---|---|---|---|
+| 0-2 | `N+front_pad[-4]`, `H+front_pad[-2]`, `C+front_pad[-3]` | `N`,`H`,`C` | yes |
+| 3 | `stick_size` | `stick_size_bytes` | yes |
+| 4-6 | `N_padded`,`H_padded`,`C_padded` | same | yes |
+| 7 | `stick_size_padded` | same | yes |
+| 8 | `stick_size_padded_front` | `stick_size_padded_front` **and** `front_padding` (two names, one slot) | yes |
+| 9 | `stick_size_padded_end` | declared `:70` | **dead** |
+| 10 | `div_up(stick_size_padded,512)` | `num_zero_pad_sticks_read` `:71` | **dead** |
+| 11 | `stick_size_padded % 512 …` | `last_zero_stick_size` `:72` | **dead** |
+| 12 | `not_pad_by_zero` | same | yes |
+| 13 | `packed_pad_value` | read via `kernel_compile_time_args[13]` `:85` | yes |
+| 14 | `row_major_min_bytes` | *not declared in kernel* | **dead** |
+| 15 | `stick_size_padded_front / row_major_min_bytes` | *not declared* | **dead** |
+| 16 | `stick_size_padded_end / row_major_min_bytes` | *not declared* | **dead** |
+| 17 | `stick_size_padded / row_major_min_bytes` | *not declared* | **dead** |
+| 18 | `stick_size_padded_aligned` | same | yes |
+| 19 | `unaligned` | same | yes |
+| 20 | `num_input_pages_in_row` | same | yes |
+| 21 | `input_accessor_page_size` | `accessor_page_size` | **TensorAccessor 3rd arg — dropped** |
+| 22.. | `TensorAccessorArgs(src)` | `TensorAccessorArgs<22>()` | dropped |
+
+Writer CTA slot map: 0 `src0_cb_index` (→ DFB binding), 1 `stick_size_padded` (kernel
+`stick_size_bytes`), 2 `stick_size_padded_aligned`, 3 `num_output_pages_in_row`,
+4 `output_accessor_page_size` (**3rd arg — dropped**), 5.. `TensorAccessorArgs(dst)` (dropped).
+
+#### `PadRmShardedHeightOnlyProgramFactory`
+
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | opt_level | config |
+|---|---|---|---|---|---|---|
+| reader | `…/reader_pad_dims_rm_sharded.cpp` | `all_cores_padded` (output shard grid) | `{stick_size_padded, shard_height_padded}` @ `:335` | variable-length block, per core (`:158-186`) | `O2` (unset) | `ReaderConfigDescriptor{}` |
+| writer | `…/writer_pad_dims_rm_sharded.cpp` | `all_cores_padded` | 13 values @ `:337-350` | `{num_sticks_per_core_padded, curr_sticks_read, front_pad[-4], front_pad[-3], front_pad[-2]}` + `num_dims` × `start_dim_offset` (`:77-84`) | `O2` (unset) | `WriterConfigDescriptor{}` |
+
+Reader RTA block layout (`get_pad_runtime_args_rm_sharded`, `:158-186`): `num_cores`, then
+`2·num_cores` interleaved NoC (x,y), then `num_cores` chunk counts, then `2·Σchunks`
+`(chunk_start_id, chunk_length)` pairs. The kernel reaches all but the first through
+`get_arg_addr()` at **runtime-computed** offsets (`:20-22`).
+
+Writer CTA slot map: 0-2 `N+front_pad[-4]`/`H+front_pad[-2]`/`C+front_pad[-3]`, 3 `stick_size_padded`,
+4-6 `N_padded`/`H_padded`/`C_padded`, 7 `num_zero_pad_sticks_read`, 8 `zero_pad_stick_size`,
+9 `not_pad_by_zero`, 10 `packed_pad_value`, 11 `row_major_min_bytes`,
+12 `stick_size_padded/row_major_min_bytes`. Slots 10-12 are read via `kernel_compile_time_args[10..12]`
+inside `if constexpr (not_pad_by_zero)` at **constant** indices; the host emits them
+unconditionally — a fixed named set, **not** a CTA vararg block. All 13 are live.
+
+#### `PadRmShardedWidthOnlyProgramFactory`
+
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | opt_level | config |
+|---|---|---|---|---|---|---|
+| reader | `…/reader_pad_dims_rm_sharded_stickwise.cpp` | `all_cores_padded` | 9 values @ `:134-143` | **empty list** per core (`:175`) | `O2` (unset) | `ReaderConfigDescriptor{}` |
+| writer | `…/writer_pad_dims_rm_sharded_stickwise.cpp` | `all_cores_padded` | 7 values @ `:145-152` | **empty list** per core (`:176`) | `O2` (unset) | `WriterConfigDescriptor{}` |
+
+Reader CTAs: 0 `unpadded_stick_bytes`, 1 `padded_stick_bytes` (**dead**), 2 `unpadded_shard_height`,
+3 `padded_shard_height` (**dead**), 4 `W_padding_front_bytes`, 5 `input_shard_cb_index` (→ DFB
+binding), 6 `output_shard_cb_index` (→ DFB binding), 7 `unpadded_stick_step`, 8 `padded_stick_step`.
+Writer CTAs: 0 `padded_stick_bytes`, 1 `shard_height_padded`, 2 `padding_value_as_u32`,
+3 `output.element_size()`, 4 `output_shard_cb_index` (→ binding), 5 `pad_val_cb_index` (→ binding),
+6 `padded_stick_step` (**never declared in the kernel — dead**).
+
+#### `PadTileCoreProgramFactory`
+
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | opt_level | config |
+|---|---|---|---|---|---|---|
+| reader | **borrowed** `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp` (`:104-105`) | `{{0,0},{0,0}}` | `TensorAccessorArgs(src)` only | `{src0_buffer, num_unpadded_tiles, 0}` | `O2` (unset) | `ReaderConfigDescriptor{}` |
+| writer | `…/writer_unary_pad_dims_interleaved.cpp` | `{{0,0},{0,0}}` | `{src0_cb_index, src1_cb_index}` + `TensorAccessorArgs(dst)` | `{dst_buffer, num_unpadded_W, num_padded_Wt, num_unpadded_Z, num_padded_Zt, num_unpadded_Yt, num_padded_Yt, num_unpadded_Xt, num_padded_Xt, packed_pad_value}` | `O2` (unset) | `WriterConfigDescriptor{}` |
+
+Writer reads `get_tile_size(cb_id_out0)` at `:28` — a **non-`constexpr`** `const uint32_t`, so it
+becomes the DFB **member getter** `dfb_out0.get_tile_size()` (whitelist rule 7; the `constexpr`
+carve-out does not apply).
+
+#### `PadTileMulticoreProgramFactory`
+
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | opt_level | config |
+|---|---|---|---|---|---|---|
+| reader | `…/reader_pad_tiled.cpp` | `all_cores` (`split_work_to_cores` over `num_pages`) | `{input_cb_index, page_size, output_padded_shape.rank()}` + `TensorAccessorArgs(input)` | `input_buffer`, `num_pages_per_core`, `input_page_offset`, then 4 × `num_dims` blocks | `O2` (unset) | `ReaderConfigDescriptor{}` |
+| writer | `…/writer_pad_tiled.cpp` | `all_cores` | `{input_cb_index, output_cb_index, pad_val_cb_index, page_size, rank, packed_pad_value, element_size}` + `TensorAccessorArgs(output)` | `output_buffer`, `num_pages_per_core`, `output_page_offset`, then the same 4 × `num_dims` blocks | `O2` (unset) | `WriterConfigDescriptor{}` |
+
+Writer CTA 1 (`output_cb_index`) is unpacked at `writer_pad_tiled.cpp:23` and **never referenced**
+— the dead CTA that accompanies the dead `c_1` CB.
+
+The 4 × `num_dims` RTA block is `input_page_shape`, `output_page_shape`, `input_id_per_dim`,
+`output_id_per_dim`, reached via `get_arg_addr(rt_ind)` plus `+ num_dims` pointer strides
+(`reader:22-25`, `writer:35-38`) and consumed in `for (d < num_dims)` loops. **`input_id_per_dim` and
+`output_id_per_dim` are *written back* in place** by `advance_tensor_index`
+(`device/kernels/dataflow/common.hpp:12-19`) — the kernel uses the RTA buffer as mutable scratch.
+
+### CBs
+
+| factory | index | total_size | core_ranges | data_format | page_size | tile |
+|---|---|---|---|---|---|---|
+| RM sc | `c_0` | `16 * cb_pagesize` | `{{0,0},{0,0}}` | input dtype | `round_up(padded_row_size_nbytes, max(src_align, TILE_WIDTH))` | unset |
+| RM mc | `c_0` | `16 * cb_pagesize` | `all_cores` | input dtype | `ceil(dst_nbytes_per_core_w / align) * align` | unset |
+| RM default | `c_0` | `16 * cb_npages * stick_size_padded_aligned` | `all_cores` | input dtype | `stick_size_padded_aligned` | unset |
+| RM default | `c_1` | `stick_size_padded_DRAM_aligned` | `all_cores` | input dtype | same | unset |
+| RM default | `c_2` | `stick_size_padded_DRAM_aligned` | `all_cores` | input dtype | same | unset — **allocated only if `stick_size_padded_front != 0 \|\| unaligned`** (`:127-139`) |
+| sharded H | `c_0` | `shard_height_unpadded * stick_size_unpadded` | `total_cores` (full grid) | input dtype | `stick_size_unpadded` | unset — **`buffer = src_buffer`** (`:294`) |
+| sharded H | `c_16` | `shard_height_padded * stick_size_padded` | `total_cores` | output dtype | `stick_size_padded` | unset — **`buffer = dst_buffer`** (`:309`) |
+| sharded H | `c_1` | `stick_size_padded` | `total_cores` | input dtype | `stick_size_padded` | unset |
+| sharded W | `c_0` | `shard_height_unpadded * unpadded_stick_bytes` | `total_cores` | input dtype | `unpadded_stick_bytes` | unset — **`buffer = input_buffer`** (`:75`) |
+| sharded W | `c_16` | `shard_height_padded * padded_stick_bytes` | `total_cores` | output dtype | `padded_stick_bytes` | unset — **`buffer = output_buffer`** (`:91`) |
+| sharded W | `c_1` | `padded_stick_bytes` | `total_cores` | input dtype | `padded_stick_bytes` | unset |
+| tile sc | `c_0` | `2 * single_tile_size` | `{{0,0},{0,0}}` | input dtype | `single_tile_size` | unset |
+| tile sc | `c_1` | `1 * single_tile_size` | `{{0,0},{0,0}}` | input dtype | `single_tile_size` | unset |
+| tile mc | `c_0` | `2 * page_size` | `all_cores` | input dtype | `page_size` | unset |
+| tile mc | `c_1` | `2 * page_size` | `all_cores` | input dtype | `page_size` | unset — **DEAD, zero touchers** |
+| tile mc | `c_2` | `page_size` | `all_cores` | input dtype | `page_size` | unset |
+
+- **No `GlobalCircularBuffer` anywhere** — the audit's feature scan is confirmed by
+  `grep -rn 'global_circular_buffer\|remote_cb\|GlobalCircularBuffer'` returning nothing.
+- **No aliased CBs** — every `CBDescriptor` has exactly one `format_descriptors` element.
+- **No `tile` field is set on any format descriptor**, so `tile_format_metadata` stays `nullopt`
+  everywhere (JIT fallback is observably identical for standard 32×32).
+- **Note — the two sharded factories give their CBs `core_ranges = total_cores` (the whole compute
+  grid) while their kernels run on `all_cores_padded` only.** Metal 2.0 *derives* DFB placement from
+  kernel bindings, so the ported DFBs land on `all_cores_padded`. Flagged below.
+
+### Semaphores
+
+none — the op declares no semaphores. `grep -rn '[Ss]emaphore'` over the op directory: zero hits.
+
+### Tensor accessors
+
+| host site (file:line) | originating Tensor | RTA slot (host) | kernel construction |
+|---|---|---|---|
+| `pad_rm_reader_writer_program_factory.cpp:82` / `:143` | input | reader/writer slot 0 | `reader_pad_dims_rm_interleaved.cpp:75` |
+| `…:83` / `:144` | output | slot 1 | `writer_pad_dims_rm_interleaved.cpp:32` |
+| `…:84` / `:156` | pad-value const (**op-owned**) | slot 13 | `reader_pad_dims_rm_interleaved.cpp:77` |
+| `…_multi_core_program_factory.cpp:246` / `:348` | input | slot 0 | same reader |
+| `…:247` / `:349` | output | slot 1 | same writer |
+| `…:248` / `:361` | pad-value const (**op-owned**) | slot 13 | same reader |
+| `…_default_program_factory.cpp:164` / `:221` | input | reader slot 0 | `reader_pad_dims_rm_interleaved_v2.cpp:95` (**3-arg**) |
+| `…:172` / `:222` | output | writer slot 0 | `writer_pad_dims_rm_interleaved_v2.cpp:25` (**3-arg**) |
+| `pad_tile_program_factory.cpp:98` / `:122` | input | reader slot 0 | donor `reader_unary_interleaved_start_id.cpp:30` |
+| `…:100` / `:126` | output | writer slot 0 | `writer_unary_pad_dims_interleaved.cpp:30` |
+| `pad_tile_multicore_program_factory.cpp:121` / `:222` | input | reader slot 0 | `reader_pad_tiled.cpp:29` |
+| `…:132` / `:223` | output | writer slot 0 | `writer_pad_tiled.cpp:42` |
+
+The two sharded factories construct **no `TensorAccessor` at all** — their kernels reach input and
+output purely through the borrowed CBs. Their two tensor parameters exist solely as
+`borrowed_from` sources.
+
+### Work split
+
+| factory | driver | groups |
+|---|---|---|
+| RM sc | n/a — single core `{0,0}` | — |
+| RM mc | `split_across_cores(grid, nbatch, ntiles_h, ntiles_w)` @ `:217` — hardcoded resnet table | one `all_cores` range; per-core args vary but there is a **single** `KernelDescriptor` per role |
+| RM default | `split_work_to_cores(grid_or_sub_core_grids, NCH_padded)` @ `:90-91` | `num_cores`, `all_cores`, `core_group_1`/`core_group_2`, `num_sticks_padded_per_core_group_1/2` — **groups differ only in a per-core RTA**, not in CTAs |
+| sharded H | output shard grid `all_cores_padded`, `num_cores_padded` | single group |
+| sharded W | `get_optimal_worker_cores_for_sharded_tensor(output)` | single group |
+| tile sc | n/a — single core `{0,0}` | — |
+| tile mc | `split_work_to_cores(grid_or_sub_core_grids, num_pages)` @ `:45-47` | `core_group_1`/`core_group_2` — again only a per-core **RTA** differs |
+
+**No factory creates more than one `KernelDescriptor` per role.** The per-group counts travel as
+runtime args in legacy already, so there is no work-split CTA multiplicity to preserve.
+
+### Shared kernels
+
+Census run as `grep -rl <filename> ttnn/cpp/ttnn/operations/ tests/`, quasar copies discarded.
+
+| kernel | class | consumers | fork? | rung |
+|---|---|---|---|---|
+| `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp` | **borrowed** | `data_movement/pad` (this factory), `data_movement/untilize_with_unpadding` ×2, `examples/example` ×2, `examples/example_multiple_return`, `experimental/transformer/nlp_create_qkv_heads_falcon7b`, `reduction/topk`, plus `tests/.../test_generic_op.{cpp,py}` | **yes** — `reader_unary_interleaved_start_id_metal2.cpp`, same directory | **rung 1 — reuse.** Bind the fork; create nothing; touch neither the original nor the fork. |
+| `reader_pad_dims_rm_interleaved.cpp`, `writer_pad_dims_rm_interleaved.cpp` | **intra-op**, 2 consumers | `PadRmReaderWriterProgramFactory`, `PadRmReaderWriterMultiCoreProgramFactory` | n/a | **both consumers convert in this change** → convert in place, no fork. |
+| every other kernel under `device/kernels/dataflow/` | private | exactly one pad factory each | n/a | convert in place |
+| `device/kernels/dataflow/common.hpp` | private | `reader_pad_tiled.cpp`, `writer_pad_tiled.cpp` (relative include, same directory) | n/a | in the port unit; both consumers convert together |
+
+**Fork vocabulary (rung-1 constraint).** `reader_unary_interleaved_start_id_metal2.cpp` declares its
+interface in its header comment: `dfb::in`, `tensor::src`, `args::num_pages`, `args::start_id`, and
+it already replaces `get_local_cb_interface(cb).fifo_page_size` with `dfb.get_entry_size()`. It gates
+nothing but `BACKWARDS`, which pad does not define. **The factory conforms to those names — note
+`tensor::src`, not `tensor::input`.** The differently-named fork at
+`copy/typecast/device/kernels/dataflow/reader_unary_interleaved_start_id_metal2.cpp` (vocabulary
+`tensor::input`) is an op-local copy, **not** the sibling of the original — do not bind it.
+
+### Flags
+
+- **No unreferenced kernel files.** All 12 kernel sources in the op directory are bound.
+- `PadRmReaderWriterMultiCoreProgramFactory` is **unreachable** from `select_program_factory`
+  (`pad_device_operation.cpp:99-101`). Ported by invoker decision; build-verified only.
+- `split_across_cores`'s `default:` branch throws at
+  `pad_rm_reader_writer_multi_core_program_factory.cpp:97` and is followed by ~30 lines of
+  unreachable code (`:99-131`). **Left untouched** — out of scope.
+- `reader_pad_dims_rm_interleaved.cpp:52` hardcodes `pad_value_const_buffer_nbytes = 64` (issue
+  #21978) while the host computes and passes the real value at slot 14. **The hardcode stays**; the
+  arg simply gets no name.
+- `pad_tile_multicore_program_factory.cpp:194-197` divides *both* trailing dims by `TILE_HEIGHT`
+  (never `TILE_WIDTH`). Benign while both are 32. **Not touched**; reported.
+
+---
+
+## TTNN ProgramFactory
+
+- **Concept (inherited from audit)**: `ProgramSpecFactoryConcept` for **all seven** factories.
+  - Six of them carry it directly from the brief.
+  - The seventh, `PadRmShardedHeightOnlyProgramFactory`, was routed to
+    `CustomProgramSpecFactoryConcept` by the audit, which simultaneously raised an open question
+    about whether that was necessary. **The invoker was asked and chose the base concept**, so the
+    `override_runtime_arguments` at `pad_rm_sharded_height_only_program_factory.cpp:412-424` (and its
+    declaration at `.hpp:22-27`) is removed rather than translated.
+  - **Justification, verified against the code.** The override's entire body re-points two CB base
+    addresses — the input CB and the output CB — and nothing else (`:420-423`). Both of those CBs are
+    `borrowed_from` DFBs in the port, and Metal 2.0 refreshes a borrowed DFB's backing L1 address from
+    its `TensorArgument` on every dispatch; on the base concept the framework refreshes every
+    `TensorArgument` on a cache hit. So the refreshed set is *identical*, statement for statement,
+    and the override has no non-tensor work to lose. `PadRmShardedWidthOnlyProgramFactory` already
+    carries the same two borrowed CBs with no override at all, which is independent evidence.
+  - Two `MeshWorkloadFactoryConcept` factories collapse to the single-program concept: each builds
+    **one** `ProgramDescriptor` above the loop and pushes the *same* object once per range in
+    `tensor_coords` (`:202-211` / `:421-429`). Nothing is per-mesh-coordinate; the
+    `WorkloadDescriptor` wrapper existed only to carry op-owned tensors, which
+    `ProgramArtifacts::op_owned_tensors` carries natively.
+- **Custom `compute_program_hash`**: **none.** Nothing to leave intact.
+- **Pybind**: `pad_nanobind.cpp` binds only the two public `ttnn::pad` overloads — **no**
+  `create_descriptor` / `create_workload_descriptor` exposure, so no pybind line disappears and
+  the port removes no user-visible API.
+- **Implementation notes**:
+  - The op directory builds under a **unity build** (`ttnn_op_data_movement` uses
+    `Unity/unity_*_cxx.cxx`), and seven factory `.cpp`s land in one translation unit. Every
+    anonymous-namespace spec-name constant is therefore **prefixed per factory** (`RM_SC_`, `RM_MC_`,
+    `RM_DEF_`, `SH_H_`, `SH_W_`, `TILE_SC_`, `TILE_MC_`) per
+    [Unity-build hygiene](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md).
+  - Each factory's `.hpp` swaps `create_descriptor` / `create_workload_descriptor` for
+    `create_program_artifacts`; nothing else in the headers changes except the include of
+    `ttnn/metal_v2_artifacts.hpp` and, for the two workload factories, dropping
+    `workload_descriptor.hpp`.
+
+---
+
+## Planned Spec Shape
+
+Naming convention: DFB spec names describe the buffer's role; accessor names are the kernel-side
+`dfb::` handles. **No name anywhere contains `cb`.**
+
+### `PadRmReaderWriterProgramFactory` (`RM_SC_`) and `PadRmReaderWriterMultiCoreProgramFactory` (`RM_MC_`)
+
+Identical shape; the two differ only in node set and per-node RTA values.
+
+- **KernelSpecs**: `reader` (`reader_pad_dims_rm_interleaved.cpp`), `writer`
+  (`writer_pad_dims_rm_interleaved.cpp`).
+- **DataflowBufferSpecs**: `in0` ← legacy `c_0`. `entry_size = cb_pagesize`, `num_entries = 16`,
+  `data_format_metadata = in_df`. reader PRODUCER (`dfb::in0`), writer CONSUMER (`dfb::in0`).
+- **SemaphoreSpecs**: none.
+- **TensorParameters**: `input` (reader binds as `tensor::src`), `output` (writer binds as
+  `tensor::dst`), `pad_value_const` (**op-owned**; reader binds as `tensor::pad_value`).
+- **WorkUnitSpecs**: one — `{reader, writer}` over `{0,0}` (sc) / `all_cores` (mc).
+- **Op-owned tensors**: one — the 32-element bfloat16 pad-value const tensor. Construction
+  (`build_pad_value_const_tensor_sc` / `_mc`) is kept **verbatim**; only the tail changes to
+  `release_mesh_tensor()` into `ProgramArtifacts::op_owned_tensors`.
+
+### `PadRmReaderWriterMultiCoreDefaultProgramFactory` (`RM_DEF_`)
+
+- **KernelSpecs**: `reader`, `writer` (the `_v2` pair).
+- **DataflowBufferSpecs**:
+  - `in0` ← `c_0`. reader PRODUCER, writer CONSUMER (plain 1:1).
+  - `pad` ← `c_1`. reader-only → **self-loop** (reader PRODUCER *and* CONSUMER, one accessor name).
+  - `pad_align` ← `c_2`. reader-only → **self-loop**, and **conditional** on
+    `stick_size_padded_front != 0 || unaligned`.
+- **TensorParameters**: `input` (reader, `tensor::src`), `output` (writer, `tensor::dst`).
+- **WorkUnitSpecs**: one — `{reader, writer}` over `all_cores`.
+- Both core groups share one `KernelSpec` per role, exactly as legacy: the group difference is a
+  per-node RTA (`num_sticks_per_core`), never a CTA.
+
+### `PadRmShardedHeightOnlyProgramFactory` (`SH_H_`)
+
+- **KernelSpecs**: `reader` (`reader_pad_dims_rm_sharded.cpp`), `writer`
+  (`writer_pad_dims_rm_sharded.cpp`).
+- **DataflowBufferSpecs**:
+  - `in_shard` ← `c_0`, `borrowed_from = input`. Reader raw-peeks only → **self-loop**.
+  - `out_shard` ← `c_16`, `borrowed_from = output`. **Two touchers** — reader is a locked producer
+    (`reserve_back`/`push_back` @ `:31,69`), writer raw-peeks `get_write_ptr()` @ `:90` with no FIFO
+    ops → **1P+1C**: reader PRODUCER, writer CONSUMER. **Not** multi-binding.
+  - `pad` ← `c_1`. Writer-only → **self-loop**.
+- **TensorParameters**: `input`, `output` — both **borrow-only**: no kernel binds either, and no
+  `TensorAccessor` exists in either kernel. The validator's "≥1 TensorBinding" rule carves out
+  exactly this case (a parameter named by `borrowed_from` counts as used).
+- **WorkUnitSpecs**: one — `{reader, writer}` over `all_cores_padded`.
+
+### `PadRmShardedWidthOnlyProgramFactory` (`SH_W_`)
+
+- **KernelSpecs**: `reader` (`…_stickwise.cpp`), `writer` (`…_stickwise.cpp`).
+- **DataflowBufferSpecs**:
+  - `in_shard` ← `c_0`, `borrowed_from = input`. Reader raw-peek only → **self-loop**.
+  - `out_shard` ← `c_16`, `borrowed_from = output`. Writer locked-producer (`reserve_back`/`push_back`
+    @ `:56,75`), reader locked-consumer (`wait_front`/`pop_front` @ `:37,55`) → **plain 1:1**
+    (writer PRODUCER, reader CONSUMER).
+  - `pad` ← `c_1`. Writer-only → **self-loop**.
+- **TensorParameters**: `input`, `output` — both borrow-only, as above.
+- **WorkUnitSpecs**: one — `{reader, writer}` over `all_cores_padded`.
+
+### `PadTileCoreProgramFactory` (`TILE_SC_`)
+
+- **KernelSpecs**: `reader` → **the existing fork**
+  `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id_metal2.cpp`;
+  `writer` → `writer_unary_pad_dims_interleaved.cpp`.
+- **DataflowBufferSpecs**:
+  - `in0` ← `c_0`. reader PRODUCER (accessor name **`in`**, fixed by the fork), writer CONSUMER
+    (accessor name `out0`, this op's choice).
+  - `pad` ← `c_1`. Writer-only — `reserve_back(1)` + `get_write_ptr()`, never pushed →
+    **self-loop**.
+- **TensorParameters**: `input` — reader binds it as **`tensor::src`** (fork's vocabulary);
+  `output` — writer binds as `tensor::dst`.
+- **WorkUnitSpecs**: one — `{reader, writer}` over `{0,0}`.
+
+### `PadTileMulticoreProgramFactory` (`TILE_MC_`)
+
+- **KernelSpecs**: `reader` (`reader_pad_tiled.cpp`), `writer` (`writer_pad_tiled.cpp`).
+- **DataflowBufferSpecs**:
+  - `in0` ← `c_0`. reader PRODUCER, writer CONSUMER.
+  - `pad` ← `c_2`. Writer-only → **self-loop**.
+  - legacy `c_1` → **no spec.** Dead in every config; the allocation
+    (`pad_tile_multicore_program_factory.cpp:70-78`) and the dead CTA it feeds
+    (`:125` → `writer_pad_tiled.cpp:23`) are both dropped.
+- **TensorParameters**: `input` (reader, `tensor::src`), `output` (writer, `tensor::dst`).
+- **WorkUnitSpecs**: one — `{reader, writer}` over `all_cores`.
+
+---
+
+## Preserved Multiplicity
+
+**none — no work-split multiplicity in legacy.** No factory emits more than one `KernelDescriptor`
+per role. `PadRmReaderWriterMultiCoreDefaultProgramFactory` and `PadTileMulticoreProgramFactory` both
+call `split_work_to_cores` and get two core groups, but the only value that differs between the
+groups is a **runtime** arg (`num_sticks_per_core` / `num_pages_per_core`) that legacy already varied
+per core. There is no per-group CTA to preserve and therefore nothing that could be demoted.
+
+---
+
+## Dropped Plumbing
+
+### Buffer-address RTAs → `TensorBinding`
+
+Every one arrives today as a `Buffer*` pushed into `KernelDescriptor::RTArgList` (the framework's
+`BufferBinding` form), never as a bare `->address()`.
+
+| legacy location (file:line) | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `pad_rm_reader_writer_program_factory.cpp:143` (reader RTA 0) | `src0_buffer` | `TensorBinding{input, "src"}` |
+| `…:144` (writer RTA 1) | `dst_buffer` | `TensorBinding{output, "dst"}` |
+| `…:156` (reader RTA 13) | `pad_value_const_buffer` | `TensorBinding{pad_value_const, "pad_value"}` |
+| `…_multi_core_program_factory.cpp:348 / 349 / 361` | same three | same three |
+| `…_default_program_factory.cpp:221` (reader RTA 0) | `src0_buffer` | `TensorBinding{input, "src"}` |
+| `…_default_program_factory.cpp:222` (writer RTA 0) | `dst_buffer` | `TensorBinding{output, "dst"}` |
+| `pad_tile_program_factory.cpp:122` (reader RTA 0) | `src0_buffer` | `TensorBinding{input, "src"}` — fork's name |
+| `pad_tile_program_factory.cpp:126` (writer RTA 0) | `dst_buffer` | `TensorBinding{output, "dst"}` |
+| `pad_tile_multicore_program_factory.cpp:222` (reader RTA 0) | `input_buffer` | `TensorBinding{input, "src"}` |
+| `pad_tile_multicore_program_factory.cpp:223` (writer RTA 0) | `output_buffer` | `TensorBinding{output, "dst"}` |
+| `…_height_only_program_factory.cpp:294 / 309` | `cb.buffer = src/dst_buffer` | `DataflowBufferSpec::borrowed_from` |
+| `…_width_only_program_factory.cpp:75 / 91` | `cb.buffer = input/output_buffer` | `DataflowBufferSpec::borrowed_from` |
+
+**Idle-core `0u` sentinel disappears.** `…_default_program_factory.cpp:224-225` and
+`pad_tile_multicore_program_factory.cpp:225-226` push a literal `0u` instead of the `Buffer*` on
+cores with no work, to skip `BufferBinding` registration. Metal 2.0 delivers the base through the
+binding channel for every node the kernel runs on, so there is nothing to skip and the branch has no
+translation — it goes away. Both kernels already short-circuit on a zero work count, and in practice
+`split_work_to_cores` returns `all_cores == group_1 ∪ group_2`, so no idle core exists today.
+
+### Magic CB indices in CTAs → `DFBBinding`
+
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| `…_default_program_factory.cpp:167` (writer CTA 0) | `src0_cb_index` | `DFBBinding{IN0, "out0", CONSUMER}` |
+| `…_width_only_program_factory.cpp:140` (reader CTA 5) | `input_shard_cb_index` | `DFBBinding{IN_SHARD, "in_shard", PRODUCER+CONSUMER}` |
+| `…_width_only_program_factory.cpp:141` (reader CTA 6) | `output_shard_cb_index` | `DFBBinding{OUT_SHARD, "out_shard", CONSUMER}` |
+| `…_width_only_program_factory.cpp:150` (writer CTA 4) | `output_shard_cb_index` | `DFBBinding{OUT_SHARD, "out_shard", PRODUCER}` |
+| `…_width_only_program_factory.cpp:151` (writer CTA 5) | `pad_val_cb_index` | `DFBBinding{PAD, "pad", PRODUCER+CONSUMER}` |
+| `pad_tile_program_factory.cpp:99` (writer CTA 0, 1) | `src0_cb_index`, `src1_cb_index` | `DFBBinding{IN0,"out0",CONSUMER}`, `DFBBinding{PAD,"pad",PRODUCER+CONSUMER}` |
+| `pad_tile_multicore_program_factory.cpp:117` (reader CTA 0) | `input_cb_index` | `DFBBinding{IN0,"in0",PRODUCER}` |
+| `pad_tile_multicore_program_factory.cpp:124,126` (writer CTA 0, 2) | `input_cb_index`, `pad_val_cb_index` | `DFBBinding{IN0,"in0",CONSUMER}`, `DFBBinding{PAD,"pad",PRODUCER+CONSUMER}` |
+| `reader_pad_dims_rm_interleaved.cpp:66`, `writer…:29` (hardcoded `tt::CBIndex::c_0`) | kernel-side magic constant | `dfb::in0` |
+| `reader_pad_dims_rm_interleaved_v2.cpp:88-90` (three hardcoded `tt::CBIndex::c_*`) | kernel-side magic constants | `dfb::in0`, `dfb::pad`, `dfb::pad_align` |
+| `reader_pad_dims_rm_sharded.cpp:24-25`, `writer…:75-76` (hardcoded) | kernel-side magic constants | `dfb::in_shard` / `dfb::out_shard` / `dfb::pad` |
+
+### `TensorAccessorArgs` plumbing → binding mechanism
+
+| host `append_to` site | kernel-side chain |
+|---|---|
+| `pad_rm_reader_writer_program_factory.cpp:82,83,84` (and `:85`, the writer's verbatim copy) | `reader…:62-64` `TensorAccessorArgs<2>()` → `next_compile_time_args_offset()` ×2; `writer…:26-27` (`src_args` declared **only** to offset `dst_args`) |
+| `…_multi_core_program_factory.cpp:246,247,248,249` | same |
+| `…_default_program_factory.cpp:164` / `:172` | `reader…_v2.cpp:81` `TensorAccessorArgs<22>()`; `writer…_v2.cpp:23` `TensorAccessorArgs<5>()` |
+| `pad_tile_program_factory.cpp:98` / `:100` | donor `:20` `TensorAccessorArgs<0>()`; `writer_unary_pad_dims_interleaved.cpp:26` `TensorAccessorArgs<2>()` |
+| `pad_tile_multicore_program_factory.cpp:121` / `:132` | `reader_pad_tiled.cpp:27` `TensorAccessorArgs<3>()`; `writer_pad_tiled.cpp:40` `TensorAccessorArgs<7>()` |
+
+### Page-size 3rd-argument CTAs
+
+| legacy CTA | host computation | kernel site |
+|---|---|---|
+| reader CTA 21 `input_accessor_page_size` (`…_default_program_factory.cpp:163`) | `:57` / `:63` | `reader_pad_dims_rm_interleaved_v2.cpp:80,95` |
+| writer CTA 4 `output_accessor_page_size` (`…_default_program_factory.cpp:171`) | `:68` / `:73` | `writer_pad_dims_rm_interleaved_v2.cpp:22,25` |
+
+Both **Class 2 (redundant)** per the audit: the sharded branch passes `buffer->aligned_page_size()`
+verbatim, the interleaved branch passes the true logical page which the interleaved accessor
+realigns to the same value. The `:57-73` computation of both goes with them. **`dynamic_tensor_shape`
+is NOT set** — these are compile-time args, so the page size cannot vary across shapes sharing one
+compiled program.
+
+> `num_input_pages_in_row` / `num_output_pages_in_row` are computed in the *same* `if is_sharded()`
+> blocks but are **live kernel logic** (`reader…_v2.cpp:36-48`, `writer…_v2.cpp:36-55`). They stay,
+> as named CTAs. Only the two `*_accessor_page_size` values drop.
+
+### Semaphore-ID RTAs
+
+none — the op has no semaphores.
+
+### Positional CTAs → named CTAs
+
+Every surviving CTA is named. The full renaming is the per-kernel CTA slot map in the Legacy
+Inventory; names are the kernel's own local names (`stick_size_bytes`, `H_padded`,
+`num_sticks_padded`, …).
+
+### Dead args dropped outright
+
+Neither named nor emitted, because no kernel reads them. Each is zero-functional-change: a CTA is a
+compile-time constant nothing reads, and a dead RTA slot is a word nothing loads.
+
+| where | slots |
+|---|---|
+| v1 RM reader RTAs | 3 `num_total_W`, 6 `num_unpadded_Y`, 7 `num_total_Y`, 14 `pad_value_const_buffer_nbytes`, 18 `start_src_stick_wi`, 23 `full_unpadded_X_nbytes` |
+| v1 RM writer RTAs | 3, 7, 9 `num_total_X`, 19 `start_dst_stick_wi`, 22 `num_local_unpadded_Y`, 24 `full_padded_X_nbytes` — plus every reader-only slot, since `writer_rt_args = reader_rt_args` no longer holds |
+| v1 RM reader/writer CTAs | 0, 1 (`unpadded_row_size_nbytes`, `padded_row_size_nbytes`) — no `get_compile_time_arg_val` exists in either kernel |
+| RM default reader CTAs | 9, 10, 11 (declared-unused), 14, 15, 16, 17 (never declared) |
+| sharded W reader CTAs | 1 `padded_stick_bytes`, 3 `padded_shard_height` |
+| sharded W writer CTAs | 6 `padded_stick_step` |
+| tile mc writer CTA | 1 `output_cb_index` — the dead-CB CTA the brief calls out |
+
+---
+
+## Applied Patterns
+
+- [**Sync-free and single-ended CBs → self-loop DFB**](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-sync-free-and-single-ended-cbs--self-loop-dfb)
+  — seven DFBs, one toucher each: `pad` and `pad_align` (RM default, reader-only), `in_shard` and
+  `pad` (sharded height-only), `in_shard` and `pad` (sharded width-only), `pad` (tile single-core),
+  `pad` (tile multicore). All are DM self-loops, legal on Gen1, Quasar-uplift debt.
+- [**Two-toucher DFB → assign 1P+1C**](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-two-toucher-dfb--assign-1p1c-dual-instance-work-split)
+  — `out_shard` in `PadRmShardedHeightOnlyProgramFactory`: reader locked-producer + writer role-free
+  raw peek (`writer_pad_dims_rm_sharded.cpp:90`) → reader PRODUCER, writer CONSUMER. Census re-derived
+  independently; agrees with the brief. **No multi-binding flag anywhere in this port.**
+- [**Conditional / optional DFB bindings**](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-conditional--optional-dfb-bindings)
+  — `pad_align` (`c_2`) in the RM default factory. The host binds it only under
+  `stick_size_padded_front != 0 || unaligned` and emits a matching
+  `compiler_options.defines` entry `PAD_ALIGN_DFB`. The kernel currently constructs the buffer and
+  calls `get_read_ptr()` **unconditionally** (`reader…_v2.cpp:93,99`) while gating only the *uses*
+  behind `if constexpr`; since `if constexpr` does not suppress `dfb::` name lookup, the
+  construction, the `get_read_ptr()`, **and the two `if constexpr` branches that reference the
+  handle** all move behind a real `#ifdef`.
+- [**Pass DFB handles directly to LLKs and kernel-lib helpers**](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-pass-dfb-handles-directly-to-llks-and-kernel-lib-helpers)
+  — not needed for LLKs (no compute kernels), but the file-local `fill_*` helpers in three kernels
+  take a `uint32_t cb_id` and build a **second** `DataflowBuffer` for a buffer the caller already
+  holds. Each helper's parameter becomes `DataflowBuffer&` so exactly one object exists per DFB, per
+  the catalog's "alias the handle, keep one object" rule.
+- [**Caution: Porting a shared kernel**](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#caution-porting-a-shared-kernel)
+  — rung 1 (reuse the existing `_metal2` fork) for the borrowed
+  `reader_unary_interleaved_start_id.cpp`. No new fork; the original is not touched.
+- [**Unity-build hygiene for anonymous-namespace symbols**](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-unity-build-hygiene-for-anonymous-namespace-symbols)
+  — seven factories in one unity TU; every spec-name constant carries a per-factory prefix.
+- [**Caution: Avoid varargs**](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#caution-avoid-varargs-unless-absolutely-necessary)
+  — two genuine vararg sites, and two look-alikes that are **named**:
+  - **Vararg** `reader_pad_dims_rm_sharded.cpp` — one named RTA (`num_cores_read`, a distinct field
+    read once) followed by a runtime-count collection: `2·num_cores` NoC (x,y), `num_cores` chunk
+    counts, `2·Σchunks` (start,length) pairs. Counts come from the data, so nothing past the first
+    word is nameable.
+  - **Vararg** `reader_pad_tiled.cpp` / `writer_pad_tiled.cpp` — four `num_dims`-long blocks, read in
+    `for (d < num_dims)` loops with `num_dims` a CTA.
+  - **Named** `reader_pad_dims_rm_interleaved_v2.cpp:59,112` and
+    `writer_pad_dims_rm_sharded.cpp:53,93` — both index a `get_arg_addr()` pointer at **fixed**
+    positions `[1]`, `[2]`, `[3]` only. Three distinct nameable fields
+    (`start_dim_offset_h/_c/_n`), not a data-directed pick.
+
+---
+
+## Deferred / Flagged
+
+New findings from planning (none blocks the port; all are reported):
+
+1. **`get_vararg()` is read-only, and `reader_pad_tiled` / `writer_pad_tiled` *write back* into their
+   vararg block.** `advance_tensor_index` (`device/kernels/dataflow/common.hpp:12-19`) mutates
+   `input_id_per_dim` / `output_id_per_dim` in place in the RTA buffer. Metal 2.0 exposes
+   `get_vararg(i)` (a value getter) and no address form, so the two mutable blocks are **copied into
+   local `uint32_t[num_dims]` arrays** at kernel entry — `num_dims` is a CTA, so these are
+   fixed-size arrays. The two read-only blocks (`input_page_shape`, `output_page_shape`) stay as
+   direct `get_vararg` reads. This is the only place the port changes *where* a value lives rather
+   than *how* it is named; behavior is identical. Friction entry in the report.
+2. **DFB placement narrows on the two sharded factories.** Their `CBDescriptor`s carry
+   `core_ranges = total_cores` (the full compute grid) while their kernels run on
+   `all_cores_padded`. Metal 2.0 derives DFB placement from kernel bindings, so the ported `pad` DFB
+   is allocated only where a kernel binds it. The borrowed DFBs allocate nothing either way; the
+   change is a strictly smaller L1 footprint on cores that ran no kernel. Not expressible otherwise
+   — `DataflowBufferSpec` has no `target_nodes` by design.
+3. **`start_dim_offset` is emitted from the live counters, not the vector.** In
+   `…_default_program_factory.cpp` and `…_height_only_program_factory.cpp` the vector is seeded to
+   `num_dims` zeros and thereafter reassigned to a literal 4-element `{0, curr_h, curr_c, curr_n}`.
+   At the point of the push, `start_dim_offset[1..3]` is **exactly** `curr_h`, `curr_c`, `curr_n`
+   (both are zero on the first core, and the reassignment happens after the push). The three named
+   args are therefore emitted straight from the counters, which is value-identical and sidesteps the
+   pre-existing rank-mismatch seeding (audit anomaly #7) without changing it.
+4. **`log_rt_args(CoreCoord{0,0}, reader_desc.compile_time_args)`
+   (`…_multi_core_program_factory.cpp:276`) loses its subject.** It logs the positional CTA vector,
+   which ceases to exist; the helper at `:20-24` then has no caller. Both are removed as part of the
+   descriptor code they belong to.
+5. **No new stop signals.** No `GlobalCircularBuffer`, no `get_cb_tiles_acked_ptr` /
+   `get_cb_tiles_received_ptr`, no compute-kernel Case 2, no host-computed `base + offset`, no
+   descriptor type outside the audit's Appendix A scope.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_REPORT.md
@@ -274,6 +274,24 @@ that was **raised with the invoker before construction and decided by them**:
 6. **The op-owned-tensor path is exercised only by the single-core RM factory here.** Its sibling
    (`PadRmReaderWriterMultiCoreProgramFactory`) carries the same allocation but is unreachable, so
    the two factories' op-owned handling has one live test subject between them.
+7. **CI caught a borrowed-DFB sizing hole the confirmed set misses: an input smaller than its own
+   shard.** `test_paged_cache_mask.py::test_update_cache[1x2_grid]` (ttnn misc ops group,
+   wh_n300_civ2) drives `from_torch(..., TILE, height-sharded (32, 128))` on a per-device
+   `(1, 16, 1, 128)` tensor; the mesh construction path builds the row-major input on device
+   already carrying the requested tile-aligned shard spec, so `prim::pad` receives 16 sticks under
+   a 32-stick shard spec. Both sharded factories sized the borrowed `in_shard` DFB as one full
+   shard (`shard_height × stick_bytes` = 8192 B), which trips `ValidateProgramSpec`'s spec-time
+   bound `dfb_bytes <= compute_packed_buffer_size_bytes()` (= 4096 B, `program_spec.cpp:1567`).
+   The legacy CB never validated this: `set_globally_allocated_address` is checked per-bank at
+   attach time, and the per-bank allocation is a full shard (8192 ≤ 8192). The confirmed set never
+   produces such a tensor — its sharded inputs always fill their shard specs.
+   **Fixed:** both sharded factories clamp `in_shard.num_entries` to
+   `min(shard_height, total input sticks)`. The count is inert on device — both readers only
+   raw-peek the DFB's base pointer, no FIFO ops — so the clamp affects validation only, and in the
+   normal (tensor ≥ one shard) case it reduces to the previous value. Reproduced and verified on
+   n150 with the exact per-device shapes (direct `ttnn.pad` on a 16-sticks-under-a-32-stick-shard
+   input, and the `from_torch` mesh path end-to-end); the confirmed set re-ran green afterward
+   (923 passed / 69 skipped / 6 xfailed — the 863/63 baseline plus item 5's added test).
 
 ### Shared kernel touches
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_REPORT.md
@@ -238,7 +238,9 @@ that was **raised with the invoker before construction and decided by them**:
    and the port preserved it per the scope discipline. The sibling
    `pad_tile_multicore_program_factory.cpp` has the correct case
    (`case DataType::FLOAT32: packed_pad_value = std::bit_cast<uint32_t>(pad_value);`), so the fix is
-   to copy that one line across. No test catches it because no test reaches this factory (item 5).
+   to copy that one line across. **Filed as #54223.** No test caught it because no test reached this
+   factory; the regression test added under item 5 now does, with the FLOAT32 non-zero-pad case
+   `xfail`ed against that issue.
 2. **`reader_pad_dims_rm_interleaved.cpp:52` hardcodes `pad_value_const_buffer_nbytes = 64`** with a
    *"fails on BH when > 64"* comment (issue #21978), while the host computed and passed the real
    value at RTA slot 14. The hardcode is preserved verbatim; the arg it shadowed simply gets no name
@@ -261,9 +263,14 @@ that was **raised with the invoker before construction and decided by them**:
    post-port variants. The port verified this factory with an ad-hoc script instead — TILE input
    with a real tile-dim change and `use_multicore=False`, across bfloat16 / float32 / uint32, plus
    three program-cache-hit iterations; everything passed except the pre-existing FLOAT32 pad-value
-   bug in item 1. **A test that pads a TILE tensor across a tile boundary with `use_multicore=False`
-   (e.g. `[1,1,32,32]` → `[1,1,64,64]`) would close the gap**, and would have caught item 1 years
-   ago.
+   bug in item 1.
+   **Closed:** `test_pad_tile_single_core` in
+   `tests/ttnn/unit_tests/operations/data_movement/test_pad.py` now pads a TILE tensor across a tile
+   boundary with `use_multicore=False` over six dtypes, two memory configs and three shapes, and
+   repeats each case three times so the second and third dispatches land on a program-cache hit.
+   60 passed / 6 skipped / 6 xfailed; the JIT cache confirms it reaches the factory (variants of
+   `writer_unary_pad_dims_interleaved` went from zero to ten). Added in response to the Copilot
+   review on the port PR.
 6. **The op-owned-tensor path is exercised only by the single-core RM factory here.** Its sibling
    (`PadRmReaderWriterMultiCoreProgramFactory`) carries the same allocation but is unreachable, so
    the two factories' op-owned handling has one live test subject between them.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PORT_REPORT.md
@@ -1,0 +1,350 @@
+# Metal 2.0 Port Report — `ttnn/cpp/ttnn/operations/data_movement/pad`
+
+## Outcome
+
+**`PORTED`** — all seven `PadDeviceOperation` factories converted to
+`ProgramSpecFactoryConcept`, together with all twelve of the op's kernel sources.
+
+| Factory | Ported | Verified |
+|---|---|---|
+| `PadRmReaderWriterProgramFactory` | ✅ | on device (test set) |
+| `PadRmReaderWriterMultiCoreProgramFactory` | ✅ | **build only — unreachable**, see Handoff points |
+| `PadRmReaderWriterMultiCoreDefaultProgramFactory` | ✅ | on device (test set), both conditional-DFB branches |
+| `PadRmShardedHeightOnlyProgramFactory` | ✅ | on device (test set) |
+| `PadRmShardedWidthOnlyProgramFactory` | ✅ | on device (test set) |
+| `PadTileCoreProgramFactory` | ✅ | on device (ad-hoc, **not** in the test set — see Open items) |
+| `PadTileMulticoreProgramFactory` | ✅ | on device (test set) |
+
+**Tests: 863 passed, 63 skipped — bit-identical to the pre-port baseline** (863 / 63), over the
+invoker-confirmed set:
+`tests/ttnn/unit_tests/operations/data_movement/test_pad.py`,
+`test_pad_subcoregrids.py`,
+`tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py`,
+`tests/tt_eager/python_api_testing/unit_testing/misc/test_padding_test.py`,
+`tests/tt_eager/python_api_testing/sweep_tests/pytests/tensor/test_pad.py`, `test_pad_to_tile.py`.
+The baseline was captured **before the first kernel edit**. The post-port run carries **2674
+`METAL2_CHECKS_FORCED` markers** from both forced translation units
+(`program_spec.cpp:2847`, `program_run_args.cpp:502`), so the green was measured with the Metal 2.0
+legality checks on. The forcing scaffolding was reverted before commit; `git diff` against the merge
+base touches no `tt_metal/` file.
+
+## Provenance
+
+- **Recipe docs (this port):** `64668f470e4 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources`
+- **Audit docs (inherited):** `64668f470e4 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources`
+
+## TTNN ProgramFactory
+
+### Concept realized
+
+`ProgramSpecFactoryConcept` on **all seven** factories — six as the audit chose, and one deviation
+that was **raised with the invoker before construction and decided by them**:
+
+- **`PadRmShardedHeightOnlyProgramFactory`: `CustomProgramSpecFactoryConcept` → base concept.** The
+  audit routed it to the custom concept because it carries an `override_runtime_arguments`, and in
+  the same breath raised an open question about whether that was necessary. Reading the method
+  settled it: its whole body (`pad_rm_sharded_height_only_program_factory.cpp:412-424`, pre-port)
+  re-points exactly two CB base addresses — the input CB and the output CB — and does nothing else.
+  Both become `borrowed_from` DFBs in the port, and Metal 2.0 resolves a borrowed DFB's backing L1
+  address from its `TensorArgument`; on the base concept the framework refreshes every
+  `TensorArgument` on a cache hit. The refreshed set is therefore identical statement-for-statement,
+  with no non-tensor work to lose. `PadRmShardedWidthOnlyProgramFactory` carries the same two
+  borrowed CBs and never had an override, which is independent evidence for the same conclusion.
+  The invoker chose to drop the override; the method and its `.hpp:22-27` declaration are gone.
+- The two `MeshWorkloadFactoryConcept` (`create_workload_descriptor`) factories collapse onto the
+  single-program concept. Each built **one** `ProgramDescriptor` above the loop and pushed the *same*
+  object once per range in `tensor_coords`; nothing was per-mesh-coordinate. The `WorkloadDescriptor`
+  wrapper existed only to carry the op-owned pad-value tensor, which
+  `ProgramArtifacts::op_owned_tensors` carries natively. **This port is the first production
+  exercise of the op-owned-tensor path we are aware of** — see Friction for what it cost.
+
+### Device-op-class edits
+
+- **Pybind entry points removed: none.** `pad_nanobind.cpp` binds only the two public `ttnn::pad`
+  overloads — no `create_descriptor` / `create_workload_descriptor` was ever exposed, so the port
+  removes no user-visible API.
+- **Custom `compute_program_hash`: none**, and no backdoor `attribute_values` / `to_hash`. Nothing
+  to leave intact, nothing touched.
+- **`pad_device_operation.{hpp,cpp}` is byte-identical.** No device-op-class edit was forced: every
+  factory already lived in a factory struct inside the `program_factory_t` variant, so
+  `ttnn_factory.md` exception 3 (direct-descriptor) did not apply.
+
+### Open items
+
+- **Relaxation candidates: none applied, none obviously available.** All seven readiness rows read
+  `relaxation = none`, and the port kept strict `TensorSpec` matching everywhere.
+- The two sharded factories would benefit from a way to say "allocate this DFB on a node set wider
+  than its bindings" — or, more likely, from someone confirming that they never needed it. See
+  Friction 2.
+
+## Handoff points
+
+1. **`PadRmReaderWriterMultiCoreProgramFactory` is ported but unverifiable.** It is declared in the
+   `program_factory_t` variant (`pad_device_operation.hpp:33`) and **never returned by
+   `select_program_factory`** — the RM multicore path returns
+   `PadRmReaderWriterMultiCoreDefaultProgramFactory` instead (`pad_device_operation.cpp:99-101`).
+   The audit asked whether it should be deleted rather than ported; the invoker chose to port it. It
+   compiles, satisfies `ProgramSpecFactoryConcept`, and its `create_program_artifacts` symbol is in
+   `_ttnncpp.so`, but **no test can select it, so its correctness is unverified by construction** —
+   including its op-owned-tensor allocation and its hardcoded resnet core split
+   (`split_across_cores`, `:27-159`). *Owner: the pad op owners.* Either wire it into
+   `select_program_factory` behind something a test can reach, or delete it; leaving it is 433 lines
+   of code no CI signal covers.
+2. **`get_vararg()` is read-only, and two kernels need to write back into their vararg block.**
+   `reader_pad_tiled.cpp` / `writer_pad_tiled.cpp` walk four `num_dims`-long RTA blocks, and
+   `advance_tensor_index` (`device/kernels/dataflow/common.hpp:12-19`) **mutates two of them in
+   place** — the legacy kernels used the RTA buffer as scratch. Metal 2.0's vararg API exposes
+   `get_vararg(i)` (a value getter, `genfiles.cpp:354`) and no address form, so there is no way to
+   write a vararg back. The port copies the two mutable blocks into local `uint32_t[num_dims]`
+   arrays at kernel entry (`num_dims` is a CTA, so these are fixed-size) and leaves the two
+   read-only blocks as direct `get_vararg` reads; `common.hpp`'s signature drops its
+   `volatile tt_l1_ptr` qualifiers accordingly. That is the only place in this port where a value
+   changes *where it lives* rather than *how it is named*, and it is forced by the API.
+   *Owner: the Metal 2.0 API team.* A `get_vararg_addr(i)` — or the planned `std::array` typed
+   arguments, which would make the whole question moot — would remove the need.
+3. **A kernel's vararg count is per-`KernelSpec`, not per-node, unless you use a deprecated field.**
+   `reader_pad_dims_rm_sharded.cpp`'s gather plan is genuinely different lengths on different cores
+   (it grows with the number of source cores and coalesced chunks that core reads from), and
+   `SetProgramRunArgs` enforces `args.size() == expected_varargs` exactly
+   (`program_run_args.cpp:189-195`). The only exact-fit API is
+   `KernelAdvancedOptions::num_runtime_varargs_per_node`, which is `[[deprecated]]` and documented
+   as "truly bizarre… will be removed". The port instead declares the **maximum** block length and
+   zero-fills shorter cores (`pad_rm_sharded_height_only_program_factory.cpp`, the
+   `num_reader_varargs` computation): the kernel walks the block using counts it reads out of the
+   block itself, so the zero tail is never read. Behaviour is identical; the cost is a few extra
+   zero words of dispatch traffic on cores whose gather plan is shorter than the longest.
+   *Owner: the Metal 2.0 API team* — a non-deprecated way to express a ragged per-node vararg block
+   would let this be exact rather than padded.
+
+## Successes
+
+- **[CB endpoints → self-loop / 1P+1C](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-two-toucher-dfb--assign-1p1c-dual-instance-work-split)
+  fired correctly on `out_shard` (legacy `c_16`) in `PadRmShardedHeightOnlyProgramFactory`.** The
+  writer's only touch of that buffer is a bare `get_write_ptr()` at
+  `device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp:90` — no FIFO op, invisible to a
+  producer/consumer trace, and easy to read as "the writer doesn't use this buffer". The brief and
+  the catalog both insisted the writer must still be *bound*; the independent census agreed, and the
+  1P+1C assignment (reader PRODUCER, writer CONSUMER) validated first time. Had the writer been left
+  unbound, the failure would have been a build-time unbound-DFB reference rather than anything
+  numerical.
+- **[Conditional / optional DFB bindings](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-conditional--optional-dfb-bindings)
+  caught the `if constexpr` trap before it cost a build.** `pad_align` (legacy `c_2`) in
+  `PadRmReaderWriterMultiCoreDefaultProgramFactory` is host-allocated only under
+  `stick_size_padded_front != 0 || unaligned`, but the legacy kernel constructed the buffer and
+  called `get_read_ptr()` **unconditionally** (`reader_pad_dims_rm_interleaved_v2.cpp:93,99`
+  pre-port), gating only the *uses* behind `if constexpr`. The pattern's "`if constexpr` does not
+  suppress `dfb::` name lookup" warning is exactly right, and it applies to the discarded `if
+  constexpr` **branches** too, not just the construction — so the `#ifdef PAD_ALIGN_DFB` gate had to
+  wrap the whole `if constexpr` chain (splicing in `} else` before `#endif` so the plain path stays
+  a single block). Both preprocessor branches were then confirmed to have actually compiled and run:
+  the JIT cache holds **49 variants of that reader with `dfb::pad_align` bound and 323 without**.
+- **[Porting a shared kernel, rung 1](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#caution-porting-a-shared-kernel)
+  and the locational fork test both paid off.** `PadTileCoreProgramFactory` borrows
+  `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp`, which already has a
+  `_metal2` fork beside it. The brief's trap warning was live: a *second*, differently-named fork of
+  the same kernel sits at
+  `copy/typecast/device/kernels/dataflow/reader_unary_interleaved_start_id_metal2.cpp` with
+  vocabulary `tensor::input`. The locational test (same stem + `_metal2`, **same directory as the
+  original**) selects the `eltwise/unary` one, whose vocabulary is `tensor::src` — so the factory was
+  written to `tensor::src` / `dfb::in` / `args::num_pages` / `args::start_id`. No new fork, no edit
+  to either the original or the fork.
+- **The [`constexpr` metadata rule](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/cb_dfb_api_whitelist.md)
+  resolved cleanly by reading the legacy declaration.** `writer_unary_pad_dims_interleaved.cpp:28`
+  reads `get_tile_size(cb_id_out0)` into a **non-`constexpr`** `const uint32_t`, so it becomes the
+  member getter `dfb_out0.get_tile_size()` — no token form needed, no `constexpr` demoted.
+- **[Unity-build hygiene](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-unity-build-hygiene-for-anonymous-namespace-symbols)
+  was load-bearing here, not theoretical.** Seven factory `.cpp`s land in one
+  `ttnn_op_data_movement` unity TU; without the per-factory prefixes (`RM_SC_`, `RM_MC_`, `RM_DEF_`,
+  `SH_H_`, `SH_W_`, `TILE_SC_`, `TILE_MC_`) all seven `READER` / `WRITER` / `IN0` / `PAD` /
+  `INPUT` / `OUTPUT` constants would have collided in the merged anonymous namespace.
+- **The recipe's "run the baseline before the first kernel edit" rule was the right sequencing.**
+  Because host-side edits are safe during a test run but kernel edits are not, the port ran as:
+  build → baseline (kernels frozen, host-side factories rewritten in parallel) → kernels → build →
+  verify. Nothing was blocked, and the baseline measured the true pre-port tree.
+
+## Friction
+
+### Gaps
+
+1. **The recipe has no verdict for "the legacy CB was allocated on nodes no kernel runs on."** Both
+   sharded factories give their `CBDescriptor`s `core_ranges = total_cores` — the *entire* compute
+   grid — while their kernels run on `all_cores_padded` only
+   (`pad_rm_sharded_height_only_program_factory.cpp:288,303,318` and
+   `pad_rm_sharded_width_only_program_factory.cpp:69,85,100`, pre-port). Metal 2.0 **derives** DFB
+   placement from kernel bindings and `DataflowBufferSpec` has no `target_nodes` by design, so the
+   ported `pad` DFB is allocated only where a kernel binds it. That is a real (if benign, and
+   strictly smaller) L1-footprint change that the port cannot avoid or express otherwise. The
+   [migration guide's](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/migration_guide.md#dataflowbufferspec)
+   "placement is derived, not specified" note explains the mechanism but doesn't say what to do when
+   the legacy `core_ranges` was *wider* than the bindings — which reads, to a porter mid-diff, like
+   a behavior change they are not entitled to make. A sentence saying "a legacy CB allocated beyond
+   its kernels' nodes narrows to the binding set; this is expected and is a footprint reduction"
+   would have saved a re-read of the whole DFB section.
+2. **Nothing in the recipe or the catalog says what to do about a kernel helper that constructs its
+   own `DataflowBuffer` from a CB id passed as a parameter.** Three kernels have one —
+   `fill_pad_cb_with_val` (`reader_pad_dims_rm_interleaved_v2.cpp:16`), `fill_pad_cb_with_val` /
+   `fill_pad_cb_with_zero` (`writer_pad_dims_rm_sharded.cpp:13,40`), and
+   `fill_cb_with_padding_value` (`writer_pad_dims_rm_sharded_stickwise.cpp:19`) — each taking
+   `const uint32_t cb_id` and building a **second** `DataflowBuffer` for a buffer the caller already
+   holds an object for. `dfb::name` converts implicitly to `uint32_t`, so the *laziest* port
+   compiles and runs: pass the token, let the helper build its own object. That is exactly what
+   [Same-FIFO aliasing](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/shared/port_patterns.md#pattern-same-fifo-aliasing-one-dfb-multiple-kernel-side-names)
+   forbids ("don't construct two `DataflowBuffer` objects from the same `DFBAccessor`… device-side
+   debug tooling depends on the object↔DFB identity"), but that entry is filed under *aliasing*, so
+   a porter looking for guidance on a *helper signature* will not find it. The port changed each
+   helper's parameter to `DataflowBuffer&`. Suggest a line in
+   [kernel-side whitelist rule 1](../../../../../../docs/source/tt-metalium/tt_metal/apis/host_apis/metal_2.0/ai/port/metal2_port.md#kernel-side-whitelist):
+   *a file-local helper taking a `uint32_t cb_id` and constructing a CB from it takes the caller's
+   `DataflowBuffer&` instead — passing `dfb::name` into it is the shim used where it does not belong.*
+3. **The dead-argument rule is stated for CBs and CTAs but not for RTAs, and this op needed it for
+   both.** The recipe covers a **dead CB** (drop it, plus the dead CTA carrying its index) and the
+   brief instructs dropping the v1 RM kernels' unread RTA slots ("give each kernel only the args it
+   actually reads"), but neither states the general rule, so each of the eight sites had to be
+   argued from first principles. What the port settled on, consistently: **an argument no kernel
+   reads gets no name and is not emitted** — a CTA nothing reads is a compile-time constant with no
+   effect, and an unread RTA slot is a word nothing loads, so both drops are zero-functional-change.
+   Full list under Open items. A one-line statement of that rule beside the dead-CB paragraph would
+   make it a lookup instead of a derivation.
+
+### Confusion
+
+4. **The brief's dead-RTA list for the v1 RM reader is one slot short.** It names reader slots 3
+   (`num_total_W`), 7 (`num_total_Y`), 18 (`start_src_stick_wi`), 23 (`full_unpadded_X_nbytes`).
+   The census adds **slot 6, `num_unpadded_Y`** — declared at
+   `device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp:46` (pre-port) and never referenced;
+   the padding test at `:87` uses `num_local_unpadded_Y` (slot 22), whose name is one word longer.
+   Following the brief rather than a per-variable census would have left a named arg for a value
+   nothing reads. Recorded per the recipe's "re-derive, don't transcribe" instruction — which is
+   written about *endpoint dispositions* but turns out to apply just as well to the brief's argument
+   inventories.
+5. **Both `writer_rt_args = reader_rt_args` factories hide how much of the arg list is dead.** With
+   the two kernels handed identical 27-slot lists, "which args does this kernel read?" cannot be
+   answered from the host side at all; it takes a per-variable grep of each kernel. The brief warned
+   about this and was right to. Post-port the reader takes 12 named args and the writer 6 — 18
+   between them instead of 54 slots pushed twice.
+
+## Open items for downstream
+
+### Findings the port deliberately preserved (bugs and oddities, not fixed)
+
+1. **`PadTileCoreProgramFactory` packs a FLOAT32 pad value as two bfloat16s.**
+   `device/pad_tile_program_factory.cpp` has cases for `INT32`/`UINT32` and `UINT16` and falls
+   through to `pack_two_bfloat16_into_uint32` for everything else — including `FLOAT32`, which
+   `pad_device_operation.cpp:157-161` explicitly admits. Measured on device: padding a FLOAT32 TILE
+   tensor with `value=7.0` fills the pad region with **7.0079193115234375** (= `0x40E040E0`, the
+   bf16 pair read back as a float32), and with `value=-3.0` gives **-3.0117**. Data is copied
+   correctly; only the pad value is wrong, and only for FLOAT32. **This is pre-existing** — the
+   packing block is byte-identical before and after the port (verified against the merge base) —
+   and the port preserved it per the scope discipline. The sibling
+   `pad_tile_multicore_program_factory.cpp` has the correct case
+   (`case DataType::FLOAT32: packed_pad_value = std::bit_cast<uint32_t>(pad_value);`), so the fix is
+   to copy that one line across. No test catches it because no test reaches this factory (item 5).
+2. **`reader_pad_dims_rm_interleaved.cpp:52` hardcodes `pad_value_const_buffer_nbytes = 64`** with a
+   *"fails on BH when > 64"* comment (issue #21978), while the host computed and passed the real
+   value at RTA slot 14. The hardcode is preserved verbatim; the arg it shadowed simply gets no name
+   now, so the host no longer computes a value nothing reads.
+3. **`pad_tile_multicore_program_factory.cpp:194-197` divides both trailing dims by `TILE_HEIGHT`,**
+   never `TILE_WIDTH`. Benign while both are 32, latent otherwise. Untouched.
+4. **`split_across_cores` has ~30 lines of unreachable code after a `TT_THROW`**
+   (`pad_rm_reader_writer_multi_core_program_factory.cpp:97-131`), including a second `TT_THROW` and
+   commented-out assignments. Untouched — it belongs to the unreachable factory (Handoff 1).
+
+### Test coverage
+
+5. **`PadTileCoreProgramFactory` (TILE, `use_multicore=False`) is not reached by any test in the
+   confirmed set** — and was not before the port either. `test_pad_op`
+   (`tests/ttnn/unit_tests/operations/data_movement/test_pad.py:603-612`) *does* parametrize
+   `TILE_LAYOUT × use_multicore=False`, but its shapes (`[1,1,18,13]` → `[1,1,32,32]`) are already
+   tile-aligned, so `invoke_tile` (`pad.cpp:478-480`) takes the `ttnn::experimental::view` fast path
+   and never reaches `prim::pad`. Confirmed empirically: after the full test run the JIT cache held
+   **zero** variants of `writer_unary_pad_dims_interleaved`, while every other pad kernel had
+   post-port variants. The port verified this factory with an ad-hoc script instead — TILE input
+   with a real tile-dim change and `use_multicore=False`, across bfloat16 / float32 / uint32, plus
+   three program-cache-hit iterations; everything passed except the pre-existing FLOAT32 pad-value
+   bug in item 1. **A test that pads a TILE tensor across a tile boundary with `use_multicore=False`
+   (e.g. `[1,1,32,32]` → `[1,1,64,64]`) would close the gap**, and would have caught item 1 years
+   ago.
+6. **The op-owned-tensor path is exercised only by the single-core RM factory here.** Its sibling
+   (`PadRmReaderWriterMultiCoreProgramFactory`) carries the same allocation but is unreachable, so
+   the two factories' op-owned handling has one live test subject between them.
+
+### Shared kernel touches
+
+7. **Borrowed, rung 1 — reused an existing fork; no new file created.**
+   - Kernel path:
+     `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp`
+   - Rung taken: **reused the existing `_metal2` fork**,
+     `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id_metal2.cpp`
+     (same directory as the original). No new file; neither the original nor the fork was edited, and
+     no pointer comment was added (the original already has one, and rung 1 forbids touching it).
+   - Adopted vocabulary: `dfb::in`, `tensor::src`, `args::num_pages`, `args::start_id`. `pad` defines
+     no `BACKWARDS`, the fork's only `#ifdef`.
+   - **Remaining unmigrated consumers of the legacy original** (the sunset checklist — the legacy copy
+     can be deleted when the last of these migrates; `data_movement/pad` is now off the list):
+     `data_movement/untilize_with_unpadding` (`untilize_with_unpadding_multi_core_interleaved_program_factory.cpp`,
+     `untilize_with_unpadding_single_core_program_factory.cpp`) · `examples/example`
+     (`multi_core_program_factory.cpp`, `single_core_program_factory.cpp`) ·
+     `examples/example_multiple_return` (`single_core_program_factory.cpp`) ·
+     `experimental/transformer/nlp_create_qkv_heads_falcon7b`
+     (`nlp_create_qkv_heads_falcon7b_program_factory.cpp`) · `reduction/topk`
+     (`topk_route_prep_program_factory.cpp`) · plus
+     `tests/ttnn/unit_tests/gtests/test_generic_op.cpp` and
+     `tests/ttnn/unit_tests/operations/debug/test_generic_op.py`.
+8. **Intra-op, converted in place — no fork needed.**
+   `device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp` and
+   `writer_pad_dims_rm_interleaved.cpp` are bound by **two** of this op's factories
+   (`PadRmReaderWriterProgramFactory` and `PadRmReaderWriterMultiCoreProgramFactory`), and **both
+   converted in this change**, so the shared-kernel Caution resolved without a fork. Their named-arg
+   set is now a shared contract between those two factories: reader takes
+   `num_unpadded_W, num_unpadded_Z, num_total_Z, unpadded_X_nbytes, padded_X_nbytes,
+   padded_X_diff_nbytes, pad_value_packed, start_src_stick_id, start_src_stick_offset, num_local_Y,
+   num_local_unpadded_Y, num_local_W`; writer takes `num_total_Z, padded_X_nbytes,
+   start_dst_stick_id, num_local_Y, dst_stick_offset, num_local_W`. A future change to either
+   factory must keep both in step.
+   The census found **no *lent* kernel**: every other source under `device/kernels/dataflow/` is
+   bound by exactly one pad factory, and `device/kernels/dataflow/common.hpp` is included relatively
+   by the two tiled kernels only.
+
+### Dead arguments dropped (each a zero-functional-change drop; recorded per the recipe)
+
+9. Nothing below is read by any kernel, so none was given a name or emitted. `file:line` refers to
+   the **pre-port** revision.
+   - **v1 RM reader RTAs** (`pad_rm_reader_writer_program_factory.cpp:141-169`,
+     `..._multi_core_program_factory.cpp:346-374`): slot 3 `num_total_W`, slot 6 `num_unpadded_Y`,
+     slot 7 `num_total_Y`, slot 14 `pad_value_const_buffer_nbytes`, slot 18 `start_src_stick_wi`,
+     slot 23 `full_unpadded_X_nbytes`.
+   - **v1 RM writer RTAs**: slots 3, 7, 9 `num_total_X`, 19 `start_dst_stick_wi` (and its dead local
+     `dst_stick_wi`), 22 `num_local_unpadded_Y`, 24 `full_padded_X_nbytes` — plus every reader-only
+     slot, since `writer_rt_args = reader_rt_args` (`:172` / `:385`) no longer holds.
+   - **v1 RM reader + writer CTAs** (`:81-85` / `:245-249`): slots 0 and 1
+     (`unpadded_row_size_nbytes`, `padded_row_size_nbytes`). Neither kernel contains a single
+     `get_compile_time_arg_val` call; the slots existed only to offset the `TensorAccessorArgs<2>()`
+     chain, and the writer's copy of the pad-value tensor's accessor args was never instantiated.
+   - **RM default reader CTAs** (`..._default_program_factory.cpp:141-163`): slot 9
+     `stick_size_padded_end`, 10 `num_zero_pad_sticks_read`, 11 `last_zero_stick_size` (all three
+     declared in the kernel and never used), and 14-17 (`row_major_min_bytes` and its three
+     quotients — never even declared kernel-side).
+   - **Sharded width-only** (`..._width_only_program_factory.cpp:134-152`): reader CTA 1
+     `padded_stick_bytes`, reader CTA 3 `padded_shard_height`, writer CTA 6 `padded_stick_step`.
+   - **Tile multicore** (`pad_tile_multicore_program_factory.cpp:125`): writer CTA 1
+     `output_cb_index` — the dead CTA that accompanies the dead CB below.
+10. **Dead CB dropped:** legacy `c_1` in `PadTileMulticoreProgramFactory`, allocated at
+    `pad_tile_multicore_program_factory.cpp:70-78` (`page_size * multi_buffering_size` bytes per
+    core) with **zero touchers in every config**; its index reached
+    `device/kernels/dataflow/writer_pad_tiled.cpp:23` as `output_cb_id` and was never read again.
+    Both the allocation and the CTA are gone. Net effect: `2 × page_size` bytes of L1 recovered per
+    core, and nothing else.
+
+### Other
+
+11. **A pre-existing `.md` citation survives in a ported kernel.**
+    `device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp:99` cites
+    `WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`. The self-audit's "no ephemeral doc cited
+    from code" sweep flags it because the sweep is scoped by the diff and the port touched that
+    file. It is **not** a port artifact (present verbatim at the merge base, line 105) and **not** a
+    tt-metal repo-relative path — it names a document in the tt-isa-documentation repo, so it does
+    not dangle the way an in-repo path would. Left alone as out of scope; recorded so the next
+    porter of this file does not re-adjudicate it.
+12. **Per-op carry-over.** `data_movement/untilize_with_unpadding` binds the same `eltwise/unary`
+    reader and will reach rung 1 on the same fork; its porter inherits the `dfb::in` / `tensor::src`
+    vocabulary recorded in item 7.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PREPORT_AUDIT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/METAL2_PREPORT_AUDIT.md
@@ -1,0 +1,607 @@
+# Metal 2.0 Audit Findings — `ttnn/cpp/ttnn/operations/data_movement/pad`
+
+One device operation, seven program factories, all declared in the `program_factory_t` variant of
+`device/pad_device_operation.hpp:32`:
+
+- **`PadDeviceOperation`** (`device/pad_device_operation.{hpp,cpp}`)
+  - `PadRmReaderWriterProgramFactory` (`pad_rm_reader_writer_program_factory.cpp`) — RM, single core, `create_workload_descriptor`
+  - `PadRmReaderWriterMultiCoreProgramFactory` (`pad_rm_reader_writer_multi_core_program_factory.cpp`) — RM, multicore, `create_workload_descriptor` — **unreachable**: never returned by `select_program_factory` (see *Misc anomalies*)
+  - `PadRmReaderWriterMultiCoreDefaultProgramFactory` (`pad_rm_reader_writer_multi_core_default_program_factory.cpp`) — RM, multicore, the default RM path
+  - `PadRmShardedHeightOnlyProgramFactory` (`pad_rm_sharded_height_only_program_factory.cpp`) — RM height-sharded, optimized
+  - `PadRmShardedWidthOnlyProgramFactory` (`pad_rm_sharded_width_only_program_factory.cpp`) — RM width-pad, sharded stickwise
+  - `PadTileCoreProgramFactory` (`pad_tile_program_factory.cpp`) — TILE, single core
+  - `PadTileMulticoreProgramFactory` (`pad_tile_multicore_program_factory.cpp`) — TILE, multicore
+
+All 12 kernel files under `device/kernels/dataflow/` are referenced by at least one factory; none is
+dead code. One kernel is instantiated from outside the op directory
+(`eltwise/unary/.../reader_unary_interleaved_start_id.cpp`, by `PadTileCoreProgramFactory`).
+
+> **`ttnn/cpp/ttnn/operations/experimental/quasar/pad/` exists and is out of bounds.** It is a
+> whole-op shortcut copy, not a precedent. Nothing in it was read for this audit, and the porter
+> should not read it either — in particular its `_metal2` kernels do **not** count as forks to reuse.
+
+**Scope:** TTNN op, Gen1 (WH/BH) target — within scope of `metal2_audit.md`.
+
+**Recipe docs:** `64668f470e4 2026-08-24 docs(metal_2.0): a run in flight freezes the kernel sources`
+
+**Readiness sheet:** fetched live this session (7 rows for `data_movement/pad`, one per factory).
+
+## Status summary
+
+| Field | Value |
+|---|---|
+| **Op directory** | `ttnn/cpp/ttnn/operations/data_movement/pad` |
+| **Overall** | **GREEN** — all seven factories cleared. One readiness-sheet cell is **outdated** and is overridden here on code evidence; see *Result*. |
+| **DOps / Factories** | `PadDeviceOperation` → 7 factories (listed above) |
+| *Prereqs* — Device 2.0 (every kernel used) | **Yes** — all 12 op kernels + the one donor kernel are structurally Device 2.0 (`Noc`, `DataflowBuffer`, `TensorAccessor`, `CoreLocalMem`). No holdovers. |
+| *Prereqs* — Cross-op escapes | Ok — one in-family header (`data_movement/common/kernels/common.hpp`, Shape 1) and one borrowed kernel file with an existing `_metal2` fork |
+| *Feature Support* — overall | **GREEN** — every Appendix A entry `N/A` |
+| *Feature Support* — Variadic-CTA | Ok (not an Appendix A entry; no varying-index CTA reads found either) |
+| *TTNN Readiness* — `Is able to port?` (the gate) | **6 × `yes`** · 1 × `no` (`PadRmShardedHeightOnlyProgramFactory`) — **the `no` is outdated and is overridden here.** It is derived from two cells the code contradicts, both fixed by PR #52556 five days before this audit. Cleared on code evidence; the sheet row still needs correcting. |
+| *TTNN Readiness* — Concept (current) | `descriptor` × 5 · `WorkloadDescriptor` × 2 (`PadRmReaderWriter*`) — cross-check ✓ |
+| *TTNN Readiness* — Secretly SPMD (WorkloadDescriptor only) | Yes on both `WorkloadDescriptor` rows (`Why secretly SPMD? = "Op-owned tensors"`) — cross-check ✓ with one nuance, see *Gate detail* |
+| *TTNN Readiness* — Custom hash | No (sheet: `no` × 7; grep for `compute_program_hash` in the op: zero hits) ✓ |
+| *TTNN Readiness* — `get_dynamic_runtime_args` | **No.** Sheet says `yes` on `PadRmShardedHeightOnlyProgramFactory`; the hook does not exist anywhere in the op. **Sheet outdated** — removed by PR #52556. |
+| *TTNN Readiness* — `override_runtime_arguments` | **Yes, on one factory** — `device/pad_rm_sharded_height_only_program_factory.cpp:412` (declared `.hpp:22`). Sheet says `no` × 7. **Sheet outdated** — added by PR #52556. Not a gate: it selects `CustomProgramSpecFactoryConcept`. |
+| *TTNN Readiness* — Pybind `create_descriptor` | No — `pad_nanobind.cpp` binds only `ttnn::pad` overloads; no `nb::class_` of the device op ✓ |
+| *TTNN Readiness* — Op-owned tensors | **Yes** on the two `WorkloadDescriptor` factories: the pad-value const tensor parked on `WorkloadDescriptor::buffers` (`pad_rm_reader_writer_program_factory.cpp:200`, `pad_rm_reader_writer_multi_core_program_factory.cpp:419`) ✓ |
+| *TTNN Readiness* — Target concept | `ProgramSpecFactoryConcept` × 6 (two of them carrying op-owned tensors) · `CustomProgramSpecFactoryConcept` × 1 (the height-only factory, per the code — the sheet has not recorded its `override_runtime_arguments` yet) |
+| *Port work* — Offset base pointer | **none** — no address RTA anywhere folds a host-side offset into its base |
+| *Port work* — Tensor bindings (per binding) | Case 1 × 12 · clean (borrowed DFB) × 4 · **no Case 2** |
+| *TTNN Readiness* — TensorParameter relaxation | `none` on all 7 rows → clears |
+| *Port work* — TensorAccessor 3rd arg | 2 sites, both **Class 2** (redundant) → drop |
+| *Port work* — CB endpoints | legal × 5 · self-loop × 7 · 1P+1C × 1 · **dead-CB drop × 1** · **conditional DFB × 1** |
+
+**CB endpoints** are dispositions, not gates: every out-of-window CB below has a port-time
+resolution. Recorded per `(CB, config)` in the *Gate detail* section.
+
+## Result
+
+**GREEN → brief issued for all seven factories.** Device 2.0, Appendix A feature compatibility,
+offset base pointers, the TensorAccessor 3rd argument, and the `TensorParameter` relaxation column
+all clear cleanly for every factory. The port can begin.
+
+**One readiness-sheet cell is outdated and is overridden here.**
+`PadRmShardedHeightOnlyProgramFactory`'s row reads `Is able to port? = no`, derived from
+`Runtime-args update (get_dynamic_runtime_args) = yes`. **The code contradicts that cell, and so does
+`Override runtime args method? (PD only) = no`.** PR **#52556** (`90ec10f4bf4`, merged to `main`
+2026-08-19, five days before this audit) — *"[ttnn] pad: replace get_dynamic_runtime_args with a
+factory override_runtime_arguments"* — removed the deprecated hook and replaced it with an
+`override_runtime_arguments` that re-points only the two sharded CB base addresses. The sheet's row
+still describes the pre-#52556 state; its `Diego validation = no`, `Op Classification = "Broken Op"`
+and `Porting Target = "(N/A)"` cells are all downstream of the same lag.
+
+Because the blocking column is factually wrong on a cheaply-verifiable point, and every gate this
+audit checks independently clears for that factory, **the verdict is recorded as GREEN on the code
+evidence** rather than on the stale cell. The factory's target concept is
+`CustomProgramSpecFactoryConcept` (per the `override_runtime_arguments` the sheet has not yet
+recorded), and it is included in the porter brief.
+
+**Still to do, but not a blocker:** the readiness-sheet owner should correct the row —
+`Runtime-args update (get_dynamic_runtime_args)` → `no`, `Override runtime args method? (PD only)` →
+`yes`, citing #52556 / `90ec10f4bf4`. Leaving it stale will mislead the next reader of that row (the
+port tracker and any other consumer), independently of this port.
+
+**Reader's caveat on the override.** `Is able to port?` is a derived cell whose formula this audit
+cannot see, so a `no` can in principle encode a consideration outside the audit's view. Here the one
+visible input to it is demonstrably wrong, and the row also carries `Diego validation = no` (never
+validated). The GREEN therefore rests on this audit's own gate-by-gate evidence for that factory —
+Device 2.0 ✓, no Appendix A features, no offset folds, no `TensorAccessor` 3rd-arg sites, CB
+endpoints all resolvable (self-loop ×2 + 1P+1C), relaxation `none` — not on a reconciled sheet.
+
+**Subject coverage.** All twelve subjects were run in full for all seven factories; nothing was
+skipped or deferred.
+
+## Gate detail
+
+- **TTNN factory concept (`Is able to port?`):** **GREEN for all seven** — six rows read `yes`; the
+  seventh reads `no` on an **outdated** cell that is overridden here (see *Result*). Per-factory
+  verdicts and the full cross-check:
+
+  | Factory (sheet row) | `Concept` | `Is able to port?` | Cross-check |
+  |---|---|---|---|
+  | `PadRmReaderWriterMultiCoreDefaultProgramFactory` | `descriptor` | `yes` | ✓ `create_descriptor` at `..._default_program_factory.cpp:32` |
+  | `PadRmReaderWriterMultiCoreProgramFactory` | `WorkloadDescriptor` | `yes` | ✓ `create_workload_descriptor` at `..._multi_core_program_factory.cpp:404`; `Op-owned tensors? = yes` ✓ (`wd.buffers` @ `:419`) |
+  | `PadRmReaderWriterProgramFactory` | `WorkloadDescriptor` | `yes` | ✓ `create_workload_descriptor` at `..._program_factory.cpp:185`; `Op-owned tensors? = yes` ✓ (`wd.buffers` @ `:200`) |
+  | **`PadRmShardedHeightOnlyProgramFactory`** | `descriptor` | `no` → **overridden, sheet outdated** | ✓ `create_descriptor` at `..._height_only_program_factory.cpp:195`; **two cells stale** — see below |
+  | `PadRmShardedWidthOnlyProgramFactory` | `descriptor` | `yes` | ✓ `create_descriptor` at `..._width_only_program_factory.cpp:20` |
+  | `PadTileCoreProgramFactory` | `descriptor` | `yes` | ✓ `create_descriptor` at `pad_tile_program_factory.cpp:18` |
+  | `PadTileMulticoreProgramFactory` | `descriptor` | `yes` | ✓ `create_descriptor` at `pad_tile_multicore_program_factory.cpp:31` |
+
+  **The two outdated cells** (both cheaply-checkable primary columns, both on the same row, both
+  fixed by PR #52556):
+
+  | Column | Sheet value (stale) | Code evidence (current) |
+  |---|---|---|
+  | `Runtime-args update (get_dynamic_runtime_args)` | `yes` | **Absent.** `grep -rn "get_dynamic_runtime_args" ttnn/cpp/ttnn/operations/data_movement/pad/` returns only a *comment* referencing its removal (`pad_rm_sharded_height_only_program_factory.hpp:21`: *"Replaces get_dynamic_runtime_args (#48928)"*). No hook on `PadDeviceOperation` (`device/pad_device_operation.hpp:41-52`). |
+  | `Override runtime args method? (PD only)` | `no` | **Present.** `void PadRmShardedHeightOnlyProgramFactory::override_runtime_arguments(...)` at `device/pad_rm_sharded_height_only_program_factory.cpp:412`, declared at `.hpp:22`. It rebuilds a CB-address-only `ProgramDescriptor` and calls `apply_descriptor_runtime_args`. |
+
+  The two are enforced mutually exclusive at the device-op level, and the code satisfies that
+  (exactly one of them exists); it is the *sheet* that carries the older of the two states — it
+  records the hook that was removed and misses the method that replaced it, which is exactly the
+  signature of a row written before #52556 landed. The cross-column invariants hold on every row (`get_dynamic_runtime_args` only on a `descriptor`
+  concept; `Op-owned tensors? = yes` only on `WorkloadDescriptor` rows). **Factory-set match: ✓** —
+  all 7 code factories have a row and all 7 sheet rows map to a live factory; no phantom, no missing.
+
+  *Nuance on `Secretly SPMD Workload? = yes`* (recorded, not a conflict). The recipe's code basis is
+  "a single entry in the `programs` vector." Both `WorkloadDescriptor` factories actually push **one
+  entry per range in `tensor_coords`** (`pad_rm_reader_writer_program_factory.cpp:205-211`,
+  `..._multi_core_program_factory.cpp:423-429`) — but every entry carries the *identical*
+  `ProgramDescriptor`, built once above the loop. That is SPMD in substance, and it collapses to the
+  single-program concept; the sheet's `yes` is right. Flagged as recipe friction below.
+
+- **Device 2.0 (every kernel used):** **GREEN.** Every kernel the op exercises is structurally
+  Device 2.0 — `Noc`, `DataflowBuffer` objects, `TensorAccessor`, `CoreLocalMem`, `UnicastEndpoint`.
+  No `InterleavedAddrGen` / `ShardedAddrGen` / raw `noc_async_*` / `cb_reserve_back` family anywhere.
+  Every `get_write_ptr()` / `get_read_ptr()` in the tree is a **method on a `DataflowBuffer`
+  instance**, not a CB-index free function — so there are no isolated holdovers either.
+
+  The only CB-index free-function calls in scope are both on the **sanctioned** list and are
+  therefore *not* violations:
+
+  | File | Line | Call | Wrapper in scope | Verdict |
+  |---|---|---|---|---|
+  | `device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp` | 28 | `get_tile_size(cb_id_out0)` | `DataflowBuffer dfb_out0` (line 32) | sanctioned — not a holdover |
+  | `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp` (donor) | 25 | `get_local_cb_interface(cb_id_in0).fifo_page_size` | `DataflowBuffer dfb` (line 33) | sanctioned — not a holdover |
+
+  Both become member lookups at *port* time (kernel-side whitelist rule 7) — a port-stage change, not
+  a Device 2.0 one. Note that for the donor the existing `_metal2` fork has already made that move
+  (`dfb.get_entry_size()`), so the porter inherits it rather than performing it.
+
+  The op owns no compute kernels — every `KernelDescriptor` in all seven factories carries a
+  `ReaderConfigDescriptor` or `WriterConfigDescriptor`. (Consequence for the port: the compute
+  `opt_level` question does not arise for this op.)
+
+- **Feature compatibility:** every Appendix A entry scanned against host code, factory code,
+  descriptors and kernels. All absent.
+
+  | Feature | Status | Notes |
+  |---|---|---|
+  | GlobalCircularBuffer | N/A | No `GlobalCircularBuffer` type, no `CreateGlobalCircularBuffer`, no `CBDescriptor::global_circular_buffer` field set, no `remote_cb_*` / `.remote_index(` / `remote_circular_buffer.h` idiom. Grep over the whole op directory: zero hits on every signal. |
+  | CBDescriptor `address_offset` (non-zero) | N/A | No `.address_offset`, no `set_address_offset`, no 4-arg `UpdateDynamicCircularBufferAddress`, no `cb_descriptor_from_sharded_tensor`. Zero hits. The two borrowed-memory CBs bind at base (`cb.buffer = src_buffer` / `dst_buffer`) with no offset field at all. |
+  | GlobalSemaphore | N/A | The op uses **no semaphores of any kind** — `grep -rn "[Ss]emaphore"` over the op directory returns zero hits. |
+
+- **CB endpoints (GATE-free):** censused per `(factory, CB, config)`, per node. All Device 2.0
+  idioms intact, so the scan is reliable (no deferral).
+
+  | Factory | CB | Touchers on a node | Verdict | Port-time resolution |
+  |---|---|---|---|---|
+  | `PadRmReaderWriterProgramFactory` | `c_0` | reader locked-producer (`reserve_back`/`push_back`, `reader_pad_dims_rm_interleaved.cpp:85,112`) + writer locked-consumer (`wait_front`/`pop_front`, `writer_pad_dims_rm_interleaved.cpp:41,50`) | plain 1:1 | legal — no action |
+  | `PadRmReaderWriterMultiCoreProgramFactory` | `c_0` | same two kernels, same roles | plain 1:1 | legal — no action |
+  | `PadRmReaderWriterMultiCoreDefaultProgramFactory` | `c_0` | reader locked-producer (`reader_..._v2.cpp:114,170`) + writer locked-consumer (`writer_..._v2.cpp:31,60`) | plain 1:1 | legal — no action |
+  | ″ | `c_1` (`cb_pad`) | reader only — local-DFB `get_write_ptr` (`reader_..._v2.cpp:19`) + `get_read_ptr` (`:98`); the writer never touches it | 1 toucher | **self-loop** |
+  | ″ | `c_2` (`dfb_pad_align`) | reader only (`:99`, `:134`, `:139`, `:142`) | 1 toucher **but config-dependent allocation** | **conditional DFB** — see the callout below |
+  | `PadRmShardedHeightOnlyProgramFactory` | `c_0` (borrowed ← input) | reader raw peek only, `get_write_ptr` (`reader_pad_dims_rm_sharded.cpp:32`) | 1 toucher, role-free | **self-loop** (+ `borrowed_from` the input tensor) |
+  | ″ | `c_16` (borrowed ← output) | reader locked-producer (`reserve_back`/`push_back`, `:31,69`) **+** writer raw peek `get_write_ptr` (`writer_pad_dims_rm_sharded.cpp:90`) | 2 touchers, 1 locked + 1 role-free | **1P+1C** — reader PRODUCER, writer CONSUMER. **Not** multi-binding. |
+  | ″ | `c_1` (`cb_pad`) | writer only (`writer_pad_dims_rm_sharded.cpp:16,22,43,82`) | 1 toucher | **self-loop** |
+  | `PadRmShardedWidthOnlyProgramFactory` | `c_0` (borrowed ← input) | reader raw peek only (`reader_..._stickwise.cpp:29`) | 1 toucher, role-free | **self-loop** (+ `borrowed_from`) |
+  | ″ | `c_16` (borrowed ← output) | reader locked-consumer (`wait_front`/`pop_front`, `:37,55`) + writer locked-producer (`reserve_back`/`push_back`, `writer_..._stickwise.cpp:56,75`) | plain 1:1 | legal — no action (+ `borrowed_from`) |
+  | ″ | `c_1` (`padding_value_cb`) | writer only (`writer_..._stickwise.cpp:24,60`) | 1 toucher | **self-loop** |
+  | `PadTileCoreProgramFactory` | `c_0` | donor reader locked-producer (`reader_unary_interleaved_start_id.cpp:43,46`) + writer locked-consumer (`writer_unary_pad_dims_interleaved.cpp:62,66`) | plain 1:1 | legal — no action |
+  | ″ | `c_1` | writer only — `reserve_back(1)` + `get_write_ptr()`, never pushed (`writer_unary_pad_dims_interleaved.cpp:35,37`) | 1 toucher | **self-loop** |
+  | `PadTileMulticoreProgramFactory` | `c_0` | reader locked-producer (`reader_pad_tiled.cpp:54,57`) + writer locked-consumer (`writer_pad_tiled.cpp:76,81`) | plain 1:1 | legal — no action |
+  | ″ | **`c_1`** | **0 touchers** | **DEAD CB** | **drop the allocation + the dead CTA** — see the callout below |
+  | ″ | `c_2` (`pad_val`) | writer only (`writer_pad_tiled.cpp:48,49,57`) | 1 toucher | **self-loop** |
+
+  No CB anywhere in this op needs the multi-binding advanced option: no node carries ≥3 distinct
+  touchers, and no two kernels are locked to the same FIFO role. The hidden-second-writer face was
+  hunted explicitly — every raw `get_write_ptr` / `get_read_ptr` in the tree was traced to its owning
+  kernel, and the only cross-kernel raw touch is `writer_pad_dims_rm_sharded.cpp:90` on `c_16`, which
+  is a role-free peek resolvable as 1P+1C. No semaphores exist in the op, so the semaphore-gated
+  co-fill shape cannot be present.
+
+  > **Conditional DFB — `c_2` in `PadRmReaderWriterMultiCoreDefaultProgramFactory`, with a kernel-side
+  > catch.** The host allocates `c_2` **only** when `stick_size_padded_front != 0 || unaligned`
+  > (`..._default_program_factory.cpp:127-139`). The kernel, however, constructs the buffer object
+  > **unconditionally** (`reader_pad_dims_rm_interleaved_v2.cpp:90-93`) and calls
+  > `dfb_pad_align_exp.get_read_ptr()` **unconditionally** at `:99` — only the *uses* at `:134/:139/:142`
+  > sit behind `if constexpr (front_padding)` / `if constexpr (unaligned)`. Under the legacy CB model
+  > the unguarded read of an unconfigured CB is harmless (the value is never used); under Metal 2.0 a
+  > kernel may not reference a DFB it has not bound, so the port cannot simply make the spec
+  > conditional and leave the kernel alone. Report it as *dead under
+  > `stick_size_padded_front == 0 && !unaligned`, live otherwise* — **do not drop it.** Note that
+  > `if constexpr` does **not** suppress `dfb::` name lookup, so gating the kernel line needs a real
+  > preprocessor `#ifdef` paired with a host-side define, not a constexpr branch.
+
+  > **Dead CB — `c_1` in `PadTileMulticoreProgramFactory`.** Allocated at
+  > `pad_tile_multicore_program_factory.cpp:70-78` (`page_size * multi_buffering_size` bytes), and its
+  > index is threaded to the writer as compile-time arg 1. **No kernel ever touches it.** Positively
+  > confirmed: `output_cb_id` appears exactly once in the entire kernel tree — its own declaration at
+  > `writer_pad_tiled.cpp:23` — and is never read again; the reader's CTA list
+  > (`pad_tile_multicore_program_factory.cpp:116-120`) does not carry the index at all; neither tiled
+  > kernel hardcodes `tt::CBIndex::c_1` or any aliased/computed index. This factory has a single
+  > instantiation shape (the allocation is unconditional, behind no branch), so the CB is dead in
+  > *every* config. A dead CB has no behavior, so removing it changes none — and a DFB with neither a
+  > producer nor a consumer binding cannot be expressed at all. **Drop the allocation and the dead CTA,
+  > and record both `file:line` in the port report.**
+
+- **Offset base pointers:** **GREEN.** No address RTA in any factory folds a host-side offset into
+  its base. Every buffer base reaches a kernel as a bare `Buffer*` pushed into
+  `KernelDescriptor::RTArgList` (the framework's `BufferBinding` form), never as
+  `buffer->address() + <expr>`. The only `->address()` call sites in the whole op are six
+  `log_debug` arguments (`pad_rm_reader_writer_program_factory.cpp:115,116,128` — inside an `#if 0`
+  block — and `pad_rm_reader_writer_multi_core_program_factory.cpp:285,286,298`); none reaches a
+  runtime-arg context. Type 3 (`address_offset`) is absent (see the feature table). Type 4
+  (`ttnn::narrow` / interior-base `MeshBuffer::create`) is absent. `data_movement/pad` does not appear
+  in the `2026-07-19_offset_base_pointers.md` triage tables, and the scan agrees — *no fold, op not in
+  the tables* → clean. All address RTAs hand off to *TensorParameter analysis* as clean bases.
+
+- **TensorAccessor 3rd argument:** **GREEN — 2 sites, both Class 2 (redundant → drop).** Both live in
+  `PadRmReaderWriterMultiCoreDefaultProgramFactory`'s kernel pair; every other `TensorAccessor` in the
+  op is 2-arg.
+
+  | Site | Value (host) | Specialization | Class |
+  |---|---|---|---|
+  | `reader_pad_dims_rm_interleaved_v2.cpp:95` — `TensorAccessor(src_args, src_addr, accessor_page_size)` | `input_accessor_page_size`, CTA 21 (`..._default_program_factory.cpp:57,63,163`) | interleaved **or** sharded, per input | **2** |
+  | `writer_pad_dims_rm_interleaved_v2.cpp:25` — `TensorAccessor(dst_args, dst_addr, accessor_page_size)` | `output_accessor_page_size`, CTA 4 (`..._default_program_factory.cpp:68,73,171`) | interleaved **or** sharded, per output | **2** |
+
+  Resolving the two classifying questions:
+
+  1. **Sharded or interleaved?** Both. This factory serves interleaved RM *and* the sharded RM
+     fall-through (`pad_device_operation.cpp:97`), so each accessor takes whichever specialization the
+     tensor's memory config selects — which is exactly why the host branches on `is_sharded()`.
+  2. **Correct or wrong magnitude?**
+     - *Sharded branch* — the host passes `buffer->aligned_page_size()` **verbatim**
+       (`:63`, `:73`). That is literally the value Metal 2.0 supplies implicitly, so the sharded
+       specialization's verbatim use is a no-op. Class 2, sub-type (a).
+     - *Interleaved branch* — the host passes the true logical page: `stick_size = W·element_size`
+       for the input (`:47,57`) and `stick_size_padded = W_padded·element_size` for the output
+       (`:48,68`). The output value is *exactly* the output buffer's page size, since
+       `compute_output_specs` builds the output from the same `output_padded_shape`
+       (`pad_device_operation.cpp:216-223`). The interleaved accessor then realigns whatever it is
+       given — `InterleavedAddrGen::aligned_page_size = align_power_of_2(page_size, allocator_alignment)`
+       (`tt_metal/hw/inc/internal/dataflow/dataflow_api_addrgen.h:289-290`) — so a correct-magnitude
+       value is inert even before alignment. Class 2, sub-type (b).
+
+  **Not Class 1**, despite being interleaved row-major: both values are **compile-time args**, not
+  runtime args, so the page size cannot vary across shapes that reuse one compiled program (a change
+  forces a recompile). Class 1's customers carry their extents as RTAs; pad carries `N/H/C/stick_size`
+  as CTAs 0-9. The porter therefore drops the arg and must **not** set `dynamic_tensor_shape`.
+
+  *Triage-doc reconciliation:* `data_movement/pad` is **absent** from
+  `2026-07-06_tensor_accessor_3rd_arg_triage.md` (only the unrelated `fill_pad` and `padded_slice`
+  appear). That is expected rather than a disagreement — the sites were introduced by PR #47507
+  (`75ee03e9dc3`, 2026-07-08), two days *after* the dated analysis. Classified here from first
+  principles, per the recipe.
+
+  One residual, recorded as a question rather than a gate: the input value uses `a.logical_shape()[3]`
+  while the same factory reads `a.padded_shape()` for the H/C/N bounds
+  (`..._default_program_factory.cpp:39-40` vs `:197-198`). If a RM input ever carried last-dim padding
+  (`padded[-1] > logical[-1]`), `stick_size` would understate the real page. That would be a
+  *pre-existing* op bug rather than a port hazard — the same `stick_size` also drives the per-stick
+  read length, so the op would already be mis-reading — and dropping the override moves the accessor
+  onto the correct `aligned_page_size`. See *Questions for the user*.
+
+## Port-work summary  *(mirrors the brief)*
+
+- **Tensor bindings** (per binding, per factory) — 12 × Case 1, 4 × clean, **no Case 2 anywhere**:
+
+  | Factory | Binding | Delivery today | Kernel use | Case |
+  |---|---|---|---|---|
+  | `PadRmReaderWriterProgramFactory` | `input` | `Buffer*` reader/writer RTA slot 0 (`:143`) | `TensorAccessor(src_args, src_addr)` (`reader_pad_dims_rm_interleaved.cpp:75`) | **1** |
+  | ″ | `output` | `Buffer*` slot 1 (`:144`) | `TensorAccessor(dst_args, dst_addr)` (`writer_pad_dims_rm_interleaved.cpp:32`) | **1** |
+  | ″ | `pad_value_const` *(op-owned)* | `Buffer*` slot 13 (`:156`) | `TensorAccessor(pad_tensor_args, …)` (`reader_pad_dims_rm_interleaved.cpp:77`) | **1** |
+  | `PadRmReaderWriterMultiCoreProgramFactory` | `input` / `output` / `pad_value_const` *(op-owned)* | `Buffer*` slots 0 / 1 / 13 (`:348,349,361`) | same three accessors | **1** ×3 |
+  | `PadRmReaderWriterMultiCoreDefaultProgramFactory` | `input` | `Buffer*` reader slot 0 (`:221`) | `TensorAccessor(src_args, src_addr, page)` (`reader_..._v2.cpp:95`) | **1** |
+  | ″ | `output` | `Buffer*` writer slot 0 (`:222`) | `TensorAccessor(dst_args, dst_addr, page)` (`writer_..._v2.cpp:25`) | **1** |
+  | `PadRmShardedHeightOnlyProgramFactory` | `input` | borrowed CB `c_0` (`cb_src0.buffer` @ `:294`) | `dfb_in0_exp.get_write_ptr()` | **clean** |
+  | ″ | `output` | borrowed CB `c_16` (`cb_output.buffer` @ `:309`) | FIFO + raw peek | **clean** |
+  | `PadRmShardedWidthOnlyProgramFactory` | `input` | borrowed CB `c_0` (`cb_input.buffer` @ `:75`) | `dfb_input_shard.get_write_ptr()` | **clean** |
+  | ″ | `output` | borrowed CB `c_16` (`cb_output.buffer` @ `:91`) | FIFO | **clean** |
+  | `PadTileCoreProgramFactory` | `input` | `Buffer*` reader slot 0 (`:122`) | donor `TensorAccessor(src_args, src_addr)` (`reader_unary_interleaved_start_id.cpp:30`) | **1** |
+  | ″ | `output` | `Buffer*` writer slot 0 (`:126`) | `TensorAccessor(dst_args, dst_addr)` (`writer_unary_pad_dims_interleaved.cpp:30`) | **1** |
+  | `PadTileMulticoreProgramFactory` | `input` | `Buffer*` reader slot 0 (`:222`) | `TensorAccessor(dst_args, input_addr)` (`reader_pad_tiled.cpp:29`) | **1** |
+  | ″ | `output` | `Buffer*` writer slot 0 (`:223`) | `TensorAccessor(dst_args, output_addr)` (`writer_pad_tiled.cpp:42`) | **1** |
+
+  Every Case-1 binding today arrives via the **`Buffer*` BufferBinding form**, not a raw
+  `->address()` RTA. That is the framework's interim patch-on-cache-hit mechanism, so **none of these
+  is the silent-wrong hazard** — the sheet's `Smuggled pointer = no` on all 7 rows agrees with the
+  code. They are still enumerated because the kernel receives a raw `uint32_t` base, and the port
+  replaces the whole mechanism with a typed `TensorParameter` / `TensorBinding`.
+
+- **TensorParameter relaxation:** `none` (all 7 rows) — nothing to apply.
+- **TensorAccessor 3rd arg:** drop the redundant page-size arg at
+  `reader_pad_dims_rm_interleaved_v2.cpp:95` and `writer_pad_dims_rm_interleaved_v2.cpp:25`, plus the
+  two host CTAs that feed them (`..._default_program_factory.cpp:163` and `:171`, and the
+  `input_accessor_page_size` / `output_accessor_page_size` computation at `:57-73`). Both Class 2 —
+  **do not** set `dynamic_tensor_shape`.
+- **CB endpoints:** self-loop `c_1`+`c_2` (default RM), `c_0`+`c_1` (sharded height-only), `c_0`+`c_1`
+  (sharded width-only), `c_1` (tile single-core), `c_2` (tile multicore) · 1P+1C on `c_16` (sharded
+  height-only) · dead-CB drop `c_1` @ `pad_tile_multicore_program_factory.cpp:70-78` (+ the dead CTA
+  at `writer_pad_tiled.cpp:23`) · conditional DFB `c_2` (default RM) · all others legal.
+
+## Heads-ups  *(mirrors the brief)*
+
+- **CB endpoints (multi-binding shapes to watch):** none. No CB in this op reaches ≥3 touchers or
+  doubles a FIFO role; the one two-toucher (`c_16` in the sharded height-only factory) resolves to a
+  plain 1P+1C assignment.
+- **Cross-op / shared kernels:** `PadTileCoreProgramFactory` file-path-instantiates
+  `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp`
+  (`pad_tile_program_factory.cpp:104-105`). A `_metal2` fork **already exists beside it** — bind it,
+  do not create a second. Details and the sunset list in *Team-only* below.
+- **RTA varargs:** two genuine vararg sites, plus two look-alikes that must be **named**, not
+  varargs — see *Team-only*.
+- **Op-owned tensors:** the two `WorkloadDescriptor` factories each allocate a 32-element bfloat16
+  pad-value const tensor and park it on `WorkloadDescriptor::buffers`
+  (`pad_rm_reader_writer_program_factory.cpp:197-200`,
+  `..._multi_core_program_factory.cpp:416-419`). `ProgramSpecFactoryConcept` carries these natively;
+  the `WorkloadDescriptor` shape exists purely to unlock the feature, so the port drops the workload
+  wrapper. **Keep holding the source `Tensor`, not just the `shared_ptr<MeshBuffer>`** — `~Tensor`
+  force-deallocates through `DeviceStorage::deallocate` regardless of external `MeshBuffer` owners
+  (issue #44565, cited in both factory headers).
+- **Idle-core `0u` sentinel:** two factories push a literal `0u` instead of the `Buffer*` on cores
+  with no work (`..._default_program_factory.cpp:224-225`,
+  `pad_tile_multicore_program_factory.cpp:225-226`), to skip `BufferBinding` registration. Under
+  Metal 2.0 the base rides a broadcast CRTA, so the branch has no equivalent and simply disappears;
+  the kernels already short-circuit on `num_sticks_per_core == 0` / `num_pages_per_core == 0`. (In
+  practice `split_work_to_cores` returns `all_cores == group_1 ∪ group_2`, so the branch is
+  unreachable today anyway.)
+
+## Team-only
+
+### Out-of-directory coupling & donor shape
+
+**Op-level roll-up: ✓ clean.** One in-family function-call escape, one cross-family file-path borrow.
+No `CircularBuffer&` donor, no pre-Device-2.0 donor, no `uint32_t sem_*` donor (the op has no
+semaphores at all).
+
+**Summary table** — one row per (op kernel, donor file):
+
+| Op kernel | Donor file | Donor class | Status |
+|---|---|---|---|
+| `reader_pad_dims_rm_interleaved_v2.cpp:13` | `ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp` | 5 — in-family shared | ✓ |
+| `writer_pad_dims_rm_interleaved_v2.cpp:10` | same | 5 — in-family shared | ✓ |
+| `reader_pad_tiled.cpp:8`, `writer_pad_tiled.cpp:8` | `device/kernels/dataflow/common.hpp` | in-directory — **not an escape** | ✓ |
+| all kernels | `api/dataflow/*`, `api/tensor/*`, `api/core_local_mem.h`, `ckernel.h` | 1 — `tt_metal/*` LLK/HAL | ✓ no concern |
+
+**Per-call detail** (only for the one real escape):
+
+| Donor function | Signature shape | Verdict |
+|---|---|---|
+| `tt::data_movement::common::noc_async_read_sharded(Noc, uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size)` (`common.hpp:375`) | `AddrGenType` is instantiated with `TensorAccessor<DSpec>` → **Shape 1** | ✓ excellent — porter constructs `TensorAccessor(tensor::name)` and passes it |
+| `tt::data_movement::common::noc_async_write_sharded(...)` (`common.hpp:325`) | same — **Shape 1** | ✓ excellent |
+
+Both callers already use the non-deprecated leading-`Noc` overload
+(`reader_..._v2.cpp:45`, `writer_..._v2.cpp:48`); the deprecated no-`Noc` overloads exist in the donor
+but are not reached from pad. No donor-side change, no fork.
+
+**Borrowed kernel files (file-path instantiation).** Exactly one:
+
+- **Path:** `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp`
+- **Owning family:** `eltwise/unary`
+- **Broadly shared** — not a one-off borrow. In-tree consumers of the legacy file (the **sunset
+  list**, i.e. who must migrate before the legacy copy can be deleted — *not* a bundled-port
+  assignment):
+  - `data_movement/pad` → `pad_tile_program_factory.cpp` *(this op)*
+  - `data_movement/untilize_with_unpadding` → `untilize_with_unpadding_multi_core_interleaved_program_factory.cpp`, `untilize_with_unpadding_single_core_program_factory.cpp`
+  - `examples/example` → `multi_core_program_factory.cpp`, `single_core_program_factory.cpp`
+  - `examples/example_multiple_return` → `single_core_program_factory.cpp`
+  - `experimental/transformer/nlp_create_qkv_heads_falcon7b` → `nlp_create_qkv_heads_falcon7b_program_factory.cpp`
+  - `reduction/topk` → `topk_route_prep_program_factory.cpp`
+  - plus `tests/ttnn/unit_tests/gtests/test_generic_op.cpp` and `tests/ttnn/unit_tests/operations/debug/test_generic_op.py`
+- **`_metal2` fork already exists beside it:** `reader_unary_interleaved_start_id_metal2.cpp`, same
+  directory. **Bind it; do not create another.** Its file header states the binding names are its
+  interface and are not renamed once a consumer exists — the factory conforms to the kernel, never
+  the reverse. Vocabulary: `dfb::in`, `tensor::src`, `args::num_pages`, `args::start_id`; the fork
+  also already replaces `get_local_cb_interface(cb).fifo_page_size` with `dfb.get_entry_size()`.
+- **Trap:** a *second*, differently-named fork of the same kernel exists at
+  `ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_unary_interleaved_start_id_metal2.cpp`
+  (vocabulary `tensor::input`, not `tensor::src`). The locational test — same stem, `_metal2` suffix,
+  **same directory as the original** — selects the `eltwise/unary` one. Do not bind the typecast copy.
+
+### RTA varargs
+
+Two genuine vararg sites, and two look-alikes the porter should **name** instead:
+
+- **Genuine vararg (a) — `reader_pad_dims_rm_sharded.cpp:17-22`** (`PadRmShardedHeightOnlyProgramFactory`).
+  The arg block is `num_cores`, then `2·num_cores` NoC x/y values, then `num_cores` chunk counts, then
+  `2·Σchunks` `(start_id, length)` pairs — read through `get_arg_addr()` at **runtime-computed**
+  offsets (`get_arg_addr(1 + num_cores_read * 2)`, `… * 3`), with per-core counts driving the loops at
+  `:38,44`. Host side at `pad_rm_sharded_height_only_program_factory.cpp:158-186`. There are no
+  per-argument names to infer — use the RTA vararg mechanism.
+- **Genuine vararg (a) — `reader_pad_tiled.cpp:22-25` and `writer_pad_tiled.cpp:35-38`**
+  (`PadTileMulticoreProgramFactory`). Four consecutive `num_dims`-long blocks (`input_page_shape`,
+  `output_page_shape`, `input_id_per_dim`, `output_id_per_dim`) reached by `get_arg_addr(rt_ind)` plus
+  `+ num_dims` pointer strides, consumed in `for (d < num_dims)` loops (`:46`, `:66`, and
+  `common.hpp:12`). `num_dims` is CTA 2 = `output_padded_shape.rank()`. A CTA-bounded loop still
+  varies across instantiations, so this is a vararg by the recipe's rule. Host side at
+  `pad_tile_multicore_program_factory.cpp:236-253`. *Caveat worth knowing:* `pad_impl` hard-asserts
+  rank == 4 (`pad.cpp:193`) and `validate_on_program_cache_miss` caps rank at 4
+  (`pad_device_operation.cpp:121`), so `num_dims` is 4 in every reachable configuration — naming the
+  16 values would also be defensible. Flagged as vararg per the rule; the porter may take the named
+  route if the kernel's rank-generic loops are simultaneously pinned.
+- **Look-alikes — name these, don't varargs them.**
+  `reader_pad_dims_rm_interleaved_v2.cpp:59` and `writer_pad_dims_rm_sharded.cpp:53` both take
+  `start_dim_offset = get_arg_addr(k)` and then read only **fixed** indices `[1]`, `[2]`, `[3]`
+  (`reader_..._v2.cpp:112`, `writer_..._sharded.cpp:93`). That is three distinct nameable fields
+  (`start_h`, `start_c`, `start_n`) reached through legacy pointer arithmetic, not a data-directed
+  pick — ordinary named RTAs.
+- **CTA varargs: none.** No kernel reads `get_compile_time_arg_val()` at a varying index. The
+  `kernel_compile_time_args[13]` / `[10..12]` reads (`reader_..._v2.cpp:85`,
+  `writer_..._sharded.cpp:70-72`) use **constant** indices inside `if constexpr (not_pad_by_zero)`
+  blocks, and the host emits those CTA slots unconditionally
+  (`..._default_program_factory.cpp:141-163`, `..._height_only_program_factory.cpp:337-350`), so they
+  are a fixed named set on both branches.
+
+### Relaxation candidates
+
+None. No custom `compute_program_hash` exists anywhere in the op, so there is no hash to mine for
+tensor properties the op actually depends on. The sheet's `TensorParameter relaxation = none` on all
+seven rows stands unchallenged.
+
+### TTNN factory analysis
+
+Sheet-derived facts with `file:line` evidence:
+
+- **Op-owned tensors — yes, on two factories.** `wd.buffers.push_back({pad_value_owner, pad_value_const_buffer})`
+  at `pad_rm_reader_writer_program_factory.cpp:200` and
+  `pad_rm_reader_writer_multi_core_program_factory.cpp:419`. The owned object is a device-resident
+  32-element bfloat16 L1 tensor built by `build_pad_value_const_tensor_sc` / `_mc`
+  (`:25-36` / `:165-178`).
+- **MeshWorkload need — an op-owned-tensor artifact, not genuine multi-program.** Both factories build
+  **one** `ProgramDescriptor` and replicate the *same* object across `tensor_coords.ranges()`
+  (`:202-211` / `:421-429`). Nothing is per-mesh-coordinate. The `create_workload_descriptor` entry
+  point exists solely because the `descriptor` form cannot carry op-owned tensors.
+- **Pybind `create_descriptor` — none.** `pad_nanobind.cpp:41-75` binds only the two public
+  `ttnn::pad` overloads; no `nb::class_` of the device op, no descriptor internals exposed. Nothing
+  for the port to delete, and no user-visible API change from this axis.
+- **Custom hash — none** (and no backdoor `attribute_values` / `to_hash`). The default hash over
+  `PadParams` + tensor specs applies.
+- **`get_dynamic_runtime_args` — none** (removed by #52556). See the *Gate detail* conflict.
+- **`override_runtime_arguments` — one**, at `pad_rm_sharded_height_only_program_factory.cpp:412`.
+  It rebuilds a two-entry CB-address-only `ProgramDescriptor` mirroring `create_descriptor`'s CB push
+  order positionally (input CB, output CB, then the unbound pad-value CB it deliberately omits) and
+  calls `apply_descriptor_runtime_args`. This selects `CustomProgramSpecFactoryConcept` for that
+  factory, and the porter translates the method into one returning a `ProgramRunArgs`. The
+  positional-mirroring contract is fragile and worth carrying into the translation as an explicit
+  comment. **Open question for the porter:** the method exists solely to re-point the two borrowed CB
+  base addresses, which is precisely what `DataflowBufferSpec::borrowed_from` plus a `TensorBinding`
+  does natively in Metal 2.0 — so the body may be wholly subsumed. If it is, the factory drops to the
+  plain `ProgramSpecFactoryConcept`; that is a concept change, so raise it rather than deciding it
+  silently. (`PadRmShardedWidthOnlyProgramFactory` has the same two borrowed CBs and no override,
+  which is the evidence that the override may be unnecessary — see *Misc anomalies* #8.)
+- **Target concepts.** `ProgramSpecFactoryConcept` for six factories — two of them
+  (`PadRmReaderWriterProgramFactory`, `PadRmReaderWriterMultiCoreProgramFactory`) additionally
+  carrying op-owned tensors. `CustomProgramSpecFactoryConcept` for
+  `PadRmShardedHeightOnlyProgramFactory`, per the code (the sheet's `Override runtime args method?`
+  cell is outdated), subject to the open question above.
+
+## Misc anomalies  *(team-only, non-gating; the port does not act on these)*
+
+1. **An entire factory is unreachable.** `PadRmReaderWriterMultiCoreProgramFactory` (433 lines) is
+   declared in the `program_factory_t` variant (`pad_device_operation.hpp:33`) but is **never
+   returned by `select_program_factory`** — the RM multicore path returns
+   `PadRmReaderWriterMultiCoreDefaultProgramFactory` instead (`pad_device_operation.cpp:99-101`), and
+   the only other reference in the tree is its own definition. It allocates an op-owned device tensor
+   on every (hypothetical) cache miss and carries a hardcoded resnet-shape core split. Candidate for
+   deletion; see *Questions*.
+2. **Dead code after `TT_THROW` in that same factory.** `split_across_cores`'s `default:` branch
+   throws at `..._multi_core_program_factory.cpp:97` and is followed by ~30 lines of unreachable
+   "generic case -- TODO" logic (`:99-131`), including a second `TT_THROW` and commented-out
+   assignments.
+3. **Dead CB + dead CTA (tile multicore).** `c_1` allocated at
+   `pad_tile_multicore_program_factory.cpp:70-78`; its index reaches `writer_pad_tiled.cpp:23` as
+   `output_cb_id` and is never used. Wastes `2 × page_size` bytes of L1 per core. *(Also recorded as
+   PORT WORK — the port drops it.)*
+4. **Hardcoded constant overriding a live RTA.** `reader_pad_dims_rm_interleaved.cpp:52` hardcodes
+   `pad_value_const_buffer_nbytes = 64` with the comment *"assumed to be 64 bytes, fails on BH when
+   > 64. TODO: generalize? (Issue #21978)"*, while the host still computes and passes the real value
+   at RTA slot 14 (`pad_rm_reader_writer_program_factory.cpp:157`). The passed value is silently
+   ignored, so the arg is dead **and** the kernel is pinned to an assumption the host does not
+   enforce.
+5. **Several dead RTAs in the v1 RM kernels.** The reader and writer are handed *identical* 27-slot
+   arg lists (`pad_rm_reader_writer_program_factory.cpp:172`, `..._multi_core_...:385`), so each
+   receives roughly half it never reads. Beyond that, values that *are* unpacked and then unused:
+   reader `num_total_W` (3), `num_total_Y` (7), `start_src_stick_wi` (18), `full_unpadded_X_nbytes`
+   (23); writer `num_total_W` (3), `num_total_Y` (7), `num_total_X` (9), `num_local_unpadded_Y` (22),
+   `full_padded_X_nbytes` (24), and `dst_stick_wi` (19, assigned at `:36` and never advanced).
+6. **Dead compile-time args in the v1 writer.** `writer_ct_args = reader_ct_args`
+   (`pad_rm_reader_writer_program_factory.cpp:85`) copies in the pad-value-const tensor's
+   `TensorAccessorArgs`, which the writer never instantiates. Harmless but misleading — and the
+   writer must still declare `src_args` (`writer_pad_dims_rm_interleaved.cpp:26`) purely to compute
+   `dst_args`' offset.
+7. **`start_dim_offset` seeded at the wrong length.** In both
+   `..._default_program_factory.cpp:199-200,264` and
+   `..._height_only_program_factory.cpp:65-66,116` the vector is initialized to `num_dims` zeros but
+   reassigned to a literal `{0, curr_h, curr_c, curr_n}` (always 4) after the first core. Benign today
+   because rank is pinned to 4 upstream (`pad.cpp:193`), but it silently breaks the rank-generic
+   intent the initialization advertises.
+8. **Sharded-factory asymmetry in cache-hit CB re-pointing.** `PadRmShardedHeightOnlyProgramFactory`
+   defines an `override_runtime_arguments` specifically to re-point its two borrowed CB addresses
+   (`..._height_only_program_factory.cpp:412-424`), while `PadRmShardedWidthOnlyProgramFactory` —
+   which has the same two borrowed CBs — defines none and relies on the framework's `cb.buffer`
+   patching (comment at `..._width_only_program_factory.cpp:170-173`). One of the two is doing
+   unnecessary work, or the other has a latent stale-address hole on cache hits. Worth an ops-team
+   look independent of the port.
+9. **Unguarded read of a possibly-unallocated CB.** `reader_pad_dims_rm_interleaved_v2.cpp:99` calls
+   `get_read_ptr()` on `c_2` unconditionally although the host allocates `c_2` only under a condition
+   (`..._default_program_factory.cpp:127-139`). Harmless today; blocks a clean conditional-DFB port.
+   *(Also recorded as PORT WORK.)*
+
+## Per-DeviceOperation attribution
+
+Single `DeviceOperation` (`PadDeviceOperation`); no bundling. Per-**factory** attribution — which is
+where this op's findings actually differ — is carried inline throughout:
+
+| Factory | Gate verdict | Target concept | In the port |
+|---|---|---|---|
+| `PadRmReaderWriterProgramFactory` | clear | `ProgramSpecFactoryConcept` + op-owned tensors | yes |
+| `PadRmReaderWriterMultiCoreProgramFactory` | clear | `ProgramSpecFactoryConcept` + op-owned tensors | yes (but unreachable — see *Questions*) |
+| `PadRmReaderWriterMultiCoreDefaultProgramFactory` | clear | `ProgramSpecFactoryConcept` | yes |
+| `PadRmShardedHeightOnlyProgramFactory` | clear — sheet cell outdated, overridden on code evidence | `CustomProgramSpecFactoryConcept` | yes |
+| `PadRmShardedWidthOnlyProgramFactory` | clear | `ProgramSpecFactoryConcept` | yes |
+| `PadTileCoreProgramFactory` | clear | `ProgramSpecFactoryConcept` | yes |
+| `PadTileMulticoreProgramFactory` | clear | `ProgramSpecFactoryConcept` | yes |
+
+## Questions for the user
+
+1. **Who corrects the readiness-sheet row, and when?** *(Does not block the port — recorded so it
+   does not get lost.)* `PadRmShardedHeightOnlyProgramFactory`'s row still describes the pre-#52556
+   code, so `Is able to port?` reads `no`. This audit overrides it, but the row itself will keep
+   misleading the port tracker and the next auditor until
+   `Runtime-args update (get_dynamic_runtime_args)` → `no` and
+   `Override runtime args method? (PD only)` → `yes`.
+2. **Should `PadRmReaderWriterMultiCoreProgramFactory` be deleted rather than ported?**
+   (`pad_device_operation.hpp:33`, `pad_rm_reader_writer_multi_core_program_factory.cpp`.) It is
+   unreachable from `select_program_factory`, and porting 433 lines of dead multicore code — including
+   an op-owned-tensor allocation and a hardcoded resnet core split — spends porter effort on something
+   no test can exercise. If it should go, deleting it *before* the port is cleaner than porting and
+   then deleting. If it is being kept deliberately (a path someone intends to re-enable), say so and
+   it stays in scope.
+3. **Can a RM input reach `pad` with last-dim padding (`padded_shape[-1] > logical_shape[-1]`)?**
+   `PadRmReaderWriterMultiCoreDefaultProgramFactory` derives `stick_size` from the **logical** last
+   dim (`:39-40,47`) while taking its H/C/N bounds from the **padded** shape (`:197-198`). If such an
+   input is reachable, the op already mis-reads (the same `stick_size` is both the accessor page and
+   the per-stick read length) — a pre-existing bug for the ops team, not a port hazard. If it is not
+   reachable, the mixed use is merely confusing. Either answer leaves the 3rd-arg site Class 2.
+
+## Recipe notes
+
+1. **`Secretly SPMD Workload?`'s code basis doesn't survive a multi-range mesh.** The recipe says
+   *"a **single entry** in its `programs` vector ⇒ SPMD"*
+   ([TTNN factory concept prerequisite](#) cross-check list). Pad's two `WorkloadDescriptor`
+   factories push **one entry per range in `tensor_coords`** — `ranges.size()` entries, each carrying
+   the *identical* `ProgramDescriptor` built once above the loop
+   (`pad_rm_reader_writer_program_factory.cpp:205-211`). On a single-range mesh that is one entry and
+   the test passes; on a multi-range one the test would say "not SPMD" about code that is plainly
+   SPMD. Suggest restating the basis as *"every entry carries the same `ProgramDescriptor`"* rather
+   than *"one entry."* I followed the substance (and the sheet) rather than the literal test.
+2. **The recipe has no verdict for "the sheet is simply out of date," and this audit needed one.**
+   *(Flagged prominently: this report deviates from the recipe as written. The deviation was the
+   report owner's explicit decision, taken after the auditor recommended against it; recorded here so
+   the maintainer sees the pressure the rule is under, not to claim the rule was followed.)*
+   The recipe is unambiguous that `Is able to port?` is the gate — *"a `no` you cannot account for is
+   still a `no`"* — and that a primary-column conflict means *"stop rather than proceed on data we
+   can't trust,"* routed to the readiness-sheet owner. Applied literally, that RED's this op on a
+   cell whose only visible input was fixed on `main` five days earlier by a PR the auditor can name
+   (#52556 / `90ec10f4bf4`). Every gate the audit checks *itself* clears for that factory. The report
+   owner judged that gating a port on a bookkeeping lag was not worth the cycle, and directed a GREEN
+   with the staleness recorded; this document reflects that.
+   The friction worth fixing: the recipe's two failure modes for a `no` are *"explained by a blocking
+   column"* (→ that column's owner) and *"primary-column conflict"* (→ sheet owner, stop). Neither
+   fits **"the blocking column is the conflicting column, and the code is already correct."** That
+   case has no honest home today, so it lands as a stop-the-world RED for what is a two-cell edit.
+   Suggest a third, explicitly-bounded outcome — *"stale-cell override"*: permitted only when the
+   contradicted column is one of the cross-checked primaries, the auditor can cite the landing commit
+   that made it stale, **and** every other gate-bearing subject clears independently; the report then
+   reads GREEN, states the override, and still routes the correction to the sheet owner. Without
+   something like that, auditors facing this shape will either over-block or quietly do what this
+   report did without labelling it.
+3. **The Red-scoping exception list doesn't mention spreadsheet-broken.** The *"Elsewhere → run
+   them"* branch enumerates *"an unattributed or held readiness verdict, an Appendix A feature
+   landing, any framework capability not yet released."* A stale/broken sheet row is the clearest
+   possible "clears with the op untouched" case — the code is already correct — yet it isn't named,
+   so a reader has to reason it in by analogy. Suggest adding it explicitly. (Moot for this report,
+   which ran every subject in full, but it is the rule the auditor reached for first.)
+4. **The conditional-DFB guidance stops at the host side.** [CB endpoints](#) covers *dead in some
+   configs, live in others* by making the `DataflowBufferSpec` conditional, and warns that the legacy
+   factory "allocates every CB unconditionally and gates only the *kernel-side* use behind an
+   `#ifdef` or a branch." Pad's `c_2` is the mirror image: the **host** allocates conditionally and
+   the **kernel** references it unconditionally
+   (`reader_pad_dims_rm_interleaved_v2.cpp:99` vs `..._default_program_factory.cpp:127-139`). Making
+   the spec conditional is then not sufficient — the kernel line needs gating too, and `if constexpr`
+   will not do it because it does not suppress `dfb::` name lookup. Worth a sentence, since this is
+   the shape that silently produces an unbound-DFB reference at build time.
+5. **Minor: the audit template has no natural home for "the op has no compute kernels."** It matters
+   (it retires the compute `opt_level` question wholesale), but it isn't a row in the status summary
+   or a listed subject, so I filed it under the Device 2.0 bullet.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
@@ -6,8 +6,7 @@
 
 // Takes in an id_per_dim and dims array, both of size ndims
 // Advances the id_per_dim by one, wrapping and carrying as needed
-static inline int advance_tensor_index(
-    volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
+static inline int advance_tensor_index(uint32_t* idx, const uint32_t* dims, uint32_t ndims) {
     // increment least-significant dim first
     for (int32_t d = ndims - 1; d >= 0; d--) {
         uint32_t v = idx[d] + 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
@@ -8,6 +8,7 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 template <typename PadAccessor>
 inline __attribute__((always_inline)) void fill_with_val_async(
@@ -38,33 +39,21 @@ inline __attribute__((always_inline)) void fill_with_val_async(
 }
 
 void kernel_main() {
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_unpadded_W = get_arg_val<uint32_t>(2);
-    const uint32_t num_total_W = get_arg_val<uint32_t>(3);
-    const uint32_t num_unpadded_Z = get_arg_val<uint32_t>(4);
-    const uint32_t num_total_Z = get_arg_val<uint32_t>(5);
-    const uint32_t num_unpadded_Y = get_arg_val<uint32_t>(6);
-    const uint32_t num_total_Y = get_arg_val<uint32_t>(7);
-    const uint32_t unpadded_X_nbytes = get_arg_val<uint32_t>(10);
-    const uint32_t padded_X_nbytes = get_arg_val<uint32_t>(11);
-    const uint32_t padded_X_diff_nbytes = get_arg_val<uint32_t>(12);
-    const uint32_t pad_value_const_buffer_addr = get_arg_val<uint32_t>(13);
+    const auto num_unpadded_W = get_arg(args::num_unpadded_W);
+    const auto num_unpadded_Z = get_arg(args::num_unpadded_Z);
+    const auto num_total_Z = get_arg(args::num_total_Z);
+    const auto unpadded_X_nbytes = get_arg(args::unpadded_X_nbytes);
+    const auto padded_X_nbytes = get_arg(args::padded_X_nbytes);
+    const auto padded_X_diff_nbytes = get_arg(args::padded_X_diff_nbytes);
     const uint32_t pad_value_const_buffer_nbytes = 64;  // assumed to be 64 bytes, fails on BH when > 64. TODO: generalize? (Issue #21978)
-    const uint32_t pad_value_packed = get_arg_val<uint32_t>(15);
-    const uint32_t start_src_stick_id = get_arg_val<uint32_t>(16);
-    const uint32_t start_src_stick_wi = get_arg_val<uint32_t>(18);
-    const uint32_t start_src_stick_offset = get_arg_val<uint32_t>(20);  // == start_src_stick_wi * elem_size
-    const uint32_t num_local_Y = get_arg_val<uint32_t>(21);
-    const uint32_t num_local_unpadded_Y = get_arg_val<uint32_t>(22);
-    const uint32_t full_unpadded_X_nbytes = get_arg_val<uint32_t>(23);
-    const uint32_t num_local_W = get_arg_val<uint32_t>(26);
+    const auto pad_value_packed = get_arg(args::pad_value_packed);
+    const auto start_src_stick_id = get_arg(args::start_src_stick_id);
+    const auto start_src_stick_offset = get_arg(args::start_src_stick_offset);  // == start_src_stick_wi * elem_size
+    const auto num_local_Y = get_arg(args::num_local_Y);
+    const auto num_local_unpadded_Y = get_arg(args::num_local_unpadded_Y);
+    const auto num_local_W = get_arg(args::num_local_W);
 
-    constexpr auto src_args = TensorAccessorArgs<2>();
-    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
-    constexpr auto pad_tensor_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
-
-    constexpr uint32_t dfb_id = tt::CBIndex::c_0;
-    DataflowBuffer dfb(dfb_id);
+    DataflowBuffer dfb(dfb::in0);
     Noc noc;
 
     // calculate the offset for alignment of padding in rows/sticks
@@ -72,9 +61,9 @@ void kernel_main() {
     const uint32_t l1_addr_align_offset =
         32 - l1_addr_partial % 32;  // NOTE: this is fine with double buffering since offset will be same for each page
 
-    const auto s0 = TensorAccessor(src_args, src_addr);
+    const auto s0 = TensorAccessor(tensor::src);
 
-    const auto s_const = TensorAccessor(pad_tensor_args, pad_value_const_buffer_addr);
+    const auto s_const = TensorAccessor(tensor::pad_value);
 
     uint16_t pad_value = pad_value_packed >> 16;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -12,10 +12,10 @@
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ckernel.h"
+#include "experimental/kernel_args.h"
 
-inline __attribute__((always_inline)) void fill_pad_cb_with_val(
-    const uint32_t cb_id, const uint32_t num_bytes, const uint32_t val) {
-    DataflowBuffer dfb(cb_id);
+inline __attribute__((always_inline)) void fill_pad_dfb_with_val(
+    DataflowBuffer& dfb, const uint32_t num_bytes, const uint32_t val) {
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb.get_write_ptr());
 
     // Round up so a non-4-byte-aligned tail stick is fully filled (the loop-back read consumes all num_bytes).
@@ -49,57 +49,54 @@ inline __attribute__((always_inline)) void read_input_stick_into_l1(
 }
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
-    uint32_t num_sticks_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_page_id = get_arg_val<uint32_t>(3);
-    uint32_t front_pad_n = get_arg_val<uint32_t>(4);
-    uint32_t front_pad_c = get_arg_val<uint32_t>(5);
-    uint32_t front_pad_h = get_arg_val<uint32_t>(6);
-    tt_l1_ptr uint32_t* start_dim_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(7));
+    auto num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    auto num_sticks_per_barrier = get_arg(args::num_sticks_per_barrier);
+    auto start_page_id = get_arg(args::start_page_id);
+    auto front_pad_n = get_arg(args::front_pad_n);
+    auto front_pad_c = get_arg(args::front_pad_c);
+    auto front_pad_h = get_arg(args::front_pad_h);
 
-    constexpr uint32_t N = get_compile_time_arg_val(0);
-    constexpr uint32_t H = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t N_padded = get_compile_time_arg_val(4);
-    constexpr uint32_t H_padded = get_compile_time_arg_val(5);
-    constexpr uint32_t C_padded = get_compile_time_arg_val(6);
-    constexpr uint32_t stick_size_padded = get_compile_time_arg_val(7);
-    constexpr uint32_t stick_size_padded_front = get_compile_time_arg_val(8);
-    constexpr uint32_t stick_size_padded_end = get_compile_time_arg_val(9);
-    constexpr uint32_t num_zero_pad_sticks_read = get_compile_time_arg_val(10);
-    constexpr uint32_t last_zero_stick_size = get_compile_time_arg_val(11);
-    constexpr uint32_t stick_size_padded_aligned = get_compile_time_arg_val(18);
+    constexpr auto N = get_arg(args::N);
+    constexpr auto H = get_arg(args::H);
+    constexpr auto C = get_arg(args::C);
+    constexpr auto stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr auto N_padded = get_arg(args::N_padded);
+    constexpr auto H_padded = get_arg(args::H_padded);
+    constexpr auto C_padded = get_arg(args::C_padded);
+    constexpr auto stick_size_padded = get_arg(args::stick_size_padded);
+    constexpr auto stick_size_padded_front = get_arg(args::stick_size_padded_front);
+    constexpr auto stick_size_padded_aligned = get_arg(args::stick_size_padded_aligned);
 
-    constexpr bool not_pad_by_zero = get_compile_time_arg_val(12) == 1;
-    constexpr uint32_t front_padding = get_compile_time_arg_val(8);
-    constexpr bool unaligned = get_compile_time_arg_val(19) == 1;
+    constexpr bool not_pad_by_zero = get_arg(args::not_pad_by_zero) == 1;
+    constexpr uint32_t front_padding = stick_size_padded_front;
+    constexpr bool unaligned = get_arg(args::unaligned) == 1;
 
-    constexpr uint32_t num_input_pages_in_row = get_compile_time_arg_val(20);
-    constexpr uint32_t accessor_page_size = get_compile_time_arg_val(21);
-    constexpr auto src_args = TensorAccessorArgs<22>();
+    constexpr auto num_input_pages_in_row = get_arg(args::num_input_pages_in_row);
 
     uint32_t packed_pad_value = 0;
     if constexpr (not_pad_by_zero) {
-        packed_pad_value = kernel_compile_time_args[13];
+        packed_pad_value = get_arg(args::packed_pad_value);
     }
 
-    constexpr uint32_t dfb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_pad = tt::CBIndex::c_1;
-    constexpr uint32_t dfb_pad_align = tt::CBIndex::c_2;
-    DataflowBuffer dfb_in0_exp(dfb_in0);
-    DataflowBuffer dfb_pad_exp(cb_pad);
-    DataflowBuffer dfb_pad_align_exp(dfb_pad_align);
+    DataflowBuffer dfb_in0_exp(dfb::in0);
+    DataflowBuffer dfb_pad_exp(dfb::pad);
+    // The realignment staging buffer is bound only when the host allocated it (front padding, or
+    // an unaligned padded stick). A kernel may not name a DFB it has not bound, and `if constexpr`
+    // does not suppress that name lookup, so every reference to it is gated at the preprocessor.
+#ifdef PAD_ALIGN_DFB
+    DataflowBuffer dfb_pad_align_exp(dfb::pad_align);
+#endif
 
-    const auto s = TensorAccessor(src_args, src_addr, accessor_page_size);
+    const auto s = TensorAccessor(tensor::src);
     Noc noc;
 
     const uint32_t pad_val_addr = dfb_pad_exp.get_read_ptr();
+#ifdef PAD_ALIGN_DFB
     const uint32_t pad_align_addr = dfb_pad_align_exp.get_read_ptr();
+#endif
 
-    fill_pad_cb_with_val(cb_pad, stick_size_padded, packed_pad_value);
-    // The fill above is baby-RISCV stores; the per-stick loop below loop-back noc.async_read's cb_pad as
+    fill_pad_dfb_with_val(dfb_pad_exp, stick_size_padded, packed_pad_value);
+    // The fill above is baby-RISCV stores; the per-stick loop below loop-back noc.async_read's the pad DFB as
     // its source. A baby-RISCV store can retire before its write-request lands in L1, and the RISCV core
     // and NoC are different L1 clients with no program-order guarantee between them
     // (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). load_blocking the last filled word (blocking
@@ -109,7 +106,8 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pad_val_addr) + (stick_size_padded / sizeof(uint32_t)) - 1);
 
     uint32_t i_page = start_page_id;
-    uint32_t curr_c = start_dim_offset[2], curr_h = start_dim_offset[1], curr_n = start_dim_offset[3];
+    uint32_t curr_c = get_arg(args::start_dim_offset_c), curr_h = get_arg(args::start_dim_offset_h),
+             curr_n = get_arg(args::start_dim_offset_n);
     for (uint32_t iter = 0; iter < num_sticks_per_core;) {
         dfb_in0_exp.reserve_back(num_sticks_per_barrier);
         uint32_t l1_write_addr = dfb_in0_exp.get_write_ptr();
@@ -130,6 +128,7 @@ void kernel_main() {
                 noc.async_read_barrier();
             }
             if (read_stick) {
+#ifdef PAD_ALIGN_DFB
                 if constexpr (front_padding) {
                     uint32_t temp_addr = dfb_pad_align_exp.get_write_ptr();
                     read_input_stick_into_l1(noc, s, i_page, temp_addr, num_input_pages_in_row, stick_size_bytes);
@@ -151,7 +150,9 @@ void kernel_main() {
                          .noc_y = (uint32_t)my_y[noc.get_noc_id()],
                          .addr = pad_align_addr},
                         {.offset_bytes = 0});
-                } else {
+                } else
+#endif
+                {
                     read_input_stick_into_l1(noc, s, i_page, l1_write_addr, num_input_pages_in_row, stick_size_bytes);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
@@ -9,22 +9,23 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(0);
-    constexpr uint32_t num_sticks_padded = get_compile_time_arg_val(1);
+    constexpr auto stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr auto num_sticks_padded = get_arg(args::num_sticks_padded);
 
-    const uint32_t num_cores_read = get_arg_val<uint32_t>(0);
-    tt_l1_ptr uint32_t* read_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(1));
-    tt_l1_ptr uint32_t* read_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-    tt_l1_ptr uint32_t* num_stick_chunks = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 2));
-    tt_l1_ptr uint32_t* chunk_start_id = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 3));
-    tt_l1_ptr uint32_t* chunk_num_sticks = (tt_l1_ptr uint32_t*)(chunk_start_id + 1);
+    // The gather plan is data-directed, so it arrives as a runtime vararg block laid out as:
+    //   [0, 2*num_cores_read)              interleaved NoC (x, y) per source core
+    //   [2*num_cores_read, 3*num_cores_read)  chunk count per source core
+    //   [3*num_cores_read, ...)            a (start_id, length) pair per chunk
+    const auto num_cores_read = get_arg(args::num_cores_read);
+    const uint32_t noc_xy_base = 0;
+    const uint32_t num_stick_chunks_base = num_cores_read * 2;
+    const uint32_t chunk_base = num_cores_read * 3;
 
-    constexpr auto dfb_in0 = tt::CBIndex::c_0;
-    constexpr auto dfb_out0 = tt::CBIndex::c_16;
-    DataflowBuffer dfb_in0_exp(dfb_in0);
-    DataflowBuffer dfb_out0_exp(dfb_out0);
+    DataflowBuffer dfb_in0_exp(dfb::in_shard);
+    DataflowBuffer dfb_out0_exp(dfb::out_shard);
 
     Noc noc;
 
@@ -36,14 +37,14 @@ void kernel_main() {
     uint32_t read_noc_xy_ptr_offset = 0;
 
     for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
-        const uint32_t src_noc_x = read_noc_x[read_noc_xy_ptr_offset];
-        const uint32_t src_noc_y = read_noc_y[read_noc_xy_ptr_offset];
+        const uint32_t src_noc_x = get_vararg(noc_xy_base + read_noc_xy_ptr_offset);
+        const uint32_t src_noc_y = get_vararg(noc_xy_base + read_noc_xy_ptr_offset + 1);
 
-        uint32_t curr_core_num_chunks = num_stick_chunks[curr_core];
+        uint32_t curr_core_num_chunks = get_vararg(num_stick_chunks_base + curr_core);
 
         for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
-            uint32_t curr_start_id = chunk_start_id[chunk_ptr_offset];
-            uint32_t curr_num_sticks = chunk_num_sticks[chunk_ptr_offset];
+            uint32_t curr_start_id = get_vararg(chunk_base + chunk_ptr_offset);
+            uint32_t curr_num_sticks = get_vararg(chunk_base + chunk_ptr_offset + 1);
 
             uint32_t l1_read_offset = curr_start_id * stick_size_bytes;
             uint32_t read_data_size_bytes = curr_num_sticks * stick_size_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp
@@ -7,24 +7,21 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint_pages.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
 #define u8_l1_ptr volatile tt_l1_ptr uint8_t*
 #define u8_vol_ptr volatile uint8_t*
 #define u8_ptr uint8_t*
 
 void kernel_main() {
-    constexpr uint32_t unpadded_stick_bytes         = get_compile_time_arg_val(0);
-    constexpr uint32_t padded_stick_bytes         = get_compile_time_arg_val(1);
-    constexpr uint32_t unpadded_shard_height        = get_compile_time_arg_val(2);
-    constexpr uint32_t padded_shard_height        = get_compile_time_arg_val(3);
-    constexpr uint32_t W_front_pad_bytes = get_compile_time_arg_val(4);
+    constexpr auto unpadded_stick_bytes = get_arg(args::unpadded_stick_bytes);
+    constexpr auto unpadded_shard_height = get_arg(args::unpadded_shard_height);
+    constexpr auto W_front_pad_bytes = get_arg(args::W_front_pad_bytes);
 
-    constexpr uint32_t input_shard_dfb = get_compile_time_arg_val(5);
-    constexpr uint32_t output_shard_dfb = get_compile_time_arg_val(6);
-    constexpr uint32_t unpadded_stick_step = get_compile_time_arg_val(7);
-    constexpr uint32_t padded_stick_step = get_compile_time_arg_val(8);
+    constexpr auto unpadded_stick_step = get_arg(args::unpadded_stick_step);
+    constexpr auto padded_stick_step = get_arg(args::padded_stick_step);
 
-    DataflowBuffer dfb_input_shard(input_shard_dfb);
-    DataflowBuffer dfb_output_shard(output_shard_dfb);
+    DataflowBuffer dfb_input_shard(dfb::in_shard);
+    DataflowBuffer dfb_output_shard(dfb::out_shard);
 
     uint32_t input_shard_base_addr = dfb_input_shard.get_write_ptr();
     uint32_t output_shard_base_addr = dfb_output_shard.get_write_ptr();

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
@@ -9,26 +9,32 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t input_dfb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t num_dims = get_compile_time_arg_val(2);
+    constexpr auto page_size = get_arg(args::page_size);
+    constexpr auto num_dims = get_arg(args::num_dims);
 
-    uint32_t rt_ind = 0;
-    const uint32_t input_addr = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
-    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
-    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* input_id_per_dim = output_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* output_id_per_dim = input_id_per_dim + num_dims;
+    const auto num_pages_to_write = get_arg(args::num_pages_to_write);
+    const auto start_offset = get_arg(args::start_offset);
 
-    constexpr auto dst_args = TensorAccessorArgs<3>();
+    // Four num_dims-long runtime vararg blocks, in host push order. The two id_per_dim blocks are
+    // advanced as this kernel walks the output, so they are copied into locals: get_vararg() reads
+    // a vararg but cannot write one back.
+    uint32_t input_page_shape[num_dims];
+    uint32_t output_page_shape[num_dims];
+    uint32_t input_id_per_dim[num_dims];
+    uint32_t output_id_per_dim[num_dims];
+    for (uint32_t d = 0; d < num_dims; d++) {
+        input_page_shape[d] = get_vararg(d);
+        output_page_shape[d] = get_vararg(num_dims + d);
+        input_id_per_dim[d] = get_vararg(2 * num_dims + d);
+        output_id_per_dim[d] = get_vararg(3 * num_dims + d);
+    }
 
-    const auto s0 = TensorAccessor(dst_args, input_addr);
+    const auto s0 = TensorAccessor(tensor::src);
     Noc noc;
-    DataflowBuffer dfb_input(input_dfb_id);
+    DataflowBuffer dfb_input(dfb::in0);
 
     bool within_input_region;
     uint32_t input_page_offset = start_offset;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp
@@ -7,33 +7,22 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    const uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    const uint32_t num_total_W = get_arg_val<uint32_t>(3);
-    const uint32_t num_total_Z = get_arg_val<uint32_t>(5);
-    const uint32_t num_total_Y = get_arg_val<uint32_t>(7);
-    const uint32_t num_total_X = get_arg_val<uint32_t>(9);
-    const uint32_t padded_X_nbytes = get_arg_val<uint32_t>(11);
-    const uint32_t start_dst_stick_id = get_arg_val<uint32_t>(17);
-    const uint32_t start_dst_stick_wi = get_arg_val<uint32_t>(19);
-    const uint32_t num_local_Y = get_arg_val<uint32_t>(21);
-    const uint32_t num_local_unpadded_Y = get_arg_val<uint32_t>(22);
-    const uint32_t full_padded_X_nbytes = get_arg_val<uint32_t>(24);
-    const uint32_t dst_stick_offset = get_arg_val<uint32_t>(25);  // == start_src_stick_wi * elem_size
-    const uint32_t num_local_W = get_arg_val<uint32_t>(26);
+    const auto num_total_Z = get_arg(args::num_total_Z);
+    const auto padded_X_nbytes = get_arg(args::padded_X_nbytes);
+    const auto start_dst_stick_id = get_arg(args::start_dst_stick_id);
+    const auto num_local_Y = get_arg(args::num_local_Y);
+    const auto dst_stick_offset = get_arg(args::dst_stick_offset);  // == start_dst_stick_wi * elem_size
+    const auto num_local_W = get_arg(args::num_local_W);
 
-    constexpr auto src_args = TensorAccessorArgs<2>();
-    constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+    DataflowBuffer dfb(dfb::in0);
 
-    constexpr uint32_t dfb_id = tt::CBIndex::c_0;
-    DataflowBuffer dfb(dfb_id);
-
-    const auto s1 = TensorAccessor(dst_args, dst_addr);
+    const auto s1 = TensorAccessor(tensor::dst);
     Noc noc;
 
     uint32_t dst_stick_id = start_dst_stick_id;
-    uint32_t dst_stick_wi = start_dst_stick_wi;
     for (uint32_t w = 0; w < num_local_W; ++w) {
         for (uint32_t z = 0; z < num_total_Z; ++z) {
             for (uint32_t y = 0; y < num_local_Y; ++y) {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp
@@ -8,23 +8,20 @@
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
-    uint32_t num_sticks_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_page_id = get_arg_val<uint32_t>(3);
+    auto num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    auto num_sticks_per_barrier = get_arg(args::num_sticks_per_barrier);
+    auto start_page_id = get_arg(args::start_page_id);
 
-    constexpr uint32_t dfb_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(1);
-    constexpr uint32_t stick_size_padded_aligned = get_compile_time_arg_val(2);
-    constexpr uint32_t num_output_pages_in_row = get_compile_time_arg_val(3);
-    constexpr uint32_t accessor_page_size = get_compile_time_arg_val(4);
-    constexpr auto dst_args = TensorAccessorArgs<5>();
+    constexpr auto stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr auto stick_size_padded_aligned = get_arg(args::stick_size_padded_aligned);
+    constexpr auto num_output_pages_in_row = get_arg(args::num_output_pages_in_row);
 
-    const auto s = TensorAccessor(dst_args, dst_addr, accessor_page_size);
+    const auto s = TensorAccessor(tensor::dst);
     Noc noc;
-    DataflowBuffer dfb_out0_exp(dfb_out0);
+    DataflowBuffer dfb_out0_exp(dfb::out0);
 
     uint32_t i_page = start_page_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core;) {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
@@ -9,10 +9,10 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
-inline __attribute__((always_inline)) void fill_pad_cb_with_val(
-    Noc& noc, const uint32_t cb_id, const uint32_t num_bytes_risc, uint32_t num_noc_transfer, const uint32_t val) {
-    DataflowBuffer dfb(cb_id);
+inline __attribute__((always_inline)) void fill_pad_dfb_with_val(
+    Noc& noc, DataflowBuffer& dfb, const uint32_t num_bytes_risc, uint32_t num_noc_transfer, const uint32_t val) {
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb.get_write_ptr());
 
     for (uint32_t i = 0; i < num_bytes_risc / 2; ++i) {
@@ -37,60 +37,57 @@ inline __attribute__((always_inline)) void fill_pad_cb_with_val(
     noc.async_read_barrier();
 }
 
-inline __attribute__((always_inline)) void fill_pad_cb_with_zero(
-    Noc& noc, const uint32_t cb_id, const uint32_t num_bytes_risc, uint32_t num_noc_transfer) {
-    DataflowBuffer dfb(cb_id);
+inline __attribute__((always_inline)) void fill_pad_dfb_with_zero(
+    Noc& noc, DataflowBuffer& dfb, const uint32_t num_bytes_risc, uint32_t num_noc_transfer) {
     noc.async_write_zeros(dfb, num_bytes_risc * num_noc_transfer);
     noc.write_zeros_l1_barrier();
 }
 
 void kernel_main() {
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t front_pad_n = get_arg_val<uint32_t>(2);
-    uint32_t front_pad_c = get_arg_val<uint32_t>(3);
-    uint32_t front_pad_h = get_arg_val<uint32_t>(4);
-    tt_l1_ptr uint32_t* start_dim_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(5));
+    auto num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    auto start_id = get_arg(args::start_id);
+    auto front_pad_n = get_arg(args::front_pad_n);
+    auto front_pad_c = get_arg(args::front_pad_c);
+    auto front_pad_h = get_arg(args::front_pad_h);
 
-    constexpr uint32_t N = get_compile_time_arg_val(0);
-    constexpr uint32_t H = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t N_padded = get_compile_time_arg_val(4);
-    constexpr uint32_t H_padded = get_compile_time_arg_val(5);
-    constexpr uint32_t C_padded = get_compile_time_arg_val(6);
-    constexpr uint32_t num_zero_pad_sticks_read = get_compile_time_arg_val(7);
-    constexpr uint32_t zero_pad_stick_size = get_compile_time_arg_val(8);
+    constexpr auto N = get_arg(args::N);
+    constexpr auto H = get_arg(args::H);
+    constexpr auto C = get_arg(args::C);
+    constexpr auto stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr auto N_padded = get_arg(args::N_padded);
+    constexpr auto H_padded = get_arg(args::H_padded);
+    constexpr auto C_padded = get_arg(args::C_padded);
+    constexpr auto num_zero_pad_sticks_read = get_arg(args::num_zero_pad_sticks_read);
+    constexpr auto zero_pad_stick_size = get_arg(args::zero_pad_stick_size);
 
-    constexpr bool not_pad_by_zero = get_compile_time_arg_val(9) == 1;
+    constexpr bool not_pad_by_zero = get_arg(args::not_pad_by_zero) == 1;
     uint32_t packed_pad_value = 0;
     uint32_t row_major_min_bytes = 0;
     uint32_t num_sticks_padded_read = 0;
     if constexpr (not_pad_by_zero) {
-        packed_pad_value = kernel_compile_time_args[10];
-        row_major_min_bytes = kernel_compile_time_args[11];
-        num_sticks_padded_read = kernel_compile_time_args[12];
+        packed_pad_value = get_arg(args::packed_pad_value);
+        row_major_min_bytes = get_arg(args::row_major_min_bytes);
+        num_sticks_padded_read = get_arg(args::num_sticks_padded_read);
     }
 
-    constexpr auto cb_pad = tt::CBIndex::c_1;
-    constexpr auto dfb_out0 = tt::CBIndex::c_16;
-    DataflowBuffer dfb_pad_exp(cb_pad);
-    DataflowBuffer dfb_out0_exp(dfb_out0);
+    DataflowBuffer dfb_pad_exp(dfb::pad);
+    DataflowBuffer dfb_out0_exp(dfb::out_shard);
 
     Noc noc;
 
     const uint32_t pad_val_addr = dfb_pad_exp.get_read_ptr();
 
     if constexpr (not_pad_by_zero) {
-        fill_pad_cb_with_val(noc, cb_pad, row_major_min_bytes, num_sticks_padded_read, packed_pad_value);
+        fill_pad_dfb_with_val(noc, dfb_pad_exp, row_major_min_bytes, num_sticks_padded_read, packed_pad_value);
     } else {
-        fill_pad_cb_with_zero(noc, cb_pad, zero_pad_stick_size, num_zero_pad_sticks_read);
+        fill_pad_dfb_with_zero(noc, dfb_pad_exp, zero_pad_stick_size, num_zero_pad_sticks_read);
     }
 
     uint32_t l1_write_addr = dfb_out0_exp.get_write_ptr();
 
     uint32_t i_stick = start_id;
-    uint32_t curr_c = start_dim_offset[2], curr_h = start_dim_offset[1], curr_n = start_dim_offset[3];
+    uint32_t curr_c = get_arg(args::start_dim_offset_c), curr_h = get_arg(args::start_dim_offset_h),
+             curr_n = get_arg(args::start_dim_offset_n);
     for (uint32_t iter = 0; iter < num_sticks_per_core; ++iter) {
         bool read_stick = (curr_h >= front_pad_h and curr_h < H) and (curr_c >= front_pad_c and curr_c < C) and
                           (curr_n >= front_pad_n and curr_n < N);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp
@@ -11,28 +11,28 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 #define u16_l1_ptr volatile tt_l1_ptr uint16_t*
 #define u32_l1_ptr volatile tt_l1_ptr uint32_t*
 
 template <uint32_t padding_value_num_bytes, uint32_t num_bytes>
-inline __attribute__((always_inline)) void fill_cb_with_padding_value(
-    const uint32_t cb_id, const uint32_t padding_value_as_u32) {
+inline __attribute__((always_inline)) void fill_dfb_with_padding_value(
+    DataflowBuffer& dfb, const uint32_t padding_value_as_u32) {
     constexpr uint32_t num_elts =
         num_bytes / padding_value_num_bytes;  // constexpr so that this division happens once on host
-    DataflowBuffer dfb(cb_id);
-    uint32_t cb_write_addr = dfb.get_write_ptr();
+    uint32_t dfb_write_addr = dfb.get_write_ptr();
 
     if constexpr (padding_value_num_bytes == 4) {
-        u32_l1_ptr cb_write_addr_as_u32 = reinterpret_cast<u32_l1_ptr>(cb_write_addr);
+        u32_l1_ptr dfb_write_addr_as_u32 = reinterpret_cast<u32_l1_ptr>(dfb_write_addr);
         for (uint32_t i = 0; i < num_elts; i++) {
-            cb_write_addr_as_u32[i] = padding_value_as_u32;
+            dfb_write_addr_as_u32[i] = padding_value_as_u32;
         }
     } else if constexpr (padding_value_num_bytes == 2) {
         uint16_t padding_value_as_u16 = static_cast<uint16_t>(padding_value_as_u32);
-        u16_l1_ptr cb_write_addr_as_u16 = reinterpret_cast<u16_l1_ptr>(cb_write_addr);
+        u16_l1_ptr dfb_write_addr_as_u16 = reinterpret_cast<u16_l1_ptr>(dfb_write_addr);
         for (uint32_t i = 0; i < num_elts; i++) {
-            cb_write_addr_as_u16[i] = padding_value_as_u16;
+            dfb_write_addr_as_u16[i] = padding_value_as_u16;
         }
     } else {
         static_assert(
@@ -41,22 +41,20 @@ inline __attribute__((always_inline)) void fill_cb_with_padding_value(
 }
 
 void kernel_main() {
-    constexpr uint32_t padded_stick_bytes         = get_compile_time_arg_val(0);
-    constexpr uint32_t padded_shard_height        = get_compile_time_arg_val(1);
-    constexpr uint32_t padding_value_as_u32         = get_compile_time_arg_val(2);
-    constexpr uint32_t padding_value_num_bytes      = get_compile_time_arg_val(3);
+    constexpr auto padded_stick_bytes = get_arg(args::padded_stick_bytes);
+    constexpr auto padded_shard_height = get_arg(args::padded_shard_height);
+    constexpr auto padding_value_as_u32 = get_arg(args::padding_value_as_u32);
+    constexpr auto padding_value_num_bytes = get_arg(args::padding_value_num_bytes);
 
-    constexpr auto output_shard_dfb = get_compile_time_arg_val(4);
-    constexpr auto padding_value_cb = get_compile_time_arg_val(5);
-    DataflowBuffer dfb_output_shard(output_shard_dfb);
-    DataflowBuffer dfb_padding_value(padding_value_cb);
+    DataflowBuffer dfb_output_shard(dfb::out_shard);
+    DataflowBuffer dfb_padding_value(dfb::pad);
 
     Noc noc;
 
     dfb_output_shard.reserve_back(padded_shard_height);
     uint32_t output_shard_base_addr = dfb_output_shard.get_write_ptr();
 
-    fill_cb_with_padding_value<padding_value_num_bytes, padded_stick_bytes>(padding_value_cb, padding_value_as_u32);
+    fill_dfb_with_padding_value<padding_value_num_bytes, padded_stick_bytes>(dfb_padding_value, padding_value_as_u32);
     uint32_t padding_value_base_addr = dfb_padding_value.get_read_ptr();
 
     CoreLocalMem<uint32_t> pad_src(padding_value_base_addr);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
@@ -10,6 +10,7 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 // This kernel keeps track of which page (tile) we are on from a logical tensor perspective, and fills the output with
 // either the input or padding respectively
@@ -19,30 +20,33 @@
 // [0:2, 0:2, 0:1, 0:1] we wait for the reader to send us the correct tile, and then write it, otherwise we
 // write padding.
 void kernel_main() {
-    constexpr uint32_t input_dfb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t output_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t pad_val_dfb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t page_size = get_compile_time_arg_val(3);
-    constexpr uint32_t num_dims = get_compile_time_arg_val(4);
-    constexpr uint32_t pad_value = get_compile_time_arg_val(5);
-    constexpr uint32_t element_size = get_compile_time_arg_val(6);
+    constexpr auto page_size = get_arg(args::page_size);
+    constexpr auto num_dims = get_arg(args::num_dims);
+    constexpr auto pad_value = get_arg(args::pad_value);
+    constexpr auto element_size = get_arg(args::element_size);
     constexpr uint32_t num_elements = page_size / element_size;
 
-    uint32_t rt_ind = 0;
-    const uint32_t output_addr = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
-    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
-    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* input_id_per_dim = output_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* output_id_per_dim = input_id_per_dim + num_dims;
+    const auto num_pages_to_write = get_arg(args::num_pages_to_write);
+    const auto start_offset = get_arg(args::start_offset);
 
-    constexpr auto dst_args = TensorAccessorArgs<7>();
+    // Four num_dims-long runtime vararg blocks, in host push order. The two id_per_dim blocks are
+    // advanced as this kernel walks the output, so they are copied into locals: get_vararg() reads
+    // a vararg but cannot write one back.
+    uint32_t input_page_shape[num_dims];
+    uint32_t output_page_shape[num_dims];
+    uint32_t input_id_per_dim[num_dims];
+    uint32_t output_id_per_dim[num_dims];
+    for (uint32_t d = 0; d < num_dims; d++) {
+        input_page_shape[d] = get_vararg(d);
+        output_page_shape[d] = get_vararg(num_dims + d);
+        input_id_per_dim[d] = get_vararg(2 * num_dims + d);
+        output_id_per_dim[d] = get_vararg(3 * num_dims + d);
+    }
 
-    const auto s0 = TensorAccessor(dst_args, output_addr);
+    const auto s0 = TensorAccessor(tensor::dst);
     Noc noc;
-    DataflowBuffer dfb_input(input_dfb_id);
-    DataflowBuffer dfb_pad_val(pad_val_dfb_id);
+    DataflowBuffer dfb_input(dfb::in0);
+    DataflowBuffer dfb_pad_val(dfb::pad);
 
     // Reserve and push the pad value into the circular buffer, generalized for any contiguous dtype
     dfb_pad_val.reserve_back(1);
@@ -55,7 +59,7 @@ void kernel_main() {
         }
     }
     dfb_pad_val.push_back(1);
-    // Our scratchpad cb is now a tile full of padding.
+    // Our scratchpad DFB is now a tile full of padding.
 
     bool within_input_region;
     uint32_t output_page_offset = start_offset;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
@@ -8,33 +8,29 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_unpadded_W = get_arg_val<uint32_t>(1);
-    const uint32_t num_padded_Wt = get_arg_val<uint32_t>(2);
-    const uint32_t num_unpadded_Z = get_arg_val<uint32_t>(3);
-    const uint32_t num_padded_Zt = get_arg_val<uint32_t>(4);
-    const uint32_t num_unpadded_Yt = get_arg_val<uint32_t>(5);
-    const uint32_t num_padded_Yt = get_arg_val<uint32_t>(6);
-    const uint32_t num_unpadded_Xt = get_arg_val<uint32_t>(7);
-    const uint32_t num_padded_Xt = get_arg_val<uint32_t>(8);
-    const uint32_t pad_value = get_arg_val<uint32_t>(9);
+    const auto num_unpadded_W = get_arg(args::num_unpadded_W);
+    const auto num_padded_Wt = get_arg(args::num_padded_Wt);
+    const auto num_unpadded_Z = get_arg(args::num_unpadded_Z);
+    const auto num_padded_Zt = get_arg(args::num_padded_Zt);
+    const auto num_unpadded_Yt = get_arg(args::num_unpadded_Yt);
+    const auto num_padded_Yt = get_arg(args::num_padded_Yt);
+    const auto num_unpadded_Xt = get_arg(args::num_unpadded_Xt);
+    const auto num_padded_Xt = get_arg(args::num_padded_Xt);
+    const auto pad_value = get_arg(args::pad_value);
 
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t dfb_id_out1 = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
-
-    const uint32_t tile_size = get_tile_size(cb_id_out0);
-
-    const auto s1 = TensorAccessor(dst_args, dst_addr);
+    const auto s1 = TensorAccessor(tensor::dst);
     Noc noc;
-    DataflowBuffer dfb_out0(cb_id_out0);
-    DataflowBuffer dfb_out1(dfb_id_out1);
+    DataflowBuffer dfb_out0(dfb::out0);
+    DataflowBuffer dfb_pad(dfb::pad);
 
-    dfb_out1.reserve_back(1);  // in this kernel we are not pushing anything into CBs, just using the space
+    const uint32_t tile_size = dfb_out0.get_tile_size();
 
-    uint32_t pad_buffer_l1_addr = dfb_out1.get_write_ptr();
+    dfb_pad.reserve_back(1);  // in this kernel we are not pushing anything into DFBs, just using the space
+
+    uint32_t pad_buffer_l1_addr = dfb_pad.get_write_ptr();
 
     // Fill pad tile with pad value
     volatile tt_l1_ptr uint32_t* pad_buffer = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pad_buffer_l1_addr);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -5,16 +5,17 @@
 #include "pad_rm_reader_writer_multi_core_default_program_factory.hpp"
 
 #include <algorithm>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 static const uint32_t max_read_size = 2048;  // max read size in bytes for reader and writer kernels
 
 namespace ttnn::prim {
@@ -27,14 +28,27 @@ uint32_t get_num_stick_per_barrier(uint32_t stick_size_padded_aligned) {
     return std::max(tt::div_up(max_read_size, stick_size_padded_aligned), 1u);
 }
 
+// Names are prefixed per factory: all seven pad factories land in one unity-build
+// translation unit, where every anonymous namespace is merged into a single scope.
+const KernelSpecName RM_DEF_READER{"reader"};
+const KernelSpecName RM_DEF_WRITER{"writer"};
+const DFBSpecName RM_DEF_IN0{"in0"};
+const DFBSpecName RM_DEF_PAD{"pad"};
+const DFBSpecName RM_DEF_PAD_ALIGN{"pad_align"};
+const TensorParamName RM_DEF_INPUT{"input"};
+const TensorParamName RM_DEF_OUTPUT{"output"};
+
 }  // namespace
 
-ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& input_tensor_start = operation_attributes.input_tensor_start;
+
+    const auto& input_mesh_tensor = a.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
 
     const auto& a_shape = a.logical_shape();
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
@@ -47,33 +61,26 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
     auto stick_size = W * a.element_size();
     auto stick_size_padded = W_padded * a.element_size();
     auto stick_size_padded_front = front_pad[-1] * a.element_size();
-    auto stick_size_padded_end = stick_size_padded - stick_size - stick_size_padded_front;
     uint32_t stick_size_padded_aligned = tt::align(stick_size_padded, hal::get_l1_alignment());
     uint32_t stick_size_padded_DRAM_aligned = tt::align(stick_size_padded, hal::get_dram_alignment());
-    uint32_t row_major_min_bytes = 16;
 
     // Input page-based addressing
     uint32_t num_input_pages_in_row = 1;
-    uint32_t input_accessor_page_size = stick_size;
     if (a.is_sharded()) {
         uint32_t shard_width =
             a.shard_spec().has_value() ? a.shard_spec().value().shape[1] : a.nd_shard_spec().value().shard_shape[-1];
         num_input_pages_in_row = tt::div_up(a.logical_shape()[-1], shard_width);
-        // Use the buffer's per-page size (shard width for W/B/ND sharded; full stick for height sharded).
-        input_accessor_page_size = a.buffer()->aligned_page_size();
     }
 
     // Output page-based addressing
     uint32_t num_output_pages_in_row = 1;
-    uint32_t output_accessor_page_size = stick_size_padded;
     if (output.is_sharded()) {
         uint32_t output_shard_width = output.shard_spec().has_value() ? output.shard_spec().value().shape[1]
                                                                       : output.nd_shard_spec().value().shard_shape[-1];
         num_output_pages_in_row = tt::div_up(W_padded, output_shard_width);
-        output_accessor_page_size = output.buffer()->aligned_page_size();
     }
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
 
     IDevice* device = a.device();
 
@@ -92,14 +99,10 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
 
     auto cores_in_order = corerange_to_cores(all_cores, num_cores, true);
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -110,96 +113,155 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }
 
-    ProgramDescriptor desc;
+    Group<DataflowBufferSpec> dataflow_buffers;
 
-    // c_1 reused for pad-value scratch on every dispatch.
-    uint32_t src1_cb_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = stick_size_padded_DRAM_aligned,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src1_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_padded_DRAM_aligned,
-        }}},
+    // pad: reused for pad-value scratch on every dispatch. Only the reader touches it — it fills
+    // the entry with baby-RISCV stores and loop-back-reads it per stick, with no FIFO ops — so the
+    // reader binds both endpoints (self-loop).
+    dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = RM_DEF_PAD,
+        .entry_size = stick_size_padded_DRAM_aligned,
+        .num_entries = 1,
+        .data_format_metadata = dfb_data_format,
     });
 
+    // pad_align: a realignment staging area, allocated only when the reader can actually take one
+    // of the two branches that use it. The kernel gates its construction and every reference to it
+    // on the matching PAD_ALIGN_DFB define, because a kernel may not name a DFB it has not bound.
     bool unaligned = stick_size_padded_aligned % hal::get_dram_alignment() != 0;
-    if (stick_size_padded_front != 0 || unaligned) {
-        uint32_t src2_cb_index = tt::CBIndex::c_2;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = stick_size_padded_DRAM_aligned,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(src2_cb_index),
-                .data_format = cb_data_format,
-                .page_size = stick_size_padded_DRAM_aligned,
-            }}},
+    const bool needs_pad_align_dfb = stick_size_padded_front != 0 || unaligned;
+    if (needs_pad_align_dfb) {
+        dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = RM_DEF_PAD_ALIGN,
+            .entry_size = stick_size_padded_DRAM_aligned,
+            .num_entries = 1,
+            .data_format_metadata = dfb_data_format,
         });
     }
 
-    std::vector<uint32_t> reader_ct_args = {
-        (std::uint32_t)N + front_pad[-4],
-        (std::uint32_t)H + front_pad[-2],
-        (std::uint32_t)C + front_pad[-3],
-        (std::uint32_t)stick_size,
-        (std::uint32_t)N_padded,
-        (std::uint32_t)H_padded,
-        (std::uint32_t)C_padded,
-        (std::uint32_t)stick_size_padded,
-        (std::uint32_t)stick_size_padded_front,
-        (std::uint32_t)stick_size_padded_end,
-        (std::uint32_t)tt::div_up(stick_size_padded, 512),  // max zero size is 512B
-        (std::uint32_t)(stick_size_padded % 512 == 0 ? 512 : stick_size_padded % 512),
-        (std::uint32_t)not_pad_by_zero,
-        (std::uint32_t)packed_pad_value,
-        (std::uint32_t)row_major_min_bytes,
-        (std::uint32_t)(stick_size_padded_front / row_major_min_bytes),
-        (std::uint32_t)(stick_size_padded_end / row_major_min_bytes),
-        (std::uint32_t)(stick_size_padded / row_major_min_bytes),
-        (std::uint32_t)stick_size_padded_aligned,
-        (std::uint32_t)unaligned,
-        (std::uint32_t)num_input_pages_in_row,
-        (std::uint32_t)input_accessor_page_size};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
+    Group<DFBBinding> reader_dfb_bindings = {
+        DFBBinding{
+            .dfb_spec_name = RM_DEF_IN0,
+            .accessor_name = "in0",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        },
+        DFBBinding{
+            .dfb_spec_name = RM_DEF_PAD,
+            .accessor_name = "pad",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        },
+        DFBBinding{
+            .dfb_spec_name = RM_DEF_PAD,
+            .accessor_name = "pad",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        },
+    };
+    KernelSpec::CompilerOptions::Defines reader_defines;
+    if (needs_pad_align_dfb) {
+        reader_dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = RM_DEF_PAD_ALIGN,
+            .accessor_name = "pad_align",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        });
+        reader_dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = RM_DEF_PAD_ALIGN,
+            .accessor_name = "pad_align",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        });
+        reader_defines.emplace("PAD_ALIGN_DFB", "1");
+    }
 
-    std::vector<uint32_t> writer_ct_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)stick_size_padded,
-        (std::uint32_t)stick_size_padded_aligned,
-        (std::uint32_t)num_output_pages_in_row,
-        (std::uint32_t)output_accessor_page_size};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+    KernelSpec reader{
+        .unique_id = RM_DEF_READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "reader_pad_dims_rm_interleaved_v2.cpp",
+        .compiler_options = {.defines = std::move(reader_defines)},
+        .dfb_bindings = std::move(reader_dfb_bindings),
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = RM_DEF_INPUT,
+                    .accessor_name = "src",
+                },
+            },
+        .compile_time_args =
+            {
+                {"N", static_cast<uint32_t>(N + front_pad[-4])},
+                {"H", static_cast<uint32_t>(H + front_pad[-2])},
+                {"C", static_cast<uint32_t>(C + front_pad[-3])},
+                {"stick_size_bytes", static_cast<uint32_t>(stick_size)},
+                {"N_padded", N_padded},
+                {"H_padded", H_padded},
+                {"C_padded", C_padded},
+                {"stick_size_padded", static_cast<uint32_t>(stick_size_padded)},
+                {"stick_size_padded_front", static_cast<uint32_t>(stick_size_padded_front)},
+                {"not_pad_by_zero", static_cast<uint32_t>(not_pad_by_zero)},
+                {"packed_pad_value", packed_pad_value},
+                {"stick_size_padded_aligned", stick_size_padded_aligned},
+                {"unaligned", static_cast<uint32_t>(unaligned)},
+                {"num_input_pages_in_row", num_input_pages_in_row},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_sticks_per_core",
+                     "num_sticks_per_barrier",
+                     "start_page_id",
+                     "front_pad_n",
+                     "front_pad_c",
+                     "front_pad_h",
+                     "start_dim_offset_h",
+                     "start_dim_offset_c",
+                     "start_dim_offset_n"},
+            },
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+    };
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    KernelSpec writer{
+        .unique_id = RM_DEF_WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "writer_pad_dims_rm_interleaved_v2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = RM_DEF_IN0,
+                    .accessor_name = "out0",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = RM_DEF_OUTPUT,
+                    .accessor_name = "dst",
+                },
+            },
+        .compile_time_args =
+            {
+                {"stick_size_bytes", static_cast<uint32_t>(stick_size_padded)},
+                {"stick_size_padded_aligned", stick_size_padded_aligned},
+                {"num_output_pages_in_row", num_output_pages_in_row},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_sticks_per_core", "num_sticks_per_barrier", "start_page_id"},
+            },
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
 
     // Build per-core runtime args inline (legacy path called get_runtime_args_rm()
-    // which produced the same data).  Slot 0 of both reader and writer is a raw
-    // buffer base address (no offset) — use Buffer* for BufferBinding so the
-    // framework patches addresses on cache hits.  Idle cores (num_sticks_per_core
-    // == 0) pass 0u to skip the binding since the kernel does nothing.
+    // which produced the same data).
     // The legacy helper used input_tensor.padded_shape() for the H/C/N bounds —
     // mirror that here.  H_padded/C_padded already use the output padded shape.
     auto input_padded_shape = a.padded_shape();
     uint32_t H_in = input_padded_shape[2], C_in = input_padded_shape[1], N_in = input_padded_shape[0];
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_padded_shape.rank());
-    std::vector<uint32_t> start_dim_offset(num_dims, 0);
 
     uint32_t num_sticks_per_barrier = get_num_stick_per_barrier(stick_size_padded_aligned);
+
+    KernelRunArgs reader_run_args{.kernel = RM_DEF_READER};
+    KernelRunArgs writer_run_args{.kernel = RM_DEF_WRITER};
 
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
     uint32_t curr_sticks_read = 0;
@@ -215,31 +277,27 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
             num_sticks_per_core = 0;
         }
 
-        KernelDescriptor::RTArgList reader_rt_args;
-        KernelDescriptor::RTArgList writer_rt_args;
-        if (num_sticks_per_core != 0) {
-            reader_rt_args.push_back(src0_buffer);
-            writer_rt_args.push_back(dst_buffer);
-        } else {
-            reader_rt_args.push_back(0u);
-            writer_rt_args.push_back(0u);
-        }
-        reader_rt_args.push_back(num_sticks_per_core);
-        reader_rt_args.push_back(num_sticks_per_barrier);
-        reader_rt_args.push_back(curr_sticks_read * num_input_pages_in_row);
-        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-4]));
-        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-3]));
-        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-2]));
-        for (uint32_t v : start_dim_offset) {
-            reader_rt_args.push_back(v);
-        }
+        // curr_h / curr_c / curr_n are this core's starting position in the padded output; they
+        // are advanced by the loop below only after these args are recorded.
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            core,
+            {{"num_sticks_per_core", num_sticks_per_core},
+             {"num_sticks_per_barrier", num_sticks_per_barrier},
+             {"start_page_id", curr_sticks_read * num_input_pages_in_row},
+             {"front_pad_n", static_cast<uint32_t>(front_pad[-4])},
+             {"front_pad_c", static_cast<uint32_t>(front_pad[-3])},
+             {"front_pad_h", static_cast<uint32_t>(front_pad[-2])},
+             {"start_dim_offset_h", curr_h},
+             {"start_dim_offset_c", curr_c},
+             {"start_dim_offset_n", curr_n}});
 
-        writer_rt_args.push_back(num_sticks_per_core);
-        writer_rt_args.push_back(num_sticks_per_barrier);
-        writer_rt_args.push_back(curr_sticks_write * num_output_pages_in_row);
-
-        reader_desc.emplace_runtime_args(core, reader_rt_args);
-        writer_desc.emplace_runtime_args(core, writer_rt_args);
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            core,
+            {{"num_sticks_per_core", num_sticks_per_core},
+             {"num_sticks_per_barrier", num_sticks_per_barrier},
+             {"start_page_id", curr_sticks_write * num_output_pages_in_row}});
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -260,26 +318,47 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
                 }
             }
         }
-
-        start_dim_offset = {0, curr_h, curr_c, curr_n};
     }
 
-    uint32_t cb_npages = get_num_stick_per_barrier(stick_size_padded_aligned);
+    uint32_t dfb_npages = get_num_stick_per_barrier(stick_size_padded_aligned);
     const uint32_t buffer_reader_writer_async_factor = 16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = buffer_reader_writer_async_factor * cb_npages * stick_size_padded_aligned,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_padded_aligned,
-        }}},
+    dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = RM_DEF_IN0,
+        .entry_size = stick_size_padded_aligned,
+        .num_entries = buffer_reader_writer_async_factor * dfb_npages,
+        .data_format_metadata = dfb_data_format,
     });
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    ProgramSpec spec{
+        .name = "pad_rm_reader_writer_multi_core_default",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = std::move(dataflow_buffers),
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = RM_DEF_INPUT, .spec = input_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = RM_DEF_OUTPUT, .spec = output_mesh_tensor.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {RM_DEF_READER, RM_DEF_WRITER},
+                    .target_nodes = all_cores,
+                },
+            },
+    };
 
-    return desc;
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {
+        {RM_DEF_INPUT, TensorArgument{input_mesh_tensor}},
+        {RM_DEF_OUTPUT, TensorArgument{output_mesh_tensor}},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+    };
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmReaderWriterMultiCoreDefaultProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_reader_writer_multi_core_program_factory.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 using namespace tt::constants;
 
 namespace ttnn::prim {
@@ -17,11 +18,14 @@ using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
-inline void log_rt_args(const CoreCoord& core, std::vector<uint32_t>& args) {
-    for (auto v : args) {
-        log_debug(tt::LogOp, "{},{} :: {}", core.x, core.y, v);
-    }
-}
+// Names are prefixed per factory: all seven pad factories land in one unity-build
+// translation unit, where every anonymous namespace is merged into a single scope.
+const KernelSpecName RM_MC_READER{"reader"};
+const KernelSpecName RM_MC_WRITER{"writer"};
+const DFBSpecName RM_MC_IN0{"in0"};
+const TensorParamName RM_MC_INPUT{"input"};
+const TensorParamName RM_MC_OUTPUT{"output"};
+const TensorParamName RM_MC_PAD_VALUE{"pad_value_const"};
 
 // This is currently mostly hardcoded for resnet shapes
 inline std::tuple<uint32_t, uint32_t, uint32_t, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t, uint32_t, uint32_t>
@@ -159,9 +163,9 @@ split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint
 }
 
 // Allocate the on-device pad-value const tensor.  Pulled out so
-// create_workload_descriptor() can build it once on cache miss and park it on
-// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
-// device memory) until the cached workload is evicted (see #44565).
+// create_program_artifacts() can build it once on cache miss and hand its
+// MeshTensor to the framework as an op-owned tensor, deferring the device
+// deallocation until the cached Program is evicted (see #44565).
 Tensor build_pad_value_const_tensor_mc(const PadInputs& tensor_args, float pad_value) {
     MeshDevice* device = tensor_args.input.device();
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
@@ -177,12 +181,23 @@ Tensor build_pad_value_const_tensor_mc(const PadInputs& tensor_args, float pad_v
         .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
 }
 
-ProgramDescriptor build_pad_rm_mc_program_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& output,
-    Buffer* pad_value_const_buffer) {
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactory::create_program_artifacts(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
+    const auto& input_mesh_tensor = a.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
+
+    // Build the pad-value const tensor once on cache miss and release its owning MeshTensor into
+    // the artifact.  The framework parks it in the cache entry, so its address stays valid for
+    // every dispatch that hits this cached Program.
+    std::vector<tt::tt_metal::MeshTensor> op_owned;
+    op_owned.reserve(1);
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor_mc(tensor_args, operation_attributes.pad_value);
+    op_owned.push_back(pad_value_const_tensor.device_storage().release_mesh_tensor());
+    const auto& pad_value_mesh_tensor = op_owned.back();
+
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
 
@@ -219,34 +234,20 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
     [[maybe_unused]] int32_t src_nbytes_per_core_w = ntiles_per_core_w * TILE_WIDTH * a.element_size();
     int32_t dst_nbytes_per_core_w = ntiles_per_core_w * TILE_WIDTH * output.element_size();
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    ProgramDescriptor desc;
-
-    uint32_t cb_id = tt::CBIndex::c_0;
-    uint32_t cb_npages = 16;  // multibuffering for perf
-    // uint32_t cb_npages = 1; // multibuffering for perf
-    uint32_t cb_page_alignment = std::max(tt::constants::TILE_WIDTH, src0_buffer->alignment());
-    uint32_t cb_pagesize =
-        static_cast<uint32_t>(std::ceil((float)dst_nbytes_per_core_w / cb_page_alignment)) * cb_page_alignment;
+    uint32_t dfb_npages = 16;  // multibuffering for perf
+    // uint32_t dfb_npages = 1; // multibuffering for perf
+    uint32_t dfb_page_alignment = std::max(tt::constants::TILE_WIDTH, a.buffer()->alignment());
+    uint32_t dfb_pagesize =
+        static_cast<uint32_t>(std::ceil((float)dst_nbytes_per_core_w / dfb_page_alignment)) * dfb_page_alignment;
     tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_npages * cb_pagesize,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_id),
-            .data_format = in_df,
-            .page_size = cb_pagesize,
-        }}},
-    });
-
-    std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = reader_ct_args;
+    DataflowBufferSpec in0_dfb{
+        .unique_id = RM_MC_IN0,
+        .entry_size = dfb_pagesize,
+        .num_entries = dfb_npages,
+        .data_format_metadata = in_df,
+    };
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -257,23 +258,84 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    KernelSpec reader{
+        .unique_id = RM_MC_READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "reader_pad_dims_rm_interleaved.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = RM_MC_IN0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = RM_MC_INPUT,
+                    .accessor_name = "src",
+                },
+                TensorBinding{
+                    .tensor_parameter_name = RM_MC_PAD_VALUE,
+                    .accessor_name = "pad_value",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_unpadded_W",
+                     "num_unpadded_Z",
+                     "num_total_Z",
+                     "unpadded_X_nbytes",
+                     "padded_X_nbytes",
+                     "padded_X_diff_nbytes",
+                     "pad_value_packed",
+                     "start_src_stick_id",
+                     "start_src_stick_offset",
+                     "num_local_Y",
+                     "num_local_unpadded_Y",
+                     "num_local_W"},
+            },
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    // int32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
-    log_rt_args(CoreCoord{0, 0}, reader_desc.compile_time_args);
+    KernelSpec writer{
+        .unique_id = RM_MC_WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "writer_pad_dims_rm_interleaved.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = RM_MC_IN0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = RM_MC_OUTPUT,
+                    .accessor_name = "dst",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_total_Z",
+                     "padded_X_nbytes",
+                     "start_dst_stick_id",
+                     "num_local_Y",
+                     "dst_stick_offset",
+                     "num_local_W"},
+            },
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
+
+    KernelRunArgs reader_run_args{.kernel = RM_MC_READER};
+    KernelRunArgs writer_run_args{.kernel = RM_MC_WRITER};
 
 #if 1
     {
@@ -282,8 +344,6 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         log_debug(tt::LogOp, "ncores_w: {}", ncores_w);
         log_debug(tt::LogOp, "ntiles_per_core_h: {}", ntiles_per_core_h);
         log_debug(tt::LogOp, "ntiles_per_core_w: {}", ntiles_per_core_w);
-        log_debug(tt::LogOp, "src0_buffer_addr: {}", src0_buffer->address());
-        log_debug(tt::LogOp, "dst_buffer_addr: {}", dst_buffer->address());
         log_debug(tt::LogOp, "a.shape[0]: {}", a.padded_shape()[0]);
         log_debug(tt::LogOp, "out.shape[0]: {}", output_shape[0]);
         log_debug(tt::LogOp, "a.shape[1]: {}", a.padded_shape()[1]);
@@ -295,7 +355,6 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
         log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
         // log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
-        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
         log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
         log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
         log_debug(tt::LogOp, "src_nbytes_per_core_w: {}", src_nbytes_per_core_w);
@@ -338,53 +397,32 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
                     curr_stick_diff_nbytes = dst_nbytes_per_core_w - curr_stick_size_nbytes;
                     rem_src_stick_size_nbytes = 0;
                 }
-                // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
-                // bind them as Buffer* so the framework patches the addresses on cache hits
-                // without rebuilding the descriptor.  The const tensor is owned by
-                // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
-                // remains valid across cache hits.
-                KernelDescriptor::RTArgList reader_rt_args;
-                reader_rt_args.reserve(27);
-                reader_rt_args.push_back(src0_buffer);
-                reader_rt_args.push_back(dst_buffer);
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
-                reader_rt_args.push_back(curr_stick_size_nbytes);
-                reader_rt_args.push_back(static_cast<uint32_t>(dst_nbytes_per_core_w));
-                reader_rt_args.push_back(static_cast<uint32_t>(curr_stick_diff_nbytes));
-                reader_rt_args.push_back(pad_value_const_buffer);
-                reader_rt_args.push_back(pad_value_const_buffer_nbytes);
-                reader_rt_args.push_back(packed_pad_value);
-                reader_rt_args.push_back(start_src_stick_id);
-                reader_rt_args.push_back(start_dst_stick_id);
-                reader_rt_args.push_back(start_src_stick_wi);
-                reader_rt_args.push_back(start_dst_stick_wi);
-                reader_rt_args.push_back(start_src_stick_wi * a.element_size());
-                reader_rt_args.push_back(static_cast<uint32_t>(local_nsticks));
-                reader_rt_args.push_back(num_local_unpadded_nsticks);
-                reader_rt_args.push_back(unpadded_row_size_nbytes);
-                reader_rt_args.push_back(padded_row_size_nbytes);
-                reader_rt_args.push_back(start_dst_stick_wi * output.element_size());
-                reader_rt_args.push_back(nbatch_per_core_h);
-                // if (core.x == 0) log_rt_args(core, reader_rt_args);
-                // if (core.x == 0) {
-                //     log_debug(tt::LogOp, "{} :: start_src_stick_id: {}", core.y, start_src_stick_id);
-                //     log_debug(tt::LogOp, "{} :: start_dst_stick_id: {}", core.y, start_dst_stick_id);
-                //     log_debug(tt::LogOp, "{} :: local_nsticks: {}", core.y, local_nsticks);
-                //     log_debug(tt::LogOp, "{} :: num_local_unpadded_nsticks: {}", core.y, num_local_unpadded_nsticks);
-                //     log_debug(tt::LogOp, "{} :: nbatch_per_core_h: {}", core.y, nbatch_per_core_h);
-                //     log_debug(tt::LogOp, "{} :: ncores_per_batch_h: {}", core.y, ncores_per_batch_h);
-                // }
-                // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
-                KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
-                reader_desc.emplace_runtime_args(core, reader_rt_args);
-                writer_desc.emplace_runtime_args(core, writer_rt_args);
+                AddRuntimeArgsForNode(
+                    reader_run_args.runtime_arg_values,
+                    core,
+                    {{"num_unpadded_W", static_cast<uint32_t>(a.padded_shape()[0])},
+                     {"num_unpadded_Z", static_cast<uint32_t>(a.padded_shape()[1])},
+                     {"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+                     {"unpadded_X_nbytes", curr_stick_size_nbytes},
+                     {"padded_X_nbytes", static_cast<uint32_t>(dst_nbytes_per_core_w)},
+                     {"padded_X_diff_nbytes", static_cast<uint32_t>(curr_stick_diff_nbytes)},
+                     {"pad_value_packed", packed_pad_value},
+                     {"start_src_stick_id", start_src_stick_id},
+                     {"start_src_stick_offset", start_src_stick_wi * a.element_size()},
+                     {"num_local_Y", static_cast<uint32_t>(local_nsticks)},
+                     {"num_local_unpadded_Y", num_local_unpadded_nsticks},
+                     {"num_local_W", nbatch_per_core_h}});
+
+                AddRuntimeArgsForNode(
+                    writer_run_args.runtime_arg_values,
+                    core,
+                    {{"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+                     {"padded_X_nbytes", static_cast<uint32_t>(dst_nbytes_per_core_w)},
+                     {"start_dst_stick_id", start_dst_stick_id},
+                     {"num_local_Y", static_cast<uint32_t>(local_nsticks)},
+                     {"dst_stick_offset", start_dst_stick_wi * output.element_size()},
+                     {"num_local_W", nbatch_per_core_h}});
+
                 start_src_stick_wi += ntiles_per_core_w * TILE_WIDTH;
                 start_dst_stick_wi += ntiles_per_core_w * TILE_WIDTH;
             }  // for ncores_w
@@ -393,41 +431,39 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         }  // for ncores_h
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    ProgramSpec spec{
+        .name = "pad_rm_reader_writer_multi_core",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = {std::move(in0_dfb)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = RM_MC_INPUT, .spec = input_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = RM_MC_OUTPUT, .spec = output_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = RM_MC_PAD_VALUE, .spec = pad_value_mesh_tensor.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {RM_MC_READER, RM_MC_WRITER},
+                    .target_nodes = all_cores,
+                },
+            },
+    };
 
-    return desc;
-}
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {
+        {RM_MC_INPUT, TensorArgument{input_mesh_tensor}},
+        {RM_MC_OUTPUT, TensorArgument{output_mesh_tensor}},
+        {RM_MC_PAD_VALUE, TensorArgument{pad_value_mesh_tensor}},
+    };
 
-}  // namespace
-
-WorkloadDescriptor PadRmReaderWriterMultiCoreProgramFactory::create_workload_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& output,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    WorkloadDescriptor wd;
-
-    // Build the pad-value const tensor once on cache miss and park it on the
-    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
-    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
-    // device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).
-    Tensor pad_value_const_tensor = build_pad_value_const_tensor_mc(tensor_args, operation_attributes.pad_value);
-    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
-    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
-    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
-
-    auto desc = build_pad_rm_mc_program_descriptor(operation_attributes, tensor_args, output, pad_value_const_buffer);
-
-    auto ranges = tensor_coords.ranges();
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        wd.programs.push_back({ranges[i], desc});
-    }
-    if (!ranges.empty()) {
-        wd.programs.push_back({ranges.back(), std::move(desc)});
-    }
-    return wd;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+        .op_owned_tensors = std::move(op_owned),
+    };
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
@@ -4,29 +4,20 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
-
 #include "ttnn/device_operation.hpp"
-#include "ttnn/distributed/types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmReaderWriterMultiCoreProgramFactory {
-    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
-    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
-    // so it outlives the cached workload via the program cache.  Holding the SOURCE
-    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
-    // the device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
-    // lets the framework patch the const tensor's address on cache hits without rerunning
-    // this factory.
-    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& output,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    // The pad-value const tensor is allocated once on cache miss inside create_program_artifacts()
+    // and handed to the framework as an op-owned tensor, so it outlives the cache miss and keeps a
+    // stable address for the cached Program's lifetime.  The owning MeshTensor is moved out of the
+    // build Tensor with release_mesh_tensor(): holding the SOURCE Tensor would not be enough on its
+    // own, because ~Tensor force-deallocates the device memory through DeviceStorage::deallocate
+    // regardless of external shared_ptr<MeshBuffer> owners (see #44565).
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_reader_writer_program_factory.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 using namespace tt::constants;
 
 namespace ttnn::prim {
@@ -18,10 +19,19 @@ using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
 
+// Names are prefixed per factory: all seven pad factories land in one unity-build
+// translation unit, where every anonymous namespace is merged into a single scope.
+const KernelSpecName RM_SC_READER{"reader"};
+const KernelSpecName RM_SC_WRITER{"writer"};
+const DFBSpecName RM_SC_IN0{"in0"};
+const TensorParamName RM_SC_INPUT{"input"};
+const TensorParamName RM_SC_OUTPUT{"output"};
+const TensorParamName RM_SC_PAD_VALUE{"pad_value_const"};
+
 // Allocate the on-device pad-value const tensor.  Pulled out so
-// create_workload_descriptor() can build it once on cache miss and park it on
-// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
-// device memory) until the cached workload is evicted (see #44565).
+// create_program_artifacts() can build it once on cache miss and hand its
+// MeshTensor to the framework as an op-owned tensor, deferring the device
+// deallocation until the cached Program is evicted (see #44565).
 Tensor build_pad_value_const_tensor_sc(const PadInputs& tensor_args, float pad_value) {
     MeshDevice* device = tensor_args.input.device();
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
@@ -35,54 +45,47 @@ Tensor build_pad_value_const_tensor_sc(const PadInputs& tensor_args, float pad_v
         .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
 }
 
-ProgramDescriptor build_pad_rm_sc_program_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& output,
-    Buffer* pad_value_const_buffer) {
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create_program_artifacts(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
+    Tensor& output = tensor_return_value;
     const auto& pad_value = operation_attributes.pad_value;
+
+    const auto& input_mesh_tensor = a.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
 
     auto output_shape = operation_attributes.output_padded_shape;
 
-    uint32_t unpadded_row_size_nbytes = tensor_args.input.padded_shape()[3] * tensor_args.input.element_size();
-    uint32_t padded_row_size_nbytes =
-        output_shape[3] * tensor_args.input.element_size();  // Assuming output is same datatype as input
+    uint32_t unpadded_row_size_nbytes = a.padded_shape()[3] * a.element_size();
+    uint32_t padded_row_size_nbytes = output_shape[3] * a.element_size();  // Assuming output is same datatype as input
     TT_ASSERT(
         unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
 
-    // construct const buffer with the pad_value
-    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
-    uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * tensor_args.input.element_size();
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    // Build the pad-value const tensor once on cache miss and release its owning MeshTensor into
+    // the artifact.  The framework parks it in the cache entry, so its address stays valid for
+    // every dispatch that hits this cached Program.
+    std::vector<tt::tt_metal::MeshTensor> op_owned;
+    op_owned.reserve(1);
+    Tensor pad_value_const_tensor = build_pad_value_const_tensor_sc(tensor_args, pad_value);
+    op_owned.push_back(pad_value_const_tensor.device_storage().release_mesh_tensor());
+    const auto& pad_value_mesh_tensor = op_owned.back();
 
-    CoreRange cores({0, 0}, {0, 0});
+    const NodeCoord node{0, 0};
 
-    ProgramDescriptor desc;
-
-    uint32_t cb_id = tt::CBIndex::c_0;
-    uint32_t cb_npages = 16;  // multibuffering
-    uint32_t cb_pagesize =
-        tt::round_up(padded_row_size_nbytes, std::max(src0_buffer->alignment(), tt::constants::TILE_WIDTH));
+    uint32_t dfb_npages = 16;  // multibuffering
+    uint32_t dfb_pagesize =
+        tt::round_up(padded_row_size_nbytes, std::max(a.buffer()->alignment(), tt::constants::TILE_WIDTH));
     tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_npages * cb_pagesize,
-        .core_ranges = cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_id),
-            .data_format = in_df,
-            .page_size = cb_pagesize,
-        }}},
-    });
-
-    std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = reader_ct_args;
+    DataflowBufferSpec in0_dfb{
+        .unique_id = RM_SC_IN0,
+        .entry_size = dfb_pagesize,
+        .num_entries = dfb_npages,
+        .data_format_metadata = in_df,
+    };
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -93,123 +96,148 @@ ProgramDescriptor build_pad_rm_sc_program_descriptor(
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    KernelSpec reader{
+        .unique_id = RM_SC_READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "reader_pad_dims_rm_interleaved.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = RM_SC_IN0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = RM_SC_INPUT,
+                    .accessor_name = "src",
+                },
+                TensorBinding{
+                    .tensor_parameter_name = RM_SC_PAD_VALUE,
+                    .accessor_name = "pad_value",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_unpadded_W",
+                     "num_unpadded_Z",
+                     "num_total_Z",
+                     "unpadded_X_nbytes",
+                     "padded_X_nbytes",
+                     "padded_X_diff_nbytes",
+                     "pad_value_packed",
+                     "start_src_stick_id",
+                     "start_src_stick_offset",
+                     "num_local_Y",
+                     "num_local_unpadded_Y",
+                     "num_local_W"},
+            },
+        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    KernelSpec writer{
+        .unique_id = RM_SC_WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "writer_pad_dims_rm_interleaved.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = RM_SC_IN0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = RM_SC_OUTPUT,
+                    .accessor_name = "dst",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_total_Z",
+                     "padded_X_nbytes",
+                     "start_dst_stick_id",
+                     "num_local_Y",
+                     "dst_stick_offset",
+                     "num_local_W"},
+            },
+        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+    };
+
     uint32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
-
-#if 0
-    {
-        log_debug(tt::LogOp, "src0_buffer_addr: {}", src0_buffer->address());
-        log_debug(tt::LogOp, "dst_buffer_addr: {}", dst_buffer->address());
-        log_debug(tt::LogOp, "a.shape[0]: {}", a.padded_shape()[0]);
-        log_debug(tt::LogOp, "out.shape[0]: {}", output_shape[0]);
-        log_debug(tt::LogOp, "a.shape[1]: {}", a.padded_shape()[1]);
-        log_debug(tt::LogOp, "out.shape[1]: {}", output_shape[1]);
-        log_debug(tt::LogOp, "a.shape[2]: {}", a.padded_shape()[2]);
-        log_debug(tt::LogOp, "out.shape[2]: {}", output_shape[2]);
-        log_debug(tt::LogOp, "s.shape[3]: {}", a.padded_shape()[3]);
-        log_debug(tt::LogOp, "out.shape[3]: {}", output_shape[3]);
-        log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
-        log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
-        log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
-        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
-        log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
-        log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
-    }
-#endif
-
     uint32_t start_src_stick_id = 0;
     uint32_t start_dst_stick_id = 0;
-    // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
-    // bind them as Buffer* so the framework patches the addresses on cache hits
-    // without rebuilding the descriptor.  The const tensor is owned by
-    // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
-    // remains valid across cache hits.
-    KernelDescriptor::RTArgList reader_rt_args;
-    reader_rt_args.reserve(27);
-    reader_rt_args.push_back(src0_buffer);
-    reader_rt_args.push_back(dst_buffer);
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
-    reader_rt_args.push_back(unpadded_row_size_nbytes);
-    reader_rt_args.push_back(padded_row_size_nbytes);
-    reader_rt_args.push_back(padded_row_diff_size_nbytes);
-    reader_rt_args.push_back(pad_value_const_buffer);
-    reader_rt_args.push_back(pad_value_const_buffer_nbytes);
-    reader_rt_args.push_back(packed_pad_value);
-    reader_rt_args.push_back(start_src_stick_id);
-    reader_rt_args.push_back(start_dst_stick_id);
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
-    reader_rt_args.push_back(unpadded_row_size_nbytes);
-    reader_rt_args.push_back(padded_row_size_nbytes);
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(static_cast<uint32_t>(output.padded_shape()[0]));
 
-    // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
-    KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
+    ProgramSpec spec{
+        .name = "pad_rm_reader_writer_single_core",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = {std::move(in0_dfb)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = RM_SC_INPUT, .spec = input_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = RM_SC_OUTPUT, .spec = output_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = RM_SC_PAD_VALUE, .spec = pad_value_mesh_tensor.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {RM_SC_READER, RM_SC_WRITER},
+                    .target_nodes = node,
+                },
+            },
+    };
 
-    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, reader_rt_args);
-    writer_desc.emplace_runtime_args(CoreCoord{0, 0}, writer_rt_args);
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {
+        KernelRunArgs{
+            .kernel = RM_SC_READER,
+            .runtime_arg_values = MakeRuntimeArgsForSingleNode(
+                node,
+                {{"num_unpadded_W", static_cast<uint32_t>(a.padded_shape()[0])},
+                 {"num_unpadded_Z", static_cast<uint32_t>(a.padded_shape()[1])},
+                 {"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+                 {"unpadded_X_nbytes", unpadded_row_size_nbytes},
+                 {"padded_X_nbytes", padded_row_size_nbytes},
+                 {"padded_X_diff_nbytes", padded_row_diff_size_nbytes},
+                 {"pad_value_packed", packed_pad_value},
+                 {"start_src_stick_id", start_src_stick_id},
+                 {"start_src_stick_offset", std::uint32_t{0}},
+                 {"num_local_Y", static_cast<uint32_t>(output_shape[2])},
+                 {"num_local_unpadded_Y", static_cast<uint32_t>(a.padded_shape()[2])},
+                 {"num_local_W", static_cast<uint32_t>(output.padded_shape()[0])}}),
+        },
+        KernelRunArgs{
+            .kernel = RM_SC_WRITER,
+            .runtime_arg_values = MakeRuntimeArgsForSingleNode(
+                node,
+                {{"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+                 {"padded_X_nbytes", padded_row_size_nbytes},
+                 {"start_dst_stick_id", start_dst_stick_id},
+                 {"num_local_Y", static_cast<uint32_t>(output_shape[2])},
+                 {"dst_stick_offset", std::uint32_t{0}},
+                 {"num_local_W", static_cast<uint32_t>(output.padded_shape()[0])}}),
+        },
+    };
+    run_args.tensor_args = {
+        {RM_SC_INPUT, TensorArgument{input_mesh_tensor}},
+        {RM_SC_OUTPUT, TensorArgument{output_mesh_tensor}},
+        {RM_SC_PAD_VALUE, TensorArgument{pad_value_mesh_tensor}},
+    };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-
-    return desc;
-}
-
-}  // namespace
-
-WorkloadDescriptor PadRmReaderWriterProgramFactory::create_workload_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& tensor_return_value,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    WorkloadDescriptor wd;
-
-    // Build the pad-value const tensor once on cache miss and park it on the
-    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
-    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
-    // device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).
-    Tensor pad_value_const_tensor = build_pad_value_const_tensor_sc(tensor_args, operation_attributes.pad_value);
-    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
-    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
-    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
-
-    auto desc = build_pad_rm_sc_program_descriptor(
-        operation_attributes, tensor_args, tensor_return_value, pad_value_const_buffer);
-
-    auto ranges = tensor_coords.ranges();
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        wd.programs.push_back({ranges[i], desc});
-    }
-    if (!ranges.empty()) {
-        wd.programs.push_back({ranges.back(), std::move(desc)});
-    }
-    return wd;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+        .op_owned_tensors = std::move(op_owned),
+    };
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
@@ -4,29 +4,20 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
-
 #include "ttnn/device_operation.hpp"
-#include "ttnn/distributed/types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmReaderWriterProgramFactory {
-    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
-    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
-    // so it outlives the cached workload via the program cache.  Holding the SOURCE
-    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
-    // the device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
-    // lets the framework patch the const tensor's address on cache hits without rerunning
-    // this factory.
-    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& tensor_return_value,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    // The pad-value const tensor is allocated once on cache miss inside create_program_artifacts()
+    // and handed to the framework as an op-owned tensor, so it outlives the cache miss and keeps a
+    // stable address for the cached Program's lifetime.  The owning MeshTensor is moved out of the
+    // build Tensor with release_mesh_tensor(): holding the SOURCE Tensor would not be enough on its
+    // own, because ~Tensor force-deallocates the device memory through DeviceStorage::deallocate
+    // regardless of external shared_ptr<MeshBuffer> owners (see #44565).
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -3,12 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_rm_sharded_height_only_program_factory.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 using namespace tt::constants;
 
 namespace ttnn::prim {
@@ -16,6 +19,32 @@ using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
+// Names are prefixed per factory: all seven pad factories land in one unity-build
+// translation unit, where every anonymous namespace is merged into a single scope.
+const KernelSpecName SH_H_READER{"reader"};
+const KernelSpecName SH_H_WRITER{"writer"};
+const DFBSpecName SH_H_IN_SHARD{"in_shard"};
+const DFBSpecName SH_H_OUT_SHARD{"out_shard"};
+const DFBSpecName SH_H_PAD{"pad"};
+const TensorParamName SH_H_INPUT{"input"};
+const TensorParamName SH_H_OUTPUT{"output"};
+
+// One core's worth of kernel arguments.
+//
+// The reader's gather plan is data-directed — num_cores source cores, then a NoC (x, y) pair per
+// source core, then a chunk count per source core, then a (start_id, length) pair per chunk — and
+// the counts come from the data itself, so nothing past num_cores has a per-element identity. That
+// block travels as runtime varargs; everything the writer takes is a distinct named field.
+struct ShardedHeightPerCoreArgs {
+    uint32_t num_cores_read = 0;
+    std::vector<uint32_t> reader_varargs;
+    uint32_t num_sticks_per_core = 0;
+    uint32_t start_id = 0;
+    uint32_t start_dim_offset_h = 0;
+    uint32_t start_dim_offset_c = 0;
+    uint32_t start_dim_offset_n = 0;
+};
+
 inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(std::vector<uint32_t>& values) {
     std::vector<std::vector<uint32_t>> chunks;
     if (values.empty()) {
@@ -42,7 +71,7 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_and_repeated_values(s
     return chunks;
 }
 
-inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_pad_runtime_args_rm_sharded(
+inline std::vector<ShardedHeightPerCoreArgs> get_pad_runtime_args_rm_sharded(
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const ttnn::Shape& input_tensor_start,
@@ -62,10 +91,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
     uint32_t H_padded = output_shape[2], C_padded = output_shape[1];
 
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-    std::vector<uint32_t> start_dim_offset(num_dims, 0);
-
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_padded);
+    std::vector<ShardedHeightPerCoreArgs> ret_val(num_cores_padded);
 
     const auto& front_pad = input_tensor_start;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
@@ -73,15 +99,15 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
         uint32_t num_sticks_per_core_padded = shard_height_padded;
 
-        // writer rt args, set on top here as interleaved version.
-        std::vector<uint32_t> writer_kernel_args = {
-            num_sticks_per_core_padded,
-            curr_sticks_read,
-            front_pad[-4],
-            front_pad[-3],
-            front_pad[-2],
-        };
-        writer_kernel_args.insert(writer_kernel_args.end(), start_dim_offset.begin(), start_dim_offset.end());
+        // Writer args, captured on top here as in the interleaved version. curr_h / curr_c /
+        // curr_n hold this core's starting position in the padded output; the stick loop below
+        // advances them for the next core.
+        ShardedHeightPerCoreArgs core_args;
+        core_args.num_sticks_per_core = num_sticks_per_core_padded;
+        core_args.start_id = curr_sticks_read;
+        core_args.start_dim_offset_h = curr_h;
+        core_args.start_dim_offset_c = curr_c;
+        core_args.start_dim_offset_n = curr_n;
 
         // figure out the start read stick id for each core, and the start id for each dim
         std::vector<int> stick_ids_per_core;
@@ -112,8 +138,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
                 }
             }
         }
-
-        start_dim_offset = {0, curr_h, curr_c, curr_n};
 
         // figure out the stick id in a shard, and the core id for the stick.
         std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
@@ -154,19 +178,19 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        // reader rt args
-        std::vector<uint32_t> reader_kernel_args;
-        reader_kernel_args.reserve(1 + 3 * core_stick_map.size() + 2 * num_sticks_per_core_padded);
-        reader_kernel_args.push_back(core_stick_map.size());  // num_cores
+        // reader varargs: the whole gather plan except num_cores, which is a named arg.
+        core_args.num_cores_read = core_stick_map.size();
+        std::vector<uint32_t>& reader_varargs = core_args.reader_varargs;
+        reader_varargs.reserve(3 * core_stick_map.size() + 2 * num_sticks_per_core_padded);
 
         for (const auto& core_stick_pair : core_stick_map) {
             auto xy_pair = core_stick_pair.first;
             if (row_major) {
-                reader_kernel_args.push_back((std::uint32_t)xy_pair.second);  // noc x
-                reader_kernel_args.push_back((std::uint32_t)xy_pair.first);   // noc y
+                reader_varargs.push_back((std::uint32_t)xy_pair.second);  // noc x
+                reader_varargs.push_back((std::uint32_t)xy_pair.first);   // noc y
             } else {
-                reader_kernel_args.push_back((std::uint32_t)xy_pair.first);   // noc x
-                reader_kernel_args.push_back((std::uint32_t)xy_pair.second);  // noc y
+                reader_varargs.push_back((std::uint32_t)xy_pair.first);   // noc x
+                reader_varargs.push_back((std::uint32_t)xy_pair.second);  // noc y
             }
         }
 
@@ -175,27 +199,29 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         stick_chunks_per_core.reserve(core_stick_map.size());
         for (auto core_stick_pair : core_stick_map) {
             auto stick_chunks = group_contiguous_and_repeated_values(core_stick_pair.second);
-            reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+            reader_varargs.push_back(stick_chunks.size());  // num_chunks for current core
             stick_chunks_per_core.push_back(std::move(stick_chunks));
         }
         for (const auto& stick_chunks : stick_chunks_per_core) {
             for (auto chunk : stick_chunks) {
-                reader_kernel_args.push_back(chunk[0]);      // start id of a chunk
-                reader_kernel_args.push_back(chunk.size());  // length of a chunk
+                reader_varargs.push_back(chunk[0]);      // start id of a chunk
+                reader_varargs.push_back(chunk.size());  // length of a chunk
             }
         }
 
-        ret_val[i] = {std::move(reader_kernel_args), std::move(writer_kernel_args)};
+        ret_val[i] = std::move(core_args);
     }
 
     return ret_val;
 }
 }  // namespace
 
-ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
     Tensor& output = tensor_return_value;
+    const auto& input_mesh_tensor = a.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& input_tensor_start = operation_attributes.input_tensor_start;
@@ -227,8 +253,8 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
         stick_size_unpadded == stick_size_padded,
         "sharded pad does not support pad on last dim currently as that will cause perf degradation");
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat dst_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
 
     IDevice* device = a.device();
 
@@ -269,59 +295,40 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
     log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    // Sharded input DFB — borrows the input buffer's L1 memory; the framework re-points it from
+    // the input TensorArgument on every dispatch. The reader only takes its base pointer (a raw
+    // peek, no FIFO ops), so the reader is its sole toucher and binds both endpoints (self-loop).
+    DataflowBufferSpec in_shard_dfb{
+        .unique_id = SH_H_IN_SHARD,
+        .entry_size = stick_size_unpadded,
+        .num_entries = shard_height_unpadded,
+        .data_format_metadata = dfb_data_format,
+        .borrowed_from = SH_H_INPUT,
+    };
 
-    Buffer* src_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
+    // Sharded output DFB — borrows the output buffer's L1 memory. Two touchers on every node: the
+    // reader is a locked FIFO producer, and the writer raw-peeks the same buffer via get_write_ptr
+    // with no FIFO ops of its own. A raw peek is role-free, so this is a plain 1P + 1C assignment
+    // (reader producer, writer consumer) — not multi-binding. The writer must still be bound: in
+    // Metal 2.0 a kernel may not touch a DFB it has not bound.
+    DataflowBufferSpec out_shard_dfb{
+        .unique_id = SH_H_OUT_SHARD,
+        .entry_size = stick_size_padded,
+        .num_entries = shard_height_padded,
+        .data_format_metadata = dst_dfb_data_format,
+        .borrowed_from = SH_H_OUTPUT,
+    };
 
-    ProgramDescriptor desc;
-
-    // Sharded input CB — globally allocated to the input buffer; framework patches
-    // the CB address on cache hits via cb.buffer.
-    uint32_t src0_cb_index = 0;
-    {
-        CBDescriptor cb_src0;
-        cb_src0.total_size = shard_height_unpadded * stick_size_unpadded;
-        cb_src0.core_ranges = total_cores;
-        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_unpadded,
-        });
-        cb_src0.buffer = src_buffer;
-        desc.cbs.push_back(std::move(cb_src0));
-    }
-
-    // Sharded output CB — globally allocated to the output buffer.
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    {
-        CBDescriptor cb_output;
-        cb_output.total_size = shard_height_padded * stick_size_padded;
-        cb_output.core_ranges = total_cores;
-        cb_output.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = stick_size_padded,
-        });
-        cb_output.buffer = dst_buffer;
-        desc.cbs.push_back(std::move(cb_output));
-    }
+    // Const buffer holding one stick of the pad value. Writer-only, no FIFO ops — self-loop.
+    DataflowBufferSpec pad_dfb{
+        .unique_id = SH_H_PAD,
+        .entry_size = stick_size_padded,
+        .num_entries = 1,
+        .data_format_metadata = dfb_data_format,
+    };
 
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
-    uint32_t src1_cb_index = 1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = stick_size_padded,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src1_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_padded,
-        }}},
-    });
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -331,39 +338,6 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     } else {
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }
-
-    std::vector<uint32_t> reader_ct_args = {(std::uint32_t)stick_size_padded, (std::uint32_t)shard_height_padded};
-
-    std::vector<uint32_t> writer_ct_args = {
-        (std::uint32_t)N + front_pad[-4],
-        (std::uint32_t)H + front_pad[-2],
-        (std::uint32_t)C + front_pad[-3],
-        (std::uint32_t)stick_size_padded,
-        (std::uint32_t)N_padded,
-        (std::uint32_t)H_padded,
-        (std::uint32_t)C_padded,
-        (std::uint32_t)num_zero_pad_sticks_read,
-        (std::uint32_t)zero_pad_stick_size,
-        (std::uint32_t)not_pad_by_zero,
-        (std::uint32_t)packed_pad_value,
-        (std::uint32_t)row_major_min_bytes,
-        (std::uint32_t)(stick_size_padded / row_major_min_bytes)};
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores_padded;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores_padded;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
 
     auto all_runtime_args = get_pad_runtime_args_rm_sharded(
         a,
@@ -377,9 +351,101 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
         num_cores_x_unpadded,
         num_cores_y_unpadded);
 
-    // Sharded readers/writers consume only constant uint32_t per-core args; no
-    // BufferBinding is needed because the CBs themselves carry the buffer
-    // addresses (via cb.buffer).
+    // The reader's vararg block length is data-dependent (it grows with the number of source
+    // cores and coalesced chunks a core gathers from), but a KernelSpec declares one vararg count
+    // for every node it runs on. Declare the longest block and zero-fill the shorter ones: the
+    // kernel walks the block using the counts it reads out of it, so the tail is never read.
+    uint32_t num_reader_varargs = 0;
+    for (const auto& core_args : all_runtime_args) {
+        num_reader_varargs = std::max<uint32_t>(num_reader_varargs, core_args.reader_varargs.size());
+    }
+
+    KernelSpec reader{
+        .unique_id = SH_H_READER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = SH_H_IN_SHARD,
+                    .accessor_name = "in_shard",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_H_IN_SHARD,
+                    .accessor_name = "in_shard",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_H_OUT_SHARD,
+                    .accessor_name = "out_shard",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"stick_size_bytes", static_cast<uint32_t>(stick_size_padded)},
+                {"num_sticks_padded", shard_height_padded},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_cores_read"}},
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+        .advanced_options = {.num_runtime_varargs = num_reader_varargs},
+    };
+
+    KernelSpec writer{
+        .unique_id = SH_H_WRITER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = SH_H_OUT_SHARD,
+                    .accessor_name = "out_shard",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_H_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_H_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"N", static_cast<uint32_t>(N + front_pad[-4])},
+                {"H", static_cast<uint32_t>(H + front_pad[-2])},
+                {"C", static_cast<uint32_t>(C + front_pad[-3])},
+                {"stick_size_bytes", static_cast<uint32_t>(stick_size_padded)},
+                {"N_padded", N_padded},
+                {"H_padded", H_padded},
+                {"C_padded", C_padded},
+                {"num_zero_pad_sticks_read", num_zero_pad_sticks_read},
+                {"zero_pad_stick_size", zero_pad_stick_size},
+                {"not_pad_by_zero", static_cast<uint32_t>(not_pad_by_zero)},
+                {"packed_pad_value", packed_pad_value},
+                {"row_major_min_bytes", row_major_min_bytes},
+                {"num_sticks_padded_read", static_cast<uint32_t>(stick_size_padded / row_major_min_bytes)},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_sticks_per_core",
+                     "start_id",
+                     "front_pad_n",
+                     "front_pad_c",
+                     "front_pad_h",
+                     "start_dim_offset_h",
+                     "start_dim_offset_c",
+                     "start_dim_offset_n"},
+            },
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
+
+    KernelRunArgs reader_run_args{.kernel = SH_H_READER};
+    KernelRunArgs writer_run_args{.kernel = SH_H_WRITER};
+
     for (uint32_t i = 0; i < num_cores_padded; i++) {
         CoreCoord core;
         if (row_major) {
@@ -389,38 +455,56 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
             core = {
                 bbox_padded.start_coord.x + i / num_cores_y_padded, bbox_padded.start_coord.y + i % num_cores_y_padded};
         }
-        KernelDescriptor::RTArgList reader_rt_args;
-        reader_rt_args.reserve(all_runtime_args[i].first.size());
-        for (uint32_t v : all_runtime_args[i].first) {
-            reader_rt_args.push_back(v);
-        }
-        KernelDescriptor::RTArgList writer_rt_args;
-        writer_rt_args.reserve(all_runtime_args[i].second.size());
-        for (uint32_t v : all_runtime_args[i].second) {
-            writer_rt_args.push_back(v);
-        }
-        reader_desc.emplace_runtime_args(core, reader_rt_args);
-        writer_desc.emplace_runtime_args(core, writer_rt_args);
+        const auto& core_args = all_runtime_args[i];
+
+        AddRuntimeArgsForNode(reader_run_args.runtime_arg_values, core, {{"num_cores_read", core_args.num_cores_read}});
+        AdvancedKernelRunArgs::Varargs reader_varargs = core_args.reader_varargs;
+        reader_varargs.resize(num_reader_varargs, 0u);
+        reader_run_args.advanced_options.runtime_varargs[core] = std::move(reader_varargs);
+
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            core,
+            {{"num_sticks_per_core", core_args.num_sticks_per_core},
+             {"start_id", core_args.start_id},
+             {"front_pad_n", static_cast<uint32_t>(front_pad[-4])},
+             {"front_pad_c", static_cast<uint32_t>(front_pad[-3])},
+             {"front_pad_h", static_cast<uint32_t>(front_pad[-2])},
+             {"start_dim_offset_h", core_args.start_dim_offset_h},
+             {"start_dim_offset_c", core_args.start_dim_offset_c},
+             {"start_dim_offset_n", core_args.start_dim_offset_n}});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    ProgramSpec spec{
+        .name = "pad_rm_sharded_height_only",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = {std::move(in_shard_dfb), std::move(out_shard_dfb), std::move(pad_dfb)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = SH_H_INPUT, .spec = input_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = SH_H_OUTPUT, .spec = output_mesh_tensor.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {SH_H_READER, SH_H_WRITER},
+                    .target_nodes = all_cores_padded,
+                },
+            },
+    };
 
-    return desc;
-}
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {
+        {SH_H_INPUT, TensorArgument{input_mesh_tensor}},
+        {SH_H_OUTPUT, TensorArgument{output_mesh_tensor}},
+    };
 
-void PadRmShardedHeightOnlyProgramFactory::override_runtime_arguments(
-    Program& program,
-    const PadParams& /*operation_attributes*/,
-    const PadInputs& tensor_args,
-    Tensor& tensor_return_value,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // create_descriptor pushes the input CB, then the output CB, then the unbound pad-value CB; mirror
-    // that order positionally so only those two base addresses are re-pointed.
-    ProgramDescriptor cb_addr_only;
-    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = tensor_args.input.buffer()});
-    cb_addr_only.cbs.push_back(CBDescriptor{.buffer = tensor_return_value.buffer()});
-    apply_descriptor_runtime_args(program, cb_addr_only);  // override-rebuild-ok: cb-addr-only
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+    };
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -228,7 +228,7 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
 
     const auto& a_shape = a.logical_shape();
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
-    [[maybe_unused]] uint32_t num_unpadded_sticks = H * C * N;
+    uint32_t num_unpadded_sticks = H * C * N;
     uint32_t W_padded = output_padded_shape[3], H_padded = output_padded_shape[2], C_padded = output_padded_shape[1],
              N_padded = output_padded_shape[0];
 
@@ -298,10 +298,16 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::c
     // Sharded input DFB — borrows the input buffer's L1 memory; the framework re-points it from
     // the input TensorArgument on every dispatch. The reader only takes its base pointer (a raw
     // peek, no FIFO ops), so the reader is its sole toucher and binds both endpoints (self-loop).
+    // The entry count is clamped to the sticks the tensor actually holds: to_layout can hand pad
+    // an input whose shard spec is taller than the whole tensor (from_torch builds the row-major
+    // input with the requested tile-aligned output sharding, so e.g. 16 sticks arrive under a
+    // 32-stick shard spec), and a full-shard DFB would then fail spec validation against the
+    // borrowed tensor's packed size. The count is inert on device — the reader never runs FIFO
+    // ops on this DFB — so the clamp only affects validation.
     DataflowBufferSpec in_shard_dfb{
         .unique_id = SH_H_IN_SHARD,
         .entry_size = stick_size_unpadded,
-        .num_entries = shard_height_unpadded,
+        .num_entries = std::min(shard_height_unpadded, num_unpadded_sticks),
         .data_format_metadata = dfb_data_format,
         .borrowed_from = SH_H_INPUT,
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
@@ -4,26 +4,18 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/device_operation.hpp"
-#include "ttnn/distributed/types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmShardedHeightOnlyProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    // Every per-core argument is pinned by the hashed shapes and shard specs, and the two shard
+    // base addresses ride borrowed-memory DFBs that the framework re-points from their
+    // TensorArguments on every dispatch. Nothing else varies per dispatch, so this factory needs
+    // no runtime-argument override. (Replaced get_dynamic_runtime_args, #48928.)
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
-
-    // Every per-core arg is pinned by the hashed shapes and shard specs; only the two sharded CB base
-    // addresses vary per dispatch. Replaces get_dynamic_runtime_args (#48928).
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -72,10 +72,15 @@ ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::cr
     // Input shard DFB — borrows the input buffer's L1 memory; the framework re-points it from the
     // input TensorArgument on every dispatch. The reader only takes its base pointer (a raw peek,
     // no FIFO ops), so the reader is its sole toucher and binds both endpoints (self-loop).
+    // The entry count is clamped to the sticks the tensor actually holds: an input whose shard
+    // spec is taller than the whole tensor would otherwise fail spec validation against the
+    // borrowed tensor's packed size. The count is inert on device — the reader never runs FIFO
+    // ops on this DFB — so the clamp only affects validation.
+    const uint32_t num_input_sticks = static_cast<uint32_t>(input_tensor.logical_shape().volume() / W);
     DataflowBufferSpec in_shard_dfb{
         .unique_id = SH_W_IN_SHARD,
         .entry_size = unpadded_stick_bytes,
-        .num_entries = shard_height_unpadded,
+        .num_entries = std::min(shard_height_unpadded, num_input_sticks),
         .data_format_metadata = input_dfb_data_format,
         .borrowed_from = SH_W_INPUT,
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -4,23 +4,39 @@
 
 #include "pad_rm_sharded_width_only_program_factory.hpp"
 
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 using namespace tt::constants;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
-ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
+namespace {
+// Names are prefixed per factory: all seven pad factories land in one unity-build
+// translation unit, where every anonymous namespace is merged into a single scope.
+const KernelSpecName SH_W_READER{"reader"};
+const KernelSpecName SH_W_WRITER{"writer"};
+const DFBSpecName SH_W_IN_SHARD{"in_shard"};
+const DFBSpecName SH_W_OUT_SHARD{"out_shard"};
+const DFBSpecName SH_W_PAD{"pad"};
+const TensorParamName SH_W_INPUT{"input"};
+const TensorParamName SH_W_OUTPUT{"output"};
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor = tensor_args.input;
     Tensor& output = tensor_return_value;
+    const auto& input_mesh_tensor = input_tensor.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& input_tensor_start = operation_attributes.input_tensor_start;
@@ -49,61 +65,38 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     const auto& ordered_cores_with_data = get_optimal_worker_cores_for_sharded_tensor(output);
     auto all_cores_padded = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
+    tt::DataFormat input_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat output_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    tt::DataFormat pad_val_dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
 
-    Buffer* input_buffer = input_tensor.buffer();
-    Buffer* output_buffer = output.buffer();
+    // Input shard DFB — borrows the input buffer's L1 memory; the framework re-points it from the
+    // input TensorArgument on every dispatch. The reader only takes its base pointer (a raw peek,
+    // no FIFO ops), so the reader is its sole toucher and binds both endpoints (self-loop).
+    DataflowBufferSpec in_shard_dfb{
+        .unique_id = SH_W_IN_SHARD,
+        .entry_size = unpadded_stick_bytes,
+        .num_entries = shard_height_unpadded,
+        .data_format_metadata = input_dfb_data_format,
+        .borrowed_from = SH_W_INPUT,
+    };
 
-    ProgramDescriptor desc;
+    // Output shard DFB — borrows the output buffer's L1 memory. A real FIFO here: the writer
+    // produces padded sticks, the reader consumes them to overwrite the data region.
+    DataflowBufferSpec out_shard_dfb{
+        .unique_id = SH_W_OUT_SHARD,
+        .entry_size = padded_stick_bytes,
+        .num_entries = shard_height_padded,
+        .data_format_metadata = output_dfb_data_format,
+        .borrowed_from = SH_W_OUTPUT,
+    };
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t input_shard_cb_index = tt::CBIndex::c_0;
-    {
-        // Sharded input CB — globally allocated to the input buffer; framework
-        // patches the CB address on cache hits via cb.buffer.
-        CBDescriptor cb_input;
-        cb_input.total_size = shard_height_unpadded * unpadded_stick_bytes;
-        cb_input.core_ranges = total_cores;
-        cb_input.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_shard_cb_index),
-            .data_format = input_cb_data_format,
-            .page_size = unpadded_stick_bytes,
-        });
-        cb_input.buffer = input_buffer;
-        desc.cbs.push_back(std::move(cb_input));
-    }
-
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-    uint32_t output_shard_cb_index = tt::CBIndex::c_16;
-    {
-        // Sharded output CB — globally allocated to the output buffer.
-        CBDescriptor cb_output;
-        cb_output.total_size = shard_height_padded * padded_stick_bytes;
-        cb_output.core_ranges = total_cores;
-        cb_output.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_shard_cb_index),
-            .data_format = output_cb_data_format,
-            .page_size = padded_stick_bytes,
-        });
-        cb_output.buffer = output_buffer;
-        desc.cbs.push_back(std::move(cb_output));
-    }
-
-    // construct const buffer with the pad_value
-    tt::DataFormat pad_val_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t pad_val_cb_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = padded_stick_bytes,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
-            .data_format = pad_val_cb_data_format,
-            .page_size = padded_stick_bytes,
-        }}},
-    });
+    // Const buffer holding one stick of the pad value. Writer-only, no FIFO ops — self-loop.
+    DataflowBufferSpec pad_dfb{
+        .unique_id = SH_W_PAD,
+        .entry_size = padded_stick_bytes,
+        .num_entries = 1,
+        .data_format_metadata = pad_val_dfb_data_format,
+    };
 
     // W front-pad offset: input_tensor_start is [N, C, H, W];
     uint32_t W_padding_front_bytes = input_tensor_start[3] * input_tensor.element_size();
@@ -131,55 +124,105 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
         unpadded_stick_bytes,
         l1_alignment_bytes);  // round unpadded_stick bytes to a multiple of l1_alignment_bytes
 
-    std::vector<uint32_t> reader_ct_args = {
-        unpadded_stick_bytes,
-        padded_stick_bytes,
-        shard_height_unpadded,
-        shard_height_padded,
-        W_padding_front_bytes,
-        input_shard_cb_index,
-        output_shard_cb_index,
-        unpadded_stick_step,
-        padded_stick_step};
+    KernelSpec reader{
+        .unique_id = SH_W_READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "reader_pad_dims_rm_sharded_stickwise.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = SH_W_IN_SHARD,
+                    .accessor_name = "in_shard",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_W_IN_SHARD,
+                    .accessor_name = "in_shard",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_W_OUT_SHARD,
+                    .accessor_name = "out_shard",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"unpadded_stick_bytes", unpadded_stick_bytes},
+                {"unpadded_shard_height", shard_height_unpadded},
+                {"W_front_pad_bytes", W_padding_front_bytes},
+                {"unpadded_stick_step", unpadded_stick_step},
+                {"padded_stick_step", padded_stick_step},
+            },
+        .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
+    };
 
-    std::vector<uint32_t> writer_ct_args = {
-        padded_stick_bytes,
-        shard_height_padded,
-        padding_value_as_u32,
-        output.element_size(),
-        output_shard_cb_index,
-        pad_val_cb_index,
-        padded_stick_step};
+    KernelSpec writer{
+        .unique_id = SH_W_WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "writer_pad_dims_rm_sharded_stickwise.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = SH_W_OUT_SHARD,
+                    .accessor_name = "out_shard",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_W_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = SH_W_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"padded_stick_bytes", padded_stick_bytes},
+                {"padded_shard_height", shard_height_padded},
+                {"padding_value_as_u32", padding_value_as_u32},
+                {"padding_value_num_bytes", static_cast<uint32_t>(output.element_size())},
+            },
+        .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
+    };
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores_padded;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // Neither sharded kernel takes runtime args: every per-core value is pinned by the hashed
+    // shapes and shard specs, and the two shard base addresses ride the borrowed DFBs.
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores_padded;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    ProgramSpec spec{
+        .name = "pad_rm_sharded_width_only",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = {std::move(in_shard_dfb), std::move(out_shard_dfb), std::move(pad_dfb)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = SH_W_INPUT, .spec = input_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = SH_W_OUTPUT, .spec = output_mesh_tensor.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {SH_W_READER, SH_W_WRITER},
+                    .target_nodes = all_cores_padded,
+                },
+            },
+    };
 
-    // Sharded readers/writers don't consume per-core runtime args (legacy code
-    // called SetRuntimeArgs(..., {}) with empty arg lists).  CB addresses are
-    // patched via cb.buffer on cache hits.  Mirror the legacy behavior by
-    // emitting an empty rtarg list per active core so the kernel reserves slots.
-    for (const auto& core : ordered_cores_with_data) {
-        reader_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
-        writer_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
-    }
+    ProgramRunArgs run_args;
+    run_args.tensor_args = {
+        {SH_W_INPUT, TensorArgument{input_mesh_tensor}},
+        {SH_W_OUTPUT, TensorArgument{output_mesh_tensor}},
+    };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+    };
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmShardedWidthOnlyProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
@@ -3,17 +3,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_tile_multicore_program_factory.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 using namespace tt::constants;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::get_num_pages;
+
+namespace {
+// Names are prefixed per factory: all seven pad factories land in one unity-build
+// translation unit, where every anonymous namespace is merged into a single scope.
+const KernelSpecName TILE_MC_READER{"reader"};
+const KernelSpecName TILE_MC_WRITER{"writer"};
+const DFBSpecName TILE_MC_IN0{"in0"};
+const DFBSpecName TILE_MC_PAD{"pad"};
+const TensorParamName TILE_MC_INPUT{"input"};
+const TensorParamName TILE_MC_OUTPUT{"output"};
+}  // namespace
 
 static inline int advance_tensor_index(std::vector<uint32_t>& idx, const ttnn::Shape& dims, uint32_t ndims) {
     // increment least-significant dim first
@@ -28,9 +41,11 @@ static inline int advance_tensor_index(std::vector<uint32_t>& idx, const ttnn::S
     return 0;  // overflowed most-significant dim
 }
 
-ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
+    const auto& input_mesh_tensor = a.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
 
@@ -48,48 +63,28 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
 
     auto cores_in_order = corerange_to_cores(all_cores, num_cores, true);
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t page_size = output.buffer()->page_size();
     uint32_t multi_buffering_size = 2;
-    uint32_t input_cb_index = tt::CBIndex::c_0;
-    uint32_t output_cb_index = tt::CBIndex::c_1;
-    uint32_t pad_val_cb_index = tt::CBIndex::c_2;
 
-    ProgramDescriptor desc;
+    DataflowBufferSpec in0_dfb{
+        .unique_id = TILE_MC_IN0,
+        .entry_size = page_size,
+        .num_entries = multi_buffering_size,
+        .data_format_metadata = dfb_data_format,
+    };
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = page_size * multi_buffering_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_cb_index),
-            .data_format = cb_data_format,
-            .page_size = page_size,
-        }}},
-    });
+    // Pad buffer: the writer fills one entry with the pad value and NoC-writes it out for every
+    // page outside the input region. Nothing drains it, so the writer is its only toucher and
+    // binds both endpoints (self-loop).
+    DataflowBufferSpec pad_dfb{
+        .unique_id = TILE_MC_PAD,
+        .entry_size = page_size,
+        .num_entries = 1,
+        .data_format_metadata = dfb_data_format,
+    };
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = page_size * multi_buffering_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = page_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
-            .data_format = cb_data_format,
-            .page_size = page_size,
-        }}},
-    });
-
-    Buffer* input_buffer = a.buffer();
-    Buffer* output_buffer = output.buffer();
-    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t packed_pad_value;
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
@@ -113,39 +108,82 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
                 "FLOAT32");
     }
 
-    std::vector<uint32_t> reader_ct_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)page_size,
-        (std::uint32_t)output_padded_shape.rank(),
+    // The four num_dims-long RTA blocks below (input/output page shapes and per-dim ids) are
+    // reached by index in `for (d < num_dims)` loops, so they travel as runtime varargs rather
+    // than named arguments.
+    const uint32_t num_dims = static_cast<uint32_t>(output_padded_shape.rank());
+    const uint32_t num_varargs = 4 * num_dims;
+
+    KernelSpec reader{
+        .unique_id = TILE_MC_READER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = TILE_MC_IN0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = TILE_MC_INPUT,
+                    .accessor_name = "src",
+                },
+            },
+        .compile_time_args =
+            {
+                {"page_size", page_size},
+                {"num_dims", num_dims},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
+        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+        .advanced_options = {.num_runtime_varargs = num_varargs},
     };
-    TensorAccessorArgs(*input_buffer).append_to(reader_ct_args);
 
-    std::vector<uint32_t> writer_ct_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)pad_val_cb_index,
-        (std::uint32_t)page_size,
-        (std::uint32_t)output_padded_shape.rank(),
-        (std::uint32_t)packed_pad_value,
-        (std::uint32_t)output.element_size(),
+    KernelSpec writer{
+        .unique_id = TILE_MC_WRITER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = TILE_MC_IN0,
+                    .accessor_name = "in0",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = TILE_MC_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = TILE_MC_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = TILE_MC_OUTPUT,
+                    .accessor_name = "dst",
+                },
+            },
+        .compile_time_args =
+            {
+                {"page_size", page_size},
+                {"num_dims", num_dims},
+                {"pad_value", packed_pad_value},
+                {"element_size", static_cast<uint32_t>(output.element_size())},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
+        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+        .advanced_options = {.num_runtime_varargs = num_varargs},
     };
-    TensorAccessorArgs(*output_buffer).append_to(writer_ct_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    KernelRunArgs reader_run_args{.kernel = TILE_MC_READER};
+    KernelRunArgs writer_run_args{.kernel = TILE_MC_WRITER};
 
     /*
     As an example, lets say we want to pad a [2, 1, 32, 32] tensor to [2, 3, 64, 64]
@@ -211,49 +249,33 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
             num_pages_per_core = 0;  // no-op
         }
 
-        // Slot 0 is a raw buffer base address (no offset).  Use Buffer* on active
-        // cores so the framework patches the address on cache hits.  Idle cores
-        // (num_pages_per_core == 0) pass 0u to skip BufferBinding registration —
-        // the kernel short-circuits and never dereferences the address.
-        KernelDescriptor::RTArgList reader_runtime_args;
-        KernelDescriptor::RTArgList writer_runtime_args;
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            core,
+            {{"num_pages_to_write", num_pages_per_core}, {"start_offset", input_page_offset}});
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            core,
+            {{"num_pages_to_write", num_pages_per_core}, {"start_offset", output_page_offset}});
 
-        if (num_pages_per_core != 0) {
-            reader_runtime_args.push_back(input_buffer);
-            writer_runtime_args.push_back(output_buffer);
-        } else {
-            reader_runtime_args.push_back(0u);
-            writer_runtime_args.push_back(0u);
-        }
-
-        reader_runtime_args.push_back(num_pages_per_core);
-        reader_runtime_args.push_back(input_page_offset);
-
-        writer_runtime_args.push_back(num_pages_per_core);
-        writer_runtime_args.push_back(output_page_offset);
-
-        // Every core should get the same input and output tile shapes.
+        // Every core should get the same input and output tile shapes, and then where the core
+        // should start writing in the output tensor.
+        AdvancedKernelRunArgs::Varargs varargs;
+        varargs.reserve(num_varargs);
         for (auto v : input_page_shape) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            varargs.push_back(v);
         }
         for (auto v : output_page_shape) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            varargs.push_back(v);
         }
-
-        // As well as where the core should start writing in the output tensor.
         for (uint32_t v : input_id_per_dim) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            varargs.push_back(v);
         }
         for (uint32_t v : output_id_per_dim) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            varargs.push_back(v);
         }
-
-        reader_desc.emplace_runtime_args(core, reader_runtime_args);
-        writer_desc.emplace_runtime_args(core, writer_runtime_args);
+        reader_run_args.advanced_options.runtime_varargs[core] = varargs;
+        writer_run_args.advanced_options.runtime_varargs[core] = std::move(varargs);
 
         // We now need to increment the input and output id_per_dims by the number of pages this core is processing
         // Similarly to in the kernel, we only increment the input id_per_dim if we are within the input region
@@ -275,10 +297,36 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
         // The input and output id_per_dim should now be set correctly for the next core
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    ProgramSpec spec{
+        .name = "pad_tile_multicore",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = {std::move(in0_dfb), std::move(pad_dfb)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = TILE_MC_INPUT, .spec = input_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = TILE_MC_OUTPUT, .spec = output_mesh_tensor.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {TILE_MC_READER, TILE_MC_WRITER},
+                    .target_nodes = all_cores,
+                },
+            },
+    };
 
-    return desc;
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)};
+    run_args.tensor_args = {
+        {TILE_MC_INPUT, TensorArgument{input_mesh_tensor}},
+        {TILE_MC_OUTPUT, TensorArgument{output_mesh_tensor}},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+    };
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadTileMulticoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -3,70 +3,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_tile_program_factory.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
-ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
+namespace {
+// Names are prefixed per factory: all seven pad factories land in one unity-build
+// translation unit, where every anonymous namespace is merged into a single scope.
+const KernelSpecName TILE_SC_READER{"reader"};
+const KernelSpecName TILE_SC_WRITER{"writer"};
+const DFBSpecName TILE_SC_IN0{"in0"};
+const DFBSpecName TILE_SC_PAD{"pad"};
+const TensorParamName TILE_SC_INPUT{"input"};
+const TensorParamName TILE_SC_OUTPUT{"output"};
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
     Tensor& output = tensor_return_value;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
 
-    const CoreRangeSet core_ranges{CoreRange{{0, 0}, {0, 0}}};
+    const auto& input_mesh_tensor = a.mesh_tensor();
+    const auto& output_mesh_tensor = output.mesh_tensor();
+
+    const NodeCoord node{0, 0};
 
     // This should allocate a DRAM buffer on the device
 
     const auto& output_shape = output_padded_shape;
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    tt::DataFormat dfb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
+    uint32_t single_tile_size = tt::tile_size(dfb_data_format);
 
     log_debug(tt::LogOp, "pad_tile");
-    log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
+    log_debug(tt::LogOp, "dfb_data_format: {}", dfb_data_format);
     log_debug(tt::LogOp, "single_tile_size: {}", single_tile_size);
     log_debug(tt::LogOp, "output_tensor_shape: {}", output_padded_shape);
     log_debug(tt::LogOp, "input_tensor_start: {}", operation_attributes.input_tensor_start);
     log_debug(tt::LogOp, "pad_value: {}", pad_value);
 
-    ProgramDescriptor desc;
-
-    const uint32_t src0_cb_index = 0;
     const uint32_t num_input_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
+    DataflowBufferSpec in0_dfb{
+        .unique_id = TILE_SC_IN0,
+        .entry_size = single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = dfb_data_format,
+    };
 
-    const uint32_t src1_cb_index = 1;  // For pad buffer
+    // Pad buffer: the writer reserves an entry and fills it with the pad value, then NoC-writes
+    // that entry out repeatedly. Nothing ever pushes or drains it, so the writer is its only
+    // toucher and binds both endpoints (self-loop).
     const uint32_t num_pad_tiles = 1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_pad_tiles * single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src1_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
+    DataflowBufferSpec pad_dfb{
+        .unique_id = TILE_SC_PAD,
+        .entry_size = single_tile_size,
+        .num_entries = num_pad_tiles,
+        .data_format_metadata = dfb_data_format,
+    };
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -92,52 +99,129 @@ ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
 
     uint32_t num_unpadded_tiles = a.physical_volume() / TILE_HW;
 
-    // Reader compile-time args
-    // Data is 32 byte aligned
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index, src1_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // Tilized reader: the Metal 2.0 fork of eltwise/unary's shared reader, which lives beside the
+    // legacy original. Its binding names (dfb::in, tensor::src) and named args (num_pages,
+    // start_id) are the fork's interface, so this spec conforms to them rather than renaming.
+    KernelSpec reader{
+        .unique_id = TILE_SC_READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+            "reader_unary_interleaved_start_id_metal2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = TILE_SC_IN0,
+                    .accessor_name = "in",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = TILE_SC_INPUT,
+                    .accessor_name = "src",
+                },
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = ttnn::create_reader_datamovement_config(a.device()->arch()),
+    };
 
-    // Tilized reader
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = core_ranges;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    KernelSpec writer{
+        .unique_id = TILE_SC_WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+            "writer_unary_pad_dims_interleaved.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{
+                    .dfb_spec_name = TILE_SC_IN0,
+                    .accessor_name = "out0",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = TILE_SC_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::PRODUCER,
+                },
+                DFBBinding{
+                    .dfb_spec_name = TILE_SC_PAD,
+                    .accessor_name = "pad",
+                    .endpoint_type = DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{
+                    .tensor_parameter_name = TILE_SC_OUTPUT,
+                    .accessor_name = "dst",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_unpadded_W",
+                     "num_padded_Wt",
+                     "num_unpadded_Z",
+                     "num_padded_Zt",
+                     "num_unpadded_Yt",
+                     "num_padded_Yt",
+                     "num_unpadded_Xt",
+                     "num_padded_Xt",
+                     "pad_value"},
+            },
+        .hw_config = ttnn::create_writer_datamovement_config(a.device()->arch()),
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = core_ranges;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    ProgramSpec spec{
+        .name = "pad_tile_single_core",
+        .kernels = {std::move(reader), std::move(writer)},
+        .dataflow_buffers = {std::move(in0_dfb), std::move(pad_dfb)},
+        .tensor_parameters =
+            {
+                TensorParameter{.unique_id = TILE_SC_INPUT, .spec = input_mesh_tensor.tensor_spec()},
+                TensorParameter{.unique_id = TILE_SC_OUTPUT, .spec = output_mesh_tensor.tensor_spec()},
+            },
+        .work_units =
+            {
+                WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {TILE_SC_READER, TILE_SC_WRITER},
+                    .target_nodes = node,
+                },
+            },
+    };
 
-    // Slot 0 of both kernels is a raw buffer base address (no offset).  Use Buffer*
-    // for BufferBinding so the framework patches addresses on cache hits without
-    // rebuilding the descriptor.
-    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, {src0_buffer, num_unpadded_tiles, std::uint32_t{0}});
+    ProgramRunArgs run_args;
+    run_args.kernel_run_args = {
+        KernelRunArgs{
+            .kernel = TILE_SC_READER,
+            .runtime_arg_values =
+                MakeRuntimeArgsForSingleNode(node, {{"num_pages", num_unpadded_tiles}, {"start_id", std::uint32_t{0}}}),
+        },
+        KernelRunArgs{
+            .kernel = TILE_SC_WRITER,
+            .runtime_arg_values = MakeRuntimeArgsForSingleNode(
+                node,
+                {{"num_unpadded_W", num_unpadded_W},
+                 {"num_padded_Wt", num_padded_Wt},
+                 {"num_unpadded_Z", num_unpadded_Z},
+                 {"num_padded_Zt", num_padded_Zt},
+                 {"num_unpadded_Yt", num_unpadded_Yt},
+                 {"num_padded_Yt", num_padded_Yt},
+                 {"num_unpadded_Xt", num_unpadded_Xt},
+                 {"num_padded_Xt", num_padded_Xt},
+                 {"pad_value", packed_pad_value}}),
+        },
+    };
+    run_args.tensor_args = {
+        {TILE_SC_INPUT, TensorArgument{input_mesh_tensor}},
+        {TILE_SC_OUTPUT, TensorArgument{output_mesh_tensor}},
+    };
 
-    writer_desc.emplace_runtime_args(
-        CoreCoord{0, 0},
-        {dst_buffer,
-         num_unpadded_W,
-         num_padded_Wt,
-         num_unpadded_Z,
-         num_padded_Zt,
-         num_unpadded_Yt,
-         num_padded_Yt,
-         num_unpadded_Xt,
-         num_padded_Xt,
-         packed_pad_value});
-
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+    };
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadTileCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Issue
Closes #54213.

### Summary

Metal 2.0 port of `data_movement/pad` — **all seven** `PadDeviceOperation` factories and all twelve of the op's kernel sources, converted to the base `ProgramSpecFactoryConcept`. Behaviour-preserving: DFB sizes, formats, defines and argument values match the legacy CB descriptors and `emplace_runtime_args` index for index. The op owns no compute kernels, so no compute `hw_config` and no `opt_level` work (every kernel is a reader/writer whose legacy default `O2` is already Metal 2.0's default).

- **Host side**: `CBDescriptor` → `DataflowBufferSpec` (`borrowed_from` for the four sharded shard buffers), buffer-address RTAs and the `cb.buffer` patching → `TensorParameter` / `TensorBinding`, positional CTAs → named compile-time args, per-core RTAs → a name-first `ProgramRunArgs` table.
- **`WorkloadDescriptor` → single `ProgramSpec`**: `PadRmReaderWriterProgramFactory` and `PadRmReaderWriterMultiCoreProgramFactory` each built **one** `ProgramDescriptor` above the loop and pushed the *same* object once per range in `tensor_coords`. Nothing was per-mesh-coordinate — the wrapper existed only to carry the pad-value const tensor, which now rides `ProgramArtifacts::op_owned_tensors`.
- **Kernels**: `CircularBuffer` → `DataflowBuffer` via `dfb::` bindings, `TensorAccessorArgs<N>()` chains → `TensorAccessor(tensor::…)`, positional args → `get_arg(args::…)`.
- `pad_device_operation.{hpp,cpp}` and `pad_nanobind.cpp` are **byte-identical** — no device-op-class edit was forced, and no user-visible API is removed.

**Verification: 863 passed / 63 skipped — bit-identical to the pre-port baseline**, over `test_pad.py`, `test_pad_subcoregrids.py`, `test_pad_universal_input.py`, `test_padding_test.py` and the two `sweep_tests/pytests/tensor` pad files. The baseline was captured before the first kernel edit; the post-port run carries 2674 `METAL2_CHECKS_FORCED` markers from both forced translation units, so the green was measured with the Metal 2.0 host-side legality checks on.

### Notes for reviewers

- **Endpoint dispositions were re-derived from a per-node kernel-touch census, not transcribed.** Seven one-toucher DFBs self-loop. `c_16` in the height-only sharded factory is a two-toucher — reader is a locked FIFO producer, and the **writer raw-peeks the same buffer** via `get_write_ptr()` at `writer_pad_dims_rm_sharded.cpp:90` with no FIFO ops — so it takes a plain **1P+1C** (reader PRODUCER, writer CONSUMER). That peek is invisible to a producer/consumer trace and is the one cross-kernel toucher in the op. **No DFB anywhere needs the multi-binding flag.**
- **`PadRmShardedHeightOnlyProgramFactory` drops to the base concept.** Its `override_runtime_arguments` re-pointed exactly two CB base addresses and did nothing else; both are `borrowed_from` DFBs now, and the framework refreshes every `TensorArgument` on a cache hit — so the refreshed set is identical statement-for-statement. `PadRmShardedWidthOnlyProgramFactory` already carried the same two borrowed CBs with no override. **This is a concept change and was raised with the op owner before construction, not decided in the diff.**
- **Conditional DFB (`c_2`, default RM factory).** The host allocated it only under `stick_size_padded_front != 0 || unaligned`, but the kernel constructed it and called `get_read_ptr()` *unconditionally*, gating only the uses behind `if constexpr`. Since `if constexpr` does not suppress `dfb::` name lookup — including in its **discarded branches** — the construction, the `get_read_ptr()` and the whole `if constexpr` chain now sit behind a `PAD_ALIGN_DFB` `#ifdef` fed by `compiler_options.defines`. Both preprocessor branches were confirmed to have actually compiled and run: the JIT cache holds 49 variants of that reader with `dfb::pad_align` bound and 323 without.
- **Shared kernel, rung 1 — no new fork.** `PadTileCoreProgramFactory` binds the existing `eltwise/unary` `_metal2` fork of `reader_unary_interleaved_start_id` and conforms to its vocabulary (`dfb::in`, `tensor::src`); neither the original nor the fork is touched. Note the decoy: a differently-named fork of the same kernel under `copy/typecast` uses `tensor::input`. `data_movement/pad` comes off that kernel's sunset list.
- **Two Metal 2.0 vararg-API limits are worked around; both are written up as handoffs.** `get_vararg()` has no address form, but the tiled kernels *write back* into their vararg block as scratch (`advance_tensor_index`), so those blocks are copied into locals. And a vararg count is per-`KernelSpec`, not per-node, while the height-only reader's gather plan is genuinely ragged — the exact-fit field is `[[deprecated]]`, so the spec declares the max and zero-fills; the kernel walks the block by counts it reads out of the block itself, so the tail is never read.

**Dead code removed** (each zero-functional-change; full `file:line` list in `METAL2_PORT_REPORT.md`):

- `c_1` in `PadTileMulticoreProgramFactory` — **zero touchers in every config**. The allocation and the CTA carrying its index are gone; `2 × page_size` of L1 recovered per core.
- Arguments no kernel reads get no name and are not emitted: the v1 RM pair's dead RTA slots (the two kernels were handed *identical* 27-slot lists, so each got ~half it never read) and both of their CTAs, seven dead reader CTAs in the default RM factory, and three in the width-only sharded factory.

**Preserved, not fixed** — `PadTileCoreProgramFactory` packs a FLOAT32 pad value as two bfloat16s, so padding with `7.0` fills the region with `7.0079193115234375`. The packing block is byte-identical before and after this port, and the sibling tile-multicore factory already has the correct `std::bit_cast` line, so this is pre-existing and preserved per the porting invariant rather than fixed here. Filed separately as **#54223** with the one-line fix.

**Test coverage added** (raised by the Copilot review) — that bug survived because **no test reached the factory**: `test_pad_op` does parametrize TILE × `use_multicore=False`, but its shapes are already tile-aligned so `invoke_tile` takes the `view` fast path and never reaches `prim::pad`. `test_pad_tile_single_core` now crosses a tile boundary so the factory is actually selected — six dtypes × two memory configs × three shapes, each dispatched three times so the second and third land on a program-cache hit. JIT-cache variants of `writer_unary_pad_dims_interleaved` went from zero to ten, confirming it reaches the factory rather than merely passing. 60 passed / 6 skipped / 6 xfailed; the FLOAT32 non-zero-pad case is `xfail`ed against #54223 and the `bfloat8_b` non-zero case skipped (it compares approximately).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-data_movement/pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-data_movement/pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-data_movement/pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-data_movement/pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-data_movement/pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-data_movement/pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-data_movement/pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-data_movement/pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-data_movement/pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-data_movement/pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-data_movement/pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-data_movement/pad)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-data_movement/pad)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-data_movement/pad)

