### PR TITLE
[tt-train] Use shared TTI exp in cross-entropy fw/bw kernels

### DIFF
--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
@@ -224,8 +224,9 @@ void calculate_sum_exp_x() {
         sub_binary_tile_init();
         sub_binary_tile(working_register, max_value_register, working_register);  // subtract max value from each tile
 
-        // Hand-scheduled TTI exp shared with SDPA: ~3x cheaper on the SFPU than the
-        // generic accurate exp_tile at bf16 output precision.
+        // exp via the shared SDPA path: on Blackhole this dispatches to the hand-scheduled
+        // TTI exp (~3x cheaper on the SFPU than the generic accurate exp_tile at bf16
+        // output precision); on Wormhole it falls back to the same accurate sfpi exp.
         sdpa_exp_tile_init();
         sdpa_exp_tile(working_register);  // calculate exp for each tile in tile register
 

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/compute/cross_entropy_bw_kernel.cpp
@@ -29,6 +29,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp"
 
 constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);  // rows to process in this kernel
 constexpr uint32_t block_size = get_compile_time_arg_val(1);         // size of block
@@ -223,8 +224,10 @@ void calculate_sum_exp_x() {
         sub_binary_tile_init();
         sub_binary_tile(working_register, max_value_register, working_register);  // subtract max value from each tile
 
-        exp_tile_init<false>();
-        exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
+        // Hand-scheduled TTI exp shared with SDPA: ~3x cheaper on the SFPU than the
+        // generic accurate exp_tile at bf16 output precision.
+        sdpa_exp_tile_init();
+        sdpa_exp_tile(working_register);  // calculate exp for each tile in tile register
 
         if constexpr (do_mask_w) {
             if (col + 1 == Wt) {
@@ -287,8 +290,8 @@ void calculate_sum_exp_x() {
             sub_binary_tile(
                 working_register, max_value_register, working_register);  // subtract max value from each tile
 
-            exp_tile_init<false>();
-            exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
+            sdpa_exp_tile_init();
+            sdpa_exp_tile(working_register);  // calculate exp for each tile in tile register
 
             if constexpr (do_mask_w) {
                 if (col + 1 == Wt) {
@@ -418,8 +421,8 @@ void kernel_main() {
                     /* tile_idx */ 0,
                     /* register idx */ block_idx);
 
-                exp_tile_init<false>();
-                exp_tile</* approx */ false>(block_idx);  // calculate exp for each tile in tile register
+                sdpa_exp_tile_init();
+                sdpa_exp_tile(block_idx);  // calculate exp for each tile in tile register
 
                 mul_binary_tile_init();
                 mul_binary_tile(block_idx, sum_exp_register, block_idx);  // multiply by scaler

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
@@ -215,8 +215,9 @@ void calculate_sum_exp_x() {
         sub_binary_tile_init();
         sub_binary_tile(working_register, max_value_register, working_register);  // subtract max value from each tile
 
-        // Hand-scheduled TTI exp shared with SDPA: ~3x cheaper on the SFPU than the
-        // generic accurate exp_tile at bf16 output precision.
+        // exp via the shared SDPA path: on Blackhole this dispatches to the hand-scheduled
+        // TTI exp (~3x cheaper on the SFPU than the generic accurate exp_tile at bf16
+        // output precision); on Wormhole it falls back to the same accurate sfpi exp.
         sdpa_exp_tile_init();
         sdpa_exp_tile(working_register);  // calculate exp for each tile in tile register
 

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/compute/cross_entropy_fw_kernel.cpp
@@ -28,6 +28,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/reduce.h"
 #include "api/compute/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp"
 
 constexpr uint32_t num_rows_per_core = get_compile_time_arg_val(0);  // rows to process in this kernel
 constexpr uint32_t block_size = get_compile_time_arg_val(1);         // size of block
@@ -214,8 +215,10 @@ void calculate_sum_exp_x() {
         sub_binary_tile_init();
         sub_binary_tile(working_register, max_value_register, working_register);  // subtract max value from each tile
 
-        exp_tile_init();
-        exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
+        // Hand-scheduled TTI exp shared with SDPA: ~3x cheaper on the SFPU than the
+        // generic accurate exp_tile at bf16 output precision.
+        sdpa_exp_tile_init();
+        sdpa_exp_tile(working_register);  // calculate exp for each tile in tile register
 
         if constexpr (do_mask_w) {
             if (col + 1 == Wt) {
@@ -277,8 +280,8 @@ void calculate_sum_exp_x() {
             sub_binary_tile(
                 working_register, max_value_register, working_register);  // subtract max value from each tile
 
-            exp_tile_init();
-            exp_tile</* approx */ false>(working_register);  // calculate exp for each tile in tile register
+            sdpa_exp_tile_init();
+            sdpa_exp_tile(working_register);  // calculate exp for each tile in tile register
 
             if constexpr (do_mask_w) {
                 if (col + 1 == Wt) {


### PR DESCRIPTION
### What

Replace the generic accurate `exp_tile</*approx*/false>` in the cross-entropy
forward and backward compute kernels (5 call sites) with the hand-scheduled TTI
exp already used by SDPA (`sdpa_exp_tile` from
`metal/common/sdpa_compute_utils_common.hpp`). No host/factory changes — kernel
sources only.

### Why

Device profiling (Tracy, Blackhole p150b, W=128k vocab, streaming path) shows
both CE kernels are compute-bound on the MATH thread, and the accurate exp is
the single hot spot:

| metric (per tile-row) | stock exp | TTI exp | speedup |
|---|---|---|---|
| exp alone (MATH) | 1434 cyc/tile (76% of MATH) | 427 cyc/tile | **3.4x** |
| MATH per-tile total | 1888 cyc/tile | 986 cyc/tile | 1.9x |
| CE fw op, W=128k | ~6930 us/row | ~4450 us/row | **1.56x** |

Direct stall measurement confirms the mechanism: during the exp phase the
reader is backpressured on `cb_reserve_back` ~90% of the time while compute
waits on input only 7% — the SFPU exp is the pacer. After the swap the op
approaches the DRAM-bound floor demonstrated by its own MAX phase.

### Accuracy / testing

- Full `*CrossEntropy*` gtest suite green on Blackhole, including both
  `NIGHTLY_*_Huge_*` 128k-vocab cases (fw `allclose(3e-2, 1e-2)`).
- End-to-end sanity: 500-step TinyLlama (nano_gpt, Shakespeare) on Blackhole,
  branch vs main — C++ 1665.8 vs 1670.0 ms/step, Python 1662.8 vs 1664.1
  ms/step (unchanged, as expected: CE is a few ms of a ~1.7 s step at 32k
  vocab), identical loss convergence. The win is at the op level and grows
  with vocab size.

### Notes / follow-ups

- The `sdpa_`-named header is used as is to keep this PR kernel-only
  (2 files); the branch already sits on top of #53217's changes to these
  helpers. Hoisting them into a neutral `metal/common/exp_utils.hpp` and
  renaming `sdpa_exp_tile*` touches every SDPA fw/bw call site, so it's left
  as a mechanical follow-up.
- Further CE headroom identified by the same profiling (not in this PR):
  moving the max-subtract to the FPU (`sub_tiles_bcast_cols`, as SDPA does) and
  pack-side L1-accumulate for the exp-sum; ceiling ~2.4x for the current
  two-pass structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vmelnykov/perf/cross-entropy-tti-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vmelnykov/perf/cross-entropy-tti-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vmelnykov/perf/cross-entropy-tti-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vmelnykov/perf/cross-entropy-tti-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vmelnykov/perf/cross-entropy-tti-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vmelnykov/perf/cross-entropy-tti-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vmelnykov/perf/cross-entropy-tti-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vmelnykov/perf/cross-entropy-tti-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vmelnykov/perf/cross-entropy-tti-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vmelnykov/perf/cross-entropy-tti-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vmelnykov/perf/cross-entropy-tti-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vmelnykov/perf/cross-entropy-tti-exp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vmelnykov/perf/cross-entropy-tti-exp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vmelnykov/perf/cross-entropy-tti-exp)
