### PR TITLE
Scale comp_pcc's constant-tensor allclose fallback to the compared dtype

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -492,6 +492,17 @@ def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
     if golden.dtype != calculated.dtype:
         calculated = calculated.type(golden.dtype)
 
+    # PCC is undefined for constant tensors, so the two checks below fall back to
+    # allclose. The caller's default rtol/atol are fp32-grade and unreachable for a
+    # lower-precision dtype: bfloat16 carries eps = 2^-7, so a single-element
+    # bfloat16 result that agrees with torch to within 2 ULP still fails the
+    # fallback and gets reported as PCC 0.0. Widen the fallback bound to the
+    # precision the compared dtype actually carries, never tightening it below what
+    # the caller asked for. A wrong golden on a constant tensor is off by orders of
+    # magnitude rather than a few ULP, so it is still caught.
+    _dtype_tol = 4 * torch.finfo(golden.dtype).eps if golden.dtype.is_floating_point else 0.0
+    fallback_rtol, fallback_atol = max(rtol, _dtype_tol), max(atol, _dtype_tol)
+
     if torch.all(torch.isnan(golden)) and torch.all(torch.isnan(calculated)):
         logger.warning("Both tensors are 'nan'")
         return True, 1.0
@@ -505,7 +516,7 @@ def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
     # within the caller's tolerances.
     if torch.any(golden.bool()) != torch.any(calculated.bool()):
         logger.warning("One tensor is all zero. PCC undefined; falling back to allclose.")
-        result = torch.allclose(golden, calculated, rtol=rtol, atol=atol)
+        result = torch.allclose(golden, calculated, rtol=fallback_rtol, atol=fallback_atol)
         return result, float(result)
 
     golden = torch.squeeze(golden).flatten()
@@ -561,7 +572,7 @@ def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
     # Fall back to allclose rather than returning a misleading 1.0.
     if math.isnan(cal_pcc):
         logger.warning("PCC is NaN (zero variance / constant tensor). Falling back to allclose check.")
-        result = torch.allclose(golden, calculated, rtol=rtol, atol=atol)
+        result = torch.allclose(golden, calculated, rtol=fallback_rtol, atol=fallback_atol)
         return result, float(result)
 
     return cal_pcc >= pcc, cal_pcc


### PR DESCRIPTION
### Problem

When PCC is undefined (constant / single-element tensor), `comp_pcc` falls back to `torch.allclose(rtol=1e-5, atol=1e-4)`. Those are **fp32-grade tolerances**, and a bfloat16 result cannot meet them — bf16 eps is 2^-7.

A 1-element bfloat16 `tanh` that agrees with torch to within 2 ULP therefore fails and is reported as **PCC 0.0**:

```
input      : -0.75        (bfloat16)
torch tanh : -0.63671875
device tanh: -0.6328125   <- 2 bf16 ULP apart, normal SFPU error
result     : (False, '0.0')
```

This is what fails the `tanh_model_traced` config `80b39652` (shape `(1,)`, bf16) in lead-model runs.

### Fix

Widen the fallback bound to the precision the compared dtype actually carries, **never tightening below what the caller asked for** (`max(rtol, 4*eps)`). fp32 and integer comparisons are unchanged; only bf16/fp16 constant-tensor comparisons that already failed can now pass — the change is monotone-loosening, so nothing that passes today can start failing.

The wrong-golden detection this fallback was added for (#42848) is preserved.

### Verification

| case | expected | result |
|---|---|---|
| 1-element bf16 tanh, 2 ULP apart | pass | pass (1.0) |
| wrong golden 4.0 vs 3.0 (bf16 constant) | **fail** | fail (0.0) |
| wrong golden 1.0 vs 0.0 (near zero) | **fail** | fail (0.0) |
| wrong golden 11% off | **fail** | fail (0.0) |
| fp32 constant 2 ULP apart | fail (unchanged) | fail (0.0) |
| all-inf identical | pass | pass (1.0) |
| int32 constant equal / differing | pass / fail | pass / fail |
| normal PCC path (identical / uncorrelated) | pass / fail | pass / fail |

The failing vector passes end-to-end on device after the change. The master trace set has **218 single-element tensor arguments across 18 ops**, so this covers a class of latent failures rather than one config.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-constant-tensor-pcc-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-constant-tensor-pcc-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-constant-tensor-pcc-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-constant-tensor-pcc-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-constant-tensor-pcc-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-constant-tensor-pcc-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-constant-tensor-pcc-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-constant-tensor-pcc-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-constant-tensor-pcc-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-constant-tensor-pcc-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-constant-tensor-pcc-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-constant-tensor-pcc-tolerance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-constant-tensor-pcc-tolerance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-constant-tensor-pcc-tolerance)