### PR TITLE
[skip ci] [Documentation Only] Extend documentation: equal block division across dest banks for untilize

### DIFF
--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -118,6 +118,10 @@ ALWI void pack_untilize_init_impl(uint32_t icb, uint32_t ocb, uint32_t call_line
  * | Template   | configure_remap      | Whether to (re)configure BH DEST remap (BH only)    | bool      | true/false                | False (default true)  |
  * | Template   | is_fp32_dest_acc_en  | DEST accumulation mode                              | bool      | true/false                | False                 |
  * | Function   | ocb                  | Output circular buffer identifier                   | uint32_t  | 0 to 31                   | True                  |
+ *
+ * NOTE: When a row is processed in multiple blocks, every block must use the same block_ct_dim;
+ * full_ct_dim must be divisible by block_ct_dim. Remainder blocks are unsupported because the L1 column offset
+ * is computed as block_c_index * block_ct_dim.
  */
 // clang-format on
 template <
@@ -170,6 +174,10 @@ ALWI void pack_untilize_dest_init(uint32_t ocb, uint32_t call_line = __builtin_L
  * | Template   | is_fp32_dest_acc_en | DEST accumulation mode                     | bool      | true/false                | False                   |
  * | Function   | icb                 | Input circular buffer identifier           | uint32_t  | 0 to 31                   | True                    |
  * | Function   | ocb                 | Output circular buffer identifier          | uint32_t  | 0 to 31                   | True                    |
+ *
+ * NOTE: When a row is processed in multiple blocks, every block must use the same block_ct_dim;
+ * full_ct_dim must be divisible by block_ct_dim. Remainder blocks are unsupported because the L1 column offset
+ * is computed as block_c_index * block_ct_dim.
  */
 // clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
@@ -195,6 +203,10 @@ ALWI void pack_untilize_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __
  * | Template   | is_fp32_dest_acc_en | DEST accumulation mode            | bool     | true/false                | False               |
  * | Function   | icb                 | Input circular buffer identifier  | uint32_t | 0 to 31                   | True                |
  * | Function   | ocb                 | Output circular buffer identifier | uint32_t | 0 to 31                   | True                |
+ *
+ * NOTE: When a row is processed in multiple blocks, every block must use the same block_ct_dim;
+ * full_ct_dim must be divisible by block_ct_dim. Remainder blocks are unsupported because the L1 column offset
+ * is computed as block_c_index * block_ct_dim.
  */
 // clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
@@ -226,7 +238,11 @@ ALWI void pack_untilize_init_skip_remap(uint32_t icb, uint32_t ocb, uint32_t cal
  * | Function   | icb          | Input circular buffer identifier            | uint32_t  | 0 to 31                   | True                |
  * | Function   | block_rt_dim | Height of a single block in tiles           | uint32_t  | >= 1                      | True                |
  * | Function   | ocb          | Output circular buffer identifier           | uint32_t  | 0 to 31                   | True                |
- * | Function   | block_c_index | Index of the currently processed block     | uint32_t  | >= 0                      | False               |
+ * | Function   | block_c_index | Index of the currently processed block     | uint32_t  | 0 to (full_ct_dim / block_ct_dim) - 1 | False |
+ *
+ * NOTE: When a row is processed in multiple blocks, every block must use the same block_ct_dim;
+ * full_ct_dim must be divisible by block_ct_dim. Remainder blocks are unsupported because the L1 column offset
+ * is computed as block_c_index * block_ct_dim.
  */
 // clang-format on
 template <uint32_t block_ct_dim = 8, uint32_t full_ct_dim = block_ct_dim, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
@@ -287,8 +303,12 @@ ALWI void pack_untilize_block(uint32_t icb, uint32_t block_rt_dim, uint32_t ocb,
  * | Template   | dense              | Packs two 2 face tiles in a single 4 face region                             | bool      | true/false                              | False (default false) |
  * | Function   | ocb                | Output circular buffer identifier                                            | uint32_t  | 0 to 31                                 | True                  |
  * | Function   | block_rt_dim       | Height of a single block in tiles                                            | uint32_t  | >= 1                                    | False (default=1)     |
- * | Function   | block_c_index      | Block column index (used when full_ct_dim > block_ct_dim)                    | uint32_t  | >= 0                                    | False (default=0)     |
+ * | Function   | block_c_index      | Block column index (used when full_ct_dim > block_ct_dim)                    | uint32_t  | 0 to (full_ct_dim / block_ct_dim) - 1   | False (default=0)     |
  * | Function   | tile_dst_offset    | Runtime offset for the index of the tile in the dest from which to pack      | uint32_t  | 0 to 7 (0 to 3 if fp32 dest is enabled) | False (default=0)     |
+ *
+ * NOTE: When a row is processed in multiple blocks, every block must use the same block_ct_dim;
+ * full_ct_dim must be divisible by block_ct_dim. Remainder blocks are unsupported because the L1 column offset
+ * is computed as block_c_index * block_ct_dim.
  *
  * NOTE: Face geometry (face_r_dim, num_faces) is derived from the output circular buffer metadata configured on
  * the host via CircularBufferConfig::set_unpack_face_geometry / CBFormatDescriptor::face_geometry.


### PR DESCRIPTION
### PR Category
Documentation

### Summary
llk_pack_untilize derives the L1 write address as block_c_index * block_ct_dim — a column offset in units of the block's own width. A row split into MAX-wide blocks with a narrower remainder block therefore can't address the last one: its index truncates and the slice lands short, overwriting the previous block and leaving the end of the row unwritten.

This PR extends the compute API Doxygen to mention that equal division across dest banks is necessary, and no modulo/remainder is allowed.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/untilize_extend_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/untilize_extend_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/untilize_extend_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/untilize_extend_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/untilize_extend_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/untilize_extend_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/untilize_extend_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/untilize_extend_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/untilize_extend_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/untilize_extend_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/untilize_extend_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/untilize_extend_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/untilize_extend_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/untilize_extend_doc)