### PR TITLE
[Bug fix] ttnn.topk: validate the preallocated output indices width

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -394,6 +394,48 @@ def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device, expect_
         ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))
 
 
+@pytest.mark.parametrize(
+    "W, input_dtype, index_dtype, raises",
+    [
+        (64, ttnn.bfloat16, ttnn.uint16, False),
+        (64, ttnn.bfloat16, ttnn.uint32, False),
+        (UINT16_MAX + 1, ttnn.bfloat16, ttnn.uint32, False),
+        (UINT16_MAX + 1, ttnn.bfloat16, ttnn.uint16, True),
+        (64, ttnn.float32, ttnn.uint16, True),
+    ],
+    ids=["w64_u16", "w64_u32", "w65536_u32", "w65536_u16_raises", "fp32_u16_raises"],
+)
+def test_topk_preallocated_indices_width(W, input_dtype, index_dtype, raises, device, expect_error):
+    # index_dtype is the preallocated output indices tensor. A 16-bit one on an input that needs
+    # 32 bits is rejected; wider than needed is legal. fp32 needs 32 bits at any width.
+    torch.manual_seed(0)
+    k = 32
+    shape = [1, 1, 32, W]
+    torch_dtype = torch.float32 if input_dtype == ttnn.float32 else torch.bfloat16
+
+    torch_input = torch.randn(shape, dtype=torch_dtype)
+    ttnn_input = ttnn.from_torch(torch_input, input_dtype, layout=ttnn.Layout.TILE, device=device)
+    value_tensor = ttnn.from_torch(
+        torch.zeros([1, 1, 32, k], dtype=torch_dtype), input_dtype, layout=ttnn.Layout.TILE, device=device
+    )
+    index_tensor = ttnn.from_torch(
+        torch.zeros([1, 1, 32, k], dtype=torch.int32), index_dtype, layout=ttnn.Layout.TILE, device=device
+    )
+
+    if raises:
+        with expect_error(RuntimeError, "Preallocated indices tensor must be"):
+            ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))
+        return
+
+    values, indices = ttnn.topk(
+        ttnn_input, k=k, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor)
+    )
+
+    assert indices.dtype == index_dtype
+    gathered = torch.gather(torch_input, -1, ttnn.to_torch(indices).to(torch.int64))
+    assert_equal(gathered, ttnn.to_torch(values))
+
+
 def test_topk_fp32_input_with_uint16_indices_tensor_raise(device, expect_error):
     # fp32 input forces UINT32 index CBs; a UINT16 indices_tensor would silently produce wrong indices.
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -423,7 +423,7 @@ def test_topk_preallocated_indices_width(W, input_dtype, index_dtype, raises, de
     )
 
     if raises:
-        with expect_error(RuntimeError, "Preallocated indices tensor must be"):
+        with expect_error(RuntimeError, "must be 32-bit"):
             ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))
         return
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -280,6 +280,15 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
                 output_tensor1_dtype == DataType::INT32,
             "Preallocated indices tensor must be UINT16, UINT32, or INT32 got: {}",
             output_tensor1_dtype);
+        // The preallocated indices tensor sets the index width for the whole op. A 16-bit one
+        // on an input that needs 32 bits wraps past 65535 and returns the wrong columns.
+        const DataType required_dtype = required_index_dtype(input_tensor, args.dim);
+        const bool indices_too_narrow = output_tensor1_dtype == DataType::UINT16 && required_dtype != DataType::UINT16;
+        TT_FATAL(
+            !indices_too_narrow,
+            "Preallocated indices tensor must be {} for this input, got: {}",
+            required_dtype,
+            output_tensor1_dtype);
         TT_FATAL(
             output_tensor0_dtype == input_tensor_dtype,
             "Preallocated output tensor dtype must match input tensor dtype. Got output: {}, input: {}",

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -37,7 +37,7 @@ DataType resolve_index_dtype(
             return indices_dtype;
         }
     }
-    return required_index_dtype(tensor_args.input, args.dim);
+    return is_uint32_index_required(tensor_args.input, args.dim) ? DataType::UINT32 : DataType::UINT16;
 }
 
 // Maps the resolved index dtype onto the circular-buffer data format used by the sort datapath. 16-bit indices
@@ -282,12 +282,11 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
             output_tensor1_dtype);
         // The preallocated indices tensor sets the index width for the whole op. A 16-bit one
         // on an input that needs 32 bits wraps past 65535 and returns the wrong columns.
-        const DataType required_dtype = required_index_dtype(input_tensor, args.dim);
-        const bool indices_too_narrow = output_tensor1_dtype == DataType::UINT16 && required_dtype != DataType::UINT16;
+        const bool indices_too_narrow =
+            output_tensor1_dtype == DataType::UINT16 && is_uint32_index_required(input_tensor, args.dim);
         TT_FATAL(
             !indices_too_narrow,
-            "Preallocated indices tensor must be {} for this input, got: {}",
-            required_dtype,
+            "Preallocated indices tensor must be 32-bit (UINT32 or INT32) for this input, got: {}",
             output_tensor1_dtype);
         TT_FATAL(
             output_tensor0_dtype == input_tensor_dtype,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -338,10 +338,10 @@ bool verify_single_core_cost(const ttnn::Tensor& input_tensor, uint32_t k, bool 
     return memory_cost_local < device->l1_size_per_core();
 }
 
-tt::tt_metal::DataType required_index_dtype(const ttnn::Tensor& input_tensor, int8_t dim) {
+bool is_uint32_index_required(const ttnn::Tensor& input_tensor, int8_t dim) {
     const bool dim_fits_uint16 = input_tensor.padded_shape()[dim] <= std::numeric_limits<uint16_t>::max();
     const bool is_fp32 = input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32;
-    return (dim_fits_uint16 && !is_fp32) ? tt::tt_metal::DataType::UINT16 : tt::tt_metal::DataType::UINT32;
+    return !dim_fits_uint16 || is_fp32;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.hpp
@@ -57,8 +57,7 @@ bool verify_multi_core_cost(
 
 bool verify_single_core_cost(const ttnn::Tensor& input_tensor, uint32_t k, bool uint16_output);
 
-// The index dtype the op picks on its own: UINT16 if the padded reduced dim fits in 16 bits, else
-// UINT32. fp32 input also forces UINT32 -- it sorts with fp32 dest accumulation, which loads
-// indices as INT32.
-tt::tt_metal::DataType required_index_dtype(const ttnn::Tensor& input_tensor, int8_t dim);
+// True when the op must use 32-bit indices: the padded reduced dim does not fit in 16 bits, or the
+// input is fp32, which sorts with fp32 dest accumulation and loads indices as INT32.
+bool is_uint32_index_required(const ttnn::Tensor& input_tensor, int8_t dim);
 }  // namespace ttnn::prim


### PR DESCRIPTION
### PR Category

- Bug fix

### Summary

- Closes #51959

A preallocated output indices tensor sets the index width for the whole op, and nothing checked that width against what the input needs. A `uint16` indices buffer on an input needing 32 bits wrapped past 65535 and returned indices for the wrong columns, with correct values and no error.

Only defect 2 from the issue is left. Defect 1, a `uint32` buffer on a narrow input, was already resolved before #54168.

### Solution

```cpp
const DataType required_dtype = required_index_dtype(input_tensor, args.dim);
const bool indices_too_narrow = output_tensor1_dtype == DataType::UINT16 && required_dtype != DataType::UINT16;
TT_FATAL(
    !indices_too_narrow,
    "Preallocated indices tensor must be {} for this input, got: {}",
    required_dtype,
    output_tensor1_dtype);
```

Only too-narrow is rejected. A buffer wider than needed is correct and stays legal, so this is deliberately not `prealloc == required`. It also catches `float32` input, which needs 32-bit indices at any width because fp32 sorts with fp32 dest accumulation. 

### Tests

`test_topk_preallocated_indices_width` covers the five combinations, using `65536` for the wide cases. The passing rows gather the input by the returned indices and compare against the returned values, so a wrong index fails and not just a missing error.

### Notes for reviewers

- Behaviour change: a `uint16` preallocated indices buffer with a wide or `float32` input now raises instead of returning wrong indices. No caller in the repo preallocates topk outputs outside the tests.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-51959-prealloc-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-51959-prealloc-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-51959-prealloc-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-51959-prealloc-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-51959-prealloc-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-51959-prealloc-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-51959-prealloc-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-51959-prealloc-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-51959-prealloc-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-51959-prealloc-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-51959-prealloc-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-51959-prealloc-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-51959-prealloc-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-51959-prealloc-output)