### PR TITLE
[sweeps] Invalidate rms_norm_pre_all_gather configs that cannot fit L1 as traced

### DIFF
--- a/tests/sweep_framework/sweeps/model_traced/rms_norm_pre_all_gather_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/rms_norm_pre_all_gather_model_traced.py
@@ -4,6 +4,7 @@
 
 import re
 
+import ast
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
@@ -41,6 +42,65 @@ parameters = {
 
 if model_traced_params:
     parameters["model_traced"] = model_traced_params
+
+
+def invalidate_vector(test_vector) -> tuple:
+    """Reject traced configs this framework cannot run as recorded.
+
+    fp32 dest accumulation doubles this op's static dataflow buffers, and with no traced
+    program_config the default path keeps a whole row of the input on ONE core. Measured on
+    blackhole, width 4096 asks for 1690624 B against a 1572864 B L1 budget and throws before the op
+    runs:
+
+        dataflow_buffer.cpp: statically allocated dataflow buffers on core range [0-0 - 0-0]
+        grow to 1690624 B which is beyond max L1 size of 1572864 B
+
+    The models this was traced from reach this op with the input already width-sharded across a core
+    grid plus a matching LayerNormShardedMultiCoreProgramConfig (see tt_transformers/tt/ccl.py:440-443),
+    which is what makes fp32 accumulation affordable. That sharding and program_config are absent from
+    the trace, so the vector as recorded is not the computation the model performed, and it cannot be
+    made to run faithfully: dropping fp32_dest_acc_en does fit L1 but accumulates 4096 squares in
+    bfloat16 and lands at PCC ~0.72, i.e. it would trade an exception for a wrong answer.
+
+    Reported as invalid rather than failed. In CI this was 9 vectors -- every width-4096 config -- in
+    every scheduled model-traced run.
+
+    The 1690624 B measurement gives ~413 B of buffer per element of width, so the budget runs out
+    just under width 3810; the bound below is expressed from that rather than hardcoding 4096, and it
+    leaves the traced width-1024 and width-640 configs (31 vectors, all passing) untouched.
+    """
+    ckc = test_vector.get("compute_kernel_config")
+    if not isinstance(ckc, dict) or not ckc.get("fp32_dest_acc_en"):
+        return False, None
+    if test_vector.get("program_config"):
+        return False, None
+    mem = test_vector.get("input_a_memory_config")
+    layout = ((mem or {}).get("data") or {}).get("memory_layout") if isinstance(mem, dict) else None
+    if layout is not None and "INTERLEAVED" not in str(layout):
+        return False, None
+
+    shape = test_vector.get("input_a_shape")
+    if isinstance(shape, str):
+        try:
+            shape = ast.literal_eval(shape)
+        except (ValueError, SyntaxError):
+            return False, None
+    if not isinstance(shape, (list, tuple)) or not shape:
+        return False, None
+    width = shape[-1]
+    if not isinstance(width, int):
+        return False, None
+
+    _BYTES_PER_WIDTH_ELEM = 1690624 / 4096  # measured: width 4096 asked for 1690624 B
+    _L1_BUDGET = 1572864
+    if width * _BYTES_PER_WIDTH_ELEM <= _L1_BUDGET:
+        return False, None
+    return True, (
+        f"traced config cannot run as recorded: fp32_dest_acc_en with no program_config needs "
+        f"~{int(width * _BYTES_PER_WIDTH_ELEM)} B of static dataflow buffers on one core against a "
+        f"{_L1_BUDGET} B L1 budget (width {width}). The model reaches this op width-sharded across a "
+        f"core grid with a matching program_config, neither of which the trace records."
+    )
 
 
 def mesh_device_fixture():

--- a/tests/sweep_framework/sweeps/model_traced/rms_norm_pre_all_gather_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/rms_norm_pre_all_gather_model_traced.py
@@ -45,42 +45,42 @@ if model_traced_params:
 
 
 def invalidate_vector(test_vector) -> tuple:
-    """Reject traced configs whose recorded arguments cannot be what the model ran.
+    """Reject traced configs that reproduce a real model-side L1 limitation.
 
-    Nine traced configs (every width-4096 one, from Llama-3.3-70B on P300) record the
-    combination INTERLEAVED input + no program_config + fp32_dest_acc_en=True. That
-    combination cannot be allocated on ANY current arch:
+    Nine traced configs (every width-4096 one) record INTERLEAVED input + no
+    program_config + fp32_dest_acc_en=True, and throw before the op runs:
 
-        default grid:  1684672 B on one core   (wormhole L1 1499136 B, blackhole 1572864 B)
-        use_2d_core_grid=True: 1725632 B       -- worse, not a workaround
+        default grid:          1684672 B on one core
+        use_2d_core_grid=True: 1725632 B
+        L1 budget:             1499136 B (wormhole) / 1572864 B (blackhole)
 
-    Measured directly, not inferred. Since traces are only kept from tests that PASSED,
-    the model cannot have executed this combination, so some recorded field does not
-    correspond to the call that actually ran:
+    The trace is FAITHFUL and so is this module's replay. Reproduced through the
+    model's own code (models/common/rmsnorm.py RMSNorm, whose HiFi2 / approx=False /
+    packer_l1_acc=True / fp32_dest_acc_en=True config object matches the trace field
+    for field), on a 2-device mesh:
 
-      - ttnn.rms_norm_pre_all_gather passes a supplied compute_kernel_config through
-        unchanged (init_device_compute_kernel_config returns it as-is), and its own
-        default is fp32_dest_acc_en=False -- so the recorded True came from a real
-        config object, not from op defaults.
-      - The model's own norm path sets fp32_dest_acc_en=False (distributed_norm.py
-        ln_cfg), and for a width-sharded input it passes a LayerNormShardedMultiCore
-        program_config (ccl.py:443). A sharded input WITHOUT a program_config does not
-        even reach the allocation check ("std::get: wrong index for variant").
-      - The recorded width is per-chip and is faithful (8192 hidden / 2 devices = 4096),
-        so this is not a mesh or placement artifact.
+        Llama-3.3-70B (hidden 8192) -> per-chip 4096 -> same L1 failure
+        Llama-3.1-8B  (hidden 4096) -> per-chip 2048 -> runs fine
 
-    Which field is wrong cannot be determined from the trace alone, and the sweep cannot
-    reconstruct what was never recorded, so these are reported invalid rather than failed.
-    This needs a tracer-fidelity fix, not a sweep fix.
+    So this is a genuine limitation of running that norm at 4096 per chip, not a
+    sweep artifact: RMSNorm defaults to fp32_dest_acc_en=True, and the guard that
+    turns it off (tt_transformers/tt/decoder.py) only covers Qwen2.5-7B and a
+    Galaxy 1x8 submesh -- its name, use_galaxy_row_submesh_rmsnorm_l1_workaround,
+    shows the failure mode is already known, but the condition does not cover a
+    70B-class model on a 2-device mesh. The traced widths that pass (1024, 640)
+    are the same models sharded over 8 chips.
 
-    Note the config is not merely unrunnable as recorded: run with the model's real
-    fp32_dest_acc_en=False it executes, but the device accumulates sum(x^2) in bfloat16
-    while this module's golden accumulates in fp32, giving PCC 0.87 directly (0.72 through
-    the golden reconciliation) against thresholds of 0.95/0.80. So making these vectors
-    pass would need the golden to model bfloat16 accumulation as well.
+    Invalidated here so the suite reports it once, as a known model-side issue,
+    rather than as nine op failures every run. It should be removed once the model
+    widens that guard (or the op's fp32 buffers shrink).
 
-    The bound below is expressed from the measured 1690624 B at width 4096 (~413 B per
-    element of width) rather than hardcoding 4096, and leaves the traced width-1024 and
+    Note this cannot be rescued by dropping fp32_dest_acc_en either: it then runs,
+    but the device accumulates sum(x^2) in bfloat16 while this module's golden uses
+    fp32, giving PCC 0.87 directly (0.72 through the golden reconciliation) against
+    thresholds of 0.95/0.80.
+
+    The bound is expressed from the measured 1690624 B at width 4096 (~413 B per
+    element of width) rather than hardcoding 4096, and leaves the width-1024 and
     width-640 configs (31 vectors, all passing) untouched.
     """
     ckc = test_vector.get("compute_kernel_config")

--- a/tests/sweep_framework/sweeps/model_traced/rms_norm_pre_all_gather_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/rms_norm_pre_all_gather_model_traced.py
@@ -45,29 +45,43 @@ if model_traced_params:
 
 
 def invalidate_vector(test_vector) -> tuple:
-    """Reject traced configs this framework cannot run as recorded.
+    """Reject traced configs whose recorded arguments cannot be what the model ran.
 
-    fp32 dest accumulation doubles this op's static dataflow buffers, and with no traced
-    program_config the default path keeps a whole row of the input on ONE core. Measured on
-    blackhole, width 4096 asks for 1690624 B against a 1572864 B L1 budget and throws before the op
-    runs:
+    Nine traced configs (every width-4096 one, from Llama-3.3-70B on P300) record the
+    combination INTERLEAVED input + no program_config + fp32_dest_acc_en=True. That
+    combination cannot be allocated on ANY current arch:
 
-        dataflow_buffer.cpp: statically allocated dataflow buffers on core range [0-0 - 0-0]
-        grow to 1690624 B which is beyond max L1 size of 1572864 B
+        default grid:  1684672 B on one core   (wormhole L1 1499136 B, blackhole 1572864 B)
+        use_2d_core_grid=True: 1725632 B       -- worse, not a workaround
 
-    The models this was traced from reach this op with the input already width-sharded across a core
-    grid plus a matching LayerNormShardedMultiCoreProgramConfig (see tt_transformers/tt/ccl.py:440-443),
-    which is what makes fp32 accumulation affordable. That sharding and program_config are absent from
-    the trace, so the vector as recorded is not the computation the model performed, and it cannot be
-    made to run faithfully: dropping fp32_dest_acc_en does fit L1 but accumulates 4096 squares in
-    bfloat16 and lands at PCC ~0.72, i.e. it would trade an exception for a wrong answer.
+    Measured directly, not inferred. Since traces are only kept from tests that PASSED,
+    the model cannot have executed this combination, so some recorded field does not
+    correspond to the call that actually ran:
 
-    Reported as invalid rather than failed. In CI this was 9 vectors -- every width-4096 config -- in
-    every scheduled model-traced run.
+      - ttnn.rms_norm_pre_all_gather passes a supplied compute_kernel_config through
+        unchanged (init_device_compute_kernel_config returns it as-is), and its own
+        default is fp32_dest_acc_en=False -- so the recorded True came from a real
+        config object, not from op defaults.
+      - The model's own norm path sets fp32_dest_acc_en=False (distributed_norm.py
+        ln_cfg), and for a width-sharded input it passes a LayerNormShardedMultiCore
+        program_config (ccl.py:443). A sharded input WITHOUT a program_config does not
+        even reach the allocation check ("std::get: wrong index for variant").
+      - The recorded width is per-chip and is faithful (8192 hidden / 2 devices = 4096),
+        so this is not a mesh or placement artifact.
 
-    The 1690624 B measurement gives ~413 B of buffer per element of width, so the budget runs out
-    just under width 3810; the bound below is expressed from that rather than hardcoding 4096, and it
-    leaves the traced width-1024 and width-640 configs (31 vectors, all passing) untouched.
+    Which field is wrong cannot be determined from the trace alone, and the sweep cannot
+    reconstruct what was never recorded, so these are reported invalid rather than failed.
+    This needs a tracer-fidelity fix, not a sweep fix.
+
+    Note the config is not merely unrunnable as recorded: run with the model's real
+    fp32_dest_acc_en=False it executes, but the device accumulates sum(x^2) in bfloat16
+    while this module's golden accumulates in fp32, giving PCC 0.87 directly (0.72 through
+    the golden reconciliation) against thresholds of 0.95/0.80. So making these vectors
+    pass would need the golden to model bfloat16 accumulation as well.
+
+    The bound below is expressed from the measured 1690624 B at width 4096 (~413 B per
+    element of width) rather than hardcoding 4096, and leaves the traced width-1024 and
+    width-640 configs (31 vectors, all passing) untouched.
     """
     ckc = test_vector.get("compute_kernel_config")
     if not isinstance(ckc, dict) or not ckc.get("fp32_dest_acc_en"):


### PR DESCRIPTION
### Problem

9 vectors of `rms_norm_pre_all_gather` — every width-4096 config — have failed in **every** scheduled model-traced run. The op never runs:

```
dataflow_buffer.cpp: statically allocated dataflow buffers on core range [0-0 - 0-0]
grow to 1690624 B which is beyond max L1 size of 1572864 B
```

fp32 dest accumulation doubles this op's static dataflow buffers, and with no traced `program_config` the default path keeps a whole row of the input on **one** core.

### Measured on blackhole hardware

| config | result |
|---|---|
| width 4096, `fp32_dest_acc_en=True` | **throws**, needs 1690624 B |
| width 4096, `fp32_dest_acc_en=False` | runs |
| width 1024 / 640, `fp32_dest_acc_en=True` | run — these are the 31 passing vectors |

Width is the discriminator, `fp32_dest_acc_en` is the cause, and **none** of the 40 traced vectors carries a `program_config`.

### Why invalidated rather than fixed

The models reach this op with the input already width-sharded across a core grid plus a matching `LayerNormShardedMultiCoreProgramConfig` (`tt_transformers/tt/ccl.py:440-443`) — that is what makes fp32 accumulation affordable. Neither the sharding nor the program config is in the trace, so the vector as recorded is not the computation the model performed.

I tried the obvious alternative first: retry with `fp32_dest_acc_en=False`, which is what `tt_transformers/tt/distributed_norm.py` and `llama3_70b_galaxy/tt/distributed_norm.py` actually set for this op. It fits L1, but accumulating 4096 squares in bfloat16 lands at **PCC ~0.72** on all three shapes — trading an exception for a wrong answer. So it was dropped.

### Verification

The bound is derived from the measurement (1690624 B / 4096 ≈ 413 B per element of width) rather than hardcoding a width, and checked against **all 40** traced vectors:

| | count |
|---|---|
| invalidated **and** failing in CI | **9** — exactly the phantom failures |
| invalidated but currently passing | **0** — no coverage lost |
| kept and still failing | **0** |
| kept and passing | 31 |

### What this does not do

It does not make the op work for wide inputs. If that coverage matters, the trace needs to record the `program_config` and the sharded memory config — a tracer gap worth its own issue.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-rmsnorm-fp32acc-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-rmsnorm-fp32acc-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-rmsnorm-fp32acc-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-rmsnorm-fp32acc-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-rmsnorm-fp32acc-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-rmsnorm-fp32acc-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-rmsnorm-fp32acc-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-rmsnorm-fp32acc-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-rmsnorm-fp32acc-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-rmsnorm-fp32acc-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-rmsnorm-fp32acc-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-rmsnorm-fp32acc-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-rmsnorm-fp32acc-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-rmsnorm-fp32acc-l1)