### PR TITLE
[skip ci] ci: skip the AI run summary on cancelled runs

### DIFF
--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -509,7 +509,10 @@ jobs:
       - t3-unit-tests
       - t3-e2e-tests
       - vllm-tests
-    if: always()
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -159,7 +159,10 @@ jobs:
     # expected-jobs, so the matrix script runs only once per SKU (in
     # the impl) and there's no logic duplication across workflows.
     needs: [build-artifact, generate-card-matrix, blackhole-e2e-tests]
-    if: always()
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -169,7 +169,10 @@ jobs:
     # into expected-jobs so legs that produced no ai_job_summary artifact are
     # reconciled as infra failures rather than silently dropped.
     needs: [Galaxy-Blaze-models-prefill, Galaxy-Blaze-models-prefill-SDPA-Perf-tests, Galaxy-Blaze-models-prefill-sc4]
-    if: always() && !cancelled()
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -199,7 +199,10 @@ jobs:
   ai-run-summary:
     name: "AI Run Summary"
     needs: [load-test-matrix, demo-sp-release-tests]
-    if: always()
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -234,7 +234,10 @@ jobs:
   ai-run-summary:
     name: "AI Run Summary"
     needs: [load-test-matrix, models-device-perf-tests]
-    if: always()
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -130,7 +130,10 @@ jobs:
   ai-run-summary:
     name: "AI Run Summary"
     needs: [release-demo-tests]
-    if: always() && needs.release-demo-tests.result != 'skipped'
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() && needs.release-demo-tests.result != 'skipped' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -542,16 +542,16 @@ jobs:
       - ttsim-sanity-tests
       - runtime-sim-sanity-tests
       - blackhole-multi-card-fast-sanity-tests
-    # always(): a cancelled run still reports on the legs that finished. A
-    # cancelled child contributes no expected-jobs, so its unfinished legs are
-    # not stubbed as infra failures.
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
     #
     # A caller that invokes this workflow twice per run (sanity-tests-debug)
     # passes false, so the two reports don't collide on the artifact name.
     # The github.workflow arm covers this workflow's own push/schedule triggers,
     # where the `inputs` context is empty and the default above never applies;
     # it is the caller's workflow name for a workflow_call, so it is false there.
-    if: ${{ always() && (inputs.publish-run-summary || github.workflow == 'Sanity tests') }}
+    if: ${{ !cancelled() && (inputs.publish-run-summary || github.workflow == 'Sanity tests') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/t3000-e2e-tests-impl.yaml
+++ b/.github/workflows/t3000-e2e-tests-impl.yaml
@@ -123,7 +123,10 @@ jobs:
   ai-run-summary:
     name: "AI Run Summary"
     needs: [load-test-matrix, t3000-e2e-tests]
-    if: always()
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -674,7 +674,10 @@ jobs:
   ai-run-summary:
     name: "AI Run Summary"
     needs: [load-test-matrix, vllm-tests]
-    if: always()
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Ticket
Reported by @nsexton-tt in #metal-green-berets on [this run](https://github.com/tenstorrent/tt-metal/actions/runs/32768595050): the AI run summary still runs when a run is cancelled.

### Problem description
`ai-run-summary` was gated on `always()`. `always()` is true for a cancelled run, so cancelling a run still scheduled the summary job, which checked out the repo, aggregated whatever legs had finished, and spent an LLM call producing a report for a run that had no outcome to report on.

[Attempt 1](https://github.com/tenstorrent/tt-metal/actions/runs/32768595050/attempts/1) of the linked run was cancelled at 19:56 UTC, and [AI Run Summary](https://github.com/tenstorrent/tt-metal/actions/runs/32768595050/job/97570914865) ran to completion anyway.

### What's changed
Gate the job on `!cancelled()` instead.

`!cancelled()` is a status-check function, so — exactly like `always()` — it suppresses the implicit `success()` and the job still runs when an upstream `needs` job **failed**. That is the case the summary exists for and it is unaffected. The only behavior that changes is cancellation, which now skips the job.

Applied to all nine workflows defining an `ai-run-summary` job:

| Workflow | Before | After |
|---|---|---|
| `all-model-tests.yaml` | `always()` | `!cancelled()` |
| `blackhole-e2e-tests.yaml` | `always()` | `!cancelled()` |
| `blaze-models-prefill-tests.yaml` | `always() && !cancelled()` | `!cancelled()` |
| `demo-sp-release-impl.yaml` | `always()` | `!cancelled()` |
| `models-device-perf-tests-impl.yaml` | `always()` | `!cancelled()` |
| `release-build-test-publish.yaml` | `always() && needs.release-demo-tests.result != 'skipped'` | `!cancelled() && needs.release-demo-tests.result != 'skipped'` |
| `sanity-tests.yaml` | `always() && (inputs.publish-run-summary \|\| github.workflow == 'Sanity tests')` | `!cancelled() && (inputs.publish-run-summary \|\| github.workflow == 'Sanity tests')` |
| `t3000-e2e-tests-impl.yaml` | `always()` | `!cancelled()` |
| `vllm-model-tests-impl.yaml` | `always()` | `!cancelled()` |

`blaze-models-prefill-tests` already had the intended behavior; `always() && !cancelled()` reduces to `!cancelled()` and is now spelled the same way as the rest.

The `sanity-tests.yaml` comment justifying `always()` ("a cancelled run still reports on the legs that finished") is replaced, since that is no longer the intent.

### Note on a related case this does *not* change
The aggregation step still filters out **child jobs** whose individual result is `cancelled`, and still maps a cancelled child to a `cancelled` run-result. That path is still reachable on a run that was not itself cancelled — e.g. a single matrix leg cancelled by a timeout — so that logic is left alone.

### Checklist
- [x] All nine workflow files parse as valid YAML
- [x] `actionlint` reports no new findings (2 pre-existing findings in `release-build-test-publish.yaml`, at lines 18 and 383, are untouched by this diff and present on `main`)
- [ ] Post-merge: confirm on the next cancelled run that `AI Run Summary` reports as skipped

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/ai-run-summary-skip-cancelled)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/ai-run-summary-skip-cancelled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/ai-run-summary-skip-cancelled)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/ai-run-summary-skip-cancelled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/ai-run-summary-skip-cancelled)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/ai-run-summary-skip-cancelled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/ai-run-summary-skip-cancelled)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/ai-run-summary-skip-cancelled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/ai-run-summary-skip-cancelled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/ai-run-summary-skip-cancelled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/ai-run-summary-skip-cancelled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/ai-run-summary-skip-cancelled)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/ai-run-summary-skip-cancelled)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/ai-run-summary-skip-cancelled)