### PR TITLE
tests: reuse devices in Quasar binary suites

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_binary_ng_bcast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_binary_ng_bcast.py
@@ -39,6 +39,8 @@ from tests.ttnn.nightly.unit_tests.operations.experimental.quasar.binary_ng_quas
     _width_sharded_config,
 )
 
+pytestmark = pytest.mark.use_module_device
+
 
 # a is the full [H,W]; the other operand broadcasts. ROW_B: b has one (logical) row. ROW_A: a has one.
 # subtract (non-commutative) is included alongside add so an lhs/rhs (BCAST_INPUT) operand swap would

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_binary_ng_no_bcast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_binary_ng_no_bcast.py
@@ -41,6 +41,8 @@ from tests.ttnn.nightly.unit_tests.operations.experimental.quasar.binary_ng_quas
     _width_sharded_config,
 )
 
+pytestmark = pytest.mark.use_module_device
+
 # Interleaved tensor: 32x40 tiles (1280 tiles) so split_work_to_cores spreads many tiles per core on
 # both an 8x8 (Wormhole) and an 8x4 (Quasar sim) worker grid -- ~20 tiles/core on 8x8, ~40/core on 8x4,
 # so the compute kernel's per-tile loop runs many iterations. No operand is sharded here, so the size is


### PR DESCRIPTION
## Summary

Reuse one module-scoped device within each of the two Quasar binary-operation test modules.

## Measured CI impact

A topology-matched full-lane Blackhole P150b A/B reduced the two affected files from 186.097 s to 130.870 s,
saving 55.227 s (29.68%). Both runs retained the same 2698 collected tests and 1217 runtime-skipped outcomes.

### Test plan

[![L2 ttnn experimental](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/tt-metal-l2-nightly.yaml?branch=momcilo%2Fci%2Freuse-quasar-binary&event=workflow_dispatch&label=L2%20ttnn%20experimental&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Amomcilo%2Fci%2Freuse-quasar-binary)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=momcilo/ci/reuse-quasar-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:momcilo/ci/reuse-quasar-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=momcilo/ci/reuse-quasar-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:momcilo/ci/reuse-quasar-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=momcilo/ci/reuse-quasar-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:momcilo/ci/reuse-quasar-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=momcilo/ci/reuse-quasar-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:momcilo/ci/reuse-quasar-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=momcilo/ci/reuse-quasar-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:momcilo/ci/reuse-quasar-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=momcilo/ci/reuse-quasar-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:momcilo/ci/reuse-quasar-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=momcilo/ci/reuse-quasar-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:momcilo/ci/reuse-quasar-binary)
