### PR TITLE
[LLK] [Performance] Optimize tanh approx SFPU kernel: 6-entry SFPLUTFP32 table in raw TTI

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -12,7 +12,6 @@
 #include "ckernel_defs.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "ckernel_sfpu_sigmoid.h"
-#include "sfpu/ckernel_sfpu_load_config.h"
 #include "ckernel_sfpu_recip.h"
 #include "ckernel_sfpu_expm1.h"
 #include "ckernel_sfpu_trigonometry.h"
@@ -147,26 +146,67 @@ sfpi_inline void _sfpu_tanh_polynomial_x2_(
     y1 = sfpi::copysgn(sfpi::min(r1, 1.0f), x1);
 }
 
+// Approximate tanh: six-segment piecewise-linear table evaluated by SFPLUTFP32
+// (FP16_6ENTRY_TABLE1 | SGN_RETAIN), replacing a three-segment SFPLUT table whose
+// 4-bit-mantissa coefficients gave max |absolute error| 0.1447. Now 0.0117, at 3 issue slots per
+// datum instead of 4.
+//
+// Raw TTI because sfpi cannot emit the instruction: tanh is odd, so the table is fitted on |x|
+// and SGN_RETAIN copies the input's sign onto the result, but sfpi::lut2()'s six-register
+// overload always ORs SGN_RETAIN into the mod and __builtin_rvtt_sfplutfp32_6r rejects every mod
+// with that bit set, so it can never compile. (lut2_sign() does compile, but SGN_UPDATE would
+// give |tanh(x)| and cost a copysign per datum.) The restriction is sfpi's, not the hardware's:
+// the mod assembles and is verified on silicon.
+//
+// The steady state is LUT / LOAD-next / STORE-previous, writing the LUT result to LReg[7] rather
+// than to LReg[3] which the instruction already reads. That separation is where nearly all of
+// the speedup lives, and dropping the per-datum TTINCRWC is a minor part of it. Measured
+// cycles/tile (bf16, ITERATIONS=32):
+//
+//   sfpi, 3-segment SFPLUT           LOAD, LUT, STORE, INCRWC   4 slots   160.0
+//   TTI, result in LReg[3], no rotation  LOAD, LUT, STORE       3 slots   156.9   (1.02x)
+//   TTI, result in LReg[7], rotated (this)  LUT, LOAD, STORE    3 slots   125.9   (1.27x)
+//
+// For scale, a bare LOAD/STORE/INCRWC copy with no arithmetic measures 124.1, so the table
+// lookup is now essentially free. Recording the body once into the replay buffer and stepping
+// dest from an ADDR_MOD_6 with dest.incr = 2 was also measured and rejected: 156.5,
+// indistinguishable from the un-rotated form, so the replay buffer is not the limit here and
+// claiming a shared addr_mod and replay slot would buy nothing.
+constexpr int TANH_APPX_LUT6_MOD = SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1 | SFPLUTFP32_MOD0_SGN_RETAIN;
+
+template <int K, int ITERATIONS>
+sfpi_inline void _tanh_appx_lut6_step_() {
+    constexpr InstrModLoadStore IM = InstrModLoadStore::DEFAULT;
+
+    // LReg[7] = copysign(table(|LReg[3]|), LReg[3]).
+    TTI_SFPLUTFP32(p_sfpu::LREG7, TANH_APPX_LUT6_MOD);
+
+    // Goes between the LUT and the store that consumes it, and is genuinely independent: it
+    // writes LReg[3], which the LUT already consumed on issue, and leaves LReg[7] alone. The
+    // last datum has no next load, and needs nothing in its place.
+    if constexpr (K + 1 < ITERATIONS) {
+        TTI_SFPLOAD(p_sfpu::LREG3, IM, ADDR_MOD_7, 2 * (K + 1));
+    }
+
+    TTI_SFPSTORE(p_sfpu::LREG7, IM, ADDR_MOD_7, 2 * K);
+
+    if constexpr (K + 1 < ITERATIONS) {
+        _tanh_appx_lut6_step_<K + 1, ITERATIONS>();
+    }
+}
+
+template <int ITERATIONS>
+inline void _calculate_tanh_appx_lut6_() {
+    constexpr InstrModLoadStore IM = InstrModLoadStore::DEFAULT;
+    // Prologue load; every later load is issued inside the previous datum's LUT shadow.
+    TTI_SFPLOAD(p_sfpu::LREG3, IM, ADDR_MOD_7, 0);
+    _tanh_appx_lut6_step_<0, ITERATIONS>();
+}
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_tanh() {
     if constexpr (APPROXIMATION_MODE) {
-        // SFPU microcode
-        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
-        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
-        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
-
-#pragma GCC unroll 8
-        for (int d = 0; d < ITERATIONS; d++) {
-            sfpi::vFloat val = sfpi::dst_reg[0];
-            val = sfpi::lut(val, l0, l1, l2);
-            sfpi::dst_reg[0] = val;
-
-            sfpi::dst_reg++;
-        }
-
-        l_reg[sfpi::LRegs::LReg0] = l0;
-        l_reg[sfpi::LRegs::LReg1] = l1;
-        l_reg[sfpi::LRegs::LReg2] = l2;
+        _calculate_tanh_appx_lut6_<ITERATIONS>();
     } else if constexpr (is_fp32_dest_acc_en) {  // APPROXIMATION_MODE is false
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
@@ -206,12 +246,40 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanh_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
-        std::uint32_t imm0 = 0x1DFF;  // 0.90625*x
-        std::uint32_t imm1 = 0x481A;  // 0.09375*x + 0.8125
-        std::uint32_t imm2 = 0xFF00;  // 1
-        _sfpu_load_imm16_(0, imm0);
-        _sfpu_load_imm16_(1, imm1);
-        _sfpu_load_imm16_(2, imm2);
+        // Six-segment piecewise-linear fit of tanh(|x|), evaluated by SFPLUTFP32 in
+        // FP16_6ENTRY_TABLE1 mode: LReg[0..2] hold the slopes, LReg[4..6] the intercepts, two
+        // Lut16ToFp32-encoded halves per register (low half = even segment, high half = odd).
+        //
+        //   |x| <  0.5   0.942871094*|x|                 (intercept pinned to exactly 0)
+        //   |x| <  1.0   0.599121094*|x| + 0.174194336
+        //   |x| <  1.5   0.287109375*|x| + 0.481933594
+        //   |x| <  2.0   0.117736816*|x| + 0.731933594
+        //   |x| <  3.0   0.030960083*|x| + 0.905761719
+        //   |x| >= 3.0                     1.0
+        //
+        // Each segment is a minimax linear fit snapped to the nearest Lut16ToFp32-representable
+        // pair. Max |absolute error| 0.0117 (was 0.1447), max relative error 0.0571 (was 0.1899).
+        // The residual is dominated by the [0.5, 1.0) segment and is the floor for a linear fit
+        // on hardware-fixed 0.5-wide breakpoints: err ~ |tanh''|*h^2/16.
+        //
+        // Both pinned coefficients are load-bearing. The first intercept must stay exactly 0
+        // (Lut16ToFp32 code 0x7C00, which encodes zero as exponent 31, not 0x0000) or SGN_RETAIN
+        // turns it into +/-c and tanh(0) stops being 0; the tail slope must stay exactly 0 or the
+        // fit diverges as |x| grows. A zero tail slope also evaluates 0*inf for |x| = inf, so
+        // tanh(+/-inf) is NaN -- unchanged from the old table, which had one too.
+
+        // A0 = 0.942871094 (0x3B8B), A1 = 0.599121094 (0x38CB)
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x38CB3B8B);
+        // B0 = 0           (0x7C00), B1 = 0.174194336 (0x3193)
+        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x31937C00);
+        // A2 = 0.287109375 (0x3498), A3 = 0.117736816 (0x2F89)
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x2F893498);
+        // B2 = 0.481933594 (0x37B6), B3 = 0.731933594 (0x39DB)
+        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x39DB37B6);
+        // A4 = 0.030960083 (0x27ED), A5 = 0           (0x7C00)
+        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x7C0027ED);
+        // B4 = 0.905761719 (0x3B3F), B5 = 1.0         (0x3C00)
+        sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vUInt(0x3C003B3F);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
             sfpi::vConstFloatPrgm0 = 2.0f * 1.442695f;      // 2 * log2(e) == 2 / ln(2)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -182,8 +182,15 @@ sfpi_inline void _tanh_appx_lut6_step_() {
     TTI_SFPLUTFP32(p_sfpu::LREG7, TANH_APPX_LUT6_MOD);
 
     // Goes between the LUT and the store that consumes it, and is genuinely independent: it
-    // writes LReg[3], which the LUT already consumed on issue, and leaves LReg[7] alone. The
-    // last datum has no next load, and needs nothing in its place.
+    // writes LReg[3], which the LUT already consumed on issue, and leaves LReg[7] alone.
+    //
+    // The last datum has no next load and gets no filler, which leaves SFPLUTFP32 -> SFPSTORE
+    // back to back on LReg[7]. That is a real read-after-write hazard, not a free pairing: the
+    // Blackhole SFPU interlocks RAW hazards in hardware and stalls the store until the LUT's
+    // write retires -- the same behaviour ckernel_sfpu_quant.h in this directory relies on to
+    // omit its SFPNOPs -- where the Wormhole copy has to spend an explicit TTI_SFPNOP. The
+    // stall is real and measurable; hiding it for every other datum is where most of the 1.27x
+    // below comes from. This one datum eats it because there is nothing left to fill it with.
     if constexpr (K + 1 < ITERATIONS) {
         TTI_SFPLOAD(p_sfpu::LREG3, IM, ADDR_MOD_7, 2 * (K + 1));
     }
@@ -197,10 +204,14 @@ sfpi_inline void _tanh_appx_lut6_step_() {
 
 template <int ITERATIONS>
 inline void _calculate_tanh_appx_lut6_() {
+    // No zero-trip base case: _tanh_appx_lut6_step_<0, 0> would still issue the LUT and a store
+    // to dest row 0, where the loop this replaces was a no-op at ITERATIONS == 0. Unreachable
+    // today -- every instantiation is 8 or 32 -- so assert it rather than emit a runtime guard.
+    static_assert(ITERATIONS > 0, "approximate tanh requires at least one datum");
     constexpr InstrModLoadStore IM = InstrModLoadStore::DEFAULT;
     // Prologue load; every later load is issued inside the previous datum's LUT shadow.
     TTI_SFPLOAD(p_sfpu::LREG3, IM, ADDR_MOD_7, 0);
-    _tanh_appx_lut6_step_<0, ITERATIONS>();
+    _tanh_appx_lut6_step_<0 /* K */, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
@@ -250,17 +261,28 @@ inline void tanh_init() {
         // FP16_6ENTRY_TABLE1 mode: LReg[0..2] hold the slopes, LReg[4..6] the intercepts, two
         // Lut16ToFp32-encoded halves per register (low half = even segment, high half = odd).
         //
-        //   |x| <  0.5   0.942871094*|x|                 (intercept pinned to exactly 0)
-        //   |x| <  1.0   0.599121094*|x| + 0.174194336
-        //   |x| <  1.5   0.287109375*|x| + 0.481933594
+        //   |x| <  0.5   0.947265625*|x|                 (intercept pinned to exactly 0)
+        //   |x| <  1.0   0.599121094*|x| + 0.174072266
+        //   |x| <  1.5   0.269775391*|x| + 0.503417969
         //   |x| <  2.0   0.117736816*|x| + 0.731933594
         //   |x| <  3.0   0.030960083*|x| + 0.905761719
         //   |x| >= 3.0                     1.0
         //
         // Each segment is a minimax linear fit snapped to the nearest Lut16ToFp32-representable
-        // pair. Max |absolute error| 0.0117 (was 0.1447), max relative error 0.0571 (was 0.1899).
-        // The residual is dominated by the [0.5, 1.0) segment and is the floor for a linear fit
-        // on hardware-fixed 0.5-wide breakpoints: err ~ |tanh''|*h^2/16.
+        // pair, then constrained so consecutive lines never step down where they meet. tanh is
+        // strictly increasing and has no discontinuity, so a downward step at a knee inverts the
+        // order of two inputs straddling it -- and six independently fitted segments do step
+        // down: by 0.0043 at |x| = 1.0 and 0.0041 at |x| = 1.5, both larger than a bf16 ulp
+        // there, so the inversion survives the store instead of being rounded away. Segments 0-2
+        // are therefore tied to meet exactly at |x| = 0.5 and 1.0; the three remaining knees
+        // already step up (+0.00046 at 1.5, +0.00027 at 2.0, +0.00136 at 3.0), so the fit is
+        // monotone non-decreasing whatever the store rounds them to. The constraint is close to
+        // free -- max |absolute error| 0.011740 tied against
+        // 0.011721 untied (was 0.1447), and max relative error 0.0527 tied against 0.0571 untied
+        // (was 0.1899) -- and it leaves the |x| >= 2 error unchanged at 0.0049, which is what
+        // TABLE1 was picked over TABLE2 for. The residual is dominated by the [0.5, 1.0) segment
+        // and is the floor for a linear fit on hardware-fixed 0.5-wide breakpoints:
+        // err ~ |tanh''|*h^2/16.
         //
         // Both pinned coefficients are load-bearing. The first intercept must stay exactly 0
         // (Lut16ToFp32 code 0x7C00, which encodes zero as exponent 31, not 0x0000) or SGN_RETAIN
@@ -268,14 +290,14 @@ inline void tanh_init() {
         // fit diverges as |x| grows. A zero tail slope also evaluates 0*inf for |x| = inf, so
         // tanh(+/-inf) is NaN -- unchanged from the old table, which had one too.
 
-        // A0 = 0.942871094 (0x3B8B), A1 = 0.599121094 (0x38CB)
-        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x38CB3B8B);
-        // B0 = 0           (0x7C00), B1 = 0.174194336 (0x3193)
-        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x31937C00);
-        // A2 = 0.287109375 (0x3498), A3 = 0.117736816 (0x2F89)
-        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x2F893498);
-        // B2 = 0.481933594 (0x37B6), B3 = 0.731933594 (0x39DB)
-        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x39DB37B6);
+        // A0 = 0.947265625 (0x3B94), A1 = 0.599121094 (0x38CB)
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x38CB3B94);
+        // B0 = 0           (0x7C00), B1 = 0.174072266 (0x3192)
+        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x31927C00);
+        // A2 = 0.269775391 (0x3451), A3 = 0.117736816 (0x2F89)
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x2F893451);
+        // B2 = 0.503417969 (0x3807), B3 = 0.731933594 (0x39DB)
+        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x39DB3807);
         // A4 = 0.030960083 (0x27ED), A5 = 0           (0x7C00)
         sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x7C0027ED);
         // B4 = 0.905761719 (0x3B3F), B5 = 1.0         (0x3C00)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -150,26 +150,61 @@ sfpi_inline void _sfpu_tanh_polynomial_x2_(
     y1 = sfpi::copysgn(sfpi::min(r1, 1.0f), x1);
 }
 
+// Approximate tanh: six-segment piecewise-linear table evaluated by SFPLUTFP32
+// (FP16_6ENTRY_TABLE1 | SGN_RETAIN), replacing a three-segment SFPLUT table whose
+// 4-bit-mantissa coefficients gave max |absolute error| 0.1447. Now 0.0117, at 3 issue slots per
+// datum instead of 5.
+//
+// Raw TTI because sfpi cannot emit the instruction: tanh is odd, so the table is fitted on |x|
+// and SGN_RETAIN copies the input's sign onto the result, but sfpi::lut2()'s six-register
+// overload always ORs SGN_RETAIN into the mod and __builtin_rvtt_sfplutfp32_6r rejects every mod
+// with that bit set, so it can never compile. (lut2_sign() does compile, but SGN_UPDATE would
+// give |tanh(x)| and cost a copysign per datum.) The restriction is sfpi's, not the hardware's:
+// the mod assembles and is verified on silicon.
+//
+// The second reason is scheduling. SFPLUTFP32's VD is a free field, but sfpi always picks
+// LReg[3] -- the register the instruction is hardwired to read -- so the one-cycle
+// result-latency slot has to be an SFPNOP and pipelining through sfpi costs an SFPMOV pair per
+// datum. Writing the result to LReg[7] instead lets the next datum's SFPLOAD fill that slot, so
+// the steady state is LUT / LOAD-next / STORE-previous and one staging register is enough -- no
+// rotation, which is why the table's appetite for LReg[0..2] and LReg[4..6] costs nothing.
+constexpr int TANH_APPX_LUT6_MOD = SFPLUTFP32_MOD0_FP16_6ENTRY_TABLE1 | SFPLUTFP32_MOD0_SGN_RETAIN;
+
+template <int K, int ITERATIONS>
+sfpi_inline void _tanh_appx_lut6_step_() {
+    constexpr InstrModLoadStore IM = InstrModLoadStore::DEFAULT;
+
+    // LReg[7] = copysign(table(|LReg[3]|), LReg[3]).
+    TTI_SFPLUTFP32(p_sfpu::LREG7, TANH_APPX_LUT6_MOD);
+
+    // Fills the LUT's one-cycle result-latency slot, and is genuinely independent: it writes
+    // LReg[3], which the LUT already consumed on issue, and leaves LReg[7] alone.
+    if constexpr (K + 1 < ITERATIONS) {
+        TTI_SFPLOAD(p_sfpu::LREG3, IM, ADDR_MOD_3, 2 * (K + 1));
+    } else {
+        TTI_SFPNOP;
+    }
+
+    // Two cycles after the LUT, satisfying its "do not read the result on the next cycle" rule.
+    TTI_SFPSTORE(p_sfpu::LREG7, IM, ADDR_MOD_3, 2 * K);
+
+    if constexpr (K + 1 < ITERATIONS) {
+        _tanh_appx_lut6_step_<K + 1, ITERATIONS>();
+    }
+}
+
+template <int ITERATIONS>
+inline void _calculate_tanh_appx_lut6_() {
+    constexpr InstrModLoadStore IM = InstrModLoadStore::DEFAULT;
+    // Prologue load; every later load is issued inside the previous datum's latency slot.
+    TTI_SFPLOAD(p_sfpu::LREG3, IM, ADDR_MOD_3, 0);
+    _tanh_appx_lut6_step_<0, ITERATIONS>();
+}
+
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_tanh() {
     if constexpr (APPROXIMATION_MODE) {
-        // SFPU microcode
-        sfpi::vUInt l0 = l_reg[sfpi::LRegs::LReg0];
-        sfpi::vUInt l1 = l_reg[sfpi::LRegs::LReg1];
-        sfpi::vUInt l2 = l_reg[sfpi::LRegs::LReg2];
-
-#pragma GCC unroll 8
-        for (int d = 0; d < ITERATIONS; d++) {
-            sfpi::vFloat val = sfpi::dst_reg[0];
-            val = sfpi::lut(val, l0, l1, l2);
-            sfpi::dst_reg[0] = val;
-
-            sfpi::dst_reg++;
-        }
-
-        l_reg[sfpi::LRegs::LReg0] = l0;
-        l_reg[sfpi::LRegs::LReg1] = l1;
-        l_reg[sfpi::LRegs::LReg2] = l2;
+        _calculate_tanh_appx_lut6_<ITERATIONS>();
     } else if constexpr (is_fp32_dest_acc_en) {  // APPROXIMATION_MODE is false
         for (int d = 0; d < ITERATIONS; d++) {
             sfpi::vFloat val = sfpi::dst_reg[0];
@@ -209,9 +244,40 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void tanh_init() {
     math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (APPROXIMATION_MODE) {
-        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x1DFF);  // 0.90625*x
-        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x481A);  // 0.09375*x + 0.8125
-        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0xFF00);  // 1
+        // Six-segment piecewise-linear fit of tanh(|x|), evaluated by SFPLUTFP32 in
+        // FP16_6ENTRY_TABLE1 mode: LReg[0..2] hold the slopes, LReg[4..6] the intercepts, two
+        // Lut16ToFp32-encoded halves per register (low half = even segment, high half = odd).
+        //
+        //   |x| <  0.5   0.942871094*|x|                 (intercept pinned to exactly 0)
+        //   |x| <  1.0   0.599121094*|x| + 0.174194336
+        //   |x| <  1.5   0.287109375*|x| + 0.481933594
+        //   |x| <  2.0   0.117736816*|x| + 0.731933594
+        //   |x| <  3.0   0.030960083*|x| + 0.905761719
+        //   |x| >= 3.0                     1.0
+        //
+        // Each segment is a minimax linear fit snapped to the nearest Lut16ToFp32-representable
+        // pair. Max |absolute error| 0.0117 (was 0.1447), max relative error 0.0571 (was 0.1899).
+        // The residual is dominated by the [0.5, 1.0) segment and is the floor for a linear fit
+        // on hardware-fixed 0.5-wide breakpoints: err ~ |tanh''|*h^2/16.
+        //
+        // Both pinned coefficients are load-bearing. The first intercept must stay exactly 0
+        // (Lut16ToFp32 code 0x7C00, which encodes zero as exponent 31, not 0x0000) or SGN_RETAIN
+        // turns it into +/-c and tanh(0) stops being 0; the tail slope must stay exactly 0 or the
+        // fit diverges as |x| grows. A zero tail slope also evaluates 0*inf for |x| = inf, so
+        // tanh(+/-inf) is NaN -- unchanged from the old table, which had one too.
+
+        // A0 = 0.942871094 (0x3B8B), A1 = 0.599121094 (0x38CB)
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x38CB3B8B);
+        // B0 = 0           (0x7C00), B1 = 0.174194336 (0x3193)
+        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x31937C00);
+        // A2 = 0.287109375 (0x3498), A3 = 0.117736816 (0x2F89)
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x2F893498);
+        // B2 = 0.481933594 (0x37B6), B3 = 0.731933594 (0x39DB)
+        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x39DB37B6);
+        // A4 = 0.030960083 (0x27ED), A5 = 0           (0x7C00)
+        sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x7C0027ED);
+        // B4 = 0.905761719 (0x3B3F), B5 = 1.0         (0x3C00)
+        sfpi::l_reg[sfpi::LRegs::LReg6] = sfpi::vUInt(0x3C003B3F);
     } else {
         if constexpr (is_fp32_dest_acc_en) {
             sfpi::vConstFloatPrgm0 = 2.0f * 1.442695f;      // 2 * log2(e) == 2 / ln(2)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_tanh.h
@@ -195,10 +195,14 @@ sfpi_inline void _tanh_appx_lut6_step_() {
 
 template <int ITERATIONS>
 inline void _calculate_tanh_appx_lut6_() {
+    // No zero-trip base case: _tanh_appx_lut6_step_<0, 0> would still issue the LUT and a store
+    // to dest row 0, where the loop this replaces was a no-op at ITERATIONS == 0. Unreachable
+    // today -- every instantiation is 8 or 32 -- so assert it rather than emit a runtime guard.
+    static_assert(ITERATIONS > 0, "approximate tanh requires at least one datum");
     constexpr InstrModLoadStore IM = InstrModLoadStore::DEFAULT;
     // Prologue load; every later load is issued inside the previous datum's latency slot.
     TTI_SFPLOAD(p_sfpu::LREG3, IM, ADDR_MOD_3, 0);
-    _tanh_appx_lut6_step_<0, ITERATIONS>();
+    _tanh_appx_lut6_step_<0 /* K */, ITERATIONS>();
 }
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
@@ -248,17 +252,28 @@ inline void tanh_init() {
         // FP16_6ENTRY_TABLE1 mode: LReg[0..2] hold the slopes, LReg[4..6] the intercepts, two
         // Lut16ToFp32-encoded halves per register (low half = even segment, high half = odd).
         //
-        //   |x| <  0.5   0.942871094*|x|                 (intercept pinned to exactly 0)
-        //   |x| <  1.0   0.599121094*|x| + 0.174194336
-        //   |x| <  1.5   0.287109375*|x| + 0.481933594
+        //   |x| <  0.5   0.947265625*|x|                 (intercept pinned to exactly 0)
+        //   |x| <  1.0   0.599121094*|x| + 0.174072266
+        //   |x| <  1.5   0.269775391*|x| + 0.503417969
         //   |x| <  2.0   0.117736816*|x| + 0.731933594
         //   |x| <  3.0   0.030960083*|x| + 0.905761719
         //   |x| >= 3.0                     1.0
         //
         // Each segment is a minimax linear fit snapped to the nearest Lut16ToFp32-representable
-        // pair. Max |absolute error| 0.0117 (was 0.1447), max relative error 0.0571 (was 0.1899).
-        // The residual is dominated by the [0.5, 1.0) segment and is the floor for a linear fit
-        // on hardware-fixed 0.5-wide breakpoints: err ~ |tanh''|*h^2/16.
+        // pair, then constrained so consecutive lines never step down where they meet. tanh is
+        // strictly increasing and has no discontinuity, so a downward step at a knee inverts the
+        // order of two inputs straddling it -- and six independently fitted segments do step
+        // down: by 0.0043 at |x| = 1.0 and 0.0041 at |x| = 1.5, both larger than a bf16 ulp
+        // there, so the inversion survives the store instead of being rounded away. Segments 0-2
+        // are therefore tied to meet exactly at |x| = 0.5 and 1.0; the three remaining knees
+        // already step up (+0.00046 at 1.5, +0.00027 at 2.0, +0.00136 at 3.0), so the fit is
+        // monotone non-decreasing whatever the store rounds them to. The constraint is close to
+        // free -- max |absolute error| 0.011740 tied against
+        // 0.011721 untied (was 0.1447), and max relative error 0.0527 tied against 0.0571 untied
+        // (was 0.1899) -- and it leaves the |x| >= 2 error unchanged at 0.0049, which is what
+        // TABLE1 was picked over TABLE2 for. The residual is dominated by the [0.5, 1.0) segment
+        // and is the floor for a linear fit on hardware-fixed 0.5-wide breakpoints:
+        // err ~ |tanh''|*h^2/16.
         //
         // Both pinned coefficients are load-bearing. The first intercept must stay exactly 0
         // (Lut16ToFp32 code 0x7C00, which encodes zero as exponent 31, not 0x0000) or SGN_RETAIN
@@ -266,14 +281,14 @@ inline void tanh_init() {
         // fit diverges as |x| grows. A zero tail slope also evaluates 0*inf for |x| = inf, so
         // tanh(+/-inf) is NaN -- unchanged from the old table, which had one too.
 
-        // A0 = 0.942871094 (0x3B8B), A1 = 0.599121094 (0x38CB)
-        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x38CB3B8B);
-        // B0 = 0           (0x7C00), B1 = 0.174194336 (0x3193)
-        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x31937C00);
-        // A2 = 0.287109375 (0x3498), A3 = 0.117736816 (0x2F89)
-        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x2F893498);
-        // B2 = 0.481933594 (0x37B6), B3 = 0.731933594 (0x39DB)
-        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x39DB37B6);
+        // A0 = 0.947265625 (0x3B94), A1 = 0.599121094 (0x38CB)
+        sfpi::l_reg[sfpi::LRegs::LReg0] = sfpi::vUInt(0x38CB3B94);
+        // B0 = 0           (0x7C00), B1 = 0.174072266 (0x3192)
+        sfpi::l_reg[sfpi::LRegs::LReg4] = sfpi::vUInt(0x31927C00);
+        // A2 = 0.269775391 (0x3451), A3 = 0.117736816 (0x2F89)
+        sfpi::l_reg[sfpi::LRegs::LReg1] = sfpi::vUInt(0x2F893451);
+        // B2 = 0.503417969 (0x3807), B3 = 0.731933594 (0x39DB)
+        sfpi::l_reg[sfpi::LRegs::LReg5] = sfpi::vUInt(0x39DB3807);
         // A4 = 0.030960083 (0x27ED), A5 = 0           (0x7C00)
         sfpi::l_reg[sfpi::LRegs::LReg2] = sfpi::vUInt(0x7C0027ED);
         // B4 = 0.905761719 (0x3B3F), B5 = 1.0         (0x3C00)

--- a/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
+++ b/tt_metal/tt-llk/tests/python_tests/accuracy/test_sfpu_accuracy.py
@@ -61,6 +61,7 @@ APPROX_CAPABLE_OPS = [
     MathOperation.Sin,
     MathOperation.Cos,
     MathOperation.Gelu,
+    MathOperation.Tanh,
 ]
 
 FORMATS = input_output_formats(
@@ -105,9 +106,6 @@ def _skip_if_unsupported(
     formats: InputOutputFormat,
 ) -> None:
     """Skip variants the hardware / metal stack does not support."""
-    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
-        pytest.skip(reason="Metal tanh does not support approximation mode")
-
     if (
         dest_acc == DestAccumulation.No
         and TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_sfpu.py
@@ -437,9 +437,6 @@ def test_eltwise_unary_sfpu(
     if mathop == MathOperation.ReluMin:
         pytest.skip(reason="https://github.com/tenstorrent/tt-llk/issues/1120")
 
-    if mathop == MathOperation.Tanh and approx_mode == ApproximationMode.Yes:
-        pytest.skip(reason="Metal tanh does not support approximation mode")
-
     # Each profile has its own Blackhole dest_acc=No guard, measured against its own
     # format set: the broad profile runs everything except a Float16 input or
     # Float32->Float16, while the standard profile allows only Float32->Float32.


### PR DESCRIPTION
### PR Category
Performance (with an accuracy improvement riding along)

### Summary

Approximate `tanh` moves from a 3-segment `SFPLUT` table to a 6-segment `SFPLUTFP32` one, on both
Wormhole and Blackhole. It gets **more accurate and faster at the same time**, which I had
previously concluded was impossible for this op.

**Split at review request** (@fvranicTT), so the two kernels can be reverted independently. This PR
is now approximate **tanh** only; approximate **sigmoid** moved to #55061. The kernels do not
overlap — this branch touches `ckernel_sfpu_tanh.h` on both arches, that one touches
`ckernel_sfpu_sigmoid_appx.h` — so the two can land in either order. Both branches are freshly cut
from the same `main`; this one was also rebased in the process, because `main` has since renamed
`test_sfpu_unary.py` to `test_eltwise_unary_sfpu.py`.

The finding that unlocked it: `SFPLUT` / `SFPLUTFP32` take their input from `LReg[3]` by hardware,
but the destination `VD` is a free field — and **sfpi always picks `LReg[3]` for the destination
too**, the register the instruction already reads. That forces an `SFPNOP` into the result-latency
slot and makes software pipelining impossible (going 2-wide through sfpi is a _net loss_: it inserts
an `SFPMOV` pair per datum). Picking `VD = LReg[7]` instead lets the next datum's load fill that
slot, so **one** staging register suffices and a six-register table costs nothing in schedulability.
My earlier claim that the wide table would eat the LReg rotation was wrong — the rotation only ever
existed to work around sfpi pinning the destination.

**Blackhole needed the same kernel shape for a different reason, and that is the reusable lesson.**
Blackhole has no `LReg` write-latency hazard at all: sfpi emits `SFPLUT` and a dependent `SFPSTORE`
back to back with nothing between them, so there is no `SFPNOP` to remove and, on paper, nothing to
port beyond the coefficients. Measured, the naive port (raw TTI for the six-entry table,
`VD = LReg[3]`, immediate dest offsets, no rotation) gains **1.9%**. Adding the Wormhole rotation
gains **27%**. Blackhole issues a dependent pair without complaint and then *stalls* on it, so the
rotation pays as latency hiding rather than as NOP elimination. Anyone reading a Blackhole SFPU body
and counting `SFPNOP`s to find headroom will conclude there is none.

## Accuracy

Computed by decoding the coefficients back out of the patched headers and evaluating over 800k
points. **Identical on both arches** — the table ports byte-for-byte, and the two arches' existing
gelu tables are already byte-identical, which is the evidence that `Lut16ToFp32` and `SFPLUTFP32`'s
table modes mean the same thing on both.

| | max abs error | max rel error | value at 0 | monotone |
|---|---|---|---|---|
| **tanh** (approx) | 0.144656 → **0.011740** (12.3×) | 0.1899 → **0.0527** (3.6×) | 0 → 0 preserved | yes → **yes** |

These are **table** figures — the fit error alone. End to end it picks up the store's truncation. The
deterministic accuracy harness reports, for approximate tanh over its 36864 sampled rows on an n300
(max |absolute error|, by input → output format):

| input ↓ / output → | bf16 | fp16 | fp32 |
|---|---|---|---|
| **bf16** | 0.015625 | 0.013672 | 0.015625 |
| **fp16** | 0.015625 | 0.012207 | 0.012207 |
| **fp32** | 0.015625 | 0.012207 | 0.015625 |

Anything storing to bf16 lands on 0.015625 — the table's 0.011740 plus one bf16 ulp (0.003906) from
the truncating fp32 → bf16 store listed under known gaps, which dominates the fit everywhere it
applies. fp16 output lands on 0.012207, the table plus one fp16 ulp. Every worst-case row sits at
|x| ≈ 0.75–0.80, inside the [0.5, 1.0) segment named below as the residual's dominant term.

Because the store dominates, the harness's **absolute** figures are byte-for-byte identical before
and after the monotonicity retune below (checked by re-running it against the pre-retune constants);
its max **relative** error is what moves, 0.0625 → 0.058065.

### The table — 6-segment `FP16_6ENTRY_TABLE1`, slopes in `LReg[0..2]`, intercepts in `LReg[4..6]`

| range | slope | intercept |
|---|---|---|
| \|x\| < 0.5 | 0.947265625 | 0 (pinned) |
| \|x\| < 1.0 | 0.599121094 | 0.174072266 |
| \|x\| < 1.5 | 0.269775391 | 0.503417969 |
| \|x\| < 2.0 | 0.117736816 | 0.731933594 |
| \|x\| < 3.0 | 0.030960083 | 0.905761719 |
| \|x\| >= 3.0 | 0 (pinned) | 1.0 |

Each segment is a minimax linear fit snapped to the nearest `Lut16ToFp32`-representable pair, then
constrained so consecutive lines never step down where they meet (see **Monotonicity** below). The
residual is dominated by the [0.5, 1.0) segment and is the floor for a piecewise-linear fit on
hardware-fixed 0.5-wide breakpoints (err ≈ |tanh''|·h²/16 ≈ 0.0117). Six segments is the most
`SFPLUTFP32` offers and the breakpoints are not programmable, so this is the end of the road for a
piecewise-linear tanh.

### Monotonicity

Raised in review, and the review was right. Fitting the six segments **independently** — which is
what the first revision of this PR did — makes the fit step *down* at two of its knees: by 0.004272
at |x| = 1.0 and 0.004059 at |x| = 1.5. tanh is strictly increasing and the 3-segment table this
replaces was continuous at both of its knees, so that was a new defect, not a pre-existing one. It
is also not rounded away: a bf16 ulp at 0.77 is 0.00390625, so both steps are larger than one.

Fixed by tying segments 0–2 to meet **exactly** at |x| = 0.5 and 1.0. The other three knees already
stepped up (+0.00046 at 1.5, +0.00027 at 2.0, +0.00136 at 3.0), so the fit is now monotone
non-decreasing whatever the store rounds it to. Four coefficients change; segments 3–5 are
byte-identical, on both arches.

The constraint is close to free. Searching the `Lut16ToFp32` grid for the minimax fit subject to no
downward step, holding both pinned coefficients:

| | untied (first revision) | tied (shipped) |
|---|---|---|
| max abs error | 0.011721 | **0.011740** |
| max rel error | 0.057129 | **0.052734** |
| max abs error, \|x\| ≥ 2 | 0.004945 | **0.004945** |
| decreasing steps | **2** | **0** |

0.16% worse in max absolute error, 7.7% *better* in relative error, and the |x| ≥ 2 error is
unchanged — which matters, because that is the figure TABLE1 was chosen over TABLE2 on. The tied
solution equioscillates at ≈0.0115–0.0117 across all five fitted segments, the signature of it being
the constrained optimum rather than a lucky pick.

A **fully continuous** table also exists at 0.011740, but continuity forces the [2, 3) segment to
hit exactly 1.0 at x = 3 and pushes the tail error to 0.009177 — 1.9× worse, and past TABLE2's
0.00732. Rejected for that reason; upward steps at the last three knees cost nothing.

Verified on silicon rather than modelled. A 1755-point ladder over [0, 8], dense either side of
every knee, run through the real kernel on an n300 at `Float32 → Float32` and `Float32 → Float16_b`:

| | untied | tied (shipped) |
|---|---|---|
| max abs error (fp32 out) | 0.011638 | 0.011740 |
| max abs error, \|x\| ≥ 2 | 0.004945 | 0.004945 |
| max rel error | 0.057120 | 0.052725 |
| decreasing output steps, fp32 out | **2** | **0** |
| decreasing output steps, bf16 out | **2** (one full bf16 ulp each) | **0** |

**No performance cost, and that is checked rather than argued.** The generated `math.elf` differs
from the pre-retune build in exactly four `sfploadi` immediates, at identical addresses with an
identical instruction count, on *both* arches — so every cycle figure below stands as measured. (The
tt-llk build cache keys on paths, not header contents, so each variant was built under its own fresh
`RUNNER_TEMP`; the two builds landing on the same content hash is what makes the ELF diff
meaningful.)

Two coefficients are **pinned rather than fitted**, and both matter: the first intercept must be
exactly 0 (`Lut16ToFp32` code `0x7C00`, which encodes zero as exponent 31, not `0x0000`) because
`SGN_RETAIN` copies the input's sign onto the whole result including the intercept — a non-zero
value there makes `tanh(0)` come back as ±c. The tail slope must be exactly 0 or the fit diverges as
|x| grows. Both were held fixed by the monotonicity search above.

`FP16_6ENTRY_TABLE2` (final breakpoint 4.0 instead of 3.0) was evaluated: same overall error but
worse in the tail (max error for |x| ≥ 2 is 0.00732 vs TABLE1's 0.00495). TABLE1 chosen.
`FP32_3ENTRY` gives *exact* fp32 coefficients but only three segments and measures 0.082 — 7×
worse. **Segment count dominates coefficient precision here by a wide margin.**

**Test tolerances tightened, not loosened.** The tt-llk suite had been *skipping approx tanh
entirely* (`"Metal tanh does not support approximation mode"`) — not because it was unsupported, but
because 0.1447 abs error could never pass the 0.05 atol gate. Skip removed, and no tolerance entry
is added in its place, so a regression in the table fails instead of being absorbed.

## Performance

`MATH_ISOLATE`, ITERATIONS=32, Float16_b. Real before/after: kernels stashed to the base commit,
measured, restored, re-measured, with a fresh `RUNNER_TEMP` per variant (it is the build root —
reusing it serves a stale ELF that silently reports the previous variant's cycles).

The two arches' absolute numbers are **not comparable to each other**: the Wormhole figures are
whole-loop `TILE_LOOP` totals as the harness reported them at the time, the Blackhole ones are the
per-tile normalisation it reports now. Ratios are comparable.

### Wormhole n300

| op | marker | before | after | speedup |
|---|---|---|---|---|
| **tanh** | TILE_LOOP | 24594 | **16264** | **1.51×** |
| tanh | KERNEL | 25021 | 16694 | 1.50× |
| tanh | INIT | 237 | 247 | 0.96× |

1.51× is against a 5/3 = 1.67× slot ceiling. The gap is RISC-V issue bandwidth: per-datum immediate
offsets mean the body can no longer be recorded once into the replay buffer, so the RISC-V issues 3
instructions per datum where it previously issued one `TTREPLAY`. `INIT` is slightly slower because
the table is six `LReg` writes instead of three — once per kernel, not per tile.

### Blackhole p100a — every op these changes can reach

Cycles per tile, `TILE_LOOP`, Float16_b → Float16_b, loop_factor=16. **Re-measured from scratch
after the exp split**, so `before` is the clean base commit. All 32 rows reproduced to the hundredth
and a repeat run of the whole set deviated on none of them; observed noise floor is ±0.03
cycles/tile.

| op | approx | dest_acc | before | after | |
|---|---|---|---|---|---|
| **tanh** | Yes | No | 159.98 | **125.95** | **1.270×** |
| **tanh** | Yes | Yes | 160.01 | **125.94** | **1.271×** |
| tanh | No | No / Yes | 528.98 / 1436.01 | unchanged | flat |
| sigmoid | Yes / No | No | 221.04 / 1247.02 | unchanged | flat |
| sigmoid_appx | — | No / Yes | 221.02 / 221.05 | unchanged | flat |
| exp | Yes / No | No | 93.59 / 577.98 | unchanged | flat |
| gelu_appx | Yes / No | No / Yes | 220.92 / 220.98 | unchanged | flat |
| silu | Yes / No | No | 1373.05 | unchanged | flat |
| sqrt | Yes | No / Yes | 543.02 / 511.02 | unchanged | flat |
| sqrt | No | No / Yes | 895.02 / 862.98 | unchanged | flat |
| rsqrt | Yes | No / Yes | 671.01 / 639.02 | unchanged | flat |
| rsqrt | No | No / Yes | 1022.99 / 991.02 | unchanged | flat |
| identity | — | No / Yes | 124.06 / 124.11 | unchanged | floor |

Per-marker for dest_acc=No: KERNEL 20781 → 16430, INIT 165 → 167.

Every untouched op lands on the same number to the hundredth. The `sigmoid` / `sigmoid_appx` rows
are **controls in this PR** — they move in #55061, not here. `exp` shares no code with this kernel
and is measured only to prove it.

`identity` — a bare `LOAD/STORE/INCRWC` dest-to-dest copy with no arithmetic — is the reference
point, not a control. At **124.06**, approx tanh's 125.95 means the table lookup is now essentially
free on Blackhole. Going below that floor needs `SFPLOADMACRO` (which is what makes approx exp's
93.59 possible) and `SFPLUTFP32` may not be able to join it at all: the instruction has no source
field, so its input is pinned to `LReg[3]` and datums cannot be cycled through `LReg[0..3]` the way
exp's compute macro does.

### Where the Blackhole win actually comes from

| body | slots/datum | cycles/tile | vs baseline |
|---|---|---|---|
| sfpi, 3-segment `SFPLUT` (`LOAD, LUT, STORE, INCRWC`) | 4 | 159.98 | — |
| TTI, `VD = LReg[3]`, immediate offsets, no rotation | 3 | 156.94 | 1.02× |
| TTI, `VD = LReg[7]`, rotated — **shipped** | 3 | **125.95** | **1.27×** |

Dropping a slot is worth 1.9%; separating the LUT from the store that consumes it is worth the other
25%. On Blackhole the issue-slot count is a poor proxy for cost.

**Two alternatives were built and rejected**, both re-measured from the base rather than quoted from
an earlier run:

* Recording the three-instruction body once into the replay buffer and driving dest stepping from an
  `ADDR_MOD_6` with `dest.incr = 2` — the arrangement `ckernel_sfpu_mac.h` already uses on BH —
  reaches **156.54**, indistinguishable from the un-rotated form. The replay buffer is not what
  limits this kernel, so claiming a shared `addr_mod` slot and a shared replay slot buys nothing.
* Re-recording per call instead of once in init is actively worse (**177.78**) — `lltt::record` still
  has to *issue* the instructions it captures.

Wormhole's remaining gap to its slot ceiling is attributed above to RISC-V issue bandwidth; the
Blackhole result means that is still a **hypothesis** on Wormhole rather than a measured cause, and
building the replay variant there is the cheap way to settle it before paying for an `ADDR_MOD`
audit.

## Functional

| | before | after |
|---|---|---|
| Wormhole n300 | — | **2207 passed, 0 failed** |
| Blackhole p100a | 48 Tanh failed | **1885 passed, 0 failed** |

Tanh/Sigmoid/Silu/Gelu/Sqrt/Rsqrt/Exp sweeps and edge tests. Both figures are from the combined
branch before the split; the 48 pre-split Blackhole failures are the approx-tanh cases the removed
skip exposed while only Wormhole had the better table, which the second commit here fixes. Approx
tanh passes 80/80 on Wormhole and 70/70 on Blackhole (ten format combinations skipped by the arch
guard) at the **default** tolerance.

**Re-verified after the monotonicity retune**, on Wormhole n300: approx tanh **80/80**, the
Tanh-family sweep (`-k Tanh`, functional + edges) **692 passed / 0 failed**, and
`accuracy/test_sfpu_accuracy.py -k Tanh` **54 passed**.

There is **no Blackhole board on the host the retune was done on**, so for that commit the BH kernel
is **compile-verified only** — built with `CHIP_ARCH=blackhole --compile-producer`, with all six
init registers confirmed against the intended encodings in the ELF disassembly
(`0x3B94`/`0x38CB`, `0x7C00`/`0x3192`, `0x3451`/`0x2F89`, `0x3807`/`0x39DB`, `0x27ED`/`0x7C00`,
`0x3B3F`/`0x3C00`) and its instruction stream byte-identical to the pre-retune build apart from the
four changed immediates. The BH numbers above are from the earlier silicon run of the same kernel
shape. **A Blackhole re-run of the Tanh sweep is the one outstanding check on this PR.**

The deterministic accuracy harness (`accuracy/test_sfpu_accuracy.py`, 434 passed / 124 skipped) also
covers approximate tanh now — it previously did not construct such a case at all, because that
module keeps its own `APPROX_CAPABLE_OPS` list and `Tanh` was not on it, so all three of its sweeps
silently ran only `ApproximationMode.No`. Adding it takes the approximate-tanh case count there from
0 to 18 and retires a second stale "does not support approximation mode" skip. That module is
sanity-assert only (no ULP gating) and is excluded from the default CI marker expression, so this
widens an on-demand report rather than adding a gate.

## Notes for reviewers

**The kernel is raw TTI out of necessity, not preference.** `sfpi::lut2()`'s six-register overload
**can never compile**: it always ORs `SFPLUTFP32_MOD0_SGN_RETAIN` into the mod, and
`__builtin_rvtt_sfplutfp32_6r` rejects every mod with that bit set. tanh is odd and needs
`SGN_RETAIN` so the hardware copies the input's sign onto the result. Probed exhaustively against
the pinned sfpi:

| mod | `sfplutfp32_6r` | `sfplutfp32_3r` |
|---|---|---|
| 0 (FP32_3ENTRY, SGN_UPDATE) | rejected | OK |
| 2 (FP16_6ENTRY_TABLE1) | **OK** | rejected |
| 3 (FP16_6ENTRY_TABLE2) | **OK** | rejected |
| 4 (FP32_3ENTRY \| SGN_RETAIN) | rejected | OK |
| 6, 7 (6ENTRY \| SGN_RETAIN) | rejected | rejected |
| 10, 14 (FP16_3ENTRY ± SGN_RETAIN) | rejected | OK |

So through sfpi a six-entry table is available only with `SGN_UPDATE` — fine for gelu, whose fitted
function is even, and unusable for tanh. The restriction is **sfpi's, not the hardware's**:
`SFPLUTFP32`'s functional model applies `SGN_RETAIN` for every table mode, mod 6/7 assembles, and
correctness is verified on silicon on both boards. `lut2_sign()` does compile, but `SGN_UPDATE`
would give |tanh(x)| and cost a copysign per datum.

**sqrt/rsqrt NOP removal was requested and is NOT in this PR** — flagged rather than quietly
dropped. The premise was a stale measurement of mine: sfpi **7.35.3** rather than the pinned
7.68.0/7.71.0, taken with the inf and negative guards stripped out because 7.35.3 could not compile
them. Re-measured on the pinned toolchain, real kernels, guards intact, ITERATIONS=8, per datum:

| variant | slots | `SFPNOP` | `SFPMOV` | `SFPLOADI` | `TTINCRWC` |
|---|---|---|---|---|---|
| sqrt approx, dest_acc=Yes / No | 17 / 18 | **0** | 2 | 2 | 1 |
| sqrt accurate, dest_acc=Yes / No | 27 / 28 | 3 | 4 | 2 | 1 |
| rsqrt approx, dest_acc=Yes / No | 21 / 22 | **0** | 4 | 2 | 1 |
| rsqrt accurate, dest_acc=Yes / No | 31 / 32 | 3 | 5 | 2 | 1 |

**The approximate paths contain no NOPs at all** — the guards are what fills the latency shadows
(`SFPSETCC` / `SFPENCC` / `SFPLOADI` are independent of the arithmetic chain, so the newer toolchain
schedules them into exactly the slots that were empty without them). Stripping the guards is what
created the NOPs I originally measured.

The accurate paths' three NOPs are irreducible. They sit in a strictly serial four-deep chain
(`SFPADD` → `SFPMAD` → `SFPMUL` → `SFPMUL`), and filling them needs work independent of the chain:
every other instruction either feeds it or depends on it; the two `SFPSETCC`-bearing instructions
are independent but hoisting either would leave the following slots predicated, wrong for the lanes
the guard excludes; and a second datum does not fit — the accurate body holds x, y, xy,
c/one_minus_xyy, the inf pattern and half_xy simultaneously, **6 of the 8 general LRegs**, so a
second datum would need two `SFPMOV`s to migrate once the first retires, cancelling the three NOPs
it just filled.

What *is* removable: the `SFPMOV` before `SFPSHFT` (1 slot — `SFPSHFT` has separate `lreg_c` /
`lreg_dest`, sfpi's intrinsic is dest==src), the `TTINCRWC` (1 slot, via immediate dest offsets as
in this PR's tanh), and for the accurate path the `SFPMOV` + `SFPMULI` for half_xy (1 slot, by
preloading 0.5 into a spare LReg). The two `SFPLOADI`s look loop-invariant but hoisting buys nothing
(the inf pattern is consumed destructively by `SFPIADD`, so a hoisted copy needs an `SFPMOV` per
datum — the same slot), and the negate `SFPMOV`s cannot fold into the multiply-add (`SFPMAD`'s Mod1
has only `INDIRECT_VA`/`INDIRECT_VD`, no operand-negate bit).

So the achievable win is **~10%** (2 slots of 17–22 approx, 3 of 27–32 accurate), for hand-writing
condition-code sequences across four template variants of an op whose inf/NaN/±0 behaviour is
IEEE-specified and asserted. A mistake there is silent and lands on exactly the inputs the
arithmetic is not exercising. Easy to overrule; the safe route is transliteration first (sfpi's own
emitted sequence is a working reference for the predication), verified against sweep **and** edges,
and only then re-scheduled. On Blackhole the premise is weaker still: with no write-latency hazard
there are no NOPs to remove in *either* path.

**Known gaps, all commented in-header:** `tanh(±inf)` still returns NaN on both arches (the tail
segment evaluates `0 * inf + 1`; unchanged from the old table, which also had an exactly-zero tail
slope, and the edges test skips tanh — it is not in `SPECIALS_READY_OPS`). The store truncates
fp32 → bf16 rather than rounding to nearest, matching the old path; an explicit
`convert<vFloat16b>` would cost a slot.

**Retracted since the first Blackhole push.** An earlier revision of this PR claimed accurate `Sqrt`
(`Float32->Float32`) hangs the TRISC on Blackhole "reproducibly, in isolation, on pristine `HEAD`",
and that several BH perf parametrisations wedge the board. **Both were wrong.** An unrelated
experiment of mine wedged the core, and **a wedged Tensix is not cleared by starting a new pytest
process** — only by `tt-smi -r`. Every run afterwards failed with the same timeout naming whatever
kernel it happened to be testing; two of those were Sqrt, so Sqrt looked guilty. After a board reset
accurate `Sqrt` passes, the full sweep is 1885/0, and the perf matrix runs all 32 node ids in a
single consumer invocation. The harness bug that turned one dead core into 57–73
independent-looking failures is fixed on **`sfpu-exp-skip-negative-sanitize`** (three separate
desync/recovery defects). Until that lands, treat any `TENSIX TIMED OUT` as invalidating the rest of
the run.

**Pre-existing, not caused by this PR:** the Wormhole exp sweep reports 6 XPASS — a stale
`_APPROX_EXP_ACCURACY_XFAIL` set on that board (3 format combos × 2 tile shapes). It reproduces with
this branch's kernels stashed.

**Split out of this PR:**

* approximate **sigmoid** (`ckernel_sfpu_sigmoid_appx.h`, both arches) → **#55061**
* approximate **exp** (`SKIP_NEGATIVE_SANITIZE`) and the test-harness fix →
  **`sfpu-exp-skip-negative-sanitize`**

so each reviews and reverts on its own terms. No file is touched by more than one of the three.

## Reproducing

```bash
cd tt_metal/tt-llk/tests && source .venv/bin/activate && cd python_tests

# functional
pytest test_eltwise_unary_sfpu.py -k "Tanh or Sigmoid or Silu or Gelu or Sqrt or Rsqrt or Exp"

# deterministic accuracy harness (approximate tanh, 18 cases)
pytest accuracy/test_sfpu_accuracy.py -k "Tanh"

# perf (MATH_ISOLATE), two phases. RUNNER_TEMP must be a fresh directory per variant:
# it is the build root, and reusing it serves a stale ELF that reports the previous
# variant's cycles.
export RUNNER_TEMP=$(mktemp -d)
pytest --speed-of-light --compile-producer -n 4 -m perf <node-ids>
pytest --speed-of-light --compile-consumer -n 1 -m perf <node-ids>
# read marker == "TILE_LOOP", column mean(MATH_ISOLATE), from
#   tt_metal/tt-llk/perf_data/perf_eltwise_unary_sfpu/perf_eltwise_unary_sfpu.post.csv
```

Target exact node ids rather than `-k` for the perf runs: the parametrize ids contain `->` (e.g.
`formats:Float16_b->Float16_b`), which pytest's `-k` expression parser does not accept.

If any test reports `TENSIX TIMED OUT`, reset the board (`tt-smi -r`) before drawing any conclusion
from the rest of the run — see the retraction above for why that is not optional.

Slot counts are read off the generated kernel, not argued from the source:

```bash
riscv-tt-elf-objdump -d --no-show-raw-insn <build>/elf/math.elf
```

