### PR TITLE
#54220: Re-center Kimi-K2.6-1T traced chunked prefill perf baseline

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -149,22 +149,26 @@ INDEXER_K_PCC_THRESHOLD = 0.95
 # gap swamps the depth ramp entirely.
 KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
-    # (55k / code_debug), measured after the Fabric2D TorusXY routing fixes. Each entry is the median
-    # across the per-run medians from run 31944546064/job 95160035844 and run 31951045807/job
-    # 95176102903. With two runs, that is the midpoint of the two observations rather than either
-    # run's one-sided value.
+    # (55k / code_debug). Re-centered 2026-08-24 (issue #54220): the op got 2-6% FASTER and 7/11 chunks
+    # fell out the bottom of the old band -- the baseline was stale, not the margin too tight. Likely
+    # source is #53968 (active-ERISC __global_pointer$ link fix); a branch that is 08-23 main with
+    # #53968 reverted (run 32666670314) still measures the pre-shift level.
+    #
+    # These are the per-chunk medians of run 32722605093/job 97446035784 (main) verbatim -- the current
+    # level, measured on main, is the baseline. Run 32731794058/job 97448128368 independently agrees to
+    # <=0.010 s on every chunk, so it also sits well inside the +/- 3% band around these numbers.
     (61, 11, 10): [
-        0.5660,
-        0.5695,
-        0.6120,
-        0.6615,
-        0.6925,
-        0.7205,
-        0.7455,
-        0.7785,
-        0.8200,
-        0.8585,
-        0.8935,
+        0.547,
+        0.550,
+        0.596,
+        0.624,
+        0.660,
+        0.691,
+        0.705,
+        0.744,
+        0.798,
+        0.835,
+        0.875,
     ],
 }
 KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {


### PR DESCRIPTION
### Problem

`test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-margin_auto-traced]`
fails on main with **7/11 chunks below the −3% edge** of `KIMI_TRACED_BASELINE_CHUNK_TIMES_S` — the op got
2–6% faster and the baseline is stale.

[Failing run 32722605093](https://github.com/tenstorrent/tt-metal/actions/runs/32722605093/job/97446035784)

### Fix

Set the baseline to the measured medians from that run. **`TRACED_PERF_MARGIN` stays at 3%** — the band is
not widened.

| chunk | old | new (run 32722605093) | Δ |
|---|---|---|---|
| 0 | 0.5660 | 0.547 | −3.4% |
| 1 | 0.5695 | 0.550 | −3.4% |
| 2 | 0.6120 | 0.596 | −2.6% |
| 3 | 0.6615 | 0.624 | −5.7% |
| 4 | 0.6925 | 0.660 | −4.7% |
| 5 | 0.7205 | 0.691 | −4.1% |
| 6 | 0.7455 | 0.705 | −5.4% |
| 7 | 0.7785 | 0.744 | −4.4% |
| 8 | 0.8200 | 0.798 | −2.7% |
| 9 | 0.8585 | 0.835 | −2.7% |
| 10 | 0.8935 | 0.875 | −2.1% |

Corroboration: run 32731794058 (different branch, same day) measures
`0.547 0.551 0.597 0.625 0.660 0.692 0.704 0.740 0.791 0.827 0.865` — agreeing to ≤0.010 s per chunk and
landing within 1.2% of the new baseline, so it stays comfortably inside the ±3% band.

Likely source of the speedup: #53968 (active-ERISC `__global_pointer$` link fix). Run 32666670314, a
branch that is 08-23 main with #53968 reverted, still measures the pre-shift level (`0.560 … 0.893`).

The untraced twin is untouched: separate table, separate margin, host-dispatch bound.

### CI

`kimi_chunked` only (traced + untraced pair): https://github.com/tenstorrent/tt-metal/actions/runs/32775296866

Closes #54220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
