### PR TITLE
Fix softplus boundary comparison: < → <= at threshold (#53261)

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -78,6 +78,11 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"negative", {{"SFPU_OP_CHAIN_0", "negative_tile_init(); negative_tile(0);"}}},
     {"softplus",
      {{"SFPU_OP_CHAIN_0", "softplus_tile_init(); softplus_tile(0, /* beta */ 0x3F800000u, /* recip */0x3F800000u, /* threshold */ 0x41A00000u);"}}},
+    // Softplus with threshold=0.5 (beta=1.0) so input=0.5 hits the boundary exactly.
+    // Exercises the <= vs < comparison fix: at t==threshold the kernel must still
+    // evaluate softplus, not fall back to the linear branch.
+    {"softplus_boundary",
+     {{"SFPU_OP_CHAIN_0", "softplus_tile_init(); softplus_tile(0, /* beta */ 0x3F800000u, /* recip */0x3F800000u, /* threshold */ 0x3F000000u);"}}},
     {"clamp", {{"SFPU_OP_CHAIN_0", "clamp_tile_init(); clamp_tile(0, 0xBF800000u, 0x3F800000u);"}}},  // [-1.0f, 1.0f]
     // Comparison-to-zero family (unary): result = 1.0f if predicate(x, 0) else 0.0f.
     {"eqz", {{"SFPU_OP_CHAIN_0", "eqz_tile_init(); eqz_tile(0);"}}},
@@ -188,6 +193,15 @@ float sfpu_function(const std::string& op_name, float input) {
     }
     if (op_name == "softplus") {
         return (input > 20.0f) ? input : std::log1p(std::exp(input));
+    }
+    if (op_name == "softplus_boundary") {
+        // Mirror the kernel's parametrized path: beta=1.0, threshold=0.5.
+        // At input == 0.5 (t == threshold), PyTorch still evaluates softplus
+        // (uses > not >=), so the golden is log1p(exp(0.5)) ≈ 0.974.
+        float beta = 1.0f;
+        float threshold = 0.5f;
+        float t = beta * input;
+        return (t > threshold) ? input : std::log1p(std::exp(t)) / beta;
     }
     if (op_name == "clamp") {
         return std::clamp(input, -1.0f, 1.0f);
@@ -315,6 +329,12 @@ vector<uint32_t> generate_packed_sfpu_input(const unsigned int numel, const std:
     if (op_name == "softplus") {
         return generate_packed_uniform_random_vector<uint32_t, bfloat16>(-5.0f, 30.0f, numel, seed);
     }
+    if (op_name == "softplus_boundary") {
+        // Include exact boundary hit (0.5) alongside random values so the
+        // t == threshold comparison fix is deterministically exercised.
+        auto possible_values = vector<bfloat16>({-2.0f, -0.5f, 0.0f, 0.5f, 1.0f, 2.0f});
+        return generate_packed_random_vector_from_vector<uint32_t, bfloat16>(possible_values, numel, seed);
+    }
     if (op_name == "clamp") {
         return generate_packed_uniform_random_vector<uint32_t, bfloat16>(-2.0f, 2.0f, numel, seed);
     }
@@ -402,6 +422,11 @@ std::pair<float, float> sfpu_tolerance(const std::string& op_name, bool fp32_des
         return {0.03f, 0.02f};
     }
     if (op_name == "softplus") {
+        return {0.06f, 0.02f};
+    }
+    if (op_name == "softplus_boundary") {
+        // Same tolerance as softplus; the boundary point is within the polynomial
+        // domain so accuracy is unchanged.
         return {0.06f, 0.02f};
     }
     return {0.06f, 0.006f};
@@ -1610,7 +1635,9 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "negative"),
         std::make_tuple(4, "negative"),
         std::make_tuple(1, "softplus"),
+        std::make_tuple(1, "softplus_boundary"),
         std::make_tuple(4, "softplus"),
+        std::make_tuple(4, "softplus_boundary"),
         std::make_tuple(1, "clamp"),
         std::make_tuple(4, "clamp"),
         std::make_tuple(1, "relu"),
@@ -1741,7 +1768,9 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "negative"),
         std::make_tuple(4, "negative"),
         std::make_tuple(1, "softplus"),
+        std::make_tuple(1, "softplus_boundary"),
         std::make_tuple(4, "softplus"),
+        std::make_tuple(4, "softplus_boundary"),
         std::make_tuple(1, "clamp"),
         std::make_tuple(4, "clamp"),
         std::make_tuple(1, "relu"),

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -100,7 +100,7 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
     sfpi::vFloat val = sfpi::dst_reg[0];
     sfpi::vFloat t = beta * val;
 
-    v_if(t < threshold) {
+    v_if(t <= threshold) {
         // a = |t| via setsgn (clear sign bit, no branch)
         sfpi::vFloat a = sfpi::setsgn(t, 0);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -55,7 +55,7 @@ sfpi_inline void _calculate_softplus_body_(const float beta, const float beta_re
     sfpi::vFloat result = val;
 
     // `t < threshold` relies on vConstNeg1/LREG11 == -1.0 (re-established per launch by _init_sfpu_config_reg_).
-    v_if (t < threshold)
+    v_if (t <= threshold)
     {
         sfpi::vFloat a = sfpi::abs(t);
         sfpi::vFloat residual;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h
@@ -100,7 +100,7 @@ inline void calculate_softplus_body(const float beta, const float beta_reciproca
     sfpi::vFloat val = sfpi::dst_reg[0];
     sfpi::vFloat t = beta * val;
 
-    v_if(t < threshold) {
+    v_if(t <= threshold) {
         // a = |t| via setsgn (clear sign bit, no branch)
         sfpi::vFloat a = sfpi::setsgn(t, 0);
 


### PR DESCRIPTION
## Summary

Fixes #53261

`ttnn.softplus` takes its linear-fallback branch at exactly `input * beta == threshold`, where PyTorch still evaluates the softplus. The kernel uses a strict `<` where the reference semantics require `<=`, so at the boundary point it returns the raw linear value `x` instead of `log1p(exp(beta*x))/beta`.

## Problem

PyTorch documents the linear fallback as a strict inequality: softplus "reverts to the linear function when `input * beta > threshold`." So at exactly `input * beta == threshold`, the true result is `log1p(exp(beta*x)) / beta`, not `x`.

The kernel code branches:
```cpp
v_if(t < threshold) {          // t = input * beta
    ... evaluate softplus ...
}
v_endif;
```

At `t == threshold`, `t < threshold` is false, so control falls to the linear branch and returns `input`. The comparison needs to be `t <= threshold`.

### Impact

Deterministic, and largest when the threshold is small:

| beta | threshold | x | kernel returns (buggy) | true softplus | abs error |
|---|---|---|---|---|---|
| 1.0 | 0.5 | 0.5 | 0.5 | 0.974077 | 0.474 (49%) |
| 2.0 | 1.0 | 0.5 | 0.5 | 0.656631 | 0.157 (24%) |
| 1.0 | 2.0 | 2.0 | 2.0 | 2.126928 | 0.127 (6.0%) |
| 4.0 | 1.0 | 0.25 | 0.25 | 0.328315 | 0.078 (24%) |

## Changes

### 1. Kernel fix — `v_if(t < threshold)` → `v_if(t <= threshold)`

Fixed in all three softplus kernel variants:
- `tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h:103`
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h:103`
- `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softplus.h:58`

### 2. Parametrized boundary test case

Added a new `softplus_boundary` test variant in `test_sfpu_compute.cpp` with `beta=1.0, threshold=0.5` so that input `0.5` hits the boundary exactly (`t == threshold`). The test uses discrete input values `{-2.0, -0.5, 0.0, 0.5, 1.0, 2.0}` to deterministically exercise the boundary comparison.

The golden reference mirrors PyTorch semantics: `(t > threshold) ? input : log1p(exp(t)) / beta`.

## Testing

- [x] Code compiles (C++ syntax verified)
- [ ] Hardware CI (requires Tenstorrent device)
- [x] Boundary values verified by hand: at `x=0.5, beta=1.0, threshold=0.5`, `t == threshold` now enters the softplus branch and returns `log1p(exp(0.5)) ≈ 0.974` instead of `0.5`

## Checklist

- [x] Fix is minimal (one-character change per kernel file)
- [x] All three kernel variants (Wormhole B0, Blackhole, Quasar) fixed
- [x] Test case added that deterministically exercises the boundary
- [x] PR description explains the issue, impact, and fix
- [x] Linked to issue #53261