### PR TITLE
tests: reuse devices in DeepSeek prefill suites

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
@@ -25,6 +25,8 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 
+pytestmark = pytest.mark.use_module_device
+
 NUM_TOKENS = 3200
 NUM_EXPERTS = 8
 EXPERT_DIM = 2

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
@@ -18,7 +18,10 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
 
-pytestmark = pytest.mark.uncollect_if(pred=ci_pruning.no_production_counterpart)
+pytestmark = [
+    pytest.mark.uncollect_if(pred=ci_pruning.no_production_counterpart),
+    pytest.mark.use_module_device,
+]
 
 
 GLOBAL_ROWS = 64

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_insert.py
@@ -18,7 +18,10 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
 
-pytestmark = pytest.mark.uncollect_if(pred=ci_pruning.no_production_counterpart)
+pytestmark = [
+    pytest.mark.uncollect_if(pred=ci_pruning.no_production_counterpart),
+    pytest.mark.use_module_device,
+]
 
 
 GLOBAL_ROWS = 128

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
@@ -24,6 +24,8 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
 )
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
+pytestmark = pytest.mark.use_module_device
+
 
 TEST_PARAMS = [(1, 1, 1), (1, 1, 33), (1, 1, 128), (1, 1, 3200)]
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_hash_gate.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_hash_gate.py
@@ -22,6 +22,8 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     hash_gate_golden_act,
 )
 
+pytestmark = pytest.mark.use_module_device
+
 
 # (seq_len,) with num_batches == batch_size == 1 (single prefill sequence).
 SEQ_LENS = [32, 128, 100, 3200]

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -28,6 +28,8 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from tests.ttnn.utils_for_testing import comp_pcc
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
 
+pytestmark = pytest.mark.use_module_device
+
 
 SINGLE_CHIP_MESH_PARAMS = [
     pytest.param(


### PR DESCRIPTION
## Summary

Reuse one module-scoped device within each of six stateless DeepSeek prefill test modules.

## Measured CI impact

A topology-matched full-lane Blackhole P150b A/B reduced the six affected files from 871.860 s to 787.081 s,
saving 84.779 s (9.72%). Both runs retained the same 2698 collected tests and 1217 runtime-skipped outcomes.

### Test plan

[![L2 ttnn experimental](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/tt-metal-l2-nightly.yaml?branch=momcilo%2Fci%2Freuse-deepseek-prefill&event=workflow_dispatch&label=L2%20ttnn%20experimental&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Amomcilo%2Fci%2Freuse-deepseek-prefill)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=momcilo/ci/reuse-deepseek-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:momcilo/ci/reuse-deepseek-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=momcilo/ci/reuse-deepseek-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:momcilo/ci/reuse-deepseek-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=momcilo/ci/reuse-deepseek-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:momcilo/ci/reuse-deepseek-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=momcilo/ci/reuse-deepseek-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:momcilo/ci/reuse-deepseek-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=momcilo/ci/reuse-deepseek-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:momcilo/ci/reuse-deepseek-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=momcilo/ci/reuse-deepseek-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:momcilo/ci/reuse-deepseek-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=momcilo/ci/reuse-deepseek-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:momcilo/ci/reuse-deepseek-prefill)
