### PR TITLE
[MiniMax M3] Pipeline-parallel KV-cache migration for prefill

### DIFF
--- a/models/demos/common/prefill/runners/migration.py
+++ b/models/demos/common/prefill/runners/migration.py
@@ -241,6 +241,32 @@ def _build_device_map(mesh_device, mesh_shape) -> list[tuple[int, int, int]]:
     return device_map
 
 
+def rank_scoped_device_map_path(path: str, rank: int, num_ranks: int) -> str:
+    """Per-rank JSON device-map path: ``<stem>_r<rank><ext>`` when num_ranks > 1, else ``path``
+    unchanged. Co-located ranks (an intragalaxy pipeline) would otherwise overwrite each other's map
+    at the shared host-local path, leaving device-less readers only the last writer's chips; readers
+    glob the ``_r*`` siblings back together (see prefill_producer._read_device_map)."""
+    if num_ranks <= 1:
+        return path
+    stem, ext = os.path.splitext(path)
+    return f"{stem}_r{rank}{ext}"
+
+
+def validate_stage_layout_contiguous(stage_layout) -> int:
+    """Check a gathered layout's layer ranges tile ``[0, total)`` contiguously (no gaps/overlaps) and
+    return that cache's layer total. ``compute_layer_split`` produces a contiguous partition, so a
+    violation means the ranks disagree on the split (tt-blaze's missing-layer guard)."""
+    expected = 0
+    for s in sorted(stage_layout, key=lambda s: s["first_layer"]):
+        if s["first_layer"] != expected:
+            raise RuntimeError(
+                f"gathered layer ranges are not contiguous: expected next stage at layer {expected} but got "
+                f"first_layer={s['first_layer']} (stages={[(x['first_layer'], x['count']) for x in stage_layout]})"
+            )
+        expected += s["count"]
+    return expected
+
+
 def serialize_device_map(mesh_device, path: str) -> str:
     """Write a JSON {"<mesh_id>:<chip_id>": <asic_unique_id>} device map so a device-less consumer
     (the prefill_producer) can resolve a table's FabricNodeIds to the ASIC unique_id that

--- a/models/demos/common/prefill/runners/migration.py
+++ b/models/demos/common/prefill/runners/migration.py
@@ -266,6 +266,20 @@ def validate_stage_layout_contiguous(stage_layout) -> int:
     return expected
 
 
+def remove_stale_device_map_sidecars(path: str) -> None:
+    """Drop the JSON device map and its rank-scoped ``_r*`` siblings left by a prior run — a leftover
+    (e.g. from a run with more ranks) would silently merge into this run's map. Call BEFORE the
+    stage-layout all-gather: every rank writes its own fresh file only after that barrier, so
+    co-located ranks racing here can never delete a fresh one."""
+    stem, ext = os.path.splitext(path)
+    for stale in [path, *glob.glob(f"{stem}_r*{ext}")]:
+        try:
+            os.remove(stale)
+            logger.warning(f"[migration] removed stale device map {stale} from a prior run")
+        except FileNotFoundError:
+            pass
+
+
 def serialize_device_map(mesh_device, path: str) -> str:
     """Write a JSON {"<mesh_id>:<chip_id>": <asic_unique_id>} device map so a device-less consumer
     (the prefill_producer) can resolve a table's FabricNodeIds to the ASIC unique_id that

--- a/models/demos/common/prefill/runners/migration.py
+++ b/models/demos/common/prefill/runners/migration.py
@@ -244,8 +244,7 @@ def _build_device_map(mesh_device, mesh_shape) -> list[tuple[int, int, int]]:
 def rank_scoped_device_map_path(path: str, rank: int, num_ranks: int) -> str:
     """Per-rank JSON device-map path: ``<stem>_r<rank><ext>`` when num_ranks > 1, else ``path``
     unchanged. Co-located ranks (an intragalaxy pipeline) would otherwise overwrite each other's map
-    at the shared host-local path, leaving device-less readers only the last writer's chips; readers
-    glob the ``_r*`` siblings back together (see prefill_producer._read_device_map)."""
+    at the shared host-local path; readers glob the ``_r*`` siblings back together."""
     if num_ranks <= 1:
         return path
     stem, ext = os.path.splitext(path)
@@ -255,7 +254,7 @@ def rank_scoped_device_map_path(path: str, rank: int, num_ranks: int) -> str:
 def validate_stage_layout_contiguous(stage_layout) -> int:
     """Check a gathered layout's layer ranges tile ``[0, total)`` contiguously (no gaps/overlaps) and
     return that cache's layer total. ``compute_layer_split`` produces a contiguous partition, so a
-    violation means the ranks disagree on the split (tt-blaze's missing-layer guard)."""
+    violation means the ranks disagree on the split."""
     expected = 0
     for s in sorted(stage_layout, key=lambda s: s["first_layer"]):
         if s["first_layer"] != expected:

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -280,9 +280,9 @@ def _read_device_map(timeout_s: int) -> dict:
     The runner's two publishers do not share an encoding -- the shmem path writes JSON keyed
     "<mesh>:<chip>", the file-export path writes "<mesh> <chip> <umd>" lines -- so accept either.
 
-    A multi-rank runner writes one rank-scoped file per co-located rank (``<stem>_r<rank>.json`` -- see
-    migration.rank_scoped_device_map_path), so all matches on this host are merged. Clear stale
-    ``_r*`` siblings between runs whose topology changed -- a leftover file would merge in."""
+    A multi-rank runner writes one rank-scoped file per co-located rank (``<stem>_r<rank>.json``), so
+    all matches on this host are merged. Clear stale ``_r*`` siblings between runs whose topology
+    changed -- a leftover file would merge in."""
     import glob as _glob
     import json
 
@@ -783,7 +783,7 @@ def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, r
     mins = {"k": 1.0, "v": 1.0}
     checked = 0
     for layer in range(NUM_LAYERS):
-        # Host-local filter (same as the MLA path): skip layers owned by another host's stage.
+        # Skip layers owned by another host's stage (their chips are not in this host's device map).
         loc0 = table.lookup(layer, 0, slot_id, 0)
         try:
             _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
@@ -819,8 +819,7 @@ def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, r
         f"[producer] slot {slot_id} GPT-OSS KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} (min {min_pcc:.6f})"
     )
-    # No layer resolved against this host's device map: the mins are still their 1.0 inits, which would
-    # masquerade as a perfect pass — fail loudly instead (wrong device map / stage split).
+    # Zero resolved layers would return the 1.0 inits as a perfect pass — fail loudly instead.
     if checked == 0:
         raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
     return mins
@@ -854,8 +853,7 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
     checked = 0
     ik_checked = 0
     for layer in range(NUM_LAYERS):
-        # Host-local filter (same as the MLA path): a merged multi-rank table spans every host's
-        # layers, so skip any layer whose chips resolve to no local unique_id (owned by another host).
+        # Skip layers owned by another host's stage (their chips are not in this host's device map).
         loc0 = table.lookup(layer, 0, slot_id, 0)
         try:
             _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
@@ -905,8 +903,7 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
         f"[producer] slot {slot_id} M3 KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} index_k={mins['index_k']:.5f} (min {min_pcc:.6f})"
     )
-    # No layer resolved against this host's device map: the mins are still their 1.0 inits, which would
-    # masquerade as a perfect pass — fail loudly instead (wrong device map / stage split).
+    # Zero resolved layers would return the 1.0 inits as a perfect pass — fail loudly instead.
     if checked == 0:
         raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
     # Only some traces carry an index_k golden. Its min is still the 1.0 init when none did, so drop the

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -278,31 +278,51 @@ def _read_device_map(timeout_s: int) -> dict:
     chips by unique_id without touching the ControlPlane. Returns {(mesh_id, chip_id): unique_id}.
 
     The runner's two publishers do not share an encoding -- the shmem path writes JSON keyed
-    "<mesh>:<chip>", the file-export path writes "<mesh> <chip> <umd>" lines -- so accept either."""
+    "<mesh>:<chip>", the file-export path writes "<mesh> <chip> <umd>" lines -- so accept either.
+
+    A multi-rank runner writes one rank-scoped file per co-located rank (``<stem>_r<rank>.json`` -- see
+    migration.rank_scoped_device_map_path), so all matches on this host are merged. Clear stale
+    ``_r*`` siblings between runs whose topology changed -- a leftover file would merge in."""
+    import glob as _glob
     import json
 
+    def _parse(raw: str) -> dict:
+        try:
+            return {tuple(int(x) for x in key.split(":")): int(unique_id) for key, unique_id in json.loads(raw).items()}
+        except json.JSONDecodeError:
+            parsed = {}
+            for line in raw.splitlines():
+                if not line.strip():
+                    continue
+                mesh_id, chip_id, unique_id = line.split()
+                parsed[(int(mesh_id), int(chip_id))] = int(unique_id)
+            return parsed
+
     path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
+    stem, ext = os.path.splitext(path)
+
+    def _matches():
+        return ([path] if os.path.exists(path) else []) + sorted(_glob.glob(f"{stem}_r*{ext}"))
+
     deadline = time.perf_counter() + timeout_s
-    while not os.path.exists(path):
+    files = _matches()
+    while not files:
         if time.perf_counter() > deadline:
-            logger.warning(f"[producer] device map {path} not found after {timeout_s}s; skipping KV read.")
+            logger.warning(
+                f"[producer] device map {path} (or {stem}_r*{ext}) not found after {timeout_s}s; skipping KV read."
+            )
             return {}
         time.sleep(0.1)
+        files = _matches()
 
-    with open(path) as f:
-        raw = f.read()
-    try:
-        device_map = {
-            tuple(int(x) for x in key.split(":")): int(unique_id) for key, unique_id in json.loads(raw).items()
-        }
-    except json.JSONDecodeError:
-        device_map = {}
-        for line in raw.splitlines():
-            if not line.strip():
-                continue
-            mesh_id, chip_id, unique_id = line.split()
-            device_map[(int(mesh_id), int(chip_id))] = int(unique_id)
-    logger.info(f"[producer] read device map {path}: {len(device_map)} chips")
+    device_map = {}
+    for f_path in files:
+        with open(f_path) as f:
+            parsed = _parse(f.read())
+        device_map.update(parsed)
+        logger.info(f"[producer] read device map {f_path}: {len(parsed)} chips")
+    if len(files) > 1:
+        logger.info(f"[producer] merged {len(files)} device maps: {len(device_map)} chips total")
     return device_map
 
 
@@ -761,7 +781,15 @@ def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, r
     )
     kv_dir = Path(trace_dir) / "kv_cache"
     mins = {"k": 1.0, "v": 1.0}
+    checked = 0
     for layer in range(NUM_LAYERS):
+        # Host-local filter (same as the MLA path): skip layers owned by another host's stage.
+        loc0 = table.lookup(layer, 0, slot_id, 0)
+        try:
+            _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
+        except KeyError:
+            continue
+        checked += 1
         dev_k = torch.stack(
             [
                 _read_kv_slice(table, device_map, h, layer, slot_id, read_len, head_dim, _decode_bfp8_chunk)
@@ -788,9 +816,13 @@ def _read_slot_kv_and_check_pcc_gpt_oss(table, device_map: dict, slot_id: int, r
 
     min_pcc = min(mins.values())
     logger.info(
-        f"[producer] slot {slot_id} GPT-OSS KV PCC over [0,{real_len}) across {NUM_LAYERS} layers -> "
+        f"[producer] slot {slot_id} GPT-OSS KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} (min {min_pcc:.6f})"
     )
+    # No layer resolved against this host's device map: the mins are still their 1.0 inits, which would
+    # masquerade as a perfect pass — fail loudly instead (wrong device map / stage split).
+    if checked == 0:
+        raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
     return mins
 
 
@@ -819,8 +851,17 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
     )
     kv_dir = Path(trace_dir) / "kv_cache"
     mins = {"k": 1.0, "v": 1.0, "index_k": 1.0}
+    checked = 0
     ik_checked = 0
     for layer in range(NUM_LAYERS):
+        # Host-local filter (same as the MLA path): a merged multi-rank table spans every host's
+        # layers, so skip any layer whose chips resolve to no local unique_id (owned by another host).
+        loc0 = table.lookup(layer, 0, slot_id, 0)
+        try:
+            _resolve_unique_id(table.get_device_group(loc0.device_group_index).fabric_node_ids, device_map)
+        except KeyError:
+            continue
+        checked += 1
         dev_k = torch.stack(
             [
                 _read_kv_slice(table, device_map, h, layer, slot_id, read_len, head_dim, _decode_bfp8_chunk)
@@ -861,9 +902,13 @@ def _read_slot_kv_and_check_pcc_m3(table, device_map: dict, slot_id: int, real_l
 
     min_pcc = min(mins.values())
     logger.info(
-        f"[producer] slot {slot_id} M3 KV PCC over [0,{real_len}) across {NUM_LAYERS} layers -> "
+        f"[producer] slot {slot_id} M3 KV PCC over [0,{real_len}) across {checked}/{NUM_LAYERS} local layers -> "
         f"K={mins['k']:.5f} V={mins['v']:.5f} index_k={mins['index_k']:.5f} (min {min_pcc:.6f})"
     )
+    # No layer resolved against this host's device map: the mins are still their 1.0 inits, which would
+    # masquerade as a perfect pass — fail loudly instead (wrong device map / stage split).
+    if checked == 0:
+        raise RuntimeError(f"slot {slot_id}: no local layers resolved against the device map (nothing verified)")
     # Only some traces carry an index_k golden. Its min is still the 1.0 init when none did, so drop the
     # key rather than reporting an unmeasured cache as perfect.
     if not ik_checked:

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -39,7 +39,11 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_blackhole
 from models.demos.common.prefill.adapter import DEFAULT_MODEL, PrefillRunParams, get_adapter
-from models.demos.common.prefill.runners.migration import migration_file_export_enabled, serialize_device_map
+from models.demos.common.prefill.runners.migration import (
+    migration_file_export_enabled,
+    remove_stale_device_map_sidecars,
+    serialize_device_map,
+)
 from models.demos.common.prefill.runners.runner_utils import (
     activation_global_spec,
     build_h2d_service,
@@ -799,7 +803,9 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         _mock_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
         runtime.build_kv_chunk_table(kv_caches, path=_mock_table_path)
         # fabric_node -> ASIC unique_id, so the producer can resolve chips for read_dram_umd without
-        # touching the ControlPlane.
+        # touching the ControlPlane. Stale rank-scoped siblings from a prior multi-rank run would
+        # merge into the reader's map, so drop them first.
+        remove_stale_device_map_sidecars(_mock_map_path)
         serialize_device_map(mesh_device, _mock_map_path)
         logger.info(
             f"[mock-migration] KV chunk table -> {_mock_table_path}, device map -> {_mock_map_path} "
@@ -824,6 +830,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             migration_device_map_file_path,
             publish_serialized_table_and_wait_ready,
             rank_scoped_device_map_path,
+            remove_stale_device_map_sidecars,
         )
 
         # This rank's pipeline stage owns layers [first_layer_idx, first_layer_idx + num_my_layers).
@@ -855,6 +862,14 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         if is_first_rank and os.path.exists(table_path):
             logger.warning(f"[migration] removing stale KV chunk table {table_path} from a prior run")
             os.remove(table_path)
+
+        # Same rationale for the JSON device-map sidecars: a leftover rank-scoped file from a run with
+        # a different rank count would silently merge into this run's map. Must stay BEFORE the
+        # all-gather barrier below — every rank writes its fresh map only after it.
+        if not _file_export:
+            remove_stale_device_map_sidecars(
+                os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
+            )
 
         # ALL RANKS join the stage-layout all-gather (collective barrier; rank 0 needs the merged
         # layout to build the table). Real migration also delivers this rank's local FNID->UMD map to

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -823,6 +823,7 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             export_device_map_file_and_gather_stage_layouts,
             migration_device_map_file_path,
             publish_serialized_table_and_wait_ready,
+            rank_scoped_device_map_path,
         )
 
         # This rank's pipeline stage owns layers [first_layer_idx, first_layer_idx + num_my_layers).
@@ -900,11 +901,16 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             #
             # EVERY rank serializes its OWN local fabric_node -> ASIC unique_id device map so each
             # co-located producer can resolve only its host's chips for read_dram_umd (the multi-rank
-            # merged table carries every host's fnids; a producer with just its local map naturally
-            # filters to its own layers). The device-map path is host-local (each rank overwrites the
-            # same name on its own host); the table path MUST be on shared storage (only rank 0 writes
-            # it, but every host's reader resolves the same path) — enforced above for num_ranks > 1.
-            device_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
+            # merged table carries every host's fnids; a producer merges the local maps and skips
+            # layers owned by another host). Rank-scoped filename for num_ranks > 1 — co-located ranks
+            # would otherwise overwrite each other at the shared host-local path; the table path MUST
+            # be on shared storage (only rank 0 writes it, but every host's reader resolves the same
+            # path) — enforced above for num_ranks > 1.
+            device_map_path = rank_scoped_device_map_path(
+                os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json"),
+                rank,
+                num_ranks,
+            )
             serialize_device_map(mesh_device, device_map_path)
             if is_first_rank:
                 # RANK 0 builds the merged table spanning every gathered stage — identical to the real
@@ -936,9 +942,13 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             # device-less reader downstream: migration_driver's destination verification
             # (--verify-migration, both dst-bytes and dst-golden) and prefill_producer's source-KV
             # PCC each resolve chips through this file, log "device map ... not found", and FAIL —
-            # so a real migration run could never verify what it copied. Host-local by design (one
-            # file per host, each rank overwriting its own).
-            device_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
+            # so a real migration run could never verify what it copied. Host-local by design;
+            # rank-scoped filename for num_ranks > 1 so co-located ranks don't overwrite each other.
+            device_map_path = rank_scoped_device_map_path(
+                os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json"),
+                rank,
+                num_ranks,
+            )
             serialize_device_map(mesh_device, device_map_path)
             logger.info(f"[migration] rank {rank}: local device map -> {device_map_path}")
 

--- a/models/demos/minimax_m3/docs/PIPELINE_PREFILL_TESTING.md
+++ b/models/demos/minimax_m3/docs/PIPELINE_PREFILL_TESTING.md
@@ -2,6 +2,8 @@
 
 Multi-galaxy pipeline-parallel prefill for MiniMax-M3 via the common prefill runner. Serving is always
 request mode (runner + producer); accuracy (KV PCC) and throughput differ only in the producer flags.
+A single galaxy carved into sub-meshes runs the same machinery — see
+[Intragalaxy pipeline](#intragalaxy-pipeline-single-galaxy-carved-into-sub-meshes).
 
 ## Setup
 
@@ -159,6 +161,83 @@ python -m models.demos.deepseek_v3_d_p.scripts.plot_pipeline_trace \
 
 Hold `PREFILL_CHUNK_SIZE`, the trace, and per-stage `NUM_USERS` fixed across runs; compare `E2E_CLOCK`
 (per rank) or `parse_iteration_times.py`.
+
+## Intragalaxy pipeline (single galaxy carved into sub-meshes)
+
+The same rank/stage machinery runs on ONE 8×4 galaxy split into Z-linked sub-meshes:
+2 stages of [4,4] (30 layers each, `pipeline_prefill_request_intragalaxy_2rank.yaml`) or 4 stages of
+[2,4] (15 layers each, `..._intragalaxy_4rank.yaml`), both under
+`models/demos/common/prefill/runners/topology_configuration/`. All ranks are co-located, so shell
+exports reach every rank and no binding copy is needed for the manifest.
+
+Three prerequisites specific to this mode:
+
+- **Per-mesh-shape weight cache.** The tilized cache is keyed by mesh shape — the sub-meshes need
+  `tensor_cache_bfp8_MeshShape([4, 4])` / `([2, 4])`, which the default checkpoint dir does not carry
+  (populating takes ~1 h per shape, once; the ranks populate their own slices in parallel). Point
+  `TT_CACHE_PATH` at a root that has them — both shapes are currently populated at
+  `/data/zbaczewski/m3_pp_cache` (its `[8, 4]` dir is empty, so do NOT use it for whole-galaxy runs).
+- **PRTE slot fix.** Multi-rank on one host under a Slurm allocation fails with "All nodes which are
+  allocated for this job are already filled" (the galaxy advertises `CPUTot=1`). Before launching:
+  ```bash
+  unset $(env | sed -n 's/^\(SLURM[^=]*\)=.*/\1/p')
+  export PRTE_MCA_ras="^slurm" PRTE_MCA_plm="^slurm"
+  ```
+- **Raise RLIMIT_NPROC first.** The limit is per-user node-wide and a live multi-rank runner's threads
+  exhaust it — a later terminal then can't even fork. Make `ulimit -u <big>` (e.g. `2318144`) the FIRST
+  line of every terminal/step on the node.
+
+### Perf
+
+Same two-process flow as multi-galaxy; both terminals are on the one node. The producer's transport env
+must match the SUB-MESH: `PREFILL_SP=4` (2-stage) or `PREFILL_SP=2` (4-stage), `PREFILL_TP=4`.
+
+```bash
+# 2-stage runner
+TT_CACHE_PATH=<pp-cache-root> PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json \
+  ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+  models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml \
+  $(hostname -s):2 2>&1 | tee pp_intra2.log
+
+# 4-stage runner
+TT_CACHE_PATH=<pp-cache-root> PREFILL_MANIFEST=models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json \
+  ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+  models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml \
+  $(hostname -s):4 2>&1 | tee pp_intra4.log
+```
+
+The producer command is the multi-galaxy one with `PREFILL_SP=4` (2-stage) / `PREFILL_SP=2` (4-stage) —
+same plot/readout (`parse_iteration_times.py`, `plot_pipeline_trace`).
+
+### Accuracy — KV PCC (merged mock)
+
+Ready-made manifests (10240 ISL, 2 chunks/slot; the merged-mock env, table on shared storage, producer
+PCC threshold set to M3's 0.88 gate):
+
+```bash
+# 2-stage
+TT_CACHE_PATH=<pp-cache-root> ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+  models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml $(hostname -s):2
+python -m models.demos.common.prefill.runners.prefill_producer \
+  --manifest models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
+
+# 4-stage
+TT_CACHE_PATH=<pp-cache-root> ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+  models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_4rank.yaml $(hostname -s):4
+PREFILL_SP=2 python -m models.demos.common.prefill.runners.prefill_producer \
+  --manifest models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
+```
+
+**Expect:** rank 0 logs the merged 60-layer 9-config table; each rank writes a rank-scoped device map
+(`/tmp/m3_kv_device_map_r<rank>.json`, merged by the producer); per-layer K/V/index_k over
+`60/60 local layers`, then `KV cache PCC PASSED`.
+
+### Loopback migration (real endpoint + worker)
+
+The intragalaxy 2-stage loopback-migration gate (P2) — endpoint, 2-rank runner, migration driver with
+`--verify-migration both` — is documented next to the manifests in
+`models/demos/minimax_m3/tt/runners/PREFILL_MIGRATION_TESTING.md` (Gates P0/P1/P2). Validated 2026-08-25:
+source PCC 60/60 layers, dst==src byte-identical over all 345600 chunks, migrated slots ≥ 0.88 vs golden.
 
 ## Env knobs
 

--- a/models/demos/minimax_m3/docs/PIPELINE_PREFILL_TESTING.md
+++ b/models/demos/minimax_m3/docs/PIPELINE_PREFILL_TESTING.md
@@ -26,17 +26,24 @@ Run the commands below from inside the allocation.
 ## Accuracy — KV PCC
 
 Same two processes as the perf run below (runner under `tt-run`, producer on rank 0's host); the producer
-reads the KV back and PCCs it against the golden trace. `PREFILL_MOCK_MIGRATION=1` makes the runner
-publish its KV chunk table for the read-back gate (without it the producer has nothing to PCC). On the
-producer (Process 2) add `PREFILL_PRODUCER_CHECK_PCC=1` and set `PREFILL_PRODUCER_MAX_REQUESTS=1` so every
-slot's KV is still resident when it is read back. PASS = `[producer] KV cache PCC PASSED` (threshold
-`PREFILL_STANDALONE_CHUNKED_PCC`, default `0.93`).
+reads the KV back and PCCs it against the golden trace. Single-rank, `PREFILL_MOCK_MIGRATION=1` makes the
+runner publish its KV chunk table for the read-back gate (without it the producer has nothing to PCC).
+Multi-rank, bare `PREFILL_MOCK_MIGRATION=1` is rejected (each rank would publish a table covering only its
+own layer slice); set `PREFILL_ENABLE_MIGRATION: "1"` ALONGSIDE it in the binding's `global_env` to select
+the merged mock — every rank joins the stage-layout all-gather, rank 0 publishes ONE table spanning all
+layers, and each rank writes a rank-scoped device map (`<stem>_r<rank>.json`; the producer merges the
+local ones). The table path must then be on shared storage (`PREFILL_MIGRATION_TABLE_PATH`, not `/tmp`).
+On the producer (Process 2) add `PREFILL_PRODUCER_CHECK_PCC=1` and set `PREFILL_PRODUCER_MAX_REQUESTS=1`
+so every slot's KV is still resident when it is read back. PASS = `[producer] KV cache PCC PASSED`
+(threshold `PREFILL_STANDALONE_CHUNKED_PCC`, default `0.93`).
 
 Both `PREFILL_MANIFEST` and `PREFILL_MOCK_MIGRATION` are shell-forwarded with `mpirun -x`, which lands on
 the launch-host rank only — fine at 1 galaxy (one rank), but at 2+ galaxies the remote ranks never see
 them and silently run the default model without publishing their table. For multi-host, put both in the
 request binding's `global_env` (the same `_minimax.yaml` copy made under Process 1, plus
-`PREFILL_MOCK_MIGRATION: "1"`) and drop them from the shell.
+`PREFILL_MOCK_MIGRATION: "1"` and `PREFILL_ENABLE_MIGRATION: "1"` — see above) and drop them from the
+shell. A ready-made 2-rank example (intragalaxy) is
+`models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml`.
 
 ### 1 galaxy
 ```bash

--- a/models/demos/minimax_m3/tests/test_kv_chunk_table_merge.py
+++ b/models/demos/minimax_m3/tests/test_kv_chunk_table_merge.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+"""Device-free checks of the M3 multi-stage (pipeline-parallel) KV chunk table merge.
+
+Drives ``build_and_serialize_kv_chunk_table`` with synthetic 2-stage ``stage_layouts`` (one gathered
+layout per cache — k, v, index_k) and a stub kv_cache (the merged path reads only dtypes/shapes from it —
+addresses, fabric nodes, hosts and bank counts all come from the gathered layouts), then asserts the
+table's addressing against the layouts: per-(stage, cache) base addresses at global layer indices,
+single-member per-head device groups vs the full-row index_k replica group, and the per-(config, stage,
+row) bank-walk restart.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+import ttnn
+from models.demos.common.prefill.runners.migration import validate_stage_layout_contiguous
+from models.demos.minimax_m3.tt.attention.kv_cache import NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+from models.demos.minimax_m3.tt.runners.kv_chunk_table import _chunk_size_bytes, build_and_serialize_kv_chunk_table
+
+SP = 2
+COLS = 4  # == num_kv_heads (the builder asserts the 1:1 head->column map)
+CHUNK_SIZE = 64  # tokens_per_chunk_local = 32 == NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+SEQ_LEN = 128
+NUM_USERS = 2
+HEAD_DIM = 128
+STAGE_COUNTS = (2, 3)  # layers per stage; global total 5
+NUM_BANKS = 8
+
+
+def _fnids(mesh_id):
+    return [[ttnn.FabricNodeId(ttnn.MeshId(mesh_id), r * COLS + c) for c in range(COLS)] for r in range(SP)]
+
+
+def _base(stage_idx: int, cache_idx: int) -> int:
+    """Distinct per-(stage, cache) base so a wrong (stage, cache) pick is visible in the noc_addr."""
+    return 0x10000 * (stage_idx + 1) + cache_idx * 0x4000
+
+
+def _stage_layouts():
+    """One gathered layout per cache (k, v, index_k — the kv_migration_stages order), each spanning the
+    two pipeline stages. All three share fnids/banks/ranges; only the base address differs per cache."""
+    layouts = []
+    for cache_idx in range(3):
+        stages = []
+        first = 0
+        for i, count in enumerate(STAGE_COUNTS):
+            stages.append(
+                {
+                    "rank": i,
+                    "first_layer": first,
+                    "count": count,
+                    "base_addr": _base(i, cache_idx),
+                    "num_banks": NUM_BANKS,
+                    "host_tag": 0x1000 + i,
+                    "fnids": _fnids(i),
+                }
+            )
+            first += count
+        layouts.append(stages)
+    return layouts
+
+
+def _stub_cache(num_layers):
+    def t(dtype):
+        return SimpleNamespace(shape=(NUM_USERS * num_layers, 1, SEQ_LEN, HEAD_DIM), dtype=dtype)
+
+    return SimpleNamespace(k=t(ttnn.bfloat8_b), v=t(ttnn.bfloat8_b), index_k=t(ttnn.bfloat16))
+
+
+def _build(tmp_path, stage_layouts):
+    path = os.path.join(str(tmp_path), "m3_merge_table.pb")
+    # num_layers is THIS rank's stage count (rank 0 builds), used only for the local shape assert.
+    return build_and_serialize_kv_chunk_table(
+        mesh_device=None,
+        kv_cache=_stub_cache(STAGE_COUNTS[0]),
+        seq_len=SEQ_LEN,
+        num_layers=STAGE_COUNTS[0],
+        mesh_shape=(SP, COLS),
+        sp_axis=0,
+        num_users=NUM_USERS,
+        chunk_size=CHUNK_SIZE,
+        num_kv_heads=COLS,
+        head_dim=HEAD_DIM,
+        path=path,
+        stage_layouts=stage_layouts,
+    )
+
+
+@pytest.fixture(scope="module")
+def merged_table(tmp_path_factory):
+    path = _build(tmp_path_factory.mktemp("m3_merge"), _stage_layouts())
+    return ttnn.experimental.disaggregation.import_from_protobuf_file(path)
+
+
+def test_configs_and_global_layer_extent(merged_table):
+    assert merged_table.num_configs() == 2 * COLS + 1
+    total = sum(STAGE_COUNTS)
+    for cfg_id in range(merged_table.num_configs()):
+        assert merged_table.config(cfg_id).num_layers == total
+    # index_k carries the bf16 chunk size, K/V the bfp8 one.
+    assert merged_table.config(0).chunk_size_bytes == _chunk_size_bytes(ttnn.bfloat8_b, HEAD_DIM)
+    assert merged_table.config(2 * COLS).chunk_size_bytes == _chunk_size_bytes(ttnn.bfloat16, HEAD_DIM)
+
+
+def test_stage_addressing_and_bank_walk(merged_table):
+    stages = _stage_layouts()[0]  # k's layout; fnids/ranges identical across the three caches
+    k_bytes = _chunk_size_bytes(ttnn.bfloat8_b, HEAD_DIM)
+    for stage in stages:
+        for local_layer in (0, stage["count"] - 1):
+            global_layer = stage["first_layer"] + local_layer
+            # Row 0's first chunk of (slot 0, local layer): the walk runs slot -> local layer -> chunk,
+            # 32 tokens per bank step, restarting per (config, stage, row) — so this chunk's global
+            # index within the walk is local_layer * (SEQ_LEN // CHUNK_SIZE) * (CHUNK_SIZE // SP / 32).
+            chunks_before = (
+                local_layer * (SEQ_LEN // CHUNK_SIZE) * (CHUNK_SIZE // SP // NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK)
+            )
+            loc = merged_table.lookup(global_layer, 0, 0, 0)  # config 0 = k_h0, position 0 lives in row 0
+            bank = chunks_before % NUM_BANKS
+            offset = (chunks_before // NUM_BANKS) * k_bytes
+            assert loc.noc_addr == (bank << 32) | (stage["base_addr"] + offset), (
+                f"stage {stage['rank']} global layer {global_layer}: k_h0 chunk 0 landed at "
+                f"{loc.noc_addr:#x}, expected bank {bank} offset {offset:#x} off base "
+                f"{stage['base_addr']:#x}"
+            )
+            assert loc.size_bytes == k_bytes
+
+
+def test_v_and_index_k_use_their_own_base(merged_table):
+    stage_idx = 1
+    gl = _stage_layouts()[0][stage_idx]["first_layer"]
+    v_loc = merged_table.lookup(gl, 0, 0, COLS)  # config COLS = v_h0
+    assert (v_loc.noc_addr & 0xFFFFFFFF) == _base(stage_idx, 1)
+    ik_loc = merged_table.lookup(gl, 0, 0, 2 * COLS)
+    assert (ik_loc.noc_addr & 0xFFFFFFFF) == _base(stage_idx, 2)
+
+
+def test_device_groups_per_head_and_replica(merged_table):
+    stages = _stage_layouts()[0]
+    for stage in stages:
+        gl = stage["first_layer"]
+        for h in range(COLS):
+            loc = merged_table.lookup(gl, 0, 0, h)  # row 0 owns position 0
+            group = merged_table.get_device_group(loc.device_group_index).fabric_node_ids
+            assert [(int(f.mesh_id), int(f.chip_id)) for f in group] == [
+                (int(stage["fnids"][0][h].mesh_id), int(stage["fnids"][0][h].chip_id))
+            ], f"k_h{h} of stage {stage['rank']} must be a single-member group on column {h}"
+        ik = merged_table.lookup(gl, 0, 0, 2 * COLS)
+        group = merged_table.get_device_group(ik.device_group_index).fabric_node_ids
+        assert sorted((int(f.mesh_id), int(f.chip_id)) for f in group) == sorted(
+            (int(f.mesh_id), int(f.chip_id)) for f in stage["fnids"][0]
+        ), f"index_k of stage {stage['rank']} must replicate across the full row"
+
+
+def test_row_sharding_positions(merged_table):
+    # Position CHUNK_SIZE//SP (= row 1's first token of chunk 0) must resolve to row 1's chips.
+    stage = _stage_layouts()[0][0]
+    loc = merged_table.lookup(0, CHUNK_SIZE // SP, 0, 0)
+    group = merged_table.get_device_group(loc.device_group_index).fabric_node_ids
+    assert (int(group[0].mesh_id), int(group[0].chip_id)) == (
+        int(stage["fnids"][1][0].mesh_id),
+        int(stage["fnids"][1][0].chip_id),
+    )
+
+
+def test_non_contiguous_stage_layout_rejected(tmp_path, expect_error):
+    layouts = _stage_layouts()
+    for layout in layouts:
+        layout[1]["first_layer"] += 1  # gap after stage 0, in every cache's layout
+    with expect_error(RuntimeError, "not contiguous"):
+        _build(tmp_path, layouts)
+    with expect_error(RuntimeError, "not contiguous"):
+        validate_stage_layout_contiguous(layouts[0])
+
+
+def test_mismatched_cache_ranges_rejected(tmp_path, expect_error):
+    # M3's caches share one layer-index space; a v layout whose ranges differ from k's must be refused.
+    layouts = _stage_layouts()
+    layouts[1][0]["count"] += 1
+    layouts[1][1]["first_layer"] += 1
+    with expect_error(RuntimeError, "share one layer-index space"):
+        _build(tmp_path, layouts)

--- a/models/demos/minimax_m3/tt/runners/PREFILL_MIGRATION_TESTING.md
+++ b/models/demos/minimax_m3/tt/runners/PREFILL_MIGRATION_TESTING.md
@@ -1,0 +1,357 @@
+# MiniMax-M3 prefill KV-migration — test command sheet
+
+How to validate M3's KV-cache migration on a **single Blackhole galaxy**, no decode side — single-rank
+(SP=8 × TP=4) and 2-stage intragalaxy pipeline (two Z-linked 4×4 sub-meshes, 30 layers per stage; gates
+P1/P2 below). This is the M3 instance of `models/demos/common/prefill/docs/PREFILL_MIGRATION_TESTING.md`
+— that document explains the mechanism and the config layering; this one is the copy-pasteable version
+with M3's paths, layer count, and manifests filled in.
+
+M3 stores three cache tensors (`k`, `v`, `index_k`). `k`/`v` are TP-head-sharded (column `c` holds head
+`c`); `index_k` is replicated across the TP columns. The migration worker treats a chunk's device group as
+*replicas*, so the KV chunk table encodes **one config per (tensor, head-shard)** — 9 configs
+(`k_h0..3`, `v_h0..3`, `index_k`) — with single-member device groups for K/V and a replica group for
+`index_k` (`tt/runners/kv_chunk_table.py`). The migration layer needs no C++ change.
+
+| Gate | What it proves | Needs |
+|------|----------------|-------|
+| **0 — standalone PCC** | Prefill writes correct K / V / index_k vs golden | tt-metal tree only |
+| **1 — mock migration** | The 9-config address table is correct, read device-lessly | tt-metal tree only |
+| **2 — loopback migration** | The real DRAM → DCN → DRAM copy, and migrated-KV accuracy | + tt-llm-engine migration layer |
+| **P0 — merged-table unit test** | The multi-stage merge's address math, device-free | tt-metal tree only, no device |
+| **P1 — pipeline mock migration** | The MERGED 60-layer table over 2 stages, read device-lessly | tt-metal tree only |
+| **P2 — pipeline loopback migration** | The real copy driven off the merged table | + tt-llm-engine migration layer |
+
+(The former dependency on `nzhao/non-mla-migration-fixes` landed as #52113.)
+
+---
+
+## Config files
+
+| File | Owns |
+|------|------|
+| `manifests/minimax_m3.json` | model: `PREFILL_MODEL`, 60 layers, `M3_INDEX_CACHE_BF16` |
+| `manifests/m3_binding_mock_migration_1rank.yaml` | Gate 1 runner: 1-rank topology + mock-migration env |
+| `manifests/m3_binding_loopback_migration_1rank.yaml` | Gate 2 runner: 1-rank topology + real-migration env |
+| `manifests/m3_producer_mock_migration.yaml` | Gate 1 producer: 2 slots × 2 chunks, golden PCC |
+| `manifests/m3_producer_loopback_migration.yaml` | Gate 2 driver: prefill 0,1 → migrate to 2,3 |
+| `manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml` | Gate P1 runner: 2-stage intragalaxy + merged mock |
+| `manifests/m3_binding_loopback_migration_intragalaxy_2rank.yaml` | Gate P2 runner: 2-stage intragalaxy + real migration |
+| `manifests/m3_producer_mock_migration_2rank.yaml` | Gate P1 producer (sp=4, merged table paths) |
+| `manifests/m3_producer_loopback_migration_2rank.yaml` | Gate P2 driver (sp=4, merged table paths) |
+
+The rank bindings and producer manifests in `models/demos/common/prefill/runners/{topology_configuration,producer_manifests}/`
+are model-agnostic by design, so M3's versions live here instead. Everything M3-specific is in these
+files; the gate commands below take no per-run env.
+
+Every `PREFILL_*` the runner needs must live in the binding: it runs under `tt-run`, which forwards only
+`TT_`, `ARCH_`, `WH_`, `TTNN_`, `DEEPSEEK_` and `MESH_` prefixed shell variables
+(`ENV_PASSTHROUGH_PREFIXES` in `ttnn/ttnn/distributed/ttrun.py`). The producer and the migration driver are
+ordinary processes, so for them exported env wins over the manifest.
+
+---
+
+## 0. Shared setup (every terminal)
+
+```bash
+cd /data/philei/tt-metal
+export TT_METAL_HOME="$PWD" PYTHONPATH="$PWD"
+source python_env/bin/activate
+export HOST=$(hostname -s)
+
+export RUN=./models/demos/common/prefill/runners/run_pipeline_prefill.sh
+export M3=models/demos/minimax_m3/tt/runners/manifests
+export ENGINE=/data/philei/tt-metal/tt-llm-engine
+export MIG="$ENGINE/disaggregation/migration/build_RelWithDebInfo"
+
+# Golden trace (block-sparse MSA, separate_k_v — valid at full length). The manifests here are wired for
+# longbook_10240 (10240 tok -> 2 chunks). For another length, change PREFILL_MAX_SEQ_LEN + PREFILL_TRACE_DIR
+# in the binding and workload.chunks + model.max_seq_len in the producer manifest.
+#   longbook_5120  (5120 tok  -> 1 chunk)
+#   longbook_10240 (10240 tok -> 2 chunks)   <- what the manifests use
+#   longbook_56320 (55218 tok -> 11 chunks)  <- full length
+export GOLDEN=/data/philei/models/minimax-m3-prefill-cache/golden/longbook_10240
+```
+
+The checkpoint (`/mnt/models/MiniMaxAI/MiniMax-M3-ref/`, config + tilized weight cache) comes from the
+adapter default; override with `PREFILL_HF_MODEL` / `TT_CACHE_PATH` in the binding's `global_env`, not the
+shell. Shape constraints: `MAX_SEQ_LEN % CHUNK_SIZE == 0` and `CHUNK_SIZE % (SP*32) == 0`; 5120 satisfies
+both at SP=8.
+
+---
+
+## Gate 0 — standalone KV PCC (precondition, no migration)
+
+The runner's standalone mode was removed (#52213), so the bare-process precondition is the M3 harness
+test — same golden trace, per-layer KV PCC, no socket/second process:
+
+```bash
+env PREFILL_CHUNKED=1 PREFILL_CHUNK_SIZE=5120 \
+    PREFILL_TRACE_DIR=$GOLDEN \
+    python3 models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+```
+
+**Expect:** per-layer PCC lines and a min across 60 layers for K / V / index_k at or above
+`PREFILL_STANDALONE_CHUNKED_PCC` (default `0.88`).
+
+---
+
+## Gate 1 — mock migration + producer read-back (table addresses only)
+
+The cheapest isolated check of `build_kv_chunk_table`: the runner serializes the 9-config table and the
+fabric-node→ASIC device map, and the producer reads each chunk **device-lessly** (`read_dram_umd`, the same
+UMD path the migration worker uses) and PCCs it against golden. No endpoint, no worker, no MPI.
+
+```bash
+# ---- Terminal 1 — runner (stays up across producer runs) ----
+$RUN $M3/m3_binding_mock_migration_1rank.yaml $HOST:1
+
+# ---- Terminal 2 — producer ----
+python -m models.demos.common.prefill.runners.prefill_producer \
+  --manifest $M3/m3_producer_mock_migration.yaml
+```
+
+**Expect:** runner `[mock-migration] KV chunk table -> /tmp/m3_kv_chunk_table.pb, device map -> …`;
+producer `[producer] layer acks 240/240`, per-layer `K=… V=… index_k=…`, then
+`[producer] slot N M3 KV PCC over [0,10240) across 60 layers` and `[producer] KV cache PCC PASSED`
+(threshold `PREFILL_STANDALONE_CHUNKED_PCC`, producer default `0.93` — different from the runner's `0.88`
+default for the same variable).
+
+`index_k` is PCC'd for every layer whose golden carries `index_k_cache_layer_<L>` (dense layers carry none
+and are skipped); the read-back picks the bf16 or bf8 decoder from the config's chunk size, so
+`M3_INDEX_CACHE_BF16` must match on both sides.
+
+`prefill_producer` here, deliberately: this gate migrates nothing.
+
+The runner's request loop is unbounded, so it stays up after the producer exits — re-run the producer as
+often as you like, then stop it with Ctrl-C, or set `PREFILL_SEND_SHUTDOWN: "1"` in the producer manifest's
+`env:` block for a graceful drain-and-exit on the last push.
+
+---
+
+## Gate 2 — full loopback migration (endpoint + runner + driver)
+
+Three processes on one host — the shm queues and UMD access are host-local, so they must co-locate. Loopback
+means the destination endpoint id equals the endpoint's own, routed through its internal A→B worker pair.
+
+**One endpoint launch per runner launch.** A worker terminates on a second `SET_TABLE`
+(`control_thread.cpp:1368`), and the runner publishes a table at startup, so a second runner against a live
+endpoint kills both workers.
+
+```bash
+# ---- Between runs: stop terminal A (Ctrl-C), then clear ----
+pkill -f migration_endpoint ; pkill prun ; pkill prted ; pkill prte
+rm -f /dev/shm/mig_ep1_* /dev/shm/ep_1_[ab]_* \
+      /dev/shm/tt_h2d_* /dev/shm/tt_d2h_* /dev/shm/tt_prefill_layer_acks_* \
+      /tmp/m3_kv_chunk_table.pb /tmp/m3_kv_device_map.json /tmp/m3_migration_done.sentinel
+
+# ---- Terminal A — migration endpoint (leave running) ----
+cd /data/philei/tt-metal && ./m3_gate2_endpoint.sh
+
+# ---- Gate check — must print READY before terminal B ----
+cd /data/philei/tt-metal && ./m3_gate2_check.sh
+
+# ---- Terminal B — runner ----
+$RUN $M3/m3_binding_loopback_migration_1rank.yaml $HOST:1
+
+# ---- Terminal C — prefill + migrate (only after B prints WORKER_READY + LayerAck ready) ----
+export PREFILL_MIGRATION_CLIENT_DIR="$MIG/python"
+python -m models.demos.common.prefill.runners.migration_driver \
+  --manifest $M3/m3_producer_loopback_migration.yaml
+```
+
+`m3_gate2_endpoint.sh` wraps `launch_migration_endpoints.sh` with two things this cluster requires: the
+worker's `TT_METAL_HOME` (the engine's submodule, the tree it was built against), and a Slurm-detached
+`prte` — the endpoint's two workers need 2 launcher slots on the host, and Slurm advertises a whole galaxy
+as `CPUTot=1`, so `prte` must take its pool from `--host <node>:2` rather than from the allocation. It
+preflights a 2-rank placement before launching. The workers then outlive the allocation; the `pkill` line
+above is the teardown.
+
+The `ep_1_*` queue names are fixed per endpoint id, so a leftover pair from a killed run collides with the
+next endpoint's — `launch_migration_endpoints.sh` clears only the outward `/mig_ep1_*` set. The KV table
+must go too: the driver waits only for that file to *exist*.
+
+Terminal B before starting C (the table build is 691200 entries set one Python call at a time — expect
+minutes of silence first):
+
+```
+[migration] delivered 32 local device-map entries -> /ep_1_a_cmd     (and again for /ep_1_b_cmd)
+[migration] KV chunk address table serialized to /tmp/m3_kv_chunk_table.pb (configs=9, entries=691200)
+[migration] WORKER_READY: table=/tmp/m3_kv_chunk_table.pb
+[migration] LayerAck channel ready at /tt_prefill_layer_acks_m3_prefill
+```
+
+**Every verdict is logged by the DRIVER (terminal C), not the runner** — the runner-side
+`[kv-migrate-validate]` / `PREFILL_MIGRATE_PAIRWISE` validation was removed with the runner self-test
+(#52214). The driver's two read-backs (device-less, over UMD via the published table + device map):
+
+### 2a — destination bytes (`--verify-migration=dst-bytes`, the default)
+
+Each dst is asserted byte-equal to its src across all 9 configs — golden-free, length-agnostic, and it
+catches cross-talk between concurrent migrations.
+
+### 2b — destination golden (`--verify-migration=dst-golden`, or `both`)
+
+The dst slots are PCC'd against the golden trace (`workload.check_pcc: true` covers the SOURCE slots the
+same way). `dst-golden` needs the migrated range to span the full golden length, or it PCCs unwritten
+memory — the driver guards this and says so.
+
+---
+
+## Gates P0/P1/P2 — 2-stage intragalaxy pipeline (still one galaxy)
+
+The galaxy is carved into two Z-linked 4×4 sub-meshes (rank 0 = layers 0–29, rank 1 = 30–59; the
+TT_VISIBLE_DEVICES splits come from `topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml`).
+Migration-wise everything is the same flow at 2 ranks: both ranks join the per-cache stage-layout
+all-gathers (`kv_migration_stages` reports one `KvCacheStage` per cache — k, v, index_k), rank 0
+builds ONE merged 60-layer 9-config table (each stage's chunks at ITS cache's base address, global layer
+indices) and publishes it. Both ranks are on this host, so the producer/driver read-backs cover all 60
+layers once they merge the two rank-scoped device maps.
+
+Because num_ranks>1, the table path must be on shared storage — the bindings use
+`/data/philei/tmp/m3_kv_chunk_table_pp.pb` (`mkdir -p /data/philei/tmp` once). The weight cache for the
+4×4 mesh (`tensor_cache_bfp8_MeshShape(4,4)`) populates slowly on first use.
+
+### P0 — device-free merged-table unit test (no hardware)
+
+```bash
+pytest models/demos/minimax_m3/tests/test_kv_chunk_table_merge.py -q
+```
+
+### P1 — pipeline mock migration (merged table + producer read-back, no endpoint)
+
+```bash
+# ---- Terminal 1 — 2-rank runner ----
+$RUN $M3/m3_binding_mock_migration_intragalaxy_2rank.yaml $HOST:2
+
+# ---- Terminal 2 — producer (after rank 0 logs the merged table) ----
+python -m models.demos.common.prefill.runners.prefill_producer \
+  --manifest $M3/m3_producer_mock_migration_2rank.yaml
+```
+
+**Expect:** rank 0 `[mock-migration] merged KV chunk table -> /data/philei/tmp/m3_kv_chunk_table_pp.pb`
+(configs=9, layers=60); each rank `local device map -> /tmp/m3_kv_device_map_r<rank>.json`; producer
+merges both maps (`merged 2 device maps: 32 chips total`), then per-layer `K=… V=… index_k=…` across
+`60/60 local layers` and `KV cache PCC PASSED`.
+
+### P2 — pipeline loopback migration (endpoint + 2-rank runner + driver)
+
+Same three-terminal flow as Gate 2 — the endpoint launch (`./m3_gate2_endpoint.sh`), the readiness check
+(`./m3_gate2_check.sh`), and the teardown are unchanged (one host, endpoint id 1). Add the pipeline
+artifacts to the between-runs cleanup:
+
+```bash
+rm -f /tmp/m3_kv_device_map_r*.json /data/philei/tmp/m3_kv_chunk_table_pp.pb
+```
+
+```bash
+# ---- Terminal B — 2-rank runner ----
+$RUN $M3/m3_binding_loopback_migration_intragalaxy_2rank.yaml $HOST:2
+
+# ---- Terminal C — prefill + migrate (after B prints WORKER_READY + LayerAck ready) ----
+export PREFILL_MIGRATION_CLIENT_DIR="$MIG/python"
+python -m models.demos.common.prefill.runners.migration_driver \
+  --manifest $M3/m3_producer_loopback_migration_2rank.yaml
+```
+
+**Expect:** both ranks deliver their device maps to the co-located workers; rank 0
+`[migration] merged KV chunk table …` then `WORKER_READY`; driver `MIGRATE slot 0->2 / 1->3 complete`,
+source `check_pcc` over 60 layers, and `--verify-migration=dst-bytes` byte-equal across all 9 configs.
+Run once more with `--verify-migration=dst-golden` for the golden-anchored destination check.
+
+The merged table has 2× the single-rank entry count spread over both stages; the one-`table.set()`-per-
+entry Python build still takes minutes of silence in terminal B before `WORKER_READY`.
+
+---
+
+## tt-llm-engine — build and configure
+
+Only the **migration layer** is needed (`migration_endpoint`, `migration_worker`, `_migration_client`);
+`build-full` / `prefill_scheduler_driver` are not, since terminal C is a python process. It requires a
+tt-metal build carrying the `internal/disaggregation` headers.
+
+Build against the engine's **bundled tt-metal submodule**, which is what the CMake defaults assume. The pin
+(`3675a4e3d63`) carries those headers, and both the header and `kv_chunk_address_table.proto` are
+byte-identical to `/data/philei/tt-metal`'s, so the table the python runner writes and the table the worker
+parses agree either way.
+
+```bash
+# 1. Build the bundled submodule. Creates tt-metal/build_Release and a `build` symlink to it. Python
+#    bindings are unused by the migration layer, so skipping them cuts the largest part of the build.
+cd $ENGINE/tt-metal
+./build_metal.sh -c --without-python-bindings
+
+# 2. Migration layer. The old build dir must go — its cache points at another metal tree, and mixing
+#    objects compiled against two trees is not safe. No TT_METAL_* env: the defaults resolve TT_METAL_DIR
+#    to $ENGINE/tt-metal and TT_METAL_BUILD_DIR to its `build` symlink.
+cd $ENGINE
+rm -rf disaggregation/migration/build_RelWithDebInfo
+env -u TT_METAL_DIR -u TT_METAL_BUILD_DIR \
+  ./build_migration_layer.sh --build-type RelWithDebInfo --jobs $(nproc)
+```
+
+Check two lines of the cmake output:
+
+```
+-- protobuf: using tt-metal build (…)
+-- migration_worker: device DRAM support enabled (pure-UMD; libtt_metal NOT linked, detected at
+   …/tt-llm-engine/tt-metal/build/tt_metal/libtt_metal.so)
+```
+
+Device support is a *presence probe* for `libtt_metal.so` in the metal build dir, and step 1's failures are
+swallowed by `build_migration_layer.sh`'s `|| true` — skip or fail step 1 and you silently get a synthetic
+worker (SimulatedDram) that migrates nothing real. `readelf -d $MIG/bin/migration_worker | grep RUNPATH`
+should resolve into `$ENGINE/tt-metal/build/…`.
+
+Outputs land in `$MIG/bin/{migration_endpoint,migration_worker}` and `$MIG/python/_migration_client*.so`; the
+binding's `PREFILL_MIGRATION_CLIENT_DIR` and the terminal-C export both point at that `python/` dir.
+
+Configuration notes:
+
+* **Transport.** `disaggregation/migration/.roce_env` is present, so the launcher defaults to RoCEv2 and
+  hard-fails if the RoCE device or the UCX/PRRTE build is unusable. Single-host loopback does not need it;
+  `m3_gate2_endpoint.sh` passes `--tcp-transport`. To use RoCE instead, run `./setup_roce_mpi.sh` first.
+* **Queue names.** `--prefill_endpoint_id 1` gives `/mig_ep1_{cmd,table,resp}`. The runner's own defaults are
+  the older `/prefill_mig_{cmd,tbl,rsp}_1`, so the binding sets `PREFILL_MIGRATION_{CMD,TABLE,RESP}_QUEUE`
+  explicitly. Those are the master-only SET_TABLE / WORKER_READY channel; the device map goes to the
+  workers' own `/dev/shm/ep_1_{a,b}_*` queues, which the runner discovers by globbing.
+
+---
+
+## Values that must agree across the three processes
+
+| Value | M3 | Runner (`global_env`) | Producer / driver manifest |
+|-------|-----|----------------------|----------------------------|
+| model | `minimax_m3` | via `PREFILL_MANIFEST` | `model.variant` |
+| layers | 60 | via `PREFILL_MANIFEST` | `model.num_layers` |
+| chunk size | 5120 | `PREFILL_CHUNK_SIZE` | `model.chunk_size` |
+| cache length | 10240 | `PREFILL_MAX_SEQ_LEN` | `model.max_seq_len` |
+| mesh | 8 × 4 | `PREFILL_SP` / `PREFILL_TP` | `transport.sp` / `.tp` |
+| H2D socket | `m3_prefill` | `PREFILL_H2D_SERVICE_ID` | `transport.h2d_service_id` |
+| index dtype | bf16 | `M3_INDEX_CACHE_BF16` | `env.M3_INDEX_CACHE_BF16` |
+| KV table | `/tmp/m3_kv_chunk_table.pb` | `PREFILL_MIGRATION_TABLE_PATH` | `migration.table_path` |
+| sentinel | `/tmp/m3_migration_done.sentinel` | `MIGRATION_DONE_FILE` | `migration.done_file` |
+| queues | `/mig_ep1_*` | `PREFILL_MIGRATION_{CMD,TABLE,RESP}_QUEUE` | `migration.{cmd,table,resp}_queue` |
+| slot count | 4 (0,1 → 2,3) | `PREFILL_NUM_USERS` | `workload.num_users` = 2 src |
+| chunk budget | 4 | `PREFILL_STANDALONE_CHUNKED_NCHUNKS` | `num_users` × `chunks` |
+
+`PREFILL_STANDALONE_CHUNKED_NCHUNKS` is the one worth double-checking: the driver never sends a shutdown
+push, so the runner uses that count to know prefill is done before it polls the sentinel. Too low and it
+exits mid-prefill; too high and it blocks on chunks that never come — no PCC either way.
+
+---
+
+## Notes / gotchas
+
+- **`num_key_value_heads` must equal `TP`** (head `h` → column `h`); the table builder asserts it. M3 = 4 = TP.
+- **Config-id order is the src↔dst contract.** Loopback is self-consistent (one table is both source and
+  destination). A real prefill→decode run needs the decode endpoint to publish its configs in the same order
+  (`k_h0..N-1`, `v_h0..N-1`, `index_k`). Not exercised here.
+- **The JSON device map is written on BOTH paths now.** The real-migration branch delivers the map to the
+  workers over the client AND writes the sidecar, so producer-side `check_pcc` and the driver's
+  `--verify-migration` read-backs work in Gate 2 too. With num_ranks>1 each rank writes a rank-scoped
+  sidecar (`<stem>_r<rank>.json`); readers glob and merge them — clear stale `_r*.json` between runs whose
+  topology changed.
+- **Table build is ~9× the DeepSeek entry count** (9 configs, 691200 entries). It runs once at startup;
+  slowness there is Python `table.set()` overhead, not a correctness problem.
+- `_migration_client not importable` → `PREFILL_MIGRATION_CLIENT_DIR` must point at `$MIG/python`, in the
+  binding for the runner **and** exported for the driver.

--- a/models/demos/minimax_m3/tt/runners/adapters/minimax_m3.py
+++ b/models/demos/minimax_m3/tt/runners/adapters/minimax_m3.py
@@ -14,9 +14,10 @@ architecture (GQA + block-sparse MSA) with a REGULAR TP-head-sharded triple KV c
 not the DeepSeek merged/replicated kvpe cache. Single-rank AND pipeline-parallel (multi-galaxy D2D)
 prefill are wired: the runtime slices the model by rank (first_layer_idx / is_first_rank / is_last_rank),
 and the D2D activation ships emb-replicated across TP (pipeline_activation_emb_tp_sharded=False) to match
-M3's SP residual layout. KV-chunk-table migration IS wired for the single-rank case: the multi-tensor
-cache is described by a multi-config table (one config per (tensor, head-shard); see
-``tt/runners/kv_chunk_table.py``); pipelined migration is not yet wired (same limit as DeepSeek).
+M3's SP residual layout. KV-chunk-table migration is wired for BOTH: the multi-tensor cache is described
+by a multi-config table (one config per (tensor, head-shard); see ``tt/runners/kv_chunk_table.py``), and
+with a pipeline the gathered stage layouts merge every stage's layers into one table at global layer
+indices (one layout per cache — k, v, index_k — via ``kv_migration_stages``).
 
 Import-safety: the heavy stack (TtPrefillRuntime / Model / transformers AutoConfig / weight loading) is
 imported lazily inside the methods that need it, so ``import ...adapters.minimax_m3`` stays cheap enough

--- a/models/demos/minimax_m3/tt/runners/kv_chunk_table.py
+++ b/models/demos/minimax_m3/tt/runners/kv_chunk_table.py
@@ -143,8 +143,13 @@ def build_and_serialize_kv_chunk_table(
     for cache_name, layout in zip(("v", "index_k"), stage_layouts[1:]):
         # M3's three caches share one layer-index space (index_k allocates a slot for every layer, zeros
         # on dense ones), so every cache must gather the identical per-rank ranges.
-        if validate_stage_layout_contiguous(layout) != total_layers or any(
-            (a["first_layer"], a["count"]) != (b["first_layer"], b["count"]) for a, b in zip(stage_layouts[0], layout)
+        if (
+            len(layout) != len(stage_layouts[0])
+            or validate_stage_layout_contiguous(layout) != total_layers
+            or any(
+                (a["first_layer"], a["count"]) != (b["first_layer"], b["count"])
+                for a, b in zip(stage_layouts[0], layout)
+            )
         ):
             raise RuntimeError(
                 f"{cache_name} layout's layer ranges differ from k's; M3's caches share one layer-index "

--- a/models/demos/minimax_m3/tt/runners/kv_chunk_table.py
+++ b/models/demos/minimax_m3/tt/runners/kv_chunk_table.py
@@ -144,8 +144,7 @@ def build_and_serialize_kv_chunk_table(
         # M3's three caches share one layer-index space (index_k allocates a slot for every layer, zeros
         # on dense ones), so every cache must gather the identical per-rank ranges.
         if validate_stage_layout_contiguous(layout) != total_layers or any(
-            (a["first_layer"], a["count"]) != (b["first_layer"], b["count"])
-            for a, b in zip(stage_layouts[0], layout)
+            (a["first_layer"], a["count"]) != (b["first_layer"], b["count"]) for a, b in zip(stage_layouts[0], layout)
         ):
             raise RuntimeError(
                 f"{cache_name} layout's layer ranges differ from k's; M3's caches share one layer-index "
@@ -185,11 +184,11 @@ def build_and_serialize_kv_chunk_table(
 
                 # Replay the ND-shard ROUND_ROBIN_1D walk: 32-token blocks round-robin across the DRAM
                 # banks (per chip / per tensor), advancing the per-bank offset after each full bank
-                # sweep. Same arithmetic as DeepSeek's kimi builder — the addresses are identical on
-                # every column of a row (the tensor is allocated identically everywhere); only the
-                # device group's column differs. Each stage restarts the walk from ITS base address and
-                # writes at the GLOBAL layer index; the slot fold on device is per-stage
-                # (slot * stage_count + local_layer), which this slot -> local-layer order replays.
+                # sweep. The addresses are identical on every column of a row (the tensor is allocated
+                # identically everywhere); only the device group's column differs. Each stage restarts
+                # the walk from ITS base address and writes at the GLOBAL layer index; the slot fold on
+                # device is per-stage (slot * stage_count + local_layer), which this slot ->
+                # local-layer order replays.
                 curr_bank_id = 0
                 curr_bank_offset = 0
                 for slot in range(num_users):

--- a/models/demos/minimax_m3/tt/runners/kv_chunk_table.py
+++ b/models/demos/minimax_m3/tt/runners/kv_chunk_table.py
@@ -65,13 +65,21 @@ def build_and_serialize_kv_chunk_table(
     num_kv_heads,
     head_dim,
     path,
+    stage_layouts=None,
 ) -> str:
     """Build the M3 multi-config block-cyclic KV chunk address table and serialize it to ``path`` for the
     inference server's SET_TABLE. Returns the path on success.
 
     ``chunk_size`` is the block-cyclic period (the runtime's per-``prefill_chunk`` token count), which the
     KV writer / the indexed rope use as the period — NOT a hardcoded constant (unlike the kimi builder).
-    ``kv_cache`` is the ``MiniMaxKVCache`` (``.k`` / ``.v`` / ``.index_k`` device tensors). Single-rank only.
+    ``kv_cache`` is the ``MiniMaxKVCache`` (``.k`` / ``.v`` / ``.index_k`` device tensors); ``num_layers``
+    is THIS rank's layer count (== the global total single-rank).
+
+    ``stage_layouts`` (one gathered layout per ``kv_migration_stages`` entry — k, v, index_k) selects the
+    pipeline-parallel merge: one table spanning every stage's layers, each stage's chunks placed on ITS
+    mesh at ITS cache's base address, written at the GLOBAL layer index. With stage_layouts None the
+    table covers this rank's mesh alone via local ``buffer_address()`` / fabric-node lookups — the
+    single-rank path.
     """
     tp_axis = 1 - sp_axis
     sp = mesh_shape[sp_axis]
@@ -89,6 +97,8 @@ def build_and_serialize_kv_chunk_table(
         f"M3 KV chunk table maps head h -> TP column h, so num_key_value_heads ({num_kv_heads}) must equal "
         f"the TP column count ({cols}). A different head:column ratio needs a generalized column map."
     )
+    # Only THIS rank's cache is inspectable; in a pipeline every stage allocates the same way (same
+    # model/env), so its dtypes and the slot fold generalize to the gathered stages.
     for name, t in (("k", kv_cache.k), ("v", kv_cache.v), ("index_k", kv_cache.index_k)):
         assert (
             t.shape[0] == num_users * num_layers
@@ -97,17 +107,54 @@ def build_and_serialize_kv_chunk_table(
     num_chunks_per_seq_len = seq_len // chunk_size
 
     # Config layout (id order is the src<->dst migration contract): k_h0..k_hN-1, v_h0..v_hN-1, index_k.
-    # Each entry: (label, device tensor, TP columns forming its device group, dtype).
+    # Each entry: (label, cache index into stage_layouts, TP columns forming its device group, dtype).
     specs = []
     for h in range(num_kv_heads):
-        specs.append((f"k_h{h}", kv_cache.k, [h], kv_cache.k.dtype))
+        specs.append((f"k_h{h}", 0, [h], kv_cache.k.dtype))
     for h in range(num_kv_heads):
-        specs.append((f"v_h{h}", kv_cache.v, [h], kv_cache.v.dtype))
-    specs.append(("index_k", kv_cache.index_k, list(range(cols)), kv_cache.index_k.dtype))
+        specs.append((f"v_h{h}", 1, [h], kv_cache.v.dtype))
+    specs.append(("index_k", 2, list(range(cols)), kv_cache.index_k.dtype))
+
+    if stage_layouts is None:
+        # Single-rank: synthesize one one-stage layout per cache from the local mesh so both paths
+        # share the build loop below. base_addr identical on every chip of the mesh (each cache is
+        # allocated mesh-wide).
+        local_fnids = [
+            [mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(r, c)) for c in range(cols)] for r in range(sp)
+        ]
+        stage_layouts = [
+            [
+                {
+                    "first_layer": 0,
+                    "count": num_layers,
+                    "base_addr": int(t.buffer_address()),
+                    "num_banks": BH_NUM_DRAM_BANKS,
+                    "host_name": socket.gethostname(),
+                    "fnids": local_fnids,
+                }
+            ]
+            for t in (kv_cache.k, kv_cache.v, kv_cache.index_k)
+        ]
+
+    from models.demos.common.prefill.runners.migration import validate_stage_layout_contiguous
+
+    assert len(stage_layouts) == 3, f"expected one gathered layout per cache (k, v, index_k), got {len(stage_layouts)}"
+    total_layers = validate_stage_layout_contiguous(stage_layouts[0])
+    for cache_name, layout in zip(("v", "index_k"), stage_layouts[1:]):
+        # M3's three caches share one layer-index space (index_k allocates a slot for every layer, zeros
+        # on dense ones), so every cache must gather the identical per-rank ranges.
+        if validate_stage_layout_contiguous(layout) != total_layers or any(
+            (a["first_layer"], a["count"]) != (b["first_layer"], b["count"])
+            for a, b in zip(stage_layouts[0], layout)
+        ):
+            raise RuntimeError(
+                f"{cache_name} layout's layer ranges differ from k's; M3's caches share one layer-index "
+                f"space, so kv_migration_stages must report the same range for all three."
+            )
 
     configs = [
         _make_config(
-            num_layers=num_layers,
+            num_layers=total_layers,
             max_seq_len=seq_len,
             num_users=num_users,
             chunk_size_bytes=_chunk_size_bytes(dtype, head_dim),
@@ -116,46 +163,58 @@ def build_and_serialize_kv_chunk_table(
     ]
     table = ttnn.experimental.disaggregation.KvChunkAddressTable(configs)
 
-    host_name = socket.gethostname()
     hosts_set = set()
 
-    for config_id, (label, tensor, group_cols, dtype) in enumerate(specs):
-        base_addr = tensor.buffer_address()
+    for config_id, (label, tensor_idx, group_cols, dtype) in enumerate(specs):
         chunk_bytes = _chunk_size_bytes(dtype, head_dim)
-        for global_row in range(sp):
-            fabric_node_ids = [mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(global_row, c)) for c in group_cols]
-            group_idx = table.add_device_group(fabric_node_ids)
-            for fid in fabric_node_ids:
-                key = (int(fid.mesh_id), int(fid.chip_id))
-                if key not in hosts_set:
-                    table.set_fabric_node_host(fid, host_name=host_name)
-                    hosts_set.add(key)
+        for stage in stage_layouts[tensor_idx]:
+            base_addr = stage["base_addr"]
+            num_banks = stage["num_banks"]
+            # The gathered layout carries a per-host crc32 tag (allgather_int can't move strings); the
+            # single-rank synthesized stage carries the real local hostname instead.
+            host_name = stage.get("host_name") or f"host-{stage['host_tag']:08x}"
+            first = stage["first_layer"]
+            for global_row in range(sp):
+                fabric_node_ids = [stage["fnids"][global_row][c] for c in group_cols]
+                group_idx = table.add_device_group(fabric_node_ids)
+                for fid in fabric_node_ids:
+                    key = (int(fid.mesh_id), int(fid.chip_id))
+                    if key not in hosts_set:
+                        table.set_fabric_node_host(fid, host_name=host_name)
+                        hosts_set.add(key)
 
-            # Replay the ND-shard ROUND_ROBIN_1D walk: 32-token blocks round-robin across the DRAM banks
-            # (per chip / per tensor), advancing the per-bank offset after each full bank sweep. Same
-            # arithmetic as DeepSeek's kimi builder — the addresses are identical on every column of a row
-            # (the tensor is allocated identically everywhere); only the device group's column differs.
-            curr_bank_id = 0
-            curr_bank_offset = 0
-            for slot in range(num_users):
-                for layer in range(num_layers):
-                    for seq_chunk in range(num_chunks_per_seq_len):
-                        chunk_token_start = seq_chunk * chunk_size + global_row * tokens_per_chunk_local
-                        chunk_token_end = chunk_token_start + tokens_per_chunk_local
-                        for position in range(chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
-                            location = ttnn.experimental.disaggregation.KvCacheLocation()
-                            location.noc_addr = (curr_bank_id << 32) | (base_addr + curr_bank_offset)
-                            location.size_bytes = chunk_bytes
-                            location.device_group_index = group_idx
-                            table.set(layer, position, slot, location, config_id)
+                # Replay the ND-shard ROUND_ROBIN_1D walk: 32-token blocks round-robin across the DRAM
+                # banks (per chip / per tensor), advancing the per-bank offset after each full bank
+                # sweep. Same arithmetic as DeepSeek's kimi builder — the addresses are identical on
+                # every column of a row (the tensor is allocated identically everywhere); only the
+                # device group's column differs. Each stage restarts the walk from ITS base address and
+                # writes at the GLOBAL layer index; the slot fold on device is per-stage
+                # (slot * stage_count + local_layer), which this slot -> local-layer order replays.
+                curr_bank_id = 0
+                curr_bank_offset = 0
+                for slot in range(num_users):
+                    for local_layer in range(stage["count"]):
+                        global_layer = first + local_layer
+                        for seq_chunk in range(num_chunks_per_seq_len):
+                            chunk_token_start = seq_chunk * chunk_size + global_row * tokens_per_chunk_local
+                            chunk_token_end = chunk_token_start + tokens_per_chunk_local
+                            for position in range(
+                                chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+                            ):
+                                location = ttnn.experimental.disaggregation.KvCacheLocation()
+                                location.noc_addr = (curr_bank_id << 32) | (base_addr + curr_bank_offset)
+                                location.size_bytes = chunk_bytes
+                                location.device_group_index = group_idx
+                                table.set(global_layer, position, slot, location, config_id)
 
-                            curr_bank_id = (curr_bank_id + 1) % BH_NUM_DRAM_BANKS
-                            if curr_bank_id == 0:
-                                curr_bank_offset += chunk_bytes
+                                curr_bank_id = (curr_bank_id + 1) % num_banks
+                                if curr_bank_id == 0:
+                                    curr_bank_offset += chunk_bytes
 
     ttnn.experimental.disaggregation.export_to_protobuf_file(table, path)
     logger.info(
         f"[migration] M3 KV chunk address table serialized to {path} "
-        f"(configs={len(specs)} [{', '.join(s[0] for s in specs)}], entries={table.total_entries()})"
+        f"(configs={len(specs)} [{', '.join(s[0] for s in specs)}], stages={len(stage_layouts[0])}, "
+        f"layers={total_layers}, entries={table.total_entries()})"
     )
     return path

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_2galaxy_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_2galaxy_2rank.yaml
@@ -1,0 +1,41 @@
+# MiniMax-M3 — 2-galaxy 2-stage loopback migration rank binding (derived from
+# topology_configuration/pipeline_prefill_request_2rank.yaml + the intragalaxy loopback binding).
+# Each rank is a full 8x4 galaxy owning 30 layers; rank 0 publishes the merged 60-layer 9-config table.
+#
+# Launch (endpoint with workers on BOTH hosts must already be up):
+#   ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#     models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_2galaxy_2rank.yaml \
+#     <hostA>:1,<hostB>:1
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
+  - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
+
+mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
+
+global_env:
+  PREFILL_MANIFEST: "/data/philei/tt-metal/models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json"
+
+  PREFILL_FABRIC_MODE: "2d_torus_xy"
+  PREFILL_SP: "8"
+  PREFILL_TP: "4"
+  PREFILL_CHUNK_SIZE: "5120"
+  PREFILL_MAX_SEQ_LEN: "10240"
+  PREFILL_H2D_SERVICE_ID: "m3_prefill"
+  # Every dst slot must exist in the table: src 0,1 -> dst 2,3.
+  PREFILL_NUM_USERS: "4"
+  PREFILL_TRACE_DIR: "/data/philei/models/minimax-m3-prefill-cache/golden/longbook_10240"
+
+  PREFILL_ENABLE_MIGRATION: "1"
+  PREFILL_ENABLE_LAYER_ACK: "1"
+  PREFILL_USE_TRACE: "1"
+  PREFILL_MIGRATION_WAIT_READY_MS: "300000"
+  # num_ranks>1 rejects per-host table paths; every host resolves this shared path. Device map is
+  # host-local; each rank writes <stem>_r<rank>.json.
+  PREFILL_MIGRATION_TABLE_PATH: "/data/philei/tmp/m3_kv_chunk_table_pp.pb"
+  PREFILL_MIGRATION_DEVICE_MAP_PATH: "/tmp/m3_kv_device_map.json"
+  PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
+  PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
+  PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"
+  PREFILL_MIGRATION_CLIENT_DIR: "${PREFILL_MIGRATION_CLIENT_DIR}"
+
+  LOGURU_LEVEL: "INFO"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_2galaxy_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_2galaxy_2rank.yaml
@@ -13,7 +13,8 @@ rank_bindings:
 mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
 
 global_env:
-  PREFILL_MANIFEST: "/data/philei/tt-metal/models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json"
+  # Absolute so every rank resolves it regardless of cwd; tt-run expands ${VARS} from the launch shell.
+  PREFILL_MANIFEST: "${TT_METAL_HOME}/models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json"
 
   PREFILL_FABRIC_MODE: "2d_torus_xy"
   PREFILL_SP: "8"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_2galaxy_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_2galaxy_2rank.yaml
@@ -29,8 +29,7 @@ global_env:
   PREFILL_ENABLE_LAYER_ACK: "1"
   PREFILL_USE_TRACE: "1"
   PREFILL_MIGRATION_WAIT_READY_MS: "300000"
-  # num_ranks>1 rejects per-host table paths; every host resolves this shared path. Device map is
-  # host-local; each rank writes <stem>_r<rank>.json.
+  # Table on shared storage — num_ranks>1 rejects per-host paths like /tmp. Device map stays host-local.
   PREFILL_MIGRATION_TABLE_PATH: "/data/philei/tmp/m3_kv_chunk_table_pp.pb"
   PREFILL_MIGRATION_DEVICE_MAP_PATH: "/tmp/m3_kv_device_map.json"
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_intragalaxy_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_intragalaxy_2rank.yaml
@@ -1,0 +1,52 @@
+# MiniMax-M3 — pipeline Gate P2 (loopback migration) rank binding: 2-stage intra-galaxy pipeline on one
+# 8x4 BH galaxy carved into two Z-connected [4,4] sub-meshes (30 layers per stage), REQUEST mode.
+#
+# Every rank delivers its local device map to the co-located migration worker and joins the stage-layout
+# all-gather; rank 0 builds the merged 60-layer 9-config table, publishes it, and blocks on WORKER_READY,
+# then serves the driver's H2D pushes. It validates nothing: migration_driver owns both read-backs, so
+# run it with PREFILL_SEND_SHUTDOWN=1 or the runner never leaves its request loop.
+#
+# Launch (endpoint must already be up — one endpoint launch per runner launch, see
+# PREFILL_MIGRATION_TESTING.md Gate 2 / the pipeline gates section):
+#   ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#     models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_intragalaxy_2rank.yaml $HOST:2
+#
+# Queue names match launch_migration_endpoints.sh --prefill_endpoint_id 1 (default /mig_ep1_*); the
+# runner's own defaults are the older /prefill_mig_*_1 names, so they must be set explicitly.
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "28,29,24,25,0,4,5,1,31,26,27,30,6,7,2,3"}}
+  - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "18,22,23,19,14,15,10,11,20,16,17,21,9,8,13,12"}}
+
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
+
+global_env:
+  PREFILL_MANIFEST: "models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json"
+
+  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_SP: "4"
+  PREFILL_TP: "4"
+  PREFILL_CHUNK_SIZE: "5120"
+  PREFILL_MAX_SEQ_LEN: "10240"
+  PREFILL_H2D_SERVICE_ID: "m3_prefill"
+  # Every dst slot must exist in the table: src 0,1 -> dst 2,3.
+  PREFILL_NUM_USERS: "4"
+  PREFILL_TRACE_DIR: "/data/philei/models/minimax-m3-prefill-cache/golden/longbook_10240"
+  # Only 12B of metadata transits the queue; the default 64KB clashes with the MoE FFN L1 allocation.
+  PREFILL_PP_D2D_FIFO_BYTES: "32768"
+
+  PREFILL_ENABLE_MIGRATION: "1"
+  # The driver drains num_layers x pushes acks before it migrates; without them it copies a half-written
+  # cache. Selects the host-callback ack transport, the only one this runtime implements.
+  PREFILL_ENABLE_LAYER_ACK: "1"
+  PREFILL_USE_TRACE: "1"
+  PREFILL_MIGRATION_WAIT_READY_MS: "120000"
+  # num_ranks>1 rejects per-host table paths (/tmp, ...) — use shared storage. Device map stays
+  # host-local; each rank writes <stem>_r<rank>.json.
+  PREFILL_MIGRATION_TABLE_PATH: "/data/philei/tmp/m3_kv_chunk_table_pp.pb"
+  PREFILL_MIGRATION_DEVICE_MAP_PATH: "/tmp/m3_kv_device_map.json"
+  PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
+  PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
+  PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"
+  PREFILL_MIGRATION_CLIENT_DIR: "${PREFILL_MIGRATION_CLIENT_DIR}"
+
+  LOGURU_LEVEL: "INFO"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_intragalaxy_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_intragalaxy_2rank.yaml
@@ -1,13 +1,10 @@
-# MiniMax-M3 — pipeline Gate P2 (loopback migration) rank binding: 2-stage intra-galaxy pipeline on one
-# 8x4 BH galaxy carved into two Z-connected [4,4] sub-meshes (30 layers per stage), REQUEST mode.
-#
-# Every rank delivers its local device map to the co-located migration worker and joins the stage-layout
-# all-gather; rank 0 builds the merged 60-layer 9-config table, publishes it, and blocks on WORKER_READY,
-# then serves the driver's H2D pushes. It validates nothing: migration_driver owns both read-backs, so
-# run it with PREFILL_SEND_SHUTDOWN=1 or the runner never leaves its request loop.
+# MiniMax-M3 — pipeline Gate P2 (loopback migration): 2-stage intra-galaxy pipeline on one 8x4 BH galaxy
+# carved into two Z-connected [4,4] sub-meshes (30 layers per stage), REQUEST mode. The runner validates
+# nothing — migration_driver owns the read-backs; run the driver with PREFILL_SEND_SHUTDOWN=1 or the
+# runner never leaves its request loop.
 #
 # Launch (endpoint must already be up — one endpoint launch per runner launch, see
-# PREFILL_MIGRATION_TESTING.md Gate 2 / the pipeline gates section):
+# PREFILL_MIGRATION_TESTING.md):
 #   ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
 #     models/demos/minimax_m3/tt/runners/manifests/m3_binding_loopback_migration_intragalaxy_2rank.yaml $HOST:2
 #
@@ -35,13 +32,11 @@ global_env:
   PREFILL_PP_D2D_FIFO_BYTES: "32768"
 
   PREFILL_ENABLE_MIGRATION: "1"
-  # The driver drains num_layers x pushes acks before it migrates; without them it copies a half-written
-  # cache. Selects the host-callback ack transport, the only one this runtime implements.
+  # The driver drains num_layers x pushes acks before it migrates; without them it copies a half-written cache.
   PREFILL_ENABLE_LAYER_ACK: "1"
   PREFILL_USE_TRACE: "1"
   PREFILL_MIGRATION_WAIT_READY_MS: "120000"
-  # num_ranks>1 rejects per-host table paths (/tmp, ...) — use shared storage. Device map stays
-  # host-local; each rank writes <stem>_r<rank>.json.
+  # Table on shared storage — num_ranks>1 rejects per-host paths like /tmp. Device map stays host-local.
   PREFILL_MIGRATION_TABLE_PATH: "/data/philei/tmp/m3_kv_chunk_table_pp.pb"
   PREFILL_MIGRATION_DEVICE_MAP_PATH: "/tmp/m3_kv_device_map.json"
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml
@@ -1,18 +1,13 @@
-# MiniMax-M3 — pipeline Gate P1 (mock migration) rank binding: 2-stage intra-galaxy pipeline on one
-# 8x4 BH galaxy carved into two Z-connected [4,4] sub-meshes (30 layers per stage), REQUEST mode.
-#
-# PREFILL_ENABLE_MIGRATION=1 + PREFILL_MOCK_MIGRATION=1 selects the MERGED mock: every rank joins the
-# stage-layout all-gather, rank 0 builds ONE 60-layer 9-config table spanning both stages, each rank
-# writes a rank-scoped device map (<stem>_r<rank>.json) — no migration endpoint / worker involved.
-# prefill_producer reads the table + merged maps back device-lessly and PCCs each slot vs the golden.
+# MiniMax-M3 — pipeline Gate P1 (merged mock migration): 2-stage intra-galaxy pipeline on one 8x4 BH
+# galaxy carved into two Z-connected [4,4] sub-meshes (30 layers per stage), REQUEST mode. No migration
+# endpoint/worker; prefill_producer reads the merged table back device-lessly and PCCs vs the golden.
 #
 # Launch:
 #   ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
 #     models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml $HOST:2
 #
-# TT_VISIBLE_DEVICES: two 2x4 slices per mesh (mesh0 = {0,1}, mesh1 = {2,3}), ordered into a contiguous
-# 4x4 (same values as topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml); other
-# splits fail topology_mapper.
+# TT_VISIBLE_DEVICES: two 2x4 slices per mesh, ordered into a contiguous 4x4 (same values as
+# topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml); other splits fail topology_mapper.
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "28,29,24,25,0,4,5,1,31,26,27,30,6,7,2,3"}}
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "18,22,23,19,14,15,10,11,20,16,17,21,9,8,13,12"}}
@@ -35,8 +30,7 @@ global_env:
 
   PREFILL_ENABLE_MIGRATION: "1"
   PREFILL_MOCK_MIGRATION: "1"
-  # num_ranks>1 rejects per-host paths (/tmp, ...): rank 0 writes the merged table, every host's reader
-  # resolves the same path, so it must live on shared storage. The device map stays host-local.
+  # Table on shared storage — num_ranks>1 rejects per-host paths like /tmp. Device map stays host-local.
   PREFILL_MIGRATION_TABLE_PATH: "/data/philei/tmp/m3_kv_chunk_table_pp.pb"
   PREFILL_MIGRATION_DEVICE_MAP_PATH: "/tmp/m3_kv_device_map.json"
   # The producer's only barrier before it reads the KV back; without it the read races the device.

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml
@@ -1,0 +1,46 @@
+# MiniMax-M3 — pipeline Gate P1 (mock migration) rank binding: 2-stage intra-galaxy pipeline on one
+# 8x4 BH galaxy carved into two Z-connected [4,4] sub-meshes (30 layers per stage), REQUEST mode.
+#
+# PREFILL_ENABLE_MIGRATION=1 + PREFILL_MOCK_MIGRATION=1 selects the MERGED mock: every rank joins the
+# stage-layout all-gather, rank 0 builds ONE 60-layer 9-config table spanning both stages, each rank
+# writes a rank-scoped device map (<stem>_r<rank>.json) — no migration endpoint / worker involved.
+# prefill_producer reads the table + merged maps back device-lessly and PCCs each slot vs the golden.
+#
+# Launch:
+#   ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#     models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_2rank.yaml $HOST:2
+#
+# TT_VISIBLE_DEVICES: two 2x4 slices per mesh (mesh0 = {0,1}, mesh1 = {2,3}), ordered into a contiguous
+# 4x4 (same values as topology_configuration/pipeline_prefill_request_intragalaxy_2rank.yaml); other
+# splits fail topology_mapper.
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "28,29,24,25,0,4,5,1,31,26,27,30,6,7,2,3"}}
+  - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "18,22,23,19,14,15,10,11,20,16,17,21,9,8,13,12"}}
+
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_2x4x4_z_graph_descriptor.textproto
+
+global_env:
+  PREFILL_MANIFEST: "models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json"
+
+  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_SP: "4"
+  PREFILL_TP: "4"
+  PREFILL_CHUNK_SIZE: "5120"
+  PREFILL_MAX_SEQ_LEN: "10240"
+  PREFILL_H2D_SERVICE_ID: "m3_prefill"
+  PREFILL_NUM_USERS: "2"
+  PREFILL_TRACE_DIR: "/data/philei/models/minimax-m3-prefill-cache/golden/longbook_10240"
+  # Only 12B of metadata transits the queue; the default 64KB clashes with the MoE FFN L1 allocation.
+  PREFILL_PP_D2D_FIFO_BYTES: "32768"
+
+  PREFILL_ENABLE_MIGRATION: "1"
+  PREFILL_MOCK_MIGRATION: "1"
+  # num_ranks>1 rejects per-host paths (/tmp, ...): rank 0 writes the merged table, every host's reader
+  # resolves the same path, so it must live on shared storage. The device map stays host-local.
+  PREFILL_MIGRATION_TABLE_PATH: "/data/philei/tmp/m3_kv_chunk_table_pp.pb"
+  PREFILL_MIGRATION_DEVICE_MAP_PATH: "/tmp/m3_kv_device_map.json"
+  # The producer's only barrier before it reads the KV back; without it the read races the device.
+  PREFILL_ENABLE_LAYER_ACK: "1"
+  PREFILL_USE_TRACE: "1"
+
+  LOGURU_LEVEL: "INFO"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_4rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_4rank.yaml
@@ -1,0 +1,37 @@
+# MiniMax-M3 — 4-stage intragalaxy merged-mock accuracy gate (derived from
+# topology_configuration/pipeline_prefill_request_intragalaxy_4rank.yaml + the 2rank mock binding).
+# One 8x4 galaxy carved into 4 Z-chained [2,4] sub-meshes, 15 layers per stage.
+#
+# Launch:
+#   ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#     models/demos/minimax_m3/tt/runners/manifests/m3_binding_mock_migration_intragalaxy_4rank.yaml $HOST:4
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"}}
+  - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"}}
+  - {rank: 2, mesh_id: 2, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "16,17,18,19,20,21,22,23"}}
+  - {rank: 3, mesh_id: 3, mesh_host_rank: 0, env_overrides: {TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"}}
+
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_4x4x2_z_chain_graph_descriptor.textproto
+
+global_env:
+  PREFILL_MANIFEST: "models/demos/minimax_m3/tt/runners/manifests/minimax_m3.json"
+
+  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_SP: "2"
+  PREFILL_TP: "4"
+  PREFILL_CHUNK_SIZE: "5120"
+  PREFILL_MAX_SEQ_LEN: "10240"
+  PREFILL_H2D_SERVICE_ID: "m3_prefill"
+  PREFILL_NUM_USERS: "2"
+  PREFILL_TRACE_DIR: "/data/philei/models/minimax-m3-prefill-cache/golden/longbook_10240"
+  # Only 12B of metadata transits the queue; the default 64KB clashes with the MoE FFN L1 allocation.
+  PREFILL_PP_D2D_FIFO_BYTES: "32768"
+
+  PREFILL_ENABLE_MIGRATION: "1"
+  PREFILL_MOCK_MIGRATION: "1"
+  PREFILL_MIGRATION_TABLE_PATH: "/data/philei/tmp/m3_kv_chunk_table_pp.pb"
+  PREFILL_MIGRATION_DEVICE_MAP_PATH: "/tmp/m3_kv_device_map.json"
+  PREFILL_ENABLE_LAYER_ACK: "1"
+  PREFILL_USE_TRACE: "1"
+
+  LOGURU_LEVEL: "INFO"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration.yaml
@@ -42,3 +42,5 @@ migration:
 
 env:
   M3_INDEX_CACHE_BF16: "1"        # [MATCH RUNNER]
+  # M3's accepted KV PCC gate (producer default 0.93 is the DeepSeek convention and fails M3 at ~0.88).
+  PREFILL_STANDALONE_CHUNKED_PCC: "0.88"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration.yaml
@@ -32,7 +32,7 @@ workload:
 
 migration:
   dest_endpoint_id: 1             # == our own endpoint id => loopback
-  dst_slot_offset: 2              # dst = src + 2
+  dst_slot_offset: 2
   timeout_ms: 3600000
   done_file: /tmp/m3_migration_done.sentinel   # driver-side only; no runner counterpart
   table_path: /tmp/m3_kv_chunk_table.pb        # [MATCH RUNNER]
@@ -42,5 +42,4 @@ migration:
 
 env:
   M3_INDEX_CACHE_BF16: "1"        # [MATCH RUNNER]
-  # M3's accepted KV PCC gate (producer default 0.93 is the DeepSeek convention and fails M3 at ~0.88).
   PREFILL_STANDALONE_CHUNKED_PCC: "0.88"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2galaxy.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2galaxy.yaml
@@ -1,16 +1,10 @@
-# MiniMax-M3 — pipeline Gate P2 driver manifest: prefill slots 0,1 (2 chunks each) through the 2-stage
-# intragalaxy pipeline, then migrate 0->2 and 1->3 through the local migration endpoint (loopback) and
-# write the DONE sentinel.
+# MiniMax-M3 — 2-galaxy 2-stage loopback driver manifest: prefill slots 0,1 (2 chunks each) through the
+# 2-galaxy pipeline, then migrate 0->2 and 1->3 through the local migration endpoint (loopback).
 #
-# Pairs with m3_binding_loopback_migration_intragalaxy_2rank.yaml. Run it with migration_driver, NOT
-# prefill_producer:
-#
-#   python -m models.demos.common.prefill.runners.migration_driver \
-#     --manifest models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2rank.yaml
-#
-# Every verdict is logged HERE — the runner validates nothing. Sources come from check_pcc below,
-# destinations from --verify-migration (default dst-bytes). Add PREFILL_SEND_SHUTDOWN=1 to close the
-# runner's request loop once the gate has passed.
+# Pairs with m3_binding_loopback_migration_2galaxy_2rank.yaml. Run with migration_driver on rank 0's
+# host. Source PCC / --verify-migration read back only the layers whose chips resolve against THIS
+# host's device maps (rank 0's 30 layers); run prefill_producer with PREFILL_PRODUCER_CHECK_PCC=1 on the
+# other host for the remaining half.
 # client_dir is deliberately absent — export PREFILL_MIGRATION_CLIENT_DIR (it is per-checkout).
 
 model:
@@ -20,7 +14,7 @@ model:
   chunk_size: 5120
 
 transport:
-  sp: 4                             # per-stage sub-mesh is [4,4]
+  sp: 8                             # per-stage mesh is a full [8,4] galaxy
   tp: 4
   h2d_service_id: m3_prefill      # [MATCH RUNNER]
   connect_timeout_s: 60
@@ -45,5 +39,5 @@ migration:
 
 env:
   M3_INDEX_CACHE_BF16: "1"        # [MATCH RUNNER]
-  # M3's accepted KV PCC gate (producer default 0.93 is the DeepSeek convention and fails M3 at ~0.88).
+  # M3's accepted KV PCC gate (producer's default 0.93 is the DeepSeek convention and fails M3 at ~0.88).
   PREFILL_STANDALONE_CHUNKED_PCC: "0.88"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2galaxy.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2galaxy.yaml
@@ -2,9 +2,7 @@
 # 2-galaxy pipeline, then migrate 0->2 and 1->3 through the local migration endpoint (loopback).
 #
 # Pairs with m3_binding_loopback_migration_2galaxy_2rank.yaml. Run with migration_driver on rank 0's
-# host. Source PCC / --verify-migration read back only the layers whose chips resolve against THIS
-# host's device maps (rank 0's 30 layers); run prefill_producer with PREFILL_PRODUCER_CHECK_PCC=1 on the
-# other host for the remaining half.
+# host; its read-backs cover only the layers resident on that host — verify the other host's half there.
 # client_dir is deliberately absent — export PREFILL_MIGRATION_CLIENT_DIR (it is per-checkout).
 
 model:
@@ -28,7 +26,7 @@ workload:
 
 migration:
   dest_endpoint_id: 1             # == our own endpoint id => loopback
-  dst_slot_offset: 2              # dst = src + 2
+  dst_slot_offset: 2
   timeout_ms: 3600000
   done_file: /tmp/m3_migration_done.sentinel   # driver-side only; no runner counterpart
   table_path: /data/philei/tmp/m3_kv_chunk_table_pp.pb   # [MATCH RUNNER]
@@ -39,5 +37,4 @@ migration:
 
 env:
   M3_INDEX_CACHE_BF16: "1"        # [MATCH RUNNER]
-  # M3's accepted KV PCC gate (producer's default 0.93 is the DeepSeek convention and fails M3 at ~0.88).
   PREFILL_STANDALONE_CHUNKED_PCC: "0.88"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2rank.yaml
@@ -1,0 +1,47 @@
+# MiniMax-M3 — pipeline Gate P2 driver manifest: prefill slots 0,1 (2 chunks each) through the 2-stage
+# intragalaxy pipeline, then migrate 0->2 and 1->3 through the local migration endpoint (loopback) and
+# write the DONE sentinel.
+#
+# Pairs with m3_binding_loopback_migration_intragalaxy_2rank.yaml. Run it with migration_driver, NOT
+# prefill_producer:
+#
+#   python -m models.demos.common.prefill.runners.migration_driver \
+#     --manifest models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2rank.yaml
+#
+# Every verdict is logged HERE — the runner validates nothing. Sources come from check_pcc below,
+# destinations from --verify-migration (default dst-bytes). Add PREFILL_SEND_SHUTDOWN=1 to close the
+# runner's request loop once the gate has passed.
+# client_dir is deliberately absent — export PREFILL_MIGRATION_CLIENT_DIR (it is per-checkout).
+
+model:
+  variant: minimax_m3
+  num_layers: 60
+  max_seq_len: 10240
+  chunk_size: 5120
+
+transport:
+  sp: 4                             # per-stage sub-mesh is [4,4]
+  tp: 4
+  h2d_service_id: m3_prefill      # [MATCH RUNNER]
+  connect_timeout_s: 60
+
+workload:
+  num_users: 2                    # src slots 0,1 (the runner's table has 4 slots, so 2,3 are free dsts)
+  chunks: "2"
+  max_requests: 2                 # one resident request per slot
+  interleave: round_robin
+  check_pcc: true                 # SOURCE-slot golden PCC; --verify-migration covers the destinations
+
+migration:
+  dest_endpoint_id: 1             # == our own endpoint id => loopback
+  dst_slot_offset: 2              # dst = src + 2
+  timeout_ms: 3600000
+  done_file: /tmp/m3_migration_done.sentinel   # driver-side only; no runner counterpart
+  table_path: /data/philei/tmp/m3_kv_chunk_table_pp.pb   # [MATCH RUNNER]
+  device_map_path: /tmp/m3_kv_device_map.json            # [MATCH RUNNER] reader merges the _r*.json siblings
+  cmd_queue: /mig_ep1_cmd                      # [MATCH ENDPOINT]
+  table_queue: /mig_ep1_table
+  resp_queue: /mig_ep1_resp
+
+env:
+  M3_INDEX_CACHE_BF16: "1"        # [MATCH RUNNER]

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_loopback_migration_2rank.yaml
@@ -34,7 +34,7 @@ workload:
 
 migration:
   dest_endpoint_id: 1             # == our own endpoint id => loopback
-  dst_slot_offset: 2              # dst = src + 2
+  dst_slot_offset: 2
   timeout_ms: 3600000
   done_file: /tmp/m3_migration_done.sentinel   # driver-side only; no runner counterpart
   table_path: /data/philei/tmp/m3_kv_chunk_table_pp.pb   # [MATCH RUNNER]
@@ -45,5 +45,4 @@ migration:
 
 env:
   M3_INDEX_CACHE_BF16: "1"        # [MATCH RUNNER]
-  # M3's accepted KV PCC gate (producer default 0.93 is the DeepSeek convention and fails M3 at ~0.88).
   PREFILL_STANDALONE_CHUNKED_PCC: "0.88"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration.yaml
@@ -36,3 +36,4 @@ env:
   PREFILL_MIGRATION_DEVICE_MAP_PATH: /tmp/m3_kv_device_map.json  # [MATCH RUNNER]
   # Must match the runner — decides the index_k chunk size, hence the read-back decoder.
   M3_INDEX_CACHE_BF16: "1"
+  PREFILL_STANDALONE_CHUNKED_PCC: "0.88"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration.yaml
@@ -34,7 +34,5 @@ migration:
 env:
   PREFILL_MIGRATION_TABLE_PATH: /tmp/m3_kv_chunk_table.pb        # [MATCH RUNNER]
   PREFILL_MIGRATION_DEVICE_MAP_PATH: /tmp/m3_kv_device_map.json  # [MATCH RUNNER]
-  # index_k is PCC'd automatically for any layer whose golden carries index_k_cache_layer_<L>.
-  # M3_INDEX_CACHE_BF16 must match the runner's (the model manifest sets 1) — it decides the
-  # index_k chunk size, hence which decoder the read-back picks.
+  # Must match the runner — decides the index_k chunk size, hence the read-back decoder.
   M3_INDEX_CACHE_BF16: "1"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
@@ -37,3 +37,4 @@ env:
   PREFILL_MIGRATION_DEVICE_MAP_PATH: /tmp/m3_kv_device_map.json           # [MATCH RUNNER] reader merges the _r*.json siblings
   # Must match the runner — decides the index_k chunk size, hence the read-back decoder.
   M3_INDEX_CACHE_BF16: "1"
+  PREFILL_STANDALONE_CHUNKED_PCC: "0.88"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
@@ -1,0 +1,41 @@
+# MiniMax-M3 — pipeline Gate P1 producer manifest: push 2 slots x 2 chunks through the 2-stage
+# intragalaxy pipeline, then read the KV back device-lessly through the merged table and PCC it against
+# the golden (all 60 layers resolve locally — both stages live on this host).
+#
+# Pairs with m3_binding_mock_migration_intragalaxy_2rank.yaml. No migration endpoint.
+#
+#   python -m models.demos.common.prefill.runners.prefill_producer \
+#     --manifest models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
+#
+# prefill_producer (not migration_driver): this gate migrates nothing.
+
+model:
+  variant: minimax_m3
+  num_layers: 60
+  max_seq_len: 10240
+  chunk_size: 5120
+
+transport:
+  sp: 4                             # per-stage sub-mesh is [4,4]
+  tp: 4
+  h2d_service_id: m3_prefill      # [MATCH RUNNER]
+  connect_timeout_s: 60
+
+workload:
+  num_users: 2
+  chunks: "2"
+  max_requests: 2                 # one resident request per slot
+  interleave: round_robin
+  check_pcc: true                 # this IS the gate: per-slot read-back vs golden
+  trace_dir: /data/philei/models/minimax-m3-prefill-cache/golden/longbook_10240
+
+migration:
+  issue: false
+
+env:
+  PREFILL_MIGRATION_TABLE_PATH: /data/philei/tmp/m3_kv_chunk_table_pp.pb  # [MATCH RUNNER]
+  PREFILL_MIGRATION_DEVICE_MAP_PATH: /tmp/m3_kv_device_map.json           # [MATCH RUNNER] reader merges the _r*.json siblings
+  # index_k is PCC'd automatically for any layer whose golden carries index_k_cache_layer_<L>.
+  # M3_INDEX_CACHE_BF16 must match the runner's (the model manifest sets 1) — it decides the
+  # index_k chunk size, hence which decoder the read-back picks.
+  M3_INDEX_CACHE_BF16: "1"

--- a/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
+++ b/models/demos/minimax_m3/tt/runners/manifests/m3_producer_mock_migration_2rank.yaml
@@ -35,7 +35,5 @@ migration:
 env:
   PREFILL_MIGRATION_TABLE_PATH: /data/philei/tmp/m3_kv_chunk_table_pp.pb  # [MATCH RUNNER]
   PREFILL_MIGRATION_DEVICE_MAP_PATH: /tmp/m3_kv_device_map.json           # [MATCH RUNNER] reader merges the _r*.json siblings
-  # index_k is PCC'd automatically for any layer whose golden carries index_k_cache_layer_<L>.
-  # M3_INDEX_CACHE_BF16 must match the runner's (the model manifest sets 1) — it decides the
-  # index_k chunk size, hence which decoder the read-back picks.
+  # Must match the runner — decides the index_k chunk size, hence the read-back decoder.
   M3_INDEX_CACHE_BF16: "1"

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -425,12 +425,19 @@ class TtPrefillRuntime:
         index_k = gather(kv_cache.index_k, 0).unsqueeze(0).unsqueeze(0)
         return k, v, index_k
 
-    def kv_migration_base_address(self, kv_cache) -> int:
-        """This stage's KV base DRAM address — the engine's per-rank anchor for the migration
-        all-gather (it holds the cache but must not introspect its layout). M3's cache is three
-        tensors; the K tensor is the anchor, and since the table build is single-rank the gathered
-        layout is never consumed."""
-        return int(kv_cache.k.buffer_address())
+    def kv_migration_stages(self, kv_cache, first_layer_idx=None, num_my_layers=None):
+        """One ``KvCacheStage`` per migratable device cache, in the order ``build_kv_chunk_table``
+        consumes their gathered layouts: k, v, index_k. Unlike GLM's compacted index cache, all three
+        M3 tensors share one layer-index space (index_k allocates a slot for every layer, zeros on
+        dense ones), so every stage carries the same layer range."""
+        from models.demos.common.prefill.runners.migration import KvCacheStage
+
+        first_layer_idx = self.config.first_layer_idx if first_layer_idx is None else int(first_layer_idx)
+        num_my_layers = self.config.num_layers if num_my_layers is None else int(num_my_layers)
+        return [
+            KvCacheStage(int(t.buffer_address()), first_layer_idx, num_my_layers)
+            for t in (kv_cache.k, kv_cache.v, kv_cache.index_k)
+        ]
 
     def build_kv_chunk_table(
         self,
@@ -439,19 +446,17 @@ class TtPrefillRuntime:
         *,
         first_layer_idx: int = 0,
         num_my_layers: Optional[int] = None,
-        stage_layout=None,
+        stage_layouts=None,
     ) -> str:
         """Build + serialize M3's multi-config KV chunk address table (k_h0..N, v_h0..N, index_k) to
         ``path`` and return it. The engine then PUBLISHES it to the migration worker (this issues no
         comms). Called by the runner when PREFILL_ENABLE_MIGRATION=1 / PREFILL_MOCK_MIGRATION=1.
 
-        Single-rank only: this describes the whole-model cache and has no cross-stage merge, so a
-        gathered layout spanning more than this rank's stage is rejected rather than silently dropped."""
-        if stage_layout is not None and len(stage_layout) > 1:
-            raise NotImplementedError(
-                f"MiniMax-M3 KV migration is single-rank only; got a {len(stage_layout)}-stage layout. "
-                "The multi-config (per head-shard) table has no cross-stage merge."
-            )
+        Multi-rank (pipeline-parallel): this rank owns layers [first_layer_idx, first_layer_idx +
+        num_my_layers). The runner all-gathers one layout per ``kv_migration_stages`` entry (k, v,
+        index_k) and passes them as ``stage_layouts`` so ONLY rank 0 builds the table spanning every
+        stage; with stage_layouts None the table covers config.num_layers == the full model from this
+        rank's own mesh."""
         from models.demos.minimax_m3.tt.runners.kv_chunk_table import build_and_serialize_kv_chunk_table
 
         c = self.config
@@ -467,6 +472,7 @@ class TtPrefillRuntime:
             num_kv_heads=self.hf_config.num_key_value_heads,
             head_dim=self.hf_config.head_dim,
             path=path,
+            stage_layouts=stage_layouts,
         )
 
     def read_slot_kv(self, kv_cache, slot: int):

--- a/models/demos/minimax_m3/tt/tt_prefill_runtime.py
+++ b/models/demos/minimax_m3/tt/tt_prefill_runtime.py
@@ -427,9 +427,8 @@ class TtPrefillRuntime:
 
     def kv_migration_stages(self, kv_cache, first_layer_idx=None, num_my_layers=None):
         """One ``KvCacheStage`` per migratable device cache, in the order ``build_kv_chunk_table``
-        consumes their gathered layouts: k, v, index_k. Unlike GLM's compacted index cache, all three
-        M3 tensors share one layer-index space (index_k allocates a slot for every layer, zeros on
-        dense ones), so every stage carries the same layer range."""
+        consumes their gathered layouts: k, v, index_k. All three share one layer-index space (index_k
+        allocates a slot for every layer, zeros on dense ones), so every stage carries the same range."""
         from models.demos.common.prefill.runners.migration import KvCacheStage
 
         first_layer_idx = self.config.first_layer_idx if first_layer_idx is None else int(first_layer_idx)


### PR DESCRIPTION
## What

Wires MiniMax-M3's multi-config KV chunk table (k_h0..3, v_h0..3, index_k) into the pipeline-parallel stage merge, on top of the per-cache stage-layout API from #53637: `kv_migration_stages` reports one `KvCacheStage` per cache tensor, and the M3 builder merges the gathered per-cache layouts into one table at global layer indices. Drops the previous `NotImplementedError` for multi-stage layouts.

Common-runner changes:
- Rank-scoped device-map sidecars (`<stem>_r<rank>.json`) so co-located ranks (intragalaxy pipelines) don't overwrite each other; readers glob and merge them.
- Host-local layer skip in the M3/gpt-oss producer read-backs (same pattern as the MLA reader), so multi-host verification skips remote layers instead of failing.

Plus intragalaxy 2/4-rank and 2-galaxy manifests, a device-free merged-table pytest, and doc updates. The M3 loopback driver manifests pin the source-PCC gate to 0.88.

## Validation (all on hardware, 2026-08-25)

- `models/demos/minimax_m3/tests/test_kv_chunk_table_merge.py` (device-free) — 7/7
- Single-rank Gate 2 loopback — regression pass
- Intragalaxy 2-stage loopback — source PCC 60/60 layers, dst==src byte-identical (345600 chunks), migrated slots ≥ 0.88 vs golden
- 2-galaxy 2-stage loopback (b08u02+b09u02) — source PCC + dst-bytes per host, both halves golden-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=philei/m3-pipeline-kv-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:philei/m3-pipeline-kv-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=philei/m3-pipeline-kv-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:philei/m3-pipeline-kv-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=philei/m3-pipeline-kv-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:philei/m3-pipeline-kv-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=philei/m3-pipeline-kv-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:philei/m3-pipeline-kv-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=philei/m3-pipeline-kv-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:philei/m3-pipeline-kv-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=philei/m3-pipeline-kv-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:philei/m3-pipeline-kv-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=philei/m3-pipeline-kv-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:philei/m3-pipeline-kv-migration)