### PR TITLE
[resnet] tilizeA_B srcB tiny-tile

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -407,27 +407,6 @@ void kernel_main() {
                     // Push the whole stick once, after every c-block has packed its slice, so the DM reader
                     // consumes exactly one full stick per wait_front/pop_front(scratch_npages) -- the previous
                     // per-c-block push overran the ring (see the reserve note above).
-                    //
-                    // [DEBUG scratch scaffold] Producer-side pack-write commit barrier. push_back() below posts
-                    // the SPSC credit the DM reader spins on (reader_pool_2d.cpp wait_front), after which it reads
-                    // this stick's row DIRECTLY from TL1. On HW the credit instruction itself waits for the packer
-                    // write to drain (TT_PUSH_TILES packer_wr_done_wait_mask=0x1 in llk_push_tiles), but the Quasar
-                    // emulator does NOT honor that embedded sub-field, so the counter can post before
-                    // pack_untilize_dest's TL1 write lands -> the reader reads a stale/empty scratch slot (a
-                    // fraction of sticks dropped->0 or dup->neighbor: PCC 0.897; watcher latency hides it, since
-                    // the scratch CB is single-buffered so the credit is the only producer->consumer serializer).
-                    // Drain the packer engine before posting the credit. Mirrors the "wait for pack to finish"
-                    // STALLWAIT idiom in llk_pack_common.h:307. No-op-equivalent on HW (redundant with the wr_done
-                    // wait); remove once the sim models PUSH_TILES.packer_wr_done_wait_mask.
-                    // Quasar-only: this barrier fixes the emulator's failure to honor PUSH_TILES'
-                    // packer_wr_done_wait_mask (see comment above). WH/BH HW honor it, so the stall is a no-op
-                    // there -- and TTI_STALLWAIT has a DIFFERENT arity per arch (Quasar takes 4 args, WH takes 2),
-                    // so it must be arch-gated to compile at all. NB: TTI_STALLWAIT expands to a bare __asm__
-                    // statement, so it must NOT be wrapped in the expression-form PACK((...)) parens -- PACK(...)
-                    // is variadic, so the comma-separated p_stall args pass straight through as one asm statement.
-#ifdef ARCH_QUASAR
-                    PACK(TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::NOTHING, p_stall::NOTHING, p_stall::PACK));
-#endif
                     curr_scratch_cb.push_back(scratch_npages);  // hand off to the DM reader, which writes the output
                 }
 #else

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -679,7 +679,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
     // -----------------------------------------------------------------------
     // Dataflow buffers.
     // -----------------------------------------------------------------------
-    const auto scalar_face = FaceGeometry{.face_r_dim = 1, .num_faces = 4};
+    const auto scalar_face = FaceGeometry{.face_r_dim = 1, .num_faces = 1};
     const uint32_t window_size_hw = kernel_h * kernel_w;
     // WORKAROUND (Quasar): the input-CB tile's face_r_dim feeds both the reduce tensor-shape and the
     // TDMA buffer-descriptor y_dim, and Quasar LLK restricts both to powers of 2 <= 16


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
Maxpool in resnet uses one row of srcB scalars, but forced `FaceGeometry={.num_faces=4}`. This is incorrect, as this results in a BFD programming of `x=16, y=1, z=4` which is not allowed ([`validate_buffer_desc()`](https://github.com/tenstorrent/tt-metal/blob/ce91f33c0c7184618d60553e4b32910c5ebdbfaa/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h#L139)). This required a workaround where BFD programming validation asserts were removed. This PR updates this incorrect FaceGeometry in the ttnn program factory to `num_faces=1`, as `tilizeA_B` does not require more than one 1x16 row.

In addition, an unnecessary stallwait was removed from `compute_pool_2d.cpp` as identified by @amokanTT.

All resnet sanity tests pass:
```
TT_METAL_WATCHER_DISABLE_NOC_SANITIZE=1 TT_METAL_WATCHER=10 TTNN_CONFIG_OVERRIDES='{"enable_fast_runtime_mode": false, "enable_logging": true}' TT_METAL_SLOW_DISPATCH_MODE=1 pytest -q
models/demos/vision/classification/resnet50/quasar/tests/ops/test_reshape_tiled.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_padded_slice.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_reallocate.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_reshape.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_sharded_to_interleaved.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_slice_write.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_tilize.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_to_layout.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_to_memory_config.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_untilize_with_unpadding.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_add.py
models/demos/vision/classification/resnet50/quasar/tests/ops/test_max_pool2d.py
```

### Notes for reviewers
Actual tiny-tile support for tilizeA_B srcB became available as of https://github.com/tenstorrent/tt-metal/pull/52762, this PR just removes the necessity of the workaround for resnet

Ran with CSR timeout = 0x100000:

Original workaround (num_faces=4, face_r_dim=1):
```
TT_METAL_DPRINT_CORES=all TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_FORCE_JIT_COMPILE=1 pytest -q --timeout=0 models/demos/vision/classification/resnet50/quasar/tests/ops/test_max_pool2d.py
```
```
PASSED models/demos/vision/classification/resnet50/quasar/tests/ops/test_max_pool2d.py::test_max_pool2d_resnet50_stem[quasar-device_params0]
=============================================================================================== 1 passed in 344.71s (0:05:44)
```

With ttnn fix (num_faces=1):
```
TT_METAL_DPRINT_CORES=all TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_FORCE_JIT_COMPILE=1 pytest -q --timeout=0 models/demos/vision/classification/resnet50/quasar/tests/ops/test_max_pool2d.py
```
```
PASSED models/demos/vision/classification/resnet50/quasar/tests/ops/test_max_pool2d.py::test_max_pool2d_resnet50_stem[quasar-device_params0]
=============================================================================================== 1 passed in 323.66s (0:05:23)
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jihoonyou/qsr-maxpool-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jihoonyou/qsr-maxpool-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jihoonyou/qsr-maxpool-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jihoonyou/qsr-maxpool-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jihoonyou/qsr-maxpool-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jihoonyou/qsr-maxpool-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jihoonyou/qsr-maxpool-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jihoonyou/qsr-maxpool-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jihoonyou/qsr-maxpool-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jihoonyou/qsr-maxpool-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jihoonyou/qsr-maxpool-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jihoonyou/qsr-maxpool-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jihoonyou/qsr-maxpool-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jihoonyou/qsr-maxpool-srcb)