### PR TITLE
[Feature] CI: generic Jira adapter for CI failures

### DIFF
--- a/.github/actions/scripts/ci_failure_routing.json
+++ b/.github/actions/scripts/ci_failure_routing.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Routing for the generic CI-failure Jira adapter (MINFRA-1611). A failure is matched against `routes` in order; the first whose stated fields all match wins, and an omitted field is a wildcard. `default` applies when nothing matches. AI/IP release-test failures are NOT routed here -- those are filed per test by file_rtl_sim_jira.py onto the RELEASE board.",
+  "min_confidence": 0.6,
+  "default": {
+    "project": "MINFRA",
+    "issue_type": "Bug",
+    "triage_assignee": null,
+    "labels": ["ci-failure", "ai-summary"]
+  },
+  "routes": [
+    {
+      "_note": "infrastructure faults are not a code owner's problem",
+      "error_layer": "infra",
+      "project": "MINFRA",
+      "issue_type": "Bug",
+      "labels": ["ci-failure", "ai-summary", "infra"]
+    },
+    {
+      "category": "model",
+      "project": "MINFRA",
+      "issue_type": "Bug",
+      "labels": ["ci-failure", "ai-summary", "models"]
+    }
+  ]
+}

--- a/.github/actions/scripts/file_ci_failure_jira.py
+++ b/.github/actions/scripts/file_ci_failure_jira.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""File a Jira issue for a CI failure described by a normalized payload.
+
+The AI Summary action analyses logs and produces structured failure detail; this
+adapter does routing, de-duplication, ticket creation and owner assignment. It
+knows nothing about any particular workflow -- a monitored workflow publishes the
+payload below and this decides where it goes (MINFRA-1611).
+
+AI/IP release-test failures do NOT come through here: those are filed per test,
+routed to their AIIPSW requirement, by file_rtl_sim_jira.py onto RELEASE.
+
+Payload (JSON, one failure per object; a list files one issue per entry):
+    repository, workflow, job          identity of the failing leg
+    run_url, job_url                   links back to CI
+    commit                             sha under test            (optional)
+    test                               failing test path         (optional)
+    error_message                      verbatim, quoted in the issue
+    category, subcategory, error_layer AI classification         (optional)
+    confidence                         0..1; below min_confidence is not filed
+    root_cause, suggested_action       AI narrative              (optional)
+    log_urls                           list of links             (optional)
+    actionable                         explicit override         (optional)
+    owner                              Jira accountId if known   (optional)
+
+Environment:
+  CI_FAILURE_PAYLOAD   path to the payload JSON                  (required)
+  CI_FAILURE_ROUTING   routing config (default: ./ci_failure_routing.json)
+  JIRA_BASE_URL / JIRA_USER_EMAIL / JIRA_API_TOKEN               (required)
+  JIRA_DRY_RUN         print instead of calling Jira
+
+Exits 0 when nothing is actionable -- reporting must never fail a pipeline.
+"""
+import hashlib
+import json
+import os
+import re
+import sys
+
+from jira_client import _env, _truthy, file_issue
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _slug(text):
+    return re.sub(r"[^A-Za-z0-9]+", "-", str(text)).strip("-").lower()
+
+
+def load_payload(path):
+    """Return a list of failure dicts; a bare object is treated as one failure."""
+    with open(path) as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        data = data.get("failures", [data])
+    return [d for d in data if isinstance(d, dict)]
+
+
+def is_actionable(failure, min_confidence):
+    """Explicit actionable wins; otherwise require confidence at or above the floor.
+
+    A missing confidence is treated as actionable: the AI declining to score is
+    not evidence that a real failure should be dropped.
+    """
+    if "actionable" in failure:
+        return bool(failure["actionable"])
+    conf = failure.get("confidence")
+    if conf is None:
+        return True
+    try:
+        return float(conf) >= float(min_confidence)
+    except (TypeError, ValueError):
+        return True
+
+
+def route_for(failure, routing):
+    """First route whose stated fields all match; an omitted field is a wildcard."""
+    for route in routing.get("routes", []):
+        fields = [k for k in ("category", "subcategory", "error_layer", "workflow") if k in route]
+        if all(str(failure.get(k, "")).lower() == str(route[k]).lower() for k in fields):
+            merged = dict(routing.get("default", {}))
+            merged.update({k: v for k, v in route.items() if not k.startswith("_")})
+            return merged
+    return dict(routing.get("default", {}))
+
+
+def dedup_key(failure):
+    """Stable identity for one recurring failure.
+
+    Deliberately excludes run/job URLs and the commit: the same test failing the
+    same way next week is the same problem, and must comment rather than open a
+    duplicate.
+    """
+    parts = [
+        failure.get("repository", ""),
+        failure.get("workflow", ""),
+        failure.get("job", ""),
+        failure.get("test", ""),
+        failure.get("category", ""),
+        failure.get("subcategory", ""),
+    ]
+    digest = hashlib.sha1("|".join(str(p) for p in parts).encode()).hexdigest()[:10]
+    label = _slug(failure.get("test") or failure.get("job") or "ci-failure")[:60]
+    return f"ci-failure:{label}:{digest}"
+
+
+def summary_for(failure):
+    what = failure.get("test") or failure.get("job") or "CI failure"
+    where = failure.get("workflow") or failure.get("repository") or "CI"
+    return f"{where}: {what} failed"[:250]
+
+
+def description_for(failure):
+    lines = ["An AI Summary classified this CI failure as actionable.\n"]
+    for label, key in [
+        ("Repository", "repository"),
+        ("Workflow", "workflow"),
+        ("Job", "job"),
+        ("Test", "test"),
+        ("Commit", "commit"),
+        ("Category", "category"),
+        ("Subcategory", "subcategory"),
+        ("Error layer", "error_layer"),
+        ("Confidence", "confidence"),
+    ]:
+        if failure.get(key) not in (None, ""):
+            lines.append(f"{label + ':':14}{failure[key]}")
+    for label, key in [("Root cause", "root_cause"), ("Suggested action", "suggested_action")]:
+        if failure.get(key):
+            lines.append(f"\n{label}:\n{failure[key]}")
+    if failure.get("error_message"):
+        lines.append(f"\nError:\n{failure['error_message']}")
+    for label, key in [("Run", "run_url"), ("Job", "job_url")]:
+        if failure.get(key):
+            lines.append(f"{label + ':':14}{failure[key]}")
+    for url in failure.get("log_urls") or []:
+        lines.append(f"Log:          {url}")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    payload_path = _env("CI_FAILURE_PAYLOAD", required=True)
+    routing_path = _env("CI_FAILURE_ROUTING", os.path.join(HERE, "ci_failure_routing.json"))
+    dry = _truthy(_env("JIRA_DRY_RUN"))
+
+    if not os.path.isfile(payload_path):
+        print(f"no payload at {payload_path}; nothing to file")
+        return 0
+    with open(routing_path) as f:
+        routing = json.load(f)
+    failures = load_payload(payload_path)
+    print(f"payload carries {len(failures)} failure(s)")
+
+    base = _env("JIRA_BASE_URL", required=True)
+    email = _env("JIRA_USER_EMAIL", required=True)
+    token = _env("JIRA_API_TOKEN", required=True)
+    min_conf = routing.get("min_confidence", 0)
+
+    filed = 0
+    for failure in failures:
+        what = failure.get("test") or failure.get("job") or "?"
+        if not is_actionable(failure, min_conf):
+            print(f"skip (not actionable, confidence={failure.get('confidence')}): {what}")
+            continue
+        route = route_for(failure, routing)
+        labels = list(route.get("labels") or [])
+        assignee = failure.get("owner") or route.get("triage_assignee")
+        if not assignee:
+            # Better an unassigned issue someone triages than a wrong assignee.
+            labels.append("needs-owner")
+        print(
+            file_issue(
+                base=base,
+                email=email,
+                token=token,
+                project=route["project"],
+                summary=summary_for(failure),
+                issue_type=route.get("issue_type", "Bug"),
+                description=description_for(failure),
+                labels=labels,
+                dedup_label=dedup_key(failure),
+                assignee=assignee,
+                dry_run=dry,
+            )
+        )
+        filed += 1
+
+    print(f"filed/updated {filed} issue(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/scripts/test_file_ci_failure_jira.py
+++ b/.github/actions/scripts/test_file_ci_failure_jira.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Tests for the generic CI-failure Jira adapter (MINFRA-1611)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from file_ci_failure_jira import (  # noqa: E402
+    dedup_key,
+    description_for,
+    is_actionable,
+    load_payload,
+    route_for,
+    summary_for,
+)
+
+ROUTING = json.loads((SCRIPTS_DIR / "ci_failure_routing.json").read_text())
+
+
+def failure(**over):
+    base = {
+        "repository": "tenstorrent/tt-metal",
+        "workflow": "All post-commit tests",
+        "job": "ttnn unit tests",
+        "test": "tests/ttnn/unit_tests/test_matmul.py::test_bcast",
+        "run_url": "https://github.com/x/runs/1",
+        "error_message": "assert 0.97 > 0.99",
+        "category": "model",
+        "error_layer": "kernel",
+        "confidence": 0.9,
+    }
+    base.update(over)
+    return base
+
+
+def test_payload_accepts_object_list_or_wrapper(tmp_path):
+    one, many = tmp_path / "a.json", tmp_path / "b.json"
+    wrap = tmp_path / "c.json"
+    one.write_text(json.dumps(failure()))
+    many.write_text(json.dumps([failure(), failure(test="t2")]))
+    wrap.write_text(json.dumps({"failures": [failure()]}))
+    assert len(load_payload(one)) == 1
+    assert len(load_payload(many)) == 2
+    assert len(load_payload(wrap)) == 1
+
+
+def test_low_confidence_is_not_filed():
+    assert not is_actionable(failure(confidence=0.1), 0.6)
+    assert is_actionable(failure(confidence=0.9), 0.6)
+
+
+def test_explicit_actionable_overrides_confidence():
+    assert not is_actionable(failure(confidence=0.99, actionable=False), 0.6)
+    assert is_actionable(failure(confidence=0.01, actionable=True), 0.6)
+
+
+def test_missing_confidence_is_filed():
+    """The AI declining to score is not evidence the failure is spurious."""
+    f = failure()
+    del f["confidence"]
+    assert is_actionable(f, 0.6)
+    assert is_actionable(failure(confidence="n/a"), 0.6)
+
+
+def test_route_matches_most_specific_first():
+    infra = route_for(failure(error_layer="infra"), ROUTING)
+    assert "infra" in infra["labels"]
+    model = route_for(failure(error_layer="kernel", category="model"), ROUTING)
+    assert "models" in model["labels"]
+
+
+def test_unmatched_failure_falls_back_to_default():
+    r = route_for(failure(category="something-new", error_layer="unknown"), ROUTING)
+    assert r["project"] == ROUTING["default"]["project"]
+    assert r["issue_type"] == ROUTING["default"]["issue_type"]
+
+
+def test_route_never_lands_on_the_ai_ip_board():
+    """RELEASE carries AI/IP commitments only; generic CI noise must not reach it."""
+    projects = {ROUTING["default"]["project"]} | {r.get("project") for r in ROUTING["routes"]}
+    assert "RELEASE" not in projects
+
+
+def test_dedup_key_is_stable_across_runs_and_commits():
+    a = dedup_key(failure(run_url="https://x/1", commit="aaa"))
+    b = dedup_key(failure(run_url="https://x/2", commit="bbb"))
+    assert a == b, "the same test failing again must comment, not open a duplicate"
+
+
+def test_dedup_key_separates_different_tests():
+    assert dedup_key(failure()) != dedup_key(failure(test="tests/other.py::test_x"))
+    assert dedup_key(failure()) != dedup_key(failure(category="infra"))
+
+
+def test_dedup_key_is_a_valid_jira_label():
+    key = dedup_key(failure(test="tests/ttnn/unit_tests/test_matmul.py::test_bcast[8-16]"))
+    assert " " not in key and len(key) <= 100
+
+
+def test_description_quotes_the_error_and_links_back():
+    d = description_for(failure(root_cause="pcc drift", suggested_action="retune"))
+    for expected in ["assert 0.97 > 0.99", "pcc drift", "retune", "https://github.com/x/runs/1"]:
+        assert expected in d
+
+
+def test_description_omits_absent_fields():
+    d = description_for({"job": "j", "error_message": "boom"})
+    assert "Test:" not in d and "Root cause" not in d
+
+
+def test_summary_is_bounded_and_identifies_the_failure():
+    s = summary_for(failure())
+    assert "test_bcast" in s and len(s) <= 250
+    assert summary_for({"job": "build"}) == "CI: build failed"


### PR DESCRIPTION

## What

The existing automation was specialised around release-workflow output. This extracts the reusable half: an adapter that takes a **normalized failure payload** and does routing, de-duplication, ticket creation and owner assignment. It knows nothing about any particular workflow.

Splits responsibilities the way the ticket asks: the AI Summary analyses logs and produces structured detail; this decides where the resulting issue goes.

## Division of boards

| Failure | Path | Board |
|---|---|---|
| AI/IP promised tests | `file_rtl_sim_jira.py`, per test, via `ai_ip_tests.json` | **RELEASE** |
| Everything else | this adapter, via `ci_failure_routing.json` | **MINFRA** (default) |

A test asserts no route can reach `RELEASE` — that board carries AI/IP commitments only, and #54205 removes the broad watcher that was polluting it.

MINFRA is the default because it is the actively-triaged infra board (1,644 issues, active daily). `GHTTMETAL` is a stale GitHub mirror, last activity April; `MET` is quiet since May. Routing is config-driven, so a different destination per domain is a config edit.

## Payload

The fields MINFRA-1611 lists: repository, workflow, job, run/job URLs, commit, test, error message, category/subcategory/error layer, confidence, root cause, suggested action, log links. Accepts one object, a list, or `{"failures": [...]}`.

## Design decisions worth reviewing

**De-dup key** is derived from repository, workflow, job, test and category — and deliberately **excludes** the run URL and commit. The same test failing the same way next week is the same problem, so it comments rather than opening a duplicate. This is what the removed watcher got wrong: a constant key made every failure land on one ticket.

**Two calls made toward not losing failures.** A missing or unparseable confidence is treated as *actionable* — the AI declining to score is not evidence the failure is spurious. And an unresolved owner produces an unassigned issue labelled `needs-owner`, rather than a guessed assignee.

## Verification

12 unit tests for the adapter, 55 across the scripts directory. Dry-run over a three-failure payload routes a model failure and an infra failure to MINFRA with the right labels, and drops a confidence-0.2 entry.

## Not included

No workflow calls it yet. Publishing the payload is the integration point with Pavle's AI Summary, whose output schema is not visible from this repo — that mapping should land with whoever owns that action, against this contract.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgnidash/ci-failure-jira-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgnidash/ci-failure-jira-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgnidash/ci-failure-jira-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgnidash/ci-failure-jira-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgnidash/ci-failure-jira-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgnidash/ci-failure-jira-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgnidash/ci-failure-jira-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgnidash/ci-failure-jira-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgnidash/ci-failure-jira-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgnidash/ci-failure-jira-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgnidash/ci-failure-jira-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgnidash/ci-failure-jira-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgnidash/ci-failure-jira-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgnidash/ci-failure-jira-adapter)