### PR TITLE
Combine op tests for externally owned models

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/gpt_oss_20b_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/gpt_oss_20b_config.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS 20B Model Configuration.
+
+Single source of truth for model dimension constants.
+Values from HuggingFace config.json for gpt-oss-20b.
+"""
+
+
+class GptOss20BConfig:
+    """GPT-OSS 20B model configuration."""
+
+    # Core dimensions
+    EMB_SIZE = 2880
+    MOE_INTERMEDIATE_SIZE = 2880
+    INTERMEDIATE_SIZE = 2880
+    HEAD_DIM = 64
+
+    # Model architecture
+    NUM_LAYERS = 24
+    VOCAB_SIZE = 201088
+    MAX_POSITION_EMBEDDINGS = 131072
+    INITIAL_CONTEXT_LENGTH = 4096
+
+    # Attention
+    NUM_ATTENTION_HEADS = 64
+    NUM_KEY_VALUE_HEADS = 8
+    ATTENTION_BIAS = True
+    ATTENTION_DROPOUT = 0.0
+    SLIDING_WINDOW = 128
+
+    LAYER_TYPES = (
+        "sliding_attention",
+        "full_attention",
+    ) * 12
+
+    # RoPE / YaRN
+    ROPE_THETA = 150000
+    ROPE_PARAMETERS = {
+        "rope_type": "yarn",
+        "factor": 32.0,
+        "beta_fast": 32.0,
+        "beta_slow": 1.0,
+        "truncate": False,
+        "original_max_position_embeddings": 4096,
+    }
+
+    # MoE
+    NUM_ROUTED_EXPERTS = 32
+    NUM_EXPERTS_PER_TOKEN = 4
+    NUM_SHARED_EXPERTS = 0  # Derived: no shared-expert block
+
+    # GPT-OSS SwiGLU
+    HIDDEN_ACT = "silu"
+    SWIGLU_ALPHA = 1.702
+    SWIGLU_LIMIT = 7.0
+
+    # Normalization / initialization
+    RMS_NORM_EPS = 1e-5
+    INITIALIZER_RANGE = 0.02
+
+    # Miscellaneous model config
+    ROUTER_AUX_LOSS_COEF = 0.9
+    OUTPUT_ROUTER_LOGITS = False
+    USE_CACHE = True
+    TIE_WORD_EMBEDDINGS = False
+    PAD_TOKEN_ID = 199999
+    EOS_TOKEN_ID = 200002
+
+    # Weight format, not an architectural hyperparameter
+    QUANT_METHOD = "mxfp4"
+
+    # Implementation-specific, not from the HF model config
+    FABRIC_PAYLOAD_SIZE = EMB_SIZE

--- a/models/demos/deepseek_v3_d_p/reference/minimax_m3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/minimax_m3_config.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MiniMax M3 Model Configuration.
+
+Single source of truth for model dimension constants.
+Values from HuggingFace config.json for MiniMax-M3.
+"""
+
+
+class MiniMaxM3Config:
+    """MiniMax-M3 text-backbone model dimensions and hyperparameters."""
+
+    # Core dimensions
+    EMB_SIZE = 6144
+    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # Implementation-specific; keep in sync with migration code
+
+    # FFN dimensions
+    MOE_INTERMEDIATE_SIZE = 3072  # Routed-expert FFN hidden dimension
+    SHARED_INTERMEDIATE_SIZE = 3072  # Always-on shared expert
+    INTERMEDIATE_SIZE = 12288  # Dense FFN hidden dimension
+
+    # Model architecture
+    NUM_LAYERS = 60
+    NUM_DENSE_LAYERS = 3
+    NUM_MOE_LAYERS = NUM_LAYERS - NUM_DENSE_LAYERS
+    VOCAB_SIZE = 200064
+    MAX_POSITION_EMBEDDINGS = 1_048_576
+
+    # Attention
+    NUM_ATTENTION_HEADS = 64
+    NUM_KEY_VALUE_HEADS = 4
+    HEAD_DIM = 128
+    ROTARY_DIM = 64
+    ROPE_THETA = 5_000_000
+    PARTIAL_ROTARY_FACTOR = 0.5
+    ATTENTION_DROPOUT = 0.0
+    USE_QK_NORM = True
+    QK_NORM_TYPE = "per_head"
+    USE_GEMMA_NORM = True
+    ATTENTION_OUTPUT_GATE = False
+
+    # MoE routing
+    NUM_ROUTED_EXPERTS = 128
+    NUM_EXPERTS_PER_TOKEN = 4
+    NUM_SHARED_EXPERTS = 1
+    SCORING_FUNC = "sigmoid"
+    USE_ROUTING_BIAS = True
+    ROUTE_SCALE = 2.0
+
+    # Layer schedules: 0 = dense/full-attention, 1 = MoE/sparse-attention
+    MOE_LAYER_FREQ = (0, 0, 0) + (1,) * 57
+    SPARSE_ATTENTION_FREQ = (0, 0, 0) + (1,) * 57
+
+    # Sparse attention / MSA
+    USE_SPARSE_ATTENTION = True
+    SPARSE_INDEX_DIM = 128
+    SPARSE_NUM_INDEX_HEADS = 4
+    SPARSE_BLOCK_SIZE = 128
+    SPARSE_TOPK_BLOCKS = 16
+    SPARSE_SCORE_TYPE = "max"
+    SPARSE_INIT_BLOCK = 0
+    SPARSE_LOCAL_BLOCK = 1
+
+    # SwiGLU-OAI activation
+    HIDDEN_ACT = "swigluoai"
+    SWIGLU_ALPHA = 1.702
+    SWIGLU_LIMIT = 7.0
+
+    # Other model settings
+    RMS_NORM_EPS = 1e-6
+    TIE_WORD_EMBEDDINGS = False
+    USE_CACHE = True
+    NUM_MTP_MODULES = 7
+    NUM_NEXTN_PREDICT_LAYERS = 1

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -170,7 +170,7 @@ def pytest_collection_modifyitems(config, items):
 
     CT = ttnn.cluster.ClusterType
     FC = ttnn.FabricConfig
-    DEFAULT_ALLOWED_FABRICS = frozenset({FC.DISABLED, FC.FABRIC_2D})
+    DEFAULT_ALLOWED_FABRICS = frozenset({FC.DISABLED, FC.FABRIC_1D, FC.FABRIC_2D})
     # DISABLED is listed only on shapes that already own fabric-irrelevant diagnostics
     # (currently single-chip and the P300 1x2 masked-bincount row). Do not expand it into
     # communicating-test matrices merely to make this table visually symmetric.
@@ -181,18 +181,18 @@ def pytest_collection_modifyitems(config, items):
             (1, 2): [FC.DISABLED, FC.FABRIC_2D],
         },  # 2 chips
         CT.P300_X2: {  # 4-chip QuietBox
-            (4, 1): [FC.FABRIC_2D_TORUS_Y],
+            (4, 1): [FC.FABRIC_1D, FC.FABRIC_2D_TORUS_Y],
             (2, 2): [FC.FABRIC_2D],
             (1, 4): [FC.FABRIC_2D_TORUS_X],
         },
         CT.P150_X8: {
-            (8, 1): [FC.FABRIC_2D_TORUS_Y],
+            (8, 1): [FC.FABRIC_1D, FC.FABRIC_2D_TORUS_Y],
             (4, 2): [FC.FABRIC_2D],
             (2, 4): [FC.FABRIC_2D],
             (1, 8): [FC.FABRIC_2D_TORUS_X],
         },
         CT.T3K: {
-            (8, 1): [FC.FABRIC_2D_TORUS_Y],
+            (8, 1): [FC.FABRIC_1D, FC.FABRIC_2D_TORUS_Y],
             (4, 2): [FC.FABRIC_2D],
             (2, 4): [FC.FABRIC_2D],
             (1, 8): [FC.FABRIC_2D_TORUS_X],
@@ -200,27 +200,27 @@ def pytest_collection_modifyitems(config, items):
         CT.BLACKHOLE_GALAXY: {
             (32, 1): [FC.FABRIC_2D],
             (16, 2): [FC.FABRIC_2D],
-            (8, 4): [FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
+            (8, 4): [FC.FABRIC_1D, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
             (4, 4): [FC.FABRIC_2D_TORUS_X, FC.FABRIC_2D_TORUS_Y, FC.FABRIC_2D_TORUS_XY],
-            (4, 8): [FC.FABRIC_2D],
+            (4, 8): [FC.FABRIC_1D, FC.FABRIC_2D],
             (2, 16): [FC.FABRIC_2D],
             (1, 32): [FC.FABRIC_2D],
         },
         CT.GALAXY: {
             (32, 1): [FC.FABRIC_2D],
             (16, 2): [FC.FABRIC_2D],
-            (8, 4): [FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
+            (8, 4): [FC.FABRIC_1D, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
             (4, 4): [FC.FABRIC_2D_TORUS_X, FC.FABRIC_2D_TORUS_Y, FC.FABRIC_2D_TORUS_XY],
-            (4, 8): [FC.FABRIC_2D],
+            (4, 8): [FC.FABRIC_1D, FC.FABRIC_2D],
             (2, 16): [FC.FABRIC_2D],
             (1, 32): [FC.FABRIC_2D],
         },
         CT.TG: {
             (32, 1): [FC.FABRIC_2D],
             (16, 2): [FC.FABRIC_2D],
-            (8, 4): [FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
+            (8, 4): [FC.FABRIC_1D, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
             (4, 4): [FC.FABRIC_2D_TORUS_X, FC.FABRIC_2D_TORUS_Y, FC.FABRIC_2D_TORUS_XY],
-            (4, 8): [FC.FABRIC_2D],
+            (4, 8): [FC.FABRIC_1D, FC.FABRIC_2D],
             (2, 16): [FC.FABRIC_2D],
             (1, 32): [FC.FABRIC_2D],
         },

--- a/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
+++ b/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
@@ -26,6 +26,19 @@ def fabric2d_device_params(*, fabric_payload_size=None, **overrides) -> dict:
     return params
 
 
+def fabric_1d_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+    """Unwrapped 1D fabric profile."""
+    params = {
+        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        "fabric_router_config": create_fabric_router_config(
+            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
+        ),
+        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+    }
+    params.update(overrides)
+    return params
+
+
 def torus_y_device_params(*, fabric_payload_size=None, **overrides) -> dict:
     """Fabric2D Ring/Linear profile for an Nx1 mesh."""
     params = {

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -22,9 +22,11 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
+from models.demos.deepseek_v3_d_p.reference.gpt_oss_20b_config import GptOss20BConfig
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.reference.minimax_m3_config import MiniMaxM3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import fabric_to_device_params
@@ -353,7 +355,7 @@ COMBINE_MODELS = [
 # Scales down model hyper-params for a given hardware to obtain good/meaningful proxy test
 # How exactly to scale it down is op-specific (more precisely - even op-implementation specific)
 # Thus it makes sense for this to be combine-specific function
-def _model_scaledown_for_combine(model, ref_mesh, target_mesh, pcc_only):
+def _model_scaledown(model, ref_mesh, target_mesh, pcc_only):
     # number of experts has to be reduced to preserve the experts per chip
     ref_num_chips = ref_mesh[0] * ref_mesh[1]
     target_num_chips = target_mesh[0] * target_mesh[1]
@@ -362,8 +364,11 @@ def _model_scaledown_for_combine(model, ref_mesh, target_mesh, pcc_only):
         model.NUM_ROUTED_EXPERTS = (model.NUM_ROUTED_EXPERTS // ref_num_chips) * target_num_chips
 
     # number of experts selected to proces every token (top-K) has to be scaled to preserve average expert activation per dispatch group
+    # Clamped at 1: the ideal scale is topK * target_groups / ref_groups, which lands below 1 whenever the
+    # model routes to fewer experts than the reference mesh has dispatch groups (e.g. GPT-OSS top-4 on a
+    # 4x8 reference collapsed to a single-group proxy). Routing every token to zero experts is not a test.
     if ref_mesh[1] != target_mesh[1]:
-        model.NUM_EXPERTS_PER_TOKEN = (model.NUM_EXPERTS_PER_TOKEN // ref_mesh[1]) * target_mesh[1]
+        model.NUM_EXPERTS_PER_TOKEN = max(1, (model.NUM_EXPERTS_PER_TOKEN // ref_mesh[1]) * target_mesh[1])
 
     # further reduce these two hyperparams in case of pcc check test to get faster, although not perf-representative test
     if pcc_only:
@@ -400,9 +405,7 @@ def _cross_product_conflated_cmb_test_dimensions():
                 ("perf_no_pcc", 640, 8, False),
             ]
             for test_scenario_id, seq_len_per_chip, dispatch_buffer_capacity_factor, run_pcc in test_scenarios:
-                model_config = _model_scaledown_for_combine(
-                    model_config_class(), test_meshes.full_model_mesh, target_mesh, run_pcc
-                )
+                model_config = _model_scaledown(model_config_class(), test_meshes.full_model_mesh, target_mesh, run_pcc)
 
                 num_experts = model_config.NUM_ROUTED_EXPERTS
                 topk = model_config.NUM_EXPERTS_PER_TOKEN
@@ -532,4 +535,77 @@ def test_ttnn_combine(
         run_pcc_check,
         dispatched_buffer_layout,
         use_fp8_output,
+    )
+
+
+def _all_externally_owned_test_cases():
+    def _tc(mesh, fabric_cfg, seq_len_per_chip, num_links, model):
+        model_name = model.__class__.__name__.removesuffix("Config")
+        return pytest.param(
+            mesh,
+            fabric_to_device_params(fabric_cfg),
+            seq_len_per_chip,
+            model.EMB_SIZE,
+            model.NUM_ROUTED_EXPERTS,
+            model.NUM_EXPERTS_PER_TOKEN,
+            num_links,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=mesh, topology=_topo_marker(mesh, fabric_cfg)),
+            id=f"{model_name}-{mesh[0]}x{mesh[1]}-{fabric_cfg.name.lower()}-{seq_len_per_chip}-{num_links}link-rand-pcc-tile-bf16",
+        )
+
+    return [
+        # Full scale mesh tests as invoked in production scenarios
+        _tc((4, 8), ttnn.FabricConfig.FABRIC_1D, 1024, 4, GptOss20BConfig()),
+        _tc((4, 8), ttnn.FabricConfig.FABRIC_1D, 128, 2, GptOss120BConfig()),
+        _tc((4, 8), ttnn.FabricConfig.FABRIC_1D, 1280, 2, GptOss120BConfig()),
+        _tc((8, 4), ttnn.FabricConfig.FABRIC_1D, 128, 2, MiniMaxM3Config()),
+        _tc((8, 4), ttnn.FabricConfig.FABRIC_1D, 640, 2, MiniMaxM3Config()),
+        # Proxy tests executable on CIs which run op unit tests
+        _tc((4, 1), ttnn.FabricConfig.FABRIC_1D, 1024, 4, _model_scaledown(GptOss20BConfig(), (4, 8), (4, 1), False)),
+        _tc((4, 1), ttnn.FabricConfig.FABRIC_1D, 128, 2, _model_scaledown(GptOss120BConfig(), (4, 8), (4, 1), False)),
+        _tc((4, 1), ttnn.FabricConfig.FABRIC_1D, 1280, 2, _model_scaledown(GptOss120BConfig(), (4, 8), (4, 1), False)),
+        _tc((8, 1), ttnn.FabricConfig.FABRIC_1D, 128, 2, _model_scaledown(MiniMaxM3Config(), (8, 4), (8, 1), False)),
+        _tc((8, 1), ttnn.FabricConfig.FABRIC_1D, 640, 2, _model_scaledown(MiniMaxM3Config(), (8, 4), (8, 1), False)),
+    ]
+
+
+def _unsupported_externally_owned_param_combos(**params):
+    # Blackhole exposes 2 fabric links per device, Wormhole 4.
+    if params["num_links"] > 2 and params["is_bh"]:
+        return True
+
+    return False
+
+
+@pytest.mark.uncollect_if(pred=_unsupported_externally_owned_param_combos)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, num_links",
+    _all_externally_owned_test_cases(),
+    indirect=["mesh_device", "device_params"],
+)
+def test_externally_owned_cases(
+    mesh_device,
+    device_params,
+    seq_len_per_chip,
+    emb_dim,
+    num_routed_experts,
+    num_experts_per_tok,
+    num_links,
+):
+    # Same derivation test_ttnn_combine uses: combine drives cluster_axis=0, so it wants the
+    # sp-axis topology of whatever fabric the case opened (Linear for the unwrapped FABRIC_1D).
+    topology = per_axis_topology(device_params["fabric_config"])[0]
+    run_combine(
+        mesh_device,
+        seq_len_per_chip,
+        emb_dim,
+        num_routed_experts,
+        num_experts_per_tok,
+        2,  # buffer capacity factor
+        topology,
+        use_predictable_data=False,
+        run_pcc_check=True,
+        dispatched_buffer_layout=ttnn.TILE_LAYOUT,
+        use_fp8_output=False,
+        num_links=num_links,
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -25,6 +25,7 @@ import pytest
 import ttnn
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
+    fabric_1d_device_params,
     torus_x_device_params,
     torus_xy_device_params,
     torus_y_device_params,
@@ -166,11 +167,14 @@ ALL_MESH_CONFIGS = [
 
 def fabric_to_device_params(fabric_cfg):
     assert fabric_cfg in (
+        ttnn.FabricConfig.FABRIC_1D,
         ttnn.FabricConfig.FABRIC_2D,
         ttnn.FabricConfig.FABRIC_2D_TORUS_X,
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
         ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
     )
+    if fabric_cfg == ttnn.FabricConfig.FABRIC_1D:
+        return fabric_1d_device_params()
     if fabric_cfg == ttnn.FabricConfig.FABRIC_2D:
         return fabric2d_device_params()
     if fabric_cfg == ttnn.FabricConfig.FABRIC_2D_TORUS_X:


### PR DESCRIPTION
### PR Category - TestOnly

### Summary
Adding Combine op test cases to cover parametrizations used by models owned outside the shield team.
Proxy tests run under CIs which shield regularly runs and monitors, to give shield devs early warning if something is broken.
Full mesh tests, designed for GLX are included but don't run. They are to be added to owning teams CIs (or removed from the list of test cases).

### Notes for reviewers
[More details and nicer description](https://claude.ai/code/artifact/5eabb0f9-bcc5-4f29-9ed7-d26886ba978d?via=auto_preview)

### CI Status
Failed only on one job in its setup (download timeout) - https://github.com/tenstorrent/tt-metal/actions/runs/32827360180/job/97740807500
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dlukic/combine-tests-for-externally-owned-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dlukic/combine-tests-for-externally-owned-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dlukic/combine-tests-for-externally-owned-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dlukic/combine-tests-for-externally-owned-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dlukic/combine-tests-for-externally-owned-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dlukic/combine-tests-for-externally-owned-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dlukic/combine-tests-for-externally-owned-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dlukic/combine-tests-for-externally-owned-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dlukic/combine-tests-for-externally-owned-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dlukic/combine-tests-for-externally-owned-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dlukic/combine-tests-for-externally-owned-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dlukic/combine-tests-for-externally-owned-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dlukic/combine-tests-for-externally-owned-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dlukic/combine-tests-for-externally-owned-models)