### PR TITLE
feat: import out-of-tree LLK test via suite python_tests

### DIFF
--- a/tt_metal/tt-llk/docs/tests/getting_started.md
+++ b/tt_metal/tt-llk/docs/tests/getting_started.md
@@ -545,6 +545,7 @@ An external pytest suite should:
    pytest_plugins = ["helpers.llk_pytest_plugin"]
    ```
    Invoke pytest with that suite as the rootdir (so `pytest_plugins` is legal). Set `LLK_HOME` if it cannot be inferred. `CHIP_ARCH` is optional on a live card (`check_context()`); export it for compile-only / no-device.
+   Test files should not touch `sys.path`. The plugin prepends `<rootdir>/python_tests` so suite-local packages (e.g. `goldens/`) import without per-test boilerplate. Keep suite-local Python packages there, not under a `helpers/` overlay (that name is reserved for the harness).
 
 2. Register proprietary search dirs on `TestConfig` (before or after `setup_build`):
    ```python

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_pytest_plugin.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_pytest_plugin.py
@@ -5,10 +5,16 @@
 
 In-tree tests load this via ``tests/python_tests/conftest.py``. Out-of-tree
 suites (proprietary kernels that cannot live in this public repo) load the
-same plugin after putting ``tests/python_tests`` on ``sys.path``:
+same plugin from the suite rootdir ``conftest`` after putting this
+``tests/python_tests`` on ``sys.path`` once:
 
     sys.path.insert(0, str(llk_python_tests))
     pytest_plugins = ["helpers.llk_pytest_plugin"]
+
+Test modules do not mutate ``sys.path``. ``pytest_configure`` prepends
+``<rootdir>/python_tests`` when that directory exists so suite-local
+packages (for example a ``goldens/`` tree) import like in-tree
+``helpers``.
 
 Set ``LLK_HOME`` to the tt-llk root if it cannot be inferred. Register extra
 header ``-I`` dirs with ``TestConfig.add_include_dirs(...)`` and extra
@@ -130,6 +136,24 @@ def init_llk_home():
 
 # Default LLK_HOME environment variable
 init_llk_home()
+
+
+def _prepend_sys_path(path: Path) -> None:
+    if not path.is_dir():
+        return
+    resolved = str(path.resolve())
+    if resolved not in sys.path:
+        sys.path.insert(0, resolved)
+
+
+def _ensure_suite_pythonpath(config) -> None:
+    """Make ``<rootdir>/python_tests`` importable (out-of-tree goldens, …).
+
+    In-tree runs use ``python_tests`` as the rootdir, so this is a no-op.
+    Do not prepend ``rootdir`` itself: a suite-local ``helpers/`` tree
+    (C++ include/src overlay) would shadow ``helpers.golden_generators``.
+    """
+    _prepend_sys_path(Path(config.rootpath) / "python_tests")
 
 
 @pytest.fixture()
@@ -348,6 +372,8 @@ _UNIFIED_ORDER_FILE: str = "DEFAULT"
 
 
 def pytest_configure(config):
+    _ensure_suite_pythonpath(config)
+
     # Configure loguru log level from CLI option or environment variable.
     log_level = config.getoption("--logging-level", default=None)
     configure_logger(level=log_level)


### PR DESCRIPTION
### PR Category
Feature

### Summary
The patch is a follow-up to #54182 (out-of-tree LLK harness). It has two jobs:
1. Let an external suite import its own Python packages without touching `sys.path`.
2. Harden `TestConfig` for that same out-of-tree path


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/extend-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/extend-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/extend-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/extend-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/extend-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/extend-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/extend-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/extend-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/extend-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/extend-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/extend-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/extend-llk-test-harness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/extend-llk-test-harness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/extend-llk-test-harness)