### PR TITLE
[skip ci] Bump tenstorrent-skills-reviewer pins to pick up rule corrections

### DIFF
--- a/.github/workflows/tenstorrent-skills-reviewer.lock.yml
+++ b/.github/workflows/tenstorrent-skills-reviewer.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"873d68a76231edeb9888d9611a900068887841e0a6c0ac3ead58254e7c671f64","body_hash":"adc25b4f7124ed1f790e22576a5db3f46465ba4857289dae1d56f83cda437c7c","compiler_version":"v0.86.2","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6","engine_versions":{"copilot":"1.0.79"}}
-# gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"3d3c42e5aac5ba805825da76410c181273ba90b1","version":"v7.0.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"6aab9e5b5c91c615506061f09bedd81a23babe3c","version":"v0.86.2"}],"skills":["blozano-tt/skills/llk-perf-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/llk-race-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-comment-hygiene-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-l1-memory-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-model-bringup-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-multichip-ccl-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-perf-claim-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-precision-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-review-core@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-review-router@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-test-coverage-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-trace-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-vllm-serving-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/ttnn-op-kernel-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.44","digest":"sha256:0d727725c737b58c7bdf51f640cffb928385ec46517e0917c7f1a02f1bada8b4","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.44@sha256:0d727725c737b58c7bdf51f640cffb928385ec46517e0917c7f1a02f1bada8b4"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.44","digest":"sha256:b50fbadba138f6e9aba94aca09711335c489bb3b15861220cb66f6092e042dc7","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.44@sha256:b50fbadba138f6e9aba94aca09711335c489bb3b15861220cb66f6092e042dc7"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.44","digest":"sha256:83e48bbe12c634be8c228a576832fe45f66c529ac3659db92bddbcf2eeb6d627","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.44@sha256:83e48bbe12c634be8c228a576832fe45f66c529ac3659db92bddbcf2eeb6d627"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.4.9","digest":"sha256:e5a1569aeaf41820fa7bdee3e94468cae448133cdbf00119ad24f5b74db1ab9f","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.4.9@sha256:e5a1569aeaf41820fa7bdee3e94468cae448133cdbf00119ad24f5b74db1ab9f"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:0d9f1fb5fd6610c0ac1f5194a38e45a8a1e81f8a390d5142d8e4e6f26a4b3196","pinned_image":"ghcr.io/github/gh-aw-node@sha256:0d9f1fb5fd6610c0ac1f5194a38e45a8a1e81f8a390d5142d8e4e6f26a4b3196"},{"image":"ghcr.io/github/github-mcp-server:v1.9.0","digest":"sha256:881b53d6f75f69bdbc1b5b10fc2f1361717c19054143b3a8529fb5c32061a50e","pinned_image":"ghcr.io/github/github-mcp-server:v1.9.0@sha256:881b53d6f75f69bdbc1b5b10fc2f1361717c19054143b3a8529fb5c32061a50e"}],"has_pull_request":true}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"032c9b06bbda0d68fc3ede4aeef72a4c82ea95b077abf0ebe43e4f67cba67e3f","body_hash":"adc25b4f7124ed1f790e22576a5db3f46465ba4857289dae1d56f83cda437c7c","compiler_version":"v0.86.2","strict":true,"agent_id":"copilot","agent_model":"claude-sonnet-4.6","engine_versions":{"copilot":"1.0.79"}}
+# gh-aw-manifest: {"version":1,"secrets":["GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"3d3c42e5aac5ba805825da76410c181273ba90b1","version":"v7.0.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"6aab9e5b5c91c615506061f09bedd81a23babe3c","version":"v0.86.2"}],"skills":["blozano-tt/skills/llk-perf-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/llk-race-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-comment-hygiene-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-l1-memory-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-model-bringup-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-multichip-ccl-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-perf-claim-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-precision-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-review-core@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-review-router@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-test-coverage-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-trace-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-vllm-serving-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/ttnn-op-kernel-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.44","digest":"sha256:0d727725c737b58c7bdf51f640cffb928385ec46517e0917c7f1a02f1bada8b4","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.44@sha256:0d727725c737b58c7bdf51f640cffb928385ec46517e0917c7f1a02f1bada8b4"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.44","digest":"sha256:b50fbadba138f6e9aba94aca09711335c489bb3b15861220cb66f6092e042dc7","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.44@sha256:b50fbadba138f6e9aba94aca09711335c489bb3b15861220cb66f6092e042dc7"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.44","digest":"sha256:83e48bbe12c634be8c228a576832fe45f66c529ac3659db92bddbcf2eeb6d627","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.44@sha256:83e48bbe12c634be8c228a576832fe45f66c529ac3659db92bddbcf2eeb6d627"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.4.9","digest":"sha256:e5a1569aeaf41820fa7bdee3e94468cae448133cdbf00119ad24f5b74db1ab9f","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.4.9@sha256:e5a1569aeaf41820fa7bdee3e94468cae448133cdbf00119ad24f5b74db1ab9f"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:0d9f1fb5fd6610c0ac1f5194a38e45a8a1e81f8a390d5142d8e4e6f26a4b3196","pinned_image":"ghcr.io/github/gh-aw-node@sha256:0d9f1fb5fd6610c0ac1f5194a38e45a8a1e81f8a390d5142d8e4e6f26a4b3196"},{"image":"ghcr.io/github/github-mcp-server:v1.9.0","digest":"sha256:881b53d6f75f69bdbc1b5b10fc2f1361717c19054143b3a8529fb5c32061a50e","pinned_image":"ghcr.io/github/github-mcp-server:v1.9.0@sha256:881b53d6f75f69bdbc1b5b10fc2f1361717c19054143b3a8529fb5c32061a50e"}],"has_pull_request":true}
 # This file was automatically generated by gh-aw (v0.86.2). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _
@@ -147,7 +147,7 @@ jobs:
           GH_AW_INFO_FRONTMATTER_EMOJI: "🔷"
           GH_AW_COMPILED_STRICT: "true"
           GH_AW_INFO_FEATURES: '{"gh-aw-detection":true}'
-          GH_AW_INFO_SKILLS: '["blozano-tt/skills/tt-review-core@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-review-router@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/ttnn-op-kernel-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-l1-memory-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-model-bringup-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-multichip-ccl-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-trace-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-precision-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-test-coverage-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/llk-race-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/llk-perf-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-vllm-serving-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-perf-claim-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa","blozano-tt/skills/tt-comment-hygiene-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"]'
+          GH_AW_INFO_SKILLS: '["blozano-tt/skills/tt-review-core@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-review-router@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/ttnn-op-kernel-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-l1-memory-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-model-bringup-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-multichip-ccl-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-trace-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-precision-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-test-coverage-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/llk-race-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/llk-perf-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-vllm-serving-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-perf-claim-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2","blozano-tt/skills/tt-comment-hygiene-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"]'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -265,7 +265,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-review-core@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-review-core@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -279,7 +279,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-review-router@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-review-router@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -293,7 +293,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/ttnn-op-kernel-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/ttnn-op-kernel-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -307,7 +307,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-l1-memory-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-l1-memory-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -321,7 +321,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-model-bringup-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-model-bringup-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -335,7 +335,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-multichip-ccl-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-multichip-ccl-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -349,7 +349,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-trace-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-trace-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -363,7 +363,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-precision-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-precision-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -377,7 +377,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-test-coverage-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-test-coverage-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -391,7 +391,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/llk-race-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/llk-race-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -405,7 +405,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/llk-perf-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/llk-perf-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -419,7 +419,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-vllm-serving-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-vllm-serving-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -433,7 +433,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-perf-claim-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-perf-claim-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -447,7 +447,7 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_GH_SKILL_AGENT_NAME: "github-copilot"
           GH_AW_SKILL_DIR: ".github/skills"
-          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-comment-hygiene-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa"
+          GH_AW_FRONTMATTER_SKILLS: "blozano-tt/skills/tt-comment-hygiene-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/tenstorrent-skills-reviewer.md
+++ b/.github/workflows/tenstorrent-skills-reviewer.md
@@ -111,20 +111,20 @@ safe-outputs:
     footer: "> 🔷 *Reviewed using [Tenstorrent domain skills](https://github.com/blozano-tt/skills) by [{workflow_name}]({run_url})*{ai_credits_suffix}{history_link}"
     run-failure: 🔷 [{workflow_name}]({run_url}) {status} during the Tenstorrent skills review.
 skills:
-- blozano-tt/skills/tt-review-core@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-review-router@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/ttnn-op-kernel-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-l1-memory-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-model-bringup-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-multichip-ccl-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-trace-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-precision-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-test-coverage-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/llk-race-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/llk-perf-audit-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-vllm-serving-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-perf-claim-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
-- blozano-tt/skills/tt-comment-hygiene-review@a4bd24b82af63a7023929f87a05364e8e56dd7aa
+- blozano-tt/skills/tt-review-core@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-review-router@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/ttnn-op-kernel-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-l1-memory-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-model-bringup-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-multichip-ccl-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-trace-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-precision-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-test-coverage-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/llk-race-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/llk-perf-audit-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-vllm-serving-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-perf-claim-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
+- blozano-tt/skills/tt-comment-hygiene-review@31e612028d6b50a5cf5916c869c636fa4dea2eb2
 timeout-minutes: 15
 ---
 


### PR DESCRIPTION
Bumps the 14 `blozano-tt/skills` pins in `tenstorrent-skills-reviewer` from `a4bd24b8` to `31e61202`, and regenerates the lock file.

**This is not a routine bump.** The currently-pinned revision carries four defects inherited from the `bug_checker` rules when they were vendored into that repo. One of them makes the reviewer give *actively wrong* guidance rather than merely miss a finding.

| Defect on the current pin | Corrected on the new pin |
|---|---|
| **`is_sharded()` offered as a sufficient guard** for a `shard_spec().value()` dereference | It is not. `is_sharded()` is true for `ND_SHARDED`, whose `MemoryConfig` sets `shard_spec` to `nullopt` with the spec in `nd_shard_spec()`. **A reviewer following the old guidance would approve the exact pattern that throws.** Now guards on `has_value()` |
| **Math config writes need both math engines drained**, stated universally | Architecture- and field-specific. Blackhole uses the single-engine form **9 times against 3** for the pair, so the universal rule flagged correct code |
| **A non-restoring `_uninit_` is a bug shape** | A no-op teardown is correct where the state is transient and reprogrammed by the next init — the in-tree implementations document this |
| **`apply_descriptor_runtime_args()` treated as a rebuild** | It applies args from an existing descriptor; against a minimal CB-only descriptor it is a cheap cache-hit repair, used that way in-tree |

Credit: the defects were found by a GPT-5.6 analysis posted by @bbradelTT on #54114. Each was verified against the tree before being corrected — of that analysis's seven claims, five were correct, one correct in substance, and one wrong on its stated reason.

The upstream `bug_checker` rules in #54114 still carry all seven, including two that never reached the skills repo. The corrections here are directly reusable there.

## Verification

- **All 14 pins verified to resolve** at `31e61202` before compiling. gh-aw reports a failed skill install as a *non-fatal warning*, so an unresolvable pin degrades the review into a generic one rather than failing the run.
- `gh aw compile` succeeds; lock file regenerated.
- The diff is confined to the pin lines and their compiled equivalents — no behavioural change to the workflow itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=chore/bump-skill-pins)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:chore/bump-skill-pins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=chore/bump-skill-pins)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:chore/bump-skill-pins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=chore/bump-skill-pins)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:chore/bump-skill-pins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=chore/bump-skill-pins)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:chore/bump-skill-pins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=chore/bump-skill-pins)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:chore/bump-skill-pins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=chore/bump-skill-pins)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:chore/bump-skill-pins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=chore/bump-skill-pins)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:chore/bump-skill-pins)