### PR TITLE
tests: pairwise-cover block padding dimensions

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -390,9 +390,30 @@ def test_linear_dtype_compute_config(
     assert check_result["relative_rmse"] < RMSE_THRESHOLD
 
 
-@pytest.mark.parametrize("M", [32, 96, 320, 4096])
-@pytest.mark.parametrize("K", [32, 96, 320, 4096])
-@pytest.mark.parametrize("N", [32, 96, 320, 4096])
+# Pairwise covering array over the four M/K/N levels. The N level is the sum
+# of the M and K level indices modulo four, so every M-K, M-N, and K-N pair
+# appears exactly once in these 16 cases.
+@pytest.mark.parametrize(
+    "M,K,N",
+    [
+        (32, 32, 32),
+        (32, 96, 96),
+        (32, 320, 320),
+        (32, 4096, 4096),
+        (96, 32, 96),
+        (96, 96, 320),
+        (96, 320, 4096),
+        (96, 4096, 32),
+        (320, 32, 320),
+        (320, 96, 4096),
+        (320, 320, 32),
+        (320, 4096, 96),
+        (4096, 32, 4096),
+        (4096, 96, 32),
+        (4096, 320, 96),
+        (4096, 4096, 320),
+    ],
+)
 @pytest.mark.parametrize(
     "M_block_size, K_block_size, N_block_size, subblock_h, subblock_w",
     [(8, 8, 8, 2, 2)],


### PR DESCRIPTION
## Summary

Replace the 64-cell M/K/N block-padding cube with a 16-cell Latin-square covering array that
retains every M–K, M–N, and K–N boundary pair exactly once.

## Measured CI impact

Three cold Blackhole P150b samples reduced the focused median from 60.548 s to 21.294 s, saving
39.254 s (64.83%) while reducing collection from 64 to 16 nodes. All 240 parent/candidate executions
passed; candidate PCC was 0.9999911–0.9999924 with relative RMSE 0.0048–0.0051.

### Test plan

[![L2 ttnn experimental](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/tt-metal-l2-nightly.yaml?branch=momcilo%2Fci%2Fprune-block-padding&event=workflow_dispatch&label=L2%20ttnn%20experimental&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Amomcilo%2Fci%2Fprune-block-padding)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=momcilo/ci/prune-block-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:momcilo/ci/prune-block-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=momcilo/ci/prune-block-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:momcilo/ci/prune-block-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=momcilo/ci/prune-block-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:momcilo/ci/prune-block-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=momcilo/ci/prune-block-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:momcilo/ci/prune-block-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=momcilo/ci/prune-block-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:momcilo/ci/prune-block-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=momcilo/ci/prune-block-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:momcilo/ci/prune-block-padding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=momcilo/ci/prune-block-padding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:momcilo/ci/prune-block-padding)
