### PR TITLE
[Quasar Resnet] Use up to 8 tiles per reduction and remove STALLWAIT workaround

### DIFF
--- a/models/demos/vision/classification/resnet50/quasar/tests/ops/test_max_pool2d_channel_sweep.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/ops/test_max_pool2d_channel_sweep.py
@@ -5,13 +5,11 @@
 """
 Quasar max_pool2d 3x3 CHANNEL sweep (channel-tile / block_ct_dim stress).
 
-Sweeps the per-core channel count 32, 64, 96, ... 256 (= 1..8 channel tiles) on a fixed 3x3
-stride-2 pad-1 HEIGHT_SHARDED pool. Because the pool is height-sharded, every core holds ALL
-`channels`, so channels/32 is exactly the number of channel tiles (block_ct_dim) the reduce sees.
-Geometry is 32x32 -> out 16x16 (out_w=16 >= 2), so later output columns exercise the row-to-row
-L1 stride: the exact path the unpack_tilizeA_B l1-index fix (PR #49485, replacing the retired
-438b29b6e20 block_ct_dim workaround) corrects. Without a correct block_ct_dim scaling, C>=64 with
-out_col>=2 aliases an earlier column's data (wrong-window max).
+Sweeps the per-core channel count 32..256 (1..8 channel tiles) plus 480 (15 tiles, wide
+reduction with multiple c-blocks) on a fixed 3x3 stride-2 pad-1 HEIGHT_SHARDED pool.
+Because the pool is height-sharded, every core holds ALL `channels`, so channels/32 is
+exactly the number of channel tiles (block_ct_dim) the reduce sees. Geometry is 32x32 ->
+out 16x16 (out_w=16 >= 2), so later output columns exercise the row-to-row L1 stride.
 
 Checks per case (identical to test_max_pool2d_correctness.py):
   1. HARD leak invariant: got.max() <= input.max() + eps.
@@ -30,8 +28,9 @@ import ttnn
 from models.common.utility_functions import is_quasar
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-# per-core channels = total channels (height-sharded); 32*n for n = 1..8 channel tiles.
-CHANNELS = [32, 64, 96, 128, 160, 192, 224, 256]
+# per-core channels = total channels (height-sharded); 32*n for n = 1..8 channel tiles,
+# plus 480 (15 tiles) which exercises the wide-reduction path (>8 tiles, multiple c-blocks).
+CHANNELS = [32, 64, 96, 128, 160, 192, 224, 256, 480]
 
 # fixed 3x3 pool geometry; 32x32 in -> 16x16 out (out_w >= 2 stresses the multi-column stride).
 IN_H = IN_W = 32

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -368,16 +368,7 @@ void kernel_main() {
                 const uint32_t curr_scratch_cb_id = scratch_cb_id_0;
                 DataflowBuffer curr_scratch_cb = scratch_cb_0;
 #endif
-                // Model A (wide-reduction fix): the scratch CB holds ONE contiguous full-width (in_ntiles_c)
-                // output stick, so reserve it ONCE per stick (on the first c-block) -- NOT per c-block.
-                // Reserving/pushing a full stick per c-block advanced wr_entry_idx mid-stick, overran the
-                // 2-slot ring, and grew the packer's L1 base (base_l1 = wr_entry_idx * ...) past the buffer-
-                // descriptor limit -> Risc IB interrupt (0x19), with the fault address creeping run-to-run as
-                // base_l1 grew. Each c-block packs its channel slice into this shared stick below; the whole
-                // stick is pushed once on the last c-block so the DM reader consumes exactly one stick per pop.
-                if (first_c_block) {
-                    curr_scratch_cb.reserve_back(scratch_npages);
-                }
+                curr_scratch_cb.reserve_back(scratch_npages);
                 // QSR fix (split-reader second stream): the top-of-kernel pack_untilize_dest_init targets
                 // scratch_cb_0 only, so odd (reader1) sticks packing into scratch_cb_1 used a packer
                 // descriptor still bound to scratch_cb_0 -> the pack landed nowhere and reader1 read an
@@ -395,41 +386,15 @@ void kernel_main() {
                 //   c1 -> block_c_index 4/2 = 2      -> tiles 4..5
                 // Init width must equal pack width per c-block (pack_untilize.h contract), so init per c-block.
                 if (last_c_block) {
-                    pack_untilize_dest_init<partial_iter_output_tiles, in_ntiles_c>(curr_scratch_cb_id);
-                    pack_untilize_dest<partial_iter_output_tiles, in_ntiles_c>(
-                        curr_scratch_cb_id, 1, (c_i * max_tiles_per_iter) / partial_iter_output_tiles);
+                    pack_untilize_dest_init<partial_iter_output_tiles>(curr_scratch_cb_id);
+                    pack_untilize_dest<partial_iter_output_tiles>(curr_scratch_cb_id, 1, 0);
                 } else {
-                    pack_untilize_dest_init<max_tiles_per_iter, in_ntiles_c>(curr_scratch_cb_id);
-                    pack_untilize_dest<max_tiles_per_iter, in_ntiles_c>(curr_scratch_cb_id, 1, c_i);
+                    pack_untilize_dest_init<max_tiles_per_iter>(curr_scratch_cb_id);
+                    pack_untilize_dest<max_tiles_per_iter>(curr_scratch_cb_id, 1, 0);
                 }
                 tile_regs_release();
-                if (last_c_block) {
-                    // Push the whole stick once, after every c-block has packed its slice, so the DM reader
-                    // consumes exactly one full stick per wait_front/pop_front(scratch_npages) -- the previous
-                    // per-c-block push overran the ring (see the reserve note above).
-                    //
-                    // [DEBUG scratch scaffold] Producer-side pack-write commit barrier. push_back() below posts
-                    // the SPSC credit the DM reader spins on (reader_pool_2d.cpp wait_front), after which it reads
-                    // this stick's row DIRECTLY from TL1. On HW the credit instruction itself waits for the packer
-                    // write to drain (TT_PUSH_TILES packer_wr_done_wait_mask=0x1 in llk_push_tiles), but the Quasar
-                    // emulator does NOT honor that embedded sub-field, so the counter can post before
-                    // pack_untilize_dest's TL1 write lands -> the reader reads a stale/empty scratch slot (a
-                    // fraction of sticks dropped->0 or dup->neighbor: PCC 0.897; watcher latency hides it, since
-                    // the scratch CB is single-buffered so the credit is the only producer->consumer serializer).
-                    // Drain the packer engine before posting the credit. Mirrors the "wait for pack to finish"
-                    // STALLWAIT idiom in llk_pack_common.h:307. No-op-equivalent on HW (redundant with the wr_done
-                    // wait); remove once the sim models PUSH_TILES.packer_wr_done_wait_mask.
-                    // Quasar-only: this barrier fixes the emulator's failure to honor PUSH_TILES'
-                    // packer_wr_done_wait_mask (see comment above). WH/BH HW honor it, so the stall is a no-op
-                    // there -- and TTI_STALLWAIT has a DIFFERENT arity per arch (Quasar takes 4 args, WH takes 2),
-                    // so it must be arch-gated to compile at all. NB: TTI_STALLWAIT expands to a bare __asm__
-                    // statement, so it must NOT be wrapped in the expression-form PACK((...)) parens -- PACK(...)
-                    // is variadic, so the comma-separated p_stall args pass straight through as one asm statement.
-#ifdef ARCH_QUASAR
-                    PACK(TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::NOTHING, p_stall::NOTHING, p_stall::PACK));
-#endif
-                    curr_scratch_cb.push_back(scratch_npages);  // hand off to the DM reader, which writes the output
-                }
+
+                curr_scratch_cb.push_back(scratch_npages);  // hand off to the DM reader, which writes the output
 #else
                 // Production RM path: narrow pack straight into out_cb (already reserved above). Pair the
                 // pack-untilize init with a matching width per c-block (same contract as the scratch path).

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -368,33 +368,46 @@ void kernel_main() {
                 const uint32_t curr_scratch_cb_id = scratch_cb_id_0;
                 DataflowBuffer curr_scratch_cb = scratch_cb_0;
 #endif
-                curr_scratch_cb.reserve_back(scratch_npages);
+                // Model A (wide-reduction fix): the scratch CB holds ONE contiguous full-width (in_ntiles_c)
+                // output stick, so reserve it ONCE per stick (on the first c-block) -- NOT per c-block.
+                // reader_pool_2d.cpp consumes one stick per output row: a single wait_front / full-row copy /
+                // pop_front(scratch_npages), treating row 0 of the entry as all channels. Reserving and pushing
+                // per c-block advances the CB write entry mid-stick, so each c-block's slice lands in a different
+                // entry (at a non-zero offset within it) and the reader sees in_nblocks_c entries for every one it
+                // pops. Each c-block packs its channel slice into this shared stick below; the whole stick is
+                // pushed once on the last c-block so the reader consumes exactly one stick per pop.
+                if (first_c_block) {
+                    curr_scratch_cb.reserve_back(scratch_npages);
+                }
                 // QSR fix (split-reader second stream): the top-of-kernel pack_untilize_dest_init targets
                 // scratch_cb_0 only, so odd (reader1) sticks packing into scratch_cb_1 used a packer
                 // descriptor still bound to scratch_cb_0 -> the pack landed nowhere and reader1 read an
                 // all-zero tile. Re-init the pack_untilize for THIS stick's scratch CB before packing so
                 // both scratch_cb_0 (even) and scratch_cb_1 (odd) get a valid, CB-matched descriptor.
-                // [DIAG] pack bounds (Bug 2 PACR0_TILE_INC 0x19): ntiles = tiles this pack_untilize_dest
-                // writes; cap = scratch CB byte capacity; npages/esz = its entry geometry. If
-                // ntiles*esz > cap (or ntiles exceeds what the scratch descriptor addresses) the pack tile
-                // increment crosses L1_LIMIT_ADDR -> fault. Printed BEFORE the pack so it flushes pre-fault.
                 // Pack this c-block into its channel slice of the shared full-width stick. full_ct_dim =
-                // in_ntiles_c makes the untilize row stride span the whole in_ntiles_c-tile-wide stick
-                // (llk_pack_untilize stride_offset_0 = num_faces_c_dim * FULL_CT_DIM); block_c_index places the
-                // slice so the c-blocks tile contiguously (l1 tile offset = block_c_index * block_ct_dim):
-                //   c0 -> block_c_index 0            -> tiles 0..3
-                //   c1 -> block_c_index 4/2 = 2      -> tiles 4..5
+                // in_ntiles_c makes the untilize row stride span the whole in_ntiles_c-tile-wide stick, and
+                // block_c_index places the slice (llk_pack_untilize: l1_tile_idx = base_l1 + block_rt *
+                // y_stride + block_c_index * block_ct_dim). For in_ntiles_c = 12, MAX_TILES_PER_REDUCTION = 8:
+                //   c0 -> width 8, block_c_index 0            -> tiles 0..7
+                //   c1 -> width 4, block_c_index (1*8)/4 = 2  -> tiles 8..11
+                // NOTE: the offset is expressed in units of block_ct_dim, so the last (narrow) block only
+                // lands correctly when partial_iter_output_tiles divides c_i * max_tiles_per_iter. It does
+                // not for in_ntiles_c % MAX_TILES_PER_REDUCTION in {3,5,6,7}: e.g. in_ntiles_c = 11 gives
+                // 8/3 = 2 -> tiles 6..8, overwriting c0's tail and leaving 9..10 stale.
                 // Init width must equal pack width per c-block (pack_untilize.h contract), so init per c-block.
                 if (last_c_block) {
-                    pack_untilize_dest_init<partial_iter_output_tiles>(curr_scratch_cb_id);
-                    pack_untilize_dest<partial_iter_output_tiles>(curr_scratch_cb_id, 1, 0);
+                    pack_untilize_dest_init<partial_iter_output_tiles, in_ntiles_c>(curr_scratch_cb_id);
+                    pack_untilize_dest<partial_iter_output_tiles, in_ntiles_c>(
+                        curr_scratch_cb_id, 1, (c_i * max_tiles_per_iter) / partial_iter_output_tiles);
                 } else {
-                    pack_untilize_dest_init<max_tiles_per_iter>(curr_scratch_cb_id);
-                    pack_untilize_dest<max_tiles_per_iter>(curr_scratch_cb_id, 1, 0);
+                    pack_untilize_dest_init<max_tiles_per_iter, in_ntiles_c>(curr_scratch_cb_id);
+                    pack_untilize_dest<max_tiles_per_iter, in_ntiles_c>(curr_scratch_cb_id, 1, c_i);
                 }
                 tile_regs_release();
 
-                curr_scratch_cb.push_back(scratch_npages);  // hand off to the DM reader, which writes the output
+                if (last_c_block) {
+                    curr_scratch_cb.push_back(scratch_npages);  // hand off to the DM reader, which writes the output
+                }
 #else
                 // Production RM path: narrow pack straight into out_cb (already reserved above). Pair the
                 // pack-untilize init with a matching width per c-block (same contract as the scratch path).

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -106,6 +106,14 @@ void kernel_main() {
     constexpr uint32_t partial_iter_output_tiles =
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
 
+#if PACK_TO_SCRATCH == 1
+    // The scratch path assembles every c-block into one full-width stick, and llk_pack_untilize places
+    // a slice at block_c_index * block_ct_dim -- an offset in units of the block's own width -- which a
+    // narrower (remainder) last block cannot express for most widths. Allow one c-block only.
+    static_assert(
+        in_ntiles_c <= MAX_TILES_PER_REDUCTION,
+        "PACK_TO_SCRATCH does not support wide reduction: channels per shard must fit in a single reduction.");
+#endif
     static_assert(REDUCE_OP == PoolType::MAX || REDUCE_OP == PoolType::AVG, "Only supports REDUCE_OP = MAX or AVG");
     constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
     constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::AVG) ? true : false;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -93,27 +93,16 @@ void kernel_main() {
         last_tile_is_partial && (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face) ? 1 : 2;
 
     constexpr bool is_avg_pool = REDUCE_OP == PoolType::AVG;
-    // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
-    // otherwise we can reduce 8 tiles at a time. Callers (e.g. grid_sample under fp32_dest_acc_en) can
-    // also force the 4-tile limit via ct_arg[16] so each chunk fits in half-sync DEST (= 4 fp32 tiles)
-    // without forcing dst_full_sync_en.
     constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
-    constexpr bool force_max_tiles_per_reduction_4 = get_arg(args::force_max_tiles_per_reduction_4);
-    constexpr uint32_t MAX_TILES_PER_REDUCTION =
-        (force_max_tiles_per_reduction_4 || (is_avg_pool && is_large_kernel)) ? 4 : 8;
+    // The host factory resolves DEST-capacity limits (fp32 vs fp16, half-sync vs full-sync) and
+    // equal-width c-block constraints into a single value; kernels consume it directly.
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = get_arg(args::max_tiles_per_reduction);
     constexpr uint32_t max_tiles_per_iter =
         in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
     constexpr uint32_t partial_iter_output_tiles =
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
+    static_assert(partial_iter_output_tiles == max_tiles_per_iter, "c-blocks must all be the same width");
 
-#if PACK_TO_SCRATCH == 1
-    // The scratch path assembles every c-block into one full-width stick, and llk_pack_untilize places
-    // a slice at block_c_index * block_ct_dim -- an offset in units of the block's own width -- which a
-    // narrower (remainder) last block cannot express for most widths. Allow one c-block only.
-    static_assert(
-        in_ntiles_c <= MAX_TILES_PER_REDUCTION,
-        "PACK_TO_SCRATCH does not support wide reduction: channels per shard must fit in a single reduction.");
-#endif
     static_assert(REDUCE_OP == PoolType::MAX || REDUCE_OP == PoolType::AVG, "Only supports REDUCE_OP = MAX or AVG");
     constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
     constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::AVG) ? true : false;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -40,14 +40,12 @@ template <
     uint32_t dilation_w,
     bool zero_pages,
     uint32_t in_cb_sz,
-    uint32_t bf16_init_value>
+    uint32_t bf16_init_value,
+    uint32_t MAX_TILES_PER_REDUCTION>
 ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base_addr) {
     constexpr uint32_t BYTES_PER_ELEM = 2;
-    // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
-    // otherwise we can reduce 8 tiles at a time.
-    constexpr uint32_t MAX_TILES_PER_REDUCTION = (is_avg_pool && is_large_kernel) ? 4 : 8;
-    constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
     constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
+    constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
     constexpr uint32_t num_tilized_rows =
         wide_reduction ? (in_cb_sz / (MAX_TILES_PER_REDUCTION * TILE_WIDTH)) : (in_cb_sz / (in_ntiles_c * TILE_WIDTH));
     constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
@@ -220,6 +218,7 @@ void kernel_main() {
     constexpr uint32_t in_nblocks_c = get_arg(args::in_nblocks_c);
     constexpr uint32_t in_cb_sz = get_arg(args::in_cb_sz);
     constexpr uint32_t max_sticks_for_reduction = get_arg(args::max_sticks_for_reduction);
+    constexpr uint32_t max_tiles_per_reduction = get_arg(args::max_tiles_per_reduction);
     constexpr uint32_t ceil_pad_w = get_arg(args::ceil_pad_w);
 
     // CB ids now come from Metal 2.0 DFB bindings. Split-reader uses per-reader input/scalar
@@ -474,7 +473,8 @@ void kernel_main() {
                 dilation_w,
                 zero_pages,
                 in_cb_sz,
-                bf16_init_value>(ind, in_l1_read_base_addr);
+                bf16_init_value,
+                max_tiles_per_reduction>(ind, in_l1_read_base_addr);
 #if ENABLE_DEBUG_PRINT == 1
             // [DIAG] Peek THIS reader's just-filled input CB (reader is producer; on DM get_read_ptr still
             // points at the base page it filled, before compute pops). Tilized face0 row0 = first 16

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -40,14 +40,12 @@ template <
     uint32_t dilation_w,
     bool zero_pages,
     uint32_t in_cb_sz,
-    uint32_t bf16_init_value,
-    bool force_max_tiles_per_reduction_4>
+    uint32_t bf16_init_value>
 ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base_addr) {
     constexpr uint32_t BYTES_PER_ELEM = 2;
     // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
     // otherwise we can reduce 8 tiles at a time.
-    constexpr uint32_t MAX_TILES_PER_REDUCTION =
-        (force_max_tiles_per_reduction_4 || (is_avg_pool && is_large_kernel)) ? 4 : 8;
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = (is_avg_pool && is_large_kernel) ? 4 : 8;
     constexpr uint32_t MAX_BYTES_PER_REDUCTION = MAX_TILES_PER_REDUCTION * TILE_WIDTH * BYTES_PER_ELEM;
     constexpr uint32_t in_ntiles_c = (in_c + TILE_WIDTH - 1) / TILE_WIDTH;
     constexpr uint32_t num_tilized_rows =
@@ -239,8 +237,6 @@ void kernel_main() {
     constexpr uint32_t in_scalar_cb_id = dfb::in_scalar_cb;
     constexpr uint32_t clear_value_cb_id = dfb::clear_value_cb;
     constexpr bool is_avg_pool = (bool)get_arg(args::pool_type_is_avg);
-    // QSR: cap tiles-per-pack to 4 (matches compute + host in_nblocks_c); see factory comment (PACR0 bounds).
-    constexpr bool force_max_tiles_per_reduction_4 = (bool)get_arg(args::force_max_tiles_per_reduction_4);
     constexpr bool one_scalar_per_core = get_arg(args::one_scalar_per_core);
     // The avg-pool scalar config DFB + tensor::config only exist when !one_scalar_per_core; the
     // host emits HAS_CONFIG to this kernel's defines exactly then. Gate every dfb::config_cb /
@@ -478,8 +474,7 @@ void kernel_main() {
                 dilation_w,
                 zero_pages,
                 in_cb_sz,
-                bf16_init_value,
-                force_max_tiles_per_reduction_4>(ind, in_l1_read_base_addr);
+                bf16_init_value>(ind, in_l1_read_base_addr);
 #if ENABLE_DEBUG_PRINT == 1
             // [DIAG] Peek THIS reader's just-filled input CB (reader is producer; on DM get_read_ptr still
             // points at the base page it filled, before compute pops). Tilized face0 row0 = first 16

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -44,6 +44,17 @@ namespace ttnn::operations::pool::quasar {
 
 namespace {
 
+// Largest divisor of total_tiles that is <= cap. Ensures all c-blocks have equal width,
+// which pack_untilize requires for correct block_c_index addressing.
+constexpr uint32_t largest_uniform_block_width(uint32_t total_tiles, uint32_t cap) {
+    for (uint32_t width = cap; width >= 1; --width) {
+        if (total_tiles % width == 0) {
+            return width;
+        }
+    }
+    return 1;
+}
+
 // ---------------------------------------------------------------------------
 // Op-owned scalar-config tensor for avg pool (unchanged host computation).
 // ---------------------------------------------------------------------------
@@ -573,6 +584,12 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         params.num_tilized_rows = tt::constants::TILE_HEIGHT;
     }
 
+    // Narrow MAX_TILES_PER_REDUCTION to the largest divisor of in_ntiles_c that fits within the
+    // DEST-capacity cap, so every c-block has equal width (pack_untilize cannot address a
+    // remainder block). The resolved value is passed to compute and reader kernels as a compile-time arg.
+    params.MAX_TILES_PER_REDUCTION = largest_uniform_block_width(params.in_ntiles_c, params.MAX_TILES_PER_REDUCTION);
+    params.is_wide_reduction = params.in_ntiles_c > params.MAX_TILES_PER_REDUCTION;
+
     const uint32_t eff_kernel_h = ((kernel_h - 1) * dilation_h) + 1;
     const uint32_t eff_kernel_w = ((kernel_w - 1) * dilation_w) + 1;
     const uint32_t in_h_padded = in_h + pad_h + setup.ceil_pad_h;
@@ -892,6 +909,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         {"in_nblocks_c", in_nblocks_c},
         {"in_cb_sz", cb_sizes.in_cb_raw_size},
         {"max_sticks_for_reduction", params.max_rows_for_reduction},
+        {"max_tiles_per_reduction", params.MAX_TILES_PER_REDUCTION},
         {"ceil_pad_w", setup.ceil_pad_w},
         {"pool_type_is_avg", static_cast<uint32_t>(params.is_avg_pool)},
         {"one_scalar_per_core", static_cast<uint32_t>(one_scalar_per_core)},
@@ -1195,7 +1213,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         {"one_scalar_per_core", static_cast<uint32_t>(one_scalar_per_core)},
         {"is_output_tiled", static_cast<uint32_t>(is_output_tiled)},
         {"is_output_block_format", static_cast<uint32_t>(is_output_block_format)},
-        {"force_max_tiles_per_reduction_4", 0u},
+        {"max_tiles_per_reduction", params.MAX_TILES_PER_REDUCTION},
         // [DEBUG scratch->out] full page count of one scratch CB (one full-tile write). Compute
         // reserves/pushes the WHOLE CB per stick so the single-tile scratch serializes cleanly.
         {"scratch_npages", (output_shard_shape[1] / tt::constants::FACE_WIDTH) * tt::constants::TILE_HEIGHT},
@@ -1340,18 +1358,12 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         /*default_l1_acc=*/false,
         /*default_dst_full_sync_en=*/(params.is_large_kernel && return_indices) || indexes_32_bit);
 
-    // QSR: fp32_dest_acc_en=true is a KNOWN-BROKEN config for the tilizeA_B reduce on Quasar (ISSUE #48504;
-    // the LLK test QuasarComputeUnpackTilizeA_B in test_untilize_tilize.cpp:1210 disables the fp32 case with a
-    // TODO). The pool reduce ALWAYS goes through tilizeA_B, so any path that would enable fp32 dest-acc here
-    // (notably avg-pool large-kernel: default_fp32_acc = is_avg_pool && is_large_kernel) would hit the broken
-    // primitive. Force it OFF until #48504 is fixed — bf16 dest accumulate is the safe fallback vs a wrong
-    // result. (MAX pool already defaults false; this pins the avg-pool/large-kernel path too.)
     ComputeHardwareConfig compute_hw = ttnn::to_compute_hardware_config(
         device_arch,
         ttnn::ComputeKernelConfig{
             .math_fidelity = get_math_fidelity(device_compute_kernel_config),
             .math_approx_mode = false,
-            .fp32_dest_acc_en = false,  // was: get_fp32_dest_acc_en(device_compute_kernel_config); see #48504
+            .fp32_dest_acc_en = get_fp32_dest_acc_en(device_compute_kernel_config),
             .dst_full_sync_en = get_dst_full_sync_en(device_compute_kernel_config)});
 
     KernelSpec compute{

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_multi_core_program_factory.cpp
@@ -559,16 +559,6 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         in_w,
         output_layout);
 
-    // QSR pack-bounds fix: cap tiles-per-pack to 4. pack_untilize_dest<N> faults with PACR0_TILE_INC
-    // (ERROR_TRISC1 code 0x19) for N>=6 -- the pack's per-tile increment crosses the scratch CB's
-    // descriptor L1_LIMIT_ADDR (N<=5 works, N>=6 faults on the emulator). Forcing MAX_TILES_PER_REDUCTION=4
-    // makes any channel count >4 tiles chunk (in_nblocks_c>1) into <=4-tile packs, staying within bounds.
-    // <=4-tile configs (incl. the resnet stem = 2 tiles) keep in_nblocks_c==1 / is_wide==false -> unchanged.
-    // Paired with force_max_tiles_per_reduction_4=1u (compute + reader compile args below) so all three
-    // agree on the 4-tile chunk size.
-    params.MAX_TILES_PER_REDUCTION = 4;
-    params.is_wide_reduction = params.in_ntiles_c > params.MAX_TILES_PER_REDUCTION;
-
     // QSR: the reduce-col strided tilize consumes a full 32x32 (num_faces=4) SrcA tile (see the
     // num_faces_in_input_tile_for_cb=4 override below; the LLK asserts total_row_dim()==total_col_dim()==32).
     // The shared WH/BH small-window optimization (pool_utils.cpp) sizes num_tilized_rows to only
@@ -904,7 +894,6 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         {"max_sticks_for_reduction", params.max_rows_for_reduction},
         {"ceil_pad_w", setup.ceil_pad_w},
         {"pool_type_is_avg", static_cast<uint32_t>(params.is_avg_pool)},
-        {"force_max_tiles_per_reduction_4", 1u},  // QSR: match compute's 4-tile pack cap (PACR0 bounds)
         {"one_scalar_per_core", static_cast<uint32_t>(one_scalar_per_core)},
         {"in_nbytes_c", in_nbytes_c},
         // [DEBUG scratch->out] output row stride (bytes) for the DM NoC copy of scratch row 0.
@@ -1206,7 +1195,7 @@ ttnn::device_operation::ProgramArtifacts pool2d_create_program_artifacts(
         {"one_scalar_per_core", static_cast<uint32_t>(one_scalar_per_core)},
         {"is_output_tiled", static_cast<uint32_t>(is_output_tiled)},
         {"is_output_block_format", static_cast<uint32_t>(is_output_block_format)},
-        {"force_max_tiles_per_reduction_4", 1u},  // QSR: cap pack_untilize_dest to 4 tiles (PACR0 bounds)
+        {"force_max_tiles_per_reduction_4", 0u},
         // [DEBUG scratch->out] full page count of one scratch CB (one full-tile write). Compute
         // reserves/pushes the WHOLE CB per stick so the single-tile scratch serializes cleanly.
         {"scratch_npages", (output_shard_shape[1] / tt::constants::FACE_WIDTH) * tt::constants::TILE_HEIGHT},


### PR DESCRIPTION
### PR Category
Bug fix, Cleanup

### Issue 
[#52966](https://github.com/tenstorrent/tt-metal/issues/52966)

### Summary
While bringing up Quasar Resnet several hacky workaround were made. This PR is a part of the effort to remove these workarounds.

**1. Removes the cap tiles per reduction to 4 workaround and uses max 8 tiles per reduction instead.**
Having more than 4 tiles per reduction was causing the 0x19 Memory access hang hw assert. This was because a GPR read was sitting behind a MOP which was parked due to GMPOOL waiting for SrcAB dvalid. The SrcAB dvalid was not coming fast enough because the compute was waiting for DM to populate L1 for longer than what the CSR timeout allowed. Increased CSR timeout enables the use of 8 tiles per reduction.

**2. Removes STALLWAIT workaround in compute_pool_2d compute kernel**
A stallwait was added for the following reason: emulator ignores packer_wr_done_wait_mask in PUSH_TILES. This was probably a misdiagnosis and the stallwait was just masking some other issue, which probably got resolved along the way. The tests pass without this stallwait now. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/resnet_pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/resnet_pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/resnet_pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/resnet_pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/resnet_pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/resnet_pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/resnet_pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/resnet_pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/resnet_pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/resnet_pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/resnet_pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/resnet_pool)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/resnet_pool)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/resnet_pool)