### PR TITLE
tt_transformers: declare scheduler-driven chunked prefill for llama, qwen and mistral

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -425,7 +425,7 @@ models:
   vllm:
     wh_galaxy_perf: 430
     bh_quietbox_2: 310
-    wh_llmbox: 297
+    wh_llmbox: 342
     bh_loudbox: 75
     wh_n150: 65
 umd:

--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -659,7 +659,7 @@ jobs:
               exit 1
             fi
             RESOLVED=$(grep "$EXPECTED" "${FILE_SERVER_LOG}" | tail -1 \
-              | grep -o "max_num_batched_tokens=[0-9]\+" | cut -d= -f2)
+              | grep -o "max_num_batched_tokens=[0-9]\+" | cut -d= -f2 || true)
             if [ "$RESOLVED" != "$BUDGET" ]; then
               echo "❌ server resolved max_num_batched_tokens=$RESOLVED, tests were told $BUDGET"
               exit 1

--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -139,6 +139,7 @@ jobs:
       FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG: "./output/vllm_benchmark_structured_output.log"
       FILE_MULTIMODAL_TEST_LOG: "./output/vllm_multimodal_test.log"
       FILE_SAMPLING_TESTS_LOG: "./output/vllm_sampling_tests.log"
+      FILE_CHUNKED_PREFILL_TESTS_LOG: "./output/vllm_chunked_prefill_tests.log"
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -162,6 +163,7 @@ jobs:
         FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG: "./output/vllm_benchmark_structured_output.log"
         FILE_MULTIMODAL_TEST_LOG: "./output/vllm_multimodal_test.log"
         FILE_SAMPLING_TESTS_LOG: "./output/vllm_sampling_tests.log"
+        FILE_CHUNKED_PREFILL_TESTS_LOG: "./output/vllm_chunked_prefill_tests.log"
         FILE_COHERENCE_TEST_LOG: "./output/vllm_coherence_test.log"
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
@@ -638,6 +640,36 @@ jobs:
             else
               pytest "${PLUGIN_DIR}/tests/tt" -v --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
             fi
+
+      - name: 🧪 Run chunked prefill tests
+        if: ${{ matrix.test-group.chunked-prefill-budget }}
+        timeout-minutes: ${{ matrix.test-group.chunked-prefill-test-timeout || 15 }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_CHUNKED_PREFILL_TESTS_LOG }}
+          run: |
+            # Confirm the server really has the feature on at this budget before
+            # trusting the tests. Without this they would pass against a server that
+            # silently disabled chunked prefill, e.g. one whose model class does
+            # not declare the capability.
+            BUDGET=${{ matrix.test-group.chunked-prefill-budget }}
+            EXPECTED="Chunked prefill enabled"
+            if ! grep -q "$EXPECTED" "${FILE_SERVER_LOG}"; then
+              echo "❌ server log has no '$EXPECTED' line, so chunked prefill is not active"
+              exit 1
+            fi
+            RESOLVED=$(grep "$EXPECTED" "${FILE_SERVER_LOG}" | tail -1 \
+              | grep -o "max_num_batched_tokens=[0-9]\+" | cut -d= -f2)
+            if [ "$RESOLVED" != "$BUDGET" ]; then
+              echo "❌ server resolved max_num_batched_tokens=$RESOLVED, tests were told $BUDGET"
+              exit 1
+            fi
+            echo "✅ chunked prefill active at max_num_batched_tokens=$RESOLVED"
+
+            pytest "${PLUGIN_DIR}/tests/tt/test_chunked_prefill.py" -v \
+              --tt-server-url=http://localhost:8000 \
+              --tt-model-name=${{ matrix.test-group.model }} \
+              --tt-chunked-prefill-budget="$BUDGET"
 
       - name: 🧹 Cleanup server process
         if: always()

--- a/models/common/model_capabilities.py
+++ b/models/common/model_capabilities.py
@@ -17,6 +17,33 @@ class ModelCapabilitiesMixin:
     NOTE: The default values here and per-model overrides will eventually be
     unified with the corresponding vLLM scheduler configuration so that both
     paths derive from the same source of truth.
+
+    Generator classes also carry a class-level ``model_capabilities`` dict that
+    the vLLM TT plugin reads off the resolved bridge class at config time. A
+    subclass dict replaces the inherited one rather than merging into it, so an
+    absent key means "not supported" and no reader assumes otherwise. Recognized
+    keys:
+
+    ``supports_prefix_caching`` (bool)
+        The generator accepts a nonzero ``start_pos`` for a prompt whose prefix
+        is already in the KV cache.
+    ``supports_async_decode`` (bool)
+        ``decode_forward(..., read_from_device=False)`` followed by
+        ``read_decode_output(..., async_read=True)`` is implemented, so the
+        engine may overlap scheduling with device execution.
+    ``supports_sample_on_device`` (bool)
+        The full on-device sampling pipeline is implemented.
+    ``supports_chunked_prefill`` (bool)
+        One prompt may be prefilled across several engine steps. Independent of
+        ``supports_prefix_caching``: both make the scheduler hand the generator a
+        nonzero ``start_pos``, and either one is enough to need the resume
+        plumbing, but they gate on different validation.
+    ``resumed_prefill_token_alignment`` (positive int)
+        The ``q_chunk_size`` the model's chunked-SDPA program is built with.
+        Required only of a model whose ``model_args`` exposes no
+        ``get_attn_sdpa_program_config`` for the generator to read it from, and
+        read only by the generator: the plugin never needs it, because the
+        generator floors every resume offset itself.
     """
 
     @classmethod

--- a/models/common/model_capabilities.py
+++ b/models/common/model_capabilities.py
@@ -18,11 +18,15 @@ class ModelCapabilitiesMixin:
     unified with the corresponding vLLM scheduler configuration so that both
     paths derive from the same source of truth.
 
-    Generator classes also carry a class-level ``model_capabilities`` dict that
-    the vLLM TT plugin reads off the resolved bridge class at config time. A
-    subclass dict replaces the inherited one rather than merging into it, so an
-    absent key means "not supported" and no reader assumes otherwise. Recognized
-    keys:
+    Generator classes also carry a class-level ``model_capabilities`` dict.
+    The vLLM TT plugin snapshots that class attribute during
+    ``check_and_update_config``, before any generator instance exists, so a
+    capability narrowed on ``self.model_capabilities`` inside ``__init__`` does
+    not reach the scheduler configuration. A subclass dict replaces the
+    inherited one rather than merging into it, so an absent key means "not
+    supported" and no reader assumes otherwise.
+
+    Keys:
 
     ``supports_prefix_caching`` (bool)
         The generator accepts a nonzero ``start_pos`` for a prompt whose prefix
@@ -44,6 +48,12 @@ class ModelCapabilitiesMixin:
         ``get_attn_sdpa_program_config`` for the generator to read it from, and
         read only by the generator: the plugin never needs it, because the
         generator floors every resume offset itself.
+    ``output_tokens_per_step`` (positive int)
+        Tokens committed per engine step. The plugin treats a value greater
+        than 1 as a block-output model. Defaults to 1 when absent.
+    ``accepts_trace_mode`` (bool)
+        The generator honours a ``trace_mode`` argument. Used by the common
+        LLM runtime, not by the vLLM TT plugin.
     """
 
     @classmethod

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -227,7 +227,9 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
     #
     # Default ON for non-PLI. Token-doubling under async is mitigated by
     # ``merge_async_ahead_decode_tokens`` + vLLM preempt bookkeeping. Kill-switch:
-    # ``GEMMA4_SUPPORTS_ASYNC_DECODE=0``. PLI models force False in ``__init__``.
+    # ``GEMMA4_SUPPORTS_ASYNC_DECODE=0``. PLI models narrow the instance dict
+    # in ``__init__``; that does not reach the platform, so PLI still needs
+    # the kill-switch to disable async_scheduling.
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": os.environ.get("GEMMA4_SUPPORTS_ASYNC_DECODE", "1").lower() in ("1", "true", "yes"),
@@ -303,8 +305,11 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
             _bounded_default = "1" if self._HYBRID_KV_CACHE_GROUPS_ENABLED else "0"
             self._bounded_sliding_kv_cache = os.environ.get("GEMMA4_BOUNDED_SLIDING_KV_CACHE", _bounded_default) != "0"
         # PLI models must restage decode inputs from host every step; async lag
-        # would restage a stale token. Force capability off even if env default
-        # is on (platform then disables async_scheduling).
+        # would restage a stale token. Narrow the instance dict so runtime
+        # readers (the decode-sync default below) see False. The vLLM TT plugin
+        # snapshots the class attribute during check_and_update_config, before
+        # this runs, so this does not disable scheduler_config.async_scheduling;
+        # set GEMMA4_SUPPORTS_ASYNC_DECODE=0 for that.
         if model0 is not None and (
             bool(getattr(model0, "hidden_size_per_layer_input", 0))
             or bool(getattr(model0, "_tt_vllm_always_refresh_decode_trace_inputs", False))
@@ -317,11 +322,9 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
         # SamplingGenerator. That needs the per-device vocab shard to fit ttnn's
         # 64k topk width: Gemma4's vocab is 262144, so TP>=4 shards to <=65536 and
         # works, but TP=2 (WH N300 1x2) shards to 131072 and Gemma4Model leaves
-        # ``self.sampling = None``. Advertising the capability anyway made vLLM
-        # request on-device decode logits and the engine died on the
-        # ``self.sampling is not None`` assert in ``ttnn_decode_forward``. Report
-        # what the model can really do so the platform falls back to host
-        # sampling (which all-gathers the full vocab and is correct, just slower).
+        # ``self.sampling = None``. Narrow the instance dict so runtime readers
+        # see False. The platform already snapshot the class attribute, so this
+        # does not revise sample_on_device_mode.
         if model0 is not None and not bool(getattr(model0, "_supports_on_device_sampling", True)):
             self.model_capabilities = {
                 **self.model_capabilities,

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -236,6 +236,10 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
         # align_num_cached_tokens_to_sdpa applies locally.
         "resumed_prefill_token_alignment": SDPA_CHUNK_ALIGN,
         "supports_sample_on_device": True,
+        # prefill_forward_text routes a nonzero start_pos to the chunked SDPA and
+        # floors the offset to resumed_prefill_token_alignment, so a prompt split
+        # across engine steps needs no new prefill code.
+        "supports_chunked_prefill": True,
     }
 
     # vLLM pads decode to the nearest of these (not always max_num_seqs) so B=1

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -630,6 +630,10 @@ class LlamaForCausalLM(Generator):
         "supports_prefix_caching": True,
         "supports_async_decode": True,
         "supports_sample_on_device": True,
+        # prefill_forward_single_user_text already routes a nonzero start_pos to
+        # the chunked SDPA, and the generator floors the offset to what that op
+        # needs, so a prompt split across engine steps needs no new prefill code.
+        "supports_chunked_prefill": True,
     }
 
     @classmethod
@@ -715,6 +719,10 @@ class QwenForCausalLM(Generator):
         "supports_prefix_caching": True,
         "supports_async_decode": True,
         "supports_sample_on_device": True,
+        # prefill_forward_single_user_text already routes a nonzero start_pos to
+        # the chunked SDPA, and the generator floors the offset to what that op
+        # needs, so a prompt split across engine steps needs no new prefill code.
+        "supports_chunked_prefill": True,
     }
 
     @classmethod
@@ -794,6 +802,10 @@ class MistralForCausalLM(Generator):
         "supports_prefix_caching": True,
         "supports_async_decode": True,
         "supports_sample_on_device": True,
+        # prefill_forward_single_user_text already routes a nonzero start_pos to
+        # the chunked SDPA, and the generator floors the offset to what that op
+        # needs, so a prompt split across engine steps needs no new prefill code.
+        "supports_chunked_prefill": True,
     }
 
     @classmethod

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -374,7 +374,7 @@
   model: meta-llama/Llama-3.1-8B-Instruct
   server-timeout: 15
   benchmark-timeout: 5
-  chunked-prefill-test-timeout: 10
+  chunked-prefill-test-timeout: 15
   mesh-device: T3K
   arch: arch-wormhole_b0
   tt-llama-text-ver: tt_transformers

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -21,6 +21,11 @@
 #   tt-qwen3-text-ver, tt_mm_throttle_perf: server / benchmark configuration.
 #   coherence-test / structured-output / multimodal / sampling-tests: optional test toggles.
 #   sampling-test-filter: -k filter for the sampling test step.
+#   chunked-prefill-budget: enables the chunked-prefill test step and tells it the
+#     served max_num_batched_tokens, which it uses to size prompts that are
+#     guaranteed to be split across engine steps. Must equal the
+#     --max-num-batched-tokens passed in additional-server-args.
+#   chunked-prefill-test-timeout: per-step timeout for that step (minutes, default 15).
 #
 # For max allowed timeout refer to .github/time_budget.yaml
 
@@ -363,6 +368,35 @@
       timeout: 75
       tier: 2
   owner_id: U08GELBB1AP # Ambrose Ling
+  team: models
+
+- name: "Llama-3.1-8B-Instruct (chunked prefill)"
+  model: meta-llama/Llama-3.1-8B-Instruct
+  server-timeout: 15
+  benchmark-timeout: 5
+  chunked-prefill-test-timeout: 10
+  mesh-device: T3K
+  arch: arch-wormhole_b0
+  tt-llama-text-ver: tt_transformers
+  # sample_on_device_mode is what makes this leg cover the intermediate-chunk
+  # sampling fallback: the runner forces host sampling for a step containing a
+  # mid-prompt row, and with device sampling off that branch never runs.
+  # trace_region_size as on the prefix-caching leg: declaring chunked prefill
+  # also reserves a traced resumed prefill per traced sequence length at warmup,
+  # which the 50 MB default does not cover.
+  tt-config: '{"fabric_config": "FABRIC_1D", "sample_on_device_mode": "all", "trace_region_size": 85000000}'
+  multimodal: false
+  additional-server-args: "--enable-chunked-prefill --max-num-batched-tokens 2048 --max_model_len 32768 --async-scheduling"
+  # Prompts long enough to be split, at a concurrency that makes continuations
+  # and fresh admissions land in the same prefill step.
+  additional-benchmark-args: "--random-input-len 4096 --random-output-len 32 --num-prompts 8 --max-concurrency 4"
+  chunked-prefill-budget: 2048
+  skus:
+    wh_llmbox:
+      timeout: 45
+      tier: 2
+  owner_id: U08E1JCDVNX # Pavle Petrovic
+  co-owner-2-id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 
 - name: "Llama-3.1-8B-Instruct DP=4"


### PR DESCRIPTION
Enables vLLM scheduler-driven chunked prefill for the `tt_transformers`
full-attention text bridges.

Depends on [#54435](https://github.com/tenstorrent/tt-metal/pull/54435) (merged), which
owns the resume-offset alignment and the resumed-prefill trace warmup this needs.
That has merged (`0acbde02e3b`); this branch is rebased onto current `main`
(`ee7c625d0a2`).

Pairs with
[tenstorrent/vllm-tt-plugin#79](https://github.com/tenstorrent/vllm-tt-plugin/pull/79),
which consumes the capability this declares; the two must land together (this one first, plugin second).

Implements the tt-metal half of
[vllm-tt-plugin#74](https://github.com/tenstorrent/vllm-tt-plugin/issues/74).

## What this enables

`LlamaForCausalLM`, `QwenForCausalLM` (Qwen2 and Qwen3) and `MistralForCausalLM`
declare `supports_chunked_prefill`, so one prompt may be prefilled across several
engine steps instead of occupying a whole step. Gemma 4 moves onto the same
capability so the plugin can delete its hardcoded `model_type` allowlist.

Not to be confused with generator-internal chunking (`max_prefill_chunk_size`),
which splits a long prompt inside a single `prefill_forward_*` call. This is the
scheduler splitting one prompt across engine steps, so the generator has to
accept a nonzero `start_pos`. Both enter the same branch in
`prefill_forward_single_user_text`, which is why these bridges need no new
prefill code. Open tt-metal PRs that mention "chunked prefill" for Kimi, GLM,
DeepSeek or Minimax are that generator-internal path, not this.

## Why the declaration is small

The hard part is not the declaration, it is that a resume offset must be a
multiple of both the paged KV `block_size` and the `q_chunk_size` the model's
chunked-SDPA program was built with, and the op reads the wrong prefix rather
than raising when it is not. The vLLM scheduler satisfies neither: `num_new_tokens`
comes straight out of the remaining token budget, so any step where several
prefills share the budget produces arbitrary values.

That correction is not specific to chunked prefill. Automatic prefix caching
already produced offsets the traced SDPA could not honour, so it is a live
wrong-answer bug on `main` today, independent of anything here. It is therefore
[#54435](https://github.com/tenstorrent/tt-metal/pull/54435)'s subject, together
with the resumed-prefill trace warmup that keeps the traces those replays need
from being allocated at serving time. This PR carries only what is genuinely new:

- `models/tt_transformers/tt/generator_vllm.py` - declare
  `supports_chunked_prefill` on the three text bridges. The Galaxy bridges are
  separate classes and are untouched.
- `models/demos/gemma4/tt/generator_vllm.py` - the same key on
  `Gemma4ForCausalLM.model_capabilities`, which is the class the plugin resolves.
  `Gemma4Generator` in `models/demos/gemma4/tt/generator.py` is the demo path, has
  no vLLM scheduler and is left alone. Both classes already declare
  `resumed_prefill_token_alignment: SDPA_CHUNK_ALIGN` for #54435, and both
  override `warmup_model_prefill` without calling `super()`, so declaring this
  does not reach the resumed warmup sweep.
- `models/common/model_capabilities.py`: document the `model_capabilities`
  contract the plugin reads. An absent key means False, a subclass dict
  replaces rather than merges, and the plugin snapshots the class attribute
  during `check_and_update_config` before any generator instance exists.
  Instance rebinding (Gemma 4 does this for `supports_async_decode` and
  `supports_sample_on_device`) does not reach the scheduler. The key list
  includes `output_tokens_per_step` and `accepts_trace_mode`.
- `models/demos/gemma4/tt/generator_vllm.py`: comments on the instance-level
  capability merges now match that snapshot rule. PLI still needs
  `GEMMA4_SUPPORTS_ASYNC_DECODE=0` to disable `async_scheduling`.
- CI: a T3K Llama leg that serves with a token budget far below the prompt
  length. It keeps `--async-scheduling` (the runner's async path is decode-only,
  so it does not touch chunked prefill) and sets `sample_on_device_mode: "all"`,
  which is the only way the runner's host-sampling fallback for mid-prompt rows
  is reached. The step first checks the resolved budget in the server log,
  because the device tests cannot confirm the feature is on for themselves.
  A missing `max_num_batched_tokens=` field now reaches the comparison and
  prints both values instead of exiting under `pipefail` with no message.
  Default `chunked-prefill-test-timeout` is 15 minutes.

There is no per-model alignment declaration for `tt_transformers`. #54435 derives
the `q_chunk_size` from the model's own `get_attn_sdpa_program_config` per padded
suffix length, so a short resumed span keeps its 64-token alignment instead of
being rounded to 256. An earlier revision of this PR declared a flat 256 in
`model_capabilities` and had the plugin round the token budget to it; both are
gone, because the value is not a constant and the plugin has no use for it.

## Validation

T3K, Llama-3.1-8B-Instruct, `--max-num-batched-tokens 2048 --max_model_len 32768
--async-scheduling`, `sample_on_device_mode: "all"`.

The discriminating measurement is four ~2K-token prompts issued concurrently,
each carrying its own passphrase and asked to repeat it. Twenty samples:

| resume offsets floored to | recall |
|---|---|
| chunked prefill off | 20/20 |
| `block_size` (64) only | 10/20 |
| `lcm(block_size, q_chunk_size)` | 20/20 |

Solo prefills pass in every configuration, so this only shows up once several
prefills share a step. Removing the floor entirely does not degrade output, it
kills the engine: `TT_FATAL @ tensor_apis.cpp:157 host_tensor.logical_shape() ==
device_tensor.logical_shape()`.

Also on device (pre-rebase head of this branch; the four commits here are
unchanged):

- Plugin host suite: 343 passed locally. After the rebase onto current plugin
  `main`, GitHub `unit-tests` (3.10 and 3.12, `pytest tests --ignore=tests/tt`)
  passed on [vllm-tt-plugin#79](https://github.com/tenstorrent/vllm-tt-plugin/pull/79).
- Plugin `tests/tt/test_chunked_prefill.py`: three cases (solo budget-sized
  split, 3x-budget span that pins `q_chunk_size=256`, concurrent ragged
  remainder). The T3K chunked-prefill CI leg runs all three.
- `tests/tt` with the T3K leg's `-k` filter: 42 passed, 1 skipped. Unfiltered,
  11 failed with chunked prefill on against 12 with it off, same families
  (`TestSeedingAndVariety`, `*_mixed_batch`) that
  [vllm-tt-plugin#77](https://github.com/tenstorrent/vllm-tt-plugin/pull/77)
  rewrites and the T3K leg already excludes.
- A 4200-word prompt whose middle chunk is a full 2048-token resumed span: 6/6.
- `vllm bench serve`, 8 x 4096-token prompts at concurrency 4: 8/8, mean TTFT
  1393 ms, mean ITL 35 ms.

Full `vLLM Model Tests`: https://github.com/tenstorrent/tt-metal/actions/runs/33627798946

- `Llama-3.1-8B-Instruct (chunked prefill) [wh_llmbox]` passed, including the
  server-log budget gate and the three device tests.
- Gemma 4 E2B, the other Llama 8B llmbox legs, and Qwen2.5-VL-72B passed.
- `Qwen3-VL-32B-Instruct` structured-output `correct_rate` 0% is not this PR.
  Chunked prefill stayed off (`Qwen3VLForConditionalGeneration` does not declare
  the capability). The same job already failed at 71.875% on the 31 Aug nightly
  (plugin `main`). Grammar was applied; decode quality under sampling is flaky.
- `Qwen3.6-27B (multimodal B=1)` server-ready timeout is not extra warmup.
  Chunked prefill stayed off. Nightly became ready at 1560 s / 1800 s; this host
  spent ~29 min loading 64 transformer layers and hit the 30 min cap three
  seconds into the same decode warmup nightly always runs. The sibling
  `batch=8` leg (`server-timeout: 35`) passed.
- Remaining reds (GPT-OSS, Galaxy sampling, Gemma4-31B verify) match existing
  matrix noise; Galaxy generators do not declare this capability.

The unit coverage for resume-offset alignment lives in
`models/common/tests/test_resume_offset_alignment.py`, merged with #54435.

## Known limitations

**Gemma 4 above `max_num_seqs 1` is unsound for a separate reason.** Its
sliding-window layers keep a rolling K/V tail in a single per-layer attribute
that is not keyed by request and is reset whenever any request starts at offset
0, so concurrent prefills clobber each other. This PR neither causes nor fixes
that; Gemma 4 is enabled here exactly as it was under the allowlist. Filed
separately.

**Qwen and Mistral have no device validation.** They share the tt_transformers
generator and SDPA configuration with Llama, so the Llama result is strong
evidence, but neither model's weights were available on the box used here.

**Prefix-cache hits below the alignment are recomputed.** That is #54435's
behaviour, not a change here. The Llama prefix-caching CI leg passes.

## Not duplicating

`gh pr list --repo tenstorrent/tt-metal --state open --search "chunked prefill"`
hits generator-internal prefill work (Kimi, GLM, DeepSeek, Minimax). None of
those declare `supports_chunked_prefill` on the vLLM `tt_transformers` bridges
or add the T3K Llama scheduler-split CI leg.

## AI assistance

Written with AI assistance (Claude, then Cursor Grok 4.6). Every line is to be
reviewed and defended by the human submitter.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/chunked-prefill-tt-transformers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/chunked-prefill-tt-transformers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/chunked-prefill-tt-transformers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/chunked-prefill-tt-transformers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/chunked-prefill-tt-transformers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/chunked-prefill-tt-transformers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/chunked-prefill-tt-transformers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/chunked-prefill-tt-transformers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/chunked-prefill-tt-transformers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/chunked-prefill-tt-transformers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/chunked-prefill-tt-transformers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/chunked-prefill-tt-transformers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/chunked-prefill-tt-transformers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/chunked-prefill-tt-transformers)
