### PR TITLE
tests: reduce KDA test CI time

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -339,7 +339,6 @@ ttnn/cpp/ttnn/operations/sliding_window/**/CMakeLists.txt @tenstorrent/metalium-
 # it's the status-quo fallback owner for several ops here that have no
 # team-specific CODEOWNERS rule of their own — not a deliberate, active
 # owner, just what already resolves today.
-tests/ttnn/nightly/unit_tests/operations/experimental/kda/ @tenstorrent/metalium-developers-sdpa
 ttnn/CMakeLists.txt @mbezuljTT @ppetrovicTT @pavlepopovic @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra
 ttnn/api/tools/profiler/ @mo-tenstorrent @akerteszTT
 ttnn/cpp/ttnn/operations/eltwise/ @tenstorrent/metalium-developers-eltwise
@@ -481,6 +480,7 @@ tests/ttnn/nightly/unit_tests/operations/eltwise/ @tenstorrent/metalium-develope
 tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill
 tests/ttnn/nightly/unit_tests/operations/experimental/quasar/ @tenstorrent/metalium-developers-mmfusedreduce
 tests/ttnn/nightly/unit_tests/operations/experimental/indexer_score/ @tenstorrent/metalium-developers-sdpa
+tests/ttnn/nightly/unit_tests/operations/experimental/kda/ @tenstorrent/metalium-developers-sdpa
 tests/ttnn/nightly/unit_tests/operations/experimental/test_rgb_to_yuv.py @cglagovichTT @jonathansuTT
 tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py @tenstorrent/metalium-developers-sdpa
 tests/ttnn/nightly/unit_tests/operations/fused/ @tenstorrent/metalium-developers-mmfusedreduce

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -144,19 +144,26 @@ def _run(
 
 
 @pytest.mark.parametrize(
-    ("widths", "channel_chunk_size"),
-    [((512, 512, 512), 1536), ((1024, 1024, 1024), 768), ((512, 256, 128), 896)],
+    ("widths", "channel_chunk_size", "full_contract"),
+    [
+        pytest.param((512, 512, 512), 1536, False, id="single-block"),
+        pytest.param((1024, 1024, 1024), 768, False, id="multiple-blocks"),
+        pytest.param((512, 256, 128), 896, True, id="asymmetric-split-full-contract"),
+    ],
 )
 def test_qkv_causal_conv1d_silu_contract(
-    device: ttnn.Device, widths: tuple[int, int, int], channel_chunk_size: int
+    device: ttnn.Device,
+    widths: tuple[int, int, int],
+    channel_chunk_size: int,
+    full_contract: bool,
 ) -> None:
-    """Cover one/multiple channel blocks, split widths, tap order, and runtime gates."""
+    """Cover every geometry numerically and the invariant output/trace contract once."""
     host, device_inputs = _device_inputs(device, widths=widths)
     inputs, history, taps = host
     input_tt, history_tt, taps_tt = device_inputs
     expected = _reference(inputs, history, taps, widths)
     input_tensors = (input_tt, history_tt, *taps_tt)
-    snapshots = tuple(ttnn.to_torch(tensor).clone() for tensor in input_tensors)
+    snapshots = tuple(ttnn.to_torch(tensor).clone() for tensor in input_tensors) if full_contract else ()
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
@@ -164,30 +171,32 @@ def test_qkv_causal_conv1d_silu_contract(
 
     outputs = run()
     for output, width in zip(outputs, widths, strict=True):
-        assert output.dtype == ttnn.bfloat16
-        assert output.layout == ttnn.TILE_LAYOUT
-        assert output.memory_config() == ttnn.DRAM_MEMORY_CONFIG
         assert tuple(ttnn.to_torch(output).shape) == (1, _SEQUENCE, width)
-        assert all(output.buffer_address() != tensor.buffer_address() for tensor in input_tensors)
+        if full_contract:
+            assert output.dtype == ttnn.bfloat16
+            assert output.layout == ttnn.TILE_LAYOUT
+            assert output.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+            assert all(output.buffer_address() != tensor.buffer_address() for tensor in input_tensors)
 
-    trace_id = ttnn.begin_trace_capture(device, cq_id=0)
-    traced_outputs = run()
-    ttnn.end_trace_capture(device, trace_id, cq_id=0)
-    for _ in range(2):
-        ttnn.execute_trace(device, trace_id, cq_id=0, blocking=False)
-    ttnn.synchronize_device(device)
-
-    for name, golden, output, traced in zip(("q", "k", "v"), expected, outputs, traced_outputs, strict=True):
+    for name, golden, output in zip(("q", "k", "v"), expected, outputs, strict=True):
         actual = ttnn.to_torch(output)
         assert_accurate(golden, actual, name=name, pcc_threshold=0.999)
-        assert_bit_identical(actual, ttnn.to_torch(traced), name=f"{name} trace replay")
 
-    for name, before, tensor in zip(
-        ("input", "history", "tap0", "tap1", "tap2", "tap3"), snapshots, input_tensors, strict=True
-    ):
-        assert_bit_identical(before, ttnn.to_torch(tensor), name=f"{name} immutability")
+    if full_contract:
+        trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+        traced_outputs = run()
+        ttnn.end_trace_capture(device, trace_id, cq_id=0)
+        for _ in range(2):
+            ttnn.execute_trace(device, trace_id, cq_id=0, blocking=False)
+        ttnn.synchronize_device(device)
 
-    ttnn.release_trace(device, trace_id)
+        for name, output, traced in zip(("q", "k", "v"), outputs, traced_outputs, strict=True):
+            assert_bit_identical(ttnn.to_torch(output), ttnn.to_torch(traced), name=f"{name} trace replay")
+        for name, before, tensor in zip(
+            ("input", "history", "tap0", "tap1", "tap2", "tap3"), snapshots, input_tensors, strict=True
+        ):
+            assert_bit_identical(before, ttnn.to_torch(tensor), name=f"{name} immutability")
+        ttnn.release_trace(device, trace_id)
 
 
 @pytest.mark.parametrize("case", _PRODUCTION_CASES, ids=lambda case: case.case_id)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_sigmoid_gated_rms_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_sigmoid_gated_rms_norm.py
@@ -23,7 +23,7 @@ from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
 
 pytestmark = [
     run_for_blackhole(),
-    pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True),
+    pytest.mark.use_module_device({"l1_small_size": 24576}),
 ]
 
 _BATCH = 1
@@ -392,7 +392,7 @@ def test_sigmoid_gated_rms_norm_production_performance(device: ttnn.Device, case
     )
 
 
-def test_sigmoid_gated_rms_norm_program_key_includes_epsilon(device: ttnn.Device) -> None:
+def test_sigmoid_gated_rms_norm_program_key_includes_epsilon(device: ttnn.Device, isolated_program_cache: None) -> None:
     _, (input_tt, gate_tt, weight_tt) = _device_inputs(
         device, batch=1, sequence=32, num_heads=2, value_dim=64, seed=1321
     )
@@ -404,7 +404,9 @@ def test_sigmoid_gated_rms_norm_program_key_includes_epsilon(device: ttnn.Device
     assert device.num_program_cache_entries() == entries + 1
 
 
-def test_sigmoid_gated_rms_norm_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:
+def test_sigmoid_gated_rms_norm_cache_hit_rebinds_fresh_tensors(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     host_a, device_inputs_a = _device_inputs(device, batch=1, sequence=32, num_heads=2, value_dim=64, seed=1911)
     host_b, device_inputs_b = _device_inputs(device, batch=1, sequence=32, num_heads=2, value_dim=64, seed=1912)
 
@@ -444,7 +446,9 @@ def test_sigmoid_gated_rms_norm_cache_hit_rebinds_fresh_tensors(device: ttnn.Dev
     assert not torch.equal(actual_a, actual_b)
 
 
-def test_sigmoid_gated_rms_norm_default_compute_config_matches_explicit_defaults(device: ttnn.Device) -> None:
+def test_sigmoid_gated_rms_norm_default_compute_config_matches_explicit_defaults(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     _, (input_tt, gate_tt, weight_tt) = _device_inputs(device, seed=817)
     implicit = ttnn.to_torch(_run(input_tt, gate_tt, weight_tt))
     entries = device.num_program_cache_entries()
@@ -462,7 +466,9 @@ def test_sigmoid_gated_rms_norm_default_compute_config_matches_explicit_defaults
     assert_bit_identical(implicit, explicit, name="implicit vs explicit production compute defaults")
 
 
-def test_sigmoid_gated_rms_norm_exact_math_changes_program_and_output(device: ttnn.Device) -> None:
+def test_sigmoid_gated_rms_norm_exact_math_changes_program_and_output(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     _, (input_tt, gate_tt, weight_tt) = _device_inputs(device, seed=818)
     approximate = ttnn.to_torch(_run(input_tt, gate_tt, weight_tt))
     entries = device.num_program_cache_entries()

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_sigmoid_gated_rms_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_sigmoid_gated_rms_norm.py
@@ -19,6 +19,7 @@ from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
     assert_accurate,
     assert_bit_identical,
     assert_equal,
+    collect_accuracy_and_determinism_results,
 )
 
 pytestmark = [
@@ -177,43 +178,6 @@ def _reference(
     )
 
 
-def _collect_accuracy_and_determinism_results(
-    device: ttnn.Device,
-    run: Callable[[], ttnn.Tensor],
-    *,
-    count: int = 3,
-) -> tuple[ttnn.Tensor, torch.Tensor, torch.Tensor]:
-    assert count > 1
-    reference_output = run()
-    mismatch_scratch = ttnn.empty(
-        reference_output.shape,
-        dtype=ttnn.bfloat16,
-        layout=reference_output.layout,
-        device=device,
-        memory_config=reference_output.memory_config(),
-    )
-    mismatch_marker = None
-    for _ in range(1, count):
-        output_tt = run()
-        ttnn.ne(reference_output, output_tt, dtype=ttnn.bfloat16, output_tensor=mismatch_scratch)
-        current_mismatch = ttnn.max(mismatch_scratch)
-        ttnn.deallocate(output_tt)
-        if mismatch_marker is None:
-            mismatch_marker = current_mismatch
-        else:
-            updated_marker = ttnn.maximum(mismatch_marker, current_mismatch)
-            ttnn.deallocate(mismatch_marker)
-            ttnn.deallocate(current_mismatch)
-            mismatch_marker = updated_marker
-
-    assert mismatch_marker is not None
-    reference_output_host = ttnn.to_torch(reference_output).clone()
-    mismatch_marker_host = ttnn.to_torch(mismatch_marker).clone()
-    ttnn.deallocate(mismatch_scratch)
-    ttnn.deallocate(mismatch_marker)
-    return reference_output, reference_output_host, mismatch_marker_host
-
-
 def _assert_output_contract(
     output_tt: ttnn.Tensor,
     output: torch.Tensor,
@@ -272,11 +236,11 @@ def test_sigmoid_gated_rms_norm_is_accurate_and_deterministic(
     )
     input_snapshots = tuple(ttnn.to_torch(tensor).clone() for tensor in device_inputs)
 
-    def run() -> ttnn.Tensor:
+    def run() -> tuple[ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
-            return _run(input_tt, gate_tt, weight_tt, output_dtype=output_dtype)
+            return (_run(input_tt, gate_tt, weight_tt, output_dtype=output_dtype),)
 
-    output_tt, output, mismatch_marker = _collect_accuracy_and_determinism_results(device, run)
+    (output_tt,), (output,), mismatch_marker = collect_accuracy_and_determinism_results(device, run)
     _assert_output_contract(
         output_tt,
         output,
@@ -317,18 +281,20 @@ def test_sigmoid_gated_rms_norm_production_is_accurate_and_deterministic(
     )
     compute_kernel_config = _production_compute_kernel_config(device)
 
-    def run() -> ttnn.Tensor:
+    def run() -> tuple[ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
-            return _run(
-                input_tt,
-                gate_tt,
-                weight_tt,
-                num_heads=case.num_heads,
-                compute_kernel_config=compute_kernel_config,
-                output_dtype=_PRODUCTION_OUTPUT_DTYPE,
+            return (
+                _run(
+                    input_tt,
+                    gate_tt,
+                    weight_tt,
+                    num_heads=case.num_heads,
+                    compute_kernel_config=compute_kernel_config,
+                    output_dtype=_PRODUCTION_OUTPUT_DTYPE,
+                ),
             )
 
-    output_tt, output, mismatch_marker = _collect_accuracy_and_determinism_results(device, run)
+    (output_tt,), (output,), mismatch_marker = collect_accuracy_and_determinism_results(device, run)
     _assert_output_contract(
         output_tt,
         output,


### PR DESCRIPTION
## Summary

Consolidate the KDA CI-time-budget changes in one draft PR:

- reuse one module-scoped device across sigmoid-gated RMSNorm tests while keeping explicit cache-test isolation;
- run invariant QKV trace, metadata, aliasing, and input-immutability checks on one asymmetric representative while retaining numerical and geometry coverage on all three production cases; and
- use the shared KDA accuracy/determinism collector in the sigmoid suite through a one-output tuple adapter.

## Measured CI impact

A topology-matched full-lane Blackhole P150b A/B reduced the affected files from 38.631 s to 32.051 s,
saving 6.580 s. The per-change savings below are measured within that same A/B.

| Change | Before | After | Saving | Coverage granularity after |
| --- | ---: | ---: | ---: | --- |
| Sigmoid module-scoped device reuse | 24.549 s | 18.754 s | 5.795 s (23.61%) | All 28 selected tests; one device open/close for the module |
| QKV invariant contract/trace split | 14.082 s | 13.297 s | 0.785 s (5.57%) | Numerical and geometry checks on 3 cases; invariant trace contract on the asymmetric representative |
| Shared sigmoid accuracy/determinism helper | 0 s claimed | 0 s claimed | 0 s (deduplication only) | Same accuracy and determinism checks through the shared collector |

### Test plan

[![L2 ttnn experimental](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/tt-metal-l2-nightly.yaml?branch=momcilo%2Fci%2Freuse-kda-sigmoid&event=workflow_dispatch&label=L2%20ttnn%20experimental&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Amomcilo%2Fci%2Freuse-kda-sigmoid)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=momcilo/ci/reuse-kda-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:momcilo/ci/reuse-kda-sigmoid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=momcilo/ci/reuse-kda-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:momcilo/ci/reuse-kda-sigmoid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=momcilo/ci/reuse-kda-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:momcilo/ci/reuse-kda-sigmoid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=momcilo/ci/reuse-kda-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:momcilo/ci/reuse-kda-sigmoid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=momcilo/ci/reuse-kda-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:momcilo/ci/reuse-kda-sigmoid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=momcilo/ci/reuse-kda-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:momcilo/ci/reuse-kda-sigmoid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=momcilo/ci/reuse-kda-sigmoid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:momcilo/ci/reuse-kda-sigmoid)