### PR TITLE
#53693: BH ELWMUL dest reuse — avoid ZEROACC bank-crossing on the last face

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary.py
@@ -674,7 +674,9 @@ def _compute_dest_reuse_golden(
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
     tile_dimensions=[[32, 32], [16, 32], [8, 32]],
     input_dimensions=[[512, 32]],
-    output_dimensions=[[128, 32]],
+    output_dimensions=lambda tile_dimensions: (
+        [[128, 32], [256, 32]] if tile_dimensions == [32, 32] else [[128, 32]]
+    ),
 )
 def test_eltwise_binary_dest_reuse(
     reuse_dest_type,

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary.py
@@ -674,6 +674,9 @@ def _compute_dest_reuse_golden(
     math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
     tile_dimensions=[[32, 32], [16, 32], [8, 32]],
     input_dimensions=[[512, 32]],
+    # [256, 32] fills the DEST bank (8 output tiles), which is what reaches dst_index 7.
+    # Only the Float16_b arm gets there: Float32 halves the bank, so it blocks at 4 tiles
+    # and dst_index caps at 3.
     output_dimensions=lambda tile_dimensions: (
         [[128, 32], [256, 32]] if tile_dimensions == [32, 32] else [[128, 32]]
     ),

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -509,7 +509,14 @@ inline void eltwise_binary_run_with_dest_reuse(
     constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
     // DEST rows one face spans -- what ZEROACC's 16-row mode clears in a single instruction.
     constexpr std::uint32_t DEST_ROWS_PER_FACE = FACE_R_DIM;
-    constexpr std::uint32_t DEST_ROWS_PER_TILE = 4 * DEST_ROWS_PER_FACE;
+    // DEST rows one tile slot spans. This is DEST geometry, not the tile's logical face count: every tile gets
+    // the same slot whatever its shape, because set_dst_write_addr<Tile32x32> places tiles at exactly this stride
+    // and the MOP pads partial faces to 16-row spacing (eltwise_binary_configure_mop_with_dest_reuse). A tile with
+    // fewer faces uses the low faces of its slot and leaves the rest unused. Derived from the same shift
+    // set_dst_write_addr uses so the two cannot drift apart.
+    constexpr std::uint32_t DEST_ROWS_PER_TILE = 1u << DstTileSizeLog2[DstTileShape::Tile32x32];
+    static_assert(DEST_ROWS_PER_TILE == TILE_NUM_FACES * DEST_ROWS_PER_FACE, "DEST slot must hold a full tile");
+    static_assert(MAX_TILES_IN_HALF_DEST * DEST_ROWS_PER_TILE == DEST_REGISTER_HALF_SIZE, "DEST slots tile the bank");
     // Rows in one 16-bit DEST bank. The 32-bit bank is half this, but it is excluded below.
     constexpr std::uint32_t DEST_ROWS_PER_BANK = DEST_REGISTER_HALF_SIZE;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -349,6 +349,33 @@ inline void eltwise_binary_reuse_dest_as_src()
 }
 
 /**
+ * @brief Clear one 16-row DEST face using ZEROACC's one-row mode.
+ *
+ * Rows are spelled out instead of looped because TTI_ZEROACC's operand must constant-fold; a loop
+ * would only assemble when the unroll hint is honoured, making legality depend on the optimiser.
+ * Same reason move_d2a_row_broadcast_fixed_face writes out its row moves.
+ */
+inline void zeroacc_face_by_row()
+{
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0 /*use_32_bit_mode*/, 0 /*clear_zero_flags*/, ADDR_MOD_1, 0);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 1);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 2);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 3);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 4);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 5);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 6);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 7);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 8);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 9);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 10);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 11);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 12);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 13);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 14);
+    TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0, 0, ADDR_MOD_1, 15);
+}
+
+/**
  * @brief Configure MOP for eltwise binary operations with dest reuse.
  *
  * MOP outer loop = 1 face, called multiple times externally with ZEROACC between calls.
@@ -481,9 +508,10 @@ inline void eltwise_binary_run_with_dest_reuse(
 {
     constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
     // DEST rows one face spans -- what ZEROACC's 16-row mode clears in a single instruction.
-    constexpr std::uint32_t DEST_ROWS_PER_FACE = 16;
-    // Rows in one DEST bank (half). See the bank-select note below.
-    constexpr std::uint32_t DEST_ROWS_PER_BANK = 512;
+    constexpr std::uint32_t DEST_ROWS_PER_FACE = FACE_R_DIM;
+    constexpr std::uint32_t DEST_ROWS_PER_TILE = 4 * DEST_ROWS_PER_FACE;
+    // Rows in one 16-bit DEST bank. The 32-bit bank is half this, but it is excluded below.
+    constexpr std::uint32_t DEST_ROWS_PER_BANK = DEST_REGISTER_HALF_SIZE;
 
 #pragma GCC unroll 0
     for (std::uint32_t n = 0; n < loop_count; n++)
@@ -511,18 +539,18 @@ inline void eltwise_binary_run_with_dest_reuse(
         // A 32-bit bank tops out at 240 + 15 and never trips it. ZEROACC's one-row mode addresses purely
         // in rows (dest offset + RWC + index) and has no such mismatch, so use it for that one face.
         // tt-metal#53693.
-        const std::uint32_t dest_row_offset = (local_tile << 6) + ((face_offset + n) << 4);
-        if (dest_row_offset + face_index >= DEST_ROWS_PER_BANK)
+        // The fallback is restricted to a 16-bit DEST at compile time. A 32-bit CLR_16 block is not 16
+        // consecutive DEST rows, so the row-by-row clear would not be equivalent there -- and a 32-bit
+        // bank cannot reach the boundary anyway (its offset tops out at 240 and its index at 15).
+        // Note this keys off is_fp32_dest_acc_en, not clear_fp32: with clear_fp32_dst_acc false (the
+        // LLK-level default) clear_fp32 is 0 even in FP32 mode, so it says nothing about DEST geometry.
+        constexpr bool bank_is_16bit        = !is_fp32_dest_acc_en;
+        const std::uint32_t dest_row_offset = (local_tile * DEST_ROWS_PER_TILE) + ((face_offset + n) * DEST_ROWS_PER_FACE);
+        const bool crosses_bank             = bank_is_16bit && (dest_row_offset + face_index >= DEST_ROWS_PER_BANK);
+
+        if (crosses_bank)
         {
-            // Only reachable with a 16-bit bank: in 32-bit mode the offset tops out at 240 and the index
-            // at 15. That matters because a 32-bit CLR_16 block is not 16 consecutive DEST rows, so the
-            // row-by-row fallback below would not be equivalent.
-            LLK_ASSERT(clear_fp32 == 0, "dest-reuse ZEROACC bank-crossing fallback assumes a 16-bit DEST bank");
-#pragma GCC unroll DEST_ROWS_PER_FACE
-            for (std::uint32_t row = 0; row < DEST_ROWS_PER_FACE; row++)
-            {
-                TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0 /*use_32_bit_mode*/, 0 /*clear_zero_flags*/, ADDR_MOD_1, row);
-            }
+            zeroacc_face_by_row();
         }
         else
         {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -480,6 +480,10 @@ inline void eltwise_binary_run_with_dest_reuse(
     const std::uint32_t face_r_dim)
 {
     constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+    // DEST rows one face spans -- what ZEROACC's 16-row mode clears in a single instruction.
+    constexpr std::uint32_t DEST_ROWS_PER_FACE = 16;
+    // Rows in one DEST bank (half). See the bank-select note below.
+    constexpr std::uint32_t DEST_ROWS_PER_BANK = 512;
 
 #pragma GCC unroll 0
     for (std::uint32_t n = 0; n < loop_count; n++)
@@ -490,7 +494,40 @@ inline void eltwise_binary_run_with_dest_reuse(
         int clear_fp32                     = is_fp32_dest_acc_en && clear_fp32_dst_acc ? 1 : 0;
         const std::uint32_t tiles_per_bank = clear_fp32 ? MAX_TILES_IN_HALF_DEST >> 1 : MAX_TILES_IN_HALF_DEST;
         const std::uint32_t local_tile     = dst_index & (tiles_per_bank - 1);
-        TT_ZEROACC(ZERO_ACC_MODE, clear_fp32, 0, ADDR_MOD_1, get_dest_index_in_faces(local_tile, face_offset + n));
+        const std::uint32_t face_index     = get_dest_index_in_faces(local_tile, face_offset + n);
+
+        // ZEROACC's 16-row mode takes an absolute 16-row block index within the DEST bank, but Blackhole
+        // derives that instruction's bank-select from (dest row offset + block index) -- a row offset and a
+        // block index added together. Once the sum reaches the bank size the select flips and the clear
+        // lands 512 rows away in the other DEST half: the face meant to be cleared keeps the previous
+        // accumulation step, and 16 unrelated rows of the other half are zeroed instead. ELWMUL accumulates
+        // into DEST, so the stale face surfaces as (previous step + product); ELWADD/ELWSUB overwrite DEST
+        // and issue no ZEROACC at all, which is why only ELWMUL shows it.
+        //   Measured on p150 with a fixed block index of 31: dest row offset 480 -> clears block 31 (right),
+        //   offset 488 or 496 -> clears block 63 (wrong half). At offset 496, indices 0..15 still land
+        //   correctly and 16..31 do not -- matching the (offset + index) >= 512 boundary exactly.
+        // Here the dest pointer is 64*local_tile + 16*face while the index is 4*local_tile + face, so the
+        // sum only reaches 512 on the very last face of the last tile of a 16-bit bank (496 + 31 = 527).
+        // A 32-bit bank tops out at 240 + 15 and never trips it. ZEROACC's one-row mode addresses purely
+        // in rows (dest offset + RWC + index) and has no such mismatch, so use it for that one face.
+        // tt-metal#53693.
+        const std::uint32_t dest_row_offset = (local_tile << 6) + ((face_offset + n) << 4);
+        if (dest_row_offset + face_index >= DEST_ROWS_PER_BANK)
+        {
+            // Only reachable with a 16-bit bank: in 32-bit mode the offset tops out at 240 and the index
+            // at 15. That matters because a 32-bit CLR_16 block is not 16 consecutive DEST rows, so the
+            // row-by-row fallback below would not be equivalent.
+            LLK_ASSERT(clear_fp32 == 0, "dest-reuse ZEROACC bank-crossing fallback assumes a 16-bit DEST bank");
+#pragma GCC unroll DEST_ROWS_PER_FACE
+            for (std::uint32_t row = 0; row < DEST_ROWS_PER_FACE; row++)
+            {
+                TTI_ZEROACC(p_zeroacc::CLR_SPECIFIC, 0 /*use_32_bit_mode*/, 0 /*clear_zero_flags*/, ADDR_MOD_1, row);
+            }
+        }
+        else
+        {
+            TT_ZEROACC(ZERO_ACC_MODE, clear_fp32, 0, ADDR_MOD_1, face_index);
+        }
 
         ckernel_template::run();
 


### PR DESCRIPTION
Fixes #53693.

### What goes wrong

ZEROACC's 16-row mode takes a block index within the DEST bank, but Blackhole picks the bank for that instruction from `(dest row offset + block index)` — a row offset added to a block index. Once the sum reaches 512 the bank select flips and the clear lands 512 rows away, in the other half of DEST. The face that should have been cleared keeps its old contents, and 16 unrelated rows in the other half get zeroed instead.

In the dest-reuse loop the dest pointer is `64*tile + 16*face` and the index is `4*tile + face`, so the sum only reaches 512 on the last face of the last tile of a full 16-bit bank (`496 + 31 = 527`). Every other tile/face combination stops at 510, which is why exactly one face in the bank is ever wrong.

ELWMUL accumulates into DEST, so the stale face comes out as `previous step + product`. ELWADD/ELWSUB overwrite DEST and issue no ZEROACC at all — that's why only ELWMUL shows it.

Measured on p150b with a probe that fills DEST, issues a single CLR_16, and reads back:

| dest row offset | block index | clears |
|---|---|---|
| 480 | 31 | block 31 (correct) |
| 488 | 31 | block 63 (wrong half) |
| 496 | 31 | block 63 (wrong half) |
| 496 | 0–15 | correct |
| 496 | 16–31 | wrong half |

Skipping the multiply for that one face and packing DEST out confirms it directly: the face holds the previous accumulation step, not zero.

### Fix

Clear that one face with ZEROACC's one-row mode. It addresses purely in rows (`dest offset + RWC + index`), so there's no unit mismatch and no bank crossing. Every other face keeps the single-instruction 16-row clear.

### Test

Adds the 32x32 `[256,32]` case from the issue — that's the shape that fills the bank.

### Verified on p150b

- the 4 previously failing cases pass
- `test_eltwise_binary.py`: 4408 passed, 72 skipped
- `test_bcast.py` and `test_unpack_A.py` clean

### Left for a follow-up

Three other BH LLKs use the same `get_dest_index_in_faces` + CLR_16 pattern (`llk_math_eltwise_unary_datacopy.h`, `experimental/llk_math_top32_rm.h`, `experimental/llk_math_eltwise_unary_datacopy_topk_xl_copy.h`). They're safe today because their index tops out at 15 and the offset they inherit is at most 448, but nothing in the code states that. `experimental/llk_math_sdpa_custom_mm.h:129` can reach the boundary depending on the `dst_index` it's called with — worth checking separately.

Quasar has the same shape as BH did before this fix — `tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h:333` passes `tile_start + face_num` straight to CLR_16 — and it shares `MAX_TILES_IN_HALF_DEST`, so the boundary looks reachable there too. No change here since QSR is gated on regressions, but it needs a probe or an RTL check once QSR has DEST coverage; the QSR ISA text matches BH word for word, and BH silicon is what deviates from it.

Wormhole folds the bank base into the index itself instead of relying on the hardware to pick the bank, so it doesn't have this shape. Untouched here, and untested (no WH card on hand).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/53693-elwmul-dest-reuse-implied-fmt)
