### PR TITLE
fix(metal2): skip the borrowed-DFB packed-size check for sharded specs

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1224,6 +1224,25 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOversizedFails) {
             ::testing::HasSubstr("is larger than its borrowed TensorParameter")));
 }
 
+TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBShardedLargerThanPackedSizeSucceeds) {
+    // A DFB is a per-node object and a borrowed DFB views ONE shard, so for a sharded
+    // TensorParameter the per-node shard is the quantity that must hold it -- not
+    // compute_packed_buffer_size_bytes(), which is the whole tensor's logical packed size.
+    //
+    // A shard shape padded relative to the logical volume makes the per-node shard legitimately
+    // LARGER than the whole-tensor packed size. Here: logical [1, 1, 16, 128] bfloat16 packs to
+    // 16*128*2 = 4096 B, while the 32-row shard allocates 32*128*2 = 8192 B on its one node. A
+    // 8192 B DFB fits the shard exactly and must be accepted; comparing it against the 4096 B
+    // packed size would reject it. The authoritative per-bank check still runs at attach time
+    // (AttachBorrowedDFBBuffers, against Buffer::aligned_size_per_bank).
+    ProgramSpec spec = MakeBorrowedDFBProgramSpec(
+        "borrowed_tensor", tt::tt_metal::BufferType::L1, /*dfb_entry_size=*/256, /*dfb_num_entries=*/32);
+    spec.tensor_parameters = {
+        MakeShardedTensorParameter("borrowed_tensor", tt::tt_metal::Shape{1, 1, 16, 128}, {32, 128}, /*num_cores=*/1)};
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
+}
+
 TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1551,8 +1551,19 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         // Coarse spec-time sizing check against the TensorSpec's full packed size. No Buffer is
         // available at spec time, so we can't query the per-bank allocation; the precise per-bank
         // check fires at attach time in AttachBorrowedDFBBuffers (program_run_args.cpp), where
-        // a Buffer is in hand. For sharded L1 tensors the two checks differ — a DFB can pass
-        // here against the full-tensor size and still fail per-bank later. By design.
+        // a Buffer is in hand.
+        //
+        // Sharded specs are skipped here, because the two quantities are not comparable: a DFB is a
+        // per-node object and a borrowed DFB views ONE shard, while compute_packed_buffer_size_bytes()
+        // is the whole tensor's logical packed size. A shard shape padded relative to the logical
+        // volume makes the per-node shard legitimately larger than the whole-tensor packed size --
+        // e.g. a height-sharded [1, 1, 16, 128] bf16 tensor with a 32-row shard allocates 8192 B per
+        // node against a 4096 B packed size -- so comparing them rejects specs the per-bank check
+        // accepts. The per-bank check (against Buffer::aligned_size_per_bank) is the authoritative
+        // one and still runs for these; only this early, approximate one is skipped.
+        if (tensor_spec.memory_config().is_sharded()) {
+            continue;
+        }
         const size_t dfb_bytes = static_cast<size_t>(dfb.entry_size) * static_cast<size_t>(dfb.num_entries);
         const size_t tensor_bytes = tensor_spec.compute_packed_buffer_size_bytes();
         TT_FATAL(


### PR DESCRIPTION
### Issue
Closes #54234.

### Summary

`ValidateProgramSpec` compares a borrowed DFB's total bytes against the backing `TensorParameter`'s `compute_packed_buffer_size_bytes()`. Those two quantities are **not comparable when the spec is sharded**: a DFB is a per-node object and a borrowed DFB views **one shard**, while `compute_packed_buffer_size_bytes()` is the whole tensor's *logical* packed size.

A shard shape padded relative to the logical volume makes the per-node shard legitimately larger than the whole-tensor packed size, so the check rejects valid specs:

| quantity | value |
|---|---|
| DFB, per node | `256 B/stick × 32 sticks` = **8192 B** |
| shard allocation per node (`aligned_size_per_bank`) | `32 × 128 × 2` = **8192 B** — fits exactly ✅ |
| `compute_packed_buffer_size_bytes()` (whole tensor, logical) | `16 × 128 × 2` = **4096 B** ← what the check used |

The comment above the check already anticipated the two diverging, but only in the permissive direction — *"a DFB can pass here against the full-tensor size and still fail per-bank later. By design."* This is the opposite case, and it's a **false failure** rather than a missed one.

**The fix is to skip the early check for sharded specs.** The authoritative per-bank check is untouched and still runs at attach time in `AttachBorrowedDFBBuffers` (`program_run_args.cpp:472-474`) against `Buffer::aligned_size_per_bank()` — the quantity that actually bounds a borrowed DFB. The interleaved path, where the packed size *is* the per-bank size, keeps the early check.

I chose skipping over recomputing a per-shard size in the validator deliberately: no `Buffer` exists at spec time, so any per-shard figure would have to re-derive shard geometry and page alignment by hand, and getting *that* slightly wrong reintroduces the same class of false failure one layer down. The precise check already exists and is correct.

### Notes for reviewers

- **Interleaved coverage is unchanged.** `ProgramSpecTestQuasar.BorrowedMemoryDFBOversizedFails` builds an interleaved `TensorParameter`, so it still fires; verified passing.
- **New regression test**: `BorrowedMemoryDFBShardedLargerThanPackedSizeSucceeds` pins the sharded case — an 8192 B DFB on a 32-row shard of a logical `[1, 1, 16, 128]` bf16 tensor (4096 B packed) must build. It fails before this change and passes after.
- **Verified**: all 6 `*BorrowedMemoryDFB*` gtests pass; the wider `*Borrowed*:*ProgramSpec*` filter runs 221 tests → 199 passed, 22 skipped (Quasar/multi-device fixtures), **0 failed**.

### How it was found

The Metal 2.0 port of `data_movement/pad` (#54214) is the first op to borrow a DFB from a tile-padded height-sharded tensor. It surfaced as `ttnn misc ops group [wh_n300_civ2]` → `test_paged_cache_mask.py::test_update_cache[...cache_shape=(32, 1, 32, 128)-1x2_grid]`, which reaches pad through `ttnn.experimental.paged_update_cache` with a shard shape of `nearest_y(nh, TILE_SIZE)` — a shard rounded up to a tile while the logical `nh` is 1. Green on `main`, red on that branch; **#54214 is blocked on this PR**.

The port's DFB sizing is byte-for-byte the legacy `CBDescriptor` it replaced (`cb_src0.total_size = shard_height_unpadded * stick_size_unpadded`), so this is a validator issue, not a porting one.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-borrowed-dfb-sharded-size-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-borrowed-dfb-sharded-size-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-borrowed-dfb-sharded-size-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-borrowed-dfb-sharded-size-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-borrowed-dfb-sharded-size-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-borrowed-dfb-sharded-size-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-borrowed-dfb-sharded-size-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-borrowed-dfb-sharded-size-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-borrowed-dfb-sharded-size-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-borrowed-dfb-sharded-size-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-borrowed-dfb-sharded-size-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-borrowed-dfb-sharded-size-check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-borrowed-dfb-sharded-size-check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-borrowed-dfb-sharded-size-check)
