### PR TITLE
#54138: Bug fix - binary_ng program-cache key omissions and DRAM-sharded routing

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
 from models.common.utility_functions import skip_for_slow_dispatch
 
 
@@ -593,3 +593,55 @@ def test_add_block_float_defaults_to_fpu(device, ttnn_dtype):
     )
 
     assert torch.equal(default, fast)
+
+
+def test_add_scalar_dram_sharded_input(device):
+    """REGRESSION (issue #54138, finding #6): is_native_L1_sharding()'s scalar-operand branch returns
+    !is_uneven(a) with NO buffer-type test, so a DRAM-sharded input is accepted as "native L1 sharding"
+    and routed to the globally-allocated-CB path. Metal then throws
+    "Only L1 buffers can have an associated circular buffer!" -- a message that names neither the op, nor
+    sharding, nor the unsupported combination. (The identical-shape branch of the same predicate DOES
+    reject DRAM, which is why this only bites the scalar and COL/SCALAR-broadcast branches.)
+
+    The predicate is a router, not a validator: giving it the missing buffer-type check makes it decline,
+    which routes the op down the TensorAccessor path that already serves DRAM-sharded tensors elsewhere.
+    So the op should simply produce the right answer rather than throwing."""
+    torch.manual_seed(0)
+    shape = [1, 1, 128, 128]
+
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    shard_spec = ttnn.ShardSpec(core_grid, [32, 128], ttnn.ShardOrientation.ROW_MAJOR)
+    dram_sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+    torch_a = torch.rand(shape, dtype=torch.bfloat16)
+    tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_sharded)
+
+    tt_out = ttnn.add(tt_a, 1.5)
+
+    assert_with_pcc(torch_a + 1.5, ttnn.to_torch(tt_out), 0.999)
+
+
+def test_add_col_bcast_dram_sharded_input(device):
+    """Companion to test_add_scalar_dram_sharded_input, covering the OTHER branch that issue #54138
+    finding #6 fixed. is_native_L1_sharding gates its subtile-broadcast branch on a flag that previously
+    omitted any buffer-type test, so a DRAM-sharded height-sharded `a` under a COL broadcast was also
+    accepted as "native L1" and routed to the globally-allocated-CB path. Same Metal circular-buffer
+    throw, different branch -- and the scalar test cannot reach it, because that branch requires a
+    tensor `b`."""
+    torch.manual_seed(0)
+    a_shape = [1, 1, 128, 128]
+    b_shape = [1, 1, 128, 1]  # single tile column -> COL_B subtile broadcast
+
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    shard_spec = ttnn.ShardSpec(core_grid, [32, 128], ttnn.ShardOrientation.ROW_MAJOR)
+    dram_sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+    torch_a = torch.rand(a_shape, dtype=torch.bfloat16)
+    torch_b = torch.rand(b_shape, dtype=torch.bfloat16)
+
+    tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_sharded)
+    tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    tt_out = ttnn.add(tt_a, tt_b)
+
+    assert_with_pcc(torch_a + torch_b, ttnn.to_torch(tt_out), 0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_add.py
@@ -645,3 +645,42 @@ def test_add_col_bcast_dram_sharded_input(device):
     tt_out = ttnn.add(tt_a, tt_b)
 
     assert_with_pcc(torch_a + torch_b, ttnn.to_torch(tt_out), 0.999)
+
+
+def test_add_scalar_sharded_output_grid_differs_from_input(device):
+    """REGRESSION (https://github.com/tenstorrent/tt-metal/issues/54138): the native path aliases the
+    OUTPUT's buffer as a circular buffer while deriving per-core work from A's shard, so A and C must
+    agree on their shard spec. is_native_L1_sharding's identical-shape branch rejects a grid mismatch,
+    but the scalar and subtile-broadcast branches did not -- an even L1 input with an even L1 output on
+    a DIFFERENT grid was accepted as native, and the output then gets addressed on cores where it is not
+    allocated.
+
+    Measured on Wormhole before the fix: this HANGS the device (the run had to be killed and the card
+    reset), rather than returning a wrong answer. Declining routes it through the TensorAccessor path,
+    which handles the mismatch.
+
+    Note the common case is unaffected: when no output memory config is supplied it is derived from A's,
+    so the specs match and the op still takes the native path."""
+    torch.manual_seed(0)
+    shape = [1, 1, 128, 128]
+
+    a_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    a_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(a_grid, [32, 128], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    # Same tensor, same layout, both even -- only the grid and shard height differ.
+    c_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))})
+    c_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(c_grid, [64, 128], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    torch_a = torch.rand(shape, dtype=torch.bfloat16)
+    tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=a_mem)
+
+    tt_out = ttnn.add(tt_a, 1.5, memory_config=c_mem)
+
+    assert_with_pcc(torch_a + 1.5, ttnn.to_torch(tt_out), 0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -8,19 +8,29 @@ Unit tests for binary_ng program cache behavior.
 Tests target potential caching issues.
 The binary_ng operation uses a single ProgramFactory with caching based on:
 
-to_hash(): binary_op_type, lhs/rhs/post_activations, memory_config, get_dtype(),
-           compute_kernel_config, sub_core_grids, subtile_broadcast_type,
-           is_sfpu, is_quant_op, is_where_op
+operation_attributes_t::attribute_values(): binary_op_type, lhs/rhs/post_activations,
+           memory_config, get_dtype(), compute_kernel_config, sub_core_grids,
+           worker_grid, subtile_broadcast_type, is_sfpu, is_quant_op, is_where_op,
+           input_layout_a/b, output_layout, equal_nan, the shard volumes, and
+           c_tensor_shape_in_pages (the sharded output's tensor shape in pages on the accessor path)
 
-compute_program_hash(): attributes (via to_hash()), input tensor dtypes,
-                        input tensor memory_configs, shard_volumes
+tensor_args_t::to_hash(): input tensor dtypes and memory_configs, plus each
+           sharded input's tensor shape in pages (BufferDistributionSpec::tensor_shape_in_pages)
+
+The default compute_program_hash() combines both of the above.
 
 Fields correctly excluded from hash (handled by override_runtime_arguments):
-- logical_shape: not in compute_program_hash() by design - different logical
-  shapes share a cache entry and runtime arguments are updated accordingly
-- scalar.has_value(): not in to_hash(), but compute_program_hash branches
+- logical_shape: not in compute_program_hash() by design - differently-shaped
+  INTERLEAVED calls share a cache entry and runtime arguments are updated
+  accordingly. This does not extend to sharded calls, for two reasons that no
+  runtime re-application can repair: the native-vs-accessor regime is a
+  shape-dependent COMPILE-TIME decision (is_uneven -> is_native_L1_sharding ->
+  kernel defines), and on the accessor path the TensorAccessor's page geometry is
+  baked into the program. So sharded operands and sharded outputs each contribute
+  their tensor shape in pages to the key (issue #54138)
+- scalar.has_value(): not in attribute_values(), but compute_program_hash branches
   on input_tensor_b presence
-- input_dtype: not in to_hash(), but compute_program_hash includes input
+- input_dtype: not in attribute_values(), but compute_program_hash includes input
   tensor dtypes directly
 """
 
@@ -137,7 +147,7 @@ def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, 
 def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache):
     """binary_ng in-place add on SHARDED tensors — the sharding mode SDXL exercised (silu) — driven
     through binary_ng's override_runtime_arguments cache-hit path. Repeated at the SAME shard config
-    (sharded binary_ng keys shard_volume into the hash, so a different shape would MISS, not hit) but
+    (a sharded operand's tensor shape in pages is in the key, so a different shape would MISS, not hit) but
     with freshly-allocated operands kept alive, so each cache HIT sees a DIFFERENT buffer address.
     binary_ng's tensor-backed CB / rt-arg addresses must be re-applied on the hit (no rebuild) or the
     result is stale."""
@@ -232,7 +242,7 @@ def test_ng_cache_mixed_inplace_outofplace_sharded(device, isolate_program_cache
     for i, inplace in enumerate([first_inplace, not first_inplace, first_inplace, not first_inplace]):
         ref, out = do(i, inplace)
         assert_with_pcc(ref, out, 0.999)
-    # Same shard config across all calls (sharded binary_ng keys shard_volume) → one shared cache entry.
+    # Same shard config AND same shape across all calls → identical tensor shape in pages → one shared cache entry.
     assert device.cache_entries_counter.total == 1
 
 
@@ -301,7 +311,7 @@ def test_ng_cache_miss_different_memory_configs(device, isolate_program_cache):
 
 def test_ng_cache_miss_different_subtile_broadcast(device, isolate_program_cache):
     """Different subtile broadcast types -> different cache entries.
-    subtile_broadcast_type is in to_hash() and depends on last-2-dim shapes."""
+    subtile_broadcast_type is in attribute_values() and depends on last-2-dim shapes."""
     # NONE: equal shapes
     torch_ref1, tt_out1 = run_binary_ng_op(device, ttnn.add, [1, 1, 32, 64], [1, 1, 32, 64], dtype=ttnn.float32)
     assert_with_pcc(torch_ref1, tt_out1, 0.9999)
@@ -344,7 +354,7 @@ def test_ng_cache_miss_different_output_dtypes(device, isolate_program_cache):
 
 def test_ng_scalar_vs_tensor_cache_differentiation(device, isolate_program_cache):
     """Scalar op vs tensor op -> different cache entries.
-    scalar.has_value() is not in to_hash(), but compute_program_hash()
+    scalar.has_value() is not in attribute_values(), but compute_program_hash()
     naturally differentiates because the scalar path excludes tensor_b
     from hash arguments while the tensor path includes it."""
     shape = [1, 1, 32, 64]
@@ -362,7 +372,7 @@ def test_ng_scalar_vs_tensor_cache_differentiation(device, isolate_program_cache
 
 def test_ng_cache_miss_different_sub_core_grids(device, isolate_program_cache):
     """Different sub_core_grids -> different cache entries.
-    sub_core_grids is in to_hash() and directly determines worker_grid."""
+    sub_core_grids is in attribute_values() and directly determines worker_grid."""
     shape = [1, 1, 32, 64]
 
     torch_a1 = torch.rand(shape, dtype=torch.float32)
@@ -392,7 +402,7 @@ def test_ng_cache_miss_different_sub_core_grids(device, isolate_program_cache):
 
 def test_ng_different_input_dtypes_same_output_dtype(device, isolate_program_cache):
     """Different input dtypes with same output dtype -> different cache entries.
-    input_dtype is not in to_hash(), but compute_program_hash() includes
+    input_dtype is not in attribute_values(), but compute_program_hash() includes
     input tensor dtypes directly, which compensates."""
     shape = [1, 1, 32, 64]
 
@@ -494,3 +504,254 @@ def test_ng_cache_correctness_broadcast_repeated(device, isolate_program_cache):
     for _ in range(3):
         torch_ref, tt_out = run_binary_ng_op(device, ttnn.add, shape_a, shape_b, dtype=ttnn.float32)
         assert_with_pcc(torch_ref, tt_out, 0.9999)
+
+
+# =============================================================================
+# Cache miss tests: shape state the key must carry on the SCALAR path
+# =============================================================================
+
+
+def test_ng_scalar_sharded_cache_miss_when_evenness_flips(device, isolate_program_cache):
+    """REGRESSION (issue #54138, finding #2): the tensor+scalar overload of binary_ng never populates
+    a_/b_/c_shard_volume -- binary_ng_device_operation.cpp hardcodes all three to nullopt at the
+    attribute construction site, whereas the tensor-tensor overload patches them in immediately after
+    constructing its attributes. At the time the issue was filed those three were the key's only
+    shape-derived members, so on the scalar path the key carried no shape information whatsoever.
+
+    Meanwhile the native-vs-accessor regime IS shape-dependent: is_native_L1_sharding()'s scalar branch
+    returns !is_uneven(a), and that decision is baked into the program as compile-time kernel defines
+    that no runtime re-application can repair.
+
+    This test holds ONE explicit ShardSpec constant so every key field is identical across both calls
+    (a.dtype, a.memory_config, b absent, and attributes.memory_config, which falls back to a's config
+    when no memory_config or output tensor is supplied). Only the tensor height changes, which flips
+    is_uneven:
+
+        512 rows / shard height 64 -> 8 exact shards  -> even   -> native regime compiled
+        480 rows / shard height 64 -> 7 full + 1 of 32 -> uneven -> needs the accessor regime
+
+    The two calls therefore require DIFFERENT programs while colliding on one cache entry. Before any fix
+    this hung the device: the reused native-regime program busy-waits on an uneven shape, ignoring SIGINT
+    and needing a tt-smi reset.
+
+    Honest scope note: this test no longer isolates the shard-volume fix. Because `a` is sharded, the shape
+    in pages added to tensor_args_t::to_hash() for finding #1 also separates these two shapes (16x4 pages
+    vs 15x4), and evenness and shape in pages are perfectly correlated on this path anyway -- the shard
+    height is a whole number of tiles, so equal shapes in pages imply equal evenness. The test would pass with the
+    shard-volume change reverted. It is kept as an end-to-end guard on the regime flip, not as proof that
+    the volumes are what separate the two entries."""
+    shard_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 7))])
+    shard_spec = ttnn.ShardSpec(shard_grid, [64, 128], ttnn.ShardOrientation.ROW_MAJOR)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    def scalar_add(shape, seed):
+        torch.manual_seed(seed)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+        with device.cache_entries_counter.measure():
+            tt_c = ttnn.add(tt_a, 1.5)
+        return a + 1.5, ttnn.to_torch(tt_c)
+
+    ref_even, out_even = scalar_add([1, 1, 512, 128], 0)
+    assert_with_pcc(ref_even, out_even, 0.999)
+
+    # Same ShardSpec, same dtype, same memory config, but this shape needs the accessor regime rather
+    # than the native one the first call compiled.
+    ref_uneven, out_uneven = scalar_add([1, 1, 480, 128], 1)
+    assert_with_pcc(ref_uneven, out_uneven, 0.999)
+
+    # Proves the key distinguished the two regimes rather than silently reusing the first program.
+    assert device.cache_entries_counter.total == 2
+
+
+def test_ng_sharded_output_cache_miss_across_page_counts(device, isolate_program_cache):
+    """REGRESSION (issue #54138): the OUTPUT side of the accessor-path shape collision.
+
+    Both inputs are interleaved and only the output is sharded, via an explicit memory_config. The
+    identical-shape branch of is_native_L1_sharding rejects DRAM inputs, so the native path declines and
+    the writer reaches the output through a TensorAccessor -- built over the output buffer with the same
+    ArgConfig::RuntimeTensorShape common arg that override_runtime_arguments never refreshes.
+
+    Nothing else in the key varies with the output's extent: the inputs are interleaved so their page
+    shapes in pages are absent, and attributes.memory_config carries the output's shard spec but not its shape.
+    Measured on Wormhole before the fix, small-then-big: the second call was a cache hit with 14693/16384
+    elements wrong.
+
+    This is more reachable than the input-side case, which needs an explicit ShardSpec on an input --
+    here the inputs are ordinary interleaved DRAM tensors and only memory_config is unusual."""
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    shard_spec = ttnn.ShardSpec(core_grid, [32, 128], ttnn.ShardOrientation.ROW_MAJOR)
+    out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    def add_into_sharded(shape, seed):
+        torch.manual_seed(seed)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        b = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        with device.cache_entries_counter.measure():
+            tt_c = ttnn.add(tt_a, tt_b, memory_config=out_mem)
+        return a + b, ttnn.to_torch(tt_c)
+
+    ref_small, out_small = add_into_sharded([1, 1, 64, 128], 0)
+    assert_with_pcc(ref_small, out_small, 0.999)
+
+    ref_big, out_big = add_into_sharded([1, 1, 128, 128], 1)
+    assert_with_pcc(ref_big, out_big, 0.999)
+
+    assert device.cache_entries_counter.total == 2
+
+
+def test_ng_scalar_interleaved_memcfg_with_sharded_output_cache_miss(device, isolate_program_cache):
+    """REGRESSION: an explicit INTERLEAVED memory_config alongside a SHARDED preallocated output.
+
+    mem_config_actual falls back to the output tensor's config only when no explicit memory_config was
+    given, so this combination leaves it interleaved -- while compute_output_specs returns a supplied
+    output's spec verbatim, making the real output sharded. A guard that consulted only the input and
+    mem_config_actual therefore skipped recording the output's shape in pages, and the accessor-path
+    collision reopened on this path even though the general case was fixed.
+
+    Nothing requires the two to agree: the binary_ng invoke template forwards memory_config and
+    output_tensor to the prim independently, and validate_on_program_cache_miss does not cross-check
+    them. So the guard tests the output tensor separately."""
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    shard_spec = ttnn.ShardSpec(core_grid, [32, 128], ttnn.ShardOrientation.ROW_MAJOR)
+    sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    def scalar_add_into(shape, seed):
+        torch.manual_seed(seed)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        tt_out = ttnn.from_torch(
+            torch.zeros(shape, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device, memory_config=sharded
+        )
+        with device.cache_entries_counter.measure():
+            # Interleaved memory_config, sharded output -- deliberately disagreeing.
+            tt_c = ttnn.add(tt_a, 1.5, memory_config=ttnn.DRAM_MEMORY_CONFIG, output_tensor=tt_out)
+        return a + 1.5, ttnn.to_torch(tt_c)
+
+    ref_small, out_small = scalar_add_into([1, 1, 64, 128], 0)
+    assert_with_pcc(ref_small, out_small, 0.999)
+
+    ref_big, out_big = scalar_add_into([1, 1, 128, 128], 1)
+    assert_with_pcc(ref_big, out_big, 0.999)
+
+    assert device.cache_entries_counter.total == 2
+
+
+def test_ng_scalar_dram_sharded_cache_miss_across_page_counts(device, isolate_program_cache):
+    """REGRESSION (issue #54138, finding #1) -- distinct from finding #2 above, and NOT fixed by it.
+
+    The shard volumes that #2 populates encode the SHARD's extent (shard_spec.numel() / tile_hw), not the
+    tensor's, so with one ShardSpec held constant they are identical at every tensor shape. What #2's fix
+    discriminates is populated-vs-nullopt, i.e. the native path from the accessor path. Within the
+    accessor path the key still carries no shape information whatsoever.
+
+    That matters because the two paths differ in what a cache hit can repair. On the native path
+    override_runtime_arguments re-derives every per-core arg from the live tensors, so a shape change is
+    handled. On the accessor path nothing does: tensor_shape_in_pages is a common runtime arg (binary_ng
+    requests ArgConfig::RuntimeTensorShape) but override_runtime_arguments never calls
+    GetCommonRuntimeArgs, and rank/num_banks/shard_shape/bank_coords are compile-time.
+
+    A DRAM-sharded input takes the accessor path (is_native_L1_sharding declines on buffer type), so with
+    one ShardSpec held constant these two shapes share a cache entry while needing different geometry:
+
+        [1,1, 64,128] -> 2 shards,  8 pages
+        [1,1,128,128] -> 4 shards, 16 pages
+
+    Measured on Wormhole with the DRAM routing fix applied (before it, this configuration threw Metal's
+    circular-buffer error instead of reaching the accessor). Small-then-big: the SECOND call is a cache
+    hit and returns PCC 0.179 with exactly 8192/16384 elements wrong -- half. This configuration squeezes
+    to rank 1, so tensor_shape_in_pages is Shape([8]) for the small tensor and Shape([16]) for the big
+    one; reusing the baked 8 means page ids 8..15 decompose modulo 8 and the tensor's second half
+    re-reads its first half. It corrupts silently: no hang, no throw.
+
+    The order matters. Big-then-small is correct by accident, because every page id of the smaller tensor
+    already falls below the larger baked radix (page_id % 16 == page_id % 8 for page_id < 8). Only
+    small-then-big exposes it, which is one reason this went unreproduced.
+
+    Fixed by hashing BufferDistributionSpec::tensor_shape_in_pages() for sharded operands in
+    tensor_args_t::to_hash(). That is what the accessor actually consumes, and it is already squeezed, so
+    shapes that squeeze together -- which genuinely can share a program -- still share a cache entry,
+    while shapes with distinct tensor shapes in pages get their own. A common-runtime-arg refresh would NOT have
+    been sufficient: it repairs tensor_shape_in_pages while leaving the compile-time bank table and the
+    regime #if wrong, which is a partial repair that is harder to detect than the original bug."""
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    shard_spec = ttnn.ShardSpec(core_grid, [32, 128], ttnn.ShardOrientation.ROW_MAJOR)
+    mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+    def scalar_add(shape, seed):
+        torch.manual_seed(seed)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+        with device.cache_entries_counter.measure():
+            tt_c = ttnn.add(tt_a, 1.5)
+        return a + 1.5, ttnn.to_torch(tt_c)
+
+    ref_small, out_small = scalar_add([1, 1, 64, 128], 0)
+    assert_with_pcc(ref_small, out_small, 0.999)
+
+    # Cache HIT today: same ShardSpec and dtype, and the accessor path leaves the key's only
+    # shape-derived members unset, so nothing distinguishes 8 pages from 16.
+    ref_big, out_big = scalar_add([1, 1, 128, 128], 1)
+    assert_with_pcc(ref_big, out_big, 0.999)
+
+    assert device.cache_entries_counter.total == 2
+
+
+@pytest.mark.parametrize(
+    "out_dtype",
+    [
+        ttnn.bfloat16,
+        pytest.param(
+            ttnn.float32,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="issue #54138: ttnn.where with a preallocated float32 output silently ignores the "
+                "predicate and returns t_true. Reproduces on a SINGLE call against a cold program cache, "
+                "so this is a plain correctness bug rather than the cache-key collision finding #3 "
+                "describes. Unfixed; see the docstring. strict so that fixing it fails here and forces "
+                "this marker to be removed rather than lingering as a silent XPASS.",
+            ),
+        ),
+    ],
+    ids=["out_bf16", "out_f32"],
+)
+def test_ng_where_scalar_preallocated_output_dtype(device, isolate_program_cache, out_dtype):
+    """Issue #54138 finding #3 predicted a CACHE-HIT defect: a caller-supplied output tensor reaches the
+    key only by proxy through attributes.dtype, which where_operation_with_scalar leaves as std::nullopt,
+    so get_dtype() collapses to the INPUT dtype and the real output dtype never enters the key. The
+    finding was tiered "Blocking (minor)" on the premise that "a single call with the odd value works
+    correctly" and only the cache hit goes wrong.
+
+    Measured on Wormhole, that premise does not hold. With a preallocated FLOAT32 output and bfloat16
+    inputs, a single call against a freshly-cleared program cache already returns the wrong answer --
+    2022 of 2048 elements mismatched, and the output is approximately t_true, i.e. the predicate is
+    dropped entirely. The bfloat16-output case is exact (0/2048) under the same conditions.
+
+    So this domain is broken with or without a cache, which by the issue's own cache-dependence test
+    makes it a report rather than a port blocker: adding the output dtype to the key would only give
+    each dtype its own separately-wrong program. Adding it also costs real cache reuse, because hashing
+    the output tensor's presence stops in-place and out-of-place calls from sharing one entry (it breaks
+    test_ng_cache_mixed_inplace_outofplace_interleaved). The underlying correctness bug must be fixed
+    first; only then is a key entry meaningful.
+
+    This test is parametrized so the passing bfloat16 case pins the behavior that DOES work, and the
+    xfail marks the float32 case that does not."""
+    shape = [1, 1, 32, 64]
+    torch.manual_seed(0)
+
+    pred = (torch.rand(shape) > 0.5).to(torch.bfloat16)
+    t_true = torch.rand(shape, dtype=torch.bfloat16)
+    scalar_false = 0.5
+
+    tt_pred = ttnn.from_torch(pred, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_true = ttnn.from_torch(t_true, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch.float32), dtype=out_dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+
+    res = ttnn.where(tt_pred, tt_true, scalar_false, output_tensor=tt_out)
+
+    ref = torch.where(pred.bool(), t_true.float(), torch.full(shape, scalar_false))
+    assert_with_pcc(ref, ttnn.to_torch(res).float(), 0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -512,34 +512,22 @@ def test_ng_cache_correctness_broadcast_repeated(device, isolate_program_cache):
 
 
 def test_ng_scalar_sharded_cache_miss_when_evenness_flips(device, isolate_program_cache):
-    """REGRESSION (issue #54138, finding #2): the tensor+scalar overload of binary_ng never populates
-    a_/b_/c_shard_volume -- binary_ng_device_operation.cpp hardcodes all three to nullopt at the
-    attribute construction site, whereas the tensor-tensor overload patches them in immediately after
-    constructing its attributes. At the time the issue was filed those three were the key's only
-    shape-derived members, so on the scalar path the key carried no shape information whatsoever.
+    """REGRESSION: the scalar overload must key on shape, because the native-vs-accessor regime is a
+    compile-time decision that flips with is_uneven and no runtime re-application can repair it.
 
-    Meanwhile the native-vs-accessor regime IS shape-dependent: is_native_L1_sharding()'s scalar branch
-    returns !is_uneven(a), and that decision is baked into the program as compile-time kernel defines
-    that no runtime re-application can repair.
-
-    This test holds ONE explicit ShardSpec constant so every key field is identical across both calls
-    (a.dtype, a.memory_config, b absent, and attributes.memory_config, which falls back to a's config
-    when no memory_config or output tensor is supplied). Only the tensor height changes, which flips
-    is_uneven:
+    ONE explicit ShardSpec held constant, so every other key field is identical across both calls. Only
+    the height changes, which flips evenness:
 
         512 rows / shard height 64 -> 8 exact shards  -> even   -> native regime compiled
         480 rows / shard height 64 -> 7 full + 1 of 32 -> uneven -> needs the accessor regime
 
-    The two calls therefore require DIFFERENT programs while colliding on one cache entry. Before any fix
-    this hung the device: the reused native-regime program busy-waits on an uneven shape, ignoring SIGINT
-    and needing a tt-smi reset.
+    Pre-fix this HUNG the device -- the reused native program busy-waits on an uneven shape, ignores
+    SIGINT and needs a card reset. Expect that, not a wrong answer, if it regresses.
 
-    Honest scope note: this test no longer isolates the shard-volume fix. Because `a` is sharded, the shape
-    in pages added to tensor_args_t::to_hash() for finding #1 also separates these two shapes (16x4 pages
-    vs 15x4), and evenness and shape in pages are perfectly correlated on this path anyway -- the shard
-    height is a whole number of tiles, so equal shapes in pages imply equal evenness. The test would pass with the
-    shard-volume change reverted. It is kept as an end-to-end guard on the regime flip, not as proof that
-    the volumes are what separate the two entries."""
+    Scope caveat: this does not isolate the shard-volume fix. `a` is sharded, so the shape in pages in
+    to_hash() separates these shapes too, and evenness and page count are correlated anyway (the shard
+    height is a whole number of tiles). It would pass with the shard-volume change reverted; it is an
+    end-to-end guard on the regime flip, not proof of what separates the entries."""
     shard_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 7))])
     shard_spec = ttnn.ShardSpec(shard_grid, [64, 128], ttnn.ShardOrientation.ROW_MAJOR)
     mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
@@ -640,42 +628,20 @@ def test_ng_scalar_interleaved_memcfg_with_sharded_output_cache_miss(device, iso
 
 
 def test_ng_scalar_dram_sharded_cache_miss_across_page_counts(device, isolate_program_cache):
-    """REGRESSION (issue #54138, finding #1) -- distinct from finding #2 above, and NOT fixed by it.
+    """REGRESSION: on the accessor path the cache key must carry each sharded operand's shape in pages.
 
-    The shard volumes that #2 populates encode the SHARD's extent (shard_spec.numel() / tile_hw), not the
-    tensor's, so with one ShardSpec held constant they are identical at every tensor shape. What #2's fix
-    discriminates is populated-vs-nullopt, i.e. the native path from the accessor path. Within the
-    accessor path the key still carries no shape information whatsoever.
-
-    That matters because the two paths differ in what a cache hit can repair. On the native path
-    override_runtime_arguments re-derives every per-core arg from the live tensors, so a shape change is
-    handled. On the accessor path nothing does: tensor_shape_in_pages is a common runtime arg (binary_ng
-    requests ArgConfig::RuntimeTensorShape) but override_runtime_arguments never calls
-    GetCommonRuntimeArgs, and rank/num_banks/shard_shape/bank_coords are compile-time.
-
-    A DRAM-sharded input takes the accessor path (is_native_L1_sharding declines on buffer type), so with
-    one ShardSpec held constant these two shapes share a cache entry while needing different geometry:
+    A DRAM-sharded input takes that path, so with one ShardSpec held constant these two shapes share
+    every other key field while needing different accessor geometry:
 
         [1,1, 64,128] -> 2 shards,  8 pages
         [1,1,128,128] -> 4 shards, 16 pages
 
-    Measured on Wormhole with the DRAM routing fix applied (before it, this configuration threw Metal's
-    circular-buffer error instead of reaching the accessor). Small-then-big: the SECOND call is a cache
-    hit and returns PCC 0.179 with exactly 8192/16384 elements wrong -- half. This configuration squeezes
-    to rank 1, so tensor_shape_in_pages is Shape([8]) for the small tensor and Shape([16]) for the big
-    one; reusing the baked 8 means page ids 8..15 decompose modulo 8 and the tensor's second half
-    re-reads its first half. It corrupts silently: no hang, no throw.
+    Pre-fix the second call was a cache hit returning PCC 0.179 with exactly half the output wrong.
 
-    The order matters. Big-then-small is correct by accident, because every page id of the smaller tensor
-    already falls below the larger baked radix (page_id % 16 == page_id % 8 for page_id < 8). Only
-    small-then-big exposes it, which is one reason this went unreproduced.
+    ORDER MATTERS -- do not reverse these calls. Big-then-small passes vacuously, because every page id
+    of the smaller tensor already falls below the larger baked radix. Only small-then-big exposes it.
 
-    Fixed by hashing BufferDistributionSpec::tensor_shape_in_pages() for sharded operands in
-    tensor_args_t::to_hash(). That is what the accessor actually consumes, and it is already squeezed, so
-    shapes that squeeze together -- which genuinely can share a program -- still share a cache entry,
-    while shapes with distinct tensor shapes in pages get their own. A common-runtime-arg refresh would NOT have
-    been sufficient: it repairs tensor_shape_in_pages while leaving the compile-time bank table and the
-    regime #if wrong, which is a partial repair that is harder to detect than the original bug."""
+    Requires the DRAM routing fix to reach the accessor at all; without it the config throws instead."""
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
     shard_spec = ttnn.ShardSpec(core_grid, [32, 128], ttnn.ShardOrientation.ROW_MAJOR)
     mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -707,7 +707,8 @@ def test_ng_scalar_dram_sharded_cache_miss_across_page_counts(device, isolate_pr
             ttnn.float32,
             marks=pytest.mark.xfail(
                 strict=True,
-                reason="issue #54138: ttnn.where with a preallocated float32 output silently ignores the "
+                reason="https://github.com/tenstorrent/tt-metal/issues/54138 -- ttnn.where with a preallocated "
+                "float32 output silently ignores the "
                 "predicate and returns t_true. Reproduces on a SINGLE call against a cold program cache, "
                 "so this is a plain correctness bug rather than the cache-key collision finding #3 "
                 "describes. Unfixed; see the docstring. strict so that fixing it fails here and forces "

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -262,23 +262,7 @@ DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
 namespace {
 // Key material for a sharded operand: the radix its TensorAccessor decomposes page ids with, baked at
 // build time and never refreshed. Nullopt for interleaved operands, which keeps their shape-blind cache
-// reuse. Squeezed, so shapes that share an accessor still share a cache entry. Read off the Buffer, not
-// the spec: set_page_size/set_shard_spec reset buffer_distribution_spec_ while the spec keeps it.
-std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const Tensor& tensor) {
-    // to_hash() runs before validate_on_program_cache_miss, so buffer() may throw: device_storage()
-    // TT_FATALs on host storage, get_mesh_buffer() on a deallocated tensor. This guard, not a null check.
-    if (!tensor.memory_config().is_sharded() || !tensor.is_allocated() ||
-        tensor.storage_type() != StorageType::DEVICE) {
-        return std::nullopt;
-    }
-    const auto& distribution_spec = tensor.buffer()->buffer_distribution_spec();
-    if (!distribution_spec.has_value()) {
-        return std::nullopt;
-    }
-    return distribution_spec->tensor_shape_in_pages();
-}
-
-// Same, for an op-created output that has no Tensor yet when the key is built.
+// reuse. Squeezed, so shapes that share an accessor still share a cache entry.
 std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const tt::tt_metal::TensorSpec& spec) {
     if (!spec.memory_config().is_sharded()) {
         return std::nullopt;
@@ -291,6 +275,24 @@ std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const tt::tt_me
         return std::nullopt;
     }
     return distribution_spec->tensor_shape_in_pages();
+}
+
+// Prefers the Buffer, which is the faithful record of what the accessor was built from: set_page_size
+// and set_shard_spec reset buffer_distribution_spec_ while the spec keeps it. Falls back to the spec
+// when the Buffer is unreadable -- to_hash() runs before validate_on_program_cache_miss, and buffer()
+// throws on host storage or a deallocated tensor -- so a sharded operand never contributes an empty
+// shape to the key, which would be indistinguishable from an interleaved one and would collide.
+std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const Tensor& tensor) {
+    if (!tensor.memory_config().is_sharded()) {
+        return std::nullopt;
+    }
+    if (tensor.is_allocated() && tensor.storage_type() == StorageType::DEVICE) {
+        const auto& distribution_spec = tensor.buffer()->buffer_distribution_spec();
+        if (distribution_spec.has_value()) {
+            return distribution_spec->tensor_shape_in_pages();
+        }
+    }
+    return sharded_tensor_shape_in_pages(tensor.tensor_spec());
 }
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -259,9 +259,77 @@ DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
     return this->dtype.value_or(this->input_dtype);
 }
 
+namespace {
+// The tensor shape in pages a sharded operand's TensorAccessor decomposes page ids with, or nullopt when
+// the operand is not sharded (interleaved operands build no sharded accessor, and hashing their shape would cost
+// the by-design shape-blind cache reuse that differently-shaped interleaved calls rely on).
+//
+// tensor_shape_in_pages is the accessor's radix: get_bank_and_offset decomposes a flat page id as
+// page_coord[i] = page_id % tensor_shape[i], and at rank >= 2 it also feeds shard_grid_strides. It is a
+// common runtime arg (binary_ng requests ArgConfig::RuntimeTensorShape) that override_runtime_arguments
+// never refreshes -- it does not call GetCommonRuntimeArgs -- while rank, num_banks, shard_shape and
+// bank_coords are compile-time and could not be re-applied even in principle. The shard volumes on
+// operation_attributes_t do not cover this: they encode the SHARD's extent, not the tensor's, so they are
+// identical across shapes that share one ShardSpec. Without this entry two such shapes collide on a single
+// cache entry and the second decomposes its page ids with the first's radix, silently returning a wrong
+// tensor. The output is keyed separately, via c_tensor_shape_in_pages (issue #54138).
+//
+// Hashing the tensor shape in pages rather than the padded shape is what keeps this from over-discriminating:
+// BufferDistributionSpec squeezes adjacent dimensions at construction, so shapes that squeeze together
+// produce an identical accessor, genuinely can share a program, and still share a cache entry here.
+//
+// Read off the Buffer rather than recomputed from the TensorSpec, deliberately: Buffer::set_page_size
+// and set_shard_spec reset buffer_distribution_spec_ while the spec keeps it, so the Buffer is the
+// faithful record of what the accessor was actually built from.
+std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const Tensor& tensor) {
+    // to_hash() runs before validate_on_program_cache_miss, so neither device storage nor allocation can be
+    // assumed: Tensor::buffer() goes through device_storage(), which TT_FATALs on host storage, and
+    // get_mesh_buffer(), which throws on a deallocated device tensor. Neither returns nullptr, so this
+    // guard -- not a null check on the result -- is what covers those two cases. The sharded test comes
+    // first: it is a plain accessor and skips the rest for the interleaved majority.
+    if (!tensor.memory_config().is_sharded() || !tensor.is_allocated() ||
+        tensor.storage_type() != StorageType::DEVICE) {
+        return std::nullopt;
+    }
+    const auto& distribution_spec = tensor.buffer()->buffer_distribution_spec();
+    if (!distribution_spec.has_value()) {
+        return std::nullopt;
+    }
+    return distribution_spec->tensor_shape_in_pages();
+}
+
+// Same key material for the OUTPUT, which normally has no Tensor yet when the key is built and so is
+// resolved from its TensorSpec instead. The writer builds a TensorAccessor over the output buffer with
+// the same unrefreshed RuntimeTensorShape common arg the readers use, so a sharded output on the
+// accessor path needs its extent in the key exactly as the inputs do.
+std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const tt::tt_metal::TensorSpec& spec) {
+    if (!spec.memory_config().is_sharded()) {
+        return std::nullopt;
+    }
+    // Hold the args by value: compute_buffer_sharding_args() returns a temporary, and
+    // buffer_distribution_spec() hands back a reference INTO it, which lifetime extension does not
+    // cover. Binding that reference directly dangles and silently reads as empty.
+    const auto sharding_args = spec.compute_buffer_sharding_args();
+    const auto& distribution_spec = sharding_args.buffer_distribution_spec();
+    if (!distribution_spec.has_value()) {
+        return std::nullopt;
+    }
+    return distribution_spec->tensor_shape_in_pages();
+}
+}  // namespace
+
+ttsl::hash::hash_t BinaryNgDeviceOperation::tensor_args_t::to_hash() const {
+    return ttsl::hash::hash_objects_with_default_seed(
+        input_tensor_a.dtype(),
+        input_tensor_a.memory_config(),
+        input_tensor_b.has_value() ? std::optional<DataType>{input_tensor_b->dtype()} : std::nullopt,
+        input_tensor_b.has_value() ? std::optional<MemoryConfig>{input_tensor_b->memory_config()} : std::nullopt,
+        sharded_tensor_shape_in_pages(input_tensor_a),
+        input_tensor_b.has_value() ? sharded_tensor_shape_in_pages(*input_tensor_b) : std::nullopt);
+}
+
 void BinaryNgDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    // We don't support sharding for now
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
     const auto& output_tensor = tensor_args.output_tensor;
@@ -685,14 +753,23 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         std::nullopt};
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, input_tensor_b, output_tensor};
+    const auto output_spec = OperationType::compute_output_specs(operation_attributes, tensor_args);
     const auto shard_volumes = ttnn::operations::binary_ng::get_shard_volumes(
-        input_tensor_a.tensor_spec(),
-        input_tensor_b.tensor_spec(),
-        OperationType::compute_output_specs(operation_attributes, tensor_args));
+        input_tensor_a.tensor_spec(), input_tensor_b.tensor_spec(), output_spec);
     if (shard_volumes.has_value()) {
         operation_attributes.a_shard_volume = shard_volumes->a_shard_volume;
         operation_attributes.b_shard_volume = shard_volumes->b_shard_volume;
         operation_attributes.c_shard_volume = shard_volumes->c_shard_volume;
+    } else {
+        // Accessor regime. A sharded output is reached through the writer's TensorAccessor, whose shape in
+        // pages is baked at build time and never refreshed, so it must enter the key. Nothing else in the
+        // key varies with it: the inputs may be interleaved (their shapes in pages are then absent), and
+        // attributes.memory_config carries the output's shard spec but not its shape. Prefer a supplied
+        // output's Buffer -- the faithful record of what the accessor was built from, and cheaper than
+        // rebuilding a BufferDistributionSpec from the spec.
+        operation_attributes.c_tensor_shape_in_pages =
+            output_tensor.has_value() ? operations::binary_ng::sharded_tensor_shape_in_pages(*output_tensor)
+                                      : operations::binary_ng::sharded_tensor_shape_in_pages(output_spec);
     }
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
@@ -777,6 +854,34 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         std::nullopt};
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
+    // Only a sharded operand or output needs the extra key material below, and ttnn.add(t, scalar) is
+    // overwhelmingly interleaved, so skip the output-spec computation entirely on that path rather than
+    // paying it on every dispatch. Mirrors get_shard_specs' own early-out (issue #54138).
+    // output_tensor is tested separately: mem_config_actual only falls back to it when no explicit
+    // memory_config was given, but compute_output_specs returns a supplied output's spec verbatim, so an
+    // interleaved memory_config alongside a sharded output would otherwise skip this block.
+    if (input_tensor_a.memory_config().is_sharded() || mem_config_actual.is_sharded() ||
+        (output_tensor.has_value() && output_tensor->memory_config().is_sharded())) {
+        const auto output_spec = OperationType::compute_output_specs(operation_attributes, tensor_args);
+        const auto shard_volumes =
+            ttnn::operations::binary_ng::get_shard_volumes(input_tensor_a.tensor_spec(), std::nullopt, output_spec);
+        if (shard_volumes.has_value()) {
+            // Native regime. This overload used to leave the volumes unset while the tensor-tensor
+            // overload patched them in. On this path they are in fact redundant with the input's shape in
+            // pages in tensor_args_t::to_hash() -- evenness and shape in pages move together, since the
+            // shard height is a whole number of tiles -- but they are kept so the two overloads stay
+            // symmetric and a reader need not re-derive that.
+            operation_attributes.a_shard_volume = shard_volumes->a_shard_volume;
+            operation_attributes.b_shard_volume = shard_volumes->b_shard_volume;
+            operation_attributes.c_shard_volume = shard_volumes->c_shard_volume;
+        } else {
+            // Accessor regime: the writer reaches a sharded output through a TensorAccessor whose shape in
+            // pages is baked at build time and never refreshed, so it must enter the key.
+            operation_attributes.c_tensor_shape_in_pages =
+                output_tensor.has_value() ? operations::binary_ng::sharded_tensor_shape_in_pages(*output_tensor)
+                                          : operations::binary_ng::sharded_tensor_shape_in_pages(output_spec);
+        }
+    }
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -260,33 +260,13 @@ DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
 }
 
 namespace {
-// The tensor shape in pages a sharded operand's TensorAccessor decomposes page ids with, or nullopt when
-// the operand is not sharded (interleaved operands build no sharded accessor, and hashing their shape would cost
-// the by-design shape-blind cache reuse that differently-shaped interleaved calls rely on).
-//
-// tensor_shape_in_pages is the accessor's radix: get_bank_and_offset decomposes a flat page id as
-// page_coord[i] = page_id % tensor_shape[i], and at rank >= 2 it also feeds shard_grid_strides. It is a
-// common runtime arg (binary_ng requests ArgConfig::RuntimeTensorShape) that override_runtime_arguments
-// never refreshes -- it does not call GetCommonRuntimeArgs -- while rank, num_banks, shard_shape and
-// bank_coords are compile-time and could not be re-applied even in principle. The shard volumes on
-// operation_attributes_t do not cover this: they encode the SHARD's extent, not the tensor's, so they are
-// identical across shapes that share one ShardSpec. Without this entry two such shapes collide on a single
-// cache entry and the second decomposes its page ids with the first's radix, silently returning a wrong
-// tensor. The output is keyed separately, via c_tensor_shape_in_pages (issue #54138).
-//
-// Hashing the tensor shape in pages rather than the padded shape is what keeps this from over-discriminating:
-// BufferDistributionSpec squeezes adjacent dimensions at construction, so shapes that squeeze together
-// produce an identical accessor, genuinely can share a program, and still share a cache entry here.
-//
-// Read off the Buffer rather than recomputed from the TensorSpec, deliberately: Buffer::set_page_size
-// and set_shard_spec reset buffer_distribution_spec_ while the spec keeps it, so the Buffer is the
-// faithful record of what the accessor was actually built from.
+// Key material for a sharded operand: the radix its TensorAccessor decomposes page ids with, baked at
+// build time and never refreshed. Nullopt for interleaved operands, which keeps their shape-blind cache
+// reuse. Squeezed, so shapes that share an accessor still share a cache entry. Read off the Buffer, not
+// the spec: set_page_size/set_shard_spec reset buffer_distribution_spec_ while the spec keeps it.
 std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const Tensor& tensor) {
-    // to_hash() runs before validate_on_program_cache_miss, so neither device storage nor allocation can be
-    // assumed: Tensor::buffer() goes through device_storage(), which TT_FATALs on host storage, and
-    // get_mesh_buffer(), which throws on a deallocated device tensor. Neither returns nullptr, so this
-    // guard -- not a null check on the result -- is what covers those two cases. The sharded test comes
-    // first: it is a plain accessor and skips the rest for the interleaved majority.
+    // to_hash() runs before validate_on_program_cache_miss, so buffer() may throw: device_storage()
+    // TT_FATALs on host storage, get_mesh_buffer() on a deallocated tensor. This guard, not a null check.
     if (!tensor.memory_config().is_sharded() || !tensor.is_allocated() ||
         tensor.storage_type() != StorageType::DEVICE) {
         return std::nullopt;
@@ -298,17 +278,13 @@ std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const Tensor& t
     return distribution_spec->tensor_shape_in_pages();
 }
 
-// Same key material for the OUTPUT, which normally has no Tensor yet when the key is built and so is
-// resolved from its TensorSpec instead. The writer builds a TensorAccessor over the output buffer with
-// the same unrefreshed RuntimeTensorShape common arg the readers use, so a sharded output on the
-// accessor path needs its extent in the key exactly as the inputs do.
+// Same, for an op-created output that has no Tensor yet when the key is built.
 std::optional<tt::tt_metal::Shape> sharded_tensor_shape_in_pages(const tt::tt_metal::TensorSpec& spec) {
     if (!spec.memory_config().is_sharded()) {
         return std::nullopt;
     }
-    // Hold the args by value: compute_buffer_sharding_args() returns a temporary, and
-    // buffer_distribution_spec() hands back a reference INTO it, which lifetime extension does not
-    // cover. Binding that reference directly dangles and silently reads as empty.
+    // By value: buffer_distribution_spec() returns a reference INTO this temporary, and binding it
+    // directly dangles (lifetime extension does not cover it) and silently reads as empty.
     const auto sharding_args = spec.compute_buffer_sharding_args();
     const auto& distribution_spec = sharding_args.buffer_distribution_spec();
     if (!distribution_spec.has_value()) {
@@ -761,12 +737,8 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         operation_attributes.b_shard_volume = shard_volumes->b_shard_volume;
         operation_attributes.c_shard_volume = shard_volumes->c_shard_volume;
     } else {
-        // Accessor regime. A sharded output is reached through the writer's TensorAccessor, whose shape in
-        // pages is baked at build time and never refreshed, so it must enter the key. Nothing else in the
-        // key varies with it: the inputs may be interleaved (their shapes in pages are then absent), and
-        // attributes.memory_config carries the output's shard spec but not its shape. Prefer a supplied
-        // output's Buffer -- the faithful record of what the accessor was built from, and cheaper than
-        // rebuilding a BufferDistributionSpec from the spec.
+        // Accessor regime: the output is reached through the writer's TensorAccessor, so its shape in
+        // pages must enter the key -- attributes.memory_config carries the shard spec but not the shape.
         operation_attributes.c_tensor_shape_in_pages =
             output_tensor.has_value() ? operations::binary_ng::sharded_tensor_shape_in_pages(*output_tensor)
                                       : operations::binary_ng::sharded_tensor_shape_in_pages(output_spec);
@@ -854,29 +826,22 @@ ttnn::operations::binary_ng::BinaryNgDeviceOperation::tensor_return_value_t bina
         std::nullopt};
 
     auto tensor_args = OperationType::tensor_args_t{input_tensor_a, std::nullopt, output_tensor};
-    // Only a sharded operand or output needs the extra key material below, and ttnn.add(t, scalar) is
-    // overwhelmingly interleaved, so skip the output-spec computation entirely on that path rather than
-    // paying it on every dispatch. Mirrors get_shard_specs' own early-out (issue #54138).
-    // output_tensor is tested separately: mem_config_actual only falls back to it when no explicit
-    // memory_config was given, but compute_output_specs returns a supplied output's spec verbatim, so an
-    // interleaved memory_config alongside a sharded output would otherwise skip this block.
+    // Skip the output-spec computation on the interleaved fast path. output_tensor is tested separately:
+    // mem_config_actual only falls back to it absent an explicit memory_config, but compute_output_specs
+    // returns a supplied output's spec verbatim, so interleaved config + sharded output must not skip.
     if (input_tensor_a.memory_config().is_sharded() || mem_config_actual.is_sharded() ||
         (output_tensor.has_value() && output_tensor->memory_config().is_sharded())) {
         const auto output_spec = OperationType::compute_output_specs(operation_attributes, tensor_args);
         const auto shard_volumes =
             ttnn::operations::binary_ng::get_shard_volumes(input_tensor_a.tensor_spec(), std::nullopt, output_spec);
         if (shard_volumes.has_value()) {
-            // Native regime. This overload used to leave the volumes unset while the tensor-tensor
-            // overload patched them in. On this path they are in fact redundant with the input's shape in
-            // pages in tensor_args_t::to_hash() -- evenness and shape in pages move together, since the
-            // shard height is a whole number of tiles -- but they are kept so the two overloads stay
-            // symmetric and a reader need not re-derive that.
+            // Redundant with the input's shape in pages above (evenness and page count move together),
+            // but kept so the two overloads stay symmetric.
             operation_attributes.a_shard_volume = shard_volumes->a_shard_volume;
             operation_attributes.b_shard_volume = shard_volumes->b_shard_volume;
             operation_attributes.c_shard_volume = shard_volumes->c_shard_volume;
         } else {
-            // Accessor regime: the writer reaches a sharded output through a TensorAccessor whose shape in
-            // pages is baked at build time and never refreshed, so it must enter the key.
+            // Accessor regime: see the tensor-tensor overload above.
             operation_attributes.c_tensor_shape_in_pages =
                 output_tensor.has_value() ? operations::binary_ng::sharded_tensor_shape_in_pages(*output_tensor)
                                           : operations::binary_ng::sharded_tensor_shape_in_pages(output_spec);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -61,10 +61,8 @@ struct BinaryNgDeviceOperation {
         std::optional<std::uint32_t> a_shard_volume;
         std::optional<std::uint32_t> b_shard_volume;
         std::optional<std::uint32_t> c_shard_volume;
-        // Tensor shape in pages of a sharded OUTPUT on the accessor path. The inputs' shapes in pages
-        // ride in tensor_args_t::to_hash(), but an op-created output has no Tensor at hash time, so it
-        // is resolved from its TensorSpec at invoke and carried here instead. Set only when the native
-        // path declines and the output is sharded, so interleaved outputs are unaffected.
+        // Sharded output's shape in pages on the accessor path. The inputs' equivalent rides in
+        // tensor_args_t::to_hash(); the output has no Tensor at hash time, so it is carried here.
         std::optional<tt::tt_metal::Shape> c_tensor_shape_in_pages;
 
         DataType get_dtype() const;
@@ -79,12 +77,9 @@ struct BinaryNgDeviceOperation {
             "dtype",
             "compute_kernel_config",
             "sub_core_grids",
-            // worker_grid is the core_ranges of every CB and every kernel descriptor. In the branches
-            // where it varies it is a function of already-hashed memory configs PLUS one thing nothing
-            // else in this key carries: the device's current sub-device layout. Swapping sub-device
-            // managers does not clear the program cache, so a cached program's baked core ranges can go
-            // stale with nothing to notice. With one sub-device every get_worker_grid branch yields the
-            // same set, so this costs no extra cache entries there (issue #54138).
+            // core_ranges of every CB and kernel. Depends on the device's sub-device layout, which
+            // nothing else here carries and which does not clear the cache when swapped. Same set on a
+            // single sub-device, so no extra entries there.
             "worker_grid",
             "subtile_broadcast_type",
             "is_sfpu",
@@ -130,9 +125,8 @@ struct BinaryNgDeviceOperation {
         std::optional<Tensor> input_tensor_b;
         std::optional<Tensor> output_tensor;
 
-        // Hashes the operands' dtypes and memory configs, plus -- for sharded operands -- the
-        // tensor shape in pages the TensorAccessor decomposes page ids with. Deliberately omits logical shape, so
-        // differently-shaped interleaved calls keep sharing one cache entry. Defined in the .cpp.
+        // Operand dtypes and memory configs, plus each sharded operand's shape in pages. Omits logical
+        // shape by design, so differently-shaped interleaved calls share one cache entry.
         ttsl::hash::hash_t to_hash() const;
     };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -61,6 +61,11 @@ struct BinaryNgDeviceOperation {
         std::optional<std::uint32_t> a_shard_volume;
         std::optional<std::uint32_t> b_shard_volume;
         std::optional<std::uint32_t> c_shard_volume;
+        // Tensor shape in pages of a sharded OUTPUT on the accessor path. The inputs' shapes in pages
+        // ride in tensor_args_t::to_hash(), but an op-created output has no Tensor at hash time, so it
+        // is resolved from its TensorSpec at invoke and carried here instead. Set only when the native
+        // path declines and the output is sharded, so interleaved outputs are unaffected.
+        std::optional<tt::tt_metal::Shape> c_tensor_shape_in_pages;
 
         DataType get_dtype() const;
 
@@ -74,6 +79,13 @@ struct BinaryNgDeviceOperation {
             "dtype",
             "compute_kernel_config",
             "sub_core_grids",
+            // worker_grid is the core_ranges of every CB and every kernel descriptor. In the branches
+            // where it varies it is a function of already-hashed memory configs PLUS one thing nothing
+            // else in this key carries: the device's current sub-device layout. Swapping sub-device
+            // managers does not clear the program cache, so a cached program's baked core ranges can go
+            // stale with nothing to notice. With one sub-device every get_worker_grid branch yields the
+            // same set, so this costs no extra cache entries there (issue #54138).
+            "worker_grid",
             "subtile_broadcast_type",
             "is_sfpu",
             "is_quant_op",
@@ -84,7 +96,8 @@ struct BinaryNgDeviceOperation {
             "equal_nan",
             "a_shard_volume",
             "b_shard_volume",
-            "c_shard_volume");
+            "c_shard_volume",
+            "c_tensor_shape_in_pages");
 
         auto attribute_values() const {
             return std::make_tuple(
@@ -96,6 +109,7 @@ struct BinaryNgDeviceOperation {
                 get_dtype(),
                 compute_kernel_config,
                 sub_core_grids,
+                worker_grid,
                 subtile_broadcast_type,
                 is_sfpu,
                 is_quant_op,
@@ -106,7 +120,8 @@ struct BinaryNgDeviceOperation {
                 binary_op_type == BinaryOpType::ISCLOSE ? equal_nan : false,
                 a_shard_volume,
                 b_shard_volume,
-                c_shard_volume);
+                c_shard_volume,
+                c_tensor_shape_in_pages);
         }
     };
 
@@ -115,14 +130,10 @@ struct BinaryNgDeviceOperation {
         std::optional<Tensor> input_tensor_b;
         std::optional<Tensor> output_tensor;
 
-        ttsl::hash::hash_t to_hash() const {
-            return ttsl::hash::hash_objects_with_default_seed(
-                input_tensor_a.dtype(),
-                input_tensor_a.memory_config(),
-                input_tensor_b.has_value() ? std::optional<DataType>{input_tensor_b->dtype()} : std::nullopt,
-                input_tensor_b.has_value() ? std::optional<MemoryConfig>{input_tensor_b->memory_config()}
-                                           : std::nullopt);
-        }
+        // Hashes the operands' dtypes and memory configs, plus -- for sharded operands -- the
+        // tensor shape in pages the TensorAccessor decomposes page ids with. Deliberately omits logical shape, so
+        // differently-shaped interleaved calls keep sharing one cache entry. Defined in the .cpp.
+        ttsl::hash::hash_t to_hash() const;
     };
 
     struct ProgramFactory {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -779,9 +779,18 @@ bool is_native_L1_sharding(
     const bool a_is_l1 = a.memory_config().buffer_type() == BufferType::L1;
     const bool c_is_l1 = c.buffer_type() == BufferType::L1;
 
+    // The native path also aliases the OUTPUT's buffer as a circular buffer while deriving per-core work
+    // from a's shard, so a and c must agree on their shard spec or the output is addressed on cores where
+    // it is not allocated. The identical-shape branch below already rejects a grid mismatch; these two
+    // branches did not, and an even L1 output on a different grid HANGS the device. Declining is safe --
+    // the TensorAccessor path handles the mismatch. When no output memory config is supplied it is
+    // derived from a's, so the common case still takes the native path.
+    const bool c_shard_matches_a = c.shard_spec().has_value() && a.memory_config().shard_spec().has_value() &&
+                                   *c.shard_spec() == *a.memory_config().shard_spec();
+
     // Scalar value path (b is not a tensor)
     if (!b.has_value() && a.memory_config().is_sharded()) {
-        return a_is_l1 && c_is_l1 && !is_uneven(a);
+        return a_is_l1 && c_is_l1 && c_shard_matches_a && !is_uneven(a);
     }
 
     if (!b.has_value()) {
@@ -793,11 +802,12 @@ bool is_native_L1_sharding(
     bool a_is_sharded = a.memory_config().is_sharded();
     bool b_is_sharded = b->memory_config().is_sharded();
     bool a_not_broadcast = (output_shape == a.logical_shape());
-    // Named for what it now gates: `a` is sharded, unbroadcast and even, AND both it and the output are
-    // L1-resident so the subtile-broadcast branch below may alias them as circular buffers. That branch
-    // is its only consumer, and was the second of the two that used to reach the globally-allocated-CB
-    // path without a buffer-type test (issue #54138).
-    bool a_native_cb_eligible = a_is_sharded && a_not_broadcast && !is_uneven(a) && a_is_l1 && c_is_l1;
+    // Named for what it now gates: `a` is sharded, unbroadcast and even, AND it and the output are both
+    // L1-resident and share a shard spec, so the subtile-broadcast branch below may alias them as
+    // circular buffers. That branch is its only consumer, and was the second of the two that used to
+    // reach the globally-allocated-CB path without either check (issue #54138).
+    bool a_native_cb_eligible =
+        a_is_sharded && a_not_broadcast && !is_uneven(a) && a_is_l1 && c_is_l1 && c_shard_matches_a;
 
     // avoid complex case when a and b are both sharded
     if (a_native_cb_eligible && !b_is_sharded) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -775,11 +775,15 @@ bool is_native_L1_sharding(
     const bool a_is_l1 = a.memory_config().buffer_type() == BufferType::L1;
     const bool c_is_l1 = c.buffer_type() == BufferType::L1;
 
+    // Distinct from a mismatch: an ND_SHARDED config carries nd_shard_spec instead of shard_spec, so
+    // there is nothing to compare and we decline rather than compare across representations. Checking
+    // this also keeps is_uneven() -- which dereferences shard_spec() after testing only is_sharded() --
+    // off an ND-sharded operand.
+    const bool shard_specs_comparable = a.memory_config().shard_spec().has_value() && c.shard_spec().has_value();
     // Per-core work comes from a's shard while the output buffer is aliased as a CB, so a and c must
     // agree or the output is addressed on cores where it is not allocated -- which hangs the device. An
     // unsupplied output config is derived from a's, so the common case still matches.
-    const bool c_shard_matches_a = c.shard_spec().has_value() && a.memory_config().shard_spec().has_value() &&
-                                   *c.shard_spec() == *a.memory_config().shard_spec();
+    const bool c_shard_matches_a = shard_specs_comparable && *c.shard_spec() == *a.memory_config().shard_spec();
 
     // Scalar value path (b is not a tensor)
     if (!b.has_value() && a.memory_config().is_sharded()) {
@@ -797,7 +801,7 @@ bool is_native_L1_sharding(
     bool a_not_broadcast = (output_shape == a.logical_shape());
     // Gates the subtile-broadcast branch below, its only consumer.
     bool a_native_cb_eligible =
-        a_is_sharded && a_not_broadcast && !is_uneven(a) && a_is_l1 && c_is_l1 && c_shard_matches_a;
+        a_is_sharded && a_not_broadcast && a_is_l1 && c_is_l1 && c_shard_matches_a && !is_uneven(a);
 
     // avoid complex case when a and b are both sharded
     if (a_native_cb_eligible && !b_is_sharded) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -769,22 +769,15 @@ bool is_native_L1_sharding(
         return false;
     }
 
-    // Native sharding aliases the operands' own buffers as circular buffers, which Metal permits only for
-    // L1: a DRAM-backed buffer that reaches this path dies on "Only L1 buffers can have an associated
-    // circular buffer!", a message naming neither the op nor sharding nor the unsupported combination.
-    // The identical-shape branch below rejects DRAM explicitly, but the scalar and subtile-broadcast
-    // branches did not, so they accepted DRAM-sharded tensors as "native L1" (issue #54138). This
-    // predicate is a router, not a validator -- declining sends the op down the TensorAccessor path,
-    // which already serves DRAM-sharded tensors.
+    // Native sharding aliases operand buffers as circular buffers, which Metal permits only for L1. This
+    // predicate is a router, not a validator: declining sends the op to the TensorAccessor path, which
+    // serves DRAM-sharded tensors.
     const bool a_is_l1 = a.memory_config().buffer_type() == BufferType::L1;
     const bool c_is_l1 = c.buffer_type() == BufferType::L1;
 
-    // The native path also aliases the OUTPUT's buffer as a circular buffer while deriving per-core work
-    // from a's shard, so a and c must agree on their shard spec or the output is addressed on cores where
-    // it is not allocated. The identical-shape branch below already rejects a grid mismatch; these two
-    // branches did not, and an even L1 output on a different grid HANGS the device. Declining is safe --
-    // the TensorAccessor path handles the mismatch. When no output memory config is supplied it is
-    // derived from a's, so the common case still takes the native path.
+    // Per-core work comes from a's shard while the output buffer is aliased as a CB, so a and c must
+    // agree or the output is addressed on cores where it is not allocated -- which hangs the device. An
+    // unsupplied output config is derived from a's, so the common case still matches.
     const bool c_shard_matches_a = c.shard_spec().has_value() && a.memory_config().shard_spec().has_value() &&
                                    *c.shard_spec() == *a.memory_config().shard_spec();
 
@@ -802,10 +795,7 @@ bool is_native_L1_sharding(
     bool a_is_sharded = a.memory_config().is_sharded();
     bool b_is_sharded = b->memory_config().is_sharded();
     bool a_not_broadcast = (output_shape == a.logical_shape());
-    // Named for what it now gates: `a` is sharded, unbroadcast and even, AND it and the output are both
-    // L1-resident and share a shard spec, so the subtile-broadcast branch below may alias them as
-    // circular buffers. That branch is its only consumer, and was the second of the two that used to
-    // reach the globally-allocated-CB path without either check (issue #54138).
+    // Gates the subtile-broadcast branch below, its only consumer.
     bool a_native_cb_eligible =
         a_is_sharded && a_not_broadcast && !is_uneven(a) && a_is_l1 && c_is_l1 && c_shard_matches_a;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -769,9 +769,19 @@ bool is_native_L1_sharding(
         return false;
     }
 
+    // Native sharding aliases the operands' own buffers as circular buffers, which Metal permits only for
+    // L1: a DRAM-backed buffer that reaches this path dies on "Only L1 buffers can have an associated
+    // circular buffer!", a message naming neither the op nor sharding nor the unsupported combination.
+    // The identical-shape branch below rejects DRAM explicitly, but the scalar and subtile-broadcast
+    // branches did not, so they accepted DRAM-sharded tensors as "native L1" (issue #54138). This
+    // predicate is a router, not a validator -- declining sends the op down the TensorAccessor path,
+    // which already serves DRAM-sharded tensors.
+    const bool a_is_l1 = a.memory_config().buffer_type() == BufferType::L1;
+    const bool c_is_l1 = c.buffer_type() == BufferType::L1;
+
     // Scalar value path (b is not a tensor)
     if (!b.has_value() && a.memory_config().is_sharded()) {
-        return !is_uneven(a);
+        return a_is_l1 && c_is_l1 && !is_uneven(a);
     }
 
     if (!b.has_value()) {
@@ -783,10 +793,14 @@ bool is_native_L1_sharding(
     bool a_is_sharded = a.memory_config().is_sharded();
     bool b_is_sharded = b->memory_config().is_sharded();
     bool a_not_broadcast = (output_shape == a.logical_shape());
-    bool a_sharded_ok = a_is_sharded && a_not_broadcast && !is_uneven(a);
+    // Named for what it now gates: `a` is sharded, unbroadcast and even, AND both it and the output are
+    // L1-resident so the subtile-broadcast branch below may alias them as circular buffers. That branch
+    // is its only consumer, and was the second of the two that used to reach the globally-allocated-CB
+    // path without a buffer-type test (issue #54138).
+    bool a_native_cb_eligible = a_is_sharded && a_not_broadcast && !is_uneven(a) && a_is_l1 && c_is_l1;
 
     // avoid complex case when a and b are both sharded
-    if (a_sharded_ok && !b_is_sharded) {
+    if (a_native_cb_eligible && !b_is_sharded) {
         auto subtile_bcast = get_subtile_broadcast_type(
             a.logical_shape()[-2], a.logical_shape()[-1], b->logical_shape()[-2], b->logical_shape()[-1]);
         [[maybe_unused]] bool is_height = a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Relates to #54138. That issue lists seven findings; this fixes **#1, #2, #5, #6 and #7**, plus one further defect raised in review here. **#3 and #4 are deliberately left open** (see Notes), so this does **not** close the issue.

On the TensorAccessor path the binary_ng program-cache key carried no shape state at all, so tensors sharing one `ShardSpec` at different shapes reused each other's baked accessor geometry. The `a_/b_/c_shard_volume` attributes look like they cover this but do not: they encode the **shard's** extent (`shard_spec.numel() / tile_hw`), not the tensor's, so they are identical across such shapes.

Each defect below was reproduced on Wormhole before being fixed.

| finding | symptom, measured |
|---|---|
| #1 inputs | cache hit, PCC 0.179, exactly 8192/16384 elements wrong |
| #1 output | cache hit, 14693/16384 wrong, PCC `nan` |
| #2 | **hangs the device** — busy-wait at 106% CPU, ignores SIGINT, needs `tt-smi -r 0` |
| #6 | `TT_THROW: Only L1 buffers can have an associated circular buffer!` |
| mismatched output shard spec (found in review) | **hangs the device** — killed at a 300 s timeout, card reset |

**Both sides are keyed on `BufferDistributionSpec::tensor_shape_in_pages()`** — the radix the accessor decomposes page ids with (`page_coord[i] = page_id % tensor_shape[i]`). It is a common runtime arg that `override_runtime_arguments` never refreshes, while rank, num_banks, shard_shape and bank_coords are compile-time and could not be re-applied even in principle.

Hashing that rather than the padded shape is deliberate: `BufferDistributionSpec` squeezes adjacent dimensions at construction, so shapes that squeeze together produce a bit-identical accessor, genuinely can share a program, and still share a cache entry.

- **Inputs** — via `tensor_args_t::to_hash()`.
- **Output** — via a new `c_tensor_shape_in_pages` attribute, read from a supplied output's `Buffer` or otherwise resolved from the output `TensorSpec`. The writer builds an accessor over the output buffer with the same unrefreshed common arg. This one is reachable with ordinary interleaved inputs and only `memory_config` sharded.

**A common-runtime-arg refresh would not have sufficed for either.** It repairs `tensor_shape_in_pages` while leaving the compile-time bank table and the regime `#if` wrong — a partial repair that is harder to detect than the original bug, and one that Metal 2.0's `UpdateTensorArgs` would apply silently as a side effect of porting.

Also in scope:

- **#2** — the tensor+scalar overload never populated the shard volumes, so a shape change that flips `is_uneven` reused a program compiled for the other regime. Populated as the tensor-tensor overload does, guarded so fully-interleaved calls skip the work.
- **#6** — `is_native_L1_sharding`'s scalar and subtile-broadcast branches returned with no buffer-type test, accepting DRAM-sharded tensors as "native L1". The predicate is a router, not a validator, so it now declines and the op takes the TensorAccessor path. Both branches tested.
- **Mismatched output shard spec** (raised in review on this PR) — the same two branches also skipped the shard-spec check the identical-shape branch performs. The native path aliases the output's buffer as a circular buffer while deriving per-core work from A's shard, so an even L1 input with an even L1 output on a *different grid* was accepted as native and the output addressed on cores where it is not allocated. That **hangs the device**; it now declines to the accessor path. The common case is unaffected — an unsupplied output memory config is derived from A's, so the specs match and the op still takes the native path.
- **#5** — `worker_grid` was a member of `operation_attributes_t` but absent from `attribute_names`/`attribute_values`, and only those are hashed (`hash_object` and `append_canonical` both iterate `attribute_values()`, never the struct's fields). Added to the key.
- **#7** — deleted a stale `// We don't support sharding for now` comment, and corrected several test docstrings that described `attribute_values()` as `to_hash()`.

### Notes for reviewers

**Not fixed here, deliberately:**

- **Finding #3** is mischaracterized in the issue. It is tiered "Blocking (minor)" on the premise that *"a single call with the odd value works correctly"*. Measured, that premise is false: a preallocated **float32** output for `ttnn.where` returns 2022/2048 elements wrong on a **single call against a cold cache**, with the predicate dropped entirely (output ≈ `t_true`). The bfloat16 case is exact under identical conditions. So this is a plain correctness bug, not a cache-key defect — adding the output dtype to the key would only give each dtype its own separately-wrong program. Covered by a `strict=True` xfail with the measurements in its docstring. Wants its own issue.
- **Finding #4** (tile-blind CB sizing) is real but cache-independent, and needs its own decision: refuse non-32×32 tiles, or make CB sizing tile-aware *and* key on `Tile`. Note there is currently no eltwise coverage for non-standard tiles at all, so the tile-aware option is a domain bring-up rather than a bug fix.

**Known gap in this PR:** the `worker_grid` fix (#5) is **not covered by a test** — demonstrating it needs a multi-sub-device configuration. Only the negative is shown: it adds no cache entries on a single sub-device, where every `get_worker_grid` branch yields the same set.

**Behavior change worth knowing:** sharded operands at varying shapes now get separate cache entries. This is required for correctness and costs one program build per distinct page count. Interleaved shape-blind reuse is unaffected — every test asserting it uses `DRAM_MEMORY_CONFIG`, and the page-extent entry is `nullopt` for interleaved operands. The sharded tests' own docstrings already described a different shape as a MISS.

**Pattern worth noting:** three of the defects here are the same shape — `is_native_L1_sharding` accumulated its guards per-branch, and the scalar and subtile-broadcast branches were each missing a check the identical-shape branch already performed (buffer type, then shard spec). All three configurations hang or throw rather than degrade. It may be worth reconciling that predicate's branches wholesale in a follow-up rather than continuing to patch them individually.

**Where to focus:**

1. `tensor_args_t::to_hash()` moved from an inline header body to the `.cpp`, and now calls `tensor.buffer()`. It runs *before* `validate_on_program_cache_miss`, hence the storage/allocation guard — `Tensor::buffer()` goes through `device_storage()`, which `TT_FATAL`s on host storage.
2. The deliberate two-mechanism split: `Buffer` for inputs (the faithful record of what the accessor was built from, since `set_page_size`/`set_shard_spec` reset `buffer_distribution_spec_` while the spec keeps it), `TensorSpec` for an op-created output that has no `Tensor` yet.
3. The scalar overload's guard tests `output_tensor` separately from `mem_config_actual`. That is not redundant: `mem_config_actual` only falls back to the output's config when no explicit `memory_config` was given, but `compute_output_specs` returns a supplied output's spec verbatim — so an interleaved `memory_config` alongside a sharded output would otherwise skip the block. Regression test included; it fails at PCC 0.053 without the extra clause.

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [x] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran clang-tidy code analysis on the PR branch

**Local verification (Wormhole n150):** `test_add.py`, `test_binary_bcast.py`, `test_binary_ng_typecast.py`, `test_binary_ng_bcast_fp32_dest_acc.py`, `test_binary_ng_program_cache.py` — **5540 passed, 49 skipped, 1 xfailed, 0 failed**. The single xfail is the finding #3 correctness bug above. All three changed C++ files pass `clang-format --dry-run -Werror`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/54138-binary-ng-program-cache-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/54138-binary-ng-program-cache-key)