### PR TITLE
grpo_remote_rollout: enable prefill warmup in TttGenerationWorker

### DIFF
--- a/tt-train/sources/examples/grpo_remote_rollout/utils/ttt_generation_worker.py
+++ b/tt-train/sources/examples/grpo_remote_rollout/utils/ttt_generation_worker.py
@@ -175,7 +175,7 @@ class TttGenerationWorker:
             kv_cache=self.tt_kv_cache,
             prompt_lens=prompt_lens,
             sampling_params=self._sampling_params,
-            warmup_prefill=False,
+            warmup_prefill=True,
             enable_trace=enable_trace,
         )
         prefilled_token = (prefill_out[0] if isinstance(prefill_out, tuple) else prefill_out).reshape(-1)

--- a/tt-train/tests/python/grpo_remote_rollout/test_ttt_worker_trace_capture.py
+++ b/tt-train/tests/python/grpo_remote_rollout/test_ttt_worker_trace_capture.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for TttGenerationWorker trace-capture warmup.
+
+TttGenerationWorker.generate() must set ``warmup_prefill=True`` when it
+calls ``Generator.prefill_forward_text``. If it does not, the first
+``generate(..., enable_trace=True)`` call might raise this TT_FATAL from
+``tt_metal/distributed/mesh_workload.cpp``:
+
+    Cannot load new binaries during trace capture. This program is not
+    yet in program cache. Warm up before capturing a trace.
+
+The fatal comes from the on-device sampling kernels. They are not in
+the program cache when the decode trace capture opens. ``warmup_prefill=
+True`` runs ``warmup_model_prefill`` before the capture, which puts the
+kernels in the cache.
+
+This test does one traced ``generate()`` call and shows that it does
+not raise. Uses dummy weights, so no HF token or weight download is
+needed.
+
+Run (needs >= 2 chips):
+    cd tt-train/tests/python/grpo_remote_rollout
+    python3 -m pytest -s test_ttt_worker_trace_capture.py
+"""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+
+MESH_SHAPE = (1, 2)
+# One short prompt is enough. The fatal comes from the decode trace
+# capture at prefill time, not from the decode loop itself.
+PROMPT_LEN = 8
+MAX_NEW_TOKENS = 2
+
+
+@pytest.mark.timeout(0)
+def test_traced_generate_does_not_fatal_on_first_call():
+    import ttnn
+
+    from _completer_utils import _TRACE_REGION_SIZE, build_completer
+
+    if len(ttnn.get_device_ids()) < MESH_SHAPE[0] * MESH_SHAPE[1]:
+        pytest.skip(f"needs >= {MESH_SHAPE[0] * MESH_SHAPE[1]} chips")
+
+    mesh_device = ttnn.open_mesh_device(
+        mesh_shape=ttnn.MeshShape(*MESH_SHAPE),
+        trace_region_size=_TRACE_REGION_SIZE,
+    )
+    completer = None
+    try:
+        completer = build_completer(mesh_device, dummy_weights=True, max_batch_size=1)
+
+        prompt = list(range(1, PROMPT_LEN + 1))
+
+        try:
+            completions = completer.generate(
+                [prompt],
+                max_new_tokens=MAX_NEW_TOKENS,
+                enable_trace=True,
+            )
+        except RuntimeError as e:
+            msg = str(e)
+            if "Cannot load new binaries during trace capture" in msg:
+                pytest.fail(
+                    "First traced generate() tripped the trace-capture "
+                    "fatal. TttGenerationWorker.generate() must pass "
+                    "warmup_prefill=True to Generator.prefill_forward_text "
+                    f"so sampling kernels are cached before capture.\n\n{msg}"
+                )
+            raise
+
+        assert len(completions) == 1, f"expected 1 completion, got {len(completions)}"
+    finally:
+        completer = None
+        gc.collect()
+        ttnn.close_mesh_device(mesh_device)

--- a/tt-train/tests/python/grpo_remote_rollout/test_ttt_worker_trace_capture.py
+++ b/tt-train/tests/python/grpo_remote_rollout/test_ttt_worker_trace_capture.py
@@ -66,12 +66,7 @@ def test_traced_generate_does_not_fatal_on_first_call():
         except RuntimeError as e:
             msg = str(e)
             if "Cannot load new binaries during trace capture" in msg:
-                pytest.fail(
-                    "First traced generate() tripped the trace-capture "
-                    "fatal. TttGenerationWorker.generate() must pass "
-                    "warmup_prefill=True to Generator.prefill_forward_text "
-                    f"so sampling kernels are cached before capture.\n\n{msg}"
-                )
+                pytest.fail("First traced generate() tripped the trace-capture " "fatal.")
             raise
 
         assert len(completions) == 1, f"expected 1 completion, got {len(completions)}"


### PR DESCRIPTION
### Summary

* Set `warmup_prefill=True` in `TttGenerationWorker.generate()`. The value was `False`.

### Error before this change

Without prefill warmup, the first `generate()` call might fail when the generator captures the decode trace:

```
Traceback (most recent call last):
  File "/localdev/ichovpan/tt-metal/repro_trace_capture_fatal.py", line 140, in main
    _traced_call(worker, PROMPT_LEN_BUCKET_128, label="call-1 bucket=128")
  File "/localdev/ichovpan/tt-metal/repro_trace_capture_fatal.py", line 93, in _traced_call
    completions = worker.generate([prompt], max_new_tokens=MAX_NEW_TOKENS, enable_trace=True)
  File "/localdev/ichovpan/tt-metal/tt-train/sources/examples/grpo_remote_rollout/utils/ttt_generation_worker.py", line 172, in generate
    prefill_out = self.generator.prefill_forward_text(
  File "/localdev/ichovpan/tt-metal/models/tt_transformers/tt/generator.py", line 841, in prefill_forward_text
    self.finalize_deferred_traces()
  File "/localdev/ichovpan/tt-metal/models/tt_transformers/tt/generator.py", line 264, in finalize_deferred_traces
    self._record_pending_traces()
  File "/localdev/ichovpan/tt-metal/models/tt_transformers/tt/generator.py", line 499, in _record_pending_traces
    trace_ids, tt_out_trace, *device_inputs = self._record_decode_trace_text(prepared)
  File "/localdev/ichovpan/tt-metal/models/tt_transformers/tt/generator.py", line 1908, in _record_decode_trace_text
    sampling_module.capture_trace(logits=tt_out_trace[i], tt_out_tok=tt_out_tok, skip_precompile=True)
  File "/localdev/ichovpan/tt-metal/models/common/sampling/generator.py", line 395, in capture_trace
    sampled = self._run_sampling(
  File "/localdev/ichovpan/tt-metal/models/common/sampling/generator.py", line 321, in _run_sampling
    tt_tokens, tt_log_probs = self.tt_sampling(logits, tt_out_tok=tt_out_tok)
  File "/localdev/ichovpan/tt-metal/models/common/lightweightmodule.py", line 12, in __call__
    return self.forward(*args, **kwargs)
  File "/localdev/ichovpan/tt-metal/models/common/sampling/tt_sampling.py", line 840, in forward
    x_bf16 = ttnn.typecast(x, dtype=ttnn.bfloat16, sub_core_grids=self.sub_core_grids)
  File "/localdev/ichovpan/tt-metal/ttnn/ttnn/decorators.py", line 728, in __call__
    result = self.function(*function_args, **function_kwargs)
RuntimeError: TT_FATAL @ /localdev/ichovpan/tt-metal/tt_metal/distributed/mesh_workload.cpp:160: !is_capturing_trace
info:
Cannot load new binaries during trace capture. This program is not yet in program cache. Warm up before capturing a trace. See the operation's hash signature for arguments that must match.
```

### Why this fix works

* `warmup_prefill=True` tells `Generator.prefill_forward_text` to call `warmup_model_prefill` first.
* The warmup adds the sampling kernels to the program cache before trace capture. This prevents the `Cannot load new binaries during trace capture` fatal error.
* The `Generator.already_warmed_up_prefill` flag stops more warmups. Later `generate()` calls do not repeat the work.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ichovpan/ttt-generation-worker-prefill-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ichovpan/ttt-generation-worker-prefill-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ichovpan/ttt-generation-worker-prefill-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ichovpan/ttt-generation-worker-prefill-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/ttt-generation-worker-prefill-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/ttt-generation-worker-prefill-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ichovpan/ttt-generation-worker-prefill-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ichovpan/ttt-generation-worker-prefill-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/ttt-generation-worker-prefill-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/ttt-generation-worker-prefill-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/ttt-generation-worker-prefill-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/ttt-generation-worker-prefill-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/ttt-generation-worker-prefill-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/ttt-generation-worker-prefill-warmup)