### PR TITLE
quad prefill runner in CI better logging 

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -290,21 +290,42 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
+      # archive:false makes the artifact URL a direct link to the PNG rather than a zip. Must precede the
+      # publish step below, which needs the URL.
+      - name: ⬆️ Upload prefill plots
+        id: upload-prefill-plots
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: prefill-plots-${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
+          path: ${{ env.PREFILL_SUMMARIES }}/plots/*.png
+          if-no-files-found: ignore
+          retention-days: 30
+          archive: false
+
       - name: 📊 Publish prefill summaries
         if: always() && !cancelled()
         continue-on-error: true
+        env:
+          PLOTS_URL: ${{ steps.upload-prefill-plots.outputs.artifact-url }}
         run: |
           shopt -s nullglob
           files=("$PREFILL_SUMMARIES"/perf/*.md "$PREFILL_SUMMARIES"/pcc/*.md)
           if [ ${#files[@]} -eq 0 ]; then
             echo "No prefill summary files under $PREFILL_SUMMARIES"
-            exit 0
           fi
           for f in "${files[@]}"; do
             # tee so the table shows in this step's log too, not only on the job-summary page.
             cat "$f" | tee -a "$GITHUB_STEP_SUMMARY"
             printf '\n' >> "$GITHUB_STEP_SUMMARY"
           done
+          # The job-summary sanitizer strips inlined images, so the gantt can only be offered as a link.
+          # Gate on the PNG existing: a failed matplotlib install leaves the artifact empty but still URL'd.
+          plots=("$PREFILL_SUMMARIES"/plots/*.png)
+          if [ -n "$PLOTS_URL" ] && [ ${#plots[@]} -gt 0 ]; then
+            printf '[Pipeline gantt (PNG)](%s)\n\n' "$PLOTS_URL" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "Published ${#files[@]} prefill summary file(s) to the job summary"
 
       # Keep the raw .md files for cross-run perf-trend analysis. Uploaded before cleanup; unique name per

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -5,8 +5,10 @@
 # Multi-galaxy disaggregated prefill cache-accuracy leg: a background N-rank runner opens the mesh, loads
 # the model, warmup-compiles and publishes the merged KV chunk table to shared NFS; a device-less producer
 # then feeds it, reads EVERY device cache the model published back over UMD (a sparse model's indexer key
-# cache as well as its KVPE cache) and PCCs each against the golden trace. The producer's
-# exit code is the verdict, so this script's exit code is the producer's.
+# cache as well as its KVPE cache) and PCCs each against the golden trace. The producer exits non-zero on a
+# PCC miss, but under mpirun-ulfm a lost producer daemon can still return 0 with zero caches validated, so
+# the exit code alone is not trusted: the leg is green only when a durable ok=true verdict exists for every
+# producer rank (the PCC gate near the end). Perf/timing are reported but never gate.
 #
 # Usage: run_multirank_pcc.sh <model-key>       # model-key selects a block in the case below
 #
@@ -20,12 +22,16 @@ MODEL="${1:?usage: run_multirank_pcc.sh <model-key>}"
 : "${PREFILL_SUMMARIES:?PREFILL_SUMMARIES must be set by the blaze impl (shared /ci scratch for the KV table)}"
 export PYTHONPATH="${TT_METAL_HOME}"
 MANIFEST_DIR="${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/tt/runners/manifests"
-MGD_DIR="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration"
+MGD_DIR="${TT_METAL_HOME}/models/demos/common/prefill/runners/topology_configuration/ci"
 
 # Shared defaults; a case block below overrides what its model needs. Each branch also names its own
 # scratch dir by swapping the summaries component out of PREFILL_SUMMARIES: that keeps the run-scoped leaf
 # and the shared-NFS root the blaze impl chose, while leaving the summaries dir itself alone.
-MAX_SEQ_LEN=56320
+CHUNK_SIZE=5120
+MAX_SEQ_LEN=256000
+GOLDEN_LEN=56320
+REAL_CHUNKS=$((MAX_SEQ_LEN / CHUNK_SIZE))
+WARMUP_CHUNKS=10
 PCC_THRESHOLD=0.85
 RUNNER_ENV=""
 PRODUCER_ENV=""
@@ -33,18 +39,16 @@ PRODUCER_ENV=""
 case "${MODEL}" in
   kimi27)
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/prefill_runner_kv}"
-    MGD="${MGD_DIR}/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto"
+    MGD="${MGD_DIR}/kimi27_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/kimi27.json"
-    # Dense MLA: one device cache, so the manifest's model + depth are all the producer needs. The runner
-    # needs the weight path on top: the K2.7 adapter inherits K2.6's reference default.
-    RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized;"
+    RUNNER_ENV="export PREFILL_HF_MODEL=/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized; export PREFILL_USE_TRACE=1;"
     PRODUCER_ENV="export PREFILL_PRODUCER_MANIFEST='${MANIFEST}';"
     ;;
   glm52)
     export PIPELINE_DIR="${PREFILL_SUMMARIES/prefill_summaries/glm52_prefill_runner_kv}"
     # LINE/LINE variant: GLM-5.2's MoE all_to_all deadlocks in warmup under the torus fabric modes on
     # multi-galaxy pipeline prefill, so the descriptor declares no wrap and the fabric mode stays 2d.
-    MGD="${MGD_DIR}/pipeline_prefill_4galaxy_connected_fabric2d_mesh_graph_descriptor.textproto"
+    MGD="${MGD_DIR}/glm52_mgd.textproto"
     MANIFEST="${MANIFEST_DIR}/glm52.json"
     # Sparse DSA: TWO device caches (MLA KVPE over all 78 layers + the lightning-indexer KEY cache over the
     # 21 `full` layers), both PCC'd. The trace must be the indexer-K dump -- the adapter's default golden
@@ -80,6 +84,8 @@ PCC_DIR="${MR_DIR}/pcc_verdict"
 # Per-rank stdout/stderr files (mpirun --output-filename). These survive the teardown race that truncates
 # forwarded stdout, so their tails are the authoritative debug log.
 RANKLOGS="${MR_DIR}/ranklogs"
+TIMING_DIR="${MR_DIR}/timing"
+mkdir -p "${TIMING_DIR}"
 
 # The runner idles owning the multi-galaxy allocation until the producer's shutdown sentinel; on any early
 # exit (table-publish timeout, producer failure) it must be reaped or it strands the hardware until the
@@ -103,6 +109,20 @@ cleanup() {
       echo "---- ${f#"${RANKLOGS}"/} ----"
       tail -n 40 "$f" 2>/dev/null || true
     done
+    python3 "${TT_METAL_HOME}/models/demos/common/prefill/runners/ci/summarize_ci_run.py" \
+      --ranklogs "${RANKLOGS}" --timing-dir "${TIMING_DIR}" --real-chunks "${REAL_CHUNKS}" \
+      --chunk-size "${CHUNK_SIZE}" --perf-window-chunks "${PERF_WINDOW_CHUNKS:-4}" \
+      || echo "summary generation failed (non-fatal)"
+    GANTT_DIR="${TT_METAL_HOME}/generated/test_logs"
+    mkdir -p "${GANTT_DIR}"
+    python3 -c "import matplotlib" 2>/dev/null \
+      || timeout 90 uv pip install --quiet matplotlib 2>/dev/null \
+      || timeout 90 python3 -m pip install --quiet matplotlib 2>/dev/null \
+      || echo "matplotlib install failed (gantt skipped, non-fatal)"
+    python3 "${TT_METAL_HOME}/models/demos/deepseek_v3_d_p/scripts/plot_pipeline_trace.py" \
+      --timing-dir "${TIMING_DIR}" --real-chunks "${REAL_CHUNKS}" \
+      -o "${GANTT_DIR}/${MODEL}_pipeline_gantt.png" \
+      || echo "gantt render failed (non-fatal)"
   fi
   rm -rf "${MR_DIR}"
 }
@@ -128,6 +148,8 @@ python3 "${TTRUN_PY}" \
     export PREFILL_MANIFEST='${MANIFEST}'; \
     export PREFILL_FABRIC_MODE=2d; \
     export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
+    export PREFILL_SYNC_PER_CHUNK=1; \
+    export PREFILL_TIMING_DIR='${TIMING_DIR}'; \
     export PREFILL_ENABLE_MIGRATION=1; \
     export PREFILL_MOCK_MIGRATION=1; \
     export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
@@ -165,6 +187,9 @@ set +e
     export PYTHONPATH='${TT_METAL_HOME}'; \
     export PYTHONUNBUFFERED=1; \
     export PREFILL_MAX_SEQ_LEN=${MAX_SEQ_LEN}; \
+    export PREFILL_PRODUCER_CHUNKS=${REAL_CHUNKS}; \
+    export PREFILL_PRODUCER_WARMUP_CHUNKS=${WARMUP_CHUNKS}; \
+    export PREFILL_PCC_GOLDEN_LEN=${GOLDEN_LEN}; \
     export PREFILL_MIGRATION_TABLE_PATH='${TABLE_PATH}'; \
     export PREFILL_PCC_SUMMARY_DIR='${PCC_DIR}'; \
     export PREFILL_PRODUCER_CHECK_PCC=1; \
@@ -184,4 +209,40 @@ if [ "${PROD_RC}" -eq 0 ]; then
   wait "${RUNNER_PID}" || echo "runner exited non-zero after producer success (rc=$?)"
 fi
 
-exit ${PROD_RC}
+# PCC gate. Read the durable per-rank verdicts before cleanup() rm's MR_DIR: require an ok=true verdict from
+# every producer rank (one per host in HOSTS). This catches the case the exit code misses -- a ULFM daemon
+# loss that returns 0 with no verdict written, or a rank that failed to validate. Perf/timing never gate.
+EXPECTED_RANKS=$(printf '%s' "${HOSTS}" | tr ',' '\n' | grep -c .)
+PCC_GATE_RC=0
+python3 - "${PCC_DIR}" "${EXPECTED_RANKS}" <<'PY' || PCC_GATE_RC=$?
+import glob, json, os, sys
+
+pcc_dir, expected = sys.argv[1], int(sys.argv[2])
+files = sorted(glob.glob(os.path.join(pcc_dir, "rank*.json")))
+if len(files) < expected:
+    print(f"PCC GATE FAIL: {len(files)}/{expected} producer verdict file(s) present", file=sys.stderr)
+    sys.exit(1)
+bad = 0
+for f in files:
+    name = os.path.basename(f)
+    try:
+        v = json.load(open(f))
+    except Exception as e:
+        print(f"PCC GATE FAIL: {name} unreadable: {e}", file=sys.stderr)
+        bad += 1
+        continue
+    status = "ok" if v.get("ok") else "FAIL"
+    print(f"  {name}: {status} min_pcc={v.get('min_pcc')} threshold={v.get('threshold')} per_cache={v.get('per_cache')}")
+    if not v.get("ok"):
+        bad += 1
+if bad:
+    print(f"PCC GATE FAIL: {bad}/{len(files)} rank(s) below threshold or unvalidated", file=sys.stderr)
+    sys.exit(1)
+print(f"PCC GATE PASS: {len(files)}/{expected} ranks ok, all caches >= threshold")
+PY
+
+# Green only when the producer exited clean AND every rank's PCC verdict is ok.
+if [ "${PROD_RC}" -ne 0 ]; then
+  exit "${PROD_RC}"
+fi
+exit "${PCC_GATE_RC}"

--- a/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
+++ b/models/demos/common/prefill/runners/ci/run_multirank_pcc.sh
@@ -112,8 +112,11 @@ cleanup() {
     python3 "${TT_METAL_HOME}/models/demos/common/prefill/runners/ci/summarize_ci_run.py" \
       --ranklogs "${RANKLOGS}" --timing-dir "${TIMING_DIR}" --real-chunks "${REAL_CHUNKS}" \
       --chunk-size "${CHUNK_SIZE}" --perf-window-chunks "${PERF_WINDOW_CHUNKS:-4}" \
+      --summary-name "${MODEL}" \
       || echo "summary generation failed (non-fatal)"
-    GANTT_DIR="${TT_METAL_HOME}/generated/test_logs"
+    # Under PREFILL_SUMMARIES rather than generated/test_logs: the blaze impl uploads that root with
+    # archive:false, which yields a direct PNG link on the job-summary page instead of a log zip to unpack.
+    GANTT_DIR="${PREFILL_SUMMARIES}/plots"
     mkdir -p "${GANTT_DIR}"
     python3 -c "import matplotlib" 2>/dev/null \
       || timeout 90 uv pip install --quiet matplotlib 2>/dev/null \

--- a/models/demos/common/prefill/runners/ci/summarize_ci_run.py
+++ b/models/demos/common/prefill/runners/ci/summarize_ci_run.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+"""Render the two end-of-run matrices for the disaggregated-prefill CI leg from the durable per-rank
+ranklogs (mpirun --output-filename), which survive the teardown race that truncates forwarded stdout:
+
+  * per-layer x per-cache PCC vs golden  -- from the producer ranks' "slot .. layer .. PCC" lines
+  * per-rank x per-chunk start/end time  -- from the runner ranks' CHUNK_START / CHUNK_COMPUTE lines
+
+Each producer rank validates only its own host's layers, so the PCC rows are the union across ranklogs.
+Runner timing is meaningful only with PREFILL_SYNC_PER_CHUNK=1 (else CHUNK_COMPUTE is never emitted). The
+measured request is the last --real-chunks chunks per rank; any earlier chunks are the discarded warmup.
+"""
+import argparse
+import os
+import re
+
+_KV = re.compile(r"slot\s+(\d+)\s+layer\s+(\d+)\s+KV PCC:\s+nope=([-\d.]+)\s+pe=([-\d.]+)")
+_INDEX = re.compile(r"slot\s+(\d+)\s+layer\s+(\d+)\s+\(index rank\s+(\d+)\)\s+index PCC:\s+([-\d.]+)")
+_CHUNK_START = re.compile(r"\[pp rank (\d+)\] CHUNK_START c=(\d+) compute_start=([\d.]+)")
+_CHUNK_COMPUTE = re.compile(r"\[pp rank (\d+)\] CHUNK_COMPUTE c=(\d+) compute_ms=([\d.]+)")
+
+
+def _iter_lines(root):
+    for dirpath, _dirs, files in os.walk(root):
+        for name in sorted(files):
+            path = os.path.join(dirpath, name)
+            try:
+                with open(path, errors="replace") as fh:
+                    for line in fh:
+                        yield line
+            except OSError:
+                continue
+
+
+def _pcc_matrix(root):
+    layers = {}
+    have_index = False
+    for line in _iter_lines(root):
+        m = _KV.search(line)
+        if m:
+            layer, nope, pe = int(m.group(2)), float(m.group(3)), float(m.group(4))
+            cell = layers.setdefault(layer, {})
+            cell["nope"] = min(nope, cell.get("nope", nope))
+            cell["pe"] = min(pe, cell.get("pe", pe))
+            continue
+        m = _INDEX.search(line)
+        if m:
+            layer, idx = int(m.group(2)), float(m.group(4))
+            cell = layers.setdefault(layer, {})
+            cell["index"] = min(idx, cell.get("index", idx))
+            have_index = True
+
+    print("==================== per-layer x per-cache KV PCC vs golden ====================")
+    if not layers:
+        print("no per-layer PCC lines found in ranklogs (producer verify may not have run)")
+        return
+    header = f"{'layer':>5}  {'kvpe.nope':>10}  {'kvpe.pe':>10}" + (f"  {'index':>10}" if have_index else "")
+    print(header)
+    worst = 1.0
+    for layer in sorted(layers):
+        cell = layers[layer]
+        row = f"{layer:>5}  {cell.get('nope', float('nan')):>10.5f}  {cell.get('pe', float('nan')):>10.5f}"
+        if have_index:
+            row += f"  {cell.get('index', float('nan')):>10.5f}" if "index" in cell else f"  {'-':>10}"
+        print(row)
+        worst = min([worst] + [v for v in cell.values()])
+    print(f"{'min':>5}  (worst cell across all layers/caches) -> {worst:.6f}")
+
+
+def _timing_from_csvs(timing_dir):
+    if not timing_dir or not os.path.isdir(timing_dir):
+        return None
+    ranks = {}
+    for name in sorted(os.listdir(timing_dir)):
+        if not name.endswith(".csv"):
+            continue
+        try:
+            with open(os.path.join(timing_dir, name), errors="replace") as fh:
+                for line in fh:
+                    parts = line.strip().split(",")
+                    if len(parts) != 4:
+                        continue
+                    try:
+                        rank, c, start, ms = int(parts[0]), int(parts[1]), float(parts[2]), float(parts[3])
+                    except ValueError:
+                        continue
+                    ranks.setdefault(rank, {})[c] = [start, ms]
+        except OSError:
+            continue
+    return ranks or None
+
+
+def _timing_from_ranklogs(root):
+    ranks = {}
+    for line in _iter_lines(root):
+        m = _CHUNK_START.search(line)
+        if m:
+            ranks.setdefault(int(m.group(1)), {}).setdefault(int(m.group(2)), [None, None])[0] = float(m.group(3))
+            continue
+        m = _CHUNK_COMPUTE.search(line)
+        if m:
+            ranks.setdefault(int(m.group(1)), {}).setdefault(int(m.group(2)), [None, None])[1] = float(m.group(3))
+    return ranks
+
+
+def _end(cell):
+    start, ms = cell
+    return None if (start is None or ms is None) else start + ms / 1000.0
+
+
+def _select_measured(ranks, real_chunks):
+    kept = {}
+    cs_union = set()
+    for rank, cells in ranks.items():
+        cs = sorted(cells)
+        sel = cs[-real_chunks:] if real_chunks > 0 else cs
+        kept[rank] = {c: cells[c] for c in sel}
+        cs_union.update(sel)
+    cs_sorted = sorted(cs_union)
+    disp = {c: i for i, c in enumerate(cs_sorted)}
+    return kept, cs_sorted, disp
+
+
+def _cell_metrics(kept, disp):
+    inv = {i: c for c, i in disp.items()}
+    ct, end = {}, {}
+    for d, c in inv.items():
+        starts = [kept[r][c][0] for r in kept if c in kept[r] and kept[r][c][0] is not None]
+        ends = [_end(kept[r][c]) for r in kept if c in kept[r] and _end(kept[r][c]) is not None]
+        if starts and ends:
+            ct[d] = (max(ends) - min(starts)) * 1000.0
+            end[d] = max(ends)
+    t0 = None
+    if 0 in inv:
+        s0 = [kept[r][inv[0]][0] for r in kept if inv[0] in kept[r] and kept[r][inv[0]][0] is not None]
+        t0 = min(s0) if s0 else None
+    ttft = {d: end[d] - t0 for d in end} if t0 is not None else {}
+    return ct, ttft
+
+
+def _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks):
+    n = len(cs_sorted)
+    if n == 0:
+        return
+    max_seq = n * chunk_size
+    ct, ttft = _cell_metrics(kept, disp)
+
+    def idx(tok):
+        return max(0, min(n - 1, tok // chunk_size))
+
+    print("==================== perf metrics (measured request, warmup excluded) ====================")
+    print(f"max_seq={max_seq} tok ({n} chunks x {chunk_size}); offsets snapped to the containing chunk")
+    print("chunk_time = first-rank start -> last-rank finish (cross-rank; assumes NTP-comparable clocks)")
+    for lbl, tok in (
+        ("5k@0", 0),
+        ("5k@50k", 50000),
+        ("5k@max_seq/2", max_seq // 2),
+        ("5k@max_seq-5k", max_seq - chunk_size),
+    ):
+        d = idx(tok)
+        val = f"{ct[d]:>12.3f}" if d in ct else f"{'-':>12}"
+        print(f"  chunk_time {lbl:>14} (chunk {d:>3}): {val} ms")
+    print("ttft = request start -> chunk finish")
+    for lbl, tok in (("@50k", 50000), ("@max_seq/2", max_seq // 2), ("@max_seq", max_seq)):
+        d = idx(tok)
+        val = f"{ttft[d]:>12.3f}" if d in ttft else f"{'-':>12}"
+        print(f"  ttft       {lbl:>14} (chunk {d:>3}): {val} s")
+
+    rank0 = min(kept)
+    inv = {i: c for c, i in disp.items()}
+    print(f"throughput = rank{rank0} start->start rate over the {win_chunks} chunks ending at the offset")
+    for lbl, tok in (("@50k", 50000), ("@max_seq/2", max_seq // 2), ("@max_seq", max_seq)):
+        d = idx(tok)
+        first = max(0, d - win_chunks + 1)
+        ca, cb = inv.get(first), inv.get(d)
+        usable = first < d and ca is not None and cb is not None and ca in kept[rank0] and cb in kept[rank0]
+        sa = kept[rank0][ca][0] if usable else None
+        sb = kept[rank0][cb][0] if usable else None
+        span = f"chunks {first:>3}..{d:>3}"
+        if sa is None or sb is None or sb <= sa:
+            print(f"  throughput {lbl:>14} ({span}): {'-':>12}")
+            continue
+        # start->start spans (d - first) inter-chunk intervals, i.e. that many chunks dispatched in dt.
+        dt = sb - sa
+        tokens = (d - first) * chunk_size
+        print(f"  throughput {lbl:>14} ({span}): {tokens / dt:>12,.1f} tok/s  ({dt:.3f} s)")
+
+
+def _timing_matrix(root, real_chunks, timing_dir=None, chunk_size=0, win_chunks=4):
+    ranks = _timing_from_csvs(timing_dir)
+    if ranks is None:
+        ranks = _timing_from_ranklogs(root)
+
+    print("==================== per-rank x per-chunk timing (measured request) ====================")
+    if not ranks:
+        print("no timing rows found (set PREFILL_SYNC_PER_CHUNK=1 on the runner; timing CSVs / CHUNK_* logs absent)")
+        return
+    kept, cs_sorted, disp = _select_measured(ranks, real_chunks)
+    all_starts = [c[0] for r in kept.values() for c in r.values() if c[0] is not None]
+    if not all_starts:
+        print("timing rows present but no compute_start timestamps parsed")
+        return
+    t0 = min(all_starts)
+    print(f"start/end are seconds relative to the earliest chunk start ({t0:.6f} epoch); ms = device compute time")
+    print(f"{'rank':>4}  {'chunk':>5}  {'start_s':>10}  {'end_s':>10}  {'ms':>9}")
+    for rank in sorted(kept):
+        for c in sorted(kept[rank]):
+            start, ms = kept[rank][c]
+            start_s = f"{start - t0:>10.3f}" if start is not None else f"{'-':>10}"
+            end_s = f"{start - t0 + ms / 1000.0:>10.3f}" if (start is not None and ms is not None) else f"{'-':>10}"
+            ms_s = f"{ms:>9.3f}" if ms is not None else f"{'-':>9}"
+            print(f"{rank:>4}  {disp[c]:>5}  {start_s}  {end_s}  {ms_s}")
+
+    if chunk_size > 0:
+        _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ranklogs", required=True, help="mpirun --output-filename root (runner + producer)")
+    ap.add_argument("--timing-dir", default=None, help="per-rank timing CSV dir (preferred timing source)")
+    ap.add_argument("--real-chunks", type=int, default=0, help="chunks in the measured request (0 => all)")
+    ap.add_argument("--chunk-size", type=int, default=0, help="tokens per chunk (0 => skip throughput)")
+    ap.add_argument("--perf-window-chunks", type=int, default=4, help="chunks per throughput window at each offset")
+    args = ap.parse_args()
+    if not os.path.isdir(args.ranklogs):
+        print(f"ranklogs dir {args.ranklogs} not found; nothing to summarize")
+        return
+    _pcc_matrix(args.ranklogs)
+    _timing_matrix(args.ranklogs, args.real_chunks, args.timing_dir, args.chunk_size, args.perf_window_chunks)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/common/prefill/runners/ci/summarize_ci_run.py
+++ b/models/demos/common/prefill/runners/ci/summarize_ci_run.py
@@ -13,6 +13,7 @@ measured request is the last --real-chunks chunks per rank; any earlier chunks a
 import argparse
 import os
 import re
+import sys
 
 _KV = re.compile(r"slot\s+(\d+)\s+layer\s+(\d+)\s+KV PCC:\s+nope=([-\d.]+)\s+pe=([-\d.]+)")
 _INDEX = re.compile(r"slot\s+(\d+)\s+layer\s+(\d+)\s+\(index rank\s+(\d+)\)\s+index PCC:\s+([-\d.]+)")
@@ -138,19 +139,102 @@ def _cell_metrics(kept, disp):
     return ct, ttft
 
 
+def _chunk_plot(kept, disp, height=15, width=100):
+    """Overlay per-rank device time against chunk index as characters.
+
+    The job-summary page renders markdown only -- its sanitizer strips inlined images -- so the shape of
+    the curve has to be drawn in text to be readable without fetching the gantt PNG.
+    """
+    ranks = sorted(kept)
+    inv = {i: c for c, i in disp.items()}
+    n = len(inv)
+    if not ranks or n == 0:
+        return []
+    # One column per chunk until the run outgrows the width, then fold with max() so that a single
+    # stalled chunk still shows up instead of being averaged into its neighbours.
+    cols = min(n, width)
+    series = {}
+    for r in ranks:
+        col = {}
+        for d in range(n):
+            c = inv.get(d)
+            ms = kept[r].get(c, [None, None])[1] if c is not None else None
+            if ms is None:
+                continue
+            x = d * cols // n
+            col[x] = max(col.get(x, ms), ms)
+        series[r] = col
+    vals = [v for col in series.values() for v in col.values()]
+    if not vals:
+        return []
+    lo, hi = min(vals), max(vals)
+    span = (hi - lo) or 1.0
+    marks = "0123456789abcdefghijklmnopqrstuvwxyz"
+    grid = [[" "] * cols for _ in range(height)]
+    for i, r in enumerate(ranks):
+        mark = marks[i] if i < len(marks) else "?"
+        for x, v in series[r].items():
+            row = int(round((1 - (v - lo) / span) * (height - 1)))
+            grid[row][x] = mark if grid[row][x] == " " else "*"
+
+    legend = ", ".join(f"{marks[i] if i < len(marks) else '?'}=rank{r}" for i, r in enumerate(ranks))
+    lines = [
+        "==================== per-chunk device time by rank (measured request) ====================",
+        f"ms vs chunk index; {legend}, *=two or more ranks in one cell",
+    ]
+    lines += [f"{lo + (1 - row / (height - 1)) * span:8.0f} |" + "".join(grid[row]) for row in range(height)]
+    lines.append(" " * 9 + "+" + "-" * cols)
+    ticks = [" "] * cols
+    for d in range(0, n, 10):
+        x = d * cols // n
+        for k, ch in enumerate(str(d)):
+            if x + k < cols and ticks[x + k] == " ":
+                ticks[x + k] = ch
+    lines.append(" " * 10 + "".join(ticks))
+
+    hdr = f"{'rank':>5} {'min':>9} {'median':>9} {'max':>9} {'first':>9} {'last':>9}"
+    lines += ["", hdr, "-" * len(hdr)]
+    for r in ranks:
+        v = [kept[r][c][1] for c in sorted(kept[r]) if kept[r][c][1] is not None]
+        if not v:
+            continue
+        o = sorted(v)
+        med = o[len(o) // 2] if len(o) % 2 else (o[len(o) // 2 - 1] + o[len(o) // 2]) / 2.0
+        lines.append(f"{r:>5} {min(v):>9.0f} {med:>9.0f} {max(v):>9.0f} {v[0]:>9.0f} {v[-1]:>9.0f}")
+    return lines
+
+
+def _publish(lines, name):
+    """Print the perf block, and when named also drop it where the CI publish step globs for it."""
+    title = f"disaggregated prefill perf -- {name or 'run'}"
+    if name:
+        home = os.environ.get("TT_METAL_HOME")
+        if home and home not in sys.path:
+            sys.path.insert(0, home)
+        try:
+            from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import emit_summary
+
+            emit_summary("perf", name, title, lines)
+            return
+        except Exception as exc:  # publishing is a reporting nicety; never lose the block over it
+            print(f"perf summary not published ({exc})")
+    print(title)
+    print("\n".join(lines))
+
+
 def _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks):
     n = len(cs_sorted)
     if n == 0:
-        return
+        return []
     max_seq = n * chunk_size
     ct, ttft = _cell_metrics(kept, disp)
 
     def idx(tok):
         return max(0, min(n - 1, tok // chunk_size))
 
-    print("==================== perf metrics (measured request, warmup excluded) ====================")
-    print(f"max_seq={max_seq} tok ({n} chunks x {chunk_size}); offsets snapped to the containing chunk")
-    print("chunk_time = first-rank start -> last-rank finish (cross-rank; assumes NTP-comparable clocks)")
+    out = ["==================== perf metrics (measured request, warmup excluded) ===================="]
+    out.append(f"max_seq={max_seq} tok ({n} chunks x {chunk_size}); offsets snapped to the containing chunk")
+    out.append("chunk_time = first-rank start -> last-rank finish (cross-rank; assumes NTP-comparable clocks)")
     for lbl, tok in (
         ("5k@0", 0),
         ("5k@50k", 50000),
@@ -159,16 +243,16 @@ def _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks):
     ):
         d = idx(tok)
         val = f"{ct[d]:>12.3f}" if d in ct else f"{'-':>12}"
-        print(f"  chunk_time {lbl:>14} (chunk {d:>3}): {val} ms")
-    print("ttft = request start -> chunk finish")
+        out.append(f"  chunk_time {lbl:>14} (chunk {d:>3}): {val} ms")
+    out.append("ttft = request start -> chunk finish")
     for lbl, tok in (("@50k", 50000), ("@max_seq/2", max_seq // 2), ("@max_seq", max_seq)):
         d = idx(tok)
         val = f"{ttft[d]:>12.3f}" if d in ttft else f"{'-':>12}"
-        print(f"  ttft       {lbl:>14} (chunk {d:>3}): {val} s")
+        out.append(f"  ttft       {lbl:>14} (chunk {d:>3}): {val} s")
 
     rank0 = min(kept)
     inv = {i: c for c, i in disp.items()}
-    print(f"throughput = rank{rank0} start->start rate over the {win_chunks} chunks ending at the offset")
+    out.append(f"throughput = rank{rank0} start->start rate over the {win_chunks} chunks ending at the offset")
     for lbl, tok in (("@50k", 50000), ("@max_seq/2", max_seq // 2), ("@max_seq", max_seq)):
         d = idx(tok)
         first = max(0, d - win_chunks + 1)
@@ -178,12 +262,13 @@ def _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks):
         sb = kept[rank0][cb][0] if usable else None
         span = f"chunks {first:>3}..{d:>3}"
         if sa is None or sb is None or sb <= sa:
-            print(f"  throughput {lbl:>14} ({span}): {'-':>12}")
+            out.append(f"  throughput {lbl:>14} ({span}): {'-':>12}")
             continue
         # start->start spans (d - first) inter-chunk intervals, i.e. that many chunks dispatched in dt.
         dt = sb - sa
         tokens = (d - first) * chunk_size
-        print(f"  throughput {lbl:>14} ({span}): {tokens / dt:>12,.1f} tok/s  ({dt:.3f} s)")
+        out.append(f"  throughput {lbl:>14} ({span}): {tokens / dt:>12,.1f} tok/s  ({dt:.3f} s)")
+    return out
 
 
 def _timing_matrix(root, real_chunks, timing_dir=None, chunk_size=0, win_chunks=4):
@@ -194,12 +279,12 @@ def _timing_matrix(root, real_chunks, timing_dir=None, chunk_size=0, win_chunks=
     print("==================== per-rank x per-chunk timing (measured request) ====================")
     if not ranks:
         print("no timing rows found (set PREFILL_SYNC_PER_CHUNK=1 on the runner; timing CSVs / CHUNK_* logs absent)")
-        return
+        return []
     kept, cs_sorted, disp = _select_measured(ranks, real_chunks)
     all_starts = [c[0] for r in kept.values() for c in r.values() if c[0] is not None]
     if not all_starts:
         print("timing rows present but no compute_start timestamps parsed")
-        return
+        return []
     t0 = min(all_starts)
     print(f"start/end are seconds relative to the earliest chunk start ({t0:.6f} epoch); ms = device compute time")
     print(f"{'rank':>4}  {'chunk':>5}  {'start_s':>10}  {'end_s':>10}  {'ms':>9}")
@@ -211,8 +296,10 @@ def _timing_matrix(root, real_chunks, timing_dir=None, chunk_size=0, win_chunks=
             ms_s = f"{ms:>9.3f}" if ms is not None else f"{'-':>9}"
             print(f"{rank:>4}  {disp[c]:>5}  {start_s}  {end_s}  {ms_s}")
 
+    lines = _chunk_plot(kept, disp)
     if chunk_size > 0:
-        _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks)
+        lines += [""] + _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks)
+    return lines
 
 
 def main():
@@ -222,12 +309,17 @@ def main():
     ap.add_argument("--real-chunks", type=int, default=0, help="chunks in the measured request (0 => all)")
     ap.add_argument("--chunk-size", type=int, default=0, help="tokens per chunk (0 => skip throughput)")
     ap.add_argument("--perf-window-chunks", type=int, default=4, help="chunks per throughput window at each offset")
+    ap.add_argument(
+        "--summary-name", default=None, help="publish the perf block under PREFILL_SUMMARIES/perf/<name>.md"
+    )
     args = ap.parse_args()
     if not os.path.isdir(args.ranklogs):
         print(f"ranklogs dir {args.ranklogs} not found; nothing to summarize")
         return
     _pcc_matrix(args.ranklogs)
-    _timing_matrix(args.ranklogs, args.real_chunks, args.timing_dir, args.chunk_size, args.perf_window_chunks)
+    lines = _timing_matrix(args.ranklogs, args.real_chunks, args.timing_dir, args.chunk_size, args.perf_window_chunks)
+    if lines:
+        _publish(lines, args.summary_name)
 
 
 if __name__ == "__main__":

--- a/models/demos/common/prefill/runners/ci/summarize_ci_run.py
+++ b/models/demos/common/prefill/runners/ci/summarize_ci_run.py
@@ -139,71 +139,6 @@ def _cell_metrics(kept, disp):
     return ct, ttft
 
 
-def _chunk_plot(kept, disp, height=15, width=100):
-    """Overlay per-rank device time against chunk index as characters.
-
-    The job-summary page renders markdown only -- its sanitizer strips inlined images -- so the shape of
-    the curve has to be drawn in text to be readable without fetching the gantt PNG.
-    """
-    ranks = sorted(kept)
-    inv = {i: c for c, i in disp.items()}
-    n = len(inv)
-    if not ranks or n == 0:
-        return []
-    # One column per chunk until the run outgrows the width, then fold with max() so that a single
-    # stalled chunk still shows up instead of being averaged into its neighbours.
-    cols = min(n, width)
-    series = {}
-    for r in ranks:
-        col = {}
-        for d in range(n):
-            c = inv.get(d)
-            ms = kept[r].get(c, [None, None])[1] if c is not None else None
-            if ms is None:
-                continue
-            x = d * cols // n
-            col[x] = max(col.get(x, ms), ms)
-        series[r] = col
-    vals = [v for col in series.values() for v in col.values()]
-    if not vals:
-        return []
-    lo, hi = min(vals), max(vals)
-    span = (hi - lo) or 1.0
-    marks = "0123456789abcdefghijklmnopqrstuvwxyz"
-    grid = [[" "] * cols for _ in range(height)]
-    for i, r in enumerate(ranks):
-        mark = marks[i] if i < len(marks) else "?"
-        for x, v in series[r].items():
-            row = int(round((1 - (v - lo) / span) * (height - 1)))
-            grid[row][x] = mark if grid[row][x] == " " else "*"
-
-    legend = ", ".join(f"{marks[i] if i < len(marks) else '?'}=rank{r}" for i, r in enumerate(ranks))
-    lines = [
-        "==================== per-chunk device time by rank (measured request) ====================",
-        f"ms vs chunk index; {legend}, *=two or more ranks in one cell",
-    ]
-    lines += [f"{lo + (1 - row / (height - 1)) * span:8.0f} |" + "".join(grid[row]) for row in range(height)]
-    lines.append(" " * 9 + "+" + "-" * cols)
-    ticks = [" "] * cols
-    for d in range(0, n, 10):
-        x = d * cols // n
-        for k, ch in enumerate(str(d)):
-            if x + k < cols and ticks[x + k] == " ":
-                ticks[x + k] = ch
-    lines.append(" " * 10 + "".join(ticks))
-
-    hdr = f"{'rank':>5} {'min':>9} {'median':>9} {'max':>9} {'first':>9} {'last':>9}"
-    lines += ["", hdr, "-" * len(hdr)]
-    for r in ranks:
-        v = [kept[r][c][1] for c in sorted(kept[r]) if kept[r][c][1] is not None]
-        if not v:
-            continue
-        o = sorted(v)
-        med = o[len(o) // 2] if len(o) % 2 else (o[len(o) // 2 - 1] + o[len(o) // 2]) / 2.0
-        lines.append(f"{r:>5} {min(v):>9.0f} {med:>9.0f} {max(v):>9.0f} {v[0]:>9.0f} {v[-1]:>9.0f}")
-    return lines
-
-
 def _publish(lines, name):
     """Print the perf block, and when named also drop it where the CI publish step globs for it."""
     title = f"disaggregated prefill perf -- {name or 'run'}"
@@ -296,10 +231,9 @@ def _timing_matrix(root, real_chunks, timing_dir=None, chunk_size=0, win_chunks=
             ms_s = f"{ms:>9.3f}" if ms is not None else f"{'-':>9}"
             print(f"{rank:>4}  {disp[c]:>5}  {start_s}  {end_s}  {ms_s}")
 
-    lines = _chunk_plot(kept, disp)
     if chunk_size > 0:
-        lines += [""] + _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks)
-    return lines
+        return _perf_metrics(kept, cs_sorted, disp, chunk_size, win_chunks)
+    return []
 
 
 def main():

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -724,6 +724,9 @@ def _read_slot_kv_and_check_pcc(table, device_map: dict, slot_id: int, real_len:
     The MODEL's own caches only. Under DFlash the drafter's context caches ride in the same table under
     further `dflash_*` configs, checked as a sibling gate from _verify_resident_slots (see
     dflash_kv_table_pcc_check in the deepseek dflash_prefill module)."""
+    golden_cap = int(os.environ.get("PREFILL_PCC_GOLDEN_LEN", "0"))
+    if golden_cap:
+        real_len = min(real_len, golden_cap)
     if ADAPTER.name == "minimax_m3":
         return _read_slot_kv_and_check_pcc_m3(table, device_map, slot_id, real_len, trace_dir)
     if ADAPTER.name == "gpt_oss_d_p":
@@ -1460,6 +1463,16 @@ def main() -> None:
         push_start = time.perf_counter()
         service.forward_to_tensor_bytes(chunk_bytes, metadata=_pack_metadata(slot_id, actual_start, actual_end))
         return (time.perf_counter() - push_start) * 1000.0
+
+    warmup_chunks = int(os.environ.get("PREFILL_PRODUCER_WARMUP_CHUNKS", "0"))
+    if warmup_chunks > 0:
+        logger.info(f"[producer] warmup: {warmup_chunks} throwaway chunk(s) on slot 0 (not timed, not verified)")
+        for cidx in range(warmup_chunks):
+            push_chunk(0, cidx, cidx * CHUNK_SIZE, (cidx + 1) * CHUNK_SIZE)
+        service.barrier()
+        if ack_channel is not None:
+            _drain_layer_acks(ack_channel, NUM_LAYERS * warmup_chunks)
+        logger.info("[producer] warmup complete; starting the measured request")
 
     stats = run_schedule(cfg, push_fn=push_chunk)
     service.barrier()

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -146,6 +146,7 @@ DFLASH_ENABLED = (
 # Measurement-only: synchronize the device after each chunk's forward and log the isolated per-rank
 # compute (CHUNK_COMPUTE). Off in production — the sync serializes dispatch and kills pipeline overlap.
 SYNC_PER_CHUNK = os.environ.get("PREFILL_SYNC_PER_CHUNK", "0") == "1"
+TIMING_DIR = os.environ.get("PREFILL_TIMING_DIR", "")
 # Some models (e.g. Kimi: single expert group, device gate) route the MoE routing all-gather's global
 # semaphores to L1_SMALL so they don't pin the main-L1 floor and clash with the next layer's MLA static
 # CBs, which needs the mesh opened with an L1_SMALL region. The adapter owns both knobs.
@@ -414,6 +415,21 @@ def _lease_reclaim(d2d_in, d2d_out) -> None:
         d2d_in.release_fabric_links()
 
 
+def _record_chunk_timing(rank: int, c: int, compute_start: float, compute_ms: float) -> None:
+    """Append one chunk's timing to this rank's CSV via a single O_APPEND write (per-rank file => lone
+    writer, atomic even on NFS). Telemetry must never take down the run, so any write error is swallowed."""
+    if not TIMING_DIR:
+        return
+    try:
+        fd = os.open(os.path.join(TIMING_DIR, f"rank{rank}.csv"), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, f"{rank},{c},{compute_start:.6f},{compute_ms:.3f}\n".encode())
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+
+
 def _compute_and_send(
     runtime, kv_caches, rank: int, c: int, inp, meta: dict, d2d_out, d2h_service=None, record_dev=None
 ) -> float:
@@ -422,7 +438,10 @@ def _compute_and_send(
     (NTP-comparable). CHUNK_START is logged BEFORE the forward, with this chunk's metadata, so the
     slot/KV-range is visible per rank even if prefill_chunk hangs. The trailing metadata is kept after
     compute_start so the c=/compute_start= fields stay parseable (plot_pipeline_trace.py)."""
+    if SYNC_PER_CHUNK:
+        ttnn.synchronize_device(runtime.mesh_device)
     t_start = time.time()
+    t_perf = time.perf_counter()
     logger.info(
         f"[pp rank {rank}] CHUNK_START c={c} compute_start={t_start:.6f} "
         f"slot={meta['slot_id']} [{meta['actual_start']},{meta['actual_end']})"
@@ -441,7 +460,9 @@ def _compute_and_send(
         # Block on device completion so the delta is this rank's forward alone, not the downstream-start
         # proxy. Serializes dispatch (no overlap) — measurement runs only.
         ttnn.synchronize_device(runtime.mesh_device)
-        logger.info(f"[pp rank {rank}] CHUNK_COMPUTE c={c} compute_ms={(time.time() - t_start) * 1000.0:.3f}")
+        compute_ms = (time.perf_counter() - t_perf) * 1000.0
+        logger.info(f"[pp rank {rank}] CHUNK_COMPUTE c={c} compute_ms={compute_ms:.3f}")
+        _record_chunk_timing(rank, c, t_start, compute_ms)
     if not runtime.config.is_last_rank:
         # Traced: `out` is the runtime's persistent _trace_output (the next replay overwrites it in place),
         # so the send copies it into the socket backing but must not free it. Eager: `out` is fresh — free it.
@@ -1065,6 +1086,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             master_rank=master_rank,
             ring_shm_name=ring_shm_name,
             scheduler_channel_shm_name=ack_shm_name if rank == master_rank else "",
+            teardown_timeout_ms=30000,
         )
         if use_d2h:
             # Device-record source. The reader thread reconstructs (chunk, global-layer) from a per-rank

--- a/models/demos/common/prefill/runners/topology_configuration/ci/glm52_mgd.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/ci/glm52_mgd.textproto
@@ -1,0 +1,34 @@
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, LINE ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/common/prefill/runners/topology_configuration/ci/kimi27_mgd.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/ci/kimi27_mgd.textproto
@@ -1,0 +1,34 @@
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 8, 4 ] dim_types: [ RING, RING ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels { count: 2 policy: RELAXED }
+}
+
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/deepseek_v3_d_p/scripts/plot_pipeline_trace.py
+++ b/models/demos/deepseek_v3_d_p/scripts/plot_pipeline_trace.py
@@ -14,9 +14,16 @@ CHUNK_START epoch and the post-loop E2E_CLOCK; a chunk's bar runs start(r,c) -> 
 last chunk uses last_compute_end), i.e. compute + any idle wait for the next chunk.
 
     python -m models.demos.deepseek_v3_d_p.scripts.plot_pipeline_trace <run.log> [-o out.png]
+
+Or, for gapless data under per-chunk sync, read the runner's per-rank timing CSVs directly instead of
+the fd-race-prone combined log:
+
+    python -m models.demos.deepseek_v3_d_p.scripts.plot_pipeline_trace --timing-dir <PREFILL_TIMING_DIR> [-o out.png]
 """
 
 import argparse
+import glob
+import os
 import re
 from collections import defaultdict
 
@@ -59,6 +66,45 @@ def parse(path):
     return starts, last_end, measured
 
 
+def parse_timing_dir(d):
+    """-> the same (starts, last_end, measured) as parse(), from the per-rank timing CSVs the runner
+    appends under PREFILL_TIMING_DIR (rank,c,compute_start,compute_ms). These bypass the shared-stdout
+    fd race that splices C++ lines into the CHUNK_* log records, so this source is gapless."""
+    starts = defaultdict(dict)
+    measured = defaultdict(dict)
+    last_end = {}
+    for path in sorted(glob.glob(os.path.join(d, "rank*.csv"))):
+        with open(path, errors="ignore") as f:
+            for line in f:
+                parts = line.strip().split(",")
+                if len(parts) != 4:
+                    continue
+                try:
+                    rank, c, cs, ms = int(parts[0]), int(parts[1]), float(parts[2]), float(parts[3])
+                except ValueError:
+                    continue
+                starts[rank][c] = cs
+                measured[rank][c] = ms / 1000.0
+                last_end[rank] = max(last_end.get(rank, 0.0), cs + ms / 1000.0)
+    if not starts:
+        raise SystemExit(f"no rank*.csv timing rows found under {d}")
+    return starts, last_end, measured
+
+
+def trim_to_last(starts, last_end, measured, n):
+    """Keep only the last n chunk indices, dropping the producer's warmup chunks so the chart shows the
+    same real-request window the summarizer reports. last_end is rebuilt from the kept ends so the final
+    bar isn't clipped."""
+    all_c = sorted({c for r in starts for c in starts[r]})
+    if n is None or n >= len(all_c):
+        return starts, last_end, measured
+    keep = set(all_c[-n:])
+    starts = {r: d2 for r, d in starts.items() if (d2 := {c: v for c, v in d.items() if c in keep})}
+    measured = {r: {c: v for c, v in measured.get(r, {}).items() if c in keep} for r in starts}
+    last_end = {r: max(starts[r][c] + measured.get(r, {}).get(c, 0.0) for c in starts[r]) for r in starts}
+    return starts, last_end, measured
+
+
 def slot_end(starts, last_end, rank, chunk, ordered):
     """End of (rank, chunk)'s time SLOT (compute + idle): the next chunk's start, else last_compute_end."""
     i = ordered.index(chunk)
@@ -75,16 +121,37 @@ def median(xs):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("log", help="combined pipeline-prefill run log (all ranks)")
+    ap.add_argument("log", nargs="?", help="combined pipeline-prefill run log (all ranks)")
+    ap.add_argument(
+        "--timing-dir",
+        help="dir of per-rank timing CSVs (PREFILL_TIMING_DIR); preferred over the log — gapless",
+    )
     ap.add_argument("-o", "--out", default="pipeline_trace.png")
     ap.add_argument("--no-arrows", action="store_true", help="omit the rank->rank handoff arrows")
+    ap.add_argument(
+        "--real-chunks",
+        type=int,
+        default=None,
+        help="plot only the last N chunks (drops producer warmup, matching the summarizer's window)",
+    )
     args = ap.parse_args()
 
-    starts, last_end, measured = parse(args.log)
+    if args.timing_dir:
+        starts, last_end, measured = parse_timing_dir(args.timing_dir)
+        source_label = os.path.basename(os.path.normpath(args.timing_dir))
+    elif args.log:
+        starts, last_end, measured = parse(args.log)
+        source_label = args.log.split("/")[-1]
+    else:
+        ap.error("provide a log path or --timing-dir")
+
+    starts, last_end, measured = trim_to_last(starts, last_end, measured, args.real_chunks)
     ranks = sorted(starts)
     origin = min(s for r in ranks for s in starts[r].values())  # t=0 at the first chunk start
 
-    n_chunks = max(len(starts[r]) for r in ranks)
+    all_chunks = sorted({c for r in ranks for c in starts[r]})
+    cpos = {c: i for i, c in enumerate(all_chunks)}
+    n_chunks = len(all_chunks)
     cmap = plt.get_cmap("turbo", max(n_chunks, 1))
 
     # Per-chunk compute duration, proxied by the downstream rank's start (it unblocks ~immediately when
@@ -128,7 +195,7 @@ def main():
                     ]
                     dur = slot if slot > 0 else median(own)
             comp_end = s + dur
-            color = cmap(c % cmap.N)
+            color = cmap(cpos[c])
             # Compute block (solid). The idle time (comp_end -> next chunk start) is left UNDRAWN, so
             # the white background shows through as the pipeline bubble.
             ax.broken_barh(
@@ -168,7 +235,7 @@ def main():
                         (x1, nxt - bar_h / 2),
                         arrowstyle="-|>",
                         mutation_scale=7,
-                        color=cmap(c % cmap.N),
+                        color=cmap(cpos[c]),
                         alpha=0.5,
                         linewidth=0.7,
                         shrinkA=0,
@@ -197,7 +264,7 @@ def main():
     ax.set_yticklabels([f"rank {r}" for r in ranks])
     # rank 0 at the bottom; the pipeline flows upward (default y increases upward).
     ax.set_xlabel("time since first chunk start (s)")
-    ax.set_title(f"pipeline-prefill trace — {len(ranks)} ranks, {n_chunks} chunks  ({args.log.split('/')[-1]})")
+    ax.set_title(f"pipeline-prefill trace — {len(ranks)} ranks, {n_chunks} chunks  ({source_label})")
     ax.grid(axis="x", alpha=0.3)
     fig.tight_layout()
     fig.savefig(args.out, dpi=130)

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -16,6 +16,9 @@
 #         * Chunked tests state total ISL and chunk size as <isl>@<chunk>, e.g. "code_debug 55k@5k".
 #         * Nothing else goes in parentheses -- the leading "(...)" is the model list and only that,
 #           so a qualifier is trailing prose: "... 55k@5k vs golden trace", "... 55k@5k, SC4".
+#         * No "/" in a name. The impl workflow uses the name verbatim as the test-log path and as
+#           the log/triage artifact names, so a slash buries the log in a subdirectory the console-echo
+#           glob misses and makes both uploads fail. Hyphenate, or drop the component list.
 #         * One separator, one meaning -- a job whose name reads several ways is the bug this
 #           convention exists to prevent:
 #             "+"  the distinct things this one job gates, each carrying its own shape
@@ -24,8 +27,6 @@
 #                  several shapes under one tag, or several tags under one shape
 #                  -> "(DeepSeek-V3-671B) MLA accuracy 100k, 128k"   (two shapes, one tag)
 #                  -> "ring MLA chunked 55k@5k perf, accuracy, determinism"  (one shape, three tags)
-#             "/"  components of one pipeline, not a list of gated things
-#                  -> "disaggregated prefill runner/producer"
 #         * Entries are grouped by model in file order, in the same order the name reads: a
 #           cross-model section first, then one section per model, then op-level jobs. Keep a new
 #           entry inside its model's section rather than appending it at the end.
@@ -718,10 +719,12 @@
 
 # ===== Disaggregated prefill, SC4 -- one launcher shared by both entries, keep them adjacent ===========
 
-# 4-galaxy (SC4-blitz) disaggregated prefill: a 4-rank background runner opens the mesh, loads
-# Kimi-2.7, warmup-compiles, and publishes the merged KV chunk table to shared NFS; a device-less
-# producer then reads it back and PCCs it against the golden KV cache.
-- name: "(Kimi-K2.7-1T) disaggregated prefill runner/producer KV accuracy 55k@5k, SC4"
+# 4-galaxy (SC4) disaggregated prefill: a 4-rank background runner opens the mesh, loads Kimi-2.7,
+# warmup-compiles, and publishes the merged KV chunk table to shared NFS; a device-less producer then
+# reads it back and PCCs it against the golden KV cache. The request runs to 250k so the per-chunk
+# timings cover depth, but only the 55k the golden trace spans is PCC'd -- the tail is timed, not
+# checked. A throwaway warmup request precedes the measured one, so first-chunk compile is not timed.
+- name: "(Kimi-K2.7-1T) disaggregated prefill KV accuracy 55k@5k + perf 250k@5k, SC4"
   cmd: |
     set -euo pipefail
     export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
@@ -735,7 +738,7 @@
   test_group: module
   skus:
     bh_sc4:
-      # Measured test step ~6 min; headroom for the up-to-120s producer connect plus
+      # Measured test step 8.5 min at 50 chunks; headroom for the up-to-120s producer connect plus
       # model-load/NFS variance on a 4-galaxy run. Must match the shield/demo budget.
       timeout: 15
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
@@ -748,7 +751,7 @@
 # its 21 `full` layers), and the pipeline split is layer-aware (18/20/20/20, snapped to `full` starts).
 # Both caches are PCC'd: the producer gates on min(config 0, config 1), so this is the only leg that
 # covers the merged multi-cache KV chunk table and the per-stage index-cache numbering.
-- name: "(GLM-5.2-744B) disaggregated prefill runner/producer KV accuracy 55k@5k, SC4"
+- name: "(GLM-5.2-744B) disaggregated prefill KV accuracy 55k@5k + perf 250k@5k, SC4"
   cmd: |
     set -euo pipefail
     export TT_METAL_HOME="${TT_METAL_HOME:-/home/user/tt-metal}"
@@ -762,9 +765,9 @@
   test_group: module
   skus:
     bh_sc4:
-      # 5.5 min weight load from the warm 8x4 cache, then a full-depth 11-chunk request over 78 layers
-      # plus both-cache UMD readback; headroom for the 120 s producer connect and NFS variance. Counts
-      # against the shield/demo budget together with the Kimi entry.
+      # Measured test step 9 min: weight load from the warm 8x4 cache, then 50 chunks over 78 layers
+      # plus both-cache UMD readback. The extra 5 min over the Kimi entry is cold-cache weight-load
+      # insurance. Counts against the shield/demo budget together with the Kimi entry.
       timeout: 20
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
   team: shield


### PR DESCRIPTION
Turns the two sc4 disaggregated-prefill legs (Kimi-K2.7, GLM-5.2) from a 55k accuracy check into a 250k accuracy **and** perf leg, and puts the perf numbers plus a pipeline gantt on the job-summary page so reading a run needs no artifact download.

## What changed

**Depth: run to 250k, PCC over the 55k the golden trace spans.** The launcher drives `MAX_SEQ_LEN=256000` (250k, 50 chunks of 5120) so the per-chunk timings cover real depth; the 55k trace pool auto-pads past its end. `PREFILL_PCC_GOLDEN_LEN` clamps the producer's PCC window to 56320 (2 lines in `_read_slot_kv_and_check_pcc`, uniform across mla/m3/gpt_oss). No 100k+ golden exists for either model, so **the 55k→250k tail is timed, not checked.**

**Producer-driven warmup.** A 10-chunk throwaway request on slot 0 precedes the measured one — pushed, barriered, layer-acks drained and discarded. First-chunk compile therefore never lands in a reported number. **The runner is unchanged for warmup**; this is producer-side only, and it reuses the existing slot-recycle restart-at-0 path, so no new deadlock surface.

**Per-chunk timing that survives mpirun.** Under `PREFILL_SYNC_PER_CHUNK` (now on for these legs) the runner drains the device *before* stamping the chunk start, so the start→end delta is that rank's forward alone — the blocking inbound D2D recv happens outside the bracket. Timings are appended to per-rank CSVs under `PREFILL_TIMING_DIR` with a single `O_APPEND` `os.write`. That CSV path exists because stdout is unusable as a data channel here: under mpirun the C++ (spdlog) and Python (loguru) writers share one fd with no shared lock, and C++ lines splice mid-record into `CHUNK_*`, so a log scrape has holes. The `CHUNK_*` lines are kept for hang diagnosis, and the log scrape remains a fallback. Timing writes swallow `OSError` — telemetry must never take down a run.

**Job-summary page.** New `ci/summarize_ci_run.py` emits, per model, ten numbers over the measured request: `chunk_time` at 4 offsets (0, 50k, max_seq÷2, max_seq−5k), then `ttft` and `throughput` at 3 each (50k, max_seq÷2, max_seq). `throughput` is a rank-0 start→start rate over the 4 chunks ending at the offset, not a cumulative average. It publishes through `prefill_summary_utils.emit_summary("perf", …)` — the impl workflow already cat'd `$PREFILL_SUMMARIES/perf/*.md` into `$GITHUB_STEP_SUMMARY`, but nothing in the repo wrote there, so that glob was dead. The bulkier per-layer × per-cache PCC matrix and the raw per-rank × per-chunk table stay in the step log on purpose.

**Gantt PNG as a one-click link.** `plot_pipeline_trace.py` gains `--timing-dir` (reads the gapless CSVs) and trims to the real-request window, and the plot is written under `$PREFILL_SUMMARIES/plots/` rather than `generated/test_logs/` — from `test_logs` it was uploaded, but zipped inside the `test-log-*` artifact. A new upload step uses `archive: false`, which makes `outputs.artifact-url` a direct link to the file; the publish step appends that link. Images **cannot** be inlined: `$GITHUB_STEP_SUMMARY` runs the same sanitizer as issues/PRs, so `data:` URIs are stripped and `<img src>` must be http/https behind camo, which cannot fetch an auth-gated artifact. Same pattern `tt-train-tests.yaml` already uses.

**Naming convention, now stricter.** Both leg names dropped the `/` (`runner/producer`) — the impl workflow uses the name verbatim as the test-log path and as the log/triage artifact names, so a slash buries the log in a subdirectory the console-echo glob misses and breaks both uploads. Since the sc4 container hook ignores `continue-on-error`, that made a *passing* PCC test red. The convention block in `blaze_models_prefill_tests.yaml` accordingly **removes `/` as a legal separator** and states why. Names are now `"(<Model>) disaggregated prefill KV accuracy 55k@5k + perf 250k@5k, SC4"`.

**CI MGDs.** New `topology_configuration/ci/{kimi27_mgd,glm52_mgd}.textproto`, exact copies of the connected(torus)/fabric2d(LINE) descriptors, with the launcher's `MGD_DIR` repointed. The shared `topology_configuration/` files are untouched so CI tuning can't perturb interactive runs.

## Gating

The leg is green only when the producer exits clean **and** a durable `ok=true` PCC verdict exists for every rank — read from `MR_DIR` before `cleanup()` removes it. Exit code alone is not trusted: a segfault that returns 0 without writing a verdict, or a rank that never validated, both have to be red. **Perf and timing never gate**; the verdict JSON is unchanged and the PCC gate path is untouched by everything above.

## Known limits

- Accuracy covers 55k only; the tail to 250k is timed.
- `SYNC_PER_CHUNK` serializes dispatch, so per-rank `compute_ms` is isolated forward, not overlapped e2e. The summary's `chunk_time` is a *cross-rank* span (first-rank start → last-rank finish) and so reports pipeline fill and straggler spread, not chunk cost — do not read it as per-chunk work. `ttft` and `throughput` are the stable pair. No perf thresholds are asserted; margins are deliberately out of scope here.
- Cross-rank metrics assume NTP-comparable clocks across the four galaxies.

## Validation

**Accuracy, 50 chunks** — run [32891673382](https://github.com/tenstorrent/tt-metal/actions/runs/32891673382), both legs green, real KV PCC (clamped to the 55k golden window):
- Kimi-K2.7: min PCC 0.8807 (kvpe).
- GLM-5.2: min PCC 0.8612 (kvpe) / 0.9844 (index) — the only leg covering the merged multi-cache table and per-stage index-cache numbering.

**Summary + plot** — run [33372246599](https://github.com/tenstorrent/tt-metal/actions/runs/33372246599) (PNG link) and [33377503286](https://github.com/tenstorrent/tt-metal/actions/runs/33377503286) (final summary), both SUCCESS on both legs. `kimi27_pipeline_gantt.png` and `glm52_pipeline_gantt.png` upload un-zipped and land as direct links. Reported from 33377503286 (`tok/s` = windowed over the 4 chunks ending at the offset):

| | ttft@50k | ttft@250k | tok/s @50k | tok/s @250k |
|---|---|---|---|---|
| Kimi-K2.7 | 3.44 s | 33.20 s | 17,427 | 5,248 |
| GLM-5.2 | 7.34 s | 33.75 s | 10,451 | 6,343 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-sc4-rename-slash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-sc4-rename-slash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-sc4-rename-slash)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-sc4-rename-slash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-sc4-rename-slash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-sc4-rename-slash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-sc4-rename-slash)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-sc4-rename-slash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-sc4-rename-slash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-sc4-rename-slash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-sc4-rename-slash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-sc4-rename-slash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-sc4-rename-slash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-sc4-rename-slash)


