### PR TITLE
Add program factory identity to graph tracing reports (#54158)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ project(
 message(STATUS "Metalium version: ${PROJECT_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 GenerateVersionHeader()
+AddVersionHeaderTarget()
 
 # Augment CMake's built-in per-config flags rather than replacing them wholesale.
 # Using set(CMAKE_CXX_FLAGS_<CONFIG> ...) overwrites the variable entirely, silently

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ project(
 )
 message(STATUS "Metalium version: ${PROJECT_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+GenerateVersionHeader()
 
 # Augment CMake's built-in per-config flags rather than replacing them wholesale.
 # Using set(CMAKE_CXX_FLAGS_<CONFIG> ...) overwrites the variable entirely, silently

--- a/cmake/generate_tt_metal_version.cmake
+++ b/cmake/generate_tt_metal_version.cmake
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT VERSION_TEMPLATE OR NOT VERSION_OUTPUT)
+    message(FATAL_ERROR "VERSION_TEMPLATE and VERSION_OUTPUT are required")
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/version.cmake")
+ParseGitDescribe()
+GenerateVersionHeader()

--- a/cmake/tt_metal_version.hpp.in
+++ b/cmake/tt_metal_version.hpp.in
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string_view>
+
+#ifndef TT_METAL_BUILD_TYPE
+#define TT_METAL_BUILD_TYPE "Unknown"
+#endif
+
+namespace tt::tt_metal {
+
+inline constexpr std::string_view kGitSha = "@VERSION_SHA@";
+inline constexpr std::string_view kGitShaShort = "@VERSION_HASH@";
+inline constexpr std::string_view kVersionFull = "@VERSION_FULL@";
+inline constexpr std::string_view kBuildType = TT_METAL_BUILD_TYPE;
+inline constexpr bool kGitDirty = @VERSION_DIRTY_CPP@;
+
+}  // namespace tt::tt_metal

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -111,7 +111,9 @@ function(ParseGitDescribe)
     )
     string(APPEND VERSION_DEB "~ubuntu${UBUNTU_RELEASE}")
 
-    message(STATUS "Version: ${VERSION_FULL}")
+    if(NOT VERSION_PARSE_QUIET)
+        message(STATUS "Version: ${VERSION_FULL}")
+    endif()
 
     # Output variables
     set(VERSION_FULL "${VERSION_FULL}" PARENT_SCOPE)
@@ -126,19 +128,44 @@ function(GenerateVersionHeader)
     if(NOT VERSION_SHA)
         set(VERSION_SHA "${VERSION_HASH}")
     endif()
-    if(CMAKE_BUILD_TYPE)
-        set(VERSION_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
-    else()
-        set(VERSION_BUILD_TYPE "Unknown")
-    endif()
     if(VERSION_DIRTY)
         set(VERSION_DIRTY_CPP "true")
     else()
         set(VERSION_DIRTY_CPP "false")
     endif()
-    configure_file(
-        "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tt_metal_version.hpp.in"
-        "${PROJECT_BINARY_DIR}/generated/tt_metal/impl/version.hpp"
-        @ONLY
+    if(NOT VERSION_TEMPLATE)
+        set(VERSION_TEMPLATE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tt_metal_version.hpp.in")
+    endif()
+    if(NOT VERSION_OUTPUT)
+        set(VERSION_OUTPUT "${PROJECT_BINARY_DIR}/generated/tt_metal/impl/version.hpp")
+    endif()
+    if(NOT EXISTS "${VERSION_TEMPLATE}")
+        message(FATAL_ERROR "Missing version header template: ${VERSION_TEMPLATE}")
+    endif()
+    get_filename_component(_version_outdir "${VERSION_OUTPUT}" DIRECTORY)
+    file(MAKE_DIRECTORY "${_version_outdir}")
+    set(_version_tmp "${VERSION_OUTPUT}.tmp")
+    configure_file("${VERSION_TEMPLATE}" "${_version_tmp}" @ONLY)
+    execute_process(
+        COMMAND
+            "${CMAKE_COMMAND}" -E copy_if_different "${_version_tmp}" "${VERSION_OUTPUT}"
+    )
+    file(REMOVE "${_version_tmp}")
+endfunction()
+
+function(AddVersionHeaderTarget)
+    set(_template "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tt_metal_version.hpp.in")
+    set(_script "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/generate_tt_metal_version.cmake")
+    set(_output "${PROJECT_BINARY_DIR}/generated/tt_metal/impl/version.hpp")
+    add_custom_target(
+        tt_metal_version_header
+        COMMAND
+            "${CMAKE_COMMAND}" "-DVERSION_TEMPLATE=${_template}" "-DVERSION_OUTPUT=${_output}"
+            "-DVERSION_PARSE_QUIET=TRUE" -P "${_script}"
+        BYPRODUCTS
+            "${_output}"
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+        VERBATIM
+        COMMENT "Refreshing tt-metal version header"
     )
 endfunction()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -29,6 +29,14 @@ function(ParseGitDescribe)
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET
         )
+        execute_process(
+            COMMAND
+                ${GIT_EXECUTABLE} rev-parse HEAD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE VERSION_SHA
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
     endif()
     if(NOT VERSION_HASH)
         set(VERSION_HASH ${fallbackHash})
@@ -110,4 +118,27 @@ function(ParseGitDescribe)
     set(VERSION_DEB "${VERSION_DEB}" PARENT_SCOPE)
     set(VERSION_NUMERIC "${VERSION_NUMERIC}" PARENT_SCOPE)
     set(VERSION_HASH "${VERSION_HASH}" PARENT_SCOPE)
+    set(VERSION_SHA "${VERSION_SHA}" PARENT_SCOPE)
+    set(VERSION_DIRTY "${VERSION_DIRTY}" PARENT_SCOPE)
+endfunction()
+
+function(GenerateVersionHeader)
+    if(NOT VERSION_SHA)
+        set(VERSION_SHA "${VERSION_HASH}")
+    endif()
+    if(CMAKE_BUILD_TYPE)
+        set(VERSION_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+    else()
+        set(VERSION_BUILD_TYPE "Unknown")
+    endif()
+    if(VERSION_DIRTY)
+        set(VERSION_DIRTY_CPP "true")
+    else()
+        set(VERSION_DIRTY_CPP "false")
+    endif()
+    configure_file(
+        "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tt_metal_version.hpp.in"
+        "${PROJECT_BINARY_DIR}/generated/tt_metal/impl/version.hpp"
+        @ONLY
+    )
 endfunction()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -10,6 +10,7 @@ function(ParseGitDescribe)
     # is left as an exercise to whoever is wanting to do that.
     set(fallbackVersion "$Format:%(describe)$")
     set(fallbackHash "$Format:%h$")
+    set(fallbackSha "$Format:%H$")
 
     find_package(Git)
     if(Git_FOUND)
@@ -38,8 +39,18 @@ function(ParseGitDescribe)
             ERROR_QUIET
         )
     endif()
+    if(NOT VERSION_SHA)
+        set(VERSION_SHA "${fallbackSha}")
+    endif()
     if(NOT VERSION_HASH)
-        set(VERSION_HASH ${fallbackHash})
+        set(VERSION_HASH "${fallbackHash}")
+    endif()
+    # An unsubstituted $Format token is not a real hash.
+    if(VERSION_SHA MATCHES "Format")
+        set(VERSION_SHA "")
+    endif()
+    if(VERSION_HASH MATCHES "Format")
+        set(VERSION_HASH "")
     endif()
     if(NOT version)
         set(version ${fallbackVersion})
@@ -49,12 +60,26 @@ function(ParseGitDescribe)
         endif()
     endif()
 
-    # Local modifications (dirty), or not
+    # Package +m follows describe -dirty; report dirty follows the worktree.
     set(dirtyFlagRegex "\\-dirty")
-    set(VERSION_DIRTY FALSE)
+    set(VERSION_DESCRIBE_DIRTY FALSE)
     if("${version}" MATCHES "${dirtyFlagRegex}$")
-        set(VERSION_DIRTY TRUE)
+        set(VERSION_DESCRIBE_DIRTY TRUE)
         string(REGEX REPLACE "^(.*)${dirtyFlagRegex}$" "\\1" version "${version}")
+    endif()
+    set(VERSION_DIRTY FALSE)
+    if(Git_FOUND)
+        execute_process(
+            COMMAND
+                ${GIT_EXECUTABLE} diff-index --quiet HEAD --
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            RESULT_VARIABLE _git_worktree_dirty
+            ERROR_QUIET
+        )
+        # diff-index returns 1 only when the worktree has local modifications.
+        if(_git_worktree_dirty EQUAL 1)
+            set(VERSION_DIRTY TRUE)
+        endif()
     endif()
 
     # On a Tagged commit, or not
@@ -97,7 +122,7 @@ function(ParseGitDescribe)
         string(APPEND VERSION_FULL "+${VERSION_COMMIT_COUNT}.${VERSION_HASH}")
         string(APPEND VERSION_DEB "+${VERSION_COMMIT_COUNT}.${VERSION_HASH}")
     endif()
-    if(VERSION_DIRTY)
+    if(VERSION_DESCRIBE_DIRTY)
         string(APPEND VERSION_FULL "+m")
         string(APPEND VERSION_DEB "+m")
     endif()
@@ -125,9 +150,6 @@ function(ParseGitDescribe)
 endfunction()
 
 function(GenerateVersionHeader)
-    if(NOT VERSION_SHA)
-        set(VERSION_SHA "${VERSION_HASH}")
-    endif()
     if(VERSION_DIRTY)
         set(VERSION_DIRTY_CPP "true")
     else()

--- a/tech_reports/ttnn/graph-tracing.md
+++ b/tech_reports/ttnn/graph-tracing.md
@@ -217,7 +217,7 @@ The report file contains:
 - `version`: Report format version
 - `graph`: Full graph trace (list of nodes)
 - `devices`: Device information (architecture, grid size, memory)
-- `metadata`: Capture timestamp, distributed rank, capture-time git identity (`git_sha`, `git_sha_short`, `version`, `dirty`), and the capturing binary's CMake configuration (`build_type`, from `$<CONFIG>`)
+- `metadata`: Capture timestamp, distributed rank, capture-time git identity (`git_sha` is the full commit SHA, including `git archive` builds; `git_sha_short`; `version`; `dirty` is true only when the capturing worktree had local modifications), and the capturing binary's CMake configuration (`build_type`, from `$<CONFIG>`)
 - `python_io`: Python-level I/O records (arguments, input/output tensor IDs per operation); present only when Python I/O recording is enabled
 - `per_operation_buffers`: Real buffer snapshots per operation (from `get_buffers()`); present only when `enable_detailed_buffer_tracing()` is active
 - `buffer_pages_by_address`: Compact per-address page data; present only when `enable_detailed_buffer_tracing()` is active

--- a/tech_reports/ttnn/graph-tracing.md
+++ b/tech_reports/ttnn/graph-tracing.md
@@ -81,6 +81,7 @@ The trace records:
 - **Memory events**: Buffer allocations/deallocations, circular buffers
 - **Timing**: Operation durations (wall-clock time)
 - **Call hierarchy**: Nested operations (e.g., `ttnn::add` → `ttnn::prim::binary`)
+- **Program factories**: Fully qualified factory type, variant index, and `program_cache_hit` on each device-op `function_start` (always recorded while capture is active)
 - **Stack traces**: C++ call stacks for each operation (enabled by default); Python call stacks (`full_graph_capture` always records them via `enable_python_stack_traces()`; for `begin_graph_capture` set `ttnn.CONFIG.enable_graph_python_stack_traces` to true to auto-enable)
 - **Deallocations**: `Tensor::deallocate` is tracked at the C++ level when a device buffer is actually freed (both explicit via `ttnn.deallocate()` and implicit via destructor)
 - **Python I/O**: Function arguments, input tensor IDs, and output tensor IDs recorded by the Python decorators (only when Python I/O recording is enabled — see [Capture Overhead](#reducing-capture-overhead))
@@ -216,7 +217,7 @@ The report file contains:
 - `version`: Report format version
 - `graph`: Full graph trace (list of nodes)
 - `devices`: Device information (architecture, grid size, memory)
-- `metadata`: Capture timestamp
+- `metadata`: Capture timestamp, distributed rank, and capture-time git identity (`git_sha`, `git_sha_short`, `version`, `build_type`, `dirty`)
 - `python_io`: Python-level I/O records (arguments, input/output tensor IDs per operation); present only when Python I/O recording is enabled
 - `per_operation_buffers`: Real buffer snapshots per operation (from `get_buffers()`); present only when `enable_detailed_buffer_tracing()` is active
 - `buffer_pages_by_address`: Compact per-address page data; present only when `enable_detailed_buffer_tracing()` is active
@@ -372,6 +373,7 @@ Graph capture overhead has several independently controllable layers:
 | Layer | Default | Enable/Disable |
 |---|---|---|
 | **C++ graph processor** | Always on when capture is active | Inherent to `begin_graph_capture` |
+| **Program factory identity** | Always on when capture is active | Written onto device-op `function_start` params at `function_end`; git identity is always written in file `metadata` |
 | **Python I/O recording** | Auto-enabled by Python `begin_graph_capture()`, off for C++-initiated capture | `enable_python_io_recording()` / `disable_python_io_recording()` |
 | **Python stack traces** | Off; auto-enabled for the outermost Python-started `begin_graph_capture()` when `ttnn.CONFIG.enable_graph_python_stack_traces` is true | `TTNN_CONFIG_OVERRIDES`, or `enable_python_stack_traces()` / `disable_python_stack_traces()` |
 | Per-op buffer snapshots | Off | `enable_detailed_buffer_tracing()` / `disable_detailed_buffer_tracing()` |
@@ -603,6 +605,23 @@ Operation boundaries.
 **function_start params:**
 - `name`: Operation name (e.g., `"ttnn::add"`)
 - `inputs`: Number of input parameters
+- `program_factory_type`: Fully qualified C++ type of the active program factory (device ops only)
+- `program_factory_index`: 0-based index of that factory in the op's `program_factory_t` variant (device ops only; JSON number)
+- `program_cache_hit`: Whether this launch reused a cached program (device ops only; JSON boolean)
+
+These three factory fields are written at `function_end` onto the matching `function_start` params. They are absent on Python wrappers, `create_device_tensor`, and inactive-mesh short-circuits that never select a factory.
+
+Example device-op `function_start` params:
+
+```json
+{
+  "name": "ttnn::prim::PadDeviceOperation",
+  "inputs": "2",
+  "program_factory_type": "ttnn::prim::PadRmReaderWriterMultiCoreProgramFactory",
+  "program_factory_index": 0,
+  "program_cache_hit": false
+}
+```
 
 **function_start fields:**
 - `arguments`: Serialized operation arguments

--- a/tech_reports/ttnn/graph-tracing.md
+++ b/tech_reports/ttnn/graph-tracing.md
@@ -217,7 +217,7 @@ The report file contains:
 - `version`: Report format version
 - `graph`: Full graph trace (list of nodes)
 - `devices`: Device information (architecture, grid size, memory)
-- `metadata`: Capture timestamp, distributed rank, and capture-time git identity (`git_sha`, `git_sha_short`, `version`, `build_type`, `dirty`)
+- `metadata`: Capture timestamp, distributed rank, capture-time git identity (`git_sha`, `git_sha_short`, `version`, `dirty`), and the capturing binary's CMake configuration (`build_type`, from `$<CONFIG>`)
 - `python_io`: Python-level I/O records (arguments, input/output tensor IDs per operation); present only when Python I/O recording is enabled
 - `per_operation_buffers`: Real buffer snapshots per operation (from `get_buffers()`); present only when `enable_detailed_buffer_tracing()` is active
 - `buffer_pages_by_address`: Compact per-address page data; present only when `enable_detailed_buffer_tracing()` is active

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
@@ -657,3 +657,24 @@ def test_graph_capture_inactive_with_open_device(device):
     assert (
         not ttnn.graph.is_graph_capture_active()
     ), "is_graph_capture_active() should be False after end_graph_capture()"
+
+
+def test_graph_capture_records_program_factory(device):
+    torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NO_DISPATCH)
+    _ = ttnn.relu(tt_input)
+    captured_graph = ttnn.graph.end_graph_capture()
+
+    factory_nodes = [
+        node
+        for node in captured_graph
+        if node.get("node_type") == "function_start" and "program_factory_type" in node.get("params", {})
+    ]
+    assert factory_nodes, "Expected a device-op function_start with program_factory_type"
+    for node in factory_nodes:
+        params = node["params"]
+        assert "::" in params["program_factory_type"]
+        assert isinstance(params["program_factory_index"], int)
+        assert isinstance(params["program_cache_hit"], bool)

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -2515,6 +2515,15 @@ class TestGraphReportImport:
         _ = ttnn.relu(tt_input)
         _ = ttnn.graph.end_graph_capture_to_file(report_path)
 
+        with open(report_path) as f:
+            report_json = json.load(f)
+        assert "metadata" in report_json
+        assert report_json["metadata"].get("git_sha")
+        assert len(report_json["metadata"]["git_sha"]) >= 7
+        assert report_json["metadata"].get("git_sha_short")
+        assert report_json["metadata"].get("version")
+        assert report_json["metadata"].get("build_type")
+
         db_path = graph_report.import_report(report_path, db_dir)
 
         conn = sqlite3.connect(db_path)
@@ -2525,7 +2534,7 @@ class TestGraphReportImport:
 
         assert "git_sha" in rows and "git_url" in rows
         git_meta = graph_report.get_tt_metal_git_report_metadata()
-        assert rows["git_sha"] == git_meta["git_sha"]
+        assert rows["git_sha"] == report_json["metadata"]["git_sha"]
         assert rows["git_url"] == git_meta["git_url"]
         if git_meta["git_sha"]:
             assert len(rows["git_sha"]) >= 7

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -2523,6 +2523,7 @@ class TestGraphReportImport:
         assert report_json["metadata"].get("git_sha_short")
         assert report_json["metadata"].get("version")
         assert report_json["metadata"].get("build_type")
+        assert report_json["metadata"]["build_type"] != "Unknown"
 
         db_path = graph_report.import_report(report_path, db_dir)
 

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -2519,7 +2519,7 @@ class TestGraphReportImport:
             report_json = json.load(f)
         assert "metadata" in report_json
         assert report_json["metadata"].get("git_sha")
-        assert len(report_json["metadata"]["git_sha"]) >= 7
+        assert len(report_json["metadata"]["git_sha"]) >= 40
         assert report_json["metadata"].get("git_sha_short")
         assert report_json["metadata"].get("version")
         assert report_json["metadata"].get("build_type")
@@ -2538,7 +2538,7 @@ class TestGraphReportImport:
         assert rows["git_sha"] == report_json["metadata"]["git_sha"]
         assert rows["git_url"] == git_meta["git_url"]
         if git_meta["git_sha"]:
-            assert len(rows["git_sha"]) >= 7
+            assert len(rows["git_sha"]) >= 40
 
 
 class TestSanitizeGitRemoteUrl:

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -985,6 +986,24 @@ bool looks_like_hex(const std::string& value) {
     return true;
 }
 
+class CustomCaptureProcessor : public tt::tt_metal::IGraphProcessor {};
+
+struct ScopedCustomCaptureProcessor {
+    explicit ScopedCustomCaptureProcessor(std::shared_ptr<tt::tt_metal::IGraphProcessor> processor) :
+        processor_(std::move(processor)) {
+        tt::tt_metal::GraphTracker::instance().push_processor(processor_);
+    }
+    ~ScopedCustomCaptureProcessor() { tt::tt_metal::GraphTracker::instance().pop_processor(); }
+
+    ScopedCustomCaptureProcessor(const ScopedCustomCaptureProcessor&) = delete;
+    ScopedCustomCaptureProcessor& operator=(const ScopedCustomCaptureProcessor&) = delete;
+    ScopedCustomCaptureProcessor(ScopedCustomCaptureProcessor&&) = delete;
+    ScopedCustomCaptureProcessor& operator=(ScopedCustomCaptureProcessor&&) = delete;
+
+private:
+    std::shared_ptr<tt::tt_metal::IGraphProcessor> processor_;
+};
+
 }  // namespace
 
 TEST_F(TestScopedGraphCapture, ProgramFactoryTypeOnDeviceOp) {
@@ -1166,6 +1185,48 @@ TEST_F(TestScopedGraphCapture, NestedCapturesShareProgramFactoryIdentity) {
         leak_trace = capture.end_graph_capture();
     }
     EXPECT_TRUE(function_starts_with_factory(leak_trace).empty());
+}
+
+TEST_F(TestScopedGraphCapture, CustomCaptureProcessorDoesNotLeakProgramFactory) {
+    const auto tensor_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto input_tensor = ttnn::create_device_tensor(tensor_spec, device_);
+
+    {
+        ScopedCustomCaptureProcessor custom(std::make_shared<CustomCaptureProcessor>());
+        [[maybe_unused]] const auto output_tensor = ttnn::softmax(input_tensor, -1);
+    }
+
+    nlohmann::json leak_trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        [[maybe_unused]] const auto unused = ttnn::create_device_tensor(tensor_spec, device_);
+        leak_trace = capture.end_graph_capture();
+    }
+    EXPECT_TRUE(function_starts_with_factory(leak_trace).empty());
+}
+
+TEST_F(TestScopedGraphCapture, CustomCaptureProcessorWithGraphProcessorStillRecordsFactory) {
+    const auto tensor_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto input_tensor = ttnn::create_device_tensor(tensor_spec, device_);
+
+    ScopedCustomCaptureProcessor custom(std::make_shared<CustomCaptureProcessor>());
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        [[maybe_unused]] const auto output_tensor = ttnn::softmax(input_tensor, -1);
+        trace = capture.end_graph_capture();
+    }
+    EXPECT_FALSE(function_starts_with_factory(trace).empty());
 }
 
 TEST_F(TestScopedGraphCapture, ReportMetadataContainsCaptureTimeGitIdentity) {

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -1158,5 +1158,6 @@ TEST_F(TestScopedGraphCapture, ReportMetadataContainsCaptureTimeGitIdentity) {
     EXPECT_TRUE(looks_like_hex(metadata.at(ttnn::graph::kReportGitShaShort).get<std::string>()));
     EXPECT_FALSE(metadata.at(ttnn::graph::kReportGitVersion).get<std::string>().empty());
     EXPECT_FALSE(metadata.at(ttnn::graph::kReportBuildType).get<std::string>().empty());
+    EXPECT_NE(metadata.at(ttnn::graph::kReportBuildType).get<std::string>(), "Unknown");
     EXPECT_TRUE(metadata.at(ttnn::graph::kReportGitDirty).is_boolean());
 }

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -1194,8 +1194,12 @@ TEST_F(TestScopedGraphCapture, ReportMetadataContainsCaptureTimeGitIdentity) {
     ASSERT_TRUE(metadata.contains(ttnn::graph::kReportGitVersion));
     ASSERT_TRUE(metadata.contains(ttnn::graph::kReportBuildType));
     ASSERT_TRUE(metadata.contains(ttnn::graph::kReportGitDirty));
-    EXPECT_TRUE(looks_like_hex(metadata.at(ttnn::graph::kReportGitSha).get<std::string>()));
-    EXPECT_TRUE(looks_like_hex(metadata.at(ttnn::graph::kReportGitShaShort).get<std::string>()));
+    const auto git_sha = metadata.at(ttnn::graph::kReportGitSha).get<std::string>();
+    const auto git_sha_short = metadata.at(ttnn::graph::kReportGitShaShort).get<std::string>();
+    EXPECT_TRUE(looks_like_hex(git_sha));
+    EXPECT_TRUE(looks_like_hex(git_sha_short));
+    EXPECT_GT(git_sha.size(), git_sha_short.size());
+    EXPECT_GE(git_sha.size(), 40u);
     EXPECT_FALSE(metadata.at(ttnn::graph::kReportGitVersion).get<std::string>().empty());
     EXPECT_FALSE(metadata.at(ttnn::graph::kReportBuildType).get<std::string>().empty());
     EXPECT_NE(metadata.at(ttnn::graph::kReportBuildType).get<std::string>(), "Unknown");

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -5,6 +5,7 @@
 #include <boost/move/utility_core.hpp>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -30,6 +31,7 @@
 #include "ttnn/operations/normalization/softmax/softmax.hpp"
 #include "ttnn/operations/reduction/generic/generic_reductions.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
@@ -182,7 +184,8 @@ TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
     {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
         try {
-            [[maybe_unused]] auto nested_capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+            [[maybe_unused]] auto nested_capture =
+                ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
             operation(tt::tt_metal::DataType::BFLOAT16);
             throw std::runtime_error("Expected");
         } catch (const std::exception& e) {
@@ -810,7 +813,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Test report contains cluster_descriptor when devices are present
 TEST_F(TestScopedGraphCapture, ReportContainsClusterDescriptor) {
-
     auto report_path = std::filesystem::temp_directory_path() / "test_cluster_desc_report.json";
     {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
@@ -842,7 +844,6 @@ TEST_F(TestScopedGraphCapture, ReportContainsClusterDescriptor) {
 }
 
 TEST_F(TestScopedGraphCapture, ExactBufferTypeAndMaxSizePerBankTest) {
-
     nlohmann::json trace;
     {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
@@ -877,7 +878,6 @@ TEST_F(TestScopedGraphCapture, ExactBufferTypeAndMaxSizePerBankTest) {
 }
 
 TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
-
     auto report_path = std::filesystem::temp_directory_path() / "test_per_op_buffers_report.json";
     {
         ttnn::graph::GraphProcessor::enable_detailed_buffer_tracing();
@@ -920,7 +920,6 @@ TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
 }
 
 TEST_F(TestScopedGraphCapture, DeallocateContainsBufferTypeTest) {
-
     nlohmann::json trace;
     {
         auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NORMAL);
@@ -959,4 +958,205 @@ TEST_F(TestScopedGraphCapture, DeallocateContainsBufferTypeTest) {
         }
     }
     EXPECT_TRUE(found_alloc) << "Expected at least one buffer_allocate node";
+}
+
+namespace {
+
+std::vector<nlohmann::json> function_starts_with_factory(const nlohmann::json& trace) {
+    std::vector<nlohmann::json> nodes;
+    for (const auto& node : trace) {
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeFunctionStart &&
+            node.at(ttnn::graph::kParams).contains(ttnn::graph::kProgramFactoryType)) {
+            nodes.push_back(node);
+        }
+    }
+    return nodes;
+}
+
+bool looks_like_hex(const std::string& value) {
+    if (value.empty()) {
+        return false;
+    }
+    for (unsigned char c : value) {
+        if (!std::isxdigit(c)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+TEST_F(TestScopedGraphCapture, ProgramFactoryTypeOnDeviceOp) {
+    const auto tensor_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto input_tensor = ttnn::create_device_tensor(tensor_spec, device_);
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        const auto output_tensor = ttnn::softmax(input_tensor, -1);
+        trace = capture.end_graph_capture();
+    }
+
+    auto factory_nodes = function_starts_with_factory(trace);
+    ASSERT_FALSE(factory_nodes.empty()) << "Expected a device-op function_start with program_factory_type";
+    for (const auto& node : factory_nodes) {
+        const auto& params = node.at(ttnn::graph::kParams);
+        const auto factory_type = params.at(ttnn::graph::kProgramFactoryType).get<std::string>();
+        EXPECT_FALSE(factory_type.empty());
+        EXPECT_NE(factory_type.find("::"), std::string::npos) << factory_type;
+        ASSERT_TRUE(params.contains(ttnn::graph::kProgramFactoryIndex));
+        EXPECT_TRUE(params.at(ttnn::graph::kProgramFactoryIndex).is_number_integer());
+        ASSERT_TRUE(params.contains(ttnn::graph::kProgramCacheHit));
+        EXPECT_TRUE(params.at(ttnn::graph::kProgramCacheHit).is_boolean());
+    }
+}
+
+TEST_F(TestScopedGraphCapture, ProgramFactoryIndexDiffersAcrossPadVariants) {
+    const auto tile_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto rm_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto tile_input = ttnn::create_device_tensor(tile_spec, device_);
+    const auto rm_input = ttnn::create_device_tensor(rm_spec, device_);
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        [[maybe_unused]] const auto tiled =
+            ttnn::pad(tile_input, ttnn::Array4D{1, 1, 64, 64}, ttnn::Array4D{0, 0, 0, 0}, 0.0f, true);
+        [[maybe_unused]] const auto row_major =
+            ttnn::pad(rm_input, ttnn::Array4D{1, 1, 32, 40}, ttnn::Array4D{0, 0, 0, 0}, 0.0f, true);
+        trace = capture.end_graph_capture();
+    }
+
+    auto factory_nodes = function_starts_with_factory(trace);
+    std::vector<nlohmann::json> pad_nodes;
+    for (const auto& node : factory_nodes) {
+        const auto name = node.at(ttnn::graph::kParams).at(ttnn::graph::kName).get<std::string>();
+        if (name.find("Pad") != std::string::npos) {
+            pad_nodes.push_back(node);
+        }
+    }
+    ASSERT_GE(pad_nodes.size(), 2u);
+    std::string type_a = pad_nodes[0].at(ttnn::graph::kParams).at(ttnn::graph::kProgramFactoryType).get<std::string>();
+    std::string type_b = pad_nodes[1].at(ttnn::graph::kParams).at(ttnn::graph::kProgramFactoryType).get<std::string>();
+    auto index_a = pad_nodes[0].at(ttnn::graph::kParams).at(ttnn::graph::kProgramFactoryIndex).get<int64_t>();
+    auto index_b = pad_nodes[1].at(ttnn::graph::kParams).at(ttnn::graph::kProgramFactoryIndex).get<int64_t>();
+    EXPECT_NE(type_a, type_b) << type_a << " vs " << type_b;
+    EXPECT_NE(index_a, index_b);
+    EXPECT_NE(type_a.find("Pad"), std::string::npos) << type_a;
+    EXPECT_NE(type_b.find("Pad"), std::string::npos) << type_b;
+}
+
+TEST_F(TestScopedGraphCapture, ProgramCacheHitFalseThenTrueInNormalMode) {
+    device_->clear_program_cache();
+    device_->enable_program_cache();
+
+    const auto tensor_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto input_tensor = ttnn::create_device_tensor(tensor_spec, device_);
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NORMAL);
+        const auto first = ttnn::softmax(input_tensor, -1);
+        const auto second = ttnn::softmax(input_tensor, -1);
+        trace = capture.end_graph_capture();
+    }
+
+    auto factory_nodes = function_starts_with_factory(trace);
+    std::vector<nlohmann::json> softmax_nodes;
+    for (const auto& node : factory_nodes) {
+        const auto name = node.at(ttnn::graph::kParams).at(ttnn::graph::kName).get<std::string>();
+        if (name.find("Softmax") != std::string::npos) {
+            softmax_nodes.push_back(node);
+        }
+    }
+    ASSERT_GE(softmax_nodes.size(), 2u);
+    EXPECT_FALSE(softmax_nodes[0].at(ttnn::graph::kParams).at(ttnn::graph::kProgramCacheHit).get<bool>());
+    EXPECT_TRUE(softmax_nodes[1].at(ttnn::graph::kParams).at(ttnn::graph::kProgramCacheHit).get<bool>());
+}
+
+TEST_F(TestScopedGraphCapture, ProgramCacheHitStaysFalseInNoDispatch) {
+    device_->clear_program_cache();
+    device_->enable_program_cache();
+
+    const auto tensor_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto input_tensor = ttnn::create_device_tensor(tensor_spec, device_);
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        const auto first = ttnn::softmax(input_tensor, -1);
+        const auto second = ttnn::softmax(input_tensor, -1);
+        trace = capture.end_graph_capture();
+    }
+
+    auto factory_nodes = function_starts_with_factory(trace);
+    std::vector<nlohmann::json> softmax_nodes;
+    for (const auto& node : factory_nodes) {
+        const auto name = node.at(ttnn::graph::kParams).at(ttnn::graph::kName).get<std::string>();
+        if (name.find("Softmax") != std::string::npos) {
+            softmax_nodes.push_back(node);
+        }
+    }
+    ASSERT_GE(softmax_nodes.size(), 2u);
+    EXPECT_FALSE(softmax_nodes[0].at(ttnn::graph::kParams).at(ttnn::graph::kProgramCacheHit).get<bool>());
+    EXPECT_FALSE(softmax_nodes[1].at(ttnn::graph::kParams).at(ttnn::graph::kProgramCacheHit).get<bool>());
+}
+
+TEST_F(TestScopedGraphCapture, ReportMetadataContainsCaptureTimeGitIdentity) {
+    auto report_path = std::filesystem::temp_directory_path() / "test_git_identity_report.json";
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        const auto tensor_spec = tt::tt_metal::TensorSpec(
+            ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor = ttnn::create_device_tensor(tensor_spec, device_);
+        capture.end_graph_capture_to_file(report_path);
+    }
+
+    std::ifstream file(report_path);
+    ASSERT_TRUE(file.is_open());
+    nlohmann::json report = nlohmann::json::parse(file);
+    std::filesystem::remove(report_path);
+
+    ASSERT_TRUE(report.contains(ttnn::graph::kReportMetadata));
+    const auto& metadata = report.at(ttnn::graph::kReportMetadata);
+    ASSERT_TRUE(metadata.contains(ttnn::graph::kReportGitSha));
+    ASSERT_TRUE(metadata.contains(ttnn::graph::kReportGitShaShort));
+    ASSERT_TRUE(metadata.contains(ttnn::graph::kReportGitVersion));
+    ASSERT_TRUE(metadata.contains(ttnn::graph::kReportBuildType));
+    ASSERT_TRUE(metadata.contains(ttnn::graph::kReportGitDirty));
+    EXPECT_TRUE(looks_like_hex(metadata.at(ttnn::graph::kReportGitSha).get<std::string>()));
+    EXPECT_TRUE(looks_like_hex(metadata.at(ttnn::graph::kReportGitShaShort).get<std::string>()));
+    EXPECT_FALSE(metadata.at(ttnn::graph::kReportGitVersion).get<std::string>().empty());
+    EXPECT_FALSE(metadata.at(ttnn::graph::kReportBuildType).get<std::string>().empty());
+    EXPECT_TRUE(metadata.at(ttnn::graph::kReportGitDirty).is_boolean());
 }

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -1128,6 +1128,46 @@ TEST_F(TestScopedGraphCapture, ProgramCacheHitStaysFalseInNoDispatch) {
     EXPECT_FALSE(softmax_nodes[1].at(ttnn::graph::kParams).at(ttnn::graph::kProgramCacheHit).get<bool>());
 }
 
+TEST_F(TestScopedGraphCapture, NestedCapturesShareProgramFactoryIdentity) {
+    const auto tensor_spec = tt::tt_metal::TensorSpec(
+        ttnn::Shape(ttnn::Array4D{1, 1, 32, 32}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    const auto input_tensor = ttnn::create_device_tensor(tensor_spec, device_);
+
+    nlohmann::json inner_trace;
+    nlohmann::json outer_trace;
+    {
+        auto outer = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        {
+            auto inner = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+            [[maybe_unused]] const auto output_tensor = ttnn::softmax(input_tensor, -1);
+            inner_trace = inner.end_graph_capture();
+        }
+        outer_trace = outer.end_graph_capture();
+    }
+
+    auto inner_nodes = function_starts_with_factory(inner_trace);
+    auto outer_nodes = function_starts_with_factory(outer_trace);
+    ASSERT_FALSE(inner_nodes.empty());
+    ASSERT_FALSE(outer_nodes.empty());
+    const auto& inner_params = inner_nodes[0].at(ttnn::graph::kParams);
+    const auto& outer_params = outer_nodes[0].at(ttnn::graph::kParams);
+    EXPECT_EQ(inner_params.at(ttnn::graph::kProgramFactoryType), outer_params.at(ttnn::graph::kProgramFactoryType));
+    EXPECT_EQ(inner_params.at(ttnn::graph::kProgramFactoryIndex), outer_params.at(ttnn::graph::kProgramFactoryIndex));
+    EXPECT_EQ(inner_params.at(ttnn::graph::kProgramCacheHit), outer_params.at(ttnn::graph::kProgramCacheHit));
+
+    nlohmann::json leak_trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+        [[maybe_unused]] const auto unused = ttnn::create_device_tensor(tensor_spec, device_);
+        leak_trace = capture.end_graph_capture();
+    }
+    EXPECT_TRUE(function_starts_with_factory(leak_trace).empty());
+}
+
 TEST_F(TestScopedGraphCapture, ReportMetadataContainsCaptureTimeGitIdentity) {
     auto report_path = std::filesystem::temp_directory_path() / "test_git_identity_report.json";
     {

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -153,6 +153,7 @@ target_include_directories(
         api/ttnn
         core
         cpp # FIXME: Depend on the Ops needed (make the circular obvious)
+        ${PROJECT_BINARY_DIR}/generated
 )
 target_include_directories(ttnn_core SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)
 target_link_libraries(

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(TTNN::Core ALIAS ttnn_core)
 TT_ENABLE_UNITY_BUILD(ttnn_core)
 
 target_compile_definitions(ttnn_core PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
+target_compile_definitions(ttnn_core PRIVATE "TT_METAL_BUILD_TYPE=\"$<CONFIG>\"")
 
 # Descriptor cache-hit fast-path parity check (opt-in via -DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK).
 # The #ifdef lives in ttnn/api/ttnn/mesh_device_operation_adapter.hpp, so scope the definition to the
@@ -155,6 +156,9 @@ target_include_directories(
         cpp # FIXME: Depend on the Ops needed (make the circular obvious)
         ${PROJECT_BINARY_DIR}/generated
 )
+if(TARGET tt_metal_version_header)
+    add_dependencies(ttnn_core tt_metal_version_header)
+endif()
 target_include_directories(ttnn_core SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers)
 target_link_libraries(
     ttnn_core

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -439,7 +439,7 @@ void launch_operation_with_adapter(
     }
 
     // Stash factory identity after adapter work so nested function_end events cannot consume it.
-    if (tt::tt_metal::GraphTracker::instance().is_enabled()) {
+    if (ttnn::graph::GraphProcessor::has_active_instance()) {
         // Prefer the cached index; select only when the miss was not inserted (NO_DISPATCH).
         const std::size_t program_factory_index =
             (is_program_cache_enabled && program_cache.contains(program_key))

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -440,12 +440,13 @@ void launch_operation_with_adapter(
 
     // Stash factory identity after adapter work so nested function_end events cannot consume it.
     if (tt::tt_metal::GraphTracker::instance().is_enabled()) {
+        // Prefer the cached index; select only when the miss was not inserted (NO_DISPATCH).
         const std::size_t program_factory_index =
-            program_cache_hit
+            (is_program_cache_enabled && program_cache.contains(program_key))
                 ? program_cache.get(program_key).program_factory_index
                 : mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args).index();
-        auto program_factory = map_index_to_variant(
-            program_factory_index, mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
+        auto program_factory =
+            map_index_to_variant(program_factory_index, typename mesh_device_operation_t::program_factory_t{});
         const std::string_view factory_type = std::visit(
             [](auto&& alt) -> std::string_view { return ttsl::long_type_name<std::decay_t<decltype(alt)>>; },
             program_factory);

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -7,6 +7,8 @@
 #include <concepts>
 #include <exception>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/overloaded.hpp>
 #include "ttnn/tensor/tensor.hpp"
@@ -434,6 +436,21 @@ void launch_operation_with_adapter(
             create_and_cache_mesh_workload<mesh_device_operation_t>(
                 operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_key);
         }
+    }
+
+    // Stash factory identity after adapter work so nested function_end events cannot consume it.
+    if (tt::tt_metal::GraphTracker::instance().is_enabled()) {
+        const std::size_t program_factory_index =
+            program_cache_hit
+                ? program_cache.get(program_key).program_factory_index
+                : mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args).index();
+        auto program_factory = map_index_to_variant(
+            program_factory_index, mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
+        const std::string_view factory_type = std::visit(
+            [](auto&& alt) -> std::string_view { return ttsl::long_type_name<std::decay_t<decltype(alt)>>; },
+            program_factory);
+        ttnn::graph::GraphProcessor::set_pending_program_factory(
+            std::string(factory_type), program_factory_index, program_cache_hit);
     }
 }
 

--- a/ttnn/api/ttnn/graph/graph_consts.hpp
+++ b/ttnn/api/ttnn/graph/graph_consts.hpp
@@ -34,6 +34,9 @@ constexpr auto kBorrowsMemory = "borrows_memory";
 constexpr auto kDeviceId = "device_id";
 constexpr auto kDurationNs = "duration_ns";
 constexpr auto kMaxSizePerBank = "max_size_per_bank";
+constexpr auto kProgramFactoryType = "program_factory_type";
+constexpr auto kProgramFactoryIndex = "program_factory_index";
+constexpr auto kProgramCacheHit = "program_cache_hit";
 
 // node names
 constexpr auto kNodeBuffer = "buffer";
@@ -66,6 +69,11 @@ constexpr auto kReportTimestampNs = "capture_timestamp_ns";
 constexpr auto kReportTotalDurationNs = "total_duration_ns";
 constexpr auto kReportRank = "rank";
 constexpr auto kReportWorldSize = "world_size";
+constexpr auto kReportGitSha = "git_sha";
+constexpr auto kReportGitShaShort = "git_sha_short";
+constexpr auto kReportGitVersion = "version";
+constexpr auto kReportBuildType = "build_type";
+constexpr auto kReportGitDirty = "dirty";
 
 // device info keys
 constexpr auto kDeviceNumYCores = "num_y_cores";

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -11,9 +11,12 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <filesystem>
 #include <mutex>
+#include <optional>
 #include <stack>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <any>
@@ -173,12 +176,21 @@ public:
 
     static nlohmann::json end_graph_capture_to_file(const std::filesystem::path& report_path);
 
+    static void set_pending_program_factory(std::string type, std::size_t index, bool cache_hit);
+
     // Detailed buffer tracing control
     static void enable_detailed_buffer_tracing();
     static void disable_detailed_buffer_tracing();
     static bool is_detailed_buffer_tracing_enabled();
 
 private:
+    struct PendingProgramFactory {
+        std::string type;
+        std::size_t index = 0;
+        bool cache_hit = false;
+    };
+    static thread_local std::optional<PendingProgramFactory> pending_program_factory_;
+
     static std::atomic<bool> capture_detailed_buffer_tracing_;
 };
 

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -176,6 +176,7 @@ public:
 
     static nlohmann::json end_graph_capture_to_file(const std::filesystem::path& report_path);
 
+    static bool has_active_instance();
     static void set_pending_program_factory(std::string type, std::size_t index, bool cache_hit);
 
     // Detailed buffer tracing control

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -173,7 +173,20 @@ void GraphProcessor::disable_detailed_buffer_tracing() { capture_detailed_buffer
 
 bool GraphProcessor::is_detailed_buffer_tracing_enabled() { return capture_detailed_buffer_tracing_; }
 
+bool GraphProcessor::has_active_instance() {
+    const auto& processors = tt::tt_metal::GraphTracker::instance().get_processors();
+    for (const auto& processor : processors) {
+        if (dynamic_cast<GraphProcessor*>(processor.get()) != nullptr) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void GraphProcessor::set_pending_program_factory(std::string type, std::size_t index, bool cache_hit) {
+    if (!has_active_instance()) {
+        return;
+    }
     pending_program_factory_ = PendingProgramFactory{std::move(type), index, cache_hit};
 }
 
@@ -780,6 +793,7 @@ void GraphProcessor::end_function_process(const std::vector<T>& tensor_vec) {
 
 void GraphProcessor::begin_capture(RunMode mode) {
     const std::lock_guard<std::mutex> lock(mutex);
+    pending_program_factory_.reset();
     graph.clear();
     buffer_id_to_counter.clear();
     captured_device_info.clear();

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -10,10 +10,12 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/cluster.hpp"
 #include "ttnn/reports.hpp"
+#include <tt_metal/impl/version.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <cstdlib>
 
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <enchantum/enchantum.hpp>
 #include <memory>
@@ -54,11 +56,17 @@ nlohmann::json to_json(const ttnn::graph::GraphProcessor::Vertex& data) {
         ttnn::graph::kPageSize,
         ttnn::graph::kNumCores,
         ttnn::graph::kMaxSizePerBank,
+        ttnn::graph::kProgramFactoryIndex,
+    };
+    static const std::unordered_set<std::string> boolean_params = {
+        ttnn::graph::kProgramCacheHit,
     };
     nlohmann::json params_json;
     for (const auto& [key, value] : data.params) {
         if (integer_params.contains(key)) {
             params_json[key] = std::stoll(value);
+        } else if (boolean_params.contains(key)) {
+            params_json[key] = (value == "true");
         } else {
             params_json[key] = value;
         }
@@ -151,12 +159,17 @@ std::string get_mesh_coordinate_mapping_content() {
 namespace ttnn::graph {
 
 std::atomic<bool> GraphProcessor::capture_detailed_buffer_tracing_{false};
+thread_local std::optional<GraphProcessor::PendingProgramFactory> GraphProcessor::pending_program_factory_;
 
 void GraphProcessor::enable_detailed_buffer_tracing() { capture_detailed_buffer_tracing_ = true; }
 
 void GraphProcessor::disable_detailed_buffer_tracing() { capture_detailed_buffer_tracing_ = false; }
 
 bool GraphProcessor::is_detailed_buffer_tracing_enabled() { return capture_detailed_buffer_tracing_; }
+
+void GraphProcessor::set_pending_program_factory(std::string type, std::size_t index, bool cache_hit) {
+    pending_program_factory_ = PendingProgramFactory{std::move(type), index, cache_hit};
+}
 
 GraphProcessor::GraphProcessor(RunMode mode) : run_mode(mode) { GraphProcessor::begin_capture(mode); }
 
@@ -548,6 +561,17 @@ void GraphProcessor::track_function_end_impl() {
     }
     last_finished_op_id = counter;
 
+    if (pending_program_factory_) {
+        auto& params = graph[function_start_id].params;
+        params[kProgramFactoryType] = pending_program_factory_->type;
+        params[kProgramFactoryIndex] = std::to_string(pending_program_factory_->index);
+        params[kProgramCacheHit] = pending_program_factory_->cache_hit ? "true" : "false";
+        const auto& processors = tt::tt_metal::GraphTracker::instance().get_processors();
+        if (!processors.empty() && processors.back().get() == this) {
+            pending_program_factory_.reset();
+        }
+    }
+
     // Snapshot live buffer state after each top-level operation completes.
     // Only collected when detailed buffer tracing is enabled (report/visualization path)
     // to avoid the overhead of iterating all allocated buffers on every operation.
@@ -823,6 +847,11 @@ nlohmann::json GraphProcessor::get_report() const {
     const auto& world_ctx = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
     metadata[kReportRank] = *world_ctx->rank();
     metadata[kReportWorldSize] = *world_ctx->size();
+    metadata[kReportGitSha] = std::string(tt::tt_metal::kGitSha);
+    metadata[kReportGitShaShort] = std::string(tt::tt_metal::kGitShaShort);
+    metadata[kReportGitVersion] = std::string(tt::tt_metal::kVersionFull);
+    metadata[kReportBuildType] = std::string(tt::tt_metal::kBuildType);
+    metadata[kReportGitDirty] = tt::tt_metal::kGitDirty;
     report[kReportMetadata] = metadata;
 
     // Cluster descriptor (YAML content) - always try, returns empty if unavailable

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -34,8 +34,8 @@ namespace {
 
 inline bool from_bool_param(const std::string& value) {
     return (
-        (value.length() == 4) && ('t' == value[0] || 'T' == value[0]) && ('r' == value[0] || 'R' == value[0]) &&
-        ('u' == value[0] || 'U' == value[0]) && ('e' == value[0] || 'E' == value[0]));
+        (value.length() == 4) && ('t' == value[0] || 'T' == value[0]) && ('r' == value[1] || 'R' == value[1]) &&
+        ('u' == value[2] || 'U' == value[2]) && ('e' == value[3] || 'E' == value[3]));
 }
 
 std::string tensorMemoryLayoutToString(TensorMemoryLayout layout) {

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -32,6 +32,12 @@ using namespace tt::tt_metal;
 
 namespace {
 
+inline bool from_bool_param(const std::string& value) {
+    return (
+        (value.length() == 4) && ('t' == value[0] || 'T' == value[0]) && ('r' == value[0] || 'R' == value[0]) &&
+        ('u' == value[0] || 'U' == value[0]) && ('e' == value[0] || 'E' == value[0]));
+}
+
 std::string tensorMemoryLayoutToString(TensorMemoryLayout layout) {
     switch (layout) {
         case TensorMemoryLayout::INTERLEAVED: return "INTERLEAVED";
@@ -66,7 +72,7 @@ nlohmann::json to_json(const ttnn::graph::GraphProcessor::Vertex& data) {
         if (integer_params.contains(key)) {
             params_json[key] = std::stoll(value);
         } else if (boolean_params.contains(key)) {
-            params_json[key] = (value == "true");
+            params_json[key] = from_bool_param(value);
         } else {
             params_json[key] = value;
         }
@@ -567,7 +573,15 @@ void GraphProcessor::track_function_end_impl() {
         params[kProgramFactoryIndex] = std::to_string(pending_program_factory_->index);
         params[kProgramCacheHit] = pending_program_factory_->cache_hit ? "true" : "false";
         const auto& processors = tt::tt_metal::GraphTracker::instance().get_processors();
-        if (!processors.empty() && processors.back().get() == this) {
+        // Reset after the last GraphProcessor copies.
+        bool last_graph_processor = true;
+        for (auto it = processors.rbegin(); it != processors.rend(); ++it) {
+            if (dynamic_cast<GraphProcessor*>(it->get()) != nullptr) {
+                last_graph_processor = (it->get() == this);
+                break;
+            }
+        }
+        if (last_graph_processor) {
             pending_program_factory_.reset();
         }
     }

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -575,11 +575,13 @@ void GraphProcessor::track_function_end_impl() {
         const auto& processors = tt::tt_metal::GraphTracker::instance().get_processors();
         // Reset after the last GraphProcessor copies.
         bool last_graph_processor = true;
-        for (auto it = processors.rbegin(); it != processors.rend(); ++it) {
+        auto it = processors.rbegin();
+        while (it != processors.rend()) {
             if (dynamic_cast<GraphProcessor*>(it->get()) != nullptr) {
                 last_graph_processor = (it->get() == this);
                 break;
             }
+            ++it;
         }
         if (last_graph_processor) {
             pending_program_factory_.reset();


### PR DESCRIPTION
Closes #54158

### Summary

[#54158](https://github.com/tenstorrent/tt-metal/issues/54158) asks for enough graph-tracing information to pinpoint every program factory used to generate op kernels, so Quasar porting can be prioritized correctly. The report previously had the device-op name (for example UnaryDeviceOperation / PadDeviceOperation) but not the concrete factory struct, the variant index, whether the launch was a program-cache hit, or the git identity of the binary that captured the JSON.

### Notes for reviewers
After launch_operation_with_adapter selects or restores a factory, a thread-local stash on GraphProcessor holds type, index, and cache-hit. Existing track_function_end copies those keys onto the matching device-op function_start params. Nested create_device_tensor ends cannot steal the values because the stash is set after adapter work completes.

IGraphProcessor / GraphTracker public virtuals are unchanged. Python begin_graph_capture / end_graph_capture[_to_file] are unchanged. Report format version stays 1 (new optional params keys).

JSON serializes program_factory_index as a number and program_cache_hit as a boolean.

CMake bakes git_sha, git_sha_short, version (VERSION_FULL), build_type, and dirty into a generated header. GraphProcessor::get_report() writes them into metadata so a copied JSON still names the capture-time binary (not the importer checkout).

Stash work is skipped when GraphTracker::is_enabled() is false, so background processors (SHM tracking) do not pay for type-name strings.

NO_DISPATCH still reports program_cache_hit: false on repeats because blocking hooks disable caching.

Docs: tech_reports/ttnn/graph-tracing.md.

Tests: pad variants produce different type names and indexes; two identical NORMAL launches are miss then hit; file metadata contains a hex git SHA; existing GraphProcessor gtests remain passing.


### sample of data before change

Device-op function_start params had only name and input count. File metadata had timestamp / rank / world_size, not git identity.
```json
{
  "node_type": "function_start",
  "params": {
    "inputs": "2",
    "name": "UnaryDeviceOperation"
  }
}

"metadata": {
  "capture_timestamp_ns": 1787663437470618137,
  "total_duration_ns": 1194399979,
  "rank": 0,
  "world_size": 1
}
```

The visualizer importer could still stamp git_sha into SQLite at import time from git rev-parse HEAD on the importing machine. That is not the binary that produced the factories.

### sample of data after change
Captured on this branch with ttnn.relu under RunMode.NORMAL (Blackhole, Release build):
```json
{
  "node_type": "function_start",
  "params": {
    "inputs": "2",
    "name": "UnaryDeviceOperation",
    "program_cache_hit": false,
    "program_factory_index": 0,
    "program_factory_type": "ttnn::operations::unary::UnaryDeviceOperation::ProgramFactory"
  }
}

"metadata": {
  "build_type": "Release",
  "capture_timestamp_ns": 1787663437470618137,
  "dirty": true,
  "git_sha": "8848a28daa1d49b8b420998d2a4d4eaf8c86b8ee",
  "git_sha_short": "8848a28daa",
  "rank": 0,
  "total_duration_ns": 1194399979,
  "version": "0.78.0-dev20260824+24.8848a28daa+m",
  "world_size": 1
}
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/54158_pf_to_gt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/54158_pf_to_gt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/54158_pf_to_gt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/54158_pf_to_gt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/54158_pf_to_gt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/issue/54158_pf_to_gt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/54158_pf_to_gt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/issue/54158_pf_to_gt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/54158_pf_to_gt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/issue/54158_pf_to_gt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/54158_pf_to_gt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/issue/54158_pf_to_gt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/54158_pf_to_gt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/issue/54158_pf_to_gt)