### PR TITLE
[Feature] [Blackhole] ttnn.argmax: SFPU multicore batch-shape last-dim path (use_sfpu) — shape-dispatch companion to #54105

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax_sfpu.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax_sfpu.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ttnn.argmax(..., use_sfpu=True): the opt-in Blackhole TILE-layout
+last-dim argmax path that runs phase 1 lane-parallel on the SFPU (all 32 rows
+of a tile-row per pass — the batch-shape path) and finishes each row with a
+scalar phase 2 / cross-core merge on the dataflow RISC.
+
+Gating: is_blackhole only. Unlike the RVV path there is no special-toolchain
+opt-in — the kernels are plain SFPU compute kernels that JIT with the stock
+toolchain — so these tests can run in normal Blackhole CI (no env-var gate).
+
+Goldens: the SFPU path's compare is IEEE-on-fp32 behind a bf16 special-value
+gasket (silicon-measured; see argmax_sfpu_tile_compute.cpp), NOT the scalar
+readers' bfloat16_greater bit order. On finite, normal data — including every
+exact tie — the two orders agree bit-for-bit, so finite cases score against
+the incumbent golden; NaN- and denormal-bearing cases score against the
+gasket model implemented here:
+  * NaN acts as same-signed infinity (a winning NaN reports its index but
+    max value 0x7F80, not the NaN payload; -NaN never wins),
+  * denormals and -0 flush to +0 before the compare (first zero's index wins),
+  * ties keep the smallest global index.
+The measured +2^-127 pack bias on max values below ~2^-118 is not modeled:
+no case in this bank can produce a winner in that magnitude range (denormal
+winners flush to exactly +0, which reads back 0x0000 unbiased).
+"""
+
+import numpy as np
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import is_blackhole
+
+pytestmark = [
+    pytest.mark.skipif(not is_blackhole(), reason="ttnn.argmax use_sfpu=True is currently Blackhole-only"),
+]
+
+
+SINGLE_CORE_GRID = None  # filled lazily (ttnn import-time objects inside fixtures)
+
+
+def _single_core_grid():
+    return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))])
+
+
+def _monotone(bits: np.ndarray) -> np.ndarray:
+    """Monotone uint image of the bf16 sign-magnitude order (no NaNs input)."""
+    bits = bits.astype(np.uint32)
+    return np.where(bits >= 0x8000, (~bits) & 0xFFFF, bits | 0x8000).astype(np.uint32)
+
+
+def _gasket_map(bits: np.ndarray) -> np.ndarray:
+    """The SFPU pipeline's measured bf16 special-value gasket:
+    NaN -> same-signed infinity, denormals and +/-0 -> +0."""
+    bits = bits.astype(np.uint16)
+    mag = (bits & 0x7FFF).astype(np.uint16)
+    out = bits.copy()
+    is_nan = mag > 0x7F80
+    out[is_nan] = np.where((bits[is_nan] & 0x8000) != 0, 0xFF80, 0x7F80).astype(np.uint16)
+    out[mag < 0x0080] = 0x0000  # denormals and both zeros flush to +0
+    return out
+
+
+def _gasket_argmax_row(bits_row: np.ndarray):
+    """SFPU-path semantics: IEEE compare on gasket-mapped values, smallest
+    index on ties; the max-value output is the gasket-mapped winner."""
+    g = _gasket_map(bits_row)
+    m = _monotone(g)  # post-gasket there are no NaNs and only +0, so the
+    i = int(np.argmax(m))  # monotone bit order IS the IEEE order
+    return i, int(g[i])
+
+
+_MONO_NEG_INF = 0x007F  # monotone(0xFF80): the incumbent argmax kernel's -inf init
+
+
+def _ref_argmax_row(bits_row: np.ndarray):
+    """Incumbent ttnn.argmax semantics: bfloat16_greater total order, smallest
+    index on ties, -inf init (a row that never beats -inf reports (0, 0xFF80))."""
+    m = _monotone(bits_row)
+    if int(m.max()) <= _MONO_NEG_INF:
+        return 0, 0xFF80
+    i = int(np.argmax(m))
+    return i, int(bits_row[i])
+
+
+def _bits_of(t: torch.Tensor) -> np.ndarray:
+    return t.contiguous().view(torch.int16).numpy().astype(np.uint16)
+
+
+def _make_case(name: str, v: int, b: int, rng: np.random.Generator) -> np.ndarray:
+    """Row-major [b, v] bf16 bit patterns for one battery case (same bank as
+    test_argmax_rvv.py)."""
+    x = rng.standard_normal((b, v), dtype=np.float32) * 4.0
+    bits = _bits_of(torch.from_numpy(x).bfloat16()).reshape(b, v)
+    kmax, kdecoy = 0x7F7F, 0x7F7E  # largest finite bf16 + decoy the RNG cannot reach
+    if name == "random":
+        pass
+    elif name == "unique_max":
+        bits[:, 5 * v // 8] = kmax
+        bits[:, v // 3] = kdecoy
+    elif name == "tie_first_wins":
+        bits[:, 5 * v // 8] = kmax
+        bits[:, 7 * v // 8] = kmax
+    elif name == "max_at_end":
+        bits[:, v - 1] = kmax
+    elif name == "max_at_zero":
+        bits[:, 0] = kmax
+    elif name == "denormal":
+        small = rng.integers(0, 0x0080, size=(b, v), dtype=np.uint16)  # denormals and +/-0
+        sign = (rng.integers(0, 2, size=(b, v), dtype=np.uint16) << 15).astype(np.uint16)
+        bits = (small | sign).astype(np.uint16)
+    elif name == "nan_bearing":
+        bits[:, v // 4] = 0x7FC0  # +NaN: wins as +inf on the SFPU path
+        bits[:, v // 2] = 0xFFC0  # -NaN: acts as -inf, never wins
+    elif name == "all_negative":
+        bits = (bits | 0x8000).astype(np.uint16)
+        bits[bits == 0xFF80] = 0xBF80  # avoid accidental -inf
+    elif name == "all_neginf":
+        bits = np.full((b, v), 0xFF80, dtype=np.uint16)  # the -inf init corner
+    else:
+        raise ValueError(name)
+    return bits
+
+
+CASES = [
+    "random",
+    "unique_max",
+    "tie_first_wins",
+    "max_at_end",
+    "max_at_zero",
+    "denormal",
+    "nan_bearing",
+    "all_negative",
+    "all_neginf",
+]
+
+# Classes where the gasket order provably equals the incumbent bit order
+# (finite normal data, ties included; all_neginf hits both paths' -inf rule).
+INCUMBENT_EXACT_CASES = [c for c in CASES if c not in ("denormal", "nan_bearing")]
+
+
+def _golden_row(name: str, bits_row: np.ndarray):
+    """Score finite classes against the incumbent golden (stronger claim) and
+    NaN/denormal classes against the gasket model."""
+    if name in ("denormal", "nan_bearing"):
+        return _gasket_argmax_row(bits_row)
+    return _ref_argmax_row(bits_row)
+
+
+# v boundaries: 32 = single tile (also the num_cores == 1 degenerate multicore
+# case); 2016 = 63 tiles, exercising the chunk-remainder branch and an uneven
+# multicore split; 2048/8192 = exact multiples of the 64-tile chunk; 32768 =
+# the LLM-vocab-class width the path exists for.
+@pytest.mark.parametrize("v", [32, 2016, 2048, 8192, 32768])
+@pytest.mark.parametrize("b", [1, 8, 32])
+@pytest.mark.parametrize("keepdim", [True, False])
+@pytest.mark.parametrize("with_maxval", [True, False])
+@pytest.mark.parametrize("grid", ["single", "multi"])
+def test_argmax_sfpu_battery(device, v, b, keepdim, with_maxval, grid):
+    """Bit-exact index (and optional max-value bits) against the documented
+    semantics across planted-max / tie / special-value cases, single-core and
+    multicore."""
+    sub_core_grids = _single_core_grid() if grid == "single" else None
+    rng = np.random.default_rng(1234 + v + 100 * b)
+    for name in CASES:
+        bits = _make_case(name, v, b, rng)
+        x = torch.from_numpy(bits.astype(np.int16)).view(torch.bfloat16).reshape(1, 1, b, v)
+
+        t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        mv = None
+        if with_maxval:
+            out_shape = (1, 1, b, 1) if keepdim else (1, 1, b)
+            mv = ttnn.from_torch(
+                torch.zeros(out_shape, dtype=torch.bfloat16),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+            )
+
+        idx_t = ttnn.argmax(
+            t_tile, dim=3, keepdim=keepdim, use_sfpu=True, maxval_tensor=mv, sub_core_grids=sub_core_grids
+        )
+        got_idx = ttnn.to_torch(idx_t).flatten().numpy().astype(np.uint32)
+        got_val = _bits_of(ttnn.to_torch(mv).flatten()) if with_maxval else None
+
+        for r in range(b):
+            ref_idx, ref_val = _golden_row(name, bits[r])
+            assert int(got_idx[r]) == ref_idx, f"case {name} row {r} ({grid}): idx {int(got_idx[r])} != {ref_idx}"
+            if with_maxval:
+                assert (
+                    int(got_val[r]) == ref_val
+                ), f"case {name} row {r} ({grid}): val {int(got_val[r]):#06x} != {ref_val:#06x}"
+
+
+@pytest.mark.parametrize("name", INCUMBENT_EXACT_CASES)
+@pytest.mark.parametrize("v", [32, 2016, 4096])
+@pytest.mark.parametrize("b", [1, 32])
+def test_argmax_sfpu_matches_upstream_tile_path(device, name, v, b):
+    """Index cross-check against the incumbent ttnn.argmax on the same TILE
+    tensor for every class where the two orders provably agree (finite data
+    plus the all--inf corner). The NaN/denormal classes are excluded by
+    construction — that divergence is documented, measured, and asserted
+    against the gasket model in the battery test above."""
+    rng = np.random.default_rng(42 + v + 100 * b)
+    bits = _make_case(name, v, b, rng)
+    x = torch.from_numpy(bits.astype(np.int16)).view(torch.bfloat16).reshape(1, 1, b, v)
+    t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    idx_sfpu = ttnn.to_torch(ttnn.argmax(t_tile, dim=3, keepdim=True, use_sfpu=True))
+    idx_ref = ttnn.to_torch(ttnn.argmax(t_tile, dim=3, keepdim=True))
+    assert torch.equal(
+        idx_sfpu.to(torch.int64), idx_ref.to(torch.int64)
+    ), f"SFPU/incumbent index mismatch on case {name!r} (v={v}, b={b})"
+
+
+@pytest.mark.parametrize("grid", ["single", "multi"])
+def test_argmax_sfpu_multi_tile_row_batch(device, grid):
+    """Rank-4 batch shape with several tile-row passes: outer dims 2 x 3,
+    h = 80 rows (three tile-rows, the last one partial). Exercises the
+    multi-pass credit flow-control and the padded-row masking; finite random
+    data, so results must match the incumbent bit order exactly."""
+    sub_core_grids = _single_core_grid() if grid == "single" else None
+    rng = np.random.default_rng(7)
+    outer0, outer1, h, v = 2, 3, 80, 2048
+    bits = _make_case("random", v, outer0 * outer1 * h, rng).reshape(outer0, outer1, h, v)
+    x = torch.from_numpy(bits.astype(np.int16)).view(torch.bfloat16)
+
+    t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    mv = ttnn.from_torch(
+        torch.zeros((outer0, outer1, h), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    idx_t = ttnn.argmax(t_tile, dim=3, keepdim=False, use_sfpu=True, maxval_tensor=mv, sub_core_grids=sub_core_grids)
+    got_idx = ttnn.to_torch(idx_t).flatten().numpy().astype(np.uint32)
+    got_val = _bits_of(ttnn.to_torch(mv).flatten())
+
+    flat = bits.reshape(-1, v)
+    for r in range(flat.shape[0]):
+        ref_idx, ref_val = _ref_argmax_row(flat[r])
+        assert int(got_idx[r]) == ref_idx, f"row {r} ({grid}): idx {int(got_idx[r])} != {ref_idx}"
+        assert int(got_val[r]) == ref_val, f"row {r} ({grid}): val {int(got_val[r]):#06x} != {ref_val:#06x}"
+
+
+def test_argmax_sfpu_rejects_row_major_input(device, expect_error):
+    """use_sfpu=True is a TILE-layout path; ROW_MAJOR input must be rejected."""
+    x = torch.randn(1, 1, 32, 2048).bfloat16()
+    t_rm = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    with expect_error(RuntimeError, "requires TILE layout input"):
+        ttnn.argmax(t_rm, dim=3, keepdim=True, use_sfpu=True)
+
+
+def test_argmax_sfpu_rejects_use_rvv_combo(device, expect_error):
+    """use_rvv and use_sfpu are mutually exclusive engine knobs."""
+    x = torch.randn(1, 1, 32, 2048).bfloat16()
+    t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    with expect_error(RuntimeError, "mutually exclusive"):
+        ttnn.argmax(t_tile, dim=3, keepdim=True, use_rvv=True, use_sfpu=True)
+
+
+def test_argmax_sfpu_rejects_ragged_last_dim(device, expect_error):
+    """The reduction dim must be a multiple of the tile width (no W padding)."""
+    x = torch.randn(1, 1, 32, 2000).bfloat16()
+    t_tile = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    with expect_error(RuntimeError, "multiple of the tile width"):
+        ttnn.argmax(t_tile, dim=3, keepdim=True, use_sfpu=True)

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -169,6 +169,7 @@ Tensor argmax(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> optional_output_tensor,
     bool use_rvv,
+    bool use_sfpu,
     std::optional<Tensor> optional_maxval_tensor) {
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
 
@@ -203,12 +204,14 @@ Tensor argmax(
     // no-op through the host-side fallback, which would bypass the RVV
     // eligibility checks and leave a supplied maxval_tensor untouched (stale).
     TT_FATAL(
-        !optional_maxval_tensor.has_value() || use_rvv,
-        "argmax: the max-value output tensor (maxval_tensor) is only supported with use_rvv=True");
-    if (use_rvv) {
+        !optional_maxval_tensor.has_value() || use_rvv || use_sfpu,
+        "argmax: the max-value output tensor (maxval_tensor) is only supported with use_rvv=True or use_sfpu=True");
+    TT_FATAL(!(use_rvv && use_sfpu), "argmax: use_rvv and use_sfpu are mutually exclusive");
+    if (use_rvv || use_sfpu) {
         TT_FATAL(
             rank > 0 && input_tensor.logical_volume() > 0,
-            "argmax: use_rvv=True supports only non-empty tensors of rank >= 1 (got rank {}, logical volume {})",
+            "argmax: use_rvv=True / use_sfpu=True support only non-empty tensors of rank >= 1 (got rank {}, logical "
+            "volume {})",
             rank,
             input_tensor.logical_volume());
     }
@@ -251,11 +254,14 @@ Tensor argmax(
         return preallocated_tensor;
     }
 
-    // Opt-in RVV path: TILE-layout last-dim argmax scanned on the pack RISC's
-    // vector unit (Blackhole). Takes TILE input DIRECTLY — no to_layout /
-    // untilize hop — and optionally returns the max values alongside the
-    // indices. Eligibility is validated by the device op.
-    if (use_rvv) {
+    // Opt-in RVV / SFPU paths: TILE-layout last-dim argmax (Blackhole). Both
+    // take TILE input DIRECTLY — no to_layout / untilize hop — and optionally
+    // return the max values alongside the indices. use_rvv scans on the pack
+    // RISC's vector unit (single core, fastest at B == 1); use_sfpu reduces
+    // all 32 rows of each tile-row in one lane-parallel SFPU pass and runs
+    // multicore (flat in B, the batch-shape path). Eligibility is validated
+    // by the device op.
+    if (use_rvv || use_sfpu) {
         // The reader kernel derives its output paging from the preallocated
         // tensor, so a wrong logical shape means unwritten results or writes
         // past the tensor's page count — reject it up front.
@@ -275,7 +281,8 @@ Tensor argmax(
             sub_core_grids,
             output_memory_config,
             std::move(optional_output_tensor),
-            /*use_rvv=*/true,
+            use_rvv,
+            use_sfpu,
             std::move(optional_maxval_tensor));
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
@@ -14,6 +14,7 @@ Tensor argmax(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<Tensor> optional_output_tensor = std::nullopt,
     bool use_rvv = false,
+    bool use_sfpu = false,
     std::optional<Tensor> optional_maxval_tensor = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax_nanobind.cpp
@@ -31,9 +31,25 @@ void bind_reduction_argmax_operation(nb::module_& mod) {
                     a Zve32f vector unit ("RVV"); with ``use_rvv=True`` the last-dim argmax reduction runs there,
                     reading TILE layout directly (no untilize needed). Requires BFLOAT16 input whose last dim is a
                     multiple of the tile width (32). Default: ``False``.
+                use_sfpu (bool, optional): Opt-in Blackhole-only path; mutually exclusive with ``use_rvv``. Runs the
+                    last-dim argmax on the SFPU (the Tensix vector FPU), reading TILE layout directly. All 32 rows of
+                    a tile-row are reduced in one lane-parallel pass, so batch shapes (B rows per tile-row) cost the
+                    same as B=1; the reduction dim is additionally split across cores (multicore), with a per-row
+                    scalar merge on a gather core. Pass a single-core ``sub_core_grids`` to force single-core.
+                    Requires BFLOAT16 input whose last dim is a multiple of the tile width (32).
+
+                    SEMANTICS (measured on silicon, documented divergence — the same divergence class the existing
+                    NC-dim compute path ships vs the scalar readers): the compare is IEEE-on-fp32 behind a bf16
+                    special-value gasket rather than the scalar readers' bit-pattern total order. Concretely:
+                    NaN behaves as same-signed infinity (a NaN row-max yields the NaN's index but max value +inf
+                    ``0x7F80``, not the NaN payload; -NaN never wins); -0 flushes to +0 in the max-value output and
+                    +0/-0 compare equal (first zero's index is kept); denormals flush to zero before the compare;
+                    max values below ~2^-118 carry a +2^-127 additive pack bias. All finite normal data — including
+                    every exact tie — matches the incumbent bit-for-bit (smallest index wins ties).
+                    Default: ``False``.
                 maxval_tensor (ttnn.Tensor, optional): Preallocated BFLOAT16 ROW_MAJOR tensor with the same logical
-                    shape as the index output. Only with ``use_rvv=True``: receives the winning max VALUES, so greedy
-                    sampling does not need a separate ``ttnn.max``. Default: ``None``.
+                    shape as the index output. Only with ``use_rvv=True`` or ``use_sfpu=True``: receives the winning
+                    max VALUES, so greedy sampling does not need a separate ``ttnn.max``. Default: ``None``.
 
             Supported:
 
@@ -75,6 +91,7 @@ void bind_reduction_argmax_operation(nb::module_& mod) {
         nb::arg("memory_config") = nb::none(),
         nb::arg("output_tensor") = nb::none(),
         nb::arg("use_rvv") = false,
+        nb::arg("use_sfpu") = false,
         nb::arg("maxval_tensor") = nb::none());
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.cpp
@@ -82,6 +82,10 @@ ArgMaxDeviceOperation::program_factory_t ArgMaxDeviceOperation::select_program_f
         // Eligibility is enforced in validate_on_program_cache_miss.
         return ArgMaxRvvTileProgramFactory{};
     }
+    if (args.use_sfpu) {
+        // Eligibility is enforced in validate_on_program_cache_miss.
+        return ArgMaxSfpuTileProgramFactory{};
+    }
     if (uses_multicore_path(args, tensor_args)) {
         return ArgMaxMultiCoreProgramFactory{};
     }
@@ -232,9 +236,51 @@ void ArgMaxDeviceOperation::validate_on_program_cache_miss(
             tile_w);
     }
 
+    // SFPU TILE last-dim path eligibility — like use_rvv, this is opt-in, so
+    // requesting it with an unsupported configuration is a hard error rather
+    // than a silent fallback.
+    TT_FATAL(!(args.use_rvv && args.use_sfpu), "argmax: use_rvv and use_sfpu are mutually exclusive");
+    if (args.use_sfpu) {
+        // Blackhole-only for now: the path's special-value semantics (the
+        // NaN-as-infinity / flush-to-zero gasket documented in
+        // argmax_sfpu_tile_compute.cpp) are silicon-validated on Blackhole.
+        // Nothing in the kernels is architecturally Blackhole-specific;
+        // enabling Wormhole is a follow-up gated on re-running the
+        // special-value battery there.
+        TT_FATAL(
+            tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE,
+            "argmax use_sfpu=true is currently supported on Blackhole only");
+        TT_FATAL(input_layout == Layout::TILE, "argmax use_sfpu=true requires TILE layout input, got {}", input_layout);
+        TT_FATAL(
+            input_tensor_a.dtype() == DataType::BFLOAT16,
+            "argmax use_sfpu=true requires BFLOAT16 input, got {}",
+            input_tensor_a.dtype());
+        TT_FATAL(args.dim.has_value(), "argmax use_sfpu=true requires an explicit dim (last dim)");
+        const int32_t rank = static_cast<int32_t>(input_tensor_a.logical_shape().rank());
+        const int32_t normalized_dim = normalize_dim(static_cast<int32_t>(args.dim.value()), rank);
+        TT_FATAL(
+            normalized_dim == rank - 1,
+            "argmax use_sfpu=true supports only last-dim reduction, got dim={} (normalized={}) for rank {}",
+            args.dim.value(),
+            normalized_dim,
+            rank);
+        const uint32_t tile_w = input_tensor_a.tensor_spec().tile().get_width();
+        const uint32_t tile_h = input_tensor_a.tensor_spec().tile().get_height();
+        TT_FATAL(tile_w == 32 && tile_h == 32, "argmax use_sfpu=true requires standard 32x32 tiles");
+        const auto& logical_shape = input_tensor_a.logical_shape();
+        TT_FATAL(
+            logical_shape[-1] % tile_w == 0,
+            "argmax use_sfpu=true requires the reduction dim ({}) to be a multiple of the tile width {} "
+            "(no width padding)",
+            logical_shape[-1],
+            tile_w);
+    }
+
     const auto& optional_maxval = tensor_args.optional_maxval_tensor;
     if (optional_maxval.has_value()) {
-        TT_FATAL(args.use_rvv, "argmax max-value output is only produced by the use_rvv=true path");
+        TT_FATAL(
+            args.use_rvv || args.use_sfpu,
+            "argmax max-value output is only produced by the use_rvv=true / use_sfpu=true paths");
         const auto& maxval = optional_maxval.value();
         TT_FATAL(is_device_tensor(maxval), "argmax max-value tensor must be allocated on device");
         // Device affinity: the program is launched from the input tensor, so a
@@ -290,6 +336,7 @@ ttnn::Tensor argmax(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     std::optional<ttnn::Tensor> optional_output_tensor,
     bool use_rvv,
+    bool use_sfpu,
     std::optional<ttnn::Tensor> optional_maxval_tensor) {
     return ttnn::device_operation::launch<ArgMaxDeviceOperation>(
         ArgMaxDeviceOperation::operation_attributes_t{
@@ -299,6 +346,7 @@ ttnn::Tensor argmax(
             .sub_core_grids = sub_core_grids,
             .output_mem_config = output_mem_config,
             .use_rvv = use_rvv,
+            .use_sfpu = use_sfpu,
         },
         ArgMaxDeviceOperation::tensor_args_t{
             .input = input,

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation.hpp
@@ -30,13 +30,32 @@ struct ArgMaxRvvTileProgramFactory {
         const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value);
 };
 
+// Opt-in TILE-layout last-dim argmax on the SFPU (Blackhole). Lane-parallel
+// phase 1 reduces every tile of a 32-row tile-row to one (max value, winning
+// tile) candidate per column in DST; a scalar phase 2 on the dataflow RISC
+// finishes each row with 32 lexicographic compares. All 32 rows of a tile-row
+// are reduced in the same pass, so batch shapes cost the same as B == 1.
+// Multicore: the reduction dim's tiles are split across cores, each core
+// producing per-row candidates that a gather core merges (per-row scalar
+// compares — no cross-core tile reduce). Returns indices and (optionally)
+// max values. Semantics are IEEE-compare behind the SFPU's bf16
+// special-value gasket, documented in detail in
+// kernels/argmax_sfpu_tile_compute.cpp.
+struct ArgMaxSfpuTileProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value);
+};
+
 struct ArgMaxDeviceOperation {
     using operation_attributes_t = ArgmaxParams;
     using tensor_args_t = ArgmaxInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
-    using program_factory_t =
-        std::variant<ArgMaxSingleCoreProgramFactory, ArgMaxMultiCoreProgramFactory, ArgMaxRvvTileProgramFactory>;
+    using program_factory_t = std::variant<
+        ArgMaxSingleCoreProgramFactory,
+        ArgMaxMultiCoreProgramFactory,
+        ArgMaxRvvTileProgramFactory,
+        ArgMaxSfpuTileProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
@@ -56,6 +75,7 @@ ttnn::Tensor argmax(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     std::optional<ttnn::Tensor> optional_output_tensor = std::nullopt,
     bool use_rvv = false,
+    bool use_sfpu = false,
     std::optional<ttnn::Tensor> optional_maxval_tensor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_device_operation_types.hpp
@@ -19,6 +19,14 @@ struct ArgmaxParams {
     // last-dim argmax (Blackhole only). Also enables the optional max-value
     // output (see ArgmaxInputs::optional_maxval_tensor).
     bool use_rvv{false};
+    // Opt-in: SFPU (vector FPU) TILE-layout last-dim argmax (Blackhole only).
+    // Reduces all 32 rows of a tile-row in one lane-parallel pass, so batch
+    // shapes (B rows per tile-row) cost the same as B == 1; runs multicore by
+    // splitting the reduction dim across cores. Mutually exclusive with
+    // use_rvv. Semantics: IEEE compare behind the SFPU's bf16 special-value
+    // gasket — see ArgMaxSfpuTileProgramFactory. Also enables the optional
+    // max-value output (see ArgmaxInputs::optional_maxval_tensor).
+    bool use_sfpu{false};
 };
 
 struct ArgmaxInputs {

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_sfpu_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_sfpu_tile_program_factory.cpp
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Opt-in TILE-layout last-dim argmax on the SFPU — Blackhole, single- or
+// multi-core. See kernels/argmax_sfpu_tile_compute.cpp for the algorithm and
+// the (documented, silicon-measured) special-value semantics.
+//
+// Work split: phase 1 reduces all 32 rows of a tile-row lane-parallel, so a
+// tile-row pass costs the same whether 1 or 32 rows are valid — the batch-
+// shape win. Multicore splits the REDUCTION dim's tiles across cores: core j
+// reduces slice [w_start_j, w_start_j + w_count_j) of every tile-row pass
+// and finishes it with a per-row phase 2 on its dataflow RISC; the gather
+// core (core 0) then merges the per-core per-row candidates with the same
+// lexicographic rule. The cross-core traffic is 256 B per core per pass —
+// per-row scalar candidates, never tiles.
+//
+// Core-count heuristic: per-core phase 1 costs ~800 cycles per tile while
+// the gather merge costs ~32 scalar compares per extra core per pass, so the
+// optimum sits near sqrt(w_tiles); we use ceil(sqrt(1.5 * w_tiles)) capped
+// by the grid and by w_tiles. An explicit sub_core_grids overrides the
+// heuristic (capped by w_tiles only) — pass a single-core grid to force the
+// single-core variant.
+
+#include "argmax_device_operation.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+namespace ttnn::prim {
+
+using namespace tt::tt_metal;
+
+ProgramDescriptor ArgMaxSfpuTileProgramFactory::create_descriptor(
+    const ArgmaxParams& operation_attributes, const ArgmaxInputs& tensor_args, Tensor& tensor_return_value) {
+    const auto& input = tensor_args.input.mesh_tensor();
+    const auto& output = tensor_return_value.mesh_tensor();
+    const bool has_maxval = tensor_args.optional_maxval_tensor.has_value();
+
+    const auto& padded_shape = input.padded_shape();
+    const uint32_t rank = padded_shape.size();
+    const uint32_t logical_rank = input.logical_shape().size();
+    const uint32_t tile_width = input.tensor_spec().tile().get_width();
+    const uint32_t tile_height = input.tensor_spec().tile().get_height();
+
+    const uint32_t w_tiles = padded_shape[rank - 1] / tile_width;
+    const uint32_t h_tiles = padded_shape[rank - 2] / tile_height;
+    const uint32_t w_logical = input.logical_shape()[logical_rank - 1];
+    const uint32_t h_logical = logical_rank > 1 ? input.logical_shape()[logical_rank - 2] : 1;
+    const uint32_t outer_dim_units = input.logical_volume() / (h_logical * w_logical);
+    const uint32_t num_passes = outer_dim_units * h_tiles;
+
+    const uint32_t src_page_size = input.tensor_spec().compute_page_size_bytes();
+    const uint32_t dst_page_size = output.tensor_spec().compute_page_size_bytes();
+    const uint32_t val_page_size =
+        has_maxval ? tensor_args.optional_maxval_tensor->mesh_tensor().tensor_spec().compute_page_size_bytes()
+                   : dst_page_size;
+    const uint32_t out_page_elems = dst_page_size / sizeof(uint32_t);
+
+    // ---- core selection -----------------------------------------------------
+    const IDevice* device = &output.mutable_device();
+    std::vector<CoreCoord> cores;
+    uint32_t num_cores = 0;
+    if (operation_attributes.sub_core_grids.has_value()) {
+        const auto& grids = operation_attributes.sub_core_grids.value();
+        cores = corerange_to_cores(grids, std::nullopt, true);
+        num_cores = std::min<uint32_t>(static_cast<uint32_t>(cores.size()), w_tiles);
+    } else {
+        const auto grid = device->compute_with_storage_grid_size();
+        const CoreRangeSet full_grid(CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
+        cores = corerange_to_cores(full_grid, std::nullopt, true);
+        const uint32_t want = static_cast<uint32_t>(std::ceil(std::sqrt(1.5 * static_cast<double>(w_tiles))));
+        num_cores = std::min<uint32_t>({want, static_cast<uint32_t>(cores.size()), w_tiles});
+    }
+    TT_FATAL(num_cores >= 1, "argmax use_sfpu=true requires at least one core");
+    cores.resize(num_cores);
+
+    std::vector<CoreRange> core_ranges_vec;
+    core_ranges_vec.reserve(num_cores);
+    for (const auto& c : cores) {
+        core_ranges_vec.emplace_back(c, c);
+    }
+    const CoreRangeSet all_cores(core_ranges_vec);
+
+    // Contiguous slices of the reduction dim's tiles, remainder spread over
+    // the leading cores.
+    const uint32_t w_base = w_tiles / num_cores;
+    const uint32_t w_rem = w_tiles % num_cores;
+    auto slice_count = [&](uint32_t j) { return w_base + (j < w_rem ? 1u : 0u); };
+    auto slice_start = [&](uint32_t j) { return j * w_base + std::min(j, w_rem); };
+    const uint32_t w_count_max = slice_count(0);
+
+    // Chunked double-buffered input streaming: the SFPU scan of chunk k
+    // overlaps the NOC staging of chunk k+1. Uniform across cores so the CB
+    // layout (and therefore the exchange-buffer address) is identical
+    // everywhere.
+    const uint32_t chunk_pages = std::min<uint32_t>(64, w_count_max);
+    const uint32_t in_cb_pages = 2 * chunk_pages;
+
+    ProgramDescriptor desc;
+
+    constexpr auto cb_in = tt::CBIndex::c_0;         // input tiles (ring)
+    constexpr auto cb_res_val = tt::CBIndex::c_1;    // phase-1 max-val candidate tile (bf16)
+    constexpr auto cb_res_idx = tt::CBIndex::c_2;    // phase-1 win-tile candidate tile (u32)
+    constexpr auto cb_xchg = tt::CBIndex::c_3;       // cross-core candidate exchange (raw scratch)
+    constexpr auto cb_stage_idx = tt::CBIndex::c_4;  // output-page staging (indices)
+    constexpr auto cb_stage_val = tt::CBIndex::c_5;  // output-page staging (max values)
+
+    const tt::DataFormat in_df = datatype_to_dataformat_converter(input.dtype());
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = in_cb_pages * src_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_in),
+            .data_format = in_df,
+            .page_size = src_page_size,
+        }}},
+    });
+    const uint32_t res_val_page = tile_width * tile_height * sizeof(uint16_t);
+    const uint32_t res_idx_page = tile_width * tile_height * sizeof(uint32_t);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * res_val_page,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_res_val),
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = res_val_page,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2 * res_idx_page,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_res_idx),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = res_idx_page,
+        }}},
+    });
+    // Exchange buffer: one 256 B slot per core (u32 idx[32] + u32 val[32]).
+    // Allocated identically on every core so a worker's local address equals
+    // the gather core's.
+    constexpr uint32_t xchg_slot_bytes = 64 * sizeof(uint32_t);
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_cores * xchg_slot_bytes,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_xchg),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = num_cores * xchg_slot_bytes,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = dst_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_stage_idx),
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = dst_page_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = val_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_stage_val),
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = val_page_size,
+        }}},
+    });
+
+    // Semaphores (multicore only): done = workers -> gather (cumulative),
+    // start = gather -> workers slot-reuse credit (cumulative).
+    constexpr uint32_t done_sem_id = 0;
+    constexpr uint32_t start_sem_id = 1;
+    if (num_cores > 1) {
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = done_sem_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = all_cores,
+            .initial_value = 0,
+        });
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = start_sem_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = all_cores,
+            .initial_value = 0,
+        });
+    }
+
+    const CoreCoord gather_phys = device->worker_core_from_logical_core(cores[0]);
+
+    // ---- reader (dataflow RISC): streaming + phase 2 + gather merge ---------
+    std::vector<uint32_t> reader_ct_args = {
+        static_cast<uint32_t>(cb_in),
+        static_cast<uint32_t>(cb_res_val),
+        static_cast<uint32_t>(cb_res_idx),
+        static_cast<uint32_t>(cb_xchg),
+        static_cast<uint32_t>(cb_stage_idx),
+        static_cast<uint32_t>(cb_stage_val),
+        src_page_size,
+        chunk_pages,
+        in_cb_pages,
+        h_tiles,
+        h_logical,
+        outer_dim_units,
+        out_page_elems,
+        dst_page_size,
+        val_page_size,
+        static_cast<uint32_t>(has_maxval),
+        num_cores,
+        static_cast<uint32_t>(gather_phys.x),
+        static_cast<uint32_t>(gather_phys.y),
+        done_sem_id,
+        start_sem_id,
+        w_tiles,
+    };
+    TensorAccessorArgs(input).append_to(reader_ct_args);
+    TensorAccessorArgs(output).append_to(reader_ct_args);
+    if (has_maxval) {
+        TensorAccessorArgs(tensor_args.optional_maxval_tensor->mesh_tensor()).append_to(reader_ct_args);
+    } else {
+        // Placeholder — contract with reader_argmax_sfpu_tile.cpp: the kernel
+        // unconditionally parses exactly THREE TensorAccessorArgs blocks at
+        // compile time (src, dst, val), because the constexpr offset chain
+        // (next_compile_time_args_offset) cannot be made conditional. When no
+        // maxval tensor is supplied, this copy of the output's accessor args
+        // fills the third slot so the arg counts line up; the has_maxval
+        // compile-time arg (== false) guards every use of the resulting
+        // accessor, so it is never dereferenced. Keep the two sides in sync.
+        TensorAccessorArgs(output).append_to(reader_ct_args);
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_sfpu_tile.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    for (uint32_t j = 0; j < num_cores; ++j) {
+        KernelDescriptor::RTArgList args;
+        args.push_back(input);
+        args.push_back(output);
+        if (has_maxval) {
+            args.push_back(tensor_args.optional_maxval_tensor->mesh_tensor());
+        }
+        args.push_back(j);
+        args.push_back(slice_start(j));
+        args.push_back(slice_count(j));
+        if (j == 0) {
+            // Gather core only: physical coords of every core (slot order),
+            // used to return per-pass slot-reuse credits.
+            for (uint32_t k = 0; k < num_cores; ++k) {
+                const CoreCoord phys = device->worker_core_from_logical_core(cores[k]);
+                args.push_back(static_cast<uint32_t>(phys.x));
+                args.push_back(static_cast<uint32_t>(phys.y));
+            }
+        }
+        reader_desc.emplace_runtime_args(cores[j], args);
+    }
+    desc.kernels.push_back(std::move(reader_desc));
+
+    // ---- compute (SFPU): phase 1 --------------------------------------------
+    KernelDescriptor compute_desc;
+    compute_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_sfpu_tile_compute.cpp";
+    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = all_cores;
+    compute_desc.compile_time_args = {
+        static_cast<uint32_t>(cb_in),
+        static_cast<uint32_t>(cb_res_val),
+        static_cast<uint32_t>(cb_res_idx),
+        num_passes,
+    };
+    // fp32 DST accumulation: bf16 inputs widen exactly into fp32 DST slots,
+    // and the uint32 win-tile accumulator needs 32-bit DST.
+    compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = true};
+    for (uint32_t j = 0; j < num_cores; ++j) {
+        compute_desc.emplace_runtime_args(cores[j], {slice_count(j)});
+    }
+    desc.kernels.push_back(std::move(compute_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_sfpu_tile_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_sfpu_tile_compute.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// =============================================================================
+// argmax_sfpu_tile_compute.cpp — SFPU TILE-layout last-dim argmax, PHASE 1.
+//
+// Lane-parallel vertical reduce: for each 32-row tile-row pass, reduce this
+// core's `w_count` input tiles down to ONE (max value, winning tile index)
+// candidate pair per DST lane — i.e. per (row, column) position — using the
+// argmax_nc_compute.cpp op chain:
+//
+//   DST slot 0: running max_val  (fp32; bf16 inputs widen exactly)
+//   DST slot 1: running win_tile (uint32 = LOCAL index of the winning tile t;
+//               the lane's own column c is implicit — the consumer
+//               reconstructs the element index as (w_start + t) * 32 + c)
+//   DST slots 2/3: scratch (new_val / new_tile-idx, gt mask)
+//
+//   per input tile t (5 DST-wide ops):
+//     copy_tile             new_val <- tile t
+//     gt_binary_tile        mask = (new_val > max_val)          [IEEE fp32 >]
+//     where<Float32>        max_val  = mask ? new_val : max_val
+//     fill_tile_int<UInt32> scratch  = t
+//     where<Int32>          win_tile = mask ? t : win_tile
+//
+// Storing the winning TILE index (a constant per step, like the NC kernel's
+// k) instead of the global element index removes the need for a persistent
+// column-ramp tile in DST and an add_int32 step: lane c IS column c. The
+// uint32-CB/SrcA corruption documented in argmax_nc_compute.cpp is never in
+// play — indices are materialized in DST via fill_tile_int and only ever
+// PACKED out. A single where_tile_init() serves both the fp32 and int32
+// updates (the NC kernel's SFPCONFIG-macro-collision dodge, kept verbatim).
+//
+// The candidate pair is packed out once per pass (max values -> bf16 CB,
+// winning tile indices -> UInt32 CB); PHASE 2 — the horizontal reduce of the
+// 32 per-column candidates per row, plus the cross-core merge when running
+// multicore — is 32 scalar lexicographic compares per row on the dataflow
+// RISC (reader_argmax_sfpu_tile.cpp). Phase 2 is O(32) per row vs phase 1's
+// O(32 * w_count) per lane, so it amortizes to noise for large widths.
+//
+// SEMANTICS (documented divergence from the incumbent scalar TILE reader;
+// all silicon-measured on Blackhole, planted special-value probes):
+//   The pipeline is IEEE-compare-on-fp32 behind a bf16 special-value gasket:
+//   * NaN behaves as SAME-SIGNED INFINITY end-to-end. A qNaN anywhere in the
+//     row WINS the argmax (same index the incumbent reports for single-NaN
+//     rows) but the max-value output reads 0x7F80 (+inf), not the NaN
+//     payload; -NaN acts as -inf and never wins. A row holding both a +inf
+//     and a later NaN reports the +inf's index (they tie as +inf; the
+//     incumbent's bit-pattern order picks the NaN).
+//   * -0 flushes to +0 in the value output; +0/-0 compare equal, so the
+//     FIRST zero's index is kept (the incumbent's total order prefers a
+//     later +0 over an earlier -0).
+//   * Denormals flush to zero before the compare (the incumbent ranks them
+//     normally) — same family as the known Blackhole eltwise min-normal
+//     flush behavior.
+//   * The max-value output carries a +2^-127 additive pack bias, visible
+//     only when the winner's magnitude is below ~2^-118; compare order and
+//     the index are unaffected.
+//   Everything finite and normal — including every exact tie — matches the
+//   incumbent's bfloat16_greater + smallest-index semantics bit-for-bit:
+//   strict-gt per lane keeps the lowest tile, and phase 2's lexicographic
+//   rule keeps the lowest global index across columns (and cores).
+//   PRECEDENT: ttnn.argmax already ships this divergence class between its
+//   own paths — the NC compute kernel (dim < rank-2) uses the same IEEE
+//   gt_binary_tile chain while the scalar readers use the bfloat16_greater
+//   bit order, so NaN/signed-zero corners already differ by dispatched dim.
+//
+// Compile-time args: cb_in, cb_res_val, cb_res_idx, num_passes.
+// Runtime args: [0] w_count — this core's tile count per pass (>= 1).
+// =============================================================================
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/pack.h"
+#include "api/compute/reg_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+void kernel_main() {
+    constexpr auto cb_in = static_cast<tt::CBIndex>(get_compile_time_arg_val(0));
+    constexpr auto cb_res_val = static_cast<tt::CBIndex>(get_compile_time_arg_val(1));
+    constexpr auto cb_res_idx = static_cast<tt::CBIndex>(get_compile_time_arg_val(2));
+    constexpr uint32_t num_passes = get_compile_time_arg_val(3);
+
+    const uint32_t w_count = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst_max = 0;
+    constexpr uint32_t dst_argmax = 1;
+    constexpr uint32_t dst_scratch_a = 2;
+    constexpr uint32_t dst_scratch_b = 3;
+
+    DataflowBuffer dfb_in(cb_in);
+    DataflowBuffer dfb_val(cb_res_val);
+    DataflowBuffer dfb_idx(cb_res_idx);
+
+    init_sfpu(cb_in, cb_res_val);
+    // Single where_tile_init for BOTH updates (fp32 max / int32 argmax) —
+    // where_tile_init and binary_max_min_init both write SFPCONFIG macros 0
+    // and 1, so they cannot coexist; see argmax_nc_compute.cpp.
+    gt_binary_tile_init();
+    where_tile_init();
+    fill_tile_init();
+
+    for (uint32_t pass = 0; pass < num_passes; ++pass) {
+        tile_regs_acquire();
+
+        // --- init from tile 0: max_val <- tile0, win_tile <- 0 ---
+        dfb_in.wait_front(onetile);
+        copy_tile(cb_in, 0, dst_max);
+        dfb_in.pop_front(onetile);
+        fill_tile_int<DataFormat::UInt32>(dst_argmax, 0u);
+
+        // --- reduce tiles t = 1 .. w_count-1 (5 DST-wide ops per tile) ---
+        for (uint32_t t = 1; t < w_count; ++t) {
+            dfb_in.wait_front(onetile);
+            copy_tile(cb_in, 0, dst_scratch_a);
+            dfb_in.pop_front(onetile);
+
+            gt_binary_tile(dst_scratch_a, dst_max, dst_scratch_b);
+            where_tile<DataFormat::Float32>(dst_scratch_b, dst_scratch_a, dst_max, dst_max);
+            fill_tile_int<DataFormat::UInt32>(dst_scratch_a, t);
+            where_tile<DataFormat::Int32>(dst_scratch_b, dst_scratch_a, dst_argmax, dst_argmax);
+        }
+
+        tile_regs_commit();
+
+        dfb_val.reserve_back(onetile);
+        dfb_idx.reserve_back(onetile);
+        tile_regs_wait();
+        if (pass > 0) {
+            // Passes after the first left the packer configured for the
+            // UInt32 index CB; restore the value format first.
+            pack_reconfig_data_format(cb_res_idx, cb_res_val);
+        }
+        pack_tile(dst_max, cb_res_val);
+        pack_reconfig_data_format(cb_res_val, cb_res_idx);
+        pack_tile(dst_argmax, cb_res_idx);
+        tile_regs_release();
+        dfb_val.push_back(onetile);
+        dfb_idx.push_back(onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_sfpu_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_sfpu_tile.cpp
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// =============================================================================
+// reader_argmax_sfpu_tile.cpp — dataflow side of the SFPU TILE-layout argmax.
+//
+// Per 32-row tile-row pass, every core:
+//   1. Streams its `w_count` input tiles (slice [w_start, w_start + w_count)
+//      of the tile-row) into the double-buffered input CB in chunks. The CB
+//      is treated as a ring of pages addressed by GLOBAL page index
+//      (slot = t % num_pages) on both sides, so chunk batches may wrap
+//      mid-batch without any linear-placement assumption (same scheme as
+//      reader_argmax_rvv_tile.cpp).
+//   2. Collects phase 1's two candidate tiles (max values -> bf16 CB,
+//      winning LOCAL tile indices -> UInt32 CB) and finishes its slice with
+//      PHASE 2: for each valid row r, scan the 32 per-column candidates in
+//      ascending column order with the lexicographic rule
+//          take c  iff  val_c > best_val                 (IEEE, on bf16 bits)
+//                   or (val_c == best_val && idx_c < best_idx)
+//      where idx_c = (w_start + win_tile[r][c]) * 32 + c. The IEEE compare
+//      is emulated bit-exactly on bf16 patterns (NaN never compares
+//      greater/equal; +0 == -0), matching gt_binary_tile's fp32 semantics so
+//      the whole op implements ONE documented order (phase 1 already mapped
+//      NaN -> same-signed inf and flushed denormals, so no NaN/denormal bit
+//      pattern can appear among the candidates anyway).
+//
+// MULTICORE (num_cores > 1): each core deposits its per-row (index, value)
+// candidates — 32 rows x 8 bytes = 256 B — into its slot of the exchange
+// buffer on the gather core (core_id 0) and bumps the done semaphore; the
+// gather core merges the num_cores candidates per row with the same
+// lexicographic rule (a per-row scalar merge — NOT a cross-core tile
+// reduce) and stages the final results into output pages. Slot reuse across
+// passes is flow-controlled by a cumulative credit semaphore: workers may
+// send pass p only once the gather core has consumed pass p-1. Both
+// semaphores count cumulatively (wait_min, no mid-run resets) and are
+// restored to 0 at kernel end so trace replay — which does not re-run the
+// dispatcher's semaphore init — starts clean.
+//
+// The exchange buffer is a CB allocated identically on every core, so a
+// worker's local get_write_ptr(cb_xchg) equals the gather core's address.
+//
+// Compile-time args: see the factory (argmax_sfpu_tile_program_factory.cpp).
+// Runtime args:
+//   [0] src base address, [1] dst base address, [2, optional] maxval base
+//   address; then core_id, w_start, w_count; then — gather core only —
+//   num_cores (x, y) physical coord pairs of all cores (slot order), used to
+//   return per-pass credits.
+// =============================================================================
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "internal/tt-1xx/risc_common.h"  // invalidate_l1_cache()
+
+namespace {
+
+// IEEE order on bf16 bit patterns — bit-exact emulation of an fp32 compare
+// after the exact bf16->fp32 widening the unpacker performs.
+inline bool ieee_isnan(uint16_t x) { return static_cast<uint16_t>(x & 0x7FFFu) > 0x7F80u; }
+
+inline bool ieee_gt(uint16_t a, uint16_t b) {
+    if (ieee_isnan(a) || ieee_isnan(b)) {
+        return false;
+    }
+    const bool az = static_cast<uint16_t>(a & 0x7FFFu) == 0;
+    const bool bz = static_cast<uint16_t>(b & 0x7FFFu) == 0;
+    if (az && bz) {
+        return false;  // +0 == -0
+    }
+    if ((a ^ b) & 0x8000u) {
+        return (a & 0x8000u) == 0;  // signs differ (not both zero): positive wins
+    }
+    return (a & 0x8000u) ? (a < b) : (a > b);  // sign-magnitude within a sign
+}
+
+inline bool ieee_eq(uint16_t a, uint16_t b) {
+    if (ieee_isnan(a) || ieee_isnan(b)) {
+        return false;
+    }
+    const bool az = static_cast<uint16_t>(a & 0x7FFFu) == 0;
+    const bool bz = static_cast<uint16_t>(b & 0x7FFFu) == 0;
+    if (az && bz) {
+        return true;
+    }
+    return a == b;
+}
+
+// (row, col) -> element offset inside a 32x32 tile stored as faces 0..3
+// (16x16 row-major each): face = (row<16 ? 0 : 2) + (col<16 ? 0 : 1).
+inline uint32_t face_elem(uint32_t r, uint32_t c) {
+    const uint32_t face = ((r >> 4) << 1) + (c >> 4);
+    return face * 256u + (r & 15u) * 16u + (c & 15u);
+}
+
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_res_val = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_res_idx = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_xchg = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_stage_idx = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_stage_val = get_compile_time_arg_val(5);
+    constexpr uint32_t src_page_size = get_compile_time_arg_val(6);
+    constexpr uint32_t chunk_pages = get_compile_time_arg_val(7);
+    constexpr uint32_t in_cb_pages = get_compile_time_arg_val(8);
+    constexpr uint32_t h_tiles = get_compile_time_arg_val(9);
+    constexpr uint32_t logical_height = get_compile_time_arg_val(10);
+    constexpr uint32_t outer_dim_units = get_compile_time_arg_val(11);
+    constexpr uint32_t out_page_elems = get_compile_time_arg_val(12);
+    constexpr uint32_t dst_page_size = get_compile_time_arg_val(13);
+    constexpr uint32_t val_page_size = get_compile_time_arg_val(14);
+    constexpr bool has_maxval = (bool)get_compile_time_arg_val(15);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(16);
+    constexpr uint32_t gather_noc_x = get_compile_time_arg_val(17);
+    constexpr uint32_t gather_noc_y = get_compile_time_arg_val(18);
+    constexpr uint32_t done_sem_id = get_compile_time_arg_val(19);
+    constexpr uint32_t start_sem_id = get_compile_time_arg_val(20);
+    constexpr uint32_t w_tiles_total = get_compile_time_arg_val(21);
+    constexpr uint32_t num_c_time_args = 22;
+
+    // Exchange slot layout: u32 idx[32] then u32 val[32] (bf16 bits in the
+    // low half-word) — 256 B per core.
+    constexpr uint32_t xchg_slot_words = 64;
+    constexpr uint32_t xchg_slot_bytes = xchg_slot_words * sizeof(uint32_t);
+
+    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
+    const uint32_t val_base_addr = has_maxval ? get_arg_val<uint32_t>(2) : 0;
+    uint32_t argi = has_maxval ? 3 : 2;
+    const uint32_t core_id = get_arg_val<uint32_t>(argi++);
+    const uint32_t w_start = get_arg_val<uint32_t>(argi++);
+    const uint32_t w_count = get_arg_val<uint32_t>(argi++);
+    const uint32_t coord_args_base = argi;  // gather core only: (x, y) pairs
+
+    const bool is_gather = (core_id == 0);
+
+    // Contract with the factory: exactly THREE TensorAccessorArgs blocks are
+    // appended (src, dst, val) — when no maxval tensor is supplied the dst
+    // block is duplicated as a placeholder so the constexpr offset chain
+    // lines up; has_maxval guards every use of the third accessor.
+    constexpr auto s_src_args = TensorAccessorArgs<num_c_time_args>();
+    constexpr auto s_dst_args = TensorAccessorArgs<s_src_args.next_compile_time_args_offset()>();
+    const auto s_src = TensorAccessor(s_src_args, src_base_addr, src_page_size);
+    const auto s_dst = TensorAccessor(s_dst_args, dst_base_addr, dst_page_size);
+    constexpr auto s_val_args = TensorAccessorArgs<s_dst_args.next_compile_time_args_offset()>();
+    const auto s_val = TensorAccessor(s_val_args, val_base_addr, val_page_size);
+
+    // Input CB ring base (write pointer sits at base before any push).
+    const uint32_t in_base = get_write_ptr(cb_in);
+
+    // Exchange buffer: allocated identically on every core, so the local
+    // address doubles as the gather core's address for remote deposits.
+    const uint32_t xchg_base = get_write_ptr(cb_xchg);
+    volatile tt_l1_ptr uint32_t* const my_slot = (volatile tt_l1_ptr uint32_t*)(xchg_base + core_id * xchg_slot_bytes);
+
+    // Output staging buffers (gather core only; plain L1 scratch, no FIFO
+    // semantics).
+    const uint32_t stage_idx_addr = get_write_ptr(cb_stage_idx);
+    const uint32_t stage_val_addr = get_write_ptr(cb_stage_val);
+    uint32_t* const stage_idx = (uint32_t*)stage_idx_addr;
+    uint16_t* const stage_val = (uint16_t*)stage_val_addr;
+
+    volatile tt_l1_ptr uint32_t* done_sem_ptr = nullptr;
+    volatile tt_l1_ptr uint32_t* start_sem_ptr = nullptr;
+    uint64_t gather_done_sem_noc = 0;
+    uint64_t gather_xchg_slot_noc = 0;
+    if constexpr (num_cores > 1) {
+        done_sem_ptr = (volatile tt_l1_ptr uint32_t*)get_semaphore(done_sem_id);
+        start_sem_ptr = (volatile tt_l1_ptr uint32_t*)get_semaphore(start_sem_id);
+        gather_done_sem_noc = get_noc_addr(gather_noc_x, gather_noc_y, get_semaphore(done_sem_id));
+        gather_xchg_slot_noc = get_noc_addr(gather_noc_x, gather_noc_y, xchg_base + core_id * xchg_slot_bytes);
+    }
+
+    constexpr uint32_t num_passes = outer_dim_units * h_tiles;
+
+    uint32_t t_global = 0;   // global input page counter (matches compute side)
+    uint32_t collected = 0;  // elements accumulated toward the current output page
+    uint32_t out_page_id = 0;
+    uint32_t pass = 0;
+
+    for (uint32_t outer = 0; outer < outer_dim_units; outer++) {
+        for (uint32_t i = 0; i < h_tiles; i++) {
+            const uint32_t row_base = i * 32u;
+            const uint32_t units = (logical_height - row_base < 32u) ? (logical_height - row_base) : 32u;
+            const uint32_t slice_first = (outer * h_tiles + i) * w_tiles_total + w_start;
+
+            // ---- stream this core's slice of the tile-row ------------------
+            uint32_t done = 0;
+            while (done < w_count) {
+                const uint32_t chunk = (w_count - done < chunk_pages) ? (w_count - done) : chunk_pages;
+                cb_reserve_back(cb_in, chunk);
+                for (uint32_t k = 0; k < chunk; k++) {
+                    const uint32_t slot = (t_global + k) % in_cb_pages;
+                    noc_async_read_tile(slice_first + done + k, s_src, in_base + slot * src_page_size);
+                    if ((k & 31u) == 31u) {
+                        noc_async_read_barrier();
+                    }
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_in, chunk);
+                t_global += chunk;
+                done += chunk;
+            }
+
+            // ---- phase 2: 32 lexicographic compares per valid row ----------
+            cb_wait_front(cb_res_val, 1);
+            cb_wait_front(cb_res_idx, 1);
+            invalidate_l1_cache();
+            const volatile tt_l1_ptr uint16_t* vals = (const volatile tt_l1_ptr uint16_t*)get_read_ptr(cb_res_val);
+            const volatile tt_l1_ptr uint32_t* tidx = (const volatile tt_l1_ptr uint32_t*)get_read_ptr(cb_res_idx);
+
+            for (uint32_t r = 0; r < units; r++) {
+                uint16_t best_v = vals[face_elem(r, 0)];
+                uint32_t best_i = (w_start + tidx[face_elem(r, 0)]) * 32u;
+                for (uint32_t c = 1; c < 32u; ++c) {
+                    const uint32_t e = face_elem(r, c);
+                    const uint16_t vc = vals[e];
+                    const uint32_t ic = (w_start + tidx[e]) * 32u + c;
+                    if (ieee_gt(vc, best_v) || (ieee_eq(vc, best_v) && ic < best_i)) {
+                        best_v = vc;
+                        best_i = ic;
+                    }
+                }
+                my_slot[r] = best_i;
+                my_slot[32u + r] = best_v;
+            }
+            cb_pop_front(cb_res_val, 1);
+            cb_pop_front(cb_res_idx, 1);
+
+            if constexpr (num_cores > 1) {
+                if (!is_gather) {
+                    // Slot-reuse credit: the gather core has consumed pass
+                    // p-1 once start_sem >= p (cumulative).
+                    if (pass > 0) {
+                        noc_semaphore_wait_min(start_sem_ptr, pass);
+                    }
+                    noc_async_write(xchg_base + core_id * xchg_slot_bytes, gather_xchg_slot_noc, xchg_slot_bytes);
+                    noc_async_write_barrier();
+                    noc_semaphore_inc(gather_done_sem_noc, 1);
+                    noc_async_atomic_barrier();
+                }
+            }
+
+            if (is_gather) {
+                if constexpr (num_cores > 1) {
+                    noc_semaphore_wait_min(done_sem_ptr, (pass + 1) * (num_cores - 1));
+                    invalidate_l1_cache();
+                }
+                // ---- merge the per-core candidates, stage output rows ------
+                for (uint32_t r = 0; r < units; r++) {
+                    const volatile tt_l1_ptr uint32_t* slot0 = (const volatile tt_l1_ptr uint32_t*)xchg_base;
+                    uint32_t best_i = slot0[r];
+                    uint16_t best_v = (uint16_t)slot0[32u + r];
+                    for (uint32_t j = 1; j < num_cores; j++) {
+                        const volatile tt_l1_ptr uint32_t* slot =
+                            (const volatile tt_l1_ptr uint32_t*)(xchg_base + j * xchg_slot_bytes);
+                        const uint32_t ic = slot[r];
+                        const uint16_t vc = (uint16_t)slot[32u + r];
+                        if (ieee_gt(vc, best_v) || (ieee_eq(vc, best_v) && ic < best_i)) {
+                            best_v = vc;
+                            best_i = ic;
+                        }
+                    }
+                    stage_idx[collected] = best_i;
+                    if constexpr (has_maxval) {
+                        stage_val[collected] = best_v;
+                    }
+                    collected++;
+                    if (collected == out_page_elems) {
+                        noc_async_write(stage_idx_addr, s_dst.get_noc_addr(out_page_id), dst_page_size);
+                        if constexpr (has_maxval) {
+                            noc_async_write(stage_val_addr, s_val.get_noc_addr(out_page_id), val_page_size);
+                        }
+                        noc_async_write_barrier();
+                        collected = 0;
+                        out_page_id++;
+                    }
+                }
+                if constexpr (num_cores > 1) {
+                    // Return slot-reuse credits — only if another pass will
+                    // need them, so no increment can race the workers' final
+                    // start_sem reset below.
+                    if (pass + 1 < num_passes) {
+                        for (uint32_t j = 1; j < num_cores; j++) {
+                            const uint32_t wx = get_arg_val<uint32_t>(coord_args_base + 2 * j);
+                            const uint32_t wy = get_arg_val<uint32_t>(coord_args_base + 2 * j + 1);
+                            noc_semaphore_inc(get_noc_addr(wx, wy, get_semaphore(start_sem_id)), 1);
+                        }
+                        noc_async_atomic_barrier();
+                    }
+                }
+            }
+            pass++;
+        }
+    }
+
+    // Restore semaphores to 0 for trace replay (the dispatcher's semaphore
+    // init does not re-run on replay). Race-free: the gather core's final
+    // done_sem wait has observed every worker increment, and workers receive
+    // no credit after their final wait (none is sent for the last pass).
+    if constexpr (num_cores > 1) {
+        if (is_gather) {
+            noc_semaphore_set(done_sem_ptr, 0);
+        } else {
+            noc_semaphore_set(start_sem_ptr, 0);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/reduction/sources.cmake
@@ -5,6 +5,7 @@ set(TTNN_OP_REDUCTION_SRCS
     argmax/device/argmax_device_operation.cpp
     argmax/device/argmax_multi_core_program_factory.cpp
     argmax/device/argmax_rvv_tile_program_factory.cpp
+    argmax/device/argmax_sfpu_tile_program_factory.cpp
     argmax/device/argmax_single_core_program_factory.cpp
     argmax/device/argmax_nc_device_operation.cpp
     argmax/device/argmax_nc_program_factory.cpp


### PR DESCRIPTION
### PR Category
Feature

> **CI status**: PR Gate fully green on the initial push (zero failures). The 167-test silicon battery for this path runs **ungated on any Blackhole runner** — plain SFPU, no special toolchain, unlike the RVV path's gated tests.

This is the follow-up promised on #54105: the SFPU last-dim argmax as a real
op path, so `argmax` can dispatch by shape. Credit where it's due — **this
path exists because @iwroszTT asked "why not the SFPU?" in the #54105
review.** We first built the kernel as a bench and measured it (showdown
numbers posted there); it won for batch shapes, so here it is productized:
multicore, tested, and behind an explicit opt-in knob.

### What this adds

- `ttnn.argmax(..., use_sfpu=True)` — TILE-layout last-dim argmax on the
  SFPU (Blackhole, bf16, last dim a multiple of 32, opt-in, default off;
  mutually exclusive with `use_rvv`). Takes TILE input directly — no
  untilize hop — and supports the same optional `maxval_tensor` output as
  the RVV path (greedy sampling: index + max value in one op).
- Single-core AND multicore program factory
  (`argmax_sfpu_tile_program_factory.cpp`). Multicore is the point: the
  reduction dim's tiles are split across cores (default ~`sqrt(1.5*Wt)`
  cores; `sub_core_grids` overrides — a single-core grid forces the
  single-core variant).
- A silicon battery (`test_argmax_sfpu.py`) that asserts the documented
  semantics bit-exactly — including on the NaN/denormal corners where this
  path *intentionally* diverges from the scalar readers (details below).

### Why batch shapes want this engine

Phase 1 reduces **all 32 rows of a tile-row in one lane-parallel pass** — a
tile costs the same whether 1 or 32 rows are valid. The scalar reader pays
~23 cycles per element and the RVV scan pays per valid row; the SFPU pays
per tile, flat in B. That's exactly the shape-dispatch split suggested in
the #54105 review: RVV for B=1 decode (and the fused-epilogue use), SFPU for
batch.

Design (per 32-row tile-row pass):

- **Phase 1** (compute kernel, `argmax_sfpu_tile_compute.cpp`): the
  `argmax_nc_compute.cpp` recipe applied along W — per-lane running
  `(max_val fp32, winning-tile uint32)` in DST, 5 DST-wide ops per tile
  (`copy`, `gt_binary`, `where<fp32>`, `fill_int`, `where<int32>`), one
  `where_tile_init` for both updates (the documented SFPCONFIG-collision
  dodge), indices materialized only via `fill_tile_int` (the uint32-CB/SrcA
  corruption path is never touched). Lane c IS column c, so storing the
  winning *tile* index reconstructs `idx = t*32 + c` downstream and saves a
  DST slot + an add per tile.
- **Phase 2** (dataflow RISC, `reader_argmax_sfpu_tile.cpp`): the two packed
  candidate tiles are finished with 32 lexicographic compares per valid row
  — O(32) per row vs phase 1's O(32·Wt), amortizes to noise.
- **Multicore**: each core reduces its contiguous slice of the W tiles and
  deposits 32 per-row `(idx, val)` candidates — **256 B per core per pass,
  scalar candidates, never tiles** — on a gather core that merges per row
  with the same lexicographic rule and writes the output pages. Slot reuse
  across passes is flow-controlled with cumulative-credit semaphores
  (`wait_min`, no mid-run resets; both restored to 0 at kernel end so trace
  replay starts clean).

### Measured

Device kernel duration (BH P150 @ 1350 MHz, medians of 15, eager, per-iter
sync, device profiler; all legs same chip / same branch / same toolchain,
spreads ≤ 0.5% except one 3.3%). `sfpu_mc` = this PR's default multicore
(cores in parentheses); `sfpu_sc` = same op forced single-core; `rvv` =
#54105's path (idx+maxval); `tile_sc` = incumbent TILE argmax; `rm_mc` =
incumbent ROW_MAJOR multicore (the fastest incumbent B=32 option, and it
still needs an untilize in real TILE pipelines, which is not counted here).

| V | B | **sfpu_mc** | sfpu_sc | rvv (#54105) | tile_sc | rm_mc |
|---|---|---|---|---|---|---|
| 32,768 | 8 | **35.3 µs** (40) | 618.4 µs | 191.5 µs | 5,252.7 µs | — |
| 32,768 | 32 | **78.8 µs** (40) | 640.8 µs | 764.1 µs | 19,448.9 µs | 267.3 µs |
| 131,072 | 8 | **72.9 µs** (79) | 2,443.3 µs | 687.3 µs | 21,008.1 µs | — |
| 131,072 | 32 | **136.2 µs** (79) | 2,465.8 µs | 2,711.6 µs | 77,762.4 µs | 756.3 µs |
| 262,144 | 8 | **110.9 µs** (111) | 4,876.7 µs | 1,320.5 µs | 42,012.1 µs | — |
| 262,144 | 32 | **190.0 µs** (111) | 4,899.3 µs | 5,275.4 µs | 155,560.8 µs | 1,404.7 µs |

Readings:

- **vs #54105's RVV** (the engine this dispatches against): 5.4–11.9x at
  B=8, 9.7–27.8x at B=32.
- **vs the fastest incumbent batch option** (`rm_mc`, B=32): 3.4x / 5.6x /
  7.4x — and TILE-native, so the untilize the incumbent needs disappears too.
- **vs the incumbent TILE argmax** it replaces shape-for-shape: 149–819x.
- `sfpu_sc` reproduces the standalone bench kernel's measured cycles to
  <0.1% (e.g. 6,613,990 vs the bench's 6,608,522 cycles at V=262,144 B=32)
  — the productized op kept the bench's performance.
- Phase-1 issue cost is flat in B (sfpu_sc B=8 vs B=32 differ by <4%); the
  multicore B=8→32 delta is the per-row phase-2/merge tail only.

### Semantics — documented, measured, and deliberately not oversold

This path is **NOT bit-identical to the incumbent scalar readers** on
special values, and the PR does not claim it is. The compare pipeline is
IEEE-on-fp32 behind a bf16 special-value gasket (every rule below is
silicon-measured with planted probes and asserted bit-exactly in the tests):

1. **NaN behaves as same-signed infinity**: a NaN anywhere in the row wins
   the argmax (same index the incumbent reports for single-NaN rows), but
   the max-value output reads `0x7F80` (+inf), not the NaN payload; -NaN
   never wins. A row with +inf earlier and NaN later reports the +inf index.
2. **-0 flushes to +0** in the value output; ±0 compare equal, so the first
   zero's index is kept (the incumbent's bit order prefers a later +0).
3. **Denormals flush to zero** before the compare (the incumbent ranks them).
4. Max values below ~2^-118 carry a **+2^-127 additive pack bias** (compare
   order and index unaffected).

Everything finite and normal — including every exact tie — matches the
incumbent's `bfloat16_greater` + smallest-index semantics **bit-for-bit**
(strict-gt keeps the lowest tile per lane; the lexicographic phase 2 / merge
keeps the lowest global index across columns and cores).

Precedent: **upstream argmax already ships exactly this divergence class
between its own engines** — the NC compute path (`dim < rank-2`) uses the
same IEEE `gt_binary_tile` chain while the H/W/last-dim readers use the
bit-pattern order, so NaN/signed-zero behavior already differs by which dim
you reduce. `use_sfpu` extends that existing IEEE-family behavior to the
last dim, opt-in and documented in the docstring, rather than introducing a
new semantics class. (The RVV path in #54105 remains the incumbent-exact
option, which is one more reason the engines are knobs, not silent
dispatch.)

### Tests — and they run in normal Blackhole CI

`tests/ttnn/unit_tests/operations/reduce/test_argmax_sfpu.py`, mirroring
`test_argmax_rvv.py`'s case bank: planted max / first-index ties /
max-at-end / max-at-0 / denormal / NaN-payload / all-negative / all--inf,
over V ∈ {32, 2016, 2048, 8192, 32768} × B ∈ {1, 8, 32} × keepdim ×
maxval × {single-core, multicore}, plus a rank-4 2×3×80×2048 case (multiple
tile-row passes, partial last tile-row, exercises the multicore credit flow
control) and negative tests (ROW_MAJOR reject, `use_rvv`+`use_sfpu` reject,
ragged last dim reject). Finite classes score against the incumbent golden;
NaN/denormal classes score against the gasket model — the divergence is
asserted, not skipped. **167/167 pass on silicon (72 s).**

Worth calling out: unlike the RVV path there is **no special-toolchain
opt-in here — these are plain SFPU compute kernels on the stock JIT**, so
the battery is gated `is_blackhole` only (no `TT_ENABLE_RVV_TESTS`-style env
gate) and can run in ordinary Blackhole CI from day one.

### Proposed follow-up: dispatch by shape (kept out of this PR on purpose)

This PR adds the engine with the least possible API churn: `use_rvv` is
untouched, `use_sfpu` is a sibling knob, both default off, everything
default-path is byte-identical. Once both paths have soaked, the natural
next step is the automatic policy the #54105 discussion converged on:

- **B ≥ 8 rows** (batch): SFPU multicore (this PR's path),
- **B = 1** (decode): RVV (#54105) / scalar,

with the explicit knobs kept as overrides — noting the two engines'
special-value semantics differ (RVV is incumbent-exact, SFPU is the IEEE
gasket), so silent dispatch should land only if that's acceptable per-shape,
which is the reviewer's call. Other tracked follow-ups: Wormhole enablement
(nothing in the kernels is BH-specific; gated on re-running the
special-value battery there) and pass-partitioned multicore for shapes with
very many tile-rows (the current split parallelizes within each pass, which
is optimal for B ≤ 32 batch shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Assembly notes (not part of the PR body)

- Raw rows: `sfpu_lane/oplevel/sfpu_oplevel_rows.csv`; logs + profiles in
  `sfpu_lane/oplevel/`; bench = `sfpu_op_bench.py` (lane-B methodology:
  device profiler, one V per process, scoped chip-1 resets,
  `/proc/self/fd` device-identity guard, `chip1=0000:41:00.0`).
- Every measured cell's leg VERIFY'd index-exact vs torch on its data
  before timing (`VERIFY ... OK` in the bench logs).
- Core counts 40/79/111 are the factory heuristic
  `min(ceil(sqrt(1.5*Wt)), grid, Wt)` at Wt = 1024/4096/8192.
- tt-metal branch commits: `204e2147398` (op path) + `db3447b3e8e` (tests);
  base `16ca50ec6e3` = #54105 head. Pushed over SSH (HTTPS token lacks the
  `workflow` scope GitHub wants for new-branch pushes to this repo).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/argmax-sfpu-batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/argmax-sfpu-batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/argmax-sfpu-batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/argmax-sfpu-batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/argmax-sfpu-batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/argmax-sfpu-batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/argmax-sfpu-batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/argmax-sfpu-batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/argmax-sfpu-batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/argmax-sfpu-batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/argmax-sfpu-batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/argmax-sfpu-batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/argmax-sfpu-batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/argmax-sfpu-batch)