### PR TITLE
[Cleanup] Complete the NoC address seam: no composing or splitting outside the backend

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
+++ b/tt_metal/hw/inc/api/dataflow/cross_node_dfb.h
@@ -17,6 +17,7 @@
 
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
 #include "api/dataflow/noc.h"
+#include "noc_address_backend.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/endpoints.h"
@@ -350,9 +351,9 @@ public:
         const uint8_t noc_id = noc.get_noc_id();
         const uint32_t noc_x = xy_base[2 * receiver_idx];
         const uint32_t noc_y = xy_base[2 * receiver_idx + 1];
-        const uint32_t noc_xy = uint32_t(NOC_XY_ENCODING(DYNAMIC_NOC_X(noc_id, noc_x), DYNAMIC_NOC_Y(noc_id, noc_y)));
         *local_sent += num_units;
-        const uint64_t remote_addr = get_noc_addr_helper(noc_xy, (uint32_t)local_sent);
+        const uint64_t remote_addr =
+            noc_address_backend::worker_address(noc_x, noc_y, (uint32_t)(uintptr_t)local_sent, noc_id);
         noc_semaphore_inc<true>(remote_addr, num_units, noc_id);
     }
 

--- a/tt_metal/hw/inc/api/dataflow/endpoints.h
+++ b/tt_metal/hw/inc/api/dataflow/endpoints.h
@@ -17,6 +17,34 @@ struct UnicastEndpoint {
 };
 
 /**
+ * @brief Endpoint for a fully composed unicast NoC address (e.g. a TensorAccessor or
+ * get_noc_addr result, optionally offset within the target). The address is treated as
+ * opaque - it is never decomposed into coordinates - so callers stay independent of the
+ * active NoC address backend.
+ */
+struct PrecomposedUnicastEndpoint {};
+
+template <>
+struct noc_traits_t<PrecomposedUnicastEndpoint> {
+    struct src_args_type {
+        uint64_t noc_addr{};
+    };
+    struct dst_args_type {
+        uint64_t noc_addr{};
+    };
+    template <Noc::AddressType address_type>
+    static auto src_addr(const PrecomposedUnicastEndpoint&, const Noc&, const src_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        return args.noc_addr;
+    }
+    template <Noc::AddressType address_type>
+    static auto dst_addr(const PrecomposedUnicastEndpoint&, const Noc&, const dst_args_type& args) {
+        static_assert(address_type == Noc::AddressType::NOC);
+        return args.noc_addr;
+    }
+};
+
+/**
  * @brief Wrapper around calculating multicast noc address given 2D multicast rectangle and address. This
  * allows direct address to be supplied to NoC apis
  */

--- a/tt_metal/hw/inc/api/remote_circular_buffer.h
+++ b/tt_metal/hw/inc/api/remote_circular_buffer.h
@@ -10,6 +10,7 @@
 #if defined(KERNEL_BUILD) && !defined(COMPILE_FOR_TRISC)
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "noc_address_backend.h"
 #include "api/lock.h"
 #include "tools/profiler/noc_debugging_profiler.hpp"
 #endif
@@ -56,10 +57,9 @@ FORCE_INLINE void update_pages_sent(
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(aligned_pages_sent_addr);
     volatile tt_l1_ptr uint32_t* remote_noc_xy_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_noc_xy_addr);
     for (uint32_t i = 0; i < num_receivers; ++i) {
-        uint32_t remote_noc_xy = uint32_t(
-            NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, remote_noc_xy_ptr[0]), DYNAMIC_NOC_Y(noc, remote_noc_xy_ptr[1])));
         *pages_sent_ptr += aligned_page_adjustment;
-        uint64_t remote_ack_ptr_addr = get_noc_addr_helper(remote_noc_xy, remote_pages_sent_addr);
+        uint64_t remote_ack_ptr_addr = noc_address_backend::worker_address(
+            remote_noc_xy_ptr[0], remote_noc_xy_ptr[1], remote_pages_sent_addr, noc);
         noc_fast_atomic_increment<nm>(
             noc,
             cmd_buf,
@@ -373,16 +373,18 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
         uint32_t src_addr = local_cb_addr + next_receiver_start_addr_offset;
         dest_addr = fifo_wr_ptr;
 
-        uint32_t remote_noc_xy = uint32_t(
-            NOC_XY_ENCODING(DYNAMIC_NOC_X(noc, remote_noc_xy_ptr[0]), DYNAMIC_NOC_Y(noc, remote_noc_xy_ptr[1])));
-        uint64_t dest_noc_addr = get_noc_addr_helper(remote_noc_xy, dest_addr);
+        // Receiver base address; offsets are added below (offset arithmetic on a NoC
+        // address stays within the local-address bits, so it is backend-agnostic).
+        const uint64_t receiver_base =
+            noc_address_backend::worker_address(remote_noc_xy_ptr[0], remote_noc_xy_ptr[1], 0, noc);
+        uint64_t dest_noc_addr = receiver_base + dest_addr;
 
         noc_async_write_one_packet_set_state<posted>(dest_noc_addr, coalesced_page_size, noc);
 
         for (uint32_t h = 0; h < num_rows; ++h) {
             uint32_t prev_src_addr = src_addr;
             for (uint32_t w = 0; w < coalesced_num_pages_per_row; ++w) {
-                dest_noc_addr = get_noc_addr_helper(remote_noc_xy, dest_addr);
+                dest_noc_addr = receiver_base + dest_addr;
 
                 noc_async_write_one_packet_with_state<posted>(src_addr, dest_noc_addr, noc);
 
@@ -394,7 +396,7 @@ FORCE_INLINE void remote_cb_push_back_and_write_pages(
         next_receiver_start_addr_offset += next_receiver_start_addr_stride;
         *pages_sent_ptr += pages_sent;
 
-        uint64_t remote_sent_ptr_addr = get_noc_addr_helper(remote_noc_xy, remote_sent_base);
+        uint64_t remote_sent_ptr_addr = receiver_base + remote_sent_base;
         noc_semaphore_inc<posted>(remote_sent_ptr_addr, pages_sent, noc);
         // Local stride may be smaller than the remote stride on a DRISC sender (see
         // REMOTE_CB_LOCAL_PAGES_STRIDE) — the receiver-side layout is always L1-aligned.

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -40,12 +40,10 @@ FORCE_INLINE void enhanced_noc_async_read(
                                        ? NOC_MAX_BURST_SIZE
                                        : (max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size);
     noc.async_read<NocOptions::DEFAULT, page_size>(
-        UnicastEndpoint{},
+        PrecomposedUnicastEndpoint{},
         CoreLocalMem<uint32_t>(dst_l1_addr),
         bytes,
-        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(src_noc_addr),
-         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(src_noc_addr),
-         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(src_noc_addr)},
+        {.noc_addr = src_noc_addr},
         {.offset_bytes = 0});
 }
 
@@ -65,12 +63,10 @@ FORCE_INLINE void enhanced_noc_async_write(
                                        : (max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size);
     noc.async_write<NocOptions::DEFAULT, page_size>(
         CoreLocalMem<uint32_t>(src_l1_addr),
-        UnicastEndpoint{},
+        PrecomposedUnicastEndpoint{},
         bytes,
         {.offset_bytes = 0},
-        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(dst_noc_addr),
-         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(dst_noc_addr),
-         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(dst_noc_addr)});
+        {.noc_addr = dst_noc_addr});
 }
 
 template <uint32_t max_transfer_size, bool only_writes>

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
@@ -136,12 +136,10 @@ FORCE_INLINE void load_to_dfb(
     const uint32_t l1_write_address = dfb_exp.get_write_ptr();
 
     noc.async_read(
-        UnicastEndpoint{},
+        PrecomposedUnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_address),
         chunk_size_bytes,
-        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(source_noc_address),
-         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(source_noc_address),
-         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(source_noc_address)},
+        {.noc_addr = source_noc_address},
         {.offset_bytes = 0});
     noc.async_read_barrier();
 
@@ -164,12 +162,10 @@ FORCE_INLINE void write_to_output(
 
     noc.async_write(
         CoreLocalMem<uint32_t>(l1_read_address),
-        UnicastEndpoint{},
+        PrecomposedUnicastEndpoint{},
         chunk_size_bytes,
         {.offset_bytes = 0},
-        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(destination_noc_address),
-         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(destination_noc_address),
-         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(destination_noc_address)});
+        {.noc_addr = destination_noc_address});
     noc.async_write_barrier();
 
     dfb_exp.pop_front(ONE_PAGE);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
@@ -77,17 +77,15 @@ void kernel_main() {
                 }
             } else {
                 // If there is a mis-alignment, we first load the data to a middle L1 cb, then copy to the final cb
-                // buffer. The aligned-down source is a full NoC address, so it is supplied directly via
-                // UnicastEndpoint (decomposed into x/y/local addr; NOC_XY_ADDR repacks it unchanged).
+                // buffer. The aligned-down source is a full NoC address, supplied opaquely via
+                // PrecomposedUnicastEndpoint.
                 const uint64_t aligned_src_noc_addr = (src_noc_addr + (uint64_t)start_column_id) & dram_align_mask;
                 CoreLocalMem<uint32_t> temp_dst(temp_addr);
                 noc.async_read(
-                    UnicastEndpoint{},
+                    PrecomposedUnicastEndpoint{},
                     temp_dst,
                     width_size + dram_alignment,
-                    {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(aligned_src_noc_addr),
-                     .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(aligned_src_noc_addr),
-                     .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(aligned_src_noc_addr)},
+                    {.noc_addr = aligned_src_noc_addr},
                     {.offset_bytes = 0});
 
                 // Block before copying data from tmp to cb buffer

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2_metal2.cpp
@@ -223,7 +223,7 @@ void kernel_main() {
     }
 #else
     packed_reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::reader_indices).get_noc_addr(0)));
+        noc_address_backend::extract_local_address(TensorAccessor(tensor::reader_indices).get_noc_addr(0)));
     (void)dram_config_reader_index;
 #endif
 
@@ -240,7 +240,7 @@ void kernel_main() {
 
     // Fully create act matrix and tilize it before mcast. The resident activation shard is reached by
     // L1 base address from a local TensorAccessor (tensor::act_sharded), not a borrowed self-loop CB.
-    uint32_t act_l1_read_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::act_sharded).get_noc_addr(0));
+    uint32_t act_l1_read_addr = noc_address_backend::extract_local_address(TensorAccessor(tensor::act_sharded).get_noc_addr(0));
 
     experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2_metal2.cpp
@@ -58,7 +58,7 @@ void kernel_main() {
     }
 #else
     packed_reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::reader_indices).get_noc_addr(0)));
+        noc_address_backend::extract_local_address(TensorAccessor(tensor::reader_indices).get_noc_addr(0)));
     (void)core_index;
 #endif
 
@@ -99,7 +99,7 @@ void kernel_main() {
 
     // coalesce reads along weight_size_w. The resident activation shard is reached by L1 base address
     // from a local TensorAccessor (tensor::act_sharded), not a borrowed self-loop CB.
-    uint32_t act_l1_read_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::act_sharded).get_noc_addr(0));
+    uint32_t act_l1_read_addr = noc_address_backend::extract_local_address(TensorAccessor(tensor::act_sharded).get_noc_addr(0));
 
     static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
     experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_depthwise_conv1d_metal2.cpp
@@ -77,7 +77,7 @@ void kernel_main() {
     // has no DRAM-config variant); both are reached by L1 base address from local TensorAccessors
     // (tensor::act_sharded / tensor::reader_indices), not borrowed self-loop CBs.
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::reader_indices).get_noc_addr(0)));
+        noc_address_backend::extract_local_address(TensorAccessor(tensor::reader_indices).get_noc_addr(0)));
 
     uint32_t reader_idx = 0;
 
@@ -89,7 +89,7 @@ void kernel_main() {
 
     reader_offset_idx = 0;
     uint32_t act_l1_offset = 0;
-    uint32_t act_l1_read_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::act_sharded).get_noc_addr(0));
+    uint32_t act_l1_read_addr = noc_address_backend::extract_local_address(TensorAccessor(tensor::act_sharded).get_noc_addr(0));
 
     if constexpr (coalesced_read_bytes <= NOC_MAX_BURST_SIZE) {
         experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding_metal2.cpp
@@ -145,7 +145,7 @@ void kernel_main() {
 #ifdef EXTRACT_SHARD_SUB_BLOCKS
     // The resident in0 shard is reached by L1 base address from a local TensorAccessor over the in0
     // tensor (no borrowed self-loop CB, which Metal 2.0 forbids on DM kernels).
-    noc_shard_read_start_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::in0).get_noc_addr(0));
+    noc_shard_read_start_addr = noc_address_backend::extract_local_address(TensorAccessor(tensor::in0).get_noc_addr(0));
 #endif
 
 #else

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded_metal2.cpp
@@ -122,7 +122,7 @@ void kernel_main() {
 
     // The resident in0 shard is reached by L1 base address from a local TensorAccessor over the in0
     // tensor (no borrowed self-loop CB, which Metal 2.0 forbids on DM kernels).
-    uint32_t in0_tensor_shard_read_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::in0).get_noc_addr(0));
+    uint32_t in0_tensor_shard_read_addr = noc_address_backend::extract_local_address(TensorAccessor(tensor::in0).get_noc_addr(0));
     uint32_t in0_tensor_read_addr = 0;
 
     MatmulOpReceiver fused_op_receiver;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/reader_unary_local_l1_copy_backwards.cpp
@@ -25,8 +25,8 @@ void kernel_main() {
     // We deliberately recompute the move-chunk size from these base pointers in-kernel rather than
     // receiving the host-computed (output_addr - input_addr) delta via a runtime arg, which would go
     // stale on a cache hit with different storage and silently read/write the wrong addresses.
-    uint32_t src_cb_base_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::input).get_noc_addr(0));
-    uint32_t dst_cb_base_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(TensorAccessor(tensor::output).get_noc_addr(0));
+    uint32_t src_cb_base_addr = noc_address_backend::extract_local_address(TensorAccessor(tensor::input).get_noc_addr(0));
+    uint32_t dst_cb_base_addr = noc_address_backend::extract_local_address(TensorAccessor(tensor::output).get_noc_addr(0));
 
     // The op only takes this (backwards, intra-L1, overlapping) path when the output buffer is at a
     // higher address than the input buffer, so the delta is strictly positive.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
@@ -6,11 +6,11 @@
 // Device-side NoC logic is unchanged; resource access uses Metal 2.0 named handles. Self-loop DFBs are
 // no longer permitted on data-movement kernels, so:
 //   - The input shard is read via tensor::input (a TensorAccessor over the resident shard): its local L1
-//     base address is recovered with NOC_LOCAL_ADDR_OFFSET(s.get_noc_addr(0)) and used as the source offset
+//     base address is recovered with noc_address_backend::extract_local_address(s.get_noc_addr(0)) and used as the source offset
 //     for the remote NoC reads against neighbouring shards. (No more cb_in0 borrowed fake-CB self-loop.)
 //   - cb_pad is now a CROSS-KERNEL DFB: this reader PRODUCES the pad-value stick once (fill moved here
 //     from the writer); the writer CONSUMES it. (No more writer self-loop.)
-//   - c_16 output shard is written in place via tensor::output (NOC_LOCAL_ADDR_OFFSET(s_out.get_noc_addr(0)));
+//   - c_16 output shard is written in place via tensor::output (noc_address_backend::extract_local_address(s_out.get_noc_addr(0)));
 //     the reader writes the gathered real sticks, the writer writes the pad sticks (no borrowed DFB).
 //   - The legacy variable-length arg tail (read_noc_x/y, num_stick_chunks, chunk lists) is runtime varargs.
 #include <stdint.h>
@@ -98,12 +98,12 @@ void kernel_main() {
     // Local input-shard base L1 address (the source offset replicated across all sharded cores). Recovered
     // from the resident input TensorAccessor instead of a borrowed fake-CB self-loop.
     const auto s = TensorAccessor(tensor::input);
-    uint32_t l1_read_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(s.get_noc_addr(0));
+    uint32_t l1_read_addr = noc_address_backend::extract_local_address(s.get_noc_addr(0));
 
     // Output shard base from the resident output TensorAccessor (written in place; no borrowed
     // co-write DFB — both reader and writer address the output shard directly).
     const auto s_out = TensorAccessor(tensor::output);
-    uint32_t l1_write_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(s_out.get_noc_addr(0));
+    uint32_t l1_write_addr = noc_address_backend::extract_local_address(s_out.get_noc_addr(0));
 
     uint32_t chunk_ptr_offset = 0;
     uint32_t read_noc_xy_ptr_offset = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
@@ -6,7 +6,7 @@
 // Self-loop DFBs are no longer permitted on data-movement kernels, so cb_pad is now a CROSS-KERNEL DFB:
 // the reader PRODUCES the pad-value stick (the fill logic moved there); this writer CONSUMES it (wait_front
 // -> read its address -> broadcast pad sticks -> pop_front). The c_16 output shard is written in place
-// via tensor::output (NOC_LOCAL_ADDR_OFFSET(s_out.get_noc_addr(0))) — no borrowed co-write DFB. start_dim_offset
+// via tensor::output (noc_address_backend::extract_local_address(s_out.get_noc_addr(0))) — no borrowed co-write DFB. start_dim_offset
 // is read by constant indices so it is three named scalar RTAs.
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -46,7 +46,7 @@ void kernel_main() {
     // Output shard base from the resident output TensorAccessor (written in place; no borrowed
     // co-write DFB — the reader writes the gathered sticks, this writer writes the pad sticks).
     const auto s_out = TensorAccessor(tensor::output);
-    uint32_t l1_write_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(s_out.get_noc_addr(0));
+    uint32_t l1_write_addr = noc_address_backend::extract_local_address(s_out.get_noc_addr(0));
 
     uint32_t i_stick = start_id;
     uint32_t curr_c = start_dim_c, curr_h = start_dim_h, curr_n = start_dim_n;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded.cpp
@@ -41,8 +41,8 @@ void kernel_main() {
     // (no borrowed self-loop CBs).
     const auto s_in = TensorAccessor(tensor::input);
     const auto s_out = TensorAccessor(tensor::output);
-    uint32_t l1_read_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(s_in.get_noc_addr(0));
-    uint32_t l1_write_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(s_out.get_noc_addr(0));
+    uint32_t l1_read_addr = noc_address_backend::extract_local_address(s_in.get_noc_addr(0));
+    uint32_t l1_write_addr = noc_address_backend::extract_local_address(s_out.get_noc_addr(0));
 
     // The (noc_x, noc_y) pairs occupy [1 .. 1 + 2*num_cores_read); the num_stick_chunks block
     // begins right after, and the (start_id, num_sticks) chunk pairs after that. We read the noc

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_pad_multicore_both_dims_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_pad_multicore_both_dims_metal2.cpp
@@ -146,8 +146,8 @@ void kernel_main() {
                     }
                 } else {
                     // If there is a mis-alignment, we first load the data to a middle L1 cb, then copy to the final cb
-                    // buffer. The aligned-down source is a full NoC address, so it is supplied directly via
-                    // UnicastEndpoint (decomposed into x/y/local addr; NOC_XY_ADDR repacks it unchanged).
+                    // buffer. The aligned-down source is already a full NoC address, so it is forwarded opaquely via
+                    // PrecomposedUnicastEndpoint - never decomposed or repacked.
                     const uint64_t aligned_src_noc_addr = (src_noc_addr + (uint64_t)start_column_id) & dram_align_mask;
                     {
                         // Separate lock for the staging DFB: it covers the NOC read that fills the scratch and
@@ -158,12 +158,10 @@ void kernel_main() {
                         const auto stage_lock = cb_in1.scoped_write_lock(1);
                         CoreLocalMem<uint32_t> temp_dst(temp_addr);
                         noc.async_read(
-                            UnicastEndpoint{},
+                            PrecomposedUnicastEndpoint{},
                             temp_dst,
                             width_size + dram_alignment,
-                            {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(aligned_src_noc_addr),
-                             .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(aligned_src_noc_addr),
-                             .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(aligned_src_noc_addr)},
+                            {.noc_addr = aligned_src_noc_addr},
                             {.offset_bytes = 0});
 
                         // Block before copying data from tmp to cb buffer

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
@@ -131,17 +131,15 @@ void kernel_main() {
                 }
             } else {
                 // If there is a mis-alignment, we first load the data to a middle L1 cb, then copy to the final cb
-                // buffer. The aligned-down source is a full NoC address, so it is supplied directly via
-                // UnicastEndpoint (decomposed into x/y/local addr; NOC_XY_ADDR repacks it unchanged).
+                // buffer. The aligned-down source is a full NoC address, supplied opaquely via
+                // PrecomposedUnicastEndpoint.
                 const uint64_t aligned_src_noc_addr = (src_noc_addr + (uint64_t)start_column_id) & dram_align_mask;
                 CoreLocalMem<uint32_t> temp_dst(temp_addr);
                 noc.async_read(
-                    UnicastEndpoint{},
+                    PrecomposedUnicastEndpoint{},
                     temp_dst,
                     width_size + dram_alignment,
-                    {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(aligned_src_noc_addr),
-                     .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(aligned_src_noc_addr),
-                     .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(aligned_src_noc_addr)},
+                    {.noc_addr = aligned_src_noc_addr},
                     {.offset_bytes = 0});
 
                 // Block before copying data from tmp to cb buffer

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
@@ -43,7 +43,7 @@ void kernel_main() {
 
     // Local input-shard base L1 address from the resident input TensorAccessor (no borrowed self-loop CB).
     const auto s = TensorAccessor(tensor::input);
-    uint32_t src_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(s.get_noc_addr(0));
+    uint32_t src_addr = noc_address_backend::extract_local_address(s.get_noc_addr(0));
 
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t h = 0; h < Ht; ++h) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
@@ -39,7 +39,7 @@ void kernel_main() {
 
     // Local output-shard base L1 address from the resident output TensorAccessor (no borrowed self-loop CB).
     const auto s = TensorAccessor(tensor::output);
-    uint32_t dst_addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(s.get_noc_addr(0));
+    uint32_t dst_addr = noc_address_backend::extract_local_address(s.get_noc_addr(0));
 
     // temporary fix until pack_untilze is fully fixed
     if constexpr (Ht > 8) {


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Stacked on #54199. That PR routed the shared address-construction helpers through the arch-selected `noc_address_backend`; a full-tree audit found two remaining patterns that bypass the seam, both of which would silently misbehave once a non-XY backend (Quasar ATT) is selected:

**Compose-from-(x,y):** `cross_node_dfb.h` and `remote_circular_buffer.h` built addresses by hand with `NOC_XY_ENCODING` + `get_noc_addr_helper`. Now routed through `noc_address_backend::worker_address`. The hoisted receiver loop in `remote_circular_buffer.h` keeps its shape by building a base address once and adding offsets — offset arithmetic stays within the local-address bits on every backend.

**Split-to-reissue:** five kernels decomposed a finished 64-bit NoC address back into `{noc_x, noc_y, addr}` with `NOC_UNICAST_ADDR_X/Y`/`NOC_LOCAL_ADDR_OFFSET` — only because `UnicastEndpoint`'s args take coordinates. Under ATT those bits are a window + selector, not coordinates, so the decompose produces garbage. This PR adds `PrecomposedUnicastEndpoint`, whose args carry the full address opaquely, and migrates the five call sites: `data_movement/common/kernels/common.hpp`, `scatter/.../common.hpp`, `tilize_with_val_padding` reader, and the two `experimental/quasar/tilize*` readers (which already run on Quasar).

### Notes for reviewers
- Unlike #54199 this PR is **not** byte-identical by design — removing the pack/unpack round-trips changes (improves) the code. Equivalence is proven differently:
  - Compile-time proofs on the XY backend (checked on WH, BH, and Quasar): `worker_address(x,y,addr) == (NOC_XY_ENCODING(x,y) << NOC_ADDR_COORD_SHIFT) | addr`; split+rejoin == identity (so passing the address opaquely equals the old decompose/recompose); `base + offset == compose-with-offset`.
  - An object-code sweep of 900+ kernel builds against the parent branch: every build byte-identical except the two `cross_node_dfb` test kernels, whose diff is exactly the removed pack/unpack instructions.
- The modified tilize readers were additionally compile-verified standalone with the device compiler (the `tilize/...metal2` variant only via its sibling — it needs host-generated named-arg bindings to compile standalone, a pre-existing limitation).
- With this PR, the only remaining direct XY composition/decomposition sites in device code are: the dispatch kernels (tracked for the dispatch-conversion PR), watcher/`sanitize.h` and fabric (to be compile-rejected under ATT), and the per-arch V1/V2 transport layers (arch-specific by definition).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/att-pr1p5-seam-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/att-pr1p5-seam-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/att-pr1p5-seam-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/att-pr1p5-seam-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/att-pr1p5-seam-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/att-pr1p5-seam-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/att-pr1p5-seam-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/att-pr1p5-seam-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/att-pr1p5-seam-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/att-pr1p5-seam-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/att-pr1p5-seam-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/att-pr1p5-seam-coverage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/att-pr1p5-seam-coverage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/att-pr1p5-seam-coverage)