### PR TITLE
#54280: Re-center Kimi-K3-2.8T MoE perf baseline

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
@@ -56,9 +56,16 @@ _SEQ_LEN_PER_CHIP = 640
 # Capacity factor 5 carries over from K2.6, as in the pcc parametrize.
 _DISPATCH_BUFFER_CAPACITY_FACTOR = 5
 
-# Measured 2026-08-21 on an 8x4 BH galaxy (DDR 16000, 130W), warm forward, with the routed
-# experts folded into one program.
-_EXPECTED_NS = 12_210_765
+# Re-centered 2026-08-25 (issue #54280): the forward got ~4.6% FASTER and fell out the bottom of the
+# band, so the baseline was stale rather than the margin too tight. Likely source is #53968
+# (active-ERISC __global_pointer$ link fix, 2026-08-21 16:19 UTC) -- same suspect and direction as
+# #54220 on the Kimi-K2.6 traced chunked gate; the previous 12,210,765 was measured 2026-08-21,
+# plausibly just before it landed.
+#
+# Measured on an 8x4 BH galaxy (nominal DDR, high power), warm forward, routed experts folded into one
+# program: run 32811686276/job 97720001496 (main). Run 32728173507 independently measured 11,555,528 ns
+# at the same 31-program shape, 0.8% under this value and well inside the band.
+_EXPECTED_NS = 11_646_483
 # Repeated warm measurements on that box spanned 0.63% stdev / 1.89% peak to peak, so 3% holds
 # the observed run-to-run noise; sub-nominal DDR doubles it to 6% via adjust_margin_for_ddr_speed.
 # The baseline above is a single run, not the centre of a spread -- recentre it if a regression


### PR DESCRIPTION
### Problem

`test_kimi_k3_moe_perf_galaxy[blackhole-kimi_k3-torus-xy-8x4]` fails on main with the device time **below**
the −3% edge of `_EXPECTED_NS` — the forward got faster and the baseline is stale.

[Failing run 32811686276](https://github.com/tenstorrent/tt-metal/actions/runs/32811686276/job/97720001496)

```
device time 11,646,483 ns outside band [11,844,442, 12,577,088]
(expected 12,210,765 ns, margin +/- 3.0%)
```

### Fix

Set `_EXPECTED_NS` to the measurement from that run. **`_MARGIN` stays at 3%** — the band is not widened.

| | old | new |
|---|---|---|
| `_EXPECTED_NS` | 12,210,765 ns | **11,646,483 ns** (−4.6%) |
| band | [11,844,442, 12,577,088] | [11,297,089, 11,995,877] |
| `_MARGIN` | 3% | 3% (unchanged) |

Corroboration — a second independent run at the same 31-program shape:

| run | branch | measured | Δ vs new baseline |
|---|---|---|---|
| [32811686276](https://github.com/tenstorrent/tt-metal/actions/runs/32811686276/job/97720001496) | main | 11,646,483 ns | 0.0% |
| [32728173507](https://github.com/tenstorrent/tt-metal/actions/runs/32728173507) | ipotkonjak/blaze-k3-torus-xy-profile | 11,555,528 ns | −0.8% |

Both ran at nominal DDR (margin resolved to 3.0%, not the 6% `adjust_margin_for_ddr_speed` sub-nominal
path), so this is not a telemetry artifact.

Likely source: #53968 (active-ERISC `__global_pointer$` link fix, landed 2026-08-21 16:19 UTC). Both
failing runs include it, and the old baseline was annotated "Measured 2026-08-21" — plausibly just
before. Same suspect and direction as #54222 on the Kimi-K2.6 traced chunked gate.

### CI

`kimi_k3_moe_perf` only — one job: https://github.com/tenstorrent/tt-metal/actions/runs/32830082900

Closes #54280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/54280-recenter-k3-moe-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/54280-recenter-k3-moe-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/54280-recenter-k3-moe-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/54280-recenter-k3-moe-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/54280-recenter-k3-moe-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/54280-recenter-k3-moe-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/54280-recenter-k3-moe-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/54280-recenter-k3-moe-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/54280-recenter-k3-moe-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/54280-recenter-k3-moe-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/54280-recenter-k3-moe-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/54280-recenter-k3-moe-perf-baseline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/54280-recenter-k3-moe-perf-baseline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/54280-recenter-k3-moe-perf-baseline)