### PR TITLE
[Cleanup] Deprecating legacy device creation

### DIFF
--- a/tests/tt_metal/tt_fabric/test_infra/routing_test_common.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/routing_test_common.hpp
@@ -51,7 +51,6 @@ inline tt::tt_metal::CoreCoord get_active_ethernet_core(tt::tt_metal::IDevice* d
             tt::LogTest,
             "No active ethernet link found on device {}. Need 1 active ethernet link for this test.",
             device->id());
-        tt::tt_metal::CloseDevice(device);
         throw std::runtime_error("Test cannot run on specified device.");
     }
 

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -21,12 +21,8 @@ namespace tt::tt_metal {
 using namespace tt;
 
 void CloseDevicesInPool() {
-    auto devices = MetalContext::instance().device_manager()->get_all_active_devices();
-    std::map<ChipId, IDevice*> chip_id_to_device;
-    for (const auto& dev : devices) {
-        chip_id_to_device[dev->id()] = dev;
-    }
-    detail::CloseDevices(chip_id_to_device);
+    auto& device_manager = *MetalContext::instance().device_manager();
+    device_manager.close_devices(device_manager.get_all_active_devices());
 }
 
 TEST(DevicePool, DevicePoolOpenClose) {

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -144,7 +144,7 @@ bool mock_fabric_compile_is_disabled() { return !llrt::RunTimeOptions{}.get_eris
 // router count is itself proof the compile ran.
 void expect_mock_fabric_compiles_on_2_chips() {
     const std::vector<ChipId> device_ids{0, 1};
-    auto devices = detail::CreateDevices(device_ids);
+    auto devices = distributed::MeshDevice::create_unit_meshes(device_ids);
     ASSERT_EQ(devices.size(), device_ids.size());
 
     const auto& builder_context =
@@ -153,8 +153,6 @@ void expect_mock_fabric_compiles_on_2_chips() {
         EXPECT_GT(builder_context.get_num_fabric_initialized_routers(device_id), 0u)
             << "no fabric routers were built on mock device " << device_id;
     }
-
-    detail::CloseDevices(devices);
 }
 
 }  // namespace
@@ -314,7 +312,7 @@ TEST_F(MockDeviceProfilerFixture, DeviceProfilerIsNotStartedOnMockDevice) {
         << "getDeviceProfilerState() must be false for a mock context even when profiling is "
            "requested";
 
-    auto devices = detail::CreateDevices({0});
+    auto devices = distributed::MeshDevice::create_unit_meshes({0});
     ASSERT_FALSE(devices.empty());
     const ChipId mock_device_id = devices.begin()->first;
 
@@ -324,8 +322,6 @@ TEST_F(MockDeviceProfilerFixture, DeviceProfilerIsNotStartedOnMockDevice) {
     EXPECT_FALSE(profiler_state_manager->device_profiler_map.contains(mock_device_id))
         << "Device profiler was started on mock device " << mock_device_id
         << " -- the profiler must be skipped for mock/emulated clusters";
-
-    detail::CloseDevices(devices);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
+++ b/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
@@ -69,7 +69,7 @@
 //             binary.save_to_file(this->trace_bin_path_);
 //         }
 
-//         tt::tt_metal::CloseDevice(this->device_);
+//         this->device_->close();
 
 //         // We could gaurd this to not attempt to replay empty binary, and still allow test to pass
 //         // but, would rather catch the case if the feature gets disabled at compile time.
@@ -79,7 +79,7 @@
 //             } else {
 //                 this->create_device(trace_region_size_);
 //                 RunLightMetalBinary(std::move(binary), this->device_);
-//                 tt::tt_metal::CloseDevice(this->device_);
+//                 this->device_->close();
 //             }
 //         }
 //     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/tt_align.hpp>
 #include "tt_metal/impl/host_api/temp_quasar_api.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/program/program_impl.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 
 /*
@@ -1054,7 +1055,8 @@ public:
         if (tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
         }
-        this->device_ = tt_metal::CreateDevice(0);
+        this->mesh_device_ = tt_metal::distributed::MeshDevice::create_unit_mesh(0);
+        this->device_ = this->mesh_device_->get_devices()[0];
         if (tt::tt_metal::detail::sd_cq_kernel_tests_should_skip(this->device_)) {
             GTEST_SKIP() << "Quasar SD cq-kernel tests require dispatch-engine cores in the soc descriptor";
         }
@@ -1074,10 +1076,8 @@ public:
     }
 
     void TearDown() override {
-        if (this->device_) {
-            tt_metal::CloseDevice(this->device_);
-            this->device_ = nullptr;
-        }
+        this->device_ = nullptr;
+        this->mesh_device_.reset();
     }
 
     // Executes pre-built dispatch commands via the spoof_prefetch kernel in SD mode.
@@ -1225,7 +1225,7 @@ public:
         tt_metal::SetRuntimeArgs(program, dispatch_kernel, disp_logical, {0u, 0u, 0u});
 
         device_data.overflow_check(this->device_);
-        tt_metal::detail::LaunchProgram(this->device_, program);
+        tt_metal::LaunchProgram(*this->mesh_device_, std::move(program), /*wait_until_cores_done=*/true);
         const bool pass = device_data.validate(this->device_);
         EXPECT_TRUE(pass) << "SD Dispatcher test failed validation";
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/tt_align.hpp>
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/host_api/temp_quasar_api.hpp"
+#include "tt_metal/impl/program/program_impl.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 #include <impl/dispatch/dispatch_query_manager.hpp>
 #include "tt_metal/impl/dispatch/memcpy.hpp"
@@ -2643,7 +2644,8 @@ public:
         if (tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
         }
-        this->device_ = tt_metal::CreateDevice(0);
+        this->mesh_device_ = tt_metal::distributed::MeshDevice::create_unit_mesh(0);
+        this->device_ = this->mesh_device_->get_devices()[0];
         if (tt::tt_metal::detail::sd_cq_kernel_tests_should_skip(this->device_)) {
             GTEST_SKIP() << "Quasar SD cq-kernel tests require dispatch-engine cores in the soc descriptor";
         }
@@ -2682,10 +2684,8 @@ public:
     }
 
     void TearDown() override {
-        if (this->device_) {
-            tt_metal::CloseDevice(this->device_);
-            this->device_ = nullptr;
-        }
+        this->device_ = nullptr;
+        this->mesh_device_.reset();
     }
 
     // Launches cq_prefetch.cpp (combined IS_H_VARIANT+IS_D_VARIANT) + cq_dispatch.cpp under
@@ -2966,7 +2966,7 @@ public:
         }
 
         device_data.overflow_check(this->device_);
-        tt_metal::detail::LaunchProgram(this->device_, program);
+        tt_metal::LaunchProgram(*this->mesh_device_, std::move(program), /*wait_until_cores_done=*/true);
         // Ensure host CPU sees any PCIe-written completion queue data before validating.
         tt_driver_atomics::mfence();
         // DRAM-backed Quasar CQs need a staging-buffer readback before validation; host-backed queues are

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/program/program_impl.hpp"
@@ -26,7 +27,8 @@ using namespace tt;
 
 void measure_latency(const std::string& kernel_name) {
     const int device_id = 0;
-    tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
+    auto mesh_device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
+    tt_metal::IDevice* device = mesh_device->get_devices()[0];
 
     uint16_t channel =
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
@@ -59,9 +61,7 @@ void measure_latency(const std::string& kernel_name) {
 
     tt::tt_metal::detail::SetDeviceProfilerDir(kernel_name + "_microbenchmark");
     tt::tt_metal::detail::FreshProfilerDeviceLog();
-    program.impl().compile(device);
-    tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
-    tt_metal::CloseDevice(device);
+    tt_metal::LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 }
 
 int main() {

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -141,7 +141,7 @@ struct FabricEriscDatamoverKernelConfig {
 tt::tt_metal::KernelHandle generate_erisc_datamover_kernel(const FabricEriscDatamoverKernelConfig& edm_kernel_config);
 
 /**
- * Call before CreateDevices to enable fabric, which uses the specified number of routing planes.
+ * Call before creating unit meshes to enable fabric with the specified number of routing planes.
  * Currently, setting num_routing_planes dictates how many routing planes the fabric should be active on
  * for that init sequence. The number of routing planes fabric will be initialized on will be the max
  * of all the values specified by different clients. If a client wants to initialize fabric on all the

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_switch_manager.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_switch_manager.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <map>
+#include <vector>
 #include <tt_stl/indestructible.hpp>
 #include <tt-metalium/device_types.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
@@ -69,8 +69,8 @@ private:
     FabricSwitchManager() = default;
     ~FabricSwitchManager() = default;
 
-    // Cache the device map returned by CreateDevices to use directly in CloseDevices
-    std::map<tt::ChipId, tt::tt_metal::IDevice*> switch_devices_;
+    // Devices opened for switch chips; closed explicitly in teardown() for fabric handshake.
+    std::vector<tt::tt_metal::IDevice*> switch_devices_;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -98,6 +98,7 @@ ChipId GetPCIeDeviceID(ChipId device_id);
  * | device_id  | ID of the device to target| ChipId (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
 // clang-format on
+[[deprecated("Use distributed::MeshDevice::create_unit_mesh instead. This API will be removed after 2026-09-27.")]]
 IDevice* CreateDevice(
     ChipId device_id,
     uint8_t num_hw_cqs = 1,
@@ -118,6 +119,7 @@ IDevice* CreateDevice(
  * | device_id  | ID of the device to target| ChipId (int) | 0 to (GetNumAvailableDevices - 1) | Yes      |
  * */
 // clang-format on
+[[deprecated("Use distributed::MeshDevice::create_unit_mesh instead. This API will be removed after 2026-09-27.")]]
 IDevice* CreateDeviceMinimal(
     ChipId device_id, uint8_t num_hw_cqs = 1, const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{});
 
@@ -132,6 +134,7 @@ IDevice* CreateDeviceMinimal(
  * | device   | Pointer to a device object | IDevice* |             | True     |
  */
 // clang-format on
+[[deprecated("Use MeshDevice RAII or MeshDevice::close instead. This API will be removed after 2026-09-27.")]]
 bool CloseDevice(IDevice* device);
 
 // ==================================================

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -33,6 +33,7 @@ namespace detail {
 
 bool DispatchStateCheck(bool isFastDispatch);
 
+[[deprecated("Use distributed::MeshDevice::create_unit_meshes instead. This API will be removed after 2026-09-27.")]]
 std::map<ChipId, IDevice*> CreateDevices(
     // TODO: delete this in favour of DeviceManager
     const std::vector<ChipId>& device_ids,
@@ -54,6 +55,7 @@ std::map<ChipId, IDevice*> CreateDevices(
  *
  * Return value: void
  */
+[[deprecated("Use MeshDevice RAII or MeshDevice::close instead. This API will be removed after 2026-09-27.")]]
 void CloseDevices(const std::map<ChipId, IDevice*>& devices);
 
 /**

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -81,20 +81,6 @@ namespace program_cache::detail {
 struct ProgramCache;
 }  // namespace program_cache::detail
 
-namespace experimental {
-std::map<ChipId, IDevice*> CreateDevices(
-    ContextId context_id,
-    const std::vector<ChipId>& device_ids,
-    uint8_t num_hw_cqs,
-    size_t l1_small_size,
-    size_t trace_region_size,
-    const DispatchCoreConfig& dispatch_core_config,
-    const std::vector<uint32_t>& l1_bank_remap,
-    size_t worker_l1_size,
-    bool init_profiler,
-    bool initialize_fabric_and_dispatch_fw);
-}  // namespace experimental
-
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal::distributed {
@@ -172,8 +158,8 @@ MeshDeviceImpl::ScopedDevices::ScopedDevices(
     ContextId context_id) :
     context_id_(context_id) {
     auto local_devices = extract_locals(all_device_ids);
-    opened_local_devices_ = tt_metal::experimental::CreateDevices(
-        context_id,
+    auto& ctx = MetalContext::instance(context_id);
+    ctx.initialize_device_manager(
         local_devices,
         num_command_queues,
         l1_small_size,
@@ -183,6 +169,12 @@ MeshDeviceImpl::ScopedDevices::ScopedDevices(
         worker_l1_size,
         /* init_profiler */ false,
         /* initialize_fabric_and_dispatch_fw */ false);
+    const bool is_galaxy = ctx.get_cluster().is_galaxy_cluster();
+    for (IDevice* device : ctx.device_manager()->get_all_active_devices()) {
+        if (!is_galaxy || !device->is_mmio_capable()) {
+            opened_local_devices_.emplace(device->id(), device);
+        }
+    }
 
     for (auto device_id : active_device_ids) {
         if (device_id.is_local()) {

--- a/tt_metal/fabric/fabric_switch_manager.cpp
+++ b/tt_metal/fabric/fabric_switch_manager.cpp
@@ -5,12 +5,12 @@
 #include <tt-metalium/experimental/fabric/fabric_switch_manager.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
-#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
 
-#include <map>
 #include <vector>
 
 #include "impl/context/metal_context.hpp"
+#include "impl/device/device_manager.hpp"
 #include "hostdevcommon/common_values.hpp"
 
 namespace tt::tt_fabric {
@@ -36,10 +36,10 @@ void FabricSwitchManager::setup(FabricConfig fabric_config, FabricReliabilityMod
     // The workload calling setup() knows which fabric config it needs, so we use the provided config
     tt::tt_fabric::SetFabricConfig(fabric_config, fabric_reliability_mode);
 
-    // Cache the device map returned by CreateDevices to use directly in CloseDevices
     // TODO: Issue #34040 - If routers are in standby mode, we could skip full reinitialization
-    // and just reactivate them instead of calling CreateDevices.
-    switch_devices_ = tt::tt_metal::detail::CreateDevices(
+    // and just reactivate them instead of calling DeviceManager::initialize.
+    auto& ctx = tt::tt_metal::MetalContext::instance();
+    ctx.initialize_device_manager(
         switch_device_ids,
         1,  // num_command_queues
         DEFAULT_L1_SMALL_SIZE,
@@ -48,9 +48,13 @@ void FabricSwitchManager::setup(FabricConfig fabric_config, FabricReliabilityMod
         {},                      // l1_bank_remap
         DEFAULT_WORKER_L1_SIZE,  // worker_l1_size
         false,                   // init_profiler
-        true,                    // use_max_eth_core_count_on_all_devices
-        // TOD: for future optimization, switch meshes don't need dispatch fw.
-        true);  // initialize_fabric_and_dispatch_fw
+        true);                   // initialize_fabric_and_dispatch_fw
+
+    switch_devices_.clear();
+    switch_devices_.reserve(switch_device_ids.size());
+    for (tt::ChipId device_id : switch_device_ids) {
+        switch_devices_.push_back(ctx.device_manager()->get_active_device(device_id));
+    }
 }
 
 void FabricSwitchManager::teardown() {
@@ -63,8 +67,7 @@ void FabricSwitchManager::teardown() {
     // In the future, we could keep routers in standby mode instead of fully terminating
     // them, allowing faster reactivation without recompilation and re-handshake overhead.
     if (!switch_devices_.empty()) {
-        // Use the cached device map returned by CreateDevices
-        tt::tt_metal::detail::CloseDevices(switch_devices_);
+        tt::tt_metal::MetalContext::instance().device_manager()->close_devices(switch_devices_);
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
 
         switch_devices_.clear();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -261,7 +261,7 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
         log_warning(
             tt::LogMetal,
             "Opening subset of mmio devices slows down UMD read/write to remote chips. If opening more devices, "
-            "consider using CreateDevices API.");
+            "consider using distributed::MeshDevice::create_unit_meshes().");
     }
 
     // Need to reserve eth cores for fabric before we initialize individual devices to maintain consistent state

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -149,7 +149,7 @@ void wait_for_program_vector_to_arrive_and_compare_to_host_program_vector(
 
                 match_device_program_data_with_host_program_data(
                     DISPATCH_MAP_DUMP, device_dispatch_dump_file_name.c_str());
-                CloseDevice(device);
+                device->close();
                 exit(0);
             }
         }

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -149,7 +149,7 @@ void wait_for_program_vector_to_arrive_and_compare_to_host_program_vector(
 
                 match_device_program_data_with_host_program_data(
                     DISPATCH_MAP_DUMP, device_dispatch_dump_file_name.c_str());
-                device->close();
+                MetalContext::instance().device_manager()->close_device(device->id());
                 exit(0);
             }
         }

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1359,7 +1359,7 @@ bool CloseDevice(IDevice* device) {
     // MeshDevice RAII should be used instead to ensure proper teardown.
     TT_FATAL(
         MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id,
-        "CloseDevice(device_id={}) may only be used for opening single MMIO capable devices. For multi chip clusters, "
+        "CloseDevice(device_id={}) may only be used for closing single MMIO capable devices. For multi chip clusters, "
         "use MeshDevice RAII or MeshDevice::close().",
         device_id);
 

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -412,43 +412,6 @@ std::map<ChipId, IDevice*> CreateDevices(
 
 namespace experimental {
 
-std::map<ChipId, IDevice*> CreateDevices(
-    ContextId context_id,
-    const std::vector<ChipId>& device_ids,
-    uint8_t num_hw_cqs,
-    size_t l1_small_size,
-    size_t trace_region_size,
-    const DispatchCoreConfig& dispatch_core_config,
-    const std::vector<uint32_t>& /*l1_bank_remap*/,
-    size_t worker_l1_size,
-    bool init_profiler,
-    bool initialize_fabric_and_dispatch_fw) {
-    ZoneScoped;
-    auto& ctx = MetalContext::instance(context_id);
-    bool is_galaxy = ctx.get_cluster().is_galaxy_cluster();
-    ctx.initialize_device_manager(
-        device_ids,
-        num_hw_cqs,
-        l1_small_size,
-        trace_region_size,
-        dispatch_core_config,
-        {},
-        worker_l1_size,
-        init_profiler,
-        initialize_fabric_and_dispatch_fw);
-
-    const auto devices = ctx.device_manager()->get_all_active_devices();
-    std::map<ChipId, IDevice*> ret_devices;
-    for (IDevice* dev : devices) {
-        if (is_galaxy and dev->is_mmio_capable()) {
-            continue;
-        }
-        ret_devices.insert({dev->id(), dev});
-    }
-
-    return ret_devices;
-}
-
 void DispatchCompiledProgramToDevice(IDevice* device, Program& program) {
     ZoneScoped;
 
@@ -1352,23 +1315,21 @@ IDevice* CreateDevice(
     const size_t worker_l1_size) {
     ZoneScoped;
 
-    // MMIO devices do not support dispatch on galaxy cluster
-    // Suggest the user to use the CreateDevices API
+    // MMIO devices do not support dispatch on galaxy clusters.
     if (MetalContext::instance().rtoptions().get_fast_dispatch()) {
         TT_FATAL(
             !(MetalContext::instance().get_cluster().is_galaxy_cluster() &&
               MetalContext::instance().get_cluster().get_cluster_desc()->is_chip_mmio_capable(device_id)),
-            "Galaxy cluster does not support dispatch on mmio devices. Please use CreateDevices API to open all "
-            "devices for dispatch.");
+            "Galaxy clusters do not support dispatch on MMIO devices. Use "
+            "distributed::MeshDevice::create_unit_meshes to open all devices for dispatch.");
     }
 
     // This API may not be used to create single remote device or multi chip clusters
-    // CreateDevices should be used instead to ensure proper init/teardown
+    // MeshDevice should be used instead to ensure proper initialization and teardown.
     TT_FATAL(
         MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id,
         "CreateDevice(device_id={}) may only be used for opening single MMIO capable devices. For multi chip clusters, "
-        "must use "
-        "CreateDevices().",
+        "use distributed::MeshDevice::create_unit_meshes().",
         device_id);
 
     MetalContext::instance().initialize_device_manager(
@@ -1394,13 +1355,12 @@ bool CloseDevice(IDevice* device) {
     ZoneScoped;
     auto device_id = device->id();
 
-    // This API may not be used to close single remote device or multi chip clusters
-    // CloseDevices should be used instead to ensure proper init/teardown
+    // This API may not be used to close a single remote device or multi-chip cluster.
+    // MeshDevice RAII should be used instead to ensure proper teardown.
     TT_FATAL(
         MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id,
         "CloseDevice(device_id={}) may only be used for opening single MMIO capable devices. For multi chip clusters, "
-        "must use "
-        "CloseDevices().",
+        "use MeshDevice RAII or MeshDevice::close().",
         device_id);
 
     return MetalContext::instance().device_manager()->close_device(device_id);

--- a/tt_metal/impl/internal/disaggregation/umd_dram_reader.cpp
+++ b/tt_metal/impl/internal/disaggregation/umd_dram_reader.cpp
@@ -5,7 +5,7 @@
 // ---------------------------------------------------------------------------
 // Reads a KV chunk's DRAM bytes over a bare tt::umd::Cluster and reads through on-demand TLB windows.
 // This lets a process that has NOT opened the mesh (an external scheduler / the prefill_producer)
-// read a live server's KV cache CONCURRENTLY with the runner that owns the chips via MeshDevice.
+// read a live server's KV cache CONCURRENTLY with the runner that owns the chips via CreateDevice.
 // It is a direct port of the migration worker's device_io.cpp read path
 // (tt-llm-engine disaggregation/migration/src/worker/device_io.cpp). The chip is selected by
 // ASIC unique_id (the caller resolves fabric_node -> unique_id from the runner's device-map

--- a/tt_metal/impl/internal/disaggregation/umd_dram_reader.cpp
+++ b/tt_metal/impl/internal/disaggregation/umd_dram_reader.cpp
@@ -5,7 +5,7 @@
 // ---------------------------------------------------------------------------
 // Reads a KV chunk's DRAM bytes over a bare tt::umd::Cluster and reads through on-demand TLB windows.
 // This lets a process that has NOT opened the mesh (an external scheduler / the prefill_producer)
-// read a live server's KV cache CONCURRENTLY with the runner that owns the chips via CreateDevice.
+// read a live server's KV cache CONCURRENTLY with the runner that owns the chips via MeshDevice.
 // It is a direct port of the migration worker's device_io.cpp read path
 // (tt-llm-engine disaggregation/migration/src/worker/device_io.cpp). The chip is selected by
 // ASIC unique_id (the caller resolves fabric_node -> unique_id from the runner's device-map

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -240,18 +240,21 @@ void LightMetalReplayImpl::remove_cb_handle_from_map(uint32_t global_id) { cb_ha
 // TODO (kmabee) - Hardcode for now, eventually capture/replay "systemdesc" from binary.
 // Alternatively, user can manage device open/close and pass to replay library.
 void LightMetalReplayImpl::setup_devices() {
-    log_debug(tt::LogMetalTrace, "LightMetalReplay(setup_devices) - Using hardcoded CreateDevices() as temp hack.");
+    log_debug(tt::LogMetalTrace, "LightMetalReplay(setup_devices) - Using a hardcoded unit mesh as a temporary hack.");
     TT_FATAL(!device_, "Device already setup in LightMetalReplay, no need to call setup_devices()");
     const size_t trace_region_size = 4096;  // Default is 0
     const auto dispatch_core_type = tt_metal::DispatchCoreType::WORKER;
     const ChipId mmio_device_id = 0;
-    auto devices_map = tt::tt_metal::detail::CreateDevices(
-        {mmio_device_id}, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_type);
-    this->device_ = devices_map.at(mmio_device_id);
+    mesh_device_owner_ = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(
+        mmio_device_id, DEFAULT_L1_SMALL_SIZE, trace_region_size, 1, dispatch_core_type);
+    device_ = mesh_device_owner_.get();
 }
 
 // TODO (kmabee) - Hardcode for now, eventually capture/replay "systemdesc" from binary or let user call.
-void LightMetalReplayImpl::close_devices() { CloseDevice(this->device_); }
+void LightMetalReplayImpl::close_devices() {
+    mesh_device_owner_.reset();
+    device_ = nullptr;
+}
 
 // Clear object maps for items not deallocated/destroyed naturally during replay.
 // Later can update these to be asserts once all paths covered properly.

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -12,6 +12,7 @@
 
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/circular_buffer.hpp>
 
 #include "impl/kernels/kernel.hpp"
@@ -132,6 +133,7 @@ private:
     bool show_reads_ = false;
     bool disable_checking_ = false;
 
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_owner_;
     tt::tt_metal::IDevice* device_ = nullptr;
 
     // Object maps for storing objects by global_id

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -304,12 +304,11 @@ public:
 
     // Internal routing for SD and FD enables launching user ethernet kernels and FD tunneling for all devices in the
     // cluster. When using multiple devices in a cluster, this should be the flow:
-    //       CreateDevice(0)
-    //       CreateDevice(1)
+    //       MeshDevice::create_unit_mesh(0)
+    //       MeshDevice::create_unit_mesh(1)
     //       set_internal_routing_info_for_ethernet_cores(true);
     //       set_internal_routing_info_for_ethernet_cores(false);
-    //       CloseDevice(0)
-    //       CloseDevice(1)
+    //       close unit meshes (RAII or MeshDevice::close)
     void set_internal_routing_info_for_ethernet_cores(
         const tt::tt_fabric::ControlPlane& control_plane,
         bool enable_internal_routing,

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -304,11 +304,10 @@ public:
 
     // Internal routing for SD and FD enables launching user ethernet kernels and FD tunneling for all devices in the
     // cluster. When using multiple devices in a cluster, this should be the flow:
-    //       MeshDevice::create_unit_mesh(0)
-    //       MeshDevice::create_unit_mesh(1)
+    //       auto unit_meshes = MeshDevice::create_unit_meshes({0, 1});
     //       set_internal_routing_info_for_ethernet_cores(true);
     //       set_internal_routing_info_for_ethernet_cores(false);
-    //       close unit meshes (RAII or MeshDevice::close)
+    //       unit_meshes.clear();  // or let RAII close them / MeshDevice::close
     void set_internal_routing_info_for_ethernet_cores(
         const tt::tt_fabric::ControlPlane& control_plane,
         bool enable_internal_routing,

--- a/tt_metal/tools/mem_bench/context.hpp
+++ b/tt_metal/tools/mem_bench/context.hpp
@@ -6,9 +6,10 @@
 
 #include <string>
 #include <map>
+#include <memory>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/device.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/tt_align.hpp>
 
 namespace tt::tt_metal::tools::mem_bench {
@@ -40,7 +41,7 @@ struct L1MemoryMap {
 };
 
 struct Context {
-    std::map<ChipId, IDevice*> devices;
+    std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> devices;
     L1MemoryMap device_address{};
     uint32_t total_size{0};
     uint32_t page_size{0};
@@ -51,7 +52,7 @@ struct Context {
     int iterations{0};
 
     Context(
-        const std::map<ChipId, IDevice*>& devices_,
+        const std::map<ChipId, std::shared_ptr<distributed::MeshDevice>>& devices_,
         uint32_t total_size_,
         uint32_t page_size_,
         int threads_,

--- a/tt_metal/tools/mem_bench/device_utils.cpp
+++ b/tt_metal/tools/mem_bench/device_utils.cpp
@@ -11,7 +11,6 @@
 
 #include "context.hpp"
 #include "core_coord.hpp"
-#include "device.hpp"
 #include "device_utils.hpp"
 #include "kernel_types.hpp"
 
@@ -21,7 +20,7 @@ class Program;
 
 namespace tt::tt_metal::tools::mem_bench {
 
-std::vector<uint32_t> read_cores(tt::tt_metal::IDevice* device, const CoreRange& cores, uint32_t addr) {
+std::vector<uint32_t> read_cores(distributed::MeshDevice* device, const CoreRange& cores, uint32_t addr) {
     std::vector<uint32_t> data;
     data.reserve(cores.size());
     for (size_t xi = cores.start_coord.x; xi <= cores.end_coord.x; ++xi) {
@@ -35,7 +34,7 @@ std::vector<uint32_t> read_cores(tt::tt_metal::IDevice* device, const CoreRange&
 }
 
 std::optional<CoreRange> configure_kernels(
-    tt::tt_metal::IDevice* device,
+    distributed::MeshDevice* device,
     tt::tt_metal::Program& program,
     const Context& context,
     uint32_t start_y,

--- a/tt_metal/tools/mem_bench/device_utils.hpp
+++ b/tt_metal/tools/mem_bench/device_utils.hpp
@@ -6,14 +6,13 @@
 
 #include <stdint.h>
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <optional>
 #include <vector>
 
 #include "context.hpp"
 
 namespace tt::tt_metal {
-class IDevice;
 class Program;
 
 namespace tools::mem_bench {
@@ -24,10 +23,10 @@ struct Context;
 
 namespace tt::tt_metal::tools::mem_bench {
 
-std::vector<uint32_t> read_cores(tt::tt_metal::IDevice* device, const CoreRange& cores, uint32_t addr);
+std::vector<uint32_t> read_cores(distributed::MeshDevice* device, const CoreRange& cores, uint32_t addr);
 
 std::optional<CoreRange> configure_kernels(
-    tt::tt_metal::IDevice* device,
+    distributed::MeshDevice* device,
     tt::tt_metal::Program& program,
     const Context& context,
     uint32_t start_y,

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -7,9 +7,9 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "impl/context/metal_context.hpp"
 #include <iostream>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <optional>
 #include <span>
@@ -17,15 +17,16 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
+#include <tt-metalium/mesh_command_queue.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include "context.hpp"
-#include "device.hpp"
 #include "device_utils.hpp"
 #include "host_utils.hpp"
+#include "impl/program/program_impl.hpp"
 #include "tt-metalium/program.hpp"
 #include "tt_metal/impl/dispatch/util/size_literals.hpp"
 #include "tt_metal/impl/dispatch/vector_aligned.hpp"
 #include "work_thread.hpp"
-#include <llrt/tt_cluster.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -35,11 +36,12 @@ using namespace tt::tt_metal::tools::mem_bench;
 std::optional<int> g_user_device_id;
 
 // Read L1 counters (cycles, bytes rd, bytes wr) and increment test_results
-void read_inc_data_from_cores(const Context& ctx, IDevice* device, const CoreRange& cores, TestResult& test_results) {
+void read_inc_data_from_cores(
+    const Context& ctx, distributed::MeshDevice* device, const CoreRange& cores, TestResult& test_results) {
     auto dev_cycles = read_cores(device, cores, ctx.device_address.cycles);
     auto dev_bytes_read = read_cores(device, cores, ctx.device_address.rd_bytes);
     auto dev_bytes_written = read_cores(device, cores, ctx.device_address.wr_bytes);
-    auto dev_clk = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id()) * 1e6;  // Hz
+    auto dev_clk = device->get_clock_rate_mhz() * 1e6;  // Hz
 
     double total_cycles = std::reduce(dev_cycles.begin(), dev_cycles.end(), 0ULL);
 
@@ -162,9 +164,9 @@ TestResult mem_bench_copy_multithread(benchmark::State& state) {
 TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
     TestResult results;
     auto device_ids = get_device_ids_for_single_device(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto devices = distributed::MeshDevice::create_unit_meshes(device_ids);
     const uint32_t device_id = device_ids.empty() ? 0 : device_ids[0];
-    IDevice* device = devices[device_id];
+    distributed::MeshDevice* device = devices[device_id].get();
     Context ctx{
         devices,
         static_cast<uint32_t>(state.range(0)),  // Total size
@@ -199,7 +201,7 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
             1,
             [device, &pgm](int /*thread_idx*/) {
                 // Program
-                tt::tt_metal::detail::LaunchProgram(device, pgm, true);
+                LaunchProgram(*device, std::move(pgm), true);
             },
             [&]() {
                 if (ctx.enable_host_copy_with_kernels) {
@@ -224,7 +226,6 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
     }
 
     report_device_bw(state, results);
-    tt::tt_metal::detail::CloseDevices(devices);
     return results;
 }
 
@@ -233,9 +234,9 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
 TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) {
     TestResult results;
     auto device_ids = get_device_ids_for_single_device(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto devices = distributed::MeshDevice::create_unit_meshes(device_ids);
     const uint32_t device_id = device_ids.empty() ? 0 : device_ids[0];
-    IDevice* device = devices[device_id];
+    distributed::MeshDevice* device = devices[device_id].get();
     Context ctx{
         devices,
         static_cast<uint32_t>(state.range(0)),  // Total size
@@ -264,7 +265,7 @@ TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) 
             1,
             [device, &pgm](int /*thread_idx*/) {
                 // Program
-                tt::tt_metal::detail::LaunchProgram(device, pgm, true);
+                LaunchProgram(*device, std::move(pgm), true);
             },
             [&]() {
                 // Host copy while waiting for program
@@ -284,13 +285,12 @@ TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) 
     state.SetBytesProcessed(ctx.total_size * state.iterations());
 
     report_device_bw(state, results);
-    tt::tt_metal::detail::CloseDevices(devices);
     return results;
 }
 
 // Common Multi MMIO device test.
 TestResult mem_bench_multi_mmio_devices(
-    benchmark::State& state, std::map<ChipId, IDevice*>& devices, const Context& ctx) {
+    benchmark::State& state, std::map<ChipId, std::shared_ptr<distributed::MeshDevice>>& devices, const Context& ctx) {
     TestResult results;
 
     // One thread to wait for program on each device
@@ -298,13 +298,13 @@ TestResult mem_bench_multi_mmio_devices(
     for ([[maybe_unused]] auto _ : state) {
         std::map<int, Program> programs;                  // device : programs
         std::map<int, CoreRange> configured_core_ranges;  // device : cores
-        for (auto [device_id, device] : devices) {
+        for (const auto& [device_id, device] : devices) {
             programs[device_id] = CreateProgram();
             Program& pgm = programs[device_id];
             auto device_hugepage_size = get_hugepage_size(device_id);
             configured_core_ranges.insert(
                 {device_id,
-                 configure_kernels(device, pgm, ctx, 0, ctx.number_reader_kernels, false, device_hugepage_size)
+                 configure_kernels(device.get(), pgm, ctx, 0, ctx.number_reader_kernels, false, device_hugepage_size)
                      .value()});
         }
 
@@ -313,19 +313,19 @@ TestResult mem_bench_multi_mmio_devices(
             [devices, &programs](int /*thread_idx*/) {
                 // Program
                 for (auto& [device_id, pgm] : programs) {
-                    tt::tt_metal::detail::LaunchProgram(devices.at(device_id), pgm, false);
+                    LaunchProgram(*devices.at(device_id), std::move(pgm), false);
                 }
             },
             []() {});
 
         // Wait all programs to complete
-        for (auto& [device_id, pgm] : programs) {
-            tt::tt_metal::detail::WaitProgramDone(devices.at(device_id), pgm);
+        for (const auto& device_entry : devices) {
+            device_entry.second->mesh_command_queue().finish();
         }
 
         // Read counters from each core
         for (auto& [device_id, core_range] : configured_core_ranges) {
-            read_inc_data_from_cores(ctx, devices.at(device_id), core_range, results);
+            read_inc_data_from_cores(ctx, devices.at(device_id).get(), core_range, results);
         }
 
         // This test does not report host bw
@@ -343,7 +343,7 @@ TestResult mem_bench_multi_mmio_devices(
 TestResult mem_bench_multi_mmio_devices_reading_same_node(benchmark::State& state) {
     // Node 0
     auto device_ids = get_device_ids_for_multi_device_same_node(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto devices = distributed::MeshDevice::create_unit_meshes(device_ids);
 
     Context ctx{
         devices,
@@ -356,16 +356,13 @@ TestResult mem_bench_multi_mmio_devices_reading_same_node(benchmark::State& stat
         0,                                      // Iterations is managed by the benchmark framework
     };
 
-    TestResult results = mem_bench_multi_mmio_devices(state, devices, ctx);
-    tt::tt_metal::detail::CloseDevices(devices);
-
-    return results;
+    return mem_bench_multi_mmio_devices(state, devices, ctx);
 }
 
 // Multi MMIO devices reading on different NUMA nodes.
 TestResult mem_bench_multi_mmio_devices_reading_different_node(benchmark::State& state) {
     auto device_ids = get_device_ids_for_multi_device_different_nodes(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto devices = distributed::MeshDevice::create_unit_meshes(device_ids);
 
     Context ctx{
         devices,
@@ -378,10 +375,7 @@ TestResult mem_bench_multi_mmio_devices_reading_different_node(benchmark::State&
         0,                                      // Iterations is managed by the benchmark framework
     };
 
-    TestResult results = mem_bench_multi_mmio_devices(state, devices, ctx);
-    tt::tt_metal::detail::CloseDevices(devices);
-
-    return results;
+    return mem_bench_multi_mmio_devices(state, devices, ctx);
 }
 
 // Benchmark memcpy_to_device while device is reading (prefetching) and writing (dispatching data back to host)
@@ -389,9 +383,9 @@ TestResult mem_bench_multi_mmio_devices_reading_different_node(benchmark::State&
 // Second half will be written to by device
 TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
     auto device_ids = get_device_ids_for_single_device(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto devices = distributed::MeshDevice::create_unit_meshes(device_ids);
     const uint32_t device_id = device_ids.empty() ? 0 : device_ids[0];
-    IDevice* device = devices[device_id];
+    distributed::MeshDevice* device = devices[device_id].get();
     Context ctx{
         devices,
         static_cast<uint32_t>(state.range(0)),  // Total size
@@ -428,7 +422,7 @@ TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
             1,
             [device, &pgm](int /*thread_idx*/) {
                 // Program
-                tt::tt_metal::detail::LaunchProgram(device, pgm, true);
+                LaunchProgram(*device, std::move(pgm), true);
             },
             [&]() {
                 // Host copy while waiting for program
@@ -448,7 +442,6 @@ TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
 
     state.SetBytesProcessed(ctx.total_size * state.iterations());
     report_device_bw(state, results);
-    tt::tt_metal::detail::CloseDevices(devices);
     return results;
 }
 

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -56,7 +56,7 @@ void dump_data(
         std::ofstream cq_file = std::ofstream(cq_fname);
         string iq_fname = cq_dir.string() + fmt::format("device_{}_issue_q.txt", id);
         std::ofstream iq_file = std::ofstream(iq_fname);
-        // Minimal setup, since we'll be attaching to a potentially hanging chip.
+        // Attach with minimal setup; the chip may be hung so MeshDevice::create_unit_mesh is not appropriate.
         IDevice* device = tt::tt_metal::CreateDeviceMinimal(
             id, num_hw_cqs, DispatchCoreConfig{eth_dispatch ? DispatchCoreType::ETH : DispatchCoreType::WORKER});
         devices.push_back(std::unique_ptr<IDevice>(device));


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

The following legacy single-device create/close API is deprecated in favor of `MeshDevice::create_unit_mesh(es)`:
* tt_metal::detail::CreateDevices
* tt_metal::detail::CloseDevices
* tt_metal::CreateDevice
* tt_metal::CreateDeviceMinimal
* tt_metal::CloseDevice

Internally, `DeviceManager` is used directly where `MeshDevice` API is insufficient.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-create-device-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-create-device-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-create-device-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-create-device-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-create-device-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-create-device-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-create-device-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-create-device-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-create-device-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-create-device-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-create-device-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-create-device-deprecation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-create-device-deprecation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-create-device-deprecation)