### PR TITLE
Fix incorrect output tensor accessor in all_broadcast

### DIFF
--- a/tests/nightly/t3000/ccl/test_new_all_broadcast.py
+++ b/tests/nightly/t3000/ccl/test_new_all_broadcast.py
@@ -69,6 +69,7 @@ def run_all_broadcast_impl(
     trace_mode=False,
     rand_tensor=True,
     mem_config=None,
+    output_mem_config=None,
     input_shard_shape=None,
     input_shard_grid=None,
     output_shard_shape=None,
@@ -147,7 +148,8 @@ def run_all_broadcast_impl(
     else:
         assert mem_config is not None
         input_mem_config = mem_config
-        output_mem_config = mem_config
+        if output_mem_config is None:
+            output_mem_config = input_mem_config
     ###
 
     input_tensor_mesh_list = []
@@ -583,3 +585,30 @@ def test_all_broadcast_2x4_non_flat_mesh(mesh_device, input_shape):
         for tt_torch_output_slice in tt_torch_output_slices:
             eq, output = comp_equal(tt_torch_output_slice, torch_reference)
             assert eq, f"Tensor{i} FAILED: {output}"
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True, ids=["fabric_linear"]
+)
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "mem_config, output_mem_config",
+    [
+        (ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1), ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)),
+        (ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM), ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1)),
+    ],
+    ids=["l1_to_dram", "dram_to_l1"],
+)
+def test_all_broadcast_output_mem_config(mesh_device, function_level_defaults, mem_config, output_mem_config):
+    run_all_broadcast_impl(
+        mesh_device,
+        num_devices=8,
+        output_shape=[1, 1, 32, 32],
+        num_links=1,
+        input_dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        function_level_defaults=function_level_defaults,
+        all_broadcast_topology=ttnn.Topology.Linear,
+        mem_config=mem_config,
+        output_mem_config=output_mem_config,
+    )

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -188,13 +188,14 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     writer_compile_args.insert(writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
     writer_compile_args.insert(writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
     std::map<std::string, std::string> kernel_defines;
+    const auto& output_tensor = output_tensors[ring_index];
     if (sharded) {
         kernel_defines["SHARDED"] = "1";
         shard_builder::extend_sharding_compile_time_args(input_tensor, reader_compile_args);
-        shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_args);
+        shard_builder::extend_sharding_compile_time_args(output_tensor, writer_compile_args);
     } else {
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
-        tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_args);
     }
 
     // Build kernel descriptors.  Push them onto desc.kernels NOW (before the

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -188,14 +188,13 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     writer_compile_args.insert(writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
     writer_compile_args.insert(writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
     std::map<std::string, std::string> kernel_defines;
-    const auto& output_tensor = output_tensors[ring_index];
     if (sharded) {
         kernel_defines["SHARDED"] = "1";
         shard_builder::extend_sharding_compile_time_args(input_tensor, reader_compile_args);
-        shard_builder::extend_sharding_compile_time_args(output_tensor, writer_compile_args);
+        shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_args);
     } else {
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
-        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(output_tensors[ring_index].buffer()).append_to(writer_compile_args);
     }
 
     // Build kernel descriptors.  Push them onto desc.kernels NOW (before the

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -188,13 +188,14 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_at(
     writer_compile_args.insert(writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
     writer_compile_args.insert(writer_compile_args.end(), mcast_backward_args.begin(), mcast_backward_args.end());
     std::map<std::string, std::string> kernel_defines;
+    const auto& output_tensor = output_tensors[ring_index];
     if (sharded) {
         kernel_defines["SHARDED"] = "1";
         shard_builder::extend_sharding_compile_time_args(input_tensor, reader_compile_args);
         shard_builder::extend_sharding_compile_time_args(input_tensor, writer_compile_args);
     } else {
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
-        tt::tt_metal::TensorAccessorArgs(output_tensors[ring_index].buffer()).append_to(writer_compile_args);
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_args);
     }
 
     // Build kernel descriptors.  Push them onto desc.kernels NOW (before the


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The writer's address generator is built from the input buffer but points at the output buffer, so it resolves banks in the wrong memory space. `L1 -> DRAM` and `DRAM -> L1` return PCC ~0.03; same-buffer-type passes. Fix: build it from the output tensor.

Scope is the interleaved path, and the addressing only:

- **Sharded path left as-is.** It has the same input/output confusion, but the accessor is not the whole of it — the writer's page indices are enumerated in the input's shard geometry (`num_width_shards`, `output_tile_id_start = input_tile_id_start`), and the op cannot reshard, so a differing output shard spec is unsupported end to end rather than merely mis-addressed. Changing the accessor there would look consistent without working. No caller makes the two specs differ today, and `sharded` drives a single `SHARDED` define shared by both kernels, so a mixed sharded/interleaved pair cannot be built at all.
- **Transfer size unchanged.** Still the input's `aligned_page_size`, so `DRAM -> L1` with a row that pads differently in the two still overruns. Splitting transfer size from CB stride touches all four broadcast kernels. The test uses a 64 B row, aligned in both.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-ab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-ab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ab)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-ab)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ab)