### PR TITLE
Fix failing CCL WH Galaxy test in L2 nightly

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -425,9 +425,9 @@ def fit_core_grid_to_device(mesh_device, shard_grid):
     """Use the preferred grid when the device has it, else let the device place the cores."""
     if shard_grid is None:
         return None
+    last_core = shard_grid.bounding_box().end
     device_grid = mesh_device.compute_with_storage_grid_size()
-    preferred = shard_grid.bounding_box().grid_size()
-    if preferred.x <= device_grid.x and preferred.y <= device_grid.y:
+    if last_core.x < device_grid.x and last_core.y < device_grid.y:
         return shard_grid
     return ttnn.num_cores_to_corerangeset(shard_grid.num_cores(), device_grid, row_wise=True)
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -421,6 +421,17 @@ def get_core_range_set(output_core_grid):
     return output_core_range_set
 
 
+def fit_core_grid_to_device(mesh_device, shard_grid):
+    """Use the preferred grid when the device has it, else let the device place the cores."""
+    if shard_grid is None:
+        return None
+    device_grid = mesh_device.compute_with_storage_grid_size()
+    preferred = shard_grid.bounding_box().grid_size()
+    if preferred.x <= device_grid.x and preferred.y <= device_grid.y:
+        return shard_grid
+    return ttnn.num_cores_to_corerangeset(shard_grid.num_cores(), device_grid, row_wise=True)
+
+
 CORE_RANGE_SET_1x1 = ttnn.CoreRangeSet(
     {
         ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
@@ -545,6 +556,8 @@ def test_all_gather_6u_llama(
 ):
     if mesh_device.get_num_devices() != 32:
         pytest.skip("Not TG!")
+    input_shard_grid = fit_core_grid_to_device(mesh_device, input_shard_grid)
+    output_shard_grid = fit_core_grid_to_device(mesh_device, output_shard_grid)
     if input_shard_grid is not None and input_shard_shape is not None:
         input_shard_spec = ttnn.ShardSpec(
             input_shard_grid,
@@ -708,6 +721,8 @@ def test_all_gather_tg_llama(
 ):
     if mesh_device.get_num_devices() != 32:
         pytest.skip("Not TG!")
+    input_shard_grid = fit_core_grid_to_device(mesh_device, input_shard_grid)
+    output_shard_grid = fit_core_grid_to_device(mesh_device, output_shard_grid)
     if input_shard_grid is not None and input_shard_shape is not None:
         input_shard_spec = ttnn.ShardSpec(
             input_shard_grid,


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Fix test logic for shard core grid - if exact grid shape is not available, let device place the cores.

Test run: https://github.com/tenstorrent/tt-metal/actions/runs/32873631235

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ci)