### PR TITLE
[Bug fix]  Fix for Qwen3-32B and Llama-3.3-70B sampling test failures on Galaxy

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -11,8 +11,6 @@ from typing import List, Optional
 import torch
 from loguru import logger
 
-import os
-
 import ttnn
 
 from ._utils import clamp, is_default_value, split_list
@@ -83,23 +81,6 @@ class SamplingParams:
 
 
 SAMPLING_PARAM_FIELDS = tuple(f.name for f in fields(SamplingParams))
-
-
-def uniform_from_device_seed(device_seed):
-    """Map one SeedManager device seed to a uniform in [0, 1) for the Python sampler.
-
-    Reuses the existing derivation rather than inventing a seeding scheme:
-    _hash_request_seed_to_device_seed(request_seed, counter, salt) already produces a
-    slot-independent, salt-separated per-token value, and align_seed_counters_to_positions
-    keeps the counter tied to the absolute decode position. Finishing the mapping on host
-    means the draw does not depend on per-core PRNG state, manual_seed ordering, or any SFPU
-    work between seeding and the draw -- the hazard 4b2f6978c9c had to work around.
-    """
-    x = (int(device_seed) * 0x2545F4914F6CDD1D) & _UINT64_MASK
-    x ^= x >> 33
-    x = (x * 0xFF51AFD7ED558CCD) & _UINT64_MASK
-    x ^= x >> 33
-    return (x >> 11) / float(1 << 53)
 
 
 @dataclass(frozen=True)
@@ -466,42 +447,6 @@ class SamplingGenerator:
         # Explicit request seeds update a persistent seed tensor every token;
         # run them directly so trace replay cannot observe stale seed state.
         use_internal_trace = enable_trace and not self.seed_manager.has_active_request_seed()
-        # TT_PY_SAMPLER_EAGER=1: never capture a sampling trace for the Python sampler; run it
-        # eagerly every step. The sampling trace is captured lazily on the FIRST decode step,
-        # i.e. while the decode trace is already live, and the Python sampler records ~40 ops
-        # there against ttnn.sampling's one. Eager sampling was the historical arrangement and
-        # carried the same error rate, so the trace buys little here.
-        if os.environ.get("TT_PY_SAMPLER_EAGER") and getattr(self.tt_sampling, "_py_sampler", False):
-            use_internal_trace = False
-
-        if getattr(self.tt_sampling, "_py_sampler_possible", False):
-            # Refresh the draw column OUTSIDE any trace: capture_trace runs _run_sampling
-            # inside the capture window, where device writes are illegal. The update is
-            # in-place into a persistent buffer, so trace replay picks it up each step.
-            seeds = getattr(self.seed_manager, "last_device_seeds", []) or []
-            batch = self.tt_sampling.max_batch_size * self.tt_sampling._sampling_dp
-            uniforms = []
-            for i in range(batch):
-                seed = seeds[i] if i < len(seeds) else None
-                if seed is None or int(seed) == MAX_UINT32:
-                    seed = self.seed_manager._next_unseeded_device_seed()
-                uniforms.append(uniform_from_device_seed(seed))
-            if os.environ.get("TT_PY_SEED_DEBUG"):
-                _seeded = [(i, int(seeds[i]), round(uniforms[i], 9))
-                           for i in range(min(len(seeds), batch))
-                           if seeds[i] is not None and int(seeds[i]) != MAX_UINT32]
-                logger.warning(f"[seed-dbg] batch={batch} len(seeds)={len(seeds)} "
-                               f"dp={self.tt_sampling._sampling_dp} "
-                               f"max_bs={self.tt_sampling.max_batch_size} seeded={_seeded[:6]}")
-            self.tt_sampling.set_rand_column(uniforms)
-            # REQUIRED, not optional. k/p/temp/rand are pushed with copy_host_to_device_tensor
-            # from OUTSIDE the sampling sub-device and then read by ops running on
-            # sub_core_grids; those two are not implicitly ordered, so without this barrier the
-            # draw reads stale parameters -- the visible symptom is different sampling params
-            # (greedy, temp=5, top_k=10) all producing byte-identical output. Grid placement
-            # cannot fix this one: the upload is a host->device transfer, not a device op.
-            ttnn.synchronize_device(self.mesh_device)
-
         if not use_internal_trace:
             tt_out = self._run_sampling(
                 logits,
@@ -853,7 +798,6 @@ class SeedManager:
         self.seed_counters = [0 for _ in range(max_batch_size)]
         # Last per-slot device seeds pushed by get_new_values; the Python sampler turns these
         # into its per-user uniforms so it draws from the same stream as the device PRNG path.
-        self.last_device_seeds = []
         # Disambiguates concurrent slots that carry the SAME explicit request
         # seed (n>1 completions of one prompt with a fixed seed). A slot whose
         # seed is unique among active slots always has salt 0, preserving the
@@ -1190,6 +1134,5 @@ class SeedManager:
                 assert len(empty_slots) == 1, "Cannot replicate seeds if empty_slots is not length 1"
                 new_seeds = self.max_batch_size * [new_seeds[empty_slots[0]]]
 
-        self.last_device_seeds = list(new_seeds)
         self.write_device_seed_values(new_seeds)
         self._reseted = False

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -11,6 +11,8 @@ from typing import List, Optional
 import torch
 from loguru import logger
 
+import os
+
 import ttnn
 
 from ._utils import clamp, is_default_value, split_list
@@ -83,6 +85,23 @@ class SamplingParams:
 SAMPLING_PARAM_FIELDS = tuple(f.name for f in fields(SamplingParams))
 
 
+def uniform_from_device_seed(device_seed):
+    """Map one SeedManager device seed to a uniform in [0, 1) for the Python sampler.
+
+    Reuses the existing derivation rather than inventing a seeding scheme:
+    _hash_request_seed_to_device_seed(request_seed, counter, salt) already produces a
+    slot-independent, salt-separated per-token value, and align_seed_counters_to_positions
+    keeps the counter tied to the absolute decode position. Finishing the mapping on host
+    means the draw does not depend on per-core PRNG state, manual_seed ordering, or any SFPU
+    work between seeding and the draw -- the hazard 4b2f6978c9c had to work around.
+    """
+    x = (int(device_seed) * 0x2545F4914F6CDD1D) & _UINT64_MASK
+    x ^= x >> 33
+    x = (x * 0xFF51AFD7ED558CCD) & _UINT64_MASK
+    x ^= x >> 33
+    return (x >> 11) / float(1 << 53)
+
+
 @dataclass(frozen=True)
 class _TraceKey:
     penalties_on: bool
@@ -131,6 +150,7 @@ class SamplingGenerator:
         self.seed_manager = SeedManager(
             self.tt_sampling,
             max_batch_size=seed_batch_size,
+            salt_duplicate_seeds=getattr(args, "salt_duplicate_seeds", True),
         )
 
     def _new_trace_state(self):
@@ -172,10 +192,10 @@ class SamplingGenerator:
                 continue
         self._trace_states.clear()
 
-    def reset_prompt_tokens(self, prompt_tokens):
+    def reset_prompt_tokens(self, prompt_tokens, slots: list[int] | None = None):
         if not self._penalties_active:
             return
-        self.tt_penalties.reset_prompt_tokens(prompt_tokens)
+        self.tt_penalties.reset_prompt_tokens(prompt_tokens, slots=slots)
 
     def reset_output_state(self, tokens=None):
         if not self._penalties_active:
@@ -446,6 +466,41 @@ class SamplingGenerator:
         # Explicit request seeds update a persistent seed tensor every token;
         # run them directly so trace replay cannot observe stale seed state.
         use_internal_trace = enable_trace and not self.seed_manager.has_active_request_seed()
+        # TT_PY_SAMPLER_EAGER=1: never capture a sampling trace for the Python sampler; run it
+        # eagerly every step. The sampling trace is captured lazily on the FIRST decode step,
+        # i.e. while the decode trace is already live, and the Python sampler records ~40 ops
+        # there against ttnn.sampling's one. Eager sampling was the historical arrangement and
+        # carried the same error rate, so the trace buys little here.
+        if os.environ.get("TT_PY_SAMPLER_EAGER") and getattr(self.tt_sampling, "_py_sampler", False):
+            use_internal_trace = False
+
+        if getattr(self.tt_sampling, "_py_sampler_possible", False):
+            # Refresh the draw column OUTSIDE any trace: capture_trace runs _run_sampling
+            # inside the capture window, where device writes are illegal. The update is
+            # in-place into a persistent buffer, so trace replay picks it up each step.
+            seeds = getattr(self.seed_manager, "last_device_seeds", []) or []
+            batch = self.tt_sampling.max_batch_size * self.tt_sampling._sampling_dp
+            uniforms = []
+            for i in range(batch):
+                seed = seeds[i] if i < len(seeds) else None
+                if seed is None or int(seed) == MAX_UINT32:
+                    seed = self.seed_manager._next_unseeded_device_seed()
+                uniforms.append(uniform_from_device_seed(seed))
+            if os.environ.get("TT_PY_SEED_DEBUG"):
+                _seeded = [(i, int(seeds[i]), round(uniforms[i], 9))
+                           for i in range(min(len(seeds), batch))
+                           if seeds[i] is not None and int(seeds[i]) != MAX_UINT32]
+                logger.warning(f"[seed-dbg] batch={batch} len(seeds)={len(seeds)} "
+                               f"dp={self.tt_sampling._sampling_dp} "
+                               f"max_bs={self.tt_sampling.max_batch_size} seeded={_seeded[:6]}")
+            self.tt_sampling.set_rand_column(uniforms)
+            # REQUIRED, not optional. k/p/temp/rand are pushed with copy_host_to_device_tensor
+            # from OUTSIDE the sampling sub-device and then read by ops running on
+            # sub_core_grids; those two are not implicitly ordered, so without this barrier the
+            # draw reads stale parameters -- the visible symptom is different sampling params
+            # (greedy, temp=5, top_k=10) all producing byte-identical output. Grid placement
+            # cannot fix this one: the upload is a host->device transfer, not a device op.
+            ttnn.synchronize_device(self.mesh_device)
 
         if not use_internal_trace:
             tt_out = self._run_sampling(
@@ -780,10 +835,25 @@ class SeedManager:
     writes to device. `write_device_seed_values` writes explicit seeds only.
     """
 
-    def __init__(self, tt_sampling, max_batch_size=32):
+    def __init__(self, tt_sampling, max_batch_size=32, salt_duplicate_seeds=True):
         self.max_batch_size = max_batch_size
+        # When False, concurrent slots sharing a request seed keep salt 0, so two independent
+        # requests carrying the same seed stay bit-identical (the OpenAI/vLLM reproducibility
+        # contract, asserted by the vLLM TT sampling suite).
+        #
+        # #53077 added salting for "n>1 completions of one prompt with a fixed seed occupy
+        # several slots with the same request seed". That premise does not hold on the vLLM v1
+        # path: ParentRequest._get_child_sampling_params already gives child i `seed + i`
+        # (vllm/v1/engine/parallel_sampling.py), so n>1 children never reach the backend
+        # sharing a seed. There, every duplicate seed is genuinely independent requests that
+        # MUST match, and salting them is a regression. Demo paths that do replicate one seed
+        # across slots (e.g. simple_text_demo.py) keep the default and are unaffected.
+        self.salt_duplicate_seeds = salt_duplicate_seeds
         self.seeds = [None for _ in range(max_batch_size)]
         self.seed_counters = [0 for _ in range(max_batch_size)]
+        # Last per-slot device seeds pushed by get_new_values; the Python sampler turns these
+        # into its per-user uniforms so it draws from the same stream as the device PRNG path.
+        self.last_device_seeds = []
         # Disambiguates concurrent slots that carry the SAME explicit request
         # seed (n>1 completions of one prompt with a fixed seed). A slot whose
         # seed is unique among active slots always has salt 0, preserving the
@@ -840,6 +910,8 @@ class SeedManager:
         rather than a running count -- avoids re-colliding with a surviving
         duplicate after an earlier one finished and vacated its slot.
         """
+        if not self.salt_duplicate_seeds:
+            return 0
         taken = {
             self.seed_salts[other]
             for other in range(self.max_batch_size)
@@ -1118,5 +1190,6 @@ class SeedManager:
                 assert len(empty_slots) == 1, "Cannot replicate seeds if empty_slots is not length 1"
                 new_seeds = self.max_batch_size * [new_seeds[empty_slots[0]]]
 
+        self.last_device_seeds = list(new_seeds)
         self.write_device_seed_values(new_seeds)
         self._reseted = False

--- a/models/common/sampling/tt_log_probs.py
+++ b/models/common/sampling/tt_log_probs.py
@@ -511,6 +511,28 @@ class LogProbsCalculator:
         # Subtract and put result to self.output_tensor
         ttnn.subtract(out, log_global_exp_sum, output_tensor=self.output_tensor, **self.common_args)
 
+    def _release_global_stats(self) -> None:
+        """Free the per-call global stats so they do not outlive the call.
+
+        `_compute_global_stats` parks `global_max`/`global_exp_sum` on the instance so the
+        later log-softmax steps can read them, but they are CALL-SCOPED: every call
+        overwrites them and nothing reads them across calls. Left on the instance they keep
+        two device buffers alive indefinitely -- and prefill sampling is UNTRACED, so they are
+        allocated while the prefill/decode traces are live and are still alive at
+        execute_trace. That is the allocation-behind-a-live-trace hazard of #52176, and the
+        trace-allocation tracker (TT_METAL_TRACE_ALLOC_TRACKING=1) names exactly these two
+        buffers: "Found 2 device buffer(s) still alive before trace replay".
+        """
+        for name in ("global_max", "global_exp_sum"):
+            tensor = getattr(self, name, None)
+            if tensor is None:
+                continue
+            try:
+                ttnn.deallocate(tensor)
+            except BaseException as error:  # best-effort, mirrors release()
+                logger.debug(f"Failed to deallocate {name}: {error}")
+            setattr(self, name, None)
+
     def calculate_log_probs(
         self,
         logits_tensor: ttnn.Tensor,
@@ -539,6 +561,8 @@ class LogProbsCalculator:
 
         # Calculate log-probs for each user on each chip and stores in self.output_tensor
         self._calculate_log_probs(relevant_logits)
+
+        self._release_global_stats()
 
         return self.output_tensor
 
@@ -637,6 +661,8 @@ class LogProbsCalculator:
         # Single-pass logprob computation for all gathered top-k tokens
         self._calculate_topk_log_probs_from_values(topk_local_values)
         ttnn.deallocate(topk_local_values)
+
+        self._release_global_stats()
 
         return LogProbsResult(
             topk_logprobs=self.topk_logprobs_output,

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -137,6 +137,8 @@ class TTPenalties(LightweightModule):
         self._shard_dims_gathered = shard_dims_gathered
 
         self.prompt_mask = self._alloc_int_buffer(shard_dims=shard_dims)
+        # Host shadow of the per-slot prompt tokens, so a partial update keeps other rows' masks.
+        self._prompt_tokens_host = None
         self.output_mask = self._alloc_int_buffer(shard_dims=shard_dims)
         self.output_counts_gathered = self._alloc_int_buffer(shard_dims=shard_dims_gathered)
         self.output_counts = self._alloc_int_buffer(shard_dims=shard_dims)
@@ -253,9 +255,35 @@ class TTPenalties(LightweightModule):
             return tokens_2d[: self._total_batch]
         return tokens_2d
 
-    def reset_prompt_tokens(self, prompt_tokens: torch.Tensor):
+    def reset_prompt_tokens(self, prompt_tokens: torch.Tensor, slots: list[int] | None = None):
+        """Rebuild the prompt mask. With ``slots``, only those rows are taken from
+        ``prompt_tokens``; every other row keeps the prompt it was last given.
+
+        The device buffer covers all rows at once, so a caller that only knows about the requests it
+        is prefilling used to zero everyone else's mask: rows outside the call arrive as the -1
+        padding and hash to an empty mask. repetition_penalty is the only consumer of prompt_mask, so
+        a live request silently stopped penalising its own prompt until something refreshed it.
+        Under vLLM the next decode's reset_batch does refresh it, which is why this stayed hidden;
+        the demo path never sets reset_batch and keeps the wiped mask for the whole generation.
+        """
         prompt_tokens_2d = prompt_tokens.reshape(-1, prompt_tokens.shape[-1])
         prompt_tokens_2d = self._pad_batch_to_max(prompt_tokens_2d, pad_value=-1)
+
+        if slots is None:
+            self._prompt_tokens_host = prompt_tokens_2d.clone()
+        else:
+            shadow = getattr(self, "_prompt_tokens_host", None)
+            width = max(prompt_tokens_2d.shape[-1], shadow.shape[-1] if shadow is not None else 0)
+            merged = torch.full((self._total_batch, width), -1, dtype=prompt_tokens_2d.dtype)
+            if shadow is not None:
+                merged[:, : shadow.shape[-1]] = shadow
+            for slot in slots:
+                slot = int(slot)
+                if 0 <= slot < self._total_batch:
+                    merged[slot, :] = -1
+                    merged[slot, : prompt_tokens_2d.shape[-1]] = prompt_tokens_2d[slot]
+            self._prompt_tokens_host = merged
+            prompt_tokens_2d = merged
 
         # Build reset masks on host to avoid device scatter_add races on
         # duplicate prompt token ids (common in penalty tests/prompts).

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -674,8 +674,6 @@ class TTSampling(LightweightModule):
             )
             ttnn.copy_host_to_device_tensor(self._greedy_col_new, self._greedy_col)
 
-
-
         self.log_probs_calculator.set_log_probs_mode(
             enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
         )
@@ -781,7 +779,6 @@ class TTSampling(LightweightModule):
         adjusted = ttnn.add(gathered_values, boost, sub_core_grids=scg)
         ttnn.deallocate(boost)
         return adjusted
-
 
     def forward(
         self,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -41,16 +41,6 @@ TIEBREAK_DELTA_FLOOR = 1e-30
 # that sentinel + index cannot overflow the int32 the min reduce runs in.
 TIEBREAK_INDEX_SENTINEL = 2**24
 
-# Deterministic Python-side sampler (TT_PY_SAMPLER=1). Replaces ttnn.sampling, whose internal
-# top-k orders EXACT TIES unstably (#33492); _adjust_values_for_tiebreak only covers k==1, so
-# every k>1 row (seeded requests reach k=32) has no tie protection today. The de-tie below gives
-# the candidates a TOTAL ORDER -- value desc, then token id asc -- so no tie is ever left for an
-# unstable network to resolve. Validated standalone: greedy picks the lowest-id tied maximum,
-# identical inputs give identical tokens, results are slot-permutation invariant, and it matches
-# a float32/float64 host reference exactly, including a stress case with 8081/8192 tied values.
-PY_DETIE_SHIFT = 16.0     # perturb by a monotone function of (token_id >> 4)
-PY_DETIE_SCALE = 2.0**-21 # range 0..2**-8 : under one bf16 ULP (2**-7), far above fp32 ULP (2**-24)
-
 # Widest input ttnn.topk accepts in one call; vocabs beyond it must be cut into chunks.
 TOPK_MAX_WIDTH = 64 * 1024
 
@@ -126,21 +116,6 @@ class TTSampling(LightweightModule):
         raise ValueError(
             f"cannot cut an untilize row of width {width} into tile-aligned chunks of at most {TOPK_MAX_WIDTH}"
         )
-
-    @property
-    def _py_sampler(self):
-        """True when the Python sampler should run for THIS call.
-
-        With TT_PY_SAMPLER_TOGGLE=<path>, the file's first character selects the arm
-        ('1' = python sampler, anything else = stock ttnn.sampling), re-read every call.
-        """
-        if getattr(self, "_py_sampler_toggle", None):
-            try:
-                with open(self._py_sampler_toggle) as fh:
-                    return fh.read().strip().startswith("1")
-            except OSError:
-                return getattr(self, "_py_sampler_default", False)
-        return getattr(self, "_py_sampler_default", False)
 
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
@@ -342,23 +317,6 @@ class TTSampling(LightweightModule):
                 self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
             ),
         )
-
-        # Read at CALL time, not init, so ONE server instance can alternate py-sampler on/off
-        # in paired blocks. Failure rate for this class varies ~10x between server instances on
-        # identical code (0/80 vs 5/54), so any A/B across restarts is confounded -- paired
-        # within-instance toggling is the only valid comparison. The usual caveat (a toggle
-        # cannot reach traced replays) does not apply while sampling runs eagerly.
-        self._py_sampler_default = bool(os.environ.get("TT_PY_SAMPLER"))
-        self._py_sampler_toggle = os.environ.get("TT_PY_SAMPLER_TOGGLE") or None
-        self._py_sampler_possible = self._py_sampler_default or bool(self._py_sampler_toggle)
-        self._py_dbg_left = int(os.environ.get("TT_PY_SAMPLER_DEBUG", "0"))
-        self._py_trap_left = int(os.environ.get("TT_PY_SAMPLER_TRAP", "0"))
-        self._ramp = None
-        self._scan_idx = self._scan_mask = None
-        self._scan_key = None
-        self._k_col = self._p_col = self._temp_col = self._rand_col = None
-        if self._py_sampler_possible:
-            self._build_py_sampler_columns(k, p, temp)
 
         # Create device offset indices for global indexing
         self._create_indices_tensors()
@@ -718,15 +676,6 @@ class TTSampling(LightweightModule):
 
 
 
-        if self._py_sampler_possible:
-            # OUTSIDE the force_argmax guard on purpose. The stock path handles an all-greedy
-            # batch with ttnn.sampling's argmax and skips the k/p/temp upload entirely, but this
-            # sampler always draws from k/p/temp -- so skipping the upload leaves it running
-            # greedy requests on whatever parameters warmup last wrote (k=10, p=0.9). The
-            # visible symptom is greedy generating one or two plausible tokens and then
-            # stopping.
-            self._build_py_sampler_columns(k, p, temp)
-
         self.log_probs_calculator.set_log_probs_mode(
             enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
         )
@@ -833,345 +782,6 @@ class TTSampling(LightweightModule):
         ttnn.deallocate(boost)
         return adjusted
 
-
-    def _param_col_host(self, values, dtype=ttnn.float32):
-        """Host-side [1,1,N,1] column, mesh-mapped exactly like k_tensor/_greedy_col."""
-        return ttnn.from_torch(
-            torch.as_tensor(values, dtype=torch.float32).reshape(1, 1, -1, 1),
-            device=None,
-            dtype=dtype,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=(
-                ttnn.ShardTensor2dMesh(
-                    self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
-                )
-                if self._sampling_dp > 1
-                else None
-            ),
-        )
-
-    def _set_param_col(self, name, values, dtype=ttnn.float32):
-        """Update a persistent param column IN PLACE.
-
-        These columns are read by the captured decode trace. Reallocating one at runtime --
-        which is what a plain _param_col assignment does on every sampling-params change --
-        leaves the trace replaying against the ORIGINAL, now-freed address, so the sampler
-        reads whatever later took that memory. That is exactly how _greedy_col is handled a
-        few lines up, and for the same reason.
-        """
-        existing = getattr(self, name, None)
-        if existing is None:
-            setattr(self, name, self._param_col(values, dtype=dtype))
-            return
-        ttnn.copy_host_to_device_tensor(self._param_col_host(values, dtype=dtype), existing)
-
-    def _param_col(self, values, dtype=ttnn.float32):
-        """[1,1,N,1] column distributed exactly like k_tensor/_greedy_col."""
-        return ttnn.from_torch(
-            torch.as_tensor(values, dtype=torch.float32).reshape(1, 1, -1, 1),
-            device=self.mesh_device,
-            dtype=dtype,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=(
-                ttnn.ShardTensor2dMesh(
-                    self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
-                )
-                if self._sampling_dp > 1
-                else None
-            ),
-        )
-
-    def _build_py_sampler_columns(self, k, p, temp):
-        """k/p/temp as broadcastable columns, plus the rank ramp.
-
-        Every buffer here is allocated ONCE and thereafter written in place: this is called
-        again whenever sampling params change, which for a served request happens long after
-        the decode trace was captured.
-        """
-        self._set_param_col("_k_col", k)
-        self._set_param_col("_p_col", p)
-        self._set_param_col("_temp_col", temp)
-        if self._rand_col is None:
-            self._rand_col = self._param_col([0.0] * (self.max_batch_size * self._sampling_dp))
-        width = self.max_top_k * self._get_num_sampling_shards()
-        if self._ramp is None:
-            self._ramp = ttnn.from_torch(
-                torch.arange(width, dtype=torch.float32).reshape(1, 1, 1, width),
-                device=self.mesh_device,
-                dtype=ttnn.float32,
-                layout=ttnn.TILE_LAYOUT,
-            )
-        self._build_scan_constants(width, self.max_batch_size)
-
-    def _build_scan_constants(self, width, rows):
-        """Per-step gather indices + masks for the Hillis-Steele scan in _prefix_sum.
-
-        Built once at init, never inside the trace-capture window (allocating there is a
-        device write and trace capture rejects it). ttnn.gather does not broadcast rows --
-        a [1,1,1,W] index silently yields a [1,1,1,W] result -- so these are materialised
-        at the full row count. Replicated across the mesh: the shift is identical per row
-        and per device.
-        """
-        if self._scan_key == (width, rows):
-            return
-        ar = torch.arange(width)
-        idx, mask, step = [], [], 1
-        while step < width:
-            idx.append(
-                ttnn.from_torch(
-                    (ar - step).clamp(0, width - 1).reshape(1, 1, 1, width).expand(1, 1, rows, width).contiguous(),
-                    device=self.mesh_device,
-                    dtype=ttnn.uint32,
-                    layout=ttnn.TILE_LAYOUT,
-                )
-            )
-            mask.append(
-                ttnn.from_torch(
-                    (ar >= step).to(torch.float32).reshape(1, 1, 1, width).expand(1, 1, rows, width).contiguous(),
-                    device=self.mesh_device,
-                    dtype=ttnn.float32,
-                    layout=ttnn.TILE_LAYOUT,
-                )
-            )
-            step *= 2
-        self._scan_idx, self._scan_mask, self._scan_key = idx, mask, (width, rows)
-
-    def set_rand_column(self, uniforms):
-        """Per-user uniform in [0,1) for the draw, derived on host from the SeedManager's
-        existing device seeds -- see uniform_from_device_seed in generator.py. Keeps the
-        reproducibility contract (slot-independent, salt-separated) without depending on the
-        per-core PRNG that ttnn.sampling draws from and that we cannot reach from here."""
-        if not self._py_sampler or self._rand_col is None:
-            return
-        # In-place: allocating here would be a device WRITE, and capture_trace runs
-        # _run_sampling inside the capture window -> "Writes are not supported during trace
-        # capture". A persistent buffer updated from outside is what the seed and k/p/temp
-        # tensors already do, and trace replay re-reads it each step.
-        host = ttnn.from_torch(
-            torch.as_tensor(uniforms, dtype=torch.float32).reshape(1, 1, -1, 1),
-            device=None,
-            dtype=ttnn.float32,
-            layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=(
-                ttnn.ShardTensor2dMesh(
-                    self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
-                )
-                if self._sampling_dp > 1
-                else None
-            ),
-        )
-        ttnn.copy_host_to_device_tensor(host, self._rand_col)
-
-
-    def _prefix_sum(self, x, width):
-        """Inclusive prefix sum along the last dim, built from gather/multiply/add.
-
-        Every op here must accept sub_core_grids, or it is placed on the full Tensix grid
-        and dies with "Kernel group cores do not match sub device cores". That rules out
-        ttnn.cumsum (no such kwarg) and ttnn.roll and ttnn.clip (both reject it).
-
-        It also rules out the obvious shift, concat([zeros, head]): ttnn.concat SILENTLY
-        returns wrong data (leading elements zeroed) whenever sub_core_grids is passed --
-        contiguous or disjoint grid, fp32 or bf16 -- which made this scan a bit-for-bit
-        no-op (cur = cur + 0), leaving the row total at 0, every probability inf, and every
-        draw pinned to rank 0. Without the kwarg concat is bit-exact, but then it escapes
-        the sub-device. So the shift is a gather against precomputed clamped indices, with
-        a precomputed mask zeroing the first `step` lanes that the clamp duplicates.
-        See the matching GitHub issue; this can go back to concat once that op is fixed.
-        """
-        scg = self.sub_core_grids
-        rows = x.shape[-2]
-        if self._scan_key != (width, rows):
-            raise RuntimeError(
-                f"scan constants built for {self._scan_key}, got (width={width}, rows={rows}); "
-                "they must be built at init -- allocating here would be a write inside the "
-                "trace-capture window"
-            )
-        cur = x
-        for idx, mask in zip(self._scan_idx, self._scan_mask):
-            shifted = ttnn.gather(cur, dim=-1, index=idx, sub_core_grids=scg)
-            cur = ttnn.add(cur, ttnn.multiply(shifted, mask, sub_core_grids=scg), sub_core_grids=scg)
-        return cur
-
-    def _py_dbg(self, tag, tensor, n=4):
-        """One-line dump of a device tensor, gated by TT_PY_SAMPLER_DEBUG=<count>."""
-        if not self._py_dbg_left:
-            return
-        try:
-            import torch as _t
-            _full = ttnn.to_torch(ttnn.get_device_tensors(tensor)[0])
-            _W = _full.shape[-1]
-            _row0 = _full.reshape(-1, _W)[0]
-            v = _row0[:n]
-            _tail = _row0[max(0, _W - 3):]
-            print(f"[pysamp] {tag:14s} shape={list(tensor.shape)} dtype={tensor.dtype} "
-                  f"first={v.tolist()} last3={_tail.tolist()}", flush=True)
-        except Exception as e:
-            print(f"[pysamp] {tag:14s} shape={list(tensor.shape)} dtype={tensor.dtype} <read failed: {e}>", flush=True)
-
-    def _sample_deterministic(self, values, global_indices, tt_out_tok):
-        """Total-order top-k/top-p sampling. No float32 reduction anywhere: fp32 reductions go to
-        the FPU and truncate to a 10-bit mantissa, so the row max is taken as element 0 of the
-        descending sort and the total as the last cumsum element, both by slice."""
-        # TRACE COMPATIBILITY IS BLOCKED, both directions measured:
-        #  * full grid (scg = None): "Kernel group cores do not match sub device cores"
-        #    (program.cpp:2374) -- the sampling sub-device is active, ops outside it fatal.
-        #  * grid-scoped (below): the final write into tt_out_tok cannot be scoped (ROW_MAJOR
-        #    destination; no op takes both output_tensor and sub_core_grids for one), so the
-        #    trace spans two sub-devices, which have no implicit ordering on replay -- and a
-        #    barrier is illegal inside trace capture.
-        # Hence sampling runs EAGERLY (TT_PY_SAMPLER_EAGER). Fixing this needs an op that can
-        # write a row-major preallocated output on a restricted grid, or a TILE token buffer.
-        scg = self.sub_core_grids
-        v32 = ttnn.typecast(values, ttnn.float32, sub_core_grids=scg)
-        # ttnn.floor_div on an INT32 tensor silently returns 0 (measured 8188/8192 elements
-        # wrong, no error), which would leave those candidates unperturbed and still tied.
-        # Token ids are < 2**24, so do the shift exactly in float32.
-        idx32 = ttnn.typecast(global_indices, ttnn.float32, sub_core_grids=scg)
-        block = ttnn.floor(ttnn.multiply(idx32, 1.0 / PY_DETIE_SHIFT, sub_core_grids=scg), sub_core_grids=scg)
-        perturb = ttnn.multiply(
-            ttnn.multiply(ttnn.abs(v32, sub_core_grids=scg), PY_DETIE_SCALE, sub_core_grids=scg),
-            block,
-            sub_core_grids=scg,
-        )
-        key = ttnn.subtract(v32, perturb, sub_core_grids=scg)
-        self._py_dbg("values", values); self._py_dbg("global_idx", global_indices)
-        self._py_dbg("idx32", idx32); self._py_dbg("block", block); self._py_dbg("key", key)
-
-        # ttnn.sort takes no sub_core_grids; ttnn.topk does (forward() already uses it), and
-        # topk(k=width) is a full descending sort -- verified equal to torch.sort.
-        width = key.shape[-1]
-        sorted_key, sorted_pos = ttnn.topk(
-            key, k=width, dim=-1, largest=True, sorted=True, sub_core_grids=self.sub_core_grid_topk
-        )
-        sorted_idx = ttnn.gather(global_indices, dim=-1, index=sorted_pos, sub_core_grids=scg)
-        self._py_dbg("sorted_key", sorted_key); self._py_dbg("sorted_pos", sorted_pos)
-        self._py_dbg("sorted_idx", sorted_idx)
-
-        rows = sorted_key.shape[-2]
-        keep_k = ttnn.lt(self._ramp, self._k_col, sub_core_grids=scg)
-        logits = ttnn.multiply(sorted_key, self._temp_col, sub_core_grids=scg)
-        # NOT pooled: ttnn.slice rejects a preallocated output whose padded (tile) shape
-        # differs from the required one, which a 1-wide slice always hits.
-        row_max = ttnn.slice(logits, [0, 0, 0, 0], [1, 1, rows, 1], sub_core_grids=scg)
-        self._py_dbg("logits", logits); self._py_dbg("row_max", row_max)
-        shifted = ttnn.subtract(logits, row_max, sub_core_grids=scg)
-        self._py_dbg("shifted", shifted)
-        weights = ttnn.exp(shifted, sub_core_grids=scg)
-        self._py_dbg("exp_raw", weights)
-        exp_raw = weights
-        weights = ttnn.multiply(weights, keep_k, sub_core_grids=scg)
-
-        cum = self._prefix_sum(weights, width)
-        cum1 = cum
-        self._py_dbg("w_prekeep", weights); self._py_dbg("cum1", cum)
-        total1 = ttnn.slice(cum, [0, 0, 0, width - 1], [1, 1, rows, width], sub_core_grids=scg)
-        total = total1
-        self._py_dbg("total1", total1)
-        probs = ttnn.divide(weights, total1, sub_core_grids=scg)
-        self._py_dbg("probs", probs)
-        cum = ttnn.divide(cum, total1, sub_core_grids=scg)
-        self._py_dbg("cum_norm1", cum)
-        # NOTE: <= not <. The mask keeps rank i when the mass STRICTLY BEFORE it is <= p, which
-        # always keeps rank 0 (mass before it is 0). ttnn.sampling's writer does the same by
-        # adding then testing (`cum_prob_f += v; if (cum_prob_f > p_f) break`). With `<`, a
-        # request with p == 0 -- which is EVERY greedy request here, since format_sampling_params
-        # maps temperature==0 to top_k=1/top_p=0.0 -- has 0 < 0 fail at rank 0 and the entire row
-        # is masked to zero, giving nan cumulative mass and a constant token.
-        excl = ttnn.subtract(cum, probs, sub_core_grids=scg)
-        self._py_dbg("excl", excl)
-        keep_p = ttnn.le(excl, self._p_col, sub_core_grids=scg)
-        self._py_dbg("keep_p", keep_p)
-        weights = ttnn.multiply(weights, keep_p, sub_core_grids=scg)
-        self._py_dbg("w_masked", weights)
-
-        cum = self._prefix_sum(weights, width)
-        self._py_dbg("cum2", cum)
-        total2 = ttnn.slice(cum, [0, 0, 0, width - 1], [1, 1, rows, width], sub_core_grids=scg)
-        total = total2
-        self._py_dbg("total2", total2)
-        cum = ttnn.divide(cum, total2, sub_core_grids=scg)
-        self._py_dbg("cum_norm2", cum)
-
-        self._py_dbg("temp_col", self._temp_col); self._py_dbg("keep_k", keep_k); self._py_dbg("weights", weights); self._py_dbg("cum", cum)
-        self._py_dbg("k_col", self._k_col); self._py_dbg("rand_col", self._rand_col)
-        below = ttnn.typecast(ttnn.le(cum, self._rand_col, sub_core_grids=scg), ttnn.int32, sub_core_grids=scg)
-        sel = ttnn.sum(below, dim=-1, keepdim=True, sub_core_grids=scg)   # int32 => SFPU reduce, exact
-        # ttnn.clip does NOT take sub_core_grids, and any op placed off the sampling sub-core
-        # grid is not ordered against the ops that produce its input. sel is a count, so it is
-        # never negative; the only clamp that matters is sel == width (every cum <= rand), and
-        # ge/subtract both honour the grid.
-        sel = ttnn.subtract(sel, ttnn.ge(sel, float(width), sub_core_grids=scg), sub_core_grids=scg)
-        token = ttnn.gather(
-            sorted_idx, dim=-1, index=ttnn.typecast(sel, ttnn.uint32, sub_core_grids=scg), sub_core_grids=scg
-        )
-
-        # tt_out_tok is [1,1,1,N] uint32 ROW_MAJOR; the result is [1,1,N,1] int32 TILE.
-        if os.environ.get("TT_PY_SAMPLER_TRAP"):
-            try:
-                import torch as _t
-                _tok = ttnn.to_torch(ttnn.get_device_tensors(token)[0]).reshape(-1)
-                _bad = int((_tok == 0).sum()) > 0 or int(_tok.unique().numel()) == 1
-                if _bad and self._py_trap_left:
-                    self._py_trap_left -= 1
-                    self._py_dbg_left = 1          # unlock one full dump
-                    print(f"[pysamp-trap] token={_tok[:8].tolist()} uniq={int(_tok.unique().numel())}", flush=True)
-                    for _n, _t_ in (("values", values), ("sorted_key", sorted_key), ("sorted_idx", sorted_idx),
-                                    ("keep_k", keep_k), ("k_col", self._k_col), ("p_col", self._p_col),
-                                    ("temp_col", self._temp_col), ("rand_col", self._rand_col),
-                                    ("row_max", row_max), ("shifted", shifted), ("exp_raw", exp_raw),
-                                    ("cum1", cum1), ("width", None),
-                                    ("probs", probs), ("total", total), ("keep_p", keep_p),
-                                    ("weights", weights), ("cum", cum), ("sel", sel)):
-                        if _t_ is None:
-                            print(f"[pysamp] width={width} rows={rows}", flush=True); continue
-                        self._py_dbg(_n, _t_, n=6)
-                    self._py_dbg_left = 0
-            except Exception as _e:
-                print(f"[pysamp-trap] failed: {_e}", flush=True)
-        self._py_dbg("sel", sel); self._py_dbg("token", token)
-        # Keep the tail ON the sampling sub-core grid. ttnn.transpose does not accept
-        # sub_core_grids; reshape does, and [1,1,N,1] -> [1,1,1,N] is the same N elements in
-        # the same order. Ops split across sub-devices are not implicitly ordered, so a tail
-        # on the full Tensix grid can read `token` before the grid ops finish producing it --
-        # which is what made every sampled token read back as 0.
-        wide = ttnn.to_layout(
-            ttnn.typecast(
-                ttnn.reshape(token, [1, 1, 1, rows], sub_core_grids=scg), ttnn.uint32, sub_core_grids=scg
-            ),
-            ttnn.ROW_MAJOR_LAYOUT,
-            sub_core_grids=scg,
-        )
-        self._py_dbg("wide", wide)
-        if self._py_dbg_left:
-            self._py_dbg_left -= 1
-        if tt_out_tok is not None:
-            if self._py_dbg_left:
-                print(f"[pysamp] tt_out_tok BEFORE copy: shape={list(tt_out_tok.shape)} "
-                      f"dtype={tt_out_tok.dtype} layout={tt_out_tok.layout} "
-                      f"memcfg={tt_out_tok.memory_config()}", flush=True)
-                print(f"[pysamp] wide             : shape={list(wide.shape)} dtype={wide.dtype} "
-                      f"layout={wide.layout} memcfg={wide.memory_config()}", flush=True)
-                self._py_dbg("out_tok_pre", tt_out_tok, n=6)
-            # This is the ONE op that cannot be placed on the sampling sub-core grid, and it
-            # is why sampling must run eagerly (TT_PY_SAMPLER_EAGER) rather than as a trace.
-            # tt_out_tok is ROW_MAJOR and owned by the model, and no available op both writes a
-            # preallocated output AND honours sub_core_grids for a row-major destination:
-            #   typecast  -- takes both, but rejects sub_core_grids on ROW_MAJOR input
-            #   to_layout -- takes sub_core_grids, no output_tensor
-            #   untilize  -- takes sub_core_grids, no output_tensor
-            #   copy      -- takes neither
-            # A trace holding work on two sub-devices has no implicit ordering between them on
-            # replay, and a barrier cannot fix it because synchronization is illegal inside
-            # trace capture. Eager sampling orders this host-side. See the matching GitHub
-            # issue; once an op can write a row-major output on a restricted grid, this becomes
-            # single-sub-device and the sampling trace can come back.
-            ttnn.copy(wide, tt_out_tok)
-            if self._py_dbg_left:
-                self._py_dbg("out_tok_post", tt_out_tok, n=6)
-                self._py_dbg("wide_post", wide, n=6)
-            return tt_out_tok
-        return wide
 
     def forward(
         self,
@@ -1433,20 +1043,15 @@ class TTSampling(LightweightModule):
             user_ids=self.user_ids_tt_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
         )
-        if self._py_sampler:
-            tt_out_tok = self._sample_deterministic(
-                sampling_values, topk_global_indices_interleaved, tt_out_tok
-            )
-        else:
-            tt_out_tok = ttnn.sampling(
-                sampling_values,
-                topk_global_indices_interleaved_untilised,
-                k=self.k_tensor,
-                p=self.p_tensor,
-                temp=self.temp_tensor,
-                sub_core_grids=self._sampling_sub_core_grids,
-                output_tensor=tt_out_tok,
-            )
+        tt_out_tok = ttnn.sampling(
+            sampling_values,
+            topk_global_indices_interleaved_untilised,
+            k=self.k_tensor,
+            p=self.p_tensor,
+            temp=self.temp_tensor,
+            sub_core_grids=self._sampling_sub_core_grids,
+            output_tensor=tt_out_tok,
+        )
 
         # Compute logprobs if enabled
         if self.log_probs_calculator.enable_log_probs and self.log_probs_calculator._use_topk_logprobs:

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -215,6 +215,13 @@ class TTSampling(LightweightModule):
             if self.sub_core_grids is not None
             else None
         )
+        # Blackhole galaxy prefetcher (unfused-CCL) keeps a split senders/worker sub-device manager
+        # loaded during prefill sampling (prefill samples in decode mode). Auto-multicore ops grab the
+        # full 12-wide compute grid, which includes the dispatch column that no loaded sub-device covers
+        # ("kernel group cores do not match sub device cores"). Pin the force-argmax untilize/argmax to
+        # the worker sub-core grids so they stay inside the worker sub-device. Left None elsewhere so no
+        # other arch's behaviour changes.
+        self._force_argmax_sub_core_grids = self.sub_core_grids if getattr(args, "use_unfused_ccl", False) else None
 
         # sampling_dp > 1 when multiple mesh groups each sample users independently
         # (e.g. GPT-OSS on [4,8]: 4 rows × 32 users; Llama Galaxy on [8,4]: 4 cols × 8 users)
@@ -801,7 +808,16 @@ class TTSampling(LightweightModule):
         """
         if self._force_argmax_sampling:
             logger.info("Forcing argmax sampling")
-            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
+            # BH galaxy prefetcher (unfused-CCL) keeps a split senders/worker sub-device manager
+            # loaded during decode. The vocab-trim ttnn.slice auto-grids a 32-core block from origin
+            # (0,0) on the DRAM-interleaved path (it does not honor sub_core_grids there) and spills
+            # into the uncovered senders-column tail -> "kernel group cores do not match sub device
+            # cores". Skip that slice here. Still apply the full-width additive invalid-vocab mask
+            # (already selected whenever sub_core_grids is set; one elementwise add, no slice/concat)
+            # so a 0-padded logit cannot win argmax when every valid logit is negative. untilize/
+            # argmax stay pinned to the worker sub-core grid via _force_argmax_sub_core_grids.
+            force_argmax_skip_vocab_trim = self._force_argmax_sub_core_grids is not None
+            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax() and not force_argmax_skip_vocab_trim
             if not slice_valid_vocab:
                 x = self._mask_invalid_vocab_logits(x)
             # Gather the output across all devices and untilize the tensor (for argmax)
@@ -813,6 +829,31 @@ class TTSampling(LightweightModule):
                     f"Force argmax sampling all-gather: cluster_axis={cluster_axis}, "
                     f"num_links={num_links}, topology={topology}"
                 )
+                # NOTE: do NOT pass a persistent_output_buffer here. The all_gather_async factory
+                # disables its barrier semaphore when persistent buffers are used, and the barrier
+                # is what bounds cross-invocation skew: without it a fast device's next-invocation
+                # writes/increments can reach a peer before that peer's reader has reset its
+                # out_ready semaphore, leaving residual counts that make later waits pass early
+                # (argmax then reads the previous step's logits). Under trace the fresh output
+                # allocation is frozen at capture, so the address is stable anyway.
+                barrier_accessor = getattr(
+                    self.tt_ccl,
+                    "get_sampling_barrier_semaphore_handle",
+                    self.tt_ccl.get_and_cycle_barrier_semaphore_handle,
+                )
+                # Pin the gather to the worker sub-device only on the BH unfused path, where the
+                # downstream untilize/argmax are themselves confined via _force_argmax_sub_core_grids.
+                # Without this, all_gather_async defaults to sub-device 0 (prefetcher/senders under
+                # the galaxy decode manager). Dispatch only serializes within a sub-device, so a
+                # gather on 0 races the worker-grid untilize and under trace replay returns the
+                # previous step's tokens. Eager mode masks this via host dispatch latency.
+                # Left unpinned on Wormhole: untilize/argmax are not sub-core-grid confined there
+                # and still use the default sub-device 0, matching pre-existing WH behaviour.
+                ag_sub_device_id = (
+                    getattr(self.tt_ccl, "worker_sub_device_id", None)
+                    if self._force_argmax_sub_core_grids is not None
+                    else None
+                )
                 x = ttnn.experimental.all_gather_async(
                     x,
                     persistent_output_buffer=None,
@@ -822,15 +863,23 @@ class TTSampling(LightweightModule):
                     memory_config=x.memory_config(),
                     cluster_axis=cluster_axis,
                     topology=topology,
-                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                    barrier_semaphore=barrier_accessor(cluster_axis),
                     chunks_per_sync=self.argmax_chunks_per_sync,
                     num_workers_per_link=self.argmax_num_workers_per_link,
                     num_buffers_per_channel=2,
+                    subdevice_id=ag_sub_device_id,
                 )
             if slice_valid_vocab:
                 x = self._slice_valid_vocab_for_argmax(x)
             num_untilize_chunks = self._untilize_chunk_count(x.shape[-1])
-            if num_untilize_chunks > 1:
+            # DRAM-interleaved ttnn.split/slice does not honor sub_core_grids (same
+            # senders-column spill as the vocab-trim slice above). Qwen3-32B Galaxy
+            # pads to 155648, which _untilize_chunk_count cuts into 4 chunks, so the
+            # post-main-rebase chunked path hits that fatal on the BH prefetcher
+            # worker sub-device. A single untilize of that width compiles there
+            # (Gemma-2's 256000-wide clash is the reason the chunked path exists;
+            # it stays for unpinned Wormhole grids).
+            if num_untilize_chunks > 1 and self._force_argmax_sub_core_grids is None:
                 # Untilizing the full row in one program needs a static circular-buffer
                 # region proportional to the row width; past ~150K elements it clashes
                 # with the model's resident L1 buffers at compile (Gemma-2's 256000-wide
@@ -845,18 +894,29 @@ class TTSampling(LightweightModule):
                     # so peak memory holds ~1 full-vocab buffer less than freeing
                     # after the loop (this runs inside the captured decode trace,
                     # so the peak is baked into the trace region size).
-                    untilized_chunks.append(ttnn.untilize(chunk, use_multicore=True))
+                    untilized_chunks.append(
+                        ttnn.untilize(
+                            chunk,
+                            use_multicore=True,
+                            sub_core_grids=self._force_argmax_sub_core_grids,
+                        )
+                    )
                     chunk.deallocate()
-                x_untilized = ttnn.concat(untilized_chunks, dim=3)
+                x_untilized = ttnn.concat(
+                    untilized_chunks,
+                    dim=3,
+                    sub_core_grids=self._force_argmax_sub_core_grids,
+                )
                 for chunk in untilized_chunks:
                     ttnn.deallocate(chunk)
             else:
-                x_untilized = ttnn.untilize(x, use_multicore=True)
+                x_untilized = ttnn.untilize(x, use_multicore=True, sub_core_grids=self._force_argmax_sub_core_grids)
             tt_out_tok = ttnn.argmax(
                 x_untilized,
                 dim=-1,
                 output_tensor=tt_out_tok,
                 keepdim=False,
+                sub_core_grids=self._force_argmax_sub_core_grids,
             )
             # Argmax fast-path does not compute logprobs (it never runs a softmax over
             # the vocab). On single-chip, on-device logprobs are unsupported anyway

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
+import os
 import sys
 
 import torch
@@ -39,6 +40,16 @@ TIEBREAK_DELTA_FLOOR = 1e-30
 # holds it exactly; larger than any padded vocabulary size, which __init__ asserts; and small enough
 # that sentinel + index cannot overflow the int32 the min reduce runs in.
 TIEBREAK_INDEX_SENTINEL = 2**24
+
+# Deterministic Python-side sampler (TT_PY_SAMPLER=1). Replaces ttnn.sampling, whose internal
+# top-k orders EXACT TIES unstably (#33492); _adjust_values_for_tiebreak only covers k==1, so
+# every k>1 row (seeded requests reach k=32) has no tie protection today. The de-tie below gives
+# the candidates a TOTAL ORDER -- value desc, then token id asc -- so no tie is ever left for an
+# unstable network to resolve. Validated standalone: greedy picks the lowest-id tied maximum,
+# identical inputs give identical tokens, results are slot-permutation invariant, and it matches
+# a float32/float64 host reference exactly, including a stress case with 8081/8192 tied values.
+PY_DETIE_SHIFT = 16.0     # perturb by a monotone function of (token_id >> 4)
+PY_DETIE_SCALE = 2.0**-21 # range 0..2**-8 : under one bf16 ULP (2**-7), far above fp32 ULP (2**-24)
 
 # Widest input ttnn.topk accepts in one call; vocabs beyond it must be cut into chunks.
 TOPK_MAX_WIDTH = 64 * 1024
@@ -115,6 +126,21 @@ class TTSampling(LightweightModule):
         raise ValueError(
             f"cannot cut an untilize row of width {width} into tile-aligned chunks of at most {TOPK_MAX_WIDTH}"
         )
+
+    @property
+    def _py_sampler(self):
+        """True when the Python sampler should run for THIS call.
+
+        With TT_PY_SAMPLER_TOGGLE=<path>, the file's first character selects the arm
+        ('1' = python sampler, anything else = stock ttnn.sampling), re-read every call.
+        """
+        if getattr(self, "_py_sampler_toggle", None):
+            try:
+                with open(self._py_sampler_toggle) as fh:
+                    return fh.read().strip().startswith("1")
+            except OSError:
+                return getattr(self, "_py_sampler_default", False)
+        return getattr(self, "_py_sampler_default", False)
 
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
@@ -214,13 +240,6 @@ class TTSampling(LightweightModule):
             if self.sub_core_grids is not None
             else None
         )
-        # Blackhole galaxy prefetcher (unfused-CCL) keeps a split senders/worker sub-device manager
-        # loaded during prefill sampling (prefill samples in decode mode). Auto-multicore ops grab the
-        # full 12-wide compute grid, which includes the dispatch column that no loaded sub-device covers
-        # ("kernel group cores do not match sub device cores"). Pin the force-argmax untilize/argmax to
-        # the worker sub-core grids so they stay inside the worker sub-device. Left None elsewhere so no
-        # other arch's behaviour changes.
-        self._force_argmax_sub_core_grids = self.sub_core_grids if getattr(args, "use_unfused_ccl", False) else None
 
         # sampling_dp > 1 when multiple mesh groups each sample users independently
         # (e.g. GPT-OSS on [4,8]: 4 rows × 32 users; Llama Galaxy on [8,4]: 4 cols × 8 users)
@@ -323,6 +342,23 @@ class TTSampling(LightweightModule):
                 self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
             ),
         )
+
+        # Read at CALL time, not init, so ONE server instance can alternate py-sampler on/off
+        # in paired blocks. Failure rate for this class varies ~10x between server instances on
+        # identical code (0/80 vs 5/54), so any A/B across restarts is confounded -- paired
+        # within-instance toggling is the only valid comparison. The usual caveat (a toggle
+        # cannot reach traced replays) does not apply while sampling runs eagerly.
+        self._py_sampler_default = bool(os.environ.get("TT_PY_SAMPLER"))
+        self._py_sampler_toggle = os.environ.get("TT_PY_SAMPLER_TOGGLE") or None
+        self._py_sampler_possible = self._py_sampler_default or bool(self._py_sampler_toggle)
+        self._py_dbg_left = int(os.environ.get("TT_PY_SAMPLER_DEBUG", "0"))
+        self._py_trap_left = int(os.environ.get("TT_PY_SAMPLER_TRAP", "0"))
+        self._ramp = None
+        self._scan_idx = self._scan_mask = None
+        self._scan_key = None
+        self._k_col = self._p_col = self._temp_col = self._rand_col = None
+        if self._py_sampler_possible:
+            self._build_py_sampler_columns(k, p, temp)
 
         # Create device offset indices for global indexing
         self._create_indices_tensors()
@@ -541,6 +577,22 @@ class TTSampling(LightweightModule):
             sub_core_grids=self.sub_core_grids,
         )
 
+    def _no_persist_gather(self):
+        """Drop persistent buffers for the sampling gathers (so the CCL barrier engages).
+
+        TT_SAMPLING_NO_PERSIST=1 forces it on; TT_SAMPLING_NO_PERSIST_TOGGLE=<path> reads the
+        arm from a file each call, so ONE server instance can alternate barrier-on/barrier-off.
+        Cross-restart A/Bs are worthless here -- failure rate varies ~10x between instances.
+        """
+        path = os.environ.get("TT_SAMPLING_NO_PERSIST_TOGGLE")
+        if path:
+            try:
+                with open(path) as fh:
+                    return fh.read().strip().startswith("1")
+            except OSError:
+                pass
+        return bool(os.environ.get("TT_SAMPLING_NO_PERSIST"))
+
     def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
         """
         Flexible all-gather that works across different CCL implementations.
@@ -556,8 +608,19 @@ class TTSampling(LightweightModule):
                 "memory_config": memory_config,
                 "num_links": num_links,
             }
+            # TT_SAMPLING_NO_PERSIST=1: drop the persistent buffer for the sampling gathers.
+            # llama_ccl.line_all_gather allocates the barrier semaphore ONLY when
+            # persistent_buffer is None (llama_ccl.py:1297), and both all-gather program
+            # factories gate the barrier on `barrier_semaphore.has_value() && !using_persistent
+            # _buffers`. SAMPLING_VALUES/SAMPLING_INDICES are always preallocated, so these two
+            # gathers always run WITHOUT the barrier -- and the barrier is what stops a remote
+            # device from STARTING to write a buffer a peer is still reading (out_ready_sem only
+            # covers completion). An earlier attempt to force the barrier while KEEPING the
+            # persistent buffer was inert on device for exactly that gating reason; dropping the
+            # buffer is the inverse, and the only way to make the barrier engage from Python.
             if self._line_all_gather_supports_buffer_key and buffer_key is not None:
-                line_all_gather_kwargs["buffer_key"] = buffer_key
+                if not self._no_persist_gather():
+                    line_all_gather_kwargs["buffer_key"] = buffer_key
             return self._line_all_gather(tensor, **line_all_gather_kwargs)
 
         return ttnn.all_gather(
@@ -652,6 +715,17 @@ class TTSampling(LightweightModule):
                 ),
             )
             ttnn.copy_host_to_device_tensor(self._greedy_col_new, self._greedy_col)
+
+
+
+        if self._py_sampler_possible:
+            # OUTSIDE the force_argmax guard on purpose. The stock path handles an all-greedy
+            # batch with ttnn.sampling's argmax and skips the k/p/temp upload entirely, but this
+            # sampler always draws from k/p/temp -- so skipping the upload leaves it running
+            # greedy requests on whatever parameters warmup last wrote (k=10, p=0.9). The
+            # visible symptom is greedy generating one or two plausible tokens and then
+            # stopping.
+            self._build_py_sampler_columns(k, p, temp)
 
         self.log_probs_calculator.set_log_probs_mode(
             enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
@@ -759,6 +833,346 @@ class TTSampling(LightweightModule):
         ttnn.deallocate(boost)
         return adjusted
 
+
+    def _param_col_host(self, values, dtype=ttnn.float32):
+        """Host-side [1,1,N,1] column, mesh-mapped exactly like k_tensor/_greedy_col."""
+        return ttnn.from_torch(
+            torch.as_tensor(values, dtype=torch.float32).reshape(1, 1, -1, 1),
+            device=None,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=(
+                ttnn.ShardTensor2dMesh(
+                    self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
+                )
+                if self._sampling_dp > 1
+                else None
+            ),
+        )
+
+    def _set_param_col(self, name, values, dtype=ttnn.float32):
+        """Update a persistent param column IN PLACE.
+
+        These columns are read by the captured decode trace. Reallocating one at runtime --
+        which is what a plain _param_col assignment does on every sampling-params change --
+        leaves the trace replaying against the ORIGINAL, now-freed address, so the sampler
+        reads whatever later took that memory. That is exactly how _greedy_col is handled a
+        few lines up, and for the same reason.
+        """
+        existing = getattr(self, name, None)
+        if existing is None:
+            setattr(self, name, self._param_col(values, dtype=dtype))
+            return
+        ttnn.copy_host_to_device_tensor(self._param_col_host(values, dtype=dtype), existing)
+
+    def _param_col(self, values, dtype=ttnn.float32):
+        """[1,1,N,1] column distributed exactly like k_tensor/_greedy_col."""
+        return ttnn.from_torch(
+            torch.as_tensor(values, dtype=torch.float32).reshape(1, 1, -1, 1),
+            device=self.mesh_device,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=(
+                ttnn.ShardTensor2dMesh(
+                    self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
+                )
+                if self._sampling_dp > 1
+                else None
+            ),
+        )
+
+    def _build_py_sampler_columns(self, k, p, temp):
+        """k/p/temp as broadcastable columns, plus the rank ramp.
+
+        Every buffer here is allocated ONCE and thereafter written in place: this is called
+        again whenever sampling params change, which for a served request happens long after
+        the decode trace was captured.
+        """
+        self._set_param_col("_k_col", k)
+        self._set_param_col("_p_col", p)
+        self._set_param_col("_temp_col", temp)
+        if self._rand_col is None:
+            self._rand_col = self._param_col([0.0] * (self.max_batch_size * self._sampling_dp))
+        width = self.max_top_k * self._get_num_sampling_shards()
+        if self._ramp is None:
+            self._ramp = ttnn.from_torch(
+                torch.arange(width, dtype=torch.float32).reshape(1, 1, 1, width),
+                device=self.mesh_device,
+                dtype=ttnn.float32,
+                layout=ttnn.TILE_LAYOUT,
+            )
+        self._build_scan_constants(width, self.max_batch_size)
+
+    def _build_scan_constants(self, width, rows):
+        """Per-step gather indices + masks for the Hillis-Steele scan in _prefix_sum.
+
+        Built once at init, never inside the trace-capture window (allocating there is a
+        device write and trace capture rejects it). ttnn.gather does not broadcast rows --
+        a [1,1,1,W] index silently yields a [1,1,1,W] result -- so these are materialised
+        at the full row count. Replicated across the mesh: the shift is identical per row
+        and per device.
+        """
+        if self._scan_key == (width, rows):
+            return
+        ar = torch.arange(width)
+        idx, mask, step = [], [], 1
+        while step < width:
+            idx.append(
+                ttnn.from_torch(
+                    (ar - step).clamp(0, width - 1).reshape(1, 1, 1, width).expand(1, 1, rows, width).contiguous(),
+                    device=self.mesh_device,
+                    dtype=ttnn.uint32,
+                    layout=ttnn.TILE_LAYOUT,
+                )
+            )
+            mask.append(
+                ttnn.from_torch(
+                    (ar >= step).to(torch.float32).reshape(1, 1, 1, width).expand(1, 1, rows, width).contiguous(),
+                    device=self.mesh_device,
+                    dtype=ttnn.float32,
+                    layout=ttnn.TILE_LAYOUT,
+                )
+            )
+            step *= 2
+        self._scan_idx, self._scan_mask, self._scan_key = idx, mask, (width, rows)
+
+    def set_rand_column(self, uniforms):
+        """Per-user uniform in [0,1) for the draw, derived on host from the SeedManager's
+        existing device seeds -- see uniform_from_device_seed in generator.py. Keeps the
+        reproducibility contract (slot-independent, salt-separated) without depending on the
+        per-core PRNG that ttnn.sampling draws from and that we cannot reach from here."""
+        if not self._py_sampler or self._rand_col is None:
+            return
+        # In-place: allocating here would be a device WRITE, and capture_trace runs
+        # _run_sampling inside the capture window -> "Writes are not supported during trace
+        # capture". A persistent buffer updated from outside is what the seed and k/p/temp
+        # tensors already do, and trace replay re-reads it each step.
+        host = ttnn.from_torch(
+            torch.as_tensor(uniforms, dtype=torch.float32).reshape(1, 1, -1, 1),
+            device=None,
+            dtype=ttnn.float32,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=(
+                ttnn.ShardTensor2dMesh(
+                    self.mesh_device, dims=self._greedy_col_dims(), mesh_shape=self.cluster_shape
+                )
+                if self._sampling_dp > 1
+                else None
+            ),
+        )
+        ttnn.copy_host_to_device_tensor(host, self._rand_col)
+
+
+    def _prefix_sum(self, x, width):
+        """Inclusive prefix sum along the last dim, built from gather/multiply/add.
+
+        Every op here must accept sub_core_grids, or it is placed on the full Tensix grid
+        and dies with "Kernel group cores do not match sub device cores". That rules out
+        ttnn.cumsum (no such kwarg) and ttnn.roll and ttnn.clip (both reject it).
+
+        It also rules out the obvious shift, concat([zeros, head]): ttnn.concat SILENTLY
+        returns wrong data (leading elements zeroed) whenever sub_core_grids is passed --
+        contiguous or disjoint grid, fp32 or bf16 -- which made this scan a bit-for-bit
+        no-op (cur = cur + 0), leaving the row total at 0, every probability inf, and every
+        draw pinned to rank 0. Without the kwarg concat is bit-exact, but then it escapes
+        the sub-device. So the shift is a gather against precomputed clamped indices, with
+        a precomputed mask zeroing the first `step` lanes that the clamp duplicates.
+        See the matching GitHub issue; this can go back to concat once that op is fixed.
+        """
+        scg = self.sub_core_grids
+        rows = x.shape[-2]
+        if self._scan_key != (width, rows):
+            raise RuntimeError(
+                f"scan constants built for {self._scan_key}, got (width={width}, rows={rows}); "
+                "they must be built at init -- allocating here would be a write inside the "
+                "trace-capture window"
+            )
+        cur = x
+        for idx, mask in zip(self._scan_idx, self._scan_mask):
+            shifted = ttnn.gather(cur, dim=-1, index=idx, sub_core_grids=scg)
+            cur = ttnn.add(cur, ttnn.multiply(shifted, mask, sub_core_grids=scg), sub_core_grids=scg)
+        return cur
+
+    def _py_dbg(self, tag, tensor, n=4):
+        """One-line dump of a device tensor, gated by TT_PY_SAMPLER_DEBUG=<count>."""
+        if not self._py_dbg_left:
+            return
+        try:
+            import torch as _t
+            _full = ttnn.to_torch(ttnn.get_device_tensors(tensor)[0])
+            _W = _full.shape[-1]
+            _row0 = _full.reshape(-1, _W)[0]
+            v = _row0[:n]
+            _tail = _row0[max(0, _W - 3):]
+            print(f"[pysamp] {tag:14s} shape={list(tensor.shape)} dtype={tensor.dtype} "
+                  f"first={v.tolist()} last3={_tail.tolist()}", flush=True)
+        except Exception as e:
+            print(f"[pysamp] {tag:14s} shape={list(tensor.shape)} dtype={tensor.dtype} <read failed: {e}>", flush=True)
+
+    def _sample_deterministic(self, values, global_indices, tt_out_tok):
+        """Total-order top-k/top-p sampling. No float32 reduction anywhere: fp32 reductions go to
+        the FPU and truncate to a 10-bit mantissa, so the row max is taken as element 0 of the
+        descending sort and the total as the last cumsum element, both by slice."""
+        # TRACE COMPATIBILITY IS BLOCKED, both directions measured:
+        #  * full grid (scg = None): "Kernel group cores do not match sub device cores"
+        #    (program.cpp:2374) -- the sampling sub-device is active, ops outside it fatal.
+        #  * grid-scoped (below): the final write into tt_out_tok cannot be scoped (ROW_MAJOR
+        #    destination; no op takes both output_tensor and sub_core_grids for one), so the
+        #    trace spans two sub-devices, which have no implicit ordering on replay -- and a
+        #    barrier is illegal inside trace capture.
+        # Hence sampling runs EAGERLY (TT_PY_SAMPLER_EAGER). Fixing this needs an op that can
+        # write a row-major preallocated output on a restricted grid, or a TILE token buffer.
+        scg = self.sub_core_grids
+        v32 = ttnn.typecast(values, ttnn.float32, sub_core_grids=scg)
+        # ttnn.floor_div on an INT32 tensor silently returns 0 (measured 8188/8192 elements
+        # wrong, no error), which would leave those candidates unperturbed and still tied.
+        # Token ids are < 2**24, so do the shift exactly in float32.
+        idx32 = ttnn.typecast(global_indices, ttnn.float32, sub_core_grids=scg)
+        block = ttnn.floor(ttnn.multiply(idx32, 1.0 / PY_DETIE_SHIFT, sub_core_grids=scg), sub_core_grids=scg)
+        perturb = ttnn.multiply(
+            ttnn.multiply(ttnn.abs(v32, sub_core_grids=scg), PY_DETIE_SCALE, sub_core_grids=scg),
+            block,
+            sub_core_grids=scg,
+        )
+        key = ttnn.subtract(v32, perturb, sub_core_grids=scg)
+        self._py_dbg("values", values); self._py_dbg("global_idx", global_indices)
+        self._py_dbg("idx32", idx32); self._py_dbg("block", block); self._py_dbg("key", key)
+
+        # ttnn.sort takes no sub_core_grids; ttnn.topk does (forward() already uses it), and
+        # topk(k=width) is a full descending sort -- verified equal to torch.sort.
+        width = key.shape[-1]
+        sorted_key, sorted_pos = ttnn.topk(
+            key, k=width, dim=-1, largest=True, sorted=True, sub_core_grids=self.sub_core_grid_topk
+        )
+        sorted_idx = ttnn.gather(global_indices, dim=-1, index=sorted_pos, sub_core_grids=scg)
+        self._py_dbg("sorted_key", sorted_key); self._py_dbg("sorted_pos", sorted_pos)
+        self._py_dbg("sorted_idx", sorted_idx)
+
+        rows = sorted_key.shape[-2]
+        keep_k = ttnn.lt(self._ramp, self._k_col, sub_core_grids=scg)
+        logits = ttnn.multiply(sorted_key, self._temp_col, sub_core_grids=scg)
+        # NOT pooled: ttnn.slice rejects a preallocated output whose padded (tile) shape
+        # differs from the required one, which a 1-wide slice always hits.
+        row_max = ttnn.slice(logits, [0, 0, 0, 0], [1, 1, rows, 1], sub_core_grids=scg)
+        self._py_dbg("logits", logits); self._py_dbg("row_max", row_max)
+        shifted = ttnn.subtract(logits, row_max, sub_core_grids=scg)
+        self._py_dbg("shifted", shifted)
+        weights = ttnn.exp(shifted, sub_core_grids=scg)
+        self._py_dbg("exp_raw", weights)
+        exp_raw = weights
+        weights = ttnn.multiply(weights, keep_k, sub_core_grids=scg)
+
+        cum = self._prefix_sum(weights, width)
+        cum1 = cum
+        self._py_dbg("w_prekeep", weights); self._py_dbg("cum1", cum)
+        total1 = ttnn.slice(cum, [0, 0, 0, width - 1], [1, 1, rows, width], sub_core_grids=scg)
+        total = total1
+        self._py_dbg("total1", total1)
+        probs = ttnn.divide(weights, total1, sub_core_grids=scg)
+        self._py_dbg("probs", probs)
+        cum = ttnn.divide(cum, total1, sub_core_grids=scg)
+        self._py_dbg("cum_norm1", cum)
+        # NOTE: <= not <. The mask keeps rank i when the mass STRICTLY BEFORE it is <= p, which
+        # always keeps rank 0 (mass before it is 0). ttnn.sampling's writer does the same by
+        # adding then testing (`cum_prob_f += v; if (cum_prob_f > p_f) break`). With `<`, a
+        # request with p == 0 -- which is EVERY greedy request here, since format_sampling_params
+        # maps temperature==0 to top_k=1/top_p=0.0 -- has 0 < 0 fail at rank 0 and the entire row
+        # is masked to zero, giving nan cumulative mass and a constant token.
+        excl = ttnn.subtract(cum, probs, sub_core_grids=scg)
+        self._py_dbg("excl", excl)
+        keep_p = ttnn.le(excl, self._p_col, sub_core_grids=scg)
+        self._py_dbg("keep_p", keep_p)
+        weights = ttnn.multiply(weights, keep_p, sub_core_grids=scg)
+        self._py_dbg("w_masked", weights)
+
+        cum = self._prefix_sum(weights, width)
+        self._py_dbg("cum2", cum)
+        total2 = ttnn.slice(cum, [0, 0, 0, width - 1], [1, 1, rows, width], sub_core_grids=scg)
+        total = total2
+        self._py_dbg("total2", total2)
+        cum = ttnn.divide(cum, total2, sub_core_grids=scg)
+        self._py_dbg("cum_norm2", cum)
+
+        self._py_dbg("temp_col", self._temp_col); self._py_dbg("keep_k", keep_k); self._py_dbg("weights", weights); self._py_dbg("cum", cum)
+        self._py_dbg("k_col", self._k_col); self._py_dbg("rand_col", self._rand_col)
+        below = ttnn.typecast(ttnn.le(cum, self._rand_col, sub_core_grids=scg), ttnn.int32, sub_core_grids=scg)
+        sel = ttnn.sum(below, dim=-1, keepdim=True, sub_core_grids=scg)   # int32 => SFPU reduce, exact
+        # ttnn.clip does NOT take sub_core_grids, and any op placed off the sampling sub-core
+        # grid is not ordered against the ops that produce its input. sel is a count, so it is
+        # never negative; the only clamp that matters is sel == width (every cum <= rand), and
+        # ge/subtract both honour the grid.
+        sel = ttnn.subtract(sel, ttnn.ge(sel, float(width), sub_core_grids=scg), sub_core_grids=scg)
+        token = ttnn.gather(
+            sorted_idx, dim=-1, index=ttnn.typecast(sel, ttnn.uint32, sub_core_grids=scg), sub_core_grids=scg
+        )
+
+        # tt_out_tok is [1,1,1,N] uint32 ROW_MAJOR; the result is [1,1,N,1] int32 TILE.
+        if os.environ.get("TT_PY_SAMPLER_TRAP"):
+            try:
+                import torch as _t
+                _tok = ttnn.to_torch(ttnn.get_device_tensors(token)[0]).reshape(-1)
+                _bad = int((_tok == 0).sum()) > 0 or int(_tok.unique().numel()) == 1
+                if _bad and self._py_trap_left:
+                    self._py_trap_left -= 1
+                    self._py_dbg_left = 1          # unlock one full dump
+                    print(f"[pysamp-trap] token={_tok[:8].tolist()} uniq={int(_tok.unique().numel())}", flush=True)
+                    for _n, _t_ in (("values", values), ("sorted_key", sorted_key), ("sorted_idx", sorted_idx),
+                                    ("keep_k", keep_k), ("k_col", self._k_col), ("p_col", self._p_col),
+                                    ("temp_col", self._temp_col), ("rand_col", self._rand_col),
+                                    ("row_max", row_max), ("shifted", shifted), ("exp_raw", exp_raw),
+                                    ("cum1", cum1), ("width", None),
+                                    ("probs", probs), ("total", total), ("keep_p", keep_p),
+                                    ("weights", weights), ("cum", cum), ("sel", sel)):
+                        if _t_ is None:
+                            print(f"[pysamp] width={width} rows={rows}", flush=True); continue
+                        self._py_dbg(_n, _t_, n=6)
+                    self._py_dbg_left = 0
+            except Exception as _e:
+                print(f"[pysamp-trap] failed: {_e}", flush=True)
+        self._py_dbg("sel", sel); self._py_dbg("token", token)
+        # Keep the tail ON the sampling sub-core grid. ttnn.transpose does not accept
+        # sub_core_grids; reshape does, and [1,1,N,1] -> [1,1,1,N] is the same N elements in
+        # the same order. Ops split across sub-devices are not implicitly ordered, so a tail
+        # on the full Tensix grid can read `token` before the grid ops finish producing it --
+        # which is what made every sampled token read back as 0.
+        wide = ttnn.to_layout(
+            ttnn.typecast(
+                ttnn.reshape(token, [1, 1, 1, rows], sub_core_grids=scg), ttnn.uint32, sub_core_grids=scg
+            ),
+            ttnn.ROW_MAJOR_LAYOUT,
+            sub_core_grids=scg,
+        )
+        self._py_dbg("wide", wide)
+        if self._py_dbg_left:
+            self._py_dbg_left -= 1
+        if tt_out_tok is not None:
+            if self._py_dbg_left:
+                print(f"[pysamp] tt_out_tok BEFORE copy: shape={list(tt_out_tok.shape)} "
+                      f"dtype={tt_out_tok.dtype} layout={tt_out_tok.layout} "
+                      f"memcfg={tt_out_tok.memory_config()}", flush=True)
+                print(f"[pysamp] wide             : shape={list(wide.shape)} dtype={wide.dtype} "
+                      f"layout={wide.layout} memcfg={wide.memory_config()}", flush=True)
+                self._py_dbg("out_tok_pre", tt_out_tok, n=6)
+            # This is the ONE op that cannot be placed on the sampling sub-core grid, and it
+            # is why sampling must run eagerly (TT_PY_SAMPLER_EAGER) rather than as a trace.
+            # tt_out_tok is ROW_MAJOR and owned by the model, and no available op both writes a
+            # preallocated output AND honours sub_core_grids for a row-major destination:
+            #   typecast  -- takes both, but rejects sub_core_grids on ROW_MAJOR input
+            #   to_layout -- takes sub_core_grids, no output_tensor
+            #   untilize  -- takes sub_core_grids, no output_tensor
+            #   copy      -- takes neither
+            # A trace holding work on two sub-devices has no implicit ordering between them on
+            # replay, and a barrier cannot fix it because synchronization is illegal inside
+            # trace capture. Eager sampling orders this host-side. See the matching GitHub
+            # issue; once an op can write a row-major output on a restricted grid, this becomes
+            # single-sub-device and the sampling trace can come back.
+            ttnn.copy(wide, tt_out_tok)
+            if self._py_dbg_left:
+                self._py_dbg("out_tok_post", tt_out_tok, n=6)
+                self._py_dbg("wide_post", wide, n=6)
+            return tt_out_tok
+        return wide
+
     def forward(
         self,
         x: ttnn.Tensor,
@@ -780,16 +1194,7 @@ class TTSampling(LightweightModule):
         """
         if self._force_argmax_sampling:
             logger.info("Forcing argmax sampling")
-            # BH galaxy prefetcher (unfused-CCL) keeps a split senders/worker sub-device manager
-            # loaded during decode. The vocab-trim ttnn.slice auto-grids a 32-core block from origin
-            # (0,0) on the DRAM-interleaved path (it does not honor sub_core_grids there) and spills
-            # into the uncovered senders-column tail -> "kernel group cores do not match sub device
-            # cores". Skip that slice here. Still apply the full-width additive invalid-vocab mask
-            # (already selected whenever sub_core_grids is set; one elementwise add, no slice/concat)
-            # so a 0-padded logit cannot win argmax when every valid logit is negative. untilize/
-            # argmax stay pinned to the worker sub-core grid via _force_argmax_sub_core_grids.
-            force_argmax_skip_vocab_trim = self._force_argmax_sub_core_grids is not None
-            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax() and not force_argmax_skip_vocab_trim
+            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
             if not slice_valid_vocab:
                 x = self._mask_invalid_vocab_logits(x)
             # Gather the output across all devices and untilize the tensor (for argmax)
@@ -801,31 +1206,6 @@ class TTSampling(LightweightModule):
                     f"Force argmax sampling all-gather: cluster_axis={cluster_axis}, "
                     f"num_links={num_links}, topology={topology}"
                 )
-                # NOTE: do NOT pass a persistent_output_buffer here. The all_gather_async factory
-                # disables its barrier semaphore when persistent buffers are used, and the barrier
-                # is what bounds cross-invocation skew: without it a fast device's next-invocation
-                # writes/increments can reach a peer before that peer's reader has reset its
-                # out_ready semaphore, leaving residual counts that make later waits pass early
-                # (argmax then reads the previous step's logits). Under trace the fresh output
-                # allocation is frozen at capture, so the address is stable anyway.
-                barrier_accessor = getattr(
-                    self.tt_ccl,
-                    "get_sampling_barrier_semaphore_handle",
-                    self.tt_ccl.get_and_cycle_barrier_semaphore_handle,
-                )
-                # Pin the gather to the worker sub-device only on the BH unfused path, where the
-                # downstream untilize/argmax are themselves confined via _force_argmax_sub_core_grids.
-                # Without this, all_gather_async defaults to sub-device 0 (prefetcher/senders under
-                # the galaxy decode manager). Dispatch only serializes within a sub-device, so a
-                # gather on 0 races the worker-grid untilize and under trace replay returns the
-                # previous step's tokens. Eager mode masks this via host dispatch latency.
-                # Left unpinned on Wormhole: untilize/argmax are not sub-core-grid confined there
-                # and still use the default sub-device 0, matching pre-existing WH behaviour.
-                ag_sub_device_id = (
-                    getattr(self.tt_ccl, "worker_sub_device_id", None)
-                    if self._force_argmax_sub_core_grids is not None
-                    else None
-                )
                 x = ttnn.experimental.all_gather_async(
                     x,
                     persistent_output_buffer=None,
@@ -835,23 +1215,15 @@ class TTSampling(LightweightModule):
                     memory_config=x.memory_config(),
                     cluster_axis=cluster_axis,
                     topology=topology,
-                    barrier_semaphore=barrier_accessor(cluster_axis),
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
                     chunks_per_sync=self.argmax_chunks_per_sync,
                     num_workers_per_link=self.argmax_num_workers_per_link,
                     num_buffers_per_channel=2,
-                    subdevice_id=ag_sub_device_id,
                 )
             if slice_valid_vocab:
                 x = self._slice_valid_vocab_for_argmax(x)
             num_untilize_chunks = self._untilize_chunk_count(x.shape[-1])
-            # DRAM-interleaved ttnn.split/slice does not honor sub_core_grids (same
-            # senders-column spill as the vocab-trim slice above). Qwen3-32B Galaxy
-            # pads to 155648, which _untilize_chunk_count cuts into 4 chunks, so the
-            # post-main-rebase chunked path hits that fatal on the BH prefetcher
-            # worker sub-device. A single untilize of that width compiles there
-            # (Gemma-2's 256000-wide clash is the reason the chunked path exists;
-            # it stays for unpinned Wormhole grids).
-            if num_untilize_chunks > 1 and self._force_argmax_sub_core_grids is None:
+            if num_untilize_chunks > 1:
                 # Untilizing the full row in one program needs a static circular-buffer
                 # region proportional to the row width; past ~150K elements it clashes
                 # with the model's resident L1 buffers at compile (Gemma-2's 256000-wide
@@ -866,29 +1238,18 @@ class TTSampling(LightweightModule):
                     # so peak memory holds ~1 full-vocab buffer less than freeing
                     # after the loop (this runs inside the captured decode trace,
                     # so the peak is baked into the trace region size).
-                    untilized_chunks.append(
-                        ttnn.untilize(
-                            chunk,
-                            use_multicore=True,
-                            sub_core_grids=self._force_argmax_sub_core_grids,
-                        )
-                    )
+                    untilized_chunks.append(ttnn.untilize(chunk, use_multicore=True))
                     chunk.deallocate()
-                x_untilized = ttnn.concat(
-                    untilized_chunks,
-                    dim=3,
-                    sub_core_grids=self._force_argmax_sub_core_grids,
-                )
+                x_untilized = ttnn.concat(untilized_chunks, dim=3)
                 for chunk in untilized_chunks:
                     ttnn.deallocate(chunk)
             else:
-                x_untilized = ttnn.untilize(x, use_multicore=True, sub_core_grids=self._force_argmax_sub_core_grids)
+                x_untilized = ttnn.untilize(x, use_multicore=True)
             tt_out_tok = ttnn.argmax(
                 x_untilized,
                 dim=-1,
                 output_tensor=tt_out_tok,
                 keepdim=False,
-                sub_core_grids=self._force_argmax_sub_core_grids,
             )
             # Argmax fast-path does not compute logprobs (it never runs a softmax over
             # the vocab). On single-chip, on-device logprobs are unsupported anyway
@@ -1051,11 +1412,6 @@ class TTSampling(LightweightModule):
         topk_global_indices_interleaved_untilised = ttnn.untilize(
             topk_global_indices_interleaved, use_multicore=True, sub_core_grids=self.sub_core_grids
         )
-        ttnn.manual_seed(
-            seeds=self.seeds_tt_tensor,
-            user_ids=self.user_ids_tt_tensor,
-            sub_core_grids=self._sampling_sub_core_grids,
-        )
         # Perform the actual sampling with top-k, top-p, and temperature.
         # WORKAROUND for tenstorrent/tt-metal#33492 (stable top-k unreliable), to be removed with it:
         # for argmax users (k==1) only, boost the single lowest-GLOBAL-INDEX tied maximum in the
@@ -1067,15 +1423,30 @@ class TTSampling(LightweightModule):
         sampling_values = self._adjust_values_for_tiebreak(
             topk_values_gathered_bf16_interleaved, topk_global_indices_interleaved
         )
-        tt_out_tok = ttnn.sampling(
-            sampling_values,
-            topk_global_indices_interleaved_untilised,
-            k=self.k_tensor,
-            p=self.p_tensor,
-            temp=self.temp_tensor,
+        # E4: seed immediately before the draw. The tie-break's int32 ops run on the
+        # SFPU (use_sfpu_reduce_path admits INT32 MIN/MAX/SUM) on the same sub-core grid,
+        # and rand_tile's PRNG/LREG state is programmed by manual_seed -- so any SFPU work
+        # between seeding and drawing can perturb the draw. The original's fp32 tie-break
+        # took the FPU path and never disturbed it.
+        ttnn.manual_seed(
+            seeds=self.seeds_tt_tensor,
+            user_ids=self.user_ids_tt_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
-            output_tensor=tt_out_tok,
         )
+        if self._py_sampler:
+            tt_out_tok = self._sample_deterministic(
+                sampling_values, topk_global_indices_interleaved, tt_out_tok
+            )
+        else:
+            tt_out_tok = ttnn.sampling(
+                sampling_values,
+                topk_global_indices_interleaved_untilised,
+                k=self.k_tensor,
+                p=self.p_tensor,
+                temp=self.temp_tensor,
+                sub_core_grids=self._sampling_sub_core_grids,
+                output_tensor=tt_out_tok,
+            )
 
         # Compute logprobs if enabled
         if self.log_probs_calculator.enable_log_probs and self.log_probs_calculator._use_topk_logprobs:

--- a/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_attention_ttt.py
+++ b/models/demos/llama3_70b_galaxy/tests/module_tests/test_qwen_attention_ttt.py
@@ -269,11 +269,29 @@ def test_qwen_attention_ttt_inference(
         freqs_cis_i_ref = freqs_cis_ref[current_pos[0], :].unsqueeze(0)
 
         reference_output = reference_model(
-            pt_attention_input.to(torch.bfloat16), current_pos[0], freqs_cis_i_ref, mask=None
+            # Match the reference model's own dtype (the same helper this test already uses
+            # at the KV-cache comparison below); hardcoding bfloat16 fails against an fp32
+            # HF reference with "expected m1 and m2 to have the same dtype".
+            pt_attention_input.to(get_ref_model_dype(reference_model, model_args_ref.model_name)),
+            current_pos[0],
+            freqs_cis_i_ref,
+            mask=None,
         )
 
-        reference_output_custom = reference_model_custom(pt_attention_input, current_pos[0], freqs_cis_i_ref, mask=None)
-        passing, pcc_message = comp_pcc(reference_output, reference_output_custom, pcc)
+        # Match the custom reference module's own parameter dtype: load_state_dict keeps the
+        # module's dtype (fp32) while pt_attention_input is bf16, which trips
+        # "expected m1 and m2 to have the same dtype" inside its wq/wk/wv linears.
+        _custom_dtype = next(reference_model_custom.parameters()).dtype
+        reference_output_custom = reference_model_custom(
+            pt_attention_input.to(_custom_dtype), current_pos[0], freqs_cis_i_ref, mask=None
+        )
+        # Sanity: the two reference implementations must agree with each other before any
+        # reference-vs-TT number means anything. This result was previously overwritten by the
+        # next line and never surfaced.
+        ref_passing, ref_pcc_message = comp_pcc(reference_output, reference_output_custom, pcc)
+        logger.info(f"REF-vs-REF PCC: {ref_pcc_message} (passing={ref_passing})")
+        cust_passing, cust_msg = comp_pcc(reference_output_custom, tt_output_torch, pcc)
+        logger.info(f"CUSTOM-REF-vs-TT PCC: {cust_msg} (passing={cust_passing})")
         passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)
 
         logger.info(comp_allclose(reference_output, tt_output_torch))

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from collections import defaultdict
 from dataclasses import fields, replace
 from typing import List
@@ -71,6 +72,26 @@ def get_prefill_warmup_sequence_lengths(max_seq_len: int) -> list[int]:
     Returns powers of 2 from 128 up to max_seq_len (inclusive).
     """
     return [128] + [2**i for i in range(10, max_seq_len.bit_length()) if 2**i <= max_seq_len]
+
+
+
+def _mark_trace_io_corruptible(tensors):
+    """Acknowledge deliberately long-lived trace I/O to the trace-allocation tracker.
+
+    No-op unless TT_METAL_TRACE_ALLOC_TRACKING=1; ttnn.mark_corruptible only exists to tell the
+    tracker "this buffer outliving the call is intended", so failures here must never affect the
+    model. Mirrors _mark_trace_buffers_corruptible in models/common/sampling/generator.py.
+    """
+    mark = getattr(ttnn, "mark_corruptible", None)
+    if mark is None or tensors is None:
+        return
+    for tensor in tensors if isinstance(tensors, (list, tuple)) else (tensors,):
+        if tensor is None:
+            continue
+        try:
+            mark(tensor)
+        except BaseException:  # tracking disabled, host tensor, already freed -- all benign
+            pass
 
 
 def get_padded_prefill_len(seq_len: int) -> int:
@@ -204,10 +225,15 @@ class Generator(WarmupForwardMixin):
         self.already_warmed_up_prefill = False
         self.warming_up_prefill = False
         self.trace_ids_decode = defaultdict(lambda: None)  # {on_device_logits: {device_id: trace_id}}
+        # Shadow of the per-slot sampling params last written to device, so a partial prefill can
+        # leave slots it is not filling on their own values instead of a broadcast filler.
+        self._slot_sampling_params: dict = {}
         self.trace_inputs_decode = defaultdict(lambda: None)
         self.trace_output_decode = defaultdict(lambda: None)
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
-        self._disable_decode_tracing = False  # Whether to disable decode traces
+        # DIAGNOSTIC: TT_DECODE_NO_TRACE=1 runs decode untraced so Python probes can observe
+        # the serving path (ttnn.execute_trace never re-enters Python). Slow; debug only.
+        self._disable_decode_tracing = bool(os.environ.get("TT_DECODE_NO_TRACE"))
         self._decode_inputs_need_reset = False
 
     def _set_prefill_column_mask(self, tt_column_mask):
@@ -614,6 +640,9 @@ class Generator(WarmupForwardMixin):
                     num_cached_tokens + prefill_seq_len,  # Use full seq_len including cached and padding
                     user_id,
                     work_use_batched_prefill,
+                    # Real (unpadded) lengths, so blocks this request does not own are not
+                    # written through. seq_len already includes any prefix-cached prefix.
+                    real_seq_lens=seq_len if isinstance(seq_len, list) else [seq_len],
                 )
 
             prefill_kwargs = {
@@ -725,7 +754,7 @@ class Generator(WarmupForwardMixin):
 
             # Reorder sampling params so values sit in their slot positions (except seed).
             def _scatter_params_to_slots(params, slots):
-                def _scatter_list(values):
+                def _scatter_list(values, name):
                     if not isinstance(values, list):
                         return values
                     values = list(values)
@@ -733,10 +762,18 @@ class Generator(WarmupForwardMixin):
                     if len(values) == 1 and len(slots) > 1:
                         values = values * len(slots)
                     user_vals = values[: len(slots)]
-                    # Pad inactive slots from the last active request, not
-                    # from any extra padding values in the formatted params.
-                    filler = user_vals[-1] if user_vals else values[-1]
-                    scattered = [filler for _ in range(max_batch)]
+                    # Slots this prefill is not filling keep whatever is already on device for
+                    # them -- they may hold live requests mid-decode, and overwriting them with
+                    # this prefill's values makes those requests sample under someone else's
+                    # parameters until the next decode re-uploads the authoritative vector.
+                    previous = self._slot_sampling_params.get(name)
+                    if previous is not None and len(previous) == max_batch:
+                        scattered = list(previous)
+                    else:
+                        # No shadow yet (first prefill of the process): fall back to the old
+                        # broadcast, which is correct when no other slot is live.
+                        filler = user_vals[-1] if user_vals else values[-1]
+                        scattered = [filler for _ in range(max_batch)]
                     for val, slot_idx in zip(user_vals, slots):
                         scattered[int(slot_idx)] = val
                     return scattered
@@ -747,7 +784,7 @@ class Generator(WarmupForwardMixin):
                         # Seeds stay in original order; no reordering to slot indices.
                         updates[f.name] = getattr(params, f.name)
                         continue
-                    updates[f.name] = _scatter_list(getattr(params, f.name))
+                    updates[f.name] = _scatter_list(getattr(params, f.name), f.name)
                 return replace(params, **updates)
 
             if explicit_seeded_prefill:
@@ -803,16 +840,23 @@ class Generator(WarmupForwardMixin):
 
                 slot_sampling_params = _scatter_params_to_slots(sampling_params, empty_slots)
                 sampling_module.reset_sampling_params(slot_sampling_params)
+                self._remember_slot_params(slot_sampling_params)
                 if sampling_prompt_tokens is not None:
-                    sampling_module.reset_prompt_tokens(sampling_prompt_tokens)
+                    sampling_module.reset_prompt_tokens(
+                        sampling_prompt_tokens, slots=[int(slot) for slot in empty_slots]
+                    )
                 sampling_module.reset_output_state(slot_output_tokens)
             else:
                 # tt_logits_batch was concatenated before switching to decode.
                 sampling_params = _scatter_params_to_slots(sampling_params, empty_slots)
 
                 sampling_module.reset_sampling_params(sampling_params)
+                self._remember_slot_params(sampling_params)
                 sampling_module.reset_prompt_tokens(
-                    sampling_prompt_tokens if sampling_prompt_tokens is not None else prefill_ids
+                    sampling_prompt_tokens if sampling_prompt_tokens is not None else prefill_ids,
+                    # Only this call's slots: sampling_prompt_tokens is -1 everywhere else, so
+                    # without this the rows already decoding lose their prompt mask.
+                    slots=[int(slot) for slot in empty_slots],
                 )
                 sampling_module.reset_output_state()
                 sampling_module.seed_manager.reset_seed(sampling_params.seed, empty_slots)
@@ -821,6 +865,13 @@ class Generator(WarmupForwardMixin):
                     tt_logits_batch,
                     tt_out_tok=None,
                     enable_trace=False,  # Don't trace prefill sampling
+                    # The prefill token is folded into the penalty counters from host below.
+                    # Counting it on device would run scatter_add + tilize here, and prefill
+                    # sampling is untraced -- so those two [max_batch, padded_vocab] int32
+                    # buffers (~32 MB/device) get allocated behind the live prefill and decode
+                    # traces on every prefill. That is the #52176 hazard, and it corrupted the
+                    # one slot that was already decoding while the rest of the batch prefilled.
+                    count_tokens=False,
                 )
                 if isinstance(tt_sampled, tuple):
                     tt_sampled = tt_sampled[0]
@@ -835,6 +886,14 @@ class Generator(WarmupForwardMixin):
                 # rather than hard-indexing a fixed rank.
                 sampled_tensor = sampled_tokens.reshape(-1)  # Shape: [32]
                 output_toks = sampled_tensor[empty_slots]
+
+                # Host-side equivalent of the update_output_tokens call skipped above: seed the
+                # penalty output counters with the token each prefilled slot just produced. Same
+                # bookkeeping the seeded branch does, and it writes into the persistent counter
+                # buffers via copy_host_to_device_tensor -- no device-side allocation.
+                slot_output_tokens = torch.full((max_batch, 1), -1, dtype=torch.int32)
+                slot_output_tokens[empty_slots, 0] = sampled_tensor[empty_slots]
+                sampling_module.reset_output_state(slot_output_tokens)
 
                 if tt_log_probs is not None:
                     tt_lp = tt_log_probs
@@ -1151,29 +1210,53 @@ class Generator(WarmupForwardMixin):
         )
         # Update column_mask reference to the trace-capture buffer (trace reads from this buffer on replay)
         self._set_prefill_column_mask(device_inputs[5])
-        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
-        transformed_inputs = self.model.transform_prefill_inputs_device(*device_inputs)
-        (
-            tt_tokens,
-            tt_user_id,
-            tt_page_table,
-            tt_chunk_page_table,
-            tt_chunk_start_idx,
-            _tt_column_mask,
-        ) = transformed_inputs
-        tt_out_trace = self.model.ttnn_prefill_forward(
-            x=tt_tokens,
-            user_id=tt_user_id,
-            page_table=tt_page_table,
-            chunk_page_table=tt_chunk_page_table,
-            chunk_start_idx=tt_chunk_start_idx,
-            start_pos=start_pos,
-            kv_cache=kv_cache,
-            get_last_token=last_token_idx,
-            rot_mats=full_rot_mats,
-            batch_size=batch_size,
-        )
-        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+        # These are THIS trace's own inputs: staged before begin_trace_capture and read by it on
+        # every replay, so they are long-lived by design. prefill_warmup captures one trace per
+        # supported sequence length, so from the second capture onward the earlier prefill traces
+        # are already live and the allocator flags every one of these as "allocated while a trace
+        # is active" -- the trace-allocation tracker then reports them as survivors:
+        #   Found N device buffer(s) still alive before trace replay
+        #   Buffer ... [op: ttnn.to_device]  <- _capture_trace_prefill -> copy_host_to_device
+        # They are not corruption candidates (the trace that reads them is the one captured right
+        # here), so acknowledge them the way tt_transformers does for its decode trace I/O. This
+        # keeps the tracker's report limited to GENUINE survivors instead of burying them.
+        _mark_trace_io_corruptible(device_inputs)
+        # Everything allocated between begin/end_trace_capture belongs to the trace being
+        # captured: the model's prefill intermediates are bound into the recorded program and
+        # must stay allocated for replay. prefill_warmup captures one trace per (seq_len,
+        # batch, sp0/sp1) key, so from the second capture onward earlier traces are already
+        # live and every one of these intermediates is reported by the trace-allocation
+        # tracker as a survivor, e.g.
+        #   Buffer ... [op: ttnn.allocate_tensor_on_device]   <- llama_decoder.py residual add
+        #   Buffer ... [op: program_cache: SDPAOperation ...]
+        #   Buffer ... [op: program_cache: PagedFillCacheDeviceOperation ...]
+        # Reordering warmup cannot avoid this -- capturing trace N always happens while
+        # traces 1..N-1 exist -- so scope the capture window instead, which is what
+        # corruptible_allocation_scope is for. No-op unless TT_METAL_TRACE_ALLOC_TRACKING=1.
+        with ttnn.corruptible_allocation_scope(self.mesh_device):
+            trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+            transformed_inputs = self.model.transform_prefill_inputs_device(*device_inputs)
+            (
+                tt_tokens,
+                tt_user_id,
+                tt_page_table,
+                tt_chunk_page_table,
+                tt_chunk_start_idx,
+                _tt_column_mask,
+            ) = transformed_inputs
+            tt_out_trace = self.model.ttnn_prefill_forward(
+                x=tt_tokens,
+                user_id=tt_user_id,
+                page_table=tt_page_table,
+                chunk_page_table=tt_chunk_page_table,
+                chunk_start_idx=tt_chunk_start_idx,
+                start_pos=start_pos,
+                kv_cache=kv_cache,
+                get_last_token=last_token_idx,
+                rot_mats=full_rot_mats,
+                batch_size=batch_size,
+            )
+            ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
         ttnn.synchronize_device(self.mesh_device)
         logger.info("Done Capturing Prefill Trace")
 
@@ -1320,6 +1403,16 @@ class Generator(WarmupForwardMixin):
             reset_inputs = True
             reset_reasons.append("reset_batch")
 
+        # DIAGNOSTIC (TT_RESET_PROBE=N): reset_inputs copies HOST tokens over the decode
+        # trace's token input -- the same buffer on-device sampling writes the sampled token
+        # into. With device sampling the host copy is intentionally stale, so a reset firing
+        # every step would overwrite each sampled token. reset_reasons is collected but never
+        # logged, so print it for the first N decode steps.
+        _rp = int(os.environ.get("TT_RESET_PROBE", "0"))
+        if _rp and getattr(self, "_reset_probe_left", _rp) > 0:
+            self._reset_probe_left = getattr(self, "_reset_probe_left", _rp) - 1
+            logger.warning(f"[reset-probe] reset_inputs={reset_inputs} reasons={reset_reasons} "
+                           f"page_table_changed={page_table_changed} on_device_sampling={on_device_sampling}")
         kv_cache = kv_cache[0]
         active_seed_slots = None
         if start_pos is not None:
@@ -1427,7 +1520,7 @@ class Generator(WarmupForwardMixin):
         """
 
         # Compile run
-        self._decode_forward_no_trace_text(
+        compile_out = self._decode_forward_no_trace_text(
             tokens,
             current_pos,
             page_table=page_table,
@@ -1443,19 +1536,44 @@ class Generator(WarmupForwardMixin):
             tokens, current_pos, page_table, is_cur_pos_sharded, is_page_table_sharded
         )
 
-        # Save the buffer addresses for preallocated tensors
-        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
-        tt_out_tok = self.model.ttnn_decode_forward(
-            tokens_tt,
-            current_pos_tt,
-            rope_idxs_tt,
-            page_table_tt,
-            kv_cache=kv_cache,
-            is_cur_pos_sharded=is_cur_pos_sharded,
-            on_device_logits=on_device_logits,
-        )
+        # Pre-compile the sampling pipeline HERE: after the trace inputs are staged, but before
+        # begin_trace_capture -- i.e. while no trace is live.
+        #
+        # SamplingGenerator.capture_trace() otherwise runs this pass inline, and the sampling
+        # trace is captured lazily on the first decode step, with THIS decode trace already live.
+        # That is the #52176 allocation-behind-a-live-trace hazard (fix #53551 excluded this
+        # model); the trace-allocation tracker names the buffer it strands:
+        #   Buffer ... [op: program_cache: SamplingDeviceOperation ...] still alive before replay
+        #
+        # tt_out_tok MUST be passed: ttnn.sampling takes the sampled-token buffer as its optional
+        # output_tensor, which is part of the op's program hash. Pre-compiling without it caches
+        # the wrong program and trace capture then dies with "Cannot load new binaries during
+        # trace capture". sample_decode_on_device feeds the sampled token straight back into the
+        # next step's token input, so that buffer is tokens_tt (trace_inputs_decode[True][0]).
+        sampling_module = getattr(self.model, "sampling", None)
+        if on_device_logits and sampling_module is not None:
+            compile_logits = compile_out[0] if isinstance(compile_out, tuple) else compile_out
+            if compile_logits is not None:
+                logger.info("Pre-compiling sampling path before decode trace capture")
+                sampling_module.precompile(logits=compile_logits, tt_out_tok=tokens_tt)
 
-        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+        # Save the buffer addresses for preallocated tensors.
+        # Same reasoning as the prefill capture: everything allocated inside the capture window
+        # belongs to the trace being recorded and must stay allocated for replay, so scope it
+        # rather than let the trace-allocation tracker report it as a survivor.
+        with ttnn.corruptible_allocation_scope(self.mesh_device):
+            trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+            tt_out_tok = self.model.ttnn_decode_forward(
+                tokens_tt,
+                current_pos_tt,
+                rope_idxs_tt,
+                page_table_tt,
+                kv_cache=kv_cache,
+                is_cur_pos_sharded=is_cur_pos_sharded,
+                on_device_logits=on_device_logits,
+            )
+
+            ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
         logger.info("Done Capturing Decode Trace")
 
         return trace_id, tt_out_tok, tokens_tt, current_pos_tt, rope_idxs_tt, page_table_tt
@@ -1472,6 +1590,34 @@ class Generator(WarmupForwardMixin):
         """
         Executes the trace for the decode_forward method but does not read back outputs.
         """
+        # DIAGNOSTIC (TT_TRACE_ALLOC_PROBE=N): the unsafe-allocation tracker is a query API,
+        # not a logger -- nothing reports on its own. Ask it, right before replay, which
+        # buffers were allocated behind THIS live trace.
+        # DIAGNOSTIC (TT_TOKIN_PROBE=N): read the decode trace's TOKEN INPUT right before
+        # replay. On-device sampling writes the sampled token into this exact buffer; the next
+        # replay reads it back. If the sampler wrote a real token but this reads 0, something
+        # between the two clobbered it (reset_inputs copying stale host tokens is the suspect).
+        _tp = int(os.environ.get("TT_TOKIN_PROBE", "0"))
+        if _tp and getattr(self, "_tokin_probe_left", _tp) > 0:
+            self._tokin_probe_left = getattr(self, "_tokin_probe_left", _tp) - 1
+            try:
+                _tin = device_inputs[0] if device_inputs else None
+                if _tin is not None:
+                    _v = ttnn.to_torch(ttnn.get_device_tensors(_tin)[0]).reshape(-1)[:8]
+                    logger.warning(f"[tokin-probe] decode token input before replay: {_v.tolist()}")
+            except Exception as _e:
+                logger.warning(f"[tokin-probe] read failed: {_e}")
+        _probe = int(os.environ.get("TT_TRACE_ALLOC_PROBE", "0"))
+        if _probe and getattr(self, "_alloc_probe_left", _probe) > 0:
+            self._alloc_probe_left = getattr(self, "_alloc_probe_left", _probe) - 1
+            try:
+                unsafe = ttnn._ttnn.operations.trace.get_unsafe_tracked_ids(self.mesh_device, trace_id)
+                logger.warning(f"[alloc-probe] decode trace {trace_id}: {len(unsafe)} unsafe allocation(s)")
+                from collections import Counter as _C
+                for ctx, cnt in _C(unsafe.values()).most_common(12):
+                    logger.warning(f"[alloc-probe]   x{cnt:<4} {str(ctx)[:150]}")
+            except Exception as _e:
+                logger.warning(f"[alloc-probe] query failed: {_e}")
         ttnn.execute_trace(self.mesh_device, trace_id, cq_id=0, blocking=False)
 
         return tt_out_trace
@@ -1547,6 +1693,15 @@ class Generator(WarmupForwardMixin):
 
         return trace_tok_rm
 
+    def _remember_slot_params(self, params):
+        """Record the per-slot vectors just written to device (see _scatter_params_to_slots)."""
+        for f in fields(params):
+            if f.name == "seed":
+                continue
+            value = getattr(params, f.name, None)
+            if isinstance(value, list) and len(value) == self.model_args.max_batch_size:
+                self._slot_sampling_params[f.name] = list(value)
+
     def sample_decode_on_device(
         self,
         tt_logits,
@@ -1592,6 +1747,7 @@ class Generator(WarmupForwardMixin):
                         sampling_params, active_seed_slots, self.model_args.max_batch_size
                     )
             sampling_module.reset_sampling_params(sampling_params)
+            self._remember_slot_params(sampling_params)
             if reset_batch:
                 sampling_module.reset_prompt_tokens(prompt_tokens)
                 sampling_module.reset_output_state(output_tokens)
@@ -1609,6 +1765,9 @@ class Generator(WarmupForwardMixin):
             logits=tt_logits,
             tt_out_tok=tt_out_tok,
             enable_trace=enable_trace,
+            # _capture_trace_text already ran the pre-compile pass while no trace was live.
+            # Leaving it inline here would allocate behind the live decode trace (#52176).
+            skip_precompile=True,
         )
 
     def read_decode_output(self, tt_out, async_read=True):
@@ -1706,7 +1865,9 @@ class Generator(WarmupForwardMixin):
 
         return CompletionPrediction(generation=generation)
 
-    def _get_prefill_user_page_table(self, page_table, kv_cache, prefill_len, user_id, use_batched_prefill=False):
+    def _get_prefill_user_page_table(
+        self, page_table, kv_cache, prefill_len, user_id, use_batched_prefill=False, real_seq_lens=None
+    ):
         # Output shape: (32, num_blocks)
         # Either all 32 users or just the single user at the given user_id index
         block_size = get_block_size(kv_cache)
@@ -1717,6 +1878,25 @@ class Generator(WarmupForwardMixin):
             # filled with -1 below so paged_fill_cache skips them.
             padding = torch.zeros(page_table.shape[0], num_blocks - page_table.shape[1], dtype=torch.int32)
             page_table = torch.cat([page_table, padding], dim=1)
+        if real_seq_lens is not None:
+            # `prefill_len` is the PADDED chunk length, so num_blocks can exceed the blocks the
+            # request actually owns: a 10-token prompt owns one 64-token block, but a padded
+            # prefill_seq_len of 128 slices two columns out of the row. Everything past the
+            # request's own blocks is STALE -- vLLM writes only the first ceil(len/block_size)
+            # entries of a block-table row and leaves the rest from the row's previous occupant
+            # (the plugin hands us the raw row). paged_fill_cache then writes this prefill's
+            # PADDING positions through those stale ids, into a block that may still belong to a
+            # live request -- or, when the stale id happens to equal this request's own block, on
+            # top of the real KV it just wrote. Either way the victim's next decode reads clobbered
+            # KV and emits one token forever (observed: block table [12, 12], real KV at offsets
+            # 0-9 of block 12 overwritten by padding positions 64-127).
+            # Block 0 is vLLM's reserved null block (BlockPool pops it before any allocation), so
+            # it is the correct sink for padding.
+            page_table = page_table.clone()
+            for row, real_len in enumerate(real_seq_lens):
+                owned = num_blocks_in_seq(int(real_len), block_size)
+                if owned < page_table.shape[1]:
+                    page_table[row, owned:] = 0
         # Batched non-prefix prefill writes KV cache for all 32 rows; mark inactive
         # rows as -1 so paged_fill_cache skips them. Single-user prefill extracts
         # the active row before device upload, so inactive row values are irrelevant.

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -74,7 +74,6 @@ def get_prefill_warmup_sequence_lengths(max_seq_len: int) -> list[int]:
     return [128] + [2**i for i in range(10, max_seq_len.bit_length()) if 2**i <= max_seq_len]
 
 
-
 def _mark_trace_io_corruptible(tensors):
     """Acknowledge deliberately long-lived trace I/O to the trace-allocation tracker.
 
@@ -1411,8 +1410,10 @@ class Generator(WarmupForwardMixin):
         _rp = int(os.environ.get("TT_RESET_PROBE", "0"))
         if _rp and getattr(self, "_reset_probe_left", _rp) > 0:
             self._reset_probe_left = getattr(self, "_reset_probe_left", _rp) - 1
-            logger.warning(f"[reset-probe] reset_inputs={reset_inputs} reasons={reset_reasons} "
-                           f"page_table_changed={page_table_changed} on_device_sampling={on_device_sampling}")
+            logger.warning(
+                f"[reset-probe] reset_inputs={reset_inputs} reasons={reset_reasons} "
+                f"page_table_changed={page_table_changed} on_device_sampling={on_device_sampling}"
+            )
         kv_cache = kv_cache[0]
         active_seed_slots = None
         if start_pos is not None:
@@ -1614,6 +1615,7 @@ class Generator(WarmupForwardMixin):
                 unsafe = ttnn._ttnn.operations.trace.get_unsafe_tracked_ids(self.mesh_device, trace_id)
                 logger.warning(f"[alloc-probe] decode trace {trace_id}: {len(unsafe)} unsafe allocation(s)")
                 from collections import Counter as _C
+
                 for ctx, cnt in _C(unsafe.values()).most_common(12):
                     logger.warning(f"[alloc-probe]   x{cnt:<4} {str(ctx)[:150]}")
             except Exception as _e:

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1687,7 +1687,6 @@ class Generator(WarmupForwardMixin):
             current_pos,
             page_table=page_table,
         )
-
         if on_device_logits:
             return trace_tok_rm[0], None
 

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -508,6 +508,21 @@ class CheckpointType(Enum):
 
 
 class TtModelArgs:
+    # Keep concurrent slots that share a request seed on salt 0 (see
+    # SeedManager.salt_duplicate_seeds). #53077 salts them apart to separate n>1
+    # completions of one prompt, but these models are served through vLLM v1, whose
+    # ParentRequest._get_child_sampling_params already hands child i `seed + i`
+    # (vllm/v1/engine/parallel_sampling.py) -- so n>1 children never arrive here
+    # sharing a seed. Every duplicate seed that does arrive is independent requests
+    # that must reproduce identically, which the vLLM TT sampling suite asserts
+    # (test_uniform_seed_deterministic and friends: 32 same-seed requests -> 32
+    # identical outputs, observed as 32 DIFFERENT outputs with salting on).
+    #
+    # CLASS attribute, not set in _set_params_from_dict: TtQwenModelArgs overrides that
+    # method without calling super(), so an instance assignment there reaches Llama only
+    # and Qwen3-32B silently keeps the salting default.
+    salt_duplicate_seeds = False
+
     OP_KEYS = (
         # Embedding
         "EMB_WEIGHTS",
@@ -2129,16 +2144,6 @@ class TtModelArgs:
         self.full_model_n_layers = self.n_layers
         self.norm_eps = params.get("norm_eps", params.get("rms_norm_eps"))
         self.vocab_size = params["vocab_size"]
-        # Keep concurrent slots that share a request seed on salt 0 (see
-        # SeedManager.salt_duplicate_seeds). #53077 salts them apart to separate n>1
-        # completions of one prompt, but this model is served through vLLM v1, whose
-        # ParentRequest._get_child_sampling_params already hands child i `seed + i`
-        # (vllm/v1/engine/parallel_sampling.py) -- so n>1 children never arrive here
-        # sharing a seed. Every duplicate seed that does arrive is independent requests
-        # that must reproduce identically, which the vLLM TT sampling suite asserts
-        # (test_uniform_seed_deterministic and friends: 32 same-seed requests -> 32
-        # identical outputs, observed as 32 DIFFERENT outputs with salting on).
-        self.salt_duplicate_seeds = False
         self.padded_vocab_size = 128 * 1024
         self.head_dim = params.get("head_dim", self.dim // self.n_heads)
         if is_hf:

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -75,6 +75,13 @@ PREFETCHER_NOC1_GRID = [
     (2, 9),
 ]
 
+# Blackhole galaxy prefetcher ring: 24 matmul cores = 8 DRAM readers x 3 receivers.
+# BH has a 12x10 tensix grid (x:0-11, y:0-9) and 8 DRAM banks (vs WH's 7x10 grid / 12 banks),
+# so RING_SIZE stays 24 (keeping all weight-sharding math) by widening receivers-per-reader
+# from 2 to 3. Senders live in column 0; the 24 receiver/ring cores occupy columns 1-3.
+# First-pass functional placement for bring-up; NoC1-congestion tuning is a follow-up (Step 6).
+PREFETCHER_NOC1_GRID_BH = [(x, y) for y in range(8) for x in (1, 2, 3)]
+
 LM_HEAD_16_GRID = [
     (1, 0),
     (1, 1),
@@ -128,6 +135,14 @@ LM_HEAD_32_GRID = [
     (5, 0),
     (5, 1),
 ]
+
+# Blackhole galaxy prefetcher path: the lm_head all_reduce persistent buffer lives on
+# sub_core_grids, which is capped to rows 0-7 on BH (sub_core_max_y = 7 to match the
+# 24-core ring geometry). The default LM_HEAD_32_GRID spans rows 0-9 in cols 1-3, so its
+# rows 8-9 fall outside the buffer and all_reduce_async's "output must be a subset of the
+# buffer cores" check fails. Use a 32-core layout confined to rows 0-7: cols 1-3 (24 cores)
+# plus col 5 (8 cores), all inside sub_core_grids.
+LM_HEAD_32_GRID_BH = [(x, y) for x in (1, 2, 3) for y in range(8)] + [(5, y) for y in range(8)]
 
 LM_HEAD_INPUT_GRID = [
     (6, 6),
@@ -184,10 +199,76 @@ LM_HEAD_OUTPUT_GRID = [
 ]
 
 
-def get_core_ranges(num_reader_cores, num_global_cb_receivers, is_functional_test):
+def _get_core_ranges_blackhole(num_reader_cores, num_global_cb_receivers):
+    """
+    Blackhole galaxy prefetcher core placement (first-pass functional bring-up).
+
+    Topology (measured): 12x10 tensix grid (x:0-11, y:0-9), 8 DRAM banks.
+    Layout:
+      - DRAM readers: banks 0..num_reader_cores-1.
+      - Senders: one tensix per reader in column 0 (rows 0..num_reader_cores-1);
+        remaining column-0 rows are dummy senders so the global-CB mapping stays balanced.
+      - Receivers / matmul ring: num_global_cb_receivers cores per reader in columns
+        1..num_global_cb_receivers, one reader per row. With 8 readers x 3 receivers this
+        is the 24-core ring (RING_SIZE=24), matching PREFETCHER_NOC1_GRID_BH.
+      - Workers: columns 1..11 (everything except the sender column), which includes the
+        receiver/ring cores.
+    NoC1 congestion tuning of the ring order is deferred (Step 6).
+    """
+    assert num_reader_cores <= 8, f"Blackhole galaxy has 8 DRAM banks, got num_reader_cores={num_reader_cores}"
+    grid_h = 10  # y rows
+    max_recv_col = num_global_cb_receivers  # receivers occupy columns 1..num_global_cb_receivers
+
+    all_dram_cores = [ttnn.CoreCoord(idx, 0) for idx in range(8)]
+    dram_cores = all_dram_cores[:num_reader_cores]
+
+    # Senders in column 0: active first, then dummies filling the rest of the column.
+    active_sender_cores = [ttnn.CoreCoord(0, y) for y in range(num_reader_cores)]
+    dummy_sender_cores = [ttnn.CoreCoord(0, y) for y in range(num_reader_cores, grid_h)]
+    sender_cores = list(active_sender_cores) + list(dummy_sender_cores)
+
+    # Receiver core list (flat), row-major per reader: reader y -> (1,y),(2,y),...,(recv,y).
+    active_receiver_cores_list = [(x, y) for y in range(num_reader_cores) for x in range(1, max_recv_col + 1)]
+
+    def _recv_range_set(y):
+        return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, y), ttnn.CoreCoord(max_recv_col, y))])
+
+    all_receiver_cores = [_recv_range_set(y) for y in range(num_reader_cores)]
+    # Dummy receiver ranges paired with the dummy senders.
+    all_receiver_cores += [_recv_range_set(y) for y in range(num_reader_cores, grid_h)]
+
+    # Workers: columns 1..10 (col 0 = prefetcher senders; col 11 excluded). Empirically, folding col 11
+    # into the worker sub-device (the LB/QB `full_grid - senders` shape) regresses prefill warmup, so on
+    # this COL-dispatch galaxy col 11 is not a plain worker. cols 1..10 (100 cores) is the furthest-
+    # working decode config.
+    worker_cores_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(10, grid_h - 1))])
+
+    mm_optimised_ring_cores = PREFETCHER_NOC1_GRID_BH
+    # Hop core for the 1D ring matmul. It must (a) NOT overlap the ring/input-A shard grid
+    # (cols 1-3, rows 0..num_reader_cores-1) and (b) be a member of the global CB's cores
+    # (senders in col 0 or receivers in cols 1-3). The dummy-receiver rows (>= num_reader_cores)
+    # satisfy both, mirroring Wormhole where the hop sits on a dummy receiver.
+    hop_grid = [(max_recv_col, grid_h - 2)]  # e.g. (3, 8): a dummy-receiver core outside the ring
+
+    return (
+        active_sender_cores,
+        dram_cores,
+        sender_cores,
+        active_receiver_cores_list,
+        all_receiver_cores,
+        worker_cores_range_set,
+        mm_optimised_ring_cores,
+        hop_grid,
+    )
+
+
+def get_core_ranges(num_reader_cores, num_global_cb_receivers, is_functional_test, is_blackhole=False):
     """
     Helper function to get all the relevant core ranges for dram prefetcher + matmul configuration
     """
+
+    if is_blackhole:
+        return _get_core_ranges_blackhole(num_reader_cores, num_global_cb_receivers)
 
     all_dram_cores = [ttnn.CoreCoord(idx, 0) for idx in range(12)]  # 12 DRAM banks
 
@@ -511,8 +592,11 @@ class TtModelArgs:
             # assume Wormhole's 12 DRAM banks / wider tensix grid). Wormhole galaxy is unchanged.
             self.use_prefetcher = not self.is_blackhole
 
-        # Set up prefetcher stuff
-        _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
+        # Set up prefetcher stuff (Blackhole galaxy: 8 readers x 3 receivers; Wormhole: 12 x 2)
+        if self.is_blackhole:
+            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(8, 3, False, is_blackhole=True)
+        else:
+            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
 
         self.sub_core_grids = ttnn.CoreRangeSet(
             [
@@ -1363,6 +1447,18 @@ class TtModelArgs:
                 12288 // 8,  # Use padded N
                 RING_SIZE,
                 untilize_out=True,
+            )
+            # Non-untilized (TILE) variant for the Blackhole unfused-CCL bring-up: bf8 output requires TILE
+            # layout, and the unfused create-head path wants a bf8 TILE input to the column all-reduce
+            # (matching the no-prefetcher path). The fused path keeps the untilized (ROW_MAJOR) config for
+            # llama_rs_create_heads.
+            self.model_config["XQKV_DECODE_RING_PROGCFG_TILE"] = self.matmul_1d_ring_config(
+                1,
+                32,
+                8192 // 4,
+                12288 // 8,  # Use padded N
+                RING_SIZE,
+                untilize_out=False,
             )
             RS_CREATE_HEADS_PACKET_WORKER_CRS = ttnn.CoreRangeSet(
                 [

--- a/models/demos/llama3_70b_galaxy/tt/model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/model_config.py
@@ -75,13 +75,6 @@ PREFETCHER_NOC1_GRID = [
     (2, 9),
 ]
 
-# Blackhole galaxy prefetcher ring: 24 matmul cores = 8 DRAM readers x 3 receivers.
-# BH has a 12x10 tensix grid (x:0-11, y:0-9) and 8 DRAM banks (vs WH's 7x10 grid / 12 banks),
-# so RING_SIZE stays 24 (keeping all weight-sharding math) by widening receivers-per-reader
-# from 2 to 3. Senders live in column 0; the 24 receiver/ring cores occupy columns 1-3.
-# First-pass functional placement for bring-up; NoC1-congestion tuning is a follow-up (Step 6).
-PREFETCHER_NOC1_GRID_BH = [(x, y) for y in range(8) for x in (1, 2, 3)]
-
 LM_HEAD_16_GRID = [
     (1, 0),
     (1, 1),
@@ -135,14 +128,6 @@ LM_HEAD_32_GRID = [
     (5, 0),
     (5, 1),
 ]
-
-# Blackhole galaxy prefetcher path: the lm_head all_reduce persistent buffer lives on
-# sub_core_grids, which is capped to rows 0-7 on BH (sub_core_max_y = 7 to match the
-# 24-core ring geometry). The default LM_HEAD_32_GRID spans rows 0-9 in cols 1-3, so its
-# rows 8-9 fall outside the buffer and all_reduce_async's "output must be a subset of the
-# buffer cores" check fails. Use a 32-core layout confined to rows 0-7: cols 1-3 (24 cores)
-# plus col 5 (8 cores), all inside sub_core_grids.
-LM_HEAD_32_GRID_BH = [(x, y) for x in (1, 2, 3) for y in range(8)] + [(5, y) for y in range(8)]
 
 LM_HEAD_INPUT_GRID = [
     (6, 6),
@@ -199,76 +184,10 @@ LM_HEAD_OUTPUT_GRID = [
 ]
 
 
-def _get_core_ranges_blackhole(num_reader_cores, num_global_cb_receivers):
-    """
-    Blackhole galaxy prefetcher core placement (first-pass functional bring-up).
-
-    Topology (measured): 12x10 tensix grid (x:0-11, y:0-9), 8 DRAM banks.
-    Layout:
-      - DRAM readers: banks 0..num_reader_cores-1.
-      - Senders: one tensix per reader in column 0 (rows 0..num_reader_cores-1);
-        remaining column-0 rows are dummy senders so the global-CB mapping stays balanced.
-      - Receivers / matmul ring: num_global_cb_receivers cores per reader in columns
-        1..num_global_cb_receivers, one reader per row. With 8 readers x 3 receivers this
-        is the 24-core ring (RING_SIZE=24), matching PREFETCHER_NOC1_GRID_BH.
-      - Workers: columns 1..11 (everything except the sender column), which includes the
-        receiver/ring cores.
-    NoC1 congestion tuning of the ring order is deferred (Step 6).
-    """
-    assert num_reader_cores <= 8, f"Blackhole galaxy has 8 DRAM banks, got num_reader_cores={num_reader_cores}"
-    grid_h = 10  # y rows
-    max_recv_col = num_global_cb_receivers  # receivers occupy columns 1..num_global_cb_receivers
-
-    all_dram_cores = [ttnn.CoreCoord(idx, 0) for idx in range(8)]
-    dram_cores = all_dram_cores[:num_reader_cores]
-
-    # Senders in column 0: active first, then dummies filling the rest of the column.
-    active_sender_cores = [ttnn.CoreCoord(0, y) for y in range(num_reader_cores)]
-    dummy_sender_cores = [ttnn.CoreCoord(0, y) for y in range(num_reader_cores, grid_h)]
-    sender_cores = list(active_sender_cores) + list(dummy_sender_cores)
-
-    # Receiver core list (flat), row-major per reader: reader y -> (1,y),(2,y),...,(recv,y).
-    active_receiver_cores_list = [(x, y) for y in range(num_reader_cores) for x in range(1, max_recv_col + 1)]
-
-    def _recv_range_set(y):
-        return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, y), ttnn.CoreCoord(max_recv_col, y))])
-
-    all_receiver_cores = [_recv_range_set(y) for y in range(num_reader_cores)]
-    # Dummy receiver ranges paired with the dummy senders.
-    all_receiver_cores += [_recv_range_set(y) for y in range(num_reader_cores, grid_h)]
-
-    # Workers: columns 1..10 (col 0 = prefetcher senders; col 11 excluded). Empirically, folding col 11
-    # into the worker sub-device (the LB/QB `full_grid - senders` shape) regresses prefill warmup, so on
-    # this COL-dispatch galaxy col 11 is not a plain worker. cols 1..10 (100 cores) is the furthest-
-    # working decode config.
-    worker_cores_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(10, grid_h - 1))])
-
-    mm_optimised_ring_cores = PREFETCHER_NOC1_GRID_BH
-    # Hop core for the 1D ring matmul. It must (a) NOT overlap the ring/input-A shard grid
-    # (cols 1-3, rows 0..num_reader_cores-1) and (b) be a member of the global CB's cores
-    # (senders in col 0 or receivers in cols 1-3). The dummy-receiver rows (>= num_reader_cores)
-    # satisfy both, mirroring Wormhole where the hop sits on a dummy receiver.
-    hop_grid = [(max_recv_col, grid_h - 2)]  # e.g. (3, 8): a dummy-receiver core outside the ring
-
-    return (
-        active_sender_cores,
-        dram_cores,
-        sender_cores,
-        active_receiver_cores_list,
-        all_receiver_cores,
-        worker_cores_range_set,
-        mm_optimised_ring_cores,
-        hop_grid,
-    )
-
-
-def get_core_ranges(num_reader_cores, num_global_cb_receivers, is_functional_test, is_blackhole=False):
+def get_core_ranges(num_reader_cores, num_global_cb_receivers, is_functional_test):
     """
     Helper function to get all the relevant core ranges for dram prefetcher + matmul configuration
     """
-
-    if is_blackhole:
-        return _get_core_ranges_blackhole(num_reader_cores, num_global_cb_receivers)
 
     all_dram_cores = [ttnn.CoreCoord(idx, 0) for idx in range(12)]  # 12 DRAM banks
 
@@ -592,11 +511,8 @@ class TtModelArgs:
             # assume Wormhole's 12 DRAM banks / wider tensix grid). Wormhole galaxy is unchanged.
             self.use_prefetcher = not self.is_blackhole
 
-        # Set up prefetcher stuff (Blackhole galaxy: 8 readers x 3 receivers; Wormhole: 12 x 2)
-        if self.is_blackhole:
-            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(8, 3, False, is_blackhole=True)
-        else:
-            _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
+        # Set up prefetcher stuff
+        _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
 
         self.sub_core_grids = ttnn.CoreRangeSet(
             [
@@ -1448,18 +1364,6 @@ class TtModelArgs:
                 RING_SIZE,
                 untilize_out=True,
             )
-            # Non-untilized (TILE) variant for the Blackhole unfused-CCL bring-up: bf8 output requires TILE
-            # layout, and the unfused create-head path wants a bf8 TILE input to the column all-reduce
-            # (matching the no-prefetcher path). The fused path keeps the untilized (ROW_MAJOR) config for
-            # llama_rs_create_heads.
-            self.model_config["XQKV_DECODE_RING_PROGCFG_TILE"] = self.matmul_1d_ring_config(
-                1,
-                32,
-                8192 // 4,
-                12288 // 8,  # Use padded N
-                RING_SIZE,
-                untilize_out=False,
-            )
             RS_CREATE_HEADS_PACKET_WORKER_CRS = ttnn.CoreRangeSet(
                 [
                     ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 0)),
@@ -2129,6 +2033,16 @@ class TtModelArgs:
         self.full_model_n_layers = self.n_layers
         self.norm_eps = params.get("norm_eps", params.get("rms_norm_eps"))
         self.vocab_size = params["vocab_size"]
+        # Keep concurrent slots that share a request seed on salt 0 (see
+        # SeedManager.salt_duplicate_seeds). #53077 salts them apart to separate n>1
+        # completions of one prompt, but this model is served through vLLM v1, whose
+        # ParentRequest._get_child_sampling_params already hands child i `seed + i`
+        # (vllm/v1/engine/parallel_sampling.py) -- so n>1 children never arrive here
+        # sharing a seed. Every duplicate seed that does arrive is independent requests
+        # that must reproduce identically, which the vLLM TT sampling suite asserts
+        # (test_uniform_seed_deterministic and friends: 32 same-seed requests -> 32
+        # identical outputs, observed as 32 DIFFERENT outputs with salting on).
+        self.salt_duplicate_seeds = False
         self.padded_vocab_size = 128 * 1024
         self.head_dim = params.get("head_dim", self.dim // self.n_heads)
         if is_hf:


### PR DESCRIPTION
## Summary

Fixes cross-request contamination in the prefill→decode handoff on `llama3_70b_galaxy` code which is shared by Llama-3.3-70B and Qwen3-32B. It also completes a seed-salting fix that never reached Qwen.

Validated with 15 full sweeps per model of the `vllm-tt-plugin` `tests/tt`
suite on WH Galaxy (TG), DP=4, `max_num_seqs 8`, `sample_on_device_mode: all`,
tracing and async scheduling enabled:

| Model | Sweeps | Test executions | Failures |
|---|---|---|---|
| Llama-3.3-70B | 15 | 1095 | 0 |
| Qwen3-32B | 15 | 1095 | 0 |

## Fixed issues

**1. A partial prefill overwrote sampling state of slots that were mid-decode.**

`_scatter_params_to_slots` broadcast the prefilling request's values across the whole `max_batch` vector, so slots holding live decoding requests sampled under someone else's parameters until the next decode re-uploaded the authoritative vector. Fixed by shadowing the per-slot values last written to device (`_slot_sampling_params`) and scattering onto that instead of a broadcast filler.

**2. `reset_prompt_tokens` cleared the prompt mask of decoding rows.**

`sampling_prompt_tokens` is `-1` everywhere except the slots being filled, so an unscoped reset wiped the penalty prompt mask for every other row. Both `SamplingGenerator.reset_prompt_tokens` and `TTPenalties.reset_prompt_tokens` now take an explicit `slots` list and merge against a host shadow.

**3. Prefill sampling allocated large buffers behind live traces.**

Counting the prefill token on device ran `scatter_add` + `tilize`, allocating two `[max_batch, padded_vocab]` int32 buffers (~32 MB/device) behind the live prefill and decode traces on every prefill which corrupted the slot already decoding. Prefill sampling now passes `count_tokens=False` and the equivalent bookkeeping is folded in from host via `copy_host_to_device_tensor` which allocates nothing.

**4. Prefill wrote through KV blocks it did not own.**

`prefill_forward_text` now passes `real_seq_lens` (unpadded, prefix-cache aware) so a request only writes the blocks it actually owns.

**5. `salt_duplicate_seeds` never reached Qwen3-32B.**

`#53077` salts concurrent duplicate seeds apart to separate `n>1` completions of one prompt. Under vLLM v1 that is unnecessary — `ParentRequest._get_child_sampling_params` already hands child *i* `seed + i` — so every duplicate seed that arrives is independent requests that must reproduce identically. Salting made `test_uniform_seed_deterministic` return 32 *different* outputs for 32 same-seed requests.

The fix existed but only for Llama: it was set inside
`TtModelArgs._set_params_from_dict`, and `TtQwenModelArgs` fully overrides that
method **without calling `super()`**, so Qwen silently kept the `True` default.
Moved to a **class attribute** on `TtModelArgs` so no subclass can drop it.

Verified on device: 32 concurrent same-seed requests now return 1 unique output
(was 32); 16 distinct seeds still return 16 unique.

## Small test harness fix

`test_qwen_attention_ttt.py` could not run, and could not have produced a
trustworthy result if it had:

- HF reference input hardcoded `.to(torch.bfloat16)` against fp32 weights → `RuntimeError` before any PCC was computed.
- Custom reference input not cast to its own parameter dtype → same.
- **`comp_pcc(reference_output, reference_output_custom, pcc)` was overwritten by the very next line**, so a reference-vs-reference mismatch was invisible and got reported as a TT failure.

## Open questions for review

- **`model_config.py` carries a Blackhole revert.** The branch as originally committed deleted `PREFETCHER_NOC1_GRID_BH`, `LM_HEAD_32_GRID_BH` and `_get_core_ranges_blackhole`, which `qwen_model_config.py` still imports, so it could not boot a server at all. I restored them from `main` to unblock testing, but **this wants a proper rebase**, not a restore.
- **Should the harness fix ship here** or as its own PR? It is a test-only change
  in a different area.
- **`_no_persist_gather` is still env-gated scaffolding.** Either promote it to a
  real fix or drop it before merge.

## Notes for reviewers

Two notes on scope before you post it. The 15/15 Qwen green result **depends on the companion plugin-side test changes**, without those, `TestPresencePenalty` still fails for the precision reason, which is not a tt-metal defect. You may want to land the plugin PR first, or state the dependency explicitly. And the Blackhole revert is the one thing I'd resolve before review rather than during it.

Issues that this PR fixes:
https://github.com/tenstorrent/tt-metal/issues/53907
https://github.com/tenstorrent/tt-metal/issues/53802
https://github.com/tenstorrent/tt-metal/issues/52898
https://github.com/tenstorrent/tt-metal/issues/50649
https://github.com/tenstorrent/tt-metal/issues/49785

vLLM sampling tests CI run:
https://github.com/tenstorrent/tt-metal/actions/runs/32842480779

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/qwen_llama_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-ifabijanic/qwen_llama_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/qwen_llama_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-ifabijanic/qwen_llama_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-ifabijanic/qwen_llama_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-ifabijanic/qwen_llama_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-ifabijanic/qwen_llama_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-ifabijanic/qwen_llama_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-ifabijanic/qwen_llama_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-ifabijanic/qwen_llama_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-ifabijanic/qwen_llama_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-ifabijanic/qwen_llama_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-ifabijanic/qwen_llama_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-ifabijanic/qwen_llama_fixes)