### PR TITLE
[LLK] [LLK AI Codegen] Optimize LLK issue-solver test routing and builds

### DIFF
--- a/tt_metal/tt-llk/.claude/scripts/run_qsr_metal_test.sh
+++ b/tt_metal/tt-llk/.claude/scripts/run_qsr_metal_test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Run one unit_tests_llk filter against Quasar Aether VCS/emulation.
+# Run one unit_tests_llk filter or an explicit test command against Quasar
+# Aether VCS/emulation.
 #
 # The caller owns the build and supplies a fresh TT_METAL_CACHE. This wrapper
 # owns only the scarce remote Aether execution: backend selection, the
@@ -12,6 +13,7 @@ TT_METAL_HOME_ARG=""
 CACHE=""
 LOG_DIR=""
 RUN_TIMEOUT="${TIMEOUT:-1200}"
+COMMAND=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -21,6 +23,7 @@ while [[ $# -gt 0 ]]; do
     --cache)         CACHE="$2";             shift 2 ;;
     --log-dir)       LOG_DIR="$2";           shift 2 ;;
     --timeout)       RUN_TIMEOUT="$2";        shift 2 ;;
+    --)              shift; COMMAND=("$@"); break ;;
     -h|--help)
       sed -n 's/^# \{0,1\}//p' "$0" | head -24
       exit 0
@@ -29,11 +32,23 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "$BIN" ]] || { echo "ERROR: --bin is required" >&2; exit 4; }
-[[ -n "$FILTER" ]] || { echo "ERROR: --gtest-filter is required" >&2; exit 4; }
 [[ -n "$TT_METAL_HOME_ARG" ]] || { echo "ERROR: --tt-metal-home is required" >&2; exit 4; }
 [[ -n "$CACHE" ]] || { echo "ERROR: --cache is required" >&2; exit 4; }
-[[ -x "$BIN" ]] || { echo "ERROR: test binary is not executable: $BIN" >&2; exit 3; }
+if [[ ${#COMMAND[@]} -gt 0 ]]; then
+  [[ -z "$BIN" && -z "$FILTER" ]] || {
+    echo "ERROR: explicit command cannot be combined with --bin/--gtest-filter" >&2
+    exit 4
+  }
+  command -v "${COMMAND[0]}" >/dev/null 2>&1 || {
+    echo "ERROR: command is not executable: ${COMMAND[0]}" >&2
+    exit 3
+  }
+else
+  [[ -n "$BIN" ]] || { echo "ERROR: --bin is required" >&2; exit 4; }
+  [[ -n "$FILTER" ]] || { echo "ERROR: --gtest-filter is required" >&2; exit 4; }
+  [[ -x "$BIN" ]] || { echo "ERROR: test binary is not executable: $BIN" >&2; exit 3; }
+  COMMAND=("$BIN" "--gtest_filter=$FILTER")
+fi
 
 QSR_SIM_BACKEND="${QSR_SIM_BACKEND:-emu}"
 case "$QSR_SIM_BACKEND" in
@@ -90,7 +105,7 @@ if [[ -n "$run_log" ]]; then
     TT_METAL_SIMULATOR="$SIM_PATH" \
     TT_METAL_SLOW_DISPATCH_MODE=1 \
     SSH_MACHINE_NAME="$EMU_HOST" \
-    timeout "$RUN_TIMEOUT" "$BIN" "--gtest_filter=$FILTER" 2>&1 | tee -a "$run_log"
+    timeout "$RUN_TIMEOUT" "${COMMAND[@]}" 2>&1 | tee -a "$run_log"
   rc=${PIPESTATUS[0]}
 else
   env \
@@ -99,7 +114,7 @@ else
     TT_METAL_SIMULATOR="$SIM_PATH" \
     TT_METAL_SLOW_DISPATCH_MODE=1 \
     SSH_MACHINE_NAME="$EMU_HOST" \
-    timeout "$RUN_TIMEOUT" "$BIN" "--gtest_filter=$FILTER"
+    timeout "$RUN_TIMEOUT" "${COMMAND[@]}"
   rc=$?
 fi
 set -e

--- a/tt_metal/tt-llk/codegen/CLAUDE.md
+++ b/tt_metal/tt-llk/codegen/CLAUDE.md
@@ -29,7 +29,7 @@ Four flows: kernel generation (arch-specific), single-arch issue solving, multi-
 | Kernel gen | `codegen/agents/quasar/orchestrator.md` | `codegen/agents/quasar/llk-*.md` | Quasar only today. Unaffected by multi-arch issue-solver work. |
 | Issue solver (single-arch) | `codegen/agents/issue-solver/orchestrator.md` | `codegen/agents/issue-solver/*.md` | Used when `len(TARGET_ARCHES) == 1`. Parameterized by `TARGET_ARCH` — see `codegen/references/arch-profiles.md`. |
 | Issue solver (multi-arch) | `codegen/agents/issue-solver/orchestrator-multi.md` | same `codegen/agents/issue-solver/*.md` agents, run once with `TARGET_ARCHES` | Used when `len(TARGET_ARCHES) > 1`. One analyzer, one fixer, one tester, one dashboard run, one worktree, one branch, one optional PR. |
-| Review round | `codegen/agents/issue-solver/review/orchestrator.md` | `review/addresser.md` plus the same `tester.md` / `metal-tester.md` / `reviewer.md` / `perf-tester.md` | Addresses the review comments on an **already-open** PR. No analyze stage — scope, fix layer, and verification route are inherited from the solve that produced the PR. |
+| Review round | `codegen/agents/issue-solver/review/orchestrator.md` | `review/addresser.md` plus the same `tester.md` / `metal-tester.md` / `ttnn-tester.md` / `reviewer.md` / `perf-tester.md` | Addresses the review comments on an **already-open** PR. No analyze stage — scope, fix layer, and verification route are inherited from the solve that produced the PR. |
 
 ## Step 1: Classify the Request
 

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/issue-analyzer.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/issue-analyzer.md
@@ -88,8 +88,8 @@ runs; otherwise use `TARGET_ARCH`.
    documentation or comments, and explain why no runtime assertion applies.
    A missing test or unavailable backend does not make verification optional.
    When it is `no`, also set `verifiable_in_llk_suite: no`,
-   `llk_coverage: not_applicable`, and metal coverage to `target: none` /
-   `coverage: not_applicable`.
+   `llk_coverage: not_applicable`, and both integration sections to
+   `target: none` / `coverage: not_applicable`.
 7. Set `verifiable_in_llk_suite` and `llk_coverage`:
    - `yes`: the affected behavior belongs in the Layer-1 tt-llk suite.
      Set coverage to `existing` when a source under `tests/sources/**` already
@@ -107,8 +107,11 @@ runs; otherwise use `TARGET_ARCH`.
      tests/sources tests/python_tests
    ```
 
-8. For `no` or `partial`, find the `unit_tests_llk` test that drives a compute
-   kernel calling the changed symbol:
+8. Decide Metal coverage independently. Require `unit_tests_llk` when the
+   changed behavior belongs to CKernels/Compute API, Metal runtime, or a Metal
+   LLK test, or when it is the narrowest production entry point that exposes
+   the defect. Find the test that drives a compute kernel calling the changed
+   symbol:
 
    ```bash
    rg -l '<changed_symbol>' tests/tt_metal/tt_metal/test_kernels/compute
@@ -123,20 +126,47 @@ runs; otherwise use `TARGET_ARCH`.
    dispatch mode. Use `slow` for a `*SlowDispatchOnly` fixture and `fast`
    otherwise.
 
-   If no metal test reaches required runtime behavior, keep
+   When Metal coverage is required but no test reaches the behavior, keep
    `target: unit_tests_llk`, set `coverage: add_required`, and identify the
    `tests/tt_metal/tt_metal/llk/test_*.cpp` fixture, optional test kernel, source
-   registration, and tight filter the worker must add. A Layer-4 TTNN pytest
-   that this pipeline cannot execute does not satisfy this requirement; add
-   metal coverage for the production compute path as well.
+   registration, and tight filter the worker must add.
 
-   Use `target: none` only with `verification_required: no`; set coverage to
-   `not_applicable`.
-9. Record likely production and test files, one initial hypothesis with a
+   Use `target: none` and `coverage: not_applicable` when the change does not
+   require a distinct Metal regression. Do not add a redundant Metal leaf only
+   because the LLK suite cannot reach a TTNN-only behavior.
+9. Decide TTNN coverage independently. Require a TTNN leaf when any of these is
+   true:
+   - `fix_layer: ttnn`;
+   - a `mixed` fix changes TTNN host code, an operation, a device kernel, or its
+     Python API;
+   - the issue's reproduction or acceptance contract is a TTNN API;
+   - a new or changed LLK/Compute kernel is being propagated through TTNN and
+     that end-to-end path is the behavior being delivered.
+
+   Locate the narrowest existing TTNN pytest before inventing one:
+
+   ```bash
+   rg -n '<operation>|<kernel>|<api>' tests/ttnn tests/sweep_framework models ttnn
+   python3 -m pytest --collect-only -q '<exact selector>'
+   ```
+
+   Record one exact repository-relative pytest path/node ID or
+   `path -k "expression"`. Allowed roots are `tests/ttnn/`,
+   `tests/sweep_framework/`, model test directories, and TTNN's own test tree.
+   Use `dispatch: slow` only when the test requires slow dispatch. If no test
+   reaches required behavior, set `target: ttnn`, `coverage: add_required`, and
+   name the exact test the worker must add. Use `target: none` and
+   `coverage: not_applicable` only when TTNN is not an affected or required
+   public path.
+
+   A TTNN test compiles the TTNN binding and JIT-compiles device kernels, but it
+   does not automatically replace a required LLK or Metal boundary regression.
+   Select each suite whose independently affected contract needs protection.
+10. Record likely production and test files, one initial hypothesis with a
    falsification condition, and relevant reproduction or regression test
    candidates. Mark each candidate as `existing` or `add_required` and ensure
    at least one candidate per required suite is runnable by that suite.
-10. Request architecture research only for ISA semantics, register layouts,
+11. Request architecture research only for ISA semantics, register layouts,
    scheduling, hardware contracts, or cross-architecture porting. Use
    `questions: []` when no research is needed.
 
@@ -165,7 +195,7 @@ fix_layer: llk_lib|ckernels_api|compute_api|ttnn|tt_metal_runtime|metal_tests|mi
 verification_required: yes|no
 verifiable_in_llk_suite: yes|no|partial
 llk_coverage: existing|add_required|added|not_applicable
-metal_verification:            # required when verifiable_in_llk_suite is no|partial
+metal_verification:
   target: unit_tests_llk|none
   coverage: existing|add_required|added|not_applicable
   test_file: <tests/tt_metal/tt_metal/llk/test_*.cpp>|none
@@ -173,6 +203,12 @@ metal_verification:            # required when verifiable_in_llk_suite is no|par
   kernel: <compute-kernel path>|none
   dispatch: slow|fast|none
   reason: <coverage evidence or why verification is not applicable>
+ttnn_verification:
+  target: ttnn|none
+  coverage: existing|add_required|added|not_applicable
+  test: <exact repository-relative pytest path/node or path -k expression>|none
+  dispatch: slow|fast|none
+  reason: <end-to-end coverage evidence or why TTNN is not applicable>
 
 ## Evidence
 failing_command_or_test: ...
@@ -200,6 +236,7 @@ questions:
 ## Test Candidates
 
 - test: <path, pytest id, filter, or command>
+  suite: llk|metal|ttnn|perf
   arch: blackhole|wormhole|quasar|all
   coverage: existing|add_required|added
   reason: ...

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/issue-worker.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/issue-worker.md
@@ -60,7 +60,7 @@ On retry, also read `CHANGED_FILES` and the failure evidence named in the
 prompt:
 
 - test failure: `${LOG_DIR}/agent_tester.md` or
-  `${LOG_DIR}/agent_metal_tester.md`
+  `${LOG_DIR}/agent_metal_tester.md` or `${LOG_DIR}/agent_ttnn_tester.md`
 - performance failure: `${LOG_DIR}/agent_perf_tester.md`,
   `perf_result.json`, and its baseline/current CSVs
 - review failure: `${LOG_DIR}/review_result.json`
@@ -102,10 +102,12 @@ Treat the analysis artifact as the starting contract:
 - Re-run `coverage_search` for a sweep and account for every result.
 - Use `fix_layer` to plan API propagation. Use `verification_required`,
   `verifiable_in_llk_suite`, `llk_coverage`, and `metal_verification` to
-  confirm which suites, targets, and tests must exist.
+  confirm which suites, targets, and tests must exist. Treat
+  `ttnn_verification` as an equally executable contract; a TTNN-layer fix may
+  not be routed through Metal alone.
 - Validate `Test Candidates` against the code. Put only tt-llk suite tests in
-  the plan's reproduction and regression lists; `metal-tester.md` consumes
-  `metal_verification` from the analysis.
+  the plan's reproduction and regression lists; `metal-tester.md` and
+  `ttnn-tester.md` consume their verification blocks from the analysis.
 - Use architecture research as evidence. If a required hardware fact remains
   unknown, return `BLOCKED` with the precise research question instead of
   performing separate architecture research or guessing.
@@ -116,8 +118,8 @@ editing.
 
 If implementation evidence changes `arch_scope`, `fix_layer`,
 `verification_required`, `verifiable_in_llk_suite`, `llk_coverage`, or
-`metal_verification`, update the analysis artifact with that evidence before
-returning.
+`metal_verification`, or `ttnn_verification`, update the analysis artifact with
+that evidence before returning.
 
 ## Required Test Coverage
 
@@ -136,8 +138,17 @@ or with a test the selected pipeline cannot run.
   gtest source in `tests/tt_metal/tt_metal/llk/sources.cmake`. The test should
   launch the changed production compute/dataflow kernel or the narrowest
   production path that exposes the behavior.
-- For a TTNN change, a higher-level TTNN pytest is useful but does not replace
-  required metal coverage while this pipeline cannot execute that pytest.
+- TTNN coverage belongs in the narrowest existing pytest tree for the public
+  path: `tests/ttnn/**`, `tests/sweep_framework/**`, a model test directory, or
+  TTNN's own test tree. Add or extend a focused test that invokes the changed
+  operation/kernel and record its exact path/node ID (or tight `-k` selector)
+  in `ttnn_verification.test`. The TTNN tester builds the `ttnn` target, stages
+  the fresh build-tree extension directly, and runs this selector with a fresh
+  JIT cache.
+
+Do not use one suite as a label for another. `unit_tests_llk` does not compile
+TTNN host/Python code, while TTNN end-to-end coverage does not replace an LLK
+or Metal regression when that lower boundary can fail independently.
 
 After adding coverage, change the applicable analysis state from
 `add_required` to `added`, replace proposed paths and filters with the exact
@@ -231,7 +242,7 @@ actions:
 - ...
 
 ## Test Strategy
-# tt-llk suite only; metal verification remains in the analysis artifact
+# tt-llk suite only; Metal and TTNN verification remain in the analysis artifact
 compile_checks:
 - command or "none"
 compile_check_reason: ...  # required when compile_checks is none

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/metal-tester.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/metal-tester.md
@@ -1,15 +1,19 @@
 ---
 name: metal-tester
-description: Verify Layer-2/3/4 LLK changes with the metal `unit_tests_llk` gtest suite on ttsim or silicon.
+description: Verify CKernels, Compute-API, and Metal-runtime LLK changes with the `unit_tests_llk` gtest suite on ttsim or silicon.
 tools: Bash, Read, Write, Glob, Grep
 ---
 
 # Metal Test-Suite Tester
 
-Run `unit_tests_llk` for changes that the tt-llk Python suite cannot reach:
-CKernels API, Compute API, TTNN compute kernels, and metal LLK tests. The gtest
+Run `unit_tests_llk` for lower-layer changes that need a Metal regression:
+CKernels API, Compute API, Metal runtime, and Metal LLK tests. The gtest
 honors `TT_METAL_SIMULATOR`. Compute-API headers are JIT-compiled from
 `TT_METAL_HOME`, so every run requires a fresh `TT_METAL_CACHE`.
+
+This suite does not compile TTNN host/Python code. A TTNN-layer route uses
+`ttnn-tester.md`, optionally in addition to this suite when the lower boundary
+needs its own regression.
 
 ## Core Rules
 
@@ -51,8 +55,9 @@ Optional environment:
 - `METAL_VERIFY_BUILD_DIR`: warm build directory. Fall back to
   `CODEGEN_METAL_VERIFY_BUILD_DIR`, then `<METAL_VERIFY_HOME>/build`.
 - `HW_TEST_DISPATCH_CMD`: submit silicon execution to the shared hardware-test
-  queue after the local build passes. Applies to Blackhole/Wormhole only;
-  Quasar executes on the compute runner through Aether.
+  queue after the optimized local compile gate passes. The queue rebuilds in its
+  isolated warm workspace before card execution. Applies to Blackhole/Wormhole
+  only; Quasar executes on the compute runner through Aether.
 - `HW_TEST_SESSION`: dispatch session name.
 - `QSR_SIM_BACKEND`: Quasar Aether backend, `emu` (default) or `vcs`.
 - `QSR_EMU_SIM_PATH` / `QSR_VCS_SIM_PATH`: runner-local UMD build directories.
@@ -122,10 +127,41 @@ fi
 
 ## Step A — Build `unit_tests_llk` locally
 
-This is a gate for every backend, including queued silicon. Do not submit a
-hardware job when the build fails.
+This is the early compile gate for every backend, including queued silicon. Do
+not submit a hardware job when it fails. The queue intentionally rebuilds in an
+isolated workspace; both paths must use the narrow target and warm caches below.
 
 Pick the strategy that matches what the environment provides.
+
+Install one cleanup trap before either local strategy. It preserves the warm
+tree rollback and removes only a cache directory created by this invocation:
+
+```bash
+FRESH_CACHE=
+FRESH_CACHE_ARCH=
+cleanup_fresh_cache() {
+  local cache="${FRESH_CACHE:-}" root="${TTCACHE_ROOT:-}" cache_arch="${FRESH_CACHE_ARCH:-}"
+  [ -z "$cache" ] && return 0
+  case "$root" in
+    /*) ;;
+    *) echo "ENV_ERROR: TTCACHE_ROOT must be absolute"; return 1 ;;
+  esac
+  local expected_prefix="${root%/}/ttcache_${cache_arch}."
+  case "$cache" in
+    "$expected_prefix"*) rm -rf -- "$cache" ;;
+    *) echo "ENV_ERROR: refusing to remove unexpected cache path: $cache"; return 1 ;;
+  esac
+  FRESH_CACHE=
+  FRESH_CACHE_ARCH=
+}
+cleanup_metal_tester() {
+  cleanup_fresh_cache || true
+  if [ "${VERIFY_STRATEGY:-}" = warm ] && [ -n "${FIX_PATCH:-}" ]; then
+    git -C "$METAL_VERIFY_HOME" apply -R "$FIX_PATCH" 2>/dev/null || true
+  fi
+}
+trap cleanup_metal_tester EXIT
+```
 
 ### Strategy 1: warm tree
 
@@ -158,10 +194,16 @@ git -C "$METAL_VERIFY_HOME" apply --check "$FIX_PATCH" ||
   { echo "ENV_ERROR: fix does not apply to the verification tree base"; exit 3; }
 git -C "$METAL_VERIFY_HOME" apply "$FIX_PATCH"
 
-trap 'git -C "$METAL_VERIFY_HOME" apply -R "$FIX_PATCH" 2>/dev/null || true' EXIT
-
 # Incremental build. Fast/no-op for a pure Compute-API (JIT-side) header change; a real
 # rebuild only when host-compiled metal code changed. Build failure => COMPILE_FAILED.
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ] ||
+   ! rg -q '^ENABLE_CCACHE:BOOL=(1|ON|TRUE|YES)$' "$BUILD_DIR/CMakeCache.txt" ||
+   ! rg -q '^TT_METAL_BUILD_TESTS:BOOL=(1|ON|TRUE|YES)$' "$BUILD_DIR/CMakeCache.txt"; then
+  ./build_metal.sh --enable-ccache --build-metal-tests \
+    --build-dir "$BUILD_DIR" --configure-only 2>&1 \
+    | tee -a "$LOG_DIR/metal_build.log" \
+    || { echo "COMPILE_FAILED"; exit 2; }
+fi
 if ! cmake --build "$BUILD_DIR" --target unit_tests_llk 2>&1 | tee -a "$LOG_DIR/metal_build.log"; then
   echo "COMPILE_FAILED"; exit 2
 fi
@@ -172,13 +214,21 @@ fi
 Use when no suitable warm tree exists or the fix adds files:
 
 ```bash
+set -euo pipefail
 cd "$WORKTREE_DIR"
-export CCACHE_DIR="${CCACHE_DIR:-/localdev/$USER/ccache}"
+CACHE_USER="${USER:-$(id -un)}"
+export CCACHE_DIR="${CCACHE_DIR:-/localdev/$CACHE_USER/ccache}"
 export CCACHE_BASEDIR="$WORKTREE_DIR"
-./build_metal.sh --enable-ccache --build-metal-tests --configure-only 2>&1 \
-  | tee -a "$LOG_DIR/metal_build.log" \
-  || { echo "COMPILE_FAILED"; exit 2; }
+mkdir -p "$CCACHE_DIR" || { echo "ENV_ERROR: cannot create $CCACHE_DIR"; exit 3; }
 BUILD_DIR="$WORKTREE_DIR/build"
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ] ||
+   ! rg -q '^ENABLE_CCACHE:BOOL=(1|ON|TRUE|YES)$' "$BUILD_DIR/CMakeCache.txt" ||
+   ! rg -q '^TT_METAL_BUILD_TESTS:BOOL=(1|ON|TRUE|YES)$' "$BUILD_DIR/CMakeCache.txt"; then
+  ./build_metal.sh --enable-ccache --build-metal-tests \
+    --build-dir "$BUILD_DIR" --configure-only 2>&1 \
+    | tee -a "$LOG_DIR/metal_build.log" \
+    || { echo "COMPILE_FAILED"; exit 2; }
+fi
 cmake --build "$BUILD_DIR" --target unit_tests_llk 2>&1 \
   | tee -a "$LOG_DIR/metal_build.log" \
   || { echo "COMPILE_FAILED"; exit 2; }
@@ -189,8 +239,13 @@ VERIFY_STRATEGY=worktree
 Build only the `unit_tests_llk` target — a plain `--build-metal-tests` builds the
 whole metal test suite (~1750 targets). `CCACHE_BASEDIR` is not a storage path; it
 strips the per-run worktree prefix so a rebuild can match a previous run's cache.
+On retries in the same worktree, skip explicit configuration only when the
+CMake cache exists with `ENABLE_CCACHE` and `TT_METAL_BUILD_TESTS` enabled;
+`cmake --build` regenerates the graph automatically when CMake inputs changed.
 
-Report the strategy and build wall-time in the self-log.
+Report the strategy and local build wall-time in the self-log. After queued
+dispatch, also derive the isolated producer duration from `build_started_at` to
+`built_at` in the returned job when both timestamps exist.
 
 Before requesting hardware, confirm that the locally built binary exists and
 that the filter selects at least one test:
@@ -208,16 +263,13 @@ fi
 ## Step B — Execute on queued silicon
 
 Use this route only for Blackhole/Wormhole with `TEST_BACKEND=local` and
-`HW_TEST_DISPATCH_CMD`. Compilation remains local; the queue owns card
-scheduling and silicon execution. Quasar is excluded even when the dispatch
-command is present.
-
-The current dispatch service accepts a worktree rather than a built-artifact
-reference, so it reconstructs the executable on its runner. It also omits
-untracked files from the worktree patch. Check `git status --short`; if an
-untracked path belongs to the fix, return `ENV_ERROR` without dispatching.
-These are queue transport limitations, not replacements for the mandatory
-local build gate above.
+`HW_TEST_DISPATCH_CMD`, after the local compile gate passes. The queue rebuilds
+in its own warm workspace, then its card executor consumes that artifact. Quasar
+is excluded even when the dispatch command is present. Dispatch captures
+tracked, modified, deleted, and untracked worktree files in the submitted binary
+diff. The queue uses the same narrow `unit_tests_llk` target, a normalized
+node-local ccache, and skips explicit CMake configuration when its session
+workspace already has a valid generation.
 
 ```bash
 for arch in "${ARCHES[@]}"; do
@@ -252,6 +304,11 @@ sealed identity, and derive the suite verdict and counts from its
 `tester.md`. The strict reducer is authoritative; the marker and dispatch exit
 are supporting evidence only.
 
+A marker with `failure_stage=build` is `ENV_ERROR`: the local compile already
+passed, so a queue rebuild failure means the isolated runner could not reproduce
+that build. No structured execution result exists because the job correctly
+never reached a card.
+
 For production compatibility, do not request a protocol-v2 result copy and use
 the legacy marker:
 
@@ -259,6 +316,7 @@ the legacy marker:
 |---|---|
 | `ok=true ran=true passed=true` | `SUCCESS` |
 | `ok=false ran=true` | `TESTS_FAILED` |
+| `failure_stage=build ran=false` | `ENV_ERROR` |
 | missing, malformed, or `ran=false` | `ENV_ERROR` |
 
 If legacy counts are absent, use zero and state that the queue did not report
@@ -305,9 +363,15 @@ else
   HOME_TREE="$WORKTREE_DIR"
   BIN="$WORKTREE_DIR/build/test/tt_metal/unit_tests_llk"
 fi
-TTCACHE_ROOT="${TTCACHE_ROOT:-/localdev/$USER/ttcache}"
+CACHE_USER="${USER:-$(id -un)}"
+TTCACHE_ROOT="${TTCACHE_ROOT:-/localdev/$CACHE_USER/ttcache}"
+case "$TTCACHE_ROOT" in
+  /*) ;;
+  *) echo "ENV_ERROR: TTCACHE_ROOT must be absolute"; exit 3 ;;
+esac
 mkdir -p "$TTCACHE_ROOT"
 FRESH_CACHE="$(mktemp -d "$TTCACHE_ROOT/ttcache_${arch}.XXXXXX")"
+FRESH_CACHE_ARCH="$arch"
 env_args=( TT_METAL_HOME="$HOME_TREE" TT_METAL_CACHE="$FRESH_CACHE" )
 qsr_executed=0
 # Opt-in: verify with device-side LLK asserts + Watcher so a firing assert prints a readable
@@ -361,11 +425,14 @@ if [ "${qsr_executed:-0}" != 1 ]; then
   gtest_exit=${PIPESTATUS[0]}
 fi
 set -e
+cleanup_fresh_cache || exit 3
 done
 ```
 
-Use a new cache path that does not already exist; do not reuse or delete an
-unknown cache directory.
+Use a new cache path that does not already exist. Clean up only the exact path
+created by `mktemp`; never reuse or delete an unknown cache directory. The exit
+trap handles interruptions and `cleanup_fresh_cache` prevents accumulation
+between architectures.
 
 ## Outcome Reading
 
@@ -373,6 +440,7 @@ unknown cache directory.
 |---|---|
 | `[  PASSED  ]`, all selected tests pass, exit 0 | `SUCCESS` |
 | build/link error in Step A | `COMPILE_FAILED` |
+| queued marker has `failure_stage=build` after the local build passed | `ENV_ERROR` |
 | Watcher `LLK_ASSERT`/`ASSERT` message in the run log (only with `TT_METAL_LLK_ASSERTS=1`) | `TESTS_FAILED` |
 | `[  FAILED  ]` / data mismatch / assertion / timeout | `TESTS_FAILED` |
 | missing test source, `add_required`, or zero selected tests | `TESTS_FAILED` with `MISSING_TEST_COVERAGE` |
@@ -419,11 +487,11 @@ the single `run.json` with a nested metric patch under
 JSON-encode failure evidence; do not interpolate raw output into JSON. Do not
 write the combined architecture verdict or aggregate counts.
 
-For a multi-arch `metal` route, start and end the architecture phase using the
-operations and index defined by `tester.md`. For a `both` route, reuse the
-phase started by `tester.md` and close it after the metal result is recorded.
-Its phase result fails if either required suite fails; otherwise it passes,
-including a combined compile-only or unverifiable outcome.
+For a multi-arch route without `llk`, start the architecture phase using the
+operations and index defined by `tester.md`; otherwise reuse the phase the LLK
+tester started. If the route contains `ttnn`, leave the phase open after
+recording Metal because `ttnn-tester.md` is last. Otherwise close it after the
+Metal result. Its phase result fails if any required suite fails.
 
 Do not end an already passed phase again. A retry after failure ends the phase
 once after the applicable route completes. Do not create per-architecture

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/metal-tester.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/metal-tester.md
@@ -173,13 +173,22 @@ Use when no suitable warm tree exists or the fix adds files:
 
 ```bash
 cd "$WORKTREE_DIR"
-export CCACHE_DIR="${CCACHE_DIR:-$HOME/.codegen/ccache}"
-./build_metal.sh --enable-ccache --build-metal-tests 2>&1 | tee -a "$LOG_DIR/metal_build.log" \
+export CCACHE_DIR="${CCACHE_DIR:-/localdev/$USER/ccache}"
+export CCACHE_BASEDIR="$WORKTREE_DIR"
+./build_metal.sh --enable-ccache --build-metal-tests --configure-only 2>&1 \
+  | tee -a "$LOG_DIR/metal_build.log" \
   || { echo "COMPILE_FAILED"; exit 2; }
 BUILD_DIR="$WORKTREE_DIR/build"
+cmake --build "$BUILD_DIR" --target unit_tests_llk 2>&1 \
+  | tee -a "$LOG_DIR/metal_build.log" \
+  || { echo "COMPILE_FAILED"; exit 2; }
 BIN="$BUILD_DIR/test/tt_metal/unit_tests_llk"
 VERIFY_STRATEGY=worktree
 ```
+
+Build only the `unit_tests_llk` target — a plain `--build-metal-tests` builds the
+whole metal test suite (~1750 targets). `CCACHE_BASEDIR` is not a storage path; it
+strips the per-run worktree prefix so a rebuild can match a previous run's cache.
 
 Report the strategy and build wall-time in the self-log.
 
@@ -296,7 +305,9 @@ else
   HOME_TREE="$WORKTREE_DIR"
   BIN="$WORKTREE_DIR/build/test/tt_metal/unit_tests_llk"
 fi
-FRESH_CACHE="$(mktemp -d "$LOG_DIR/ttcache_${arch}.XXXXXX")"
+TTCACHE_ROOT="${TTCACHE_ROOT:-/localdev/$USER/ttcache}"
+mkdir -p "$TTCACHE_ROOT"
+FRESH_CACHE="$(mktemp -d "$TTCACHE_ROOT/ttcache_${arch}.XXXXXX")"
 env_args=( TT_METAL_HOME="$HOME_TREE" TT_METAL_CACHE="$FRESH_CACHE" )
 qsr_executed=0
 # Opt-in: verify with device-side LLK asserts + Watcher so a firing assert prints a readable

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/orchestrator-multi.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/orchestrator-multi.md
@@ -19,8 +19,9 @@ directly.
 
 - One run, one analyzer, one optional architecture lookup, and one shared
   worker own the complete fix.
-- `tester.md` and `metal-tester.md` each run once per stage and report all
-  requested architectures. Do not spawn one tester per architecture.
+- `tester.md`, `metal-tester.md`, and `ttnn-tester.md` each run at most once per
+  stage and report all requested architectures. Do not spawn one tester per
+  architecture.
 - Run performance once per eligible architecture, sequentially.
 - Keep progress and results under the single run's `arch_results`.
 - Preserve analyzer-owned `SKIPPED` results for out-of-scope architectures.
@@ -76,13 +77,14 @@ contract. Test selection remains per architecture inside the tester.
 
 ## Functional Verification
 
-Use the shared `VERIFY_ROUTE`:
+Use the shared canonical `VERIFY_ROUTE` and run every named suite in
+`llk` → `metal` → `ttnn` order:
 
-| Route | Multi-arch action |
+| Route membership | Multi-arch action |
 |---|---|
-| `llk` | spawn `tester.md` once |
-| `metal` | spawn `metal-tester.md` once |
-| `both` | spawn each tester once; retain both verdicts per architecture |
+| contains `llk` | spawn `tester.md` once |
+| contains `metal` | spawn `metal-tester.md` once |
+| contains `ttnn` | spawn `ttnn-tester.md` once |
 | `missing` | send one combined `MISSING_TEST_COVERAGE` retry to the shared worker |
 | `none` | call `execute_step_mark_unverifiable`; valid only when verification is not applicable |
 
@@ -93,11 +95,11 @@ architecture, update the analysis coverage states, and return `FIX_UPDATED`.
 Then bump the debug counter, rerun routing, and record changed files. Do not
 convert missing per-architecture coverage to `SKIPPED` or `none`.
 
-Both testers must skip analyzer-owned out-of-scope architectures. After
+All selected testers must skip analyzer-owned out-of-scope architectures. After
 `execute_step_mark_unverifiable`, reapply their `SKIPPED` results because the
 helper initializes every target as unverifiable.
 
-After an `llk`, `metal`, or `both` route, call:
+After all suites in the functional route finish, call:
 
 ```bash
 execute_step_combine_verification_results
@@ -108,12 +110,12 @@ For production runs, the combiner retains each tester's nested suite result and
 writes the dashboard-compatible verdict and counters to
 `arch_results.<arch>`. Audit runs instead derive every architecture, suite, and
 aggregate count from the current manifest's structured result leaves; an
-agent-authored suite summary is not reducer input. For `both`, it combines the
-suites independently for each architecture:
+agent-authored suite summary is not reducer input. It combines the suites
+independently for each architecture:
 
-- any suite failure makes that architecture fail;
-- at least one `SUCCESS` with no failure makes it successful;
-- only compile-only/unverifiable outcomes make it compiled;
+- every required suite must report a terminal, nonzero `SUCCESS` for the
+  architecture to succeed;
+- any suite failure or malformed/missing result makes that architecture fail;
 - `SKIPPED` remains excluded from the combined status.
 
 For `none`, call `execute_step_mark_unverifiable` and skip the combiner.

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/orchestrator.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/orchestrator.md
@@ -154,7 +154,7 @@ execute_step_route_verification
 execute_step_record_changed_files
 ```
 
-`execute_step_route_verification` must complete before either tester is
+`execute_step_route_verification` must complete before any tester is
 advanced or spawned. It seals the checksummed manifest and writes its current
 manifest/attempt IDs to run state. `VERIFY_ROUTE=missing` means normalization
 rejected coverage, a path, or a selector; do not execute a test command.
@@ -164,20 +164,24 @@ successful empty fix.
 
 ## 4. Functional Verification
 
-Use `VERIFY_ROUTE`:
+`VERIFY_ROUTE` is a canonical `+`-separated subset of `llk`, `metal`, and
+`ttnn`. Run every named suite, in that order:
 
-| Route | Action |
+| Route membership | Action |
 |---|---|
-| `llk` | spawn `tester.md` |
-| `metal` | spawn `metal-tester.md` |
-| `both` | run `tester.md`, then `metal-tester.md`; retain both outcomes |
+| contains `llk` | spawn `tester.md` |
+| contains `metal` | spawn `metal-tester.md` |
+| contains `ttnn` | spawn `ttnn-tester.md` |
 | `missing` | send `MISSING_TEST_COVERAGE` to the worker; do not test or review |
 | `none` | run `execute_step_mark_unverifiable`; valid only when `verification_required: no` |
+
+For example, `llk+ttnn` runs the Layer-1 and end-to-end suites, while
+`llk+metal+ttnn` runs all three. Never stop after the first successful suite.
 
 The analyzer and worker must leave every required suite at coverage
 `existing` or `added`. If routing returns `missing`, consume one debug retry:
 
-1. Call `execute_step_coverage_feedback` with the missing LLK/metal coverage
+1. Call `execute_step_coverage_feedback` with the missing LLK/Metal/TTNN coverage
    and selector evidence printed by `execute_step_route_verification`.
 2. Spawn `issue-worker.md` with
    `FAILURE_CLASS=MISSING_TEST_COVERAGE`.
@@ -194,10 +198,12 @@ source codegen/scripts/issue_solver/orchestrator_steps.sh
 execute_step_advance_tester       # pass fix_tests after a retry
 # or
 execute_step_advance_metal_test
+# or
+execute_step_advance_ttnn_test
 ```
 
-After an `llk`, `metal`, or `both` route finishes, combine its required suite
-results and then aggregate the counters:
+After every suite named by a functional route finishes, combine its required
+suite results and then aggregate the counters:
 
 ```bash
 execute_step_combine_verification_results
@@ -210,11 +216,9 @@ at `arch_results.<arch>` while preserving each tester's result under
 the current manifest's structured leaves from
 `${LOG_DIR}/verification-results/<attempt>/`. A missing, duplicate, malformed,
 foreign, zero-count, identity-mismatched, artifact-mismatched, or incomplete
-leaf cannot become `SUCCESS`. For `both`, the combined functional outcome is:
-
-- failing if either suite fails;
-- `SUCCESS` if at least one suite passes and the other is non-failing;
-- otherwise `COMPILED_ONLY` or `UNVERIFIABLE_IN_LLK_SUITE`.
+leaf cannot become `SUCCESS`. The combined functional outcome is `SUCCESS`
+only when every required suite has a terminal, nonzero, fully passing result;
+any failing or malformed required suite fails the architecture.
 
 For `none`, call `execute_step_mark_unverifiable` and skip the combiner.
 `none` means runtime verification is genuinely not applicable; it never means

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/review/addresser.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/review/addresser.md
@@ -9,8 +9,9 @@ tools: Bash, Read, Write, Edit, Glob, Grep
 Turn the review feedback on an open PR into concrete code changes, and write one
 honest disposition per thread. You are the review round's equivalent of
 `issue-worker.md`: you own the edits, nothing else. The orchestrator runs the same
-tester, metal-tester, and reviewer afterwards, on real hardware, so a change you
-make here is *proved* before it ever reaches the PR.
+LLK tester, Metal tester, TTNN tester, and reviewer afterwards as selected by
+the sealed route, on real hardware, so a change you make here is *proved*
+before it ever reaches the PR.
 
 ## Core Rules
 
@@ -51,8 +52,8 @@ Read, in this order:
 
 1. `$(sg REVIEW_INPUT)` — the reviewer-feedback document (schema below).
 2. `codegen/artifacts/issue_<ISSUE_NUMBER>_analysis.md` — the solve's analysis,
-   imported into this round. Its `metal_verification` block is what routes
-   verification.
+   imported into this round. Its LLK, `metal_verification`, and
+   `ttnn_verification` fields route verification.
 3. `codegen/artifacts/issue_<ISSUE_NUMBER>_fix_plan.md` — the solve's plan.
 4. `git -C "$WORKTREE_DIR" diff origin/main...HEAD` — what the PR currently
    proposes. This checkout **is** the PR head.
@@ -114,6 +115,10 @@ it:
 - `metal_verification.gtest_filter` — widen or replace it to select the new test.
 - `metal_verification.coverage` — `added` when you added the test.
 - `metal_verification.dispatch` — `slow` when the new fixture needs slow dispatch.
+- `ttnn_verification.test` — set the exact TTNN pytest path/node or tight `-k`
+  selector when the requested coverage belongs at the TTNN public boundary.
+- `ttnn_verification.coverage` — `added` when you added that TTNN test.
+- `ttnn_verification.dispatch` — `slow` only when the test requires slow dispatch.
 - `llk_coverage` — `added` for a new Layer-1 pytest.
 - The fix plan's `## Test Strategy` — list the new selector.
 

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/review/orchestrator.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/review/orchestrator.md
@@ -58,6 +58,7 @@ verification identical to a solve's.
 | `addresser.md` | `codegen/agents/issue-solver/review/addresser.md` |
 | `tester.md` | `codegen/agents/issue-solver/tester.md` |
 | `metal-tester.md` | `codegen/agents/issue-solver/metal-tester.md` |
+| `ttnn-tester.md` | `codegen/agents/issue-solver/ttnn-tester.md` |
 | `reviewer.md` | `codegen/agents/issue-solver/reviewer.md` |
 | `perf-tester.md` | `codegen/agents/issue-solver/perf-tester.md` |
 | the solve orchestrator | `codegen/agents/issue-solver/orchestrator.md` |

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/reviewer.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/reviewer.md
@@ -103,7 +103,8 @@ source of truth.
 3. **propagation** — an LLK signature/op/behavior change not reflected in the
    metal 4-layer stack (CKernels LLK API → Compute API → TTNN bypass includes),
    an unflagged breaking change (see `metal-integration.md`), or required
-   LLK/metal coverage that does not execute the changed production behavior.
+   LLK/Metal/TTNN coverage that does not execute the changed production
+   behavior.
 4. **parity** — an in-scope architecture is missing an equivalent required
    change. Respect the analysis `arch_scope`; do not request out-of-scope
    architecture work unless a shared API contract requires it.
@@ -119,7 +120,7 @@ Do not request additional tests merely because broader coverage would be
 useful. Do flag a blocking propagation finding when analysis marks runtime
 verification required but the claimed regression is missing, is not registered,
 duplicates the implementation instead of exercising it, or cannot be run by
-the selected LLK/metal tester. Test execution success does not prove that a
+the selected LLK, Metal, or TTNN tester. Test execution success does not prove that a
 mis-scoped test covers the changed path.
 
 ## Blocking vs Advisory

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/tester.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/tester.md
@@ -16,8 +16,9 @@ orchestrator handles changes that are not verifiable in this suite.
 - Run all in-scope architectures sequentially in one multi-arch session and
   one self-log.
 - For `TEST_BACKEND=local`, compile with `.claude/scripts/run_test.sh`. When
-  `HW_TEST_DISPATCH_CMD` is set, submit only silicon execution to the shared
-  queue; otherwise let the wrapper run on the local device.
+  `HW_TEST_DISPATCH_CMD` is set for Blackhole/Wormhole, submit after that early
+  gate; the queue repeats the producer in its isolated warm workspace and its
+  card executor runs those artifacts.
 - For `TEST_BACKEND=ttsim`, run selected pytest tests directly with the
   in-process simulator library. Do not use local, RTL-simulator, or
   compile-only flows.
@@ -148,12 +149,12 @@ For every in-scope architecture, write only the LLK suite result under
 Use `run_json_writer.py metric` with a nested JSON patch. JSON-encode
 `queue_jobs` and `obstacle`; never interpolate raw failure output. Do not write
 the combined `arch_results.<arch>.verdict` or aggregate counts. The
-orchestrator combines the required LLK and metal suite results after the route
-finishes.
+orchestrator combines every required LLK, Metal, and TTNN suite result after
+the route finishes.
 
 For multi-arch runs, use the architecture's one-based position in
 `TARGET_ARCHES_JSON` as `phase_index`. Start its dashboard phase when
-`VERIFY_ROUTE=llk|both`:
+the canonical `VERIFY_ROUTE` contains `llk`:
 
 ```bash
 python codegen/scripts/run_json_writer.py message \
@@ -184,8 +185,9 @@ python codegen/scripts/run_json_writer.py phase-end \
   --test-details "$test_details"
 ```
 
-For `VERIFY_ROUTE=both`, leave the phase open; `metal-tester.md` closes it after
-both suite results exist. Map `SUCCESS` and `COMPILED_ONLY` to
+When the route also contains `metal` or `ttnn`, leave the phase open; the last
+selected tester closes it after all suite results exist. Map `SUCCESS` and
+`COMPILED_ONLY` to
 `phase_result=passed`; map other verdicts to `failed`. Because `phase-end`
 increments `phases_completed` for a pass, do not end an already passed phase
 again. A retry after failure starts a new attempt for that phase and ends it
@@ -205,7 +207,7 @@ For a functional test:
 - for Quasar, run `subcommand=compile` as the local gate and then follow
   **Local Quasar Aether**. Never submit Quasar to the silicon queue;
 - for Blackhole/Wormhole with `HW_TEST_DISPATCH_CMD`, run
-  `subcommand=compile` as the local gate and then follow **Queued Silicon**;
+  `subcommand=compile` as the early gate and then follow **Queued Silicon**;
 - without it, use `subcommand=run` so the wrapper compiles and runs on the
   local device.
 
@@ -288,15 +290,10 @@ Record the selected `QSR_SIM_BACKEND` and no queue job ID.
 
 Use this route only for Blackhole/Wormhole with `TEST_BACKEND=local` and
 `HW_TEST_DISPATCH_CMD`, after the corresponding local compile passes. The queue
-owns card scheduling and silicon execution; do not call the wrapper's `run` or
-`simulate` subcommands. Quasar is never valid on this route.
-
-The current queue accepts a worktree and pytest selector rather than the
-locally produced artifact. Its runner repeats the producer step because
-producer artifacts are node-local, and its worktree patch omits untracked
-files. Check `git status --short`; if an untracked path belongs to the fix,
-return `ENV_ERROR` without dispatching. These are queue transport limitations;
-the issue-solver's local compile remains the gate.
+repeats the producer in an isolated warm workspace, then owns card scheduling
+and silicon execution; do not call the local wrapper's `run` or `simulate`
+subcommands. Quasar is never valid on this route. Dispatch captures tracked,
+modified, deleted, and untracked worktree files in the submitted binary diff.
 
 The queue accepts the same exact pytest node or `-k` selector sealed in the
 manifest. Pass `--k "$K_FILTER"` when present; never silently run a broader
@@ -330,10 +327,20 @@ set -e
 ```
 
 Require one final `HW_TEST_RESULT arch=<arch>` marker and record its `job`
-value. For an audit run, also require `RESULT_JSON_OUT` to contain the exact
-protocol-v2 result copied by dispatch. Validate its schema, run, attempt,
-requirement, architecture, backend, and selector against the sealed manifest;
-then derive the compatibility suite summary from its structured evidence:
+value. Treat `failure_stage=build` as `ENV_ERROR`: because the local compile
+passed, the queue runner failed to reproduce it. No structured execution result
+is expected because the producer correctly did not release its artifacts to a
+card. Any other `ran=false` marker is also `ENV_ERROR`.
+
+Record both compile durations in the self-log: the local wrapper duration and,
+when the returned job has `build_started_at` and `built_at`, the queue producer
+duration.
+
+For an audit run that reached execution, also require `RESULT_JSON_OUT` to
+contain the exact protocol-v2 result copied by dispatch. Validate its schema,
+run, attempt, requirement, architecture, backend, and selector against the
+sealed manifest; then derive the compatibility suite summary from its structured
+evidence:
 
 - `classification=success` -> `SUCCESS`;
 - `candidate_failure|coverage_error` -> `TESTS_FAILED`;
@@ -353,6 +360,7 @@ legacy marker remains authoritative:
 |---|---|
 | `ok=true ran=true passed=true` | `SUCCESS` |
 | `ok=false ran=true` | `TESTS_FAILED` |
+| `failure_stage=build ran=false` | `ENV_ERROR` |
 | missing, malformed, or `ran=false` | `ENV_ERROR` |
 
 Legacy queue markers do not provide exact counts. Record zero counts with an

--- a/tt_metal/tt-llk/codegen/agents/issue-solver/ttnn-tester.md
+++ b/tt_metal/tt-llk/codegen/agents/issue-solver/ttnn-tester.md
@@ -1,0 +1,317 @@
+---
+name: ttnn-tester
+description: Build the TTNN Python binding and run exact end-to-end pytest coverage for LLK changes propagated through TTNN.
+tools: Bash, Read, Write, Glob, Grep
+---
+
+# TTNN End-to-End Tester
+
+Use this suite only for a sealed `suite=ttnn` requirement. It verifies the
+highest affected production layer: the patched TTNN host code and Python
+binding are compiled, and the selected pytest drives the patched LLK/Compute
+API/device kernel with a fresh JIT cache.
+
+The compute build is an early compile gate. For queued Blackhole/Wormhole
+silicon, the queue independently repeats the same targeted build in its warm
+workspace; never transfer the compute build to the queue.
+
+## State and pre-flight
+
+```bash
+WT="$WORKTREE_DIR"
+cd "$WT/tt_metal/tt-llk"
+LOG_DIR="$(python codegen/scripts/state.py --worktree-dir "$WT" get LOG_DIR)"
+sg() { python codegen/scripts/state.py --log-dir "$LOG_DIR" get "$1"; }
+bg() { python codegen/scripts/state.py --worktree-dir "$WT" get "$1"; }
+mkdir -p "$LOG_DIR"
+```
+
+Read `ISSUE_NUMBER`, `RUN_MODE`, `TARGET_ARCH` or `TARGET_ARCHES_JSON`,
+`TEST_BACKEND`, `TTNN_TARGET`, `TTNN_COVERAGE`, `TTNN_TEST`,
+`TTNN_DISPATCH`, `VERIFY_ROUTE`, and `REQUIRED_VERIFICATION_MANIFEST`.
+Require:
+
+- `TTNN_TARGET=ttnn` and `TTNN_COVERAGE=existing|added`;
+- one `suite=ttnn` leaf per in-scope architecture;
+- the leaf backend to match the selected execution route;
+- the leaf selector to name an existing repository-relative `.py` file under
+  `tests/ttnn`, `tests/sweep_framework`, a model `tests` directory, or TTNN's
+  own test tree.
+
+Use the manifest selector, not prose or a broader substitute. For each leaf,
+set `CODEGEN_RUN_ID`, `CODEGEN_ATTEMPT_ID`, and
+`CODEGEN_REQUIREMENT_ID` from that leaf before queue submission. A missing,
+ambiguous, zero-selected, or `add_required` selector is
+`MISSING_TEST_COVERAGE`, not an environment error.
+
+## Step A — targeted local compile gate
+
+Build once on the compute runner before any execution. The `ttnn` target
+rebuilds only its stale transitive dependencies; it does not build the broad
+`install` target. Copy the freshly linked build-tree `_ttnn.so` into the source
+Python package so pytest cannot import a stale binding. Do not use CMake's
+`tt_pybinds` install component here: it rewrites the extension's runtime path
+toward `build/lib`, whose separately installed `_ttnncpp.so` may be stale.
+
+Use the clean warm verification tree when it is available and the candidate
+has no untracked files. Apply the candidate patch there and always reverse it
+on exit. Otherwise build the issue worktree directly. Follow the same clean
+tree/base checks as `metal-tester.md`; never apply a patch to an unrelated or
+dirty warm tree. Keep the cleanup trap active through local execution so the
+candidate is still present when TTNN JIT-compiles its device kernels.
+`TTNN_PYTHON` may point at a pre-provisioned TTNN environment; otherwise use
+the selected tree's `python_env`, then the active `python3`.
+
+```bash
+set -euo pipefail
+CACHE_USER="${USER:-$(id -un)}"
+export CCACHE_DIR="${CCACHE_DIR:-/localdev/$CACHE_USER/ccache}"
+mkdir -p "$CCACHE_DIR"
+
+HOME_TREE="$WORKTREE_DIR"
+BUILD_DIR="$WORKTREE_DIR/build"
+FIX_PATCH=
+FRESH_CACHE=
+FRESH_CACHE_ARCH=
+TEMP_TTNN_SO=
+cleanup_fresh_cache() {
+  local cache="${FRESH_CACHE:-}" root="${TTCACHE_ROOT:-}" cache_arch="${FRESH_CACHE_ARCH:-}"
+  [ -z "$cache" ] && return 0
+  case "$root" in
+    /*) ;;
+    *) echo "ENV_ERROR: TTCACHE_ROOT must be absolute"; return 1 ;;
+  esac
+  local expected_prefix="${root%/}/ttcache_${cache_arch}."
+  case "$cache" in
+    "$expected_prefix"*) rm -rf -- "$cache" ;;
+    *) echo "ENV_ERROR: refusing to remove unexpected cache path: $cache"; return 1 ;;
+  esac
+  FRESH_CACHE=
+  FRESH_CACHE_ARCH=
+}
+cleanup_ttnn_build() {
+  cleanup_fresh_cache || true
+  if [ -n "${TEMP_TTNN_SO:-}" ]; then
+    case "$TEMP_TTNN_SO" in
+      "$HOME_TREE/ttnn/ttnn/._ttnn."*) rm -f -- "$TEMP_TTNN_SO" ;;
+      *) echo "ENV_ERROR: refusing to remove unexpected staging path: $TEMP_TTNN_SO" ;;
+    esac
+  fi
+  if [ -n "${FIX_PATCH:-}" ] && [ -n "${METAL_VERIFY_HOME:-}" ]; then
+    git -C "$METAL_VERIFY_HOME" apply -R "$FIX_PATCH" 2>/dev/null || true
+  fi
+}
+trap cleanup_ttnn_build EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [ -n "${METAL_VERIFY_HOME:-${CODEGEN_METAL_VERIFY_HOME:-}}" ] &&
+   ! git -C "$WORKTREE_DIR" status --porcelain | rg -q '^\?\?'; then
+  METAL_VERIFY_HOME="${METAL_VERIFY_HOME:-$CODEGEN_METAL_VERIFY_HOME}"
+  METAL_VERIFY_BUILD_DIR="${METAL_VERIFY_BUILD_DIR:-${CODEGEN_METAL_VERIFY_BUILD_DIR:-$METAL_VERIFY_HOME/build}}"
+  [ "$(git -C "$METAL_VERIFY_HOME" rev-parse HEAD)" = "$(sg GIT_COMMIT)" ] || {
+    echo "ENV_ERROR: warm verification tree is at the wrong base"; exit 3;
+  }
+  [ -z "$(git -C "$METAL_VERIFY_HOME" status --porcelain)" ] || {
+    echo "ENV_ERROR: warm verification tree is dirty"; exit 3;
+  }
+  FIX_PATCH="$LOG_DIR/ttnn_fix.patch"
+  git -C "$WORKTREE_DIR" diff --binary "$(sg GIT_COMMIT)" -- >"$FIX_PATCH"
+  git -C "$METAL_VERIFY_HOME" apply "$FIX_PATCH"
+  HOME_TREE="$METAL_VERIFY_HOME"
+  BUILD_DIR="$METAL_VERIFY_BUILD_DIR"
+fi
+
+export CCACHE_BASEDIR="$(realpath "$HOME_TREE")"
+cd "$HOME_TREE"
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ] ||
+   ! rg -q '^ENABLE_CCACHE:BOOL=(1|ON|TRUE|YES)$' "$BUILD_DIR/CMakeCache.txt" ||
+   ! rg -q '^WITH_PYTHON_BINDINGS:BOOL=(1|ON|TRUE|YES)$' "$BUILD_DIR/CMakeCache.txt"; then
+  ./build_metal.sh --enable-ccache --build-metal-tests \
+    --build-dir "$BUILD_DIR" --configure-only \
+    2>&1 | tee -a "$LOG_DIR/ttnn_build.log"
+fi
+cmake --build "$BUILD_DIR" --target ttnn \
+  2>&1 | tee -a "$LOG_DIR/ttnn_build.log"
+BUILT_TTNN_SO="$BUILD_DIR/ttnn/_ttnn.so"
+test -s "$BUILT_TTNN_SO" || {
+  echo "COMPILE_FAILED: ttnn target produced no _ttnn.so"; exit 2;
+}
+STAGED_TTNN_SO="$HOME_TREE/ttnn/ttnn/_ttnn.so"
+TEMP_TTNN_SO="$(mktemp "$HOME_TREE/ttnn/ttnn/._ttnn.XXXXXX")"
+install -m 0755 "$BUILT_TTNN_SO" "$TEMP_TTNN_SO"
+mv -f "$TEMP_TTNN_SO" "$STAGED_TTNN_SO"
+TEMP_TTNN_SO=
+test -s "$HOME_TREE/ttnn/ttnn/_ttnn.so" || {
+  echo "COMPILE_FAILED: could not stage the fresh _ttnn.so"; exit 2;
+}
+
+TTNN_PYTHON="${TTNN_PYTHON:-$HOME_TREE/python_env/bin/python3}"
+[ -x "$TTNN_PYTHON" ] || TTNN_PYTHON="$(command -v python3)"
+env TT_METAL_HOME="$HOME_TREE" TT_METAL_RUNTIME_ROOT="$HOME_TREE" \
+  PYTHONPATH="$HOME_TREE/ttnn:$HOME_TREE:$HOME_TREE/tools${PYTHONPATH:+:$PYTHONPATH}" \
+  PYTHONDONTWRITEBYTECODE=1 "$TTNN_PYTHON" -c 'import ttnn' \
+  2>&1 | tee -a "$LOG_DIR/ttnn_build.log"
+```
+
+Because `pipefail` is set, a compiler/linker failure through `tee` remains a
+failure. Record local compile wall time separately from any queue build time.
+
+## Resolve and collect each sealed selector
+
+For each architecture, extract its exact selector from the manifest:
+
+```bash
+mapfile -t SELECTOR_PARTS < <(python - "$(sg REQUIRED_VERIFICATION_MANIFEST)" "$arch" <<'PY'
+import json, sys
+manifest = json.load(open(sys.argv[1]))
+matches = [r for r in manifest["requirements"]
+           if r["architecture"] == sys.argv[2] and r["suite"] == "ttnn"]
+if len(matches) != 1:
+    raise SystemExit(f"expected one TTNN requirement, found {len(matches)}")
+s = matches[0]["selector"]
+print(s["test_id"] or s["test"])
+print(s["k"] or "")
+print(manifest["run_id"])
+print(manifest["attempt_id"])
+print(matches[0]["requirement_id"])
+PY
+)
+TEST_SELECTOR="${SELECTOR_PARTS[0]}"
+K_FILTER="${SELECTOR_PARTS[1]}"
+export CODEGEN_RUN_ID="${SELECTOR_PARTS[2]}"
+export CODEGEN_ATTEMPT_ID="${SELECTOR_PARTS[3]}"
+export CODEGEN_REQUIREMENT_ID="${SELECTOR_PARTS[4]}"
+
+TTNN_PYTHON="${TTNN_PYTHON:-$HOME_TREE/python_env/bin/python3}"
+[ -x "$TTNN_PYTHON" ] || TTNN_PYTHON="$(command -v python3)"
+pytest_args=(--collect-only -q "$TEST_SELECTOR")
+[ -z "$K_FILTER" ] || pytest_args=(-k "$K_FILTER" "${pytest_args[@]}")
+env TT_METAL_HOME="$HOME_TREE" TT_METAL_RUNTIME_ROOT="$HOME_TREE" \
+  CHIP_ARCH="$arch" \
+  ARCH_NAME="$([ "$arch" = wormhole ] && echo wormhole_b0 || echo "$arch")" \
+  PYTHONPATH="$HOME_TREE/ttnn:$HOME_TREE:$HOME_TREE/tools${PYTHONPATH:+:$PYTHONPATH}" \
+  PYTHONDONTWRITEBYTECODE=1 \
+  "$TTNN_PYTHON" -m pytest "${pytest_args[@]}" \
+  2>&1 | tee -a "$LOG_DIR/ttnn_collect_${arch}.log"
+```
+
+Require at least one collected test before execution.
+
+## Step B — queued Blackhole/Wormhole silicon
+
+Use this route for `TEST_BACKEND=local`, Blackhole/Wormhole, and a non-empty
+`HW_TEST_DISPATCH_CMD`. The queue rebuilds `ttnn`, stages the fresh build-tree
+extension, then runs the exact pytest selector with a fresh cache.
+
+```bash
+result_args=()
+if [ "${CODEGEN_RUNNER_POOL:-prod}" = audit ]; then
+  RESULT_JSON_OUT="$LOG_DIR/verification-results/${CODEGEN_ATTEMPT_ID}/${CODEGEN_REQUIREMENT_ID}.json"
+  mkdir -p "$(dirname "$RESULT_JSON_OUT")"
+  result_args+=(--result-json-out "$RESULT_JSON_OUT")
+fi
+k_args=(); [ -z "$K_FILTER" ] || k_args+=(--k "$K_FILTER")
+set +e
+$HW_TEST_DISPATCH_CMD --kind ttnn --arch "$arch" \
+  --test "$TEST_SELECTOR" "${k_args[@]}" \
+  --dispatch "${TTNN_DISPATCH:-fast}" \
+  --worktree "$WORKTREE_DIR" --base "$(sg GIT_COMMIT)" \
+  --session "${HW_TEST_SESSION:-issue-$(sg ISSUE_NUMBER)}-${arch}" \
+  "${result_args[@]}" --timeout "${TIMEOUT:-1800}" \
+  2>&1 | tee -a "$LOG_DIR/ttnn_run_${arch}.log"
+dispatch_exit=${PIPESTATUS[0]}
+set -e
+```
+
+Require exactly one final `HW_TEST_RESULT` marker for the architecture. A
+`failure_stage=build` after Step A passed is `ENV_ERROR`, because the isolated
+queue could not reproduce the compute build. A completed non-passing pytest is
+`TESTS_FAILED`. For audit jobs, the protocol-v2 result and strict reducer are
+authoritative.
+
+## Step C — local ttsim, silicon, or Quasar Aether
+
+Use this when the queue route does not apply. Create a new cache directory per
+architecture and remove only that exact directory afterward. Run from
+`HOME_TREE` with the freshly installed binding:
+
+```bash
+CACHE_USER="${USER:-$(id -un)}"
+TTCACHE_ROOT="${TTCACHE_ROOT:-/localdev/$CACHE_USER/ttcache}"
+case "$TTCACHE_ROOT" in
+  /*) ;;
+  *) echo "ENV_ERROR: TTCACHE_ROOT must be absolute"; exit 3 ;;
+esac
+mkdir -p "$TTCACHE_ROOT"
+FRESH_CACHE="$(mktemp -d "$TTCACHE_ROOT/ttcache_${arch}.XXXXXX")"
+FRESH_CACHE_ARCH="$arch"
+TTNN_PYTHON="${TTNN_PYTHON:-$HOME_TREE/python_env/bin/python3}"
+[ -x "$TTNN_PYTHON" ] || TTNN_PYTHON="$(command -v python3)"
+pytest_args=(-x "$TEST_SELECTOR" --junitxml "$LOG_DIR/ttnn_${arch}.xml")
+[ -z "$K_FILTER" ] || pytest_args=(-x -k "$K_FILTER" "$TEST_SELECTOR" --junitxml "$LOG_DIR/ttnn_${arch}.xml")
+env_args=(
+  TT_METAL_HOME="$HOME_TREE"
+  TT_METAL_RUNTIME_ROOT="$HOME_TREE"
+  TT_METAL_CACHE="$FRESH_CACHE"
+  CHIP_ARCH="$arch"
+  ARCH_NAME="$([ "$arch" = wormhole ] && echo wormhole_b0 || echo "$arch")"
+  PYTHONPATH="$HOME_TREE/ttnn:$HOME_TREE:$HOME_TREE/tools${PYTHONPATH:+:$PYTHONPATH}"
+  PYTHONDONTWRITEBYTECODE=1
+)
+[ "${TTNN_DISPATCH:-fast}" = slow ] && env_args+=(TT_METAL_SLOW_DISPATCH_MODE=1)
+```
+
+For ttsim, add the architecture's `TTSIM_SO_PATH`/`TTSIM_SO_PATHS` value as
+`TT_METAL_SIMULATOR` and force slow dispatch. For Quasar local execution, use
+the shared Aether wrapper's explicit-command mode:
+
+```bash
+bash "$WORKTREE_DIR/tt_metal/tt-llk/.claude/scripts/run_qsr_metal_test.sh" \
+  --tt-metal-home "$HOME_TREE" --cache "$FRESH_CACHE" \
+  --log-dir "$LOG_DIR" --timeout "${TIMEOUT:-1200}" -- \
+  env "${env_args[@]}" "$TTNN_PYTHON" -m pytest "${pytest_args[@]}"
+```
+
+Otherwise run
+`env "${env_args[@]}" "$TTNN_PYTHON" -m pytest "${pytest_args[@]}"`.
+Always remove `FRESH_CACHE` after the command, including after failure or
+interruption. Derive selected/executed/passed counts from the JUnit report; an
+exit-zero run with zero selected or zero executed tests is not success.
+
+## Result recording
+
+For multi-arch runs, if neither `llk` nor `metal` is in `VERIFY_ROUTE`, start
+the architecture phase using the operations and one-based index defined by
+`tester.md`. Otherwise reuse the open phase. TTNN is always the last functional
+suite in canonical route order, so close the phase after recording its result;
+the phase fails if any required suite failed.
+
+For every in-scope architecture write only
+`arch_results.<arch>.suite_results.ttnn`:
+
+```json
+{
+  "status": "done",
+  "verdict": "SUCCESS|COMPILE_FAILED|TESTS_FAILED|SIM_ISA_GAP|ENV_ERROR",
+  "tests_total": 1,
+  "tests_passed": 1,
+  "queue_jobs": [],
+  "obstacle": null
+}
+```
+
+Use `run_json_writer.py metric` with JSON-encoded values. Do not write the
+combined architecture verdict. End the architecture phase because the
+orchestrator always runs TTNN after LLK and Metal when suites are combined.
+
+Write `${LOG_DIR}/agent_ttnn_tester.md` with the target, selector, build
+strategy, local compile duration, queue producer duration when reported,
+execution route, counts, queue job IDs, and exact failure evidence.
+
+Return:
+
+```text
+TTNN_TEST_RESULT - issue #<number> (ttnn pytest, <backend>)
+<per-architecture verdict/count summary>
+```

--- a/tt_metal/tt-llk/codegen/scripts/issue_solver/orchestrator_steps.sh
+++ b/tt_metal/tt-llk/codegen/scripts/issue_solver/orchestrator_steps.sh
@@ -75,7 +75,8 @@ _PIPELINE_STEPS_MULTI='[
   {"id":"arch_lookup","name":"Research","desc":"Look up architecture facts only when needed"},
   {"id":"writer","name":"Fix","desc":"Plan and implement one coordinated multi-arch fix"},
   {"id":"tester","name":"Test","desc":"Run the tt-llk Layer-1 suite for each target arch"},
-  {"id":"metal_test","name":"Metal Test","desc":"Build+run the unit_tests_llk gtest suite for Layer-2/3/4 changes (same backend)"},
+  {"id":"metal_test","name":"Metal Test","desc":"Build+run unit_tests_llk for CKernels, Compute-API, and Metal-runtime coverage"},
+  {"id":"ttnn_test","name":"TTNN Test","desc":"Build the TTNN Python target and run exact end-to-end pytest coverage"},
   {"id":"review","name":"Review","desc":"Senior LLK review of the shared fix diff (loop, no PR)"},
   {"id":"perf","name":"Perf","desc":"Measure cycle counts vs baseline per BH/WH arch (local only)"},
   {"id":"fix_tests","name":"Retry","desc":"Debug and update the shared fix after a test, review, or perf failure"}
@@ -85,7 +86,8 @@ _PIPELINE_STEPS_SINGLE='[
   {"id":"arch_lookup","name":"Research","desc":"Look up architecture facts only when needed"},
   {"id":"writer","name":"Fix","desc":"Plan and implement the smallest fix"},
   {"id":"tester","name":"Test","desc":"Run the tt-llk Layer-1 suite"},
-  {"id":"metal_test","name":"Metal Test","desc":"Build+run the unit_tests_llk gtest for Layer-2/3/4 changes (same backend)"},
+  {"id":"metal_test","name":"Metal Test","desc":"Build+run unit_tests_llk for CKernels, Compute-API, and Metal-runtime coverage"},
+  {"id":"ttnn_test","name":"TTNN Test","desc":"Build the TTNN Python target and run exact end-to-end pytest coverage"},
   {"id":"review","name":"Review","desc":"Senior LLK review of the fix diff (loop, no PR)"},
   {"id":"perf","name":"Perf","desc":"Measure cycle counts vs baseline (BH/WH local only)"},
   {"id":"fix_tests","name":"Retry","desc":"Debug and update the fix after a test, review, or perf failure"}
@@ -95,7 +97,8 @@ _PIPELINE_STEPS_SINGLE='[
 _PIPELINE_STEPS_REVIEW='[
   {"id":"addresser","name":"Address","desc":"Turn the PR review feedback into code changes"},
   {"id":"tester","name":"Test","desc":"Run the tt-llk Layer-1 suite"},
-  {"id":"metal_test","name":"Metal Test","desc":"Build+run the unit_tests_llk gtest for Layer-2/3/4 changes"},
+  {"id":"metal_test","name":"Metal Test","desc":"Build+run unit_tests_llk for CKernels, Compute-API, and Metal-runtime coverage"},
+  {"id":"ttnn_test","name":"TTNN Test","desc":"Build the TTNN Python target and run exact end-to-end pytest coverage"},
   {"id":"review","name":"Review","desc":"Senior LLK review of the updated diff (loop, no PR)"},
   {"id":"perf","name":"Perf","desc":"Measure cycle counts only when a disposition asks for it"},
   {"id":"fix_tests","name":"Retry","desc":"Debug and update the review fix after a test or review failure"}
@@ -810,7 +813,8 @@ execute_step_route_verification() {
     P="codegen/artifacts/issue_${num}_fix_plan.md"
     M="$_L/required_verification_manifest.json"
     local FIX_LAYER VERIFY_REQUIRED VERIFIABLE LLK_COVERAGE
-    local METAL_TARGET METAL_COVERAGE METAL_FILTER METAL_DISPATCH ROUTE out
+    local METAL_TARGET METAL_COVERAGE METAL_FILTER METAL_DISPATCH
+    local TTNN_TARGET TTNN_COVERAGE TTNN_TEST TTNN_DISPATCH ROUTE out
     gval() {
         grep -ioE "$1:[[:space:]]*[A-Za-z_]+" "$A" 2>/dev/null |
             head -1 | sed -E "s/.*:[[:space:]]*//" || true
@@ -832,6 +836,15 @@ execute_step_route_verification() {
             head -1 | sed -E "s/^[[:space:]]*gtest_filter:[[:space:]]*//; s/^['\"]//; s/['\"]$//" || true
     )"
     METAL_DISPATCH="$(mval 'dispatch')"
+    tval() {
+        sed -n '/^ttnn_verification:/,/^## /p' "$A" 2>/dev/null |
+            grep -ioE "^[[:space:]]*$1:[[:space:]]*[^#]+" |
+            head -1 | sed -E "s/^[[:space:]]*$1:[[:space:]]*//; s/[[:space:]]+$//; s/^['\"]//; s/['\"]$//" || true
+    }
+    TTNN_TARGET="$(tval 'target')"
+    TTNN_COVERAGE="$(tval 'coverage')"
+    TTNN_TEST="$(tval 'test')"
+    TTNN_DISPATCH="$(tval 'dispatch')"
 
     ss FIX_LAYER      "$FIX_LAYER"
     ss VERIFIABLE_IN_LLK "$VERIFIABLE"
@@ -840,6 +853,10 @@ execute_step_route_verification() {
     ss METAL_COVERAGE "$METAL_COVERAGE"
     ss METAL_FILTER   "$METAL_FILTER"
     ss METAL_DISPATCH "$METAL_DISPATCH"
+    ss TTNN_TARGET    "$TTNN_TARGET"
+    ss TTNN_COVERAGE  "$TTNN_COVERAGE"
+    ss TTNN_TEST      "$TTNN_TEST"
+    ss TTNN_DISPATCH  "$TTNN_DISPATCH"
 
     local -a manifest_args=(
         required-verification
@@ -884,8 +901,8 @@ execute_step_route_verification() {
 import json, sys
 d = json.load(open(sys.argv[1]))
 suites = {r["suite"] for r in d["requirements"]}
-functional = suites & {"llk", "metal"}
-route = "both" if functional == {"llk", "metal"} else next(iter(functional), "none")
+functional = [suite for suite in ("llk", "metal", "ttnn") if suite in suites]
+route = "+".join(functional) or "none"
 print(route, d["attempt_id"], d["manifest_id"], len(d["requirements"]))
 PY
 )"
@@ -893,7 +910,7 @@ PY
     [ -n "$VERIFY_REQUIRED" ] || {
         if [ "$ROUTE" = none ]; then VERIFY_REQUIRED=no; else VERIFY_REQUIRED=yes; fi
     }
-    if [ -z "$LLK_COVERAGE" ] && { [ "$ROUTE" = llk ] || [ "$ROUTE" = both ]; }; then
+    if [ -z "$LLK_COVERAGE" ] && [[ "+$ROUTE+" == *"+llk+"* ]]; then
         LLK_COVERAGE=existing
         ss LLK_COVERAGE "$LLK_COVERAGE"
     fi
@@ -989,17 +1006,38 @@ execute_step_advance_tester() {
 # ===========================================================================
 execute_step_advance_metal_test() {
     local _L; _L="$(_LOG)"
-    local num mode arches route filt; num="$(sg ISSUE_NUMBER)"; mode="$(sg RUN_MODE)"
+    local num mode arches route filt agent; num="$(sg ISSUE_NUMBER)"; mode="$(sg RUN_MODE)"
     arches="$(sg TARGET_ARCHES_JSON)"; route="$(sg VERIFY_ROUTE)"; filt="$(sg METAL_FILTER)"
+    agent="${1:-writer}"
+    [[ "+$route+" == *"+llk+"* ]] && agent=tester
     local scope="issue #${num}"; [ "$mode" = multi ] && scope="issue #${num} across ${arches}"
     rj advance --new-step "metal_test" \
         --new-message "Building+running unit_tests_llk (${filt}) for ${scope}" \
-        --prev-result "success" --prev-message "${route:-metal} route" --agent "writer"
+        --prev-result "success" --prev-message "${route:-metal} route" --agent "$agent"
+}
+
+# ===========================================================================
+# Step 4c — advance to end-to-end TTNN pytest verification.
+# ===========================================================================
+execute_step_advance_ttnn_test() {
+    local _L; _L="$(_LOG)"
+    local num mode arches route test agent; num="$(sg ISSUE_NUMBER)"; mode="$(sg RUN_MODE)"
+    arches="$(sg TARGET_ARCHES_JSON)"; route="$(sg VERIFY_ROUTE)"; test="$(sg TTNN_TEST)"
+    agent="${1:-writer}"
+    if [[ "+$route+" == *"+metal+"* ]]; then
+        agent=metal_test
+    elif [[ "+$route+" == *"+llk+"* ]]; then
+        agent=tester
+    fi
+    local scope="issue #${num}"; [ "$mode" = multi ] && scope="issue #${num} across ${arches}"
+    rj advance --new-step "ttnn_test" \
+        --new-message "Building TTNN + running ${test} for ${scope}" \
+        --prev-result "success" --prev-message "${route:-ttnn} route" --agent "$agent"
 }
 
 # ===========================================================================
 # Step 4 — combine the required suite results for each architecture. Testers
-# write only arch_results.<arch>.suite_results.<llk|metal>; this function owns
+# write only arch_results.<arch>.suite_results.<llk|metal|ttnn>; this function owns
 # the compatibility verdict/count fields consumed by final status and the
 # dashboard. Missing or unknown required results fail closed as ENV_ERROR.
 # ===========================================================================
@@ -1008,7 +1046,7 @@ execute_step_combine_verification_results() {
     local route arches patch pool manifest
     route="$(sg VERIFY_ROUTE)"
     arches="$(sg TARGET_ARCHES_JSON)"
-    case "$route" in llk|metal|both) ;; *) echo "cannot combine VERIFY_ROUTE=$route" >&2; return 1 ;; esac
+    case "$route" in none|missing|"") echo "cannot combine VERIFY_ROUTE=$route" >&2; return 1 ;; esac
 
     pool="$(python - "$_L/run.json" <<'PY'
 import json, sys
@@ -1040,7 +1078,13 @@ with open(run_path) as f:
     run = json.load(f)
 
 arches = json.loads(arches_json)
-required = {"llk": ("llk",), "metal": ("metal",), "both": ("llk", "metal")}[route]
+required = tuple(route.split("+"))
+if (
+    not required
+    or len(set(required)) != len(required)
+    or any(suite not in {"llk", "metal", "ttnn"} for suite in required)
+):
+    raise ValueError(f"invalid functional verification route: {route}")
 failure_priority = ("ENV_ERROR", "COMPILE_FAILED", "TESTS_FAILED", "SIM_ISA_GAP")
 existing = run.get("arch_results") or {}
 updates = {}
@@ -1226,13 +1270,21 @@ execute_step_bump_perf()   { local _L; _L="$(_LOG)"; ss PERF_RETRIES "$(( $(sg P
 # ===========================================================================
 execute_step_advance_review() {
     local _L; _L="$(_LOG)"
-    local num mode arches rr mrr; num="$(sg ISSUE_NUMBER)"; mode="$(sg RUN_MODE)"
+    local num mode arches rr mrr route agent; num="$(sg ISSUE_NUMBER)"; mode="$(sg RUN_MODE)"
     arches="$(sg TARGET_ARCHES_JSON)"; rr="$(sg REVIEW_RETRIES)"; mrr="$(sg MAX_REVIEW_RETRIES)"
+    route="$(sg VERIFY_ROUTE)"; agent=writer
+    if [[ "+$route+" == *"+ttnn+"* ]]; then
+        agent=ttnn_test
+    elif [[ "+$route+" == *"+metal+"* ]]; then
+        agent=metal_test
+    elif [[ "+$route+" == *"+llk+"* ]]; then
+        agent=tester
+    fi
     local what="fix diff for issue #${num}"
     [ "$mode" = multi ] && what="shared fix diff for issue #${num} across ${arches}"
     rj advance --new-step "review" \
         --new-message "Reviewing ${what} (attempt $((rr+1))/$((mrr+1)))" \
-        --prev-result "success" --prev-message "Functional tests passed" --agent "tester"
+        --prev-result "success" --prev-message "Functional tests passed" --agent "$agent"
 }
 
 # ===========================================================================
@@ -1629,6 +1681,7 @@ for agent, filename in [
     ("writer", "agent_issue_worker.md"),
     ("tester", "agent_tester.md"),
     ("metal_test", "agent_metal_tester.md"),
+    ("ttnn_test", "agent_ttnn_tester.md"),
     ("reviewer", "agent_reviewer.md"),
     ("perf", "agent_perf_tester.md"),
     ("fix_tests", "agent_issue_worker_debug.md"),

--- a/tt_metal/tt-llk/codegen/scripts/issue_solver/test_review_steps.py
+++ b/tt_metal/tt-llk/codegen/scripts/issue_solver/test_review_steps.py
@@ -10,7 +10,7 @@ Covers the two helpers a review round cannot be correct without:
     verification route from the solve that produced the PR. Getting that wrong means
     verifying the wrong thing on the wrong hardware.
 * ``execute_step_route_verification`` — the executable route is derived from a
-  checksummed manifest before either tester can start.
+  checksummed manifest before any tester can start.
 * ``execute_step_record_review_dispositions`` — the gate that stops a reply the
   addresser never actually thought about from reaching a reviewer.
 * ``execute_step_combine_verification_results`` — the deterministic backstop
@@ -264,7 +264,7 @@ def test_setup_review_run_requires_the_analysis_artifact(
 
 
 # ── execute_step_route_verification ──────────────────────────────────────────
-def _route_case(tmp_path, worktree, *, missing_test=False):
+def _route_case(tmp_path, worktree, *, missing_test=False, include_ttnn=False):
     log_dir = tmp_path / "route-log"
     log_dir.mkdir()
     state = {
@@ -294,9 +294,29 @@ def _route_case(tmp_path, worktree, *, missing_test=False):
     metal = worktree / "tests" / "tt_metal" / "tt_metal" / "llk"
     metal.mkdir(parents=True)
     (metal / "test_reduce.cpp").write_text("// test\n")
+    ttnn = worktree / "tests" / "ttnn" / "unit_tests" / "operations"
+    ttnn.mkdir(parents=True)
+    (ttnn / "test_reduce.py").write_text("def test_reduce(): pass\n")
     artifacts = llk / "codegen" / "artifacts"
-    (artifacts / "issue_36142_analysis.md").write_text(
+    ttnn_verification = (
         """\
+ttnn_verification:
+  target: ttnn
+  coverage: existing
+  test: tests/ttnn/unit_tests/operations/test_reduce.py::test_reduce
+  dispatch: fast
+"""
+        if include_ttnn
+        else """\
+ttnn_verification:
+  target: none
+  coverage: not_applicable
+  test: none
+  dispatch: none
+"""
+    )
+    (artifacts / "issue_36142_analysis.md").write_text(
+        f"""\
 ## Scope
 arch_scope:
   blackhole: in_scope
@@ -311,7 +331,7 @@ metal_verification:
   test_file: tests/tt_metal/tt_metal/llk/test_reduce.cpp
   gtest_filter: LLKFixture.Reduce
   dispatch: fast
-""",
+{ttnn_verification}""",
         encoding="utf-8",
     )
     selected_test = "test_missing.py" if missing_test else "test_reduce.py::test_reduce"
@@ -329,7 +349,7 @@ def test_route_seals_manifest_before_a_tester_can_start(tmp_path, worktree):
     state = json.loads((log_dir / "state.json").read_text())
     manifest_path = Path(state["REQUIRED_VERIFICATION_MANIFEST"])
     manifest = json.loads(manifest_path.read_text())
-    assert state["VERIFY_ROUTE"] == "both"
+    assert state["VERIFY_ROUTE"] == "llk+metal"
     assert state["REQUIRED_VERIFICATION_MANIFEST_ID"] == manifest["manifest_id"]
     assert state["REQUIRED_VERIFICATION_ATTEMPT_ID"] == "attempt-001"
     assert {item["suite"] for item in manifest["requirements"]} == {"llk", "metal"}
@@ -349,6 +369,22 @@ def test_route_rejects_a_missing_selector_before_execution(tmp_path, worktree):
     assert not (log_dir / "required_verification_manifest.json").exists()
 
 
+def test_route_extracts_and_seals_ttnn_state(tmp_path, worktree):
+    result, log_dir = _route_case(tmp_path, worktree, include_ttnn=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    state = json.loads((log_dir / "state.json").read_text())
+    assert state["VERIFY_ROUTE"] == "llk+metal+ttnn"
+    assert state["TTNN_TARGET"] == "ttnn"
+    assert state["TTNN_COVERAGE"] == "existing"
+    assert state["TTNN_TEST"].endswith("test_reduce.py::test_reduce")
+    manifest = json.loads(Path(state["REQUIRED_VERIFICATION_MANIFEST"]).read_text())
+    assert [item["suite"] for item in manifest["requirements"]] == [
+        "llk",
+        "metal",
+        "ttnn",
+    ]
+
+
 # ── execute_step_combine_verification_results ────────────────────────────────
 def _combine_case(tmp_path, worktree, suite_results, route="llk", audit=False):
     log_dir = tmp_path / "combine-log"
@@ -359,7 +395,7 @@ def _combine_case(tmp_path, worktree, suite_results, route="llk", audit=False):
         "TARGET_ARCHES_JSON": ["blackhole"],
     }
     if audit:
-        suites = ("llk", "metal") if route == "both" else (route,)
+        suites = tuple(route.split("+"))
         requirements = [
             {
                 "requirement_id": f"blackhole:{suite}:1",
@@ -508,7 +544,7 @@ def test_combine_requires_every_suite_to_succeed(tmp_path, worktree):
                 "tests_passed": 0,
             },
         },
-        route="both",
+        route="llk+metal",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     combined = run["arch_results"]["blackhole"]

--- a/tt_metal/tt-llk/codegen/scripts/run_json_writer.py
+++ b/tt_metal/tt-llk/codegen/scripts/run_json_writer.py
@@ -758,6 +758,59 @@ _VERIFICATION_ARCHES = {"blackhole", "wormhole", "quasar"}
 _COVERED_STATES = {"existing", "added"}
 
 
+def _candidate_changed_paths(worktree: Path, base: str) -> set[str]:
+    """Return tracked and untracked candidate paths when ``worktree`` is Git.
+
+    Historical/unit fixtures may be plain directories, so absence of a Git
+    worktree means there is no additional path-derived routing signal. A real
+    worktree with an invalid base or unreadable diff fails closed.
+    """
+    probe = subprocess.run(
+        ["git", "-C", str(worktree), "rev-parse", "--is-inside-work-tree"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if probe.returncode != 0 or probe.stdout.strip() != "true":
+        return set()
+    diff = subprocess.run(
+        ["git", "-C", str(worktree), "diff", "--name-only", base, "--"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    untracked = subprocess.run(
+        ["git", "-C", str(worktree), "ls-files", "--others", "--exclude-standard"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if diff.returncode != 0 or untracked.returncode != 0:
+        detail = (
+            diff.stderr or untracked.stderr or "cannot inspect candidate diff"
+        ).strip()
+        raise ValueError(
+            f"cannot derive verification route from candidate paths: {detail}"
+        )
+    return {
+        value
+        for value in (*diff.stdout.splitlines(), *untracked.stdout.splitlines())
+        if value
+    }
+
+
+def _is_ttnn_candidate_path(path: str) -> bool:
+    return (
+        path.startswith("ttnn/")
+        or path.startswith("tests/ttnn/")
+        or path.startswith("tests/sweep_framework/")
+        or (path.startswith("models/") and "/tests/" in path)
+    )
+
+
 def _markdown_section(text: str, heading: str) -> str:
     """Return one exact level-two Markdown section without parsing prose."""
     match = re.search(
@@ -910,6 +963,54 @@ def _is_llk_pytest_selector(raw: str) -> bool:
         or target.startswith("tests/python_tests/")
         or target.startswith("ai_gen/")
     )
+
+
+def _normalize_ttnn_pytest_selector(raw: str, worktree: Path) -> dict[str, str | None]:
+    """Normalize one exact repository-level TTNN pytest selector."""
+    value = _markdown_value(raw)
+    try:
+        tokens = shlex.split(value)
+    except ValueError as exc:
+        raise ValueError(f"invalid TTNN pytest selector {raw!r}: {exc}") from exc
+    if len(tokens) == 3 and tokens[1] == "-k" and tokens[2]:
+        target, k_filter = tokens[0], tokens[2]
+    elif len(tokens) == 1:
+        target, k_filter = tokens[0], None
+    else:
+        raise ValueError(
+            "TTNN pytest selector must be an exact path/id or "
+            f"'path -k expression': {raw!r}"
+        )
+    if "::" in target:
+        test_path, node = target.split("::", 1)
+        if not node:
+            raise ValueError(f"TTNN pytest selector has an empty node id: {raw!r}")
+    else:
+        test_path, node = target, None
+    test_path = test_path.removeprefix("./")
+    relative = Path(test_path)
+    allowed = (
+        test_path.startswith("tests/ttnn/")
+        or test_path.startswith("tests/sweep_framework/")
+        or (test_path.startswith("models/") and "/tests/" in test_path)
+        or (test_path.startswith("ttnn/") and "/test" in test_path)
+    )
+    if (
+        not allowed
+        or relative.is_absolute()
+        or ".." in relative.parts
+        or relative.suffix != ".py"
+    ):
+        raise ValueError(f"pytest selector is outside the TTNN suite: {raw!r}")
+    actual = worktree / relative
+    if not actual.is_file():
+        raise ValueError(f"TTNN pytest selector names a missing file: {actual}")
+    test = relative.as_posix()
+    return {
+        "test": test,
+        "test_id": f"{test}::{node}" if node else None,
+        "k": k_filter,
+    }
 
 
 def _verification_backend(backend: str, arch: str) -> str:
@@ -1191,7 +1292,7 @@ def _load_required_manifest(path: Path) -> dict[str, Any]:
         identities.add(identity)
         if requirement["architecture"] not in _VERIFICATION_ARCHES:
             raise ValueError("required-verification architecture is invalid")
-        if requirement["suite"] not in {"llk", "metal", "perf"}:
+        if requirement["suite"] not in {"llk", "metal", "ttnn", "perf"}:
             raise ValueError("required-verification suite is invalid")
         if requirement["backend"] not in {"silicon", "ttsim", "quasar", "local"}:
             raise ValueError("required-verification backend is invalid")
@@ -1312,6 +1413,7 @@ def cmd_required_verification(args: argparse.Namespace) -> None:
     plan_tests = _markdown_items(strategy, {"reproduction_tests", "regression_tests"})
 
     verify_required = _markdown_scalar(verification, "verification_required")
+    fix_layer = _markdown_scalar(verification, "fix_layer")
     verifiable = _markdown_scalar(verification, "verifiable_in_llk_suite")
     llk_coverage = _markdown_scalar(verification, "llk_coverage")
     metal_match = re.search(
@@ -1324,6 +1426,15 @@ def cmd_required_verification(args: argparse.Namespace) -> None:
     metal_test_file = _markdown_scalar(metal, "test_file")
     metal_filter = _markdown_scalar(metal, "gtest_filter")
     metal_dispatch = _markdown_scalar(metal, "dispatch")
+    ttnn_match = re.search(
+        r"(?ms)^ttnn_verification[ \t]*:[^\n]*\n(.*?)(?=^[^ \t\n]|\Z)",
+        verification,
+    )
+    ttnn = ttnn_match.group(1) if ttnn_match else ""
+    ttnn_target = _markdown_scalar(ttnn, "target")
+    ttnn_coverage = _markdown_scalar(ttnn, "coverage")
+    ttnn_test = _markdown_scalar(ttnn, "test")
+    ttnn_dispatch = _markdown_scalar(ttnn, "dispatch")
 
     applicable_candidates = [
         item
@@ -1351,18 +1462,21 @@ def cmd_required_verification(args: argparse.Namespace) -> None:
         for item in plan_tests
         if item.get("test") and not _is_performance_selector(item["test"])
     ]
+    llk_plan = [
+        item for item in functional_plan if _is_llk_pytest_selector(item["test"])
+    ]
     performance_plan = [
         item
         for item in plan_tests
         if item.get("test") and _is_performance_selector(item["test"])
     ]
-    if not llk_applicable and verify_required != "no" and functional_plan:
+    if not llk_applicable and verify_required != "no" and llk_plan:
         llk_applicable = True
     if llk_applicable and not llk_coverage:
-        plan_states = {item.get("coverage", "") for item in functional_plan}
+        plan_states = {item.get("coverage", "") for item in llk_plan}
         if "add_required" in plan_states:
             llk_coverage = "add_required"
-        elif functional_plan and plan_states <= {"", *_COVERED_STATES}:
+        elif llk_plan and plan_states <= {"", *_COVERED_STATES}:
             llk_coverage = "existing"
     if args.performance_only:
         llk_applicable = False
@@ -1410,7 +1524,7 @@ def cmd_required_verification(args: argparse.Namespace) -> None:
         return requirement
 
     if llk_applicable:
-        source_items = functional_plan or applicable_candidates
+        source_items = llk_plan or applicable_candidates
         for arch in arches:
             selected = [
                 item
@@ -1452,17 +1566,54 @@ def cmd_required_verification(args: argparse.Namespace) -> None:
                 _verification_backend(args.backend, arch),
                 {"test": metal_filter, "test_id": None, "k": None},
             )
-    elif (
+    ttnn_applicable = not args.performance_only and ttnn_target not in {"", "none"}
+    if ttnn_applicable:
+        if ttnn_target != "ttnn" or ttnn_coverage not in _COVERED_STATES:
+            raise ValueError("TTNN verification target/coverage is not executable")
+        if ttnn_dispatch not in {"slow", "fast"}:
+            raise ValueError("TTNN verification dispatch must be slow|fast")
+        selector = _normalize_ttnn_pytest_selector(ttnn_test, worktree)
+        for arch in arches:
+            add_requirement(
+                arch,
+                "ttnn",
+                _verification_backend(args.backend, arch),
+                selector,
+            )
+
+    if (
+        not args.performance_only
+        and verify_required == "yes"
+        and fix_layer == "ttnn"
+        and not ttnn_applicable
+    ):
+        raise ValueError("a TTNN-layer fix requires executable TTNN verification")
+
+    changed_ttnn_paths = sorted(
+        path
+        for path in _candidate_changed_paths(worktree, args.expected_base_sha)
+        if _is_ttnn_candidate_path(path)
+    )
+    if (
+        not args.performance_only
+        and verify_required == "yes"
+        and changed_ttnn_paths
+        and not ttnn_applicable
+    ):
+        raise ValueError(
+            "TTNN source/test changes require executable TTNN verification: "
+            + ", ".join(changed_ttnn_paths[:5])
+        )
+
+    if (
         not args.performance_only
         and verifiable in {"no", "partial"}
         and verify_required == "yes"
+        and not (metal_applicable or ttnn_applicable)
     ):
-        if not llk_applicable:
-            raise ValueError(
-                "required Metal route has no executable verification section"
-            )
-        if verifiable == "partial":
-            raise ValueError("partial verification route is missing its Metal section")
+        raise ValueError(
+            "required integration route has no executable Metal or TTNN section"
+        )
 
     for arch in arches:
         selected = [
@@ -1691,8 +1842,8 @@ def cmd_required_verification(args: argparse.Namespace) -> None:
     _atomic_write(revisions, doc, destination=revision_path)
     _atomic_write(output.parent, doc, destination=output)
     suites = {item["suite"] for item in requirements}
-    functional = suites & {"llk", "metal"}
-    route = "both" if functional == {"llk", "metal"} else next(iter(functional), "none")
+    functional = [suite for suite in ("llk", "metal", "ttnn") if suite in suites]
+    route = "+".join(functional) or "none"
     print(
         f"required-verification: route={route} revision={revision} "
         f"attempt_id={doc['attempt_id']} manifest_id={doc['manifest_id']} "
@@ -2343,7 +2494,7 @@ def _load_verification_reduction(path: Path) -> dict[str, Any]:
         if (
             not isinstance(leaf["architecture"], str)
             or not leaf["architecture"]
-            or leaf["suite"] not in {"llk", "metal", "perf"}
+            or leaf["suite"] not in {"llk", "metal", "ttnn", "perf"}
             or leaf["classification"] not in _REDUCTION_PRIORITY
         ):
             raise ValueError("verification reduction leaf contract is invalid")
@@ -2455,7 +2606,7 @@ def cmd_reduce_verification(args: argparse.Namespace) -> int:
     requirements = [
         requirement
         for requirement in manifest["requirements"]
-        if args.scope == "all" or requirement["suite"] in {"llk", "metal"}
+        if args.scope == "all" or requirement["suite"] in {"llk", "metal", "ttnn"}
     ]
     all_required_by_id = {
         requirement["requirement_id"]: requirement

--- a/tt_metal/tt-llk/codegen/scripts/test_run_json_writer.py
+++ b/tt_metal/tt-llk/codegen/scripts/test_run_json_writer.py
@@ -32,7 +32,14 @@ def _run(log_dir, *args):
     )
 
 
-def _required_manifest(tmp_path, analysis, plan, *extra, check=True):
+def _required_manifest(
+    tmp_path,
+    analysis,
+    plan,
+    *extra,
+    check=True,
+    git_changes: dict[str, str] | None = None,
+):
     worktree = tmp_path / "worktree"
     llk_tests = worktree / "tt_metal" / "tt-llk" / "tests" / "python_tests"
     llk_tests.mkdir(parents=True, exist_ok=True)
@@ -41,6 +48,33 @@ def _required_manifest(tmp_path, analysis, plan, *extra, check=True):
     metal = worktree / "tests" / "tt_metal" / "tt_metal" / "llk"
     metal.mkdir(parents=True, exist_ok=True)
     (metal / "test_reduce.cpp").write_text("// test\n")
+    ttnn = worktree / "tests" / "ttnn" / "unit_tests" / "operations"
+    ttnn.mkdir(parents=True, exist_ok=True)
+    (ttnn / "test_reduce.py").write_text("def test_reduce(): pass\n")
+    expected_base = "a" * 40
+    if git_changes is not None:
+        subprocess.run(["git", "init", "-q", str(worktree)], check=True)
+        subprocess.run(
+            ["git", "-C", str(worktree), "config", "user.name", "test"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(worktree), "config", "user.email", "test@example.com"],
+            check=True,
+        )
+        subprocess.run(["git", "-C", str(worktree), "add", "-A"], check=True)
+        subprocess.run(
+            ["git", "-C", str(worktree), "commit", "-qm", "base"], check=True
+        )
+        expected_base = subprocess.run(
+            ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        for relative, contents in git_changes.items():
+            changed = worktree / relative
+            changed.parent.mkdir(parents=True, exist_ok=True)
+            changed.write_text(contents)
     analysis_path = tmp_path / "analysis.md"
     plan_path = tmp_path / "plan.md"
     analysis_path.write_text(analysis)
@@ -64,7 +98,7 @@ def _required_manifest(tmp_path, analysis, plan, *extra, check=True):
             "--run-id",
             "run-1",
             "--expected-base-sha",
-            "a" * 40,
+            expected_base,
             "--architectures-json",
             '["blackhole"]',
             "--backend",
@@ -86,6 +120,7 @@ def test_required_verification_seals_independent_suites_and_perf_measurement(
 arch_scope:
   blackhole: in_scope
 ## Verification
+fix_layer: mixed
 verification_required: yes
 verifiable_in_llk_suite: partial
 llk_coverage: existing
@@ -138,6 +173,137 @@ regression_tests:
         ).encode()
     ).hexdigest()
     assert manifest["manifest_id"] == expected
+
+
+def test_required_verification_seals_ttnn_as_an_independent_suite(tmp_path):
+    analysis = """\
+## Scope
+arch_scope:
+  blackhole: in_scope
+## Verification
+fix_layer: ttnn
+verification_required: yes
+verifiable_in_llk_suite: partial
+llk_coverage: existing
+metal_verification:
+  target: none
+  coverage: not_applicable
+  test_file: none
+  gtest_filter: none
+  dispatch: none
+ttnn_verification:
+  target: ttnn
+  coverage: added
+  test: tests/ttnn/unit_tests/operations/test_reduce.py::test_reduce
+  dispatch: fast
+"""
+    plan = """\
+## Test Strategy
+reproduction_tests:
+- arch: blackhole
+  test: tests/python_tests/test_reduce.py::test_reduce
+"""
+    proc, output = _required_manifest(tmp_path, analysis, plan)
+    requirements = json.loads(output.read_text())["requirements"]
+    assert proc.returncode == 0
+    assert [item["suite"] for item in requirements] == ["llk", "ttnn"]
+    assert requirements[1]["requirement_id"] == "blackhole:ttnn:1"
+    assert requirements[1]["selector"] == {
+        "test": "tests/ttnn/unit_tests/operations/test_reduce.py",
+        "test_id": "tests/ttnn/unit_tests/operations/test_reduce.py::test_reduce",
+        "k": None,
+    }
+    assert "route=llk+ttnn" in proc.stdout
+
+
+def test_required_verification_rejects_missing_ttnn_coverage(tmp_path):
+    analysis = """\
+## Scope
+arch_scope:
+  blackhole: in_scope
+## Verification
+fix_layer: ttnn
+verification_required: yes
+verifiable_in_llk_suite: no
+llk_coverage: not_applicable
+ttnn_verification:
+  target: ttnn
+  coverage: add_required
+  test: tests/ttnn/unit_tests/operations/test_reduce.py::test_reduce
+  dispatch: fast
+"""
+    proc, output = _required_manifest(
+        tmp_path, analysis, "## Test Strategy\ncompile_checks:\n- none\n", check=False
+    )
+    assert proc.returncode != 0
+    assert "TTNN verification target/coverage is not executable" in proc.stderr
+    assert not output.exists()
+
+
+def test_required_verification_rejects_ttnn_layer_without_ttnn_suite(tmp_path):
+    analysis = """\
+## Scope
+arch_scope:
+  blackhole: in_scope
+## Verification
+fix_layer: ttnn
+verification_required: yes
+verifiable_in_llk_suite: no
+llk_coverage: not_applicable
+metal_verification:
+  target: unit_tests_llk
+  coverage: existing
+  test_file: tests/tt_metal/tt_metal/llk/test_reduce.cpp
+  gtest_filter: LLKFixture.Reduce
+  dispatch: fast
+ttnn_verification:
+  target: none
+  coverage: not_applicable
+  test: none
+  dispatch: none
+"""
+    proc, output = _required_manifest(
+        tmp_path, analysis, "## Test Strategy\ncompile_checks:\n- none\n", check=False
+    )
+    assert proc.returncode != 0
+    assert "TTNN-layer fix requires executable TTNN verification" in proc.stderr
+    assert not output.exists()
+
+
+def test_required_verification_rejects_mixed_diff_that_omits_ttnn_suite(tmp_path):
+    analysis = """\
+## Scope
+arch_scope:
+  blackhole: in_scope
+## Verification
+fix_layer: mixed
+verification_required: yes
+verifiable_in_llk_suite: no
+llk_coverage: not_applicable
+metal_verification:
+  target: unit_tests_llk
+  coverage: existing
+  test_file: tests/tt_metal/tt_metal/llk/test_reduce.cpp
+  gtest_filter: LLKFixture.Reduce
+  dispatch: fast
+ttnn_verification:
+  target: none
+  coverage: not_applicable
+  test: none
+  dispatch: none
+"""
+    proc, output = _required_manifest(
+        tmp_path,
+        analysis,
+        "## Test Strategy\ncompile_checks:\n- none\n",
+        check=False,
+        git_changes={"ttnn/cpp/ttnn/new_operation.cpp": "// candidate\n"},
+    )
+    assert proc.returncode != 0
+    assert (
+        "TTNN source/test changes require executable TTNN verification" in proc.stderr
+    )
+    assert not output.exists()
 
 
 def test_required_verification_revisions_are_immutable_and_linked(tmp_path):
@@ -890,6 +1056,13 @@ def test_predeclared_xfail_requires_tracked_policy_and_replacement_coverage(tmp_
     (tests / "test_replacement.py").write_text(
         "def test_replacement_coverage(): pass\n", encoding="utf-8"
     )
+    # _required_manifest supplies this shared selector fixture. Keep it in the
+    # base commit so this test's candidate diff contains only the waiver edit.
+    ttnn_test = (
+        worktree / "tests" / "ttnn" / "unit_tests" / "operations" / "test_reduce.py"
+    )
+    ttnn_test.parent.mkdir(parents=True)
+    ttnn_test.write_text("def test_reduce(): pass\n", encoding="utf-8")
     selector = {
         "test": "test_known_skip.py",
         "test_id": "test_known_skip.py::test_known_limitation",


### PR DESCRIPTION
## Summary

- Route verification independently across LLK, Metal, TTNN, and performance suites according to the candidate change scope.
- Add a dedicated TTNN tester and seal exact TTNN selectors and results into the verification contract.
- Preserve node-local build caches and narrow builds to the target needed by the selected suite.
- Support direct Metal commands and gtest target/filter execution through the Quasar wrapper.
- Strengthen orchestration, review, audit, and result-reduction checks so omitted or unexecuted required coverage cannot produce a false success.

## Motivation

Avoid paying for broad Metal and TTNN builds on LLK-only changes while retaining propagation coverage when a change reaches Metal or TTNN. Each required suite remains independently selected, executed, and reduced.

## Companion dashboard change

- https://github.com/tenstorrent/llk_code_gen/pull/116

## Validation

- 106 issue-solver script tests passed.
- Repository pre-commit hooks passed, including Black, pylint, codespell, and whitespace checks.
- Real unit_tests_llk build passed; an immediate warm rebuild completed with no work.
- Exact Blackhole LLK test compilation passed.
- Real TTNN extension build, package import, exact selector collection, and a host-only TTNN test passed.
- Shell scripts and all fenced Bash examples in the affected agent definitions passed syntax checks.
