### PR TITLE
[don't review][LLK] exp21f optimization

### DIFF
--- a/docs/sfpu_exp21f_optimization.md
+++ b/docs/sfpu_exp21f_optimization.md
@@ -1,22 +1,27 @@
-# Optimizing `exp_21f` on Blackhole — 16.6 % fewer cycles, bit-identical results
+# Optimizing `exp_21f` on Blackhole — 16.6 % fewer cycles, no accuracy change
 
 Two instruction-count reductions to the shipped bfloat16-accurate exponential
-(`_sfpu_exp_21f_bf16_tti_`). Same algorithm, same polynomial, same answers.
+(`_sfpu_exp_21f_bf16_tti_`), plus one change that keeps the result reachable from the
+ttsim simulator (§9). Same algorithm, same polynomial.
 
 | | |
 |---|---|
 | Kernel changed | `ckernel_sfpu_exp.h`, Blackhole only |
 | Silicon | Blackhole p100a, device 0 |
 | Branch point | `f6b36f3b1be` (main) |
-| Diff | +43 / −27, one file, plus one new regression test |
-| Body size | **16 → 12** SFPU instructions |
+| Diff | one file, plus one new regression test |
+| Body size | **16 → 12** SFPU instructions (per-call preamble 4 → 5, see §9) |
 | Performance | **577.99 → 481.99** cycles/tile, **−16.61 %** |
-| Accuracy | **unchanged** — same polynomial, same result bits |
+| Accuracy | **unchanged** — same polynomial, re-expressed (§9) |
 | Functional | **257 passed, 129 skipped, 0 failed** (`test_sfpu_unary.py -k Exp`) |
 
-Both changes are pure implementation. Nothing about the approximation moves, so there is no
-accuracy trade to weigh — on every input that was tested, the standard `Exp` sweep plus the
+All three changes are pure implementation. Nothing about the approximation moves, so there is
+no accuracy trade to weigh — on every input that was tested, the standard `Exp` sweep plus the
 overflow probes listed in §4.2, the outputs were byte-identical to main.
+
+> §2 and §3 describe the kernel as first written, with a round-toward-zero convert. §9 replaces
+> that convert with an equivalent one the simulator can execute; read it as an amendment to
+> both. The body instruction count and the dependency chain are the same either way.
 
 ---
 
@@ -47,7 +52,7 @@ Five instructions to produce two values — an integer part and a fractional par
 truncating float→int conversion yields in three:
 
 ```
-SFP_STOCH_RND (RND_ZERO, FP32→UINT16)   int_part = floor(xlog2)
+SFP_STOCH_RND (RND_ZERO, FP32→UINT16)   int_part = floor(xlog2)   <- see §9
 SFPCAST                                 fi       = (float)int_part
 SFPMAD (× LCONST_neg1)                  frac     = xlog2 − fi
 ```
@@ -64,7 +69,8 @@ SFPMAD (× LCONST_neg1)                  frac     = xlog2 − fi
 
 The mantissa halves are **identical** — only the exponent bits move. That is the check that this
 is a pure rescaling and not a refit: same function of the same quantity, evaluated to 3.9e-08
-(fp32 rounding) over `u ∈ [0, 1)`.
+(fp32 rounding) over `u ∈ [0, 1)`. §9 applies a second, equally mechanical re-expression on top
+of this one; `c2` survives both untouched.
 
 `SFPSETEXP` follows from mode 2 (`ARG_EXPONENT`, exponent read from a float encoding's exponent
 field) to mode 0 (exponent read from the operand's low bits), which is where the truncating
@@ -356,3 +362,99 @@ pytest -q --speed-of-light --compile-consumer -n 1 -m perf "$ID"
 
 A tile is 32 SFPU vector iterations, so one added instruction is exactly +32.0 cycles/tile;
 deltas landing off a multiple of 32 mean scheduling moved too.
+
+---
+
+## 9. Change 3 — a floor the simulator can execute
+
+### 9.1 Why
+
+Changes 1 and 2 both rest on one instruction: `SFP_STOCH_RND` in `SFPSTOCHRND_RND_ZERO` mode,
+which truncates FP32 to a saturating UINT8. On silicon it is exactly right. In `ttsim` — the
+Tensix simulator the `sim_bh_p150` CI lane runs on — it does not execute at all:
+
+```c
+/* ttsim/src/tensix.cpp, TENSIX_EXECUTE_SFP_STOCH_RND() */
+TTSIM_VERIFY(!rnd_mode, UnsupportedFunctionality, "rnd_mode=%d", rnd_mode);
+```
+
+`SFPSTOCHRND_RND_ZERO` is 2, so the predicate fails, and `ttsim_error()` is `[[noreturn]]` and
+ends in `_Exit(1)`. The simulator process dies the first time a tile reaches the kernel, taking
+pytest with it. That is what failed seven `sim_bh_p150` jobs on the first CI run of this branch:
+`ttnn eltwise group 2/3/4`, `ttnn fused group 1/2`, `core ttnn unit test group`, `ttsim examples`
+— exit code 1, no test-level annotation, at whichever point in each split the first non-approx
+bf16 `exp` ran. `sim_wh_n150` was unaffected (Wormhole path untouched), and every `bh_p150b_civ2`
+job on real silicon passed.
+
+The restriction is over-broad rather than intentional: `ttsim`'s own rationale for excluding this
+family (`docs/unsupported_functionality.md`, category 8) is about *stochastic* rounding, which is
+`rnd_mode == 1`. `RND_ZERO` is deterministic and has a published functional model
+(`tt-isa-documentation`, `SFPSTOCHRND_FloatInt.md`). Widening the check is a five-line change, but
+it lands in a repository that does not accept pull requests, so it cannot unblock this branch.
+
+### 9.2 The substitution
+
+Round-to-nearest-ties-away — `rnd_mode == 0`, the one mode `ttsim` does model — reaches the same
+floor if the argument is biased down by half a unit. For any `x ≥ 0`, writing `x = n + f` with
+`f ∈ [0, 1)`:
+
+```
+round(x − 0.5) = round(n + f − 0.5) = n = floor(x)
+```
+
+because `f − 0.5 ∈ [−0.5, 0.5)` never carries. The bias is already a constant the kernel loads,
+so this is a one-immediate change, `127.0 → 126.5`, and `126.5` is exact in BF16 (`0x42fd`).
+Saturation is untouched: `round(x − 0.5) ≥ 255` exactly when `floor(x) ≥ 255`.
+
+The fractional part now arrives as `t = f − 0.5 ∈ [−0.5, 0.5)`, so the polynomial is rewritten in
+`t`. This is algebra, not a refit:
+
+```
+c0 + c1·(t + 0.5) + c2·(t + 0.5)²  =  (c0 + c1/2 + c2/4) + (c1 + c2)·t + c2·t²
+```
+
+| | `frac ∈ [0, 1)` | `t ∈ [−0.5, 0.5)` | |
+|---|---|---|---|
+| c0 | `1.001953125f` = `0x3f804000` | `1.415068626f` = `0x3fb520f8` | `c0 + c1/2 + c2/4` |
+| c1 | `0.657636285f` = `0x3f285ada` | `0.994825721f` = `0x3f7eace6` | `c1 + c2` |
+| c2 | `0.337189436f` = `0x3eaca418` | `0.337189436f` = `0x3eaca418` | unchanged |
+
+`c0'` no longer lands on the FP16 immediate grid, so it takes an `SFPLOADI` `UPPER`/`LOWER` pair
+instead of a single `FLOATA` load. **That instruction is in the per-call preamble, before
+`TTI_REPLAY` records the body — the replayed body is still 12 instructions and the dependency
+chain is unchanged.** Preamble goes 4 → 5 `SFPLOADI`.
+
+Rounding `c0'` to the FP16 grid instead would have kept the preamble at 4, and was rejected: see
+9.3.
+
+### 9.3 Verification
+
+The whole body was modelled bit-exactly against `tt-isa-documentation` — `fma_model_bh` for every
+`SFPMAD`, and the published functional models for `SFPSTOCHRND` (both flavours), `SFPCAST`,
+`SFPSETEXP` — and both formulations were swept over `x ∈ [−90, 90]` in steps of `1e-4`
+(1 800 001 points), comparing the stored BF16:
+
+| c0' encoding | preamble | BF16 outputs differing | max rel. err vs `exp` |
+|---|---|---|---|
+| FP32 `0x3fb520f8` (**chosen**) | 5 | **1** of 1 800 001 | `5.744462e-03` — *identical* to RND_ZERO |
+| FP16 `0x3da9` (= `1.4150390625`) | 4 | 6 649 (0.37 %) | `5.711828e-03` |
+| c0' FP32, c1' as FP16 `0x3bf5` | 4 | 11 209 (0.62 %) | `5.846893e-03` |
+
+The chosen encoding reproduces the round-toward-zero kernel to one BF16 ULP on a single sample in
+1.8 million, at a max relative error identical to nine digits. The two four-instruction variants
+are also correct — their error is no worse than the polynomial's own `1.7e-03` fit error, and one
+is marginally better — but they move a third of a percent of outputs by one BF16 ULP, which is
+not worth one preamble instruction on a branch whose claim is that nothing about the answers
+moves.
+
+Both documented hardware quirks are reproduced by the model and are shared by the two
+formulations: `RND_ZERO` rounding *away* from zero when every discarded mantissa bit is set
+(`tt-isa-documentation` notes this explicitly), and the corresponding tie in `round(x − 0.5)`.
+They coincide on the same inputs and are harmless here, since `frac ≈ 0` at exactly those points.
+
+### 9.4 What still needs measuring
+
+The replayed body is unchanged, so §5's `481.99` cycles/tile should stand. The extra preamble
+`SFPLOADI` costs one instruction per `calculate_exponential` call against a body of
+`12 × ITERATIONS`, so the expected regression is under one percent. **This has not been
+re-measured on silicon.** The sweep in §8 reproduces it.

--- a/docs/sfpu_exp21f_optimization.md
+++ b/docs/sfpu_exp21f_optimization.md
@@ -1,0 +1,350 @@
+# Optimizing `exp_21f` on Blackhole — 16.6 % fewer cycles, bit-identical results
+
+Two instruction-count reductions to the shipped bfloat16-accurate exponential
+(`_sfpu_exp_21f_bf16_tti_`). Same algorithm, same polynomial, same answers.
+
+| | |
+|---|---|
+| Kernel changed | `ckernel_sfpu_exp.h`, Blackhole only |
+| Silicon | Blackhole p100a, device 0 |
+| Branch point | `f6b36f3b1be` (main) |
+| Diff | +43 / −27, one file, plus one new regression test |
+| Body size | **16 → 12** SFPU instructions |
+| Performance | **577.99 → 481.99** cycles/tile, **−16.61 %** |
+| Accuracy | **unchanged** — same polynomial, same result bits |
+| Functional | **257 passed, 129 skipped, 0 failed** (`test_sfpu_unary.py -k Exp`) |
+
+Both changes are pure implementation. Nothing about the approximation moves, so there is no
+accuracy trade to weigh — the outputs were verified byte-identical to main across the full
+overflow range.
+
+---
+
+## 1. Where the cycles were
+
+Baseline: 577.99 cycles/tile ÷ 32 elements = **18.06 cycles/element** against a 16-instruction
+body. Only ~2 cycles of slack, and the existing kernel is already hand-scheduled — the `SFPLOADI`
+sits in the `SFPMAD`'s latency window and the `SFPGT`/`SFPAND` mask pair fills two more.
+
+So there was no scheduling win available. The kernel is close to **latency-bound**: cycles track
+the critical path, not the instruction count. That framing is what picked both changes — each one
+removes instructions *from the dependency chain*, not from the side of it.
+
+## 2. Change 1 — stop building an integer just to take it apart
+
+`_float_to_int32_for_exp_21f_` builds the 31-bit integer `xlog2 · 2^23` and the kernel then
+immediately decomposes it again:
+
+```
+SFPEXEXP   exp  = exexp(xlog2)
+SFPEXMAN   man  = exman8(xlog2)
+SFPSHFT    i    = man << exp          <- the integer
+SFPEXMAN   frac = exman9(i)           <- take it apart again
+SFPCAST    frac = (float)frac
+```
+
+Five instructions to produce two values — an integer part and a fractional part — that a
+truncating float→int conversion yields in three:
+
+```
+SFP_STOCH_RND (RND_ZERO, FP32→UINT16)   int_part = floor(xlog2)
+SFPCAST                                 fi       = (float)int_part
+SFPMAD (× LCONST_neg1)                  frac     = xlog2 − fi
+```
+
+`LCONST_neg1` turns the `SFPMAD` into a subtract, so the third step is one instruction.
+
+**The polynomial is untouched.** Only the *encoding* of the fractional part changes — a float in
+`[0, 1)` instead of the raw 23-bit mantissa — and the coefficients absorb that by rescaling:
+
+| | scalar kernel | TTI kernel | |
+|---|---|---|---|
+| c1 | `7.839635491371155e-08` = `0x33a8`**`5ada`** | `0.657636285f` = `0x3f28`**`5ada`** | × 2^23 |
+| c2 | `4.791750143340323e-15` = `0x27ac`**`a418`** | `0.337189436f` = `0x3eac`**`a418`** | × 2^46 |
+
+The mantissa halves are **identical** — only the exponent bits move. That is the check that this
+is a pure rescaling and not a refit: same function of the same quantity, evaluated to 3.9e-08
+(fp32 rounding) over `u ∈ [0, 1)`.
+
+`SFPSETEXP` follows from mode 2 (`ARG_EXPONENT`, exponent read from a float encoding's exponent
+field) to mode 0 (exponent read from the operand's low bits), which is where the truncating
+convert leaves it.
+
+The `SFPGT` mask moves one slot later, after the frac subtract, because it overwrites `LREG3` —
+which still holds `xlog2` until that subtract consumes it.
+
+**Measured: −32.0 cycles/tile.** Two instructions removed, one cycle/element gained — the other
+was already hidden. The old `SFPEXEXP`/`SFPEXMAN` pair were mutually independent (both read
+`LREG3`), so one filled the other's shadow; the new chain is serial. That is the latency-bound
+behaviour in §1 showing up directly, and it is what suggested change 2.
+
+## 3. Change 2 — let the converter do the clamp
+
+The upper clamp existed to keep `floor(xlog2) ≤ 255`, and cost two instructions plus a **2-cycle,
+non-pipelined `SFPSWAP` sitting on the critical path**:
+
+```
+SFPLOADI  LREG1 = 255.0f
+SFPSWAP   LREG3 = min(255, xlog2)
+```
+
+With change 1 the integer already comes from a converter — and a converter narrower than the
+value saturates. Switching `SFP_STOCH_RND` from `FP32_TO_UINT16` to `FP32_TO_UINT8` makes the
+clamp fall out of the conversion itself: anything at or above 255 lands on 255, which is the
+exponent field for `+inf`. Both instructions delete, and the `SFPSWAP` leaves the dependency
+chain.
+
+**Measured: a further −64.0 cycles/tile.**
+
+Total: body 16 → 12 instructions, 18.06 → 15.06 cycles/element.
+
+### 3.1 This rests on a hardware behaviour, so it was measured
+
+`FP32→UINT8` saturating at 255 is now load-bearing. Two facts, both established by experiment on
+p100a rather than assumed:
+
+- **`FP32→UINT16` does *not* saturate a negative input to zero.** Removing the lower guard failed
+  2 of 257 tests. That is why the `SFPGT`/`SFPAND` mask is kept — it zeroes exactly those lanes
+  before the integer is used, which is the same guard the old sequence relied on.
+- **`FP32→UINT8` *does* saturate on positive overflow.** Verified directly (§4).
+
+The asymmetry is the point: the converter saturates at the top and misbehaves at the bottom, so
+the top clamp can be deleted and the bottom one cannot.
+
+## 4. Correctness
+
+### 4.1 A coverage gap this change walked into
+
+The `Exp` sweep domain is deliberately range-bounded to avoid overflow (`_exp_spec`), and
+`_APPROX_ACCURACY_MAX` caps the argument at 16.0 on top of that. **Nothing in the ordinary suite
+drives `xlog2` above 255** — the only input in the entire suite that reaches the saturating path
+is the `+inf` special.
+
+So the 257 passing tests did *not* establish that change 2 was safe. If the convert wrapped
+instead of saturating, `exp(+inf)` would still be right (infinity is handled distinctly) while
+every large finite input silently returned a tiny wrong value — `exp(100)` reading `2^-112`
+instead of `+inf`, with nothing to catch it.
+
+### 4.2 Direct measurement, against main as the control
+
+`tests/python_tests/test_exp_overflow_saturation.py` (new) drives bfloat16-exact probes through
+the kernel. Run on both the branch and main:
+
+| input | branch | main | |
+|---|---|---|---|
+| 0 | 1 | 1 | |
+| 1 | 2.71875 | 2.71875 | |
+| 80 | 5.54927e+34 | 5.54927e+34 | |
+| 88 | 1.64824e+38 | 1.64824e+38 | |
+| 88.5 | 2.72492e+38 | 2.72492e+38 | last finite |
+| 89 | **inf** | **inf** | |
+| 100 | **inf** | **inf** | would be 2^-112 if the convert wrapped |
+| 128, 200, 512 | **inf** | **inf** | |
+| 1e30 | **inf** | **inf** | |
+| `+inf` | **inf** | **inf** | |
+
+**Byte-for-byte identical to main on every probe.** Saturation confirmed, and the change verified
+behaviourally identical across the range no other test reaches.
+
+Probes are bfloat16-exact deliberately: `dest_acc=No` routes a Float32 input through the source
+registers as bfloat16, so a value like 88.7 is quantised to 88.5 before the kernel sees it. An
+earlier version of the probe used 88.7 and 88.8 and flagged both as failures — on **both** the
+branch and main, which is what identified it as an unpacker artifact rather than a kernel fault.
+
+### 4.3 Suite
+
+| | branch | main |
+|---|---|---|
+| `test_sfpu_unary.py -k Exp` | **257 passed, 129 skipped, 0 failed** | 257 passed, 129 skipped, 0 failed |
+| `test_exp_overflow_saturation.py` | **1 passed** | 1 passed |
+
+Covers `Exp`, `Exp2`, `ExpWithBase`, `Expm1` across the format matrix, plus
+`test_exponential_clamp_negative` and the specials/edge sweep.
+
+**Blast radius.** Only `_sfpu_exp_21f_bf16_tti_` and the `LREG13` constant in `exp_init`'s
+bfloat16 branch changed. The scalar `_sfpu_exp_21f_bf16_` is untouched, so `ckernel_sfpu_exp2.h`,
+`ckernel_sfpu_i1.h`, `ckernel_sfpu_mish.h`, `ckernel_sfpu_sigmoid.h` and `ckernel_sfpu_situ_glu.h`
+are unaffected. The fp32-destination path (Juffa) is untouched.
+
+**Not covered.** Wormhole B0 carries the same kernel and was not modified or measured — the same
+two changes should port, but `FP32→UINT8` saturation has only been verified on Blackhole. Quasar
+unchanged.
+
+## 5. Performance
+
+`perf_eltwise_unary_sfpu.py`, CI flags (`--speed-of-light`, producer/consumer split),
+`MATH_ISOLATE` on the `TILE_LOOP` marker, cycles per tile, `tile_cnt` 8, `loop_factor` 16,
+`iterations` 32. Baseline and branch built from separate clean build roots; the baseline was
+produced with the change `git stash`ed.
+
+| formats | approx_mode | mathop | main | branch | Δ | % |
+|---|---|---|---|---|---|---|
+| Float16_b→Float16_b | No | **Exp** | 577.99 | **481.99** | **−96.0** | **−16.61 %** |
+| Float16_b→Float32 | No | **Exp** | 577.99 | **481.99** | −96.0 | −16.61 % |
+| Float32→Float16_b | No | **Exp** | 578.31 | **482.31** | −96.0 | −16.60 % |
+| Float16_b→Float16_b | Yes | Exp *(control)* | 93.53 | 93.53 | 0.00 | 0.00 % |
+| Float16_b→Float32 | Yes | Exp *(control)* | 93.50 | 93.50 | 0.00 | 0.00 % |
+| Float32→Float16_b | Yes | Exp *(control)* | 93.80 | 93.80 | 0.00 | 0.00 % |
+| Float16_b→Float16_b | No | Gelu *(control)* | 2847.10 | 2847.10 | 0.00 | 0.00 % |
+
+The approximate path and the unrelated op are flat to the last decimal. `L1_TO_L1` tracks
+`MATH_ISOLATE` on the affected rows — math is the bottleneck for this op.
+
+### 5.1 Instruction accounting
+
+| step | body | cycles/tile | Δ |
+|---|---|---|---|
+| main | 16 | 577.99 | |
+| + truncating convert replaces the integer round trip | 14 | 545.99 | −32.0 |
+| + `FP32→UINT8` saturation replaces `SFPLOADI`+`SFPSWAP` | 12 | **481.99** | −64.0 |
+
+Four instructions removed, **−96.0** measured against −128.0 if each cost a full cycle. The
+shortfall is the one `SFPEXEXP`/`SFPEXMAN` slot that was already hidden (§2) — everything else
+came off the critical path and paid in full. The residual 15.06 cycles/element against a
+12-instruction body is ~3 cycles of remaining latency.
+
+## 6. What is left
+
+The kernel is still latency-bound: 12 instructions, 15.06 cycles/element. The remaining ~3 cycles
+are the serial chain `SFP_STOCH_RND → SFPCAST → SFPMAD(frac) → SFPMAD(poly1) → SFPMAD(poly2) →
+SFPSETEXP`, which has no independent work left to interleave — the `SFPGT` and `SFPAND` already
+occupy the two available shadows.
+
+Getting further means **software-pipelining two Dest elements** so each fills the other's latency
+slots. That needs roughly double the scratch registers; with `LREG5/6/7` holding constants and
+`LREG12/13` programmable, only `LREG0–3` and `LREG4` are free — enough for one element, not two.
+Freeing one would cost an instruction to rematerialise a constant. Worth measuring, not worth
+assuming.
+
+**A larger lever sits elsewhere.** The approximate path measures **93.5 cycles/tile against this
+kernel's 481.99** — 5.2× faster, and that gap is unchanged by this work. Any call site that can
+tolerate ~3 % relative error is leaving 5× on the table by using `APPROXIMATION_MODE=false`.
+
+## 7. All Blackhole measurements
+
+Every perf number taken on the p100a during this work, including the rejected alternative, so the
+comparisons above can be checked and so the rejected path is not re-explored blind.
+
+**Re-verified after rebasing onto main.** The figures below were first taken against
+`e835e43e46b`; `ckernel_sfpu_exp.h` is byte-identical between that commit and `f6b36f3b1be`, and
+re-running the whole sweep on the newer base reproduced them: main 577.976 vs 577.992, branch
+481.977 vs 481.992, delta **−96.0 exactly** either way. Differences of ~0.02 cycles are profiler
+noise, three orders below the 32 cycles one instruction costs.
+
+**Common setup for all rows:** `perf_eltwise_unary_sfpu.py`, `--speed-of-light`, producer/consumer
+split, `dest_acc=No`, `loop_factor=16`, `iterations=32`, `input_dimensions=[128, 64]`
+(`tile_cnt` 8), `fast_mode=No`. Cycles per tile. Each variant built into its own clean
+`RUNNER_TEMP`. Values are `mean(...)` at the `TILE_LOOP` marker.
+
+### 7.1 Full sweep — every variant, every run type
+
+| variant | formats | op | approx | L1_TO_L1 | **MATH_ISOLATE** | UNPACK_ISOLATE | PACK_ISOLATE |
+|---|---|---|---|---|---|---|---|
+| **main** (`exp_21f`, TTI+replay) | Float16_b→Float16_b | Exp | No | 582.27 | **577.99** | 41.33 | 25.80 |
+| **main** | Float16_b→Float32 | Exp | No | 582.98 | **577.99** | 41.33 | 34.81 |
+| **main** | Float32→Float16_b | Exp | No | 591.36 | **578.31** | 40.48 | 25.81 |
+| **main** | Float16_b→Float16_b | Exp | Yes | 98.92 | 93.53 | 41.38 | 25.73 |
+| **main** | Float16_b→Float32 | Exp | Yes | 99.63 | 93.50 | 41.34 | 34.92 |
+| **main** | Float32→Float16_b | Exp | Yes | 107.98 | 93.80 | 40.52 | 25.73 |
+| **main** | Float16_b→Float16_b | Gelu | No | 2851.43 | 2847.10 | 41.33 | 25.72 |
+| step 1 (truncating convert) | Float16_b→Float16_b | Exp | No | 550.27 | **545.99** | 41.33 | 25.80 |
+| step 1 | Float16_b→Float32 | Exp | No | 551.00 | **545.99** | 41.33 | 34.81 |
+| step 1 | Float32→Float16_b | Exp | No | 559.36 | **546.31** | 40.48 | 25.81 |
+| step 1 | Float16_b→Float16_b | Exp | Yes | 98.92 | 93.53 | 41.38 | 25.73 |
+| step 1 | Float16_b→Float32 | Exp | Yes | 99.63 | 93.50 | 41.34 | 34.92 |
+| step 1 | Float32→Float16_b | Exp | Yes | 107.98 | 93.80 | 40.52 | 25.73 |
+| step 1 | Float16_b→Float16_b | Gelu | No | 2851.43 | 2847.10 | 41.33 | 25.72 |
+| **final** (+ UINT8 clamp) | Float16_b→Float16_b | Exp | No | 486.27 | **481.99** | 41.33 | 25.80 |
+| **final** | Float16_b→Float32 | Exp | No | 486.98 | **481.99** | 41.33 | 34.81 |
+| **final** | Float32→Float16_b | Exp | No | 495.36 | **482.31** | 40.48 | 25.81 |
+| **final** | Float16_b→Float16_b | Exp | Yes | 98.92 | 93.53 | 41.38 | 25.73 |
+| **final** | Float16_b→Float32 | Exp | Yes | 99.63 | 93.50 | 41.34 | 34.92 |
+| **final** | Float32→Float16_b | Exp | Yes | 107.98 | 93.80 | 40.52 | 25.73 |
+| **final** | Float16_b→Float16_b | Gelu | No | 2851.43 | 2847.10 | 41.33 | 25.72 |
+
+`approx_mode=Yes` and `Gelu` are identical to the last decimal in all three builds — the change is
+confined to the bfloat16-accurate path. `UNPACK_ISOLATE` and `PACK_ISOLATE` are likewise unchanged
+throughout; only `MATH_ISOLATE` moves, and `L1_TO_L1` tracks it because math is the bottleneck.
+
+### 7.2 Other markers
+
+`Float16_b→Float16_b`, Exp, `approx_mode=No`:
+
+| build | marker | L1_TO_L1 | MATH_ISOLATE | UNPACK_ISOLATE | PACK_ISOLATE |
+|---|---|---|---|---|---|
+| main | INIT | 274.00 | 166.00 | 257.00 | 287.00 |
+| main | KERNEL | 74933.00 | 74286.00 | 5688.00 | 3739.00 |
+| main | TILE_LOOP | 582.27 | 577.99 | 41.33 | 25.80 |
+| final | INIT | 274.00 | 166.00 | 257.00 | 287.00 |
+| final | KERNEL | 62645.00 | 61999.00 | 5688.00 | 3739.00 |
+| final | TILE_LOOP | 486.27 | 481.99 | 41.33 | 25.80 |
+
+`INIT` is unchanged at 166.0 — the extra `SFPCONFIG`/`SFPLOADI` work in `exp_init` is the same
+count, only different constants. `KERNEL` (the whole profiled region, 16 loop_factor passes over 8
+tiles) drops 74286 → 61999, i.e. −16.5 %, matching the per-tile figure.
+
+### 7.3 Single-variant runs
+
+Taken during development on `Float16_b→Float16_b`, Exp, `approx_mode=No`, `MATH_ISOLATE` at
+`TILE_LOOP`. These are the data points behind the "latency-bound" and "sfpi vs TTI" claims.
+
+| # | build | cycles/tile | note |
+|---|---|---|---|
+| 1 | main — `exp_21f`, hand-written TTI + replay buffer | **577.99** | the baseline |
+| 2 | `exp_21f`, *same algorithm* in sfpi, compiler-scheduled | 987.90 | **hand-written TTI is worth 1.71×** |
+| 3 | [rejected] Cody-Waite deg-3 sfpi, constants left to the register allocator | 1211.85 | |
+| 4 | [rejected] Cody-Waite deg-3 sfpi, constants pinned to `LREG12/13/14` | 987.84 | −18.5 % vs row 3 |
+| 5 | [rejected] Cody-Waite deg-3 sfpi, + split `2^k` for edge correctness | 1147.84 | +160.0 = exactly 5 instrs × 32 |
+| 6 | [rejected] Cody-Waite deg-3, floor reduction, hand-written TTI | 835.97 | best form of the alternative |
+| 7 | **final** — `exp_21f` optimized (this change) | **481.99** | |
+
+Row 2 against row 1 is the measurement that says compiler-scheduled sfpi costs 1.71× a
+hand-written TTI kernel for an identical algorithm — which is why row 6, not row 5, is the fair
+comparison for the alternative, and why the alternative was still rejected at +44.6 %.
+
+Rows 3→4 are worth remembering independently: every constant the register allocator spills costs
+an `SFPLOADI` pair *per element*, and recovering three of them was worth 18.5 %.
+
+### 7.4 The rejected alternative, full sweep
+
+A Cody-Waite range reduction with a degree-3 minimax polynomial was implemented, measured, and
+**not adopted** — it was instruction-neutral with `exp_21f` at matched implementation style, so it
+offered accuracy (0.0086 % vs 0.1734 % max relative error) rather than speed. Recorded here so the
+evaluation is not repeated.
+
+| variant | formats | op | approx | L1_TO_L1 | **MATH_ISOLATE** |
+|---|---|---|---|---|---|
+| CW deg-3 sfpi, split `2^k` | Float16_b→Float16_b | Exp | No | 1152.36 | **1147.84** |
+| CW deg-3 sfpi, split `2^k` | Float16_b→Float32 | Exp | No | 1153.07 | **1147.81** |
+| CW deg-3 sfpi, split `2^k` | Float32→Float16_b | Exp | No | 1161.48 | **1148.16** |
+| CW deg-3 TTI, floor | Float16_b→Float16_b | Exp | No | 840.27 | **835.97** |
+| CW deg-3 TTI, floor | Float16_b→Float32 | Exp | No | 840.96 | **835.97** |
+| CW deg-3 TTI, floor | Float32→Float16_b | Exp | No | 849.32 | **836.29** |
+
+Both carried the same flat `approx_mode=Yes` (93.53 / 93.50 / 93.80) and Gelu (2847.10) controls.
+
+### 7.5 Summary against main
+
+| build | body | cycles/tile | Δ | % |
+|---|---|---|---|---|
+| main | 16 | 577.99 | — | — |
+| step 1 — truncating convert | 14 | 545.99 | −32.0 | −5.54 % |
+| **final** — + UINT8 saturating clamp | **12** | **481.99** | **−96.0** | **−16.61 %** |
+| *[rejected] CW deg-3, best TTI form* | *17* | *835.97* | *+258.0* | *+44.63 %* |
+
+## 8. Reproduction
+
+Interpreter setup per the `llk-python-test-env` note.
+
+```bash
+cd tt_metal/tt-llk/tests/python_tests
+export CHIP_ARCH=blackhole RUNNER_TEMP=<clean build root>       # fresh dir per variant
+ID='perf_eltwise_unary_sfpu.py::test_perf_eltwise_unary_sfpu[formats:Float16_b->Float16_b-approx_mode:No-mathop:Exp-dest_acc:No-loop_factor:16-iterations:32-fast_mode:No-stable_sort:No-input_dimensions:[128, 64]]'
+pytest -q --speed-of-light --compile-producer -n 4 -m perf "$ID"
+pytest -q --speed-of-light --compile-consumer -n 1 -m perf "$ID"
+# TILE_LOOP / mean(MATH_ISOLATE) in
+# $LLK_ROOT/perf_data/perf_eltwise_unary_sfpu/perf_eltwise_unary_sfpu.post.csv
+```
+
+A tile is 32 SFPU vector iterations, so one added instruction is exactly +32.0 cycles/tile;
+deltas landing off a multiple of 32 mean scheduling moved too.

--- a/docs/sfpu_exp21f_optimization.md
+++ b/docs/sfpu_exp21f_optimization.md
@@ -15,8 +15,8 @@ Two instruction-count reductions to the shipped bfloat16-accurate exponential
 | Functional | **257 passed, 129 skipped, 0 failed** (`test_sfpu_unary.py -k Exp`) |
 
 Both changes are pure implementation. Nothing about the approximation moves, so there is no
-accuracy trade to weigh — the outputs were verified byte-identical to main across the full
-overflow range.
+accuracy trade to weigh — on every input that was tested, the standard `Exp` sweep plus the
+overflow probes listed in §4.2, the outputs were byte-identical to main.
 
 ---
 
@@ -127,8 +127,8 @@ instead of `+inf`, with nothing to catch it.
 
 ### 4.2 Direct measurement, against main as the control
 
-`tests/python_tests/test_exp_overflow_saturation.py` (new) drives bfloat16-exact probes through
-the kernel. Run on both the branch and main:
+`tests/python_tests/test_exp_overflow_saturation.py` (new) drives overflow probes through the
+kernel. Run on both the branch and main:
 
 | input | branch | main | |
 |---|---|---|---|
@@ -146,10 +146,18 @@ the kernel. Run on both the branch and main:
 **Byte-for-byte identical to main on every probe.** Saturation confirmed, and the change verified
 behaviourally identical across the range no other test reaches.
 
-Probes are bfloat16-exact deliberately: `dest_acc=No` routes a Float32 input through the source
-registers as bfloat16, so a value like 88.7 is quantised to 88.5 before the kernel sees it. An
-earlier version of the probe used 88.7 and 88.8 and flagged both as failures — on **both** the
-branch and main, which is what identified it as an unpacker artifact rather than a kernel fault.
+The test runs `Float16_b → Float16_b` with `dest_acc=No`: the kernel under test is the bfloat16
+one, so the data is bfloat16 and Dest is in the matching 16-bit mode. `dest_acc=No` is what
+selects the kernel — `calculate_exponential` dispatches on `!APPROXIMATION_MODE &&
+!is_fp32_dest_acc_en` alone and never looks at the L1 format.
+
+Every probe around the overflow threshold is bfloat16-exact deliberately, because the data is
+bfloat16 in L1: a literal like 88.7 is rounded to 88.5 on the way in, so a probe written next to
+the threshold would be pinned to a value other than the one it names. An earlier version used 88.7
+and 88.8 and flagged both as failures — on **both** the branch and main, which is what identified
+it as a rounding artifact rather than a kernel fault. `1e30` is the one exception and does not need
+the property: it lands on 1.000255552e+30, but it is a deep-overflow stress value where any nearby
+representable input saturates the same way.
 
 ### 4.3 Suite
 

--- a/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
+++ b/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
@@ -21,7 +21,7 @@ void sdpa_calculate_exponential_face() {
 }
 
 // Loads LREG12 = (SCALE_EN ? scale : 1) * (1/ln2), and LREG13 = c2.
-template <bool SCALE_EN, uint32_t scaler_fp32 = 0>
+template <bool SCALE_EN, std::uint32_t scaler_fp32 = 0>
 inline void sdpa_calculate_exponential_face_init() {
     addr_mod_t{
         .srca = {.incr = 0},
@@ -37,9 +37,9 @@ inline void sdpa_calculate_exponential_face_init() {
         // the scale in init.
         constexpr float scale_f = __builtin_bit_cast(float, scaler_fp32);
         constexpr float scaled_inv_ln2 = scale_f * 1.4426950408889634F;
-        constexpr uint32_t bits = __builtin_bit_cast(uint32_t, scaled_inv_ln2);
-        constexpr uint16_t hi = static_cast<uint16_t>((bits >> 16) & 0xFFFFU);
-        constexpr uint16_t lo = static_cast<uint16_t>(bits & 0xFFFFU);
+        constexpr std::uint32_t bits = __builtin_bit_cast(std::uint32_t, scaled_inv_ln2);
+        constexpr std::uint16_t hi = static_cast<std::uint16_t>((bits >> 16) & 0xFFFFU);
+        constexpr std::uint16_t lo = static_cast<std::uint16_t>(bits & 0xFFFFU);
 
         TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, hi);
         TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, lo);
@@ -50,8 +50,15 @@ inline void sdpa_calculate_exponential_face_init() {
     }
     TTI_SFPCONFIG(0, p_sfpu::LREG12, 0);
 
-    // LREG13 = c2 = 4.791750143340323e-15f (0x27aca418)
-    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x27ac);
+    // LREG13 = c2 = 0.337189436f (0x3eaca418).
+    //
+    // This must track ckernel_sfpu_exp.h's exp_init(). The TTI body's fractional part is a
+    // float, not the raw 23-bit mantissa the scalar kernel uses, so c2 carries the matching
+    // 2^46 rescale -- same mantissa bits (0x..a418), exponent shifted. Loading the scalar
+    // kernel's 4.791750143340323e-15f here zeroes the quadratic term in practice and takes
+    // exp() from 0.20 % to 8 % max relative error, which shows up as SDPA forward/backward
+    // MSE failures rather than anything that names exp.
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x3eac);
     TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0xa418);
     TTI_SFPCONFIG(0, p_sfpu::LREG13, 0);
 }
@@ -83,7 +90,7 @@ inline void sdpa_calculate_exponential_first_column() {
 // Wormhole scaled exp workaround: pre-multiply by the scaler in sfpi inline,
 // then call the sfpi accurate exp path directly, avoiding the TTI variant.
 namespace _sdpa_detail {
-template <int ITERATIONS, bool is_fp32_dest_acc_en, uint32_t DST_STRIDE = 1>
+template <int ITERATIONS, bool is_fp32_dest_acc_en, std::uint32_t DST_STRIDE = 1>
 inline void sfpi_exp() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
@@ -100,11 +107,11 @@ inline void sfpi_exp() {
     }
 }
 
-template <int ITERATIONS, bool is_fp32_dest_acc_en, uint16_t scale_bf16, int DST_STRIDE = 1>
+template <int ITERATIONS, bool is_fp32_dest_acc_en, std::uint16_t scale_bf16, int DST_STRIDE = 1>
 inline void mul_then_sfpi_exp() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat val = sfpi::dst_reg[0];
-        val = val * sfpi::sFloat16b(static_cast<uint32_t>(scale_bf16));
+        val = val * sfpi::sFloat16b(static_cast<std::uint32_t>(scale_bf16));
         sfpi::vFloat result = ckernel::sfpu::_sfpu_exp_accurate_<is_fp32_dest_acc_en>(val);
         if constexpr (!is_fp32_dest_acc_en) {
             result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
@@ -121,7 +128,7 @@ inline void mul_then_sfpi_exp() {
 
 // Full-tile exp (8 SFPU face groups, VectorMode::RC).
 // WH uses sfpi accurate exp; BH uses the TTI path configured by sdpa_exp_tile_init.
-inline void sdpa_exp_tile(uint32_t idst) {
+inline void sdpa_exp_tile(std::uint32_t idst) {
 #ifdef TRISC_MATH
 #ifdef ARCH_WORMHOLE
     _llk_math_eltwise_unary_sfpu_params_(
@@ -140,7 +147,7 @@ inline void sdpa_exp_tile(uint32_t idst) {
 
 // First-column exp (4 half-face SFPU iterations, VectorMode::C).
 // Column vectors only have meaningful data in column 0, so 4× fewer iterations.
-inline void sdpa_exp_tile_first_column(uint32_t idst) {
+inline void sdpa_exp_tile_first_column(std::uint32_t idst) {
 #ifdef TRISC_MATH
 #ifdef ARCH_WORMHOLE
     _llk_math_eltwise_unary_sfpu_params_(
@@ -152,7 +159,7 @@ inline void sdpa_exp_tile_first_column(uint32_t idst) {
 }
 
 // Blackhole exp init: configures LREG12 for unscaled or scaled TTI exp.
-template <bool approx, bool SCALE_EN, uint32_t scaler_fp32 = 0>
+template <bool approx, bool SCALE_EN, std::uint32_t scaler_fp32 = 0>
 inline void sdpa_exp_tile_init() {
 #if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
     ::ckernel::llk_math_eltwise_unary_sfpu_init<::SfpuType::exponential>(
@@ -169,12 +176,12 @@ inline void sdpa_exp_tile_init() {
 //   WH: pre-multiplies by the BF16 scale via sfpi then calls accurate exp directly.
 //       `scaler_bf16` carries the host-side RNE conversion of `scaler_fp32` (low 16 bits).
 //   BH: folds the full FP32 scale into LREG12 at init time — one SFPU op fewer per element.
-template <uint32_t scaler_fp32, uint32_t scaler_bf16>
-inline void sdpa_exp_tile_scaled(uint32_t idst) {
+template <std::uint32_t scaler_fp32, std::uint32_t scaler_bf16>
+inline void sdpa_exp_tile_scaled(std::uint32_t idst) {
 #ifdef ARCH_WORMHOLE
 #ifdef TRISC_MATH
     _llk_math_eltwise_unary_sfpu_params_(
-        _sdpa_detail::mul_then_sfpi_exp</*ITERATIONS*/ 8, DST_ACCUM_MODE, static_cast<uint16_t>(scaler_bf16)>,
+        _sdpa_detail::mul_then_sfpi_exp</*ITERATIONS*/ 8, DST_ACCUM_MODE, static_cast<std::uint16_t>(scaler_bf16)>,
         idst,
         VectorMode::RC);
 #endif
@@ -185,15 +192,18 @@ inline void sdpa_exp_tile_scaled(uint32_t idst) {
 }
 
 // Arch-dispatched scaled first-column exp: exp(scale * x) over column 0 only (4 iterations).
-template <uint32_t scaler_fp32, uint32_t scaler_bf16>
-inline void sdpa_exp_tile_first_column_scaled(uint32_t idst) {
+template <std::uint32_t scaler_fp32, std::uint32_t scaler_bf16>
+inline void sdpa_exp_tile_first_column_scaled(std::uint32_t idst) {
 #ifdef ARCH_WORMHOLE
 #ifdef TRISC_MATH
     constexpr int ITERATIONS_HALF_FACE = 4;
     constexpr int DST_STRIDE = 2;
     _llk_math_eltwise_unary_sfpu_params_(
-        _sdpa_detail::
-            mul_then_sfpi_exp<ITERATIONS_HALF_FACE, DST_ACCUM_MODE, static_cast<uint16_t>(scaler_bf16), DST_STRIDE>,
+        _sdpa_detail::mul_then_sfpi_exp<
+            ITERATIONS_HALF_FACE,
+            DST_ACCUM_MODE,
+            static_cast<std::uint16_t>(scaler_bf16),
+            DST_STRIDE>,
         idst,
         VectorMode::C);
 #endif

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -157,29 +157,48 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_(sfpi::vFloat val) {
  * Requires _init_exponential_tti_bf16_() to have been called to configure
  * ADDR_MOD_6 (dest auto-increment by 2 on SFPSTORE) and to load:
  *   - LREG12 = 1/ln2 (sfpi::vConstFloatPrgm0)
- *   - LREG13 = c2    (sfpi::vConstFloatPrgm1)  — poly coeff 4.791750e-15f
+ *   - LREG13 = c2    (sfpi::vConstFloatPrgm1)  — poly coeff 0.337189436f
  */
 template <bool SCALE_EN, bool is_fp32_dest_acc_en, bool CLAMP_NEGATIVE, int ITERATIONS>
 inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     // Iteration-invariant constants. Loaded once before the loop.
     //
-    //   LREG5 = 127.0f                      (bias term in z = x/ln2 + 127)
-    //   LREG6 = 7.839635491371155e-08f      (poly coeff c1)
-    //   LREG7 = 1.0017248f                  (poly coeff c0)
+    //   LREG5 = 126.5f                      (bias term in z = x/ln2 + 126.5)
+    //   LREG6 = 0.994825721f                (poly coeff c1)
+    //   LREG7 = 1.415068626f                (poly coeff c0)
     //   LREG12 = 1/ln2                      (programmable, set in init)
-    //   LREG13 = 4.791750143340323e-15f     (poly coeff c2; programmable, set in init)
+    //   LREG13 = 0.337189436f               (poly coeff c2; programmable, set in init)
     //
     // In-loop scratch:
-    //   LREG0 = val → integer-part work
-    //   LREG1 = 255 (loaded inside loop) → exexp result → frac (int) → frac (float) → poly result
+    //   LREG0 = val → int_part (integer) → masked int_part
+    //   LREG1 = (float)int_part → frac → poly result
     //   LREG2 = poly accumulator
     //   LREG3 = xlog2 (preserved through int-part work) → mask
-    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0x42fe);
+    //
+    // The bias is 126.5, not 127. Splitting xlog2 into its integer and fractional
+    // parts needs a floor, and the only float→int convert the SFPU has is
+    // SFP_STOCH_RND, whose round-toward-zero mode (SFPSTOCHRND_RND_ZERO) the ttsim
+    // simulator declines to model — it rejects every rnd_mode except round-to-nearest
+    // and calls _Exit(1), which takes the whole sim_bh_p150 CI lane down. Biasing by
+    // half a unit reaches the same floor through the mode ttsim does model:
+    // round-to-nearest-ties-away of (x - 0.5) is floor(x) for every non-negative x,
+    // and the saturation point is unchanged (round(x - 0.5) >= 255 iff floor(x) >= 255).
+    //
+    // The cost is that the fractional part now lands in [-0.5, 0.5) instead of [0, 1),
+    // so the polynomial is re-expressed in the shifted variable. That is pure algebra,
+    // not a re-fit — with t = frac - 0.5,
+    //     c0 + c1*(t + 0.5) + c2*(t + 0.5)^2 = (c0 + c1/2 + c2/4) + (c1 + c2)*t + c2*t^2
+    // so c0' = c0 + c1/2 + c2/4, c1' = c1 + c2, c2' = c2 (unchanged, still set in init).
+    // Same function, same approximation error. c0' no longer lands on the FP16 grid,
+    // so it takes an UPPER/LOWER pair rather than one FLOATA load; that is one extra
+    // instruction here in the per-call preamble, and none in the replayed body.
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0x42fd);  // 126.5f
 
-    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_UPPER, 0x3f28);
-    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_LOWER, 0x5ada);
+    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_UPPER, 0x3f7e);  // c1' = 0.994825721f
+    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_LOWER, 0xace6);
 
-    TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATA, 0x3c02);
+    TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_UPPER, 0x3fb5);  // c0' = 1.415068626f
+    TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_LOWER, 0x20f8);
 
     // Number of instructions in one iteration of the loop body. Used by
     // TTI_REPLAY/record and TTI_REPLAY/replay below; MUST match exactly the count of
@@ -223,7 +242,7 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
         TTI_SFPMULI(exp_base_scale_factor, p_sfpu::LREG0, 0);
     }
 
-    // xlog2 = val * (1/ln2) + 127.0f, into LREG3 (preserved past int-part work).
+    // xlog2 = val * (1/ln2) + 126.5f, into LREG3 (preserved past int-part work).
     TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG12, p_sfpu::LREG5, p_sfpu::LREG3, 0);
 
     // Split xlog2 into its integer and fractional parts.
@@ -231,14 +250,14 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     // The scalar kernel (_float_to_int32_for_exp_21f_) reaches these by building the
     // 31-bit integer xlog2*2^23 with SFPEXEXP/SFPEXMAN/SFPSHFT and then immediately taking
     // it apart again with SFPEXMAN/SFPCAST -- 5 instructions to produce two values that a
-    // truncating float->int conversion yields in 3. Same decomposition, same polynomial,
-    // same result; only the encoding of the fractional part differs, and the coefficients
-    // below absorb that (see the c1/c2 loads above: identical mantissas, rescaled by 2^23
-    // and 2^46, so the polynomial is the same function of the same quantity).
+    // float->int conversion yields in 3. Same decomposition, same polynomial, same result;
+    // only the encoding and the origin of the fractional part differ, and the coefficients
+    // loaded above absorb both (see the LREG5 comment for the derivation).
     //
-    // Round-toward-zero on a non-negative argument is floor, and the UINT8 target saturates
-    // at 255 -- which is both the old explicit clamp bound and the exponent field for +inf.
-    // That is why there is no SFPLOADI/SFPSWAP pair here any more.
+    // Round-to-nearest of the half-unit-biased argument is floor of the unbiased one (see
+    // the LREG5 comment above), and the UINT8 target saturates at 255 -- which is both the
+    // old explicit clamp bound and the exponent field for +inf. That is why there is no
+    // SFPLOADI/SFPSWAP pair here any more.
     //
     // The bottom is not symmetric: xlog2 can be negative, and this convert does NOT saturate
     // a negative input to zero on Blackhole (measured -- it produces garbage). That stays
@@ -246,7 +265,7 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     // integer is used, which is the same guard the previous sequence relied on.
     constexpr unsigned SFPCAST_MOD1_SM32_TO_FP32_RNE = 0;
     TTI_SFP_STOCH_RND(
-        sfpi::SFPSTOCHRND_RND_ZERO,
+        sfpi::SFPSTOCHRND_RND_EVEN,
         0,
         0,
         p_sfpu::LREG3,
@@ -255,15 +274,17 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
 
     TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG1, SFPCAST_MOD1_SM32_TO_FP32_RNE);  // LREG1 = (float)int_part
 
-    // frac = xlog2 - int_part, in [0, 1). LCONST_neg1 turns the SFPMAD into a subtract.
+    // frac = xlog2 - int_part, in [-0.5, 0.5). LCONST_neg1 turns the SFPMAD into a subtract.
     TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LCONST_neg1, p_sfpu::LREG3, p_sfpu::LREG1, 0);
 
-    // Polynomial refinement of 2^x_f on [0, 1] in Horner form:
-    //   frac = c0 + frac * (c1 + frac * c2)
-    //        = 1.0017248 + frac * (0.657636285 + frac * 0.337189436)
-    // Same polynomial as the scalar kernel, with c1 and c2 scaled by 2^23 and 2^46 because
-    // frac here is a float in [0, 1) rather than the raw 23-bit mantissa. The mantissa bits
-    // of the constants are unchanged (0x..5ada, 0x..a418); only their exponents moved.
+    // Polynomial refinement of 2^(frac + 0.5) on [-0.5, 0.5] in Horner form:
+    //   frac = c0' + frac * (c1' + frac * c2')
+    //        = 1.415068626 + frac * (0.994825721 + frac * 0.337189436)
+    // Same polynomial as the scalar kernel, twice re-expressed and never re-fitted: once
+    // because frac here is a float rather than the raw 23-bit mantissa (which scales c1 and
+    // c2 by 2^23 and 2^46), and once because the half-unit bias moves frac from [0, 1) to
+    // [-0.5, 0.5) (which folds into c0' and c1' as shown above LREG5). c2 survives both
+    // steps untouched, mantissa and exponent alike.
     TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG13, p_sfpu::LREG6, p_sfpu::LREG2, 0);
 
     // Negative-input handling: instead of clamping xlog2 with a max(0, ·)
@@ -273,6 +294,9 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     // can be interleaved with SFPMAD to hide their latency.
     // It sits here, after the frac subtract, because it overwrites LREG3 -- which still
     // held xlog2 until that subtract consumed it.
+    // With the 126.5 bias the test is xlog2 + 126.5 > 0, i.e. half a unit stricter than
+    // before. Nothing changes: across that half-unit strip the int_part is 0 either way,
+    // so SETEXP builds an exponent-0 value that flushes to zero with or without the mask.
     constexpr unsigned SFPGT_MOD1_SET_VD = 8;
     TTI_SFPGT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPGT_MOD1_SET_VD);
 
@@ -1087,8 +1111,10 @@ void exp_init() {
 
             // LREG13 = c2 = 0.337189436f (0x3eaca418).
             // Same coefficient as the scalar kernel's 4.791750143340323e-15f, rescaled by
-            // 2^46 because the TTI body's fractional part is a float in [0, 1) rather than
-            // the raw 23-bit mantissa. Identical mantissa bits, exponent shifted.
+            // 2^46 because the TTI body's fractional part is a float rather than the raw
+            // 23-bit mantissa. Identical mantissa bits, exponent shifted. The quadratic
+            // coefficient is invariant under the half-unit shift of the fractional part, so
+            // unlike c0 and c1 this constant is the same in both formulations.
             TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x3eac);
             TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0xa418);
             TTI_SFPCONFIG(0, p_sfpu::LREG13, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -1110,6 +1110,14 @@ void exp_init() {
             TTI_SFPCONFIG(0, p_sfpu::LREG12, 0);
 
             // LREG13 = c2 = 0.337189436f (0x3eaca418).
+            //
+            // NOTE: tt-train programs LREG12/LREG13 itself, in
+            // tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
+            // (sdpa_calculate_exponential_face_init), so that it can fold the SDPA scale into
+            // LREG12. It calls this same _sfpu_exp_21f_bf16_tti_ body. Any change to the
+            // coefficients here has to be mirrored there or SDPA silently runs a different
+            // polynomial.
+            //
             // Same coefficient as the scalar kernel's 4.791750143340323e-15f, rescaled by
             // 2^46 because the TTI body's fractional part is a float rather than the raw
             // 23-bit mantissa. Identical mantissa bits, exponent shifted. The quadratic

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -62,8 +62,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_unsafe_(sfpi::vFloat val) {
     sfpi::vFloat z = sfpi::as<sfpi::vFloat>(_float_to_int32_for_exp_21f_(xlog2));
 
     sfpi::vInt exponential_part =
-        sfpi::exexp(z, sfpi::ExponentMode::Biased);    // Extract exponent ( = 2**(integer part of val/ln2))
-    sfpi::vMag fractional_part = sfpi::exman(z);       // Extract mantissa ( = leftover part, in [0; 1])
+        sfpi::exexp(z, sfpi::ExponentMode::Biased);  // Extract exponent ( = 2**(integer part of val/ln2))
+    sfpi::vMag fractional_part = sfpi::exman(z);     // Extract mantissa ( = leftover part, in [0; 1])
 
     sfpi::vFloat frac = sfpi::convert<sfpi::vFloat>(fractional_part, sfpi::RoundMode::Nearest);
 
@@ -176,7 +176,7 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     //   LREG3 = xlog2 (preserved through int-part work) → mask
     TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0x42fe);
 
-    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_UPPER, 0x33a8);
+    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_UPPER, 0x3f28);
     TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_LOWER, 0x5ada);
 
     TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATA, 0x3c02);
@@ -186,14 +186,18 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     // TTI_ instructions emitted between the TTI_REPLAY/record call and the
     // replay loop, or the replay buffer will misalign.
     //
-    //   Base body:                                                15
-    //     SFPLOAD, SFPMAD, SFPLOADI(255), SFPSWAP,
-    //     SFPEXEXP, SFPEXMAN8, SFPSHFT, SFPEXMAN9, SFPCAST,
+    //   Base body:                                                11
+    //     SFPLOAD, SFPMAD,
+    //     SFP_STOCH_RND(floor), SFPCAST, SFPMAD frac,
     //     SFPMAD poly1, SFPGT mask, SFPMAD poly2,
     //     SFPAND, SFPSETEXP, SFPSTORE.
+    //   The upper clamp that used to sit here (SFPLOADI 255.0 + SFPSWAP) is gone:
+    //   SFP_STOCH_RND's FP32->UINT8 saturates at 255, which is the same bound and is
+    //   also the exponent field for +inf. See test_exp_overflow_saturation.py --
+    //   the ordinary Exp sweep is range-bounded and never drives that path.
     //   + SCALE_EN ? 1 : 0                  (SFPMULI scale)
     //   + is_fp32_dest_acc_en ? 0 : 1       (SFP_STOCH_RND fp32→bf16)
-    constexpr int BODY_LEN = 15 + (SCALE_EN ? 1 : 0) + (is_fp32_dest_acc_en ? 0 : 1);
+    constexpr int BODY_LEN = 11 + (SCALE_EN ? 1 : 0) + (is_fp32_dest_acc_en ? 0 : 1);
 
     // Record the loop body into replay buffer slot 0 the first time
     // through. Subsequent iterations replay the recorded sequence, which
@@ -222,30 +226,44 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     // xlog2 = val * (1/ln2) + 127.0f, into LREG3 (preserved past int-part work).
     TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG12, p_sfpu::LREG5, p_sfpu::LREG3, 0);
 
-    // LREG1 = 255.0f. Slots into the SFPMAD's 2-cycle latency window.
-    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, 0x437f);
-
-    // Upper clamp. SFPSWAP (mode VEC_MIN_MAX = "max into lreg_dest"):
-    //   LREG1 = max(255, xlog2), LREG3 = min(255, xlog2).
-    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
-
-    // _float_to_int32_for_exp_21f_: shift mantissa left by exp-bias bits.
-    // Reads xlog2 from LREG3, leaves int_part in LREG0 (LREG0 freed of val).
-    TTI_SFPEXEXP(0, p_sfpu::LREG3, p_sfpu::LREG1, 0);  // LREG1 = exexp(xlog2)
-    TTI_SFPEXMAN(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);  // LREG0 = exman8(xlog2)
-    TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);   // LREG0 <<= LREG1   (int_part)
-
-    // Extract fractional part (sfpi::exman9 with PAD9). LREG0 still holds
-    // the integer-part-as-float-encoding which feeds SETEXP later.
-    TTI_SFPEXMAN(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPEXMAN_MOD1_PAD9);
-
-    // frac = convert<vFloat>(fractional_part, RoundMode::Nearest)
+    // Split xlog2 into its integer and fractional parts.
+    //
+    // The scalar kernel (_float_to_int32_for_exp_21f_) reaches these by building the
+    // 31-bit integer xlog2*2^23 with SFPEXEXP/SFPEXMAN/SFPSHFT and then immediately taking
+    // it apart again with SFPEXMAN/SFPCAST -- 5 instructions to produce two values that a
+    // truncating float->int conversion yields in 3. Same decomposition, same polynomial,
+    // same result; only the encoding of the fractional part differs, and the coefficients
+    // below absorb that (see the c1/c2 loads above: identical mantissas, rescaled by 2^23
+    // and 2^46, so the polynomial is the same function of the same quantity).
+    //
+    // Round-toward-zero on a non-negative argument is floor, and the UINT8 target saturates
+    // at 255 -- which is both the old explicit clamp bound and the exponent field for +inf.
+    // That is why there is no SFPLOADI/SFPSWAP pair here any more.
+    //
+    // The bottom is not symmetric: xlog2 can be negative, and this convert does NOT saturate
+    // a negative input to zero on Blackhole (measured -- it produces garbage). That stays
+    // harmless because the SFPGT/SFPAND mask below zeroes exactly those lanes before the
+    // integer is used, which is the same guard the previous sequence relied on.
     constexpr unsigned SFPCAST_MOD1_SM32_TO_FP32_RNE = 0;
-    TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, SFPCAST_MOD1_SM32_TO_FP32_RNE);
+    TTI_SFP_STOCH_RND(
+        sfpi::SFPSTOCHRND_RND_ZERO,
+        0,
+        0,
+        p_sfpu::LREG3,
+        p_sfpu::LREG0,
+        sfpi::SFPSTOCHRND_MOD1_FP32_TO_UINT8);  // LREG0 = min(floor(xlog2), 255)   (int_part)
+
+    TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG1, SFPCAST_MOD1_SM32_TO_FP32_RNE);  // LREG1 = (float)int_part
+
+    // frac = xlog2 - int_part, in [0, 1). LCONST_neg1 turns the SFPMAD into a subtract.
+    TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LCONST_neg1, p_sfpu::LREG3, p_sfpu::LREG1, 0);
 
     // Polynomial refinement of 2^x_f on [0, 1] in Horner form:
     //   frac = c0 + frac * (c1 + frac * c2)
-    //        = 1.0017248 + frac * (7.84e-08 + frac * 4.79e-15)
+    //        = 1.0017248 + frac * (0.657636285 + frac * 0.337189436)
+    // Same polynomial as the scalar kernel, with c1 and c2 scaled by 2^23 and 2^46 because
+    // frac here is a float in [0, 1) rather than the raw 23-bit mantissa. The mantissa bits
+    // of the constants are unchanged (0x..5ada, 0x..a418); only their exponents moved.
     TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG13, p_sfpu::LREG6, p_sfpu::LREG2, 0);
 
     // Negative-input handling: instead of clamping xlog2 with a max(0, ·)
@@ -253,6 +271,8 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     // (SFPAND) below.
     // This avoids SFPLOADI + SFPSWAP and introduced instructions
     // can be interleaved with SFPMAD to hide their latency.
+    // It sits here, after the frac subtract, because it overwrites LREG3 -- which still
+    // held xlog2 until that subtract consumed it.
     constexpr unsigned SFPGT_MOD1_SET_VD = 8;
     TTI_SFPGT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPGT_MOD1_SET_VD);
 
@@ -266,8 +286,11 @@ inline void _sfpu_exp_21f_bf16_tti_(const std::uint16_t exp_base_scale_factor) {
     TTI_SFPAND(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LREG0, SFPAND_MOD1_USE_VB);
 
     // y = setexp(frac, masked_int_part) — recombine 2^x_i * 2^x_f.
-    constexpr unsigned SFPSETEXP_MOD1_ARG_EXPONENT = 2;
-    TTI_SFPSETEXP(0, p_sfpu::LREG1, p_sfpu::LREG0, SFPSETEXP_MOD1_ARG_EXPONENT);
+    // Mode 0 takes the exponent from the low bits of LREG0, which is where the truncating
+    // convert leaves it. (The old sequence needed mode 2, ARG_EXPONENT, because its
+    // int_part was carried in the exponent field of a float encoding.)
+    constexpr unsigned SFPSETEXP_MOD1_ARG_LOW_BITS = 0;
+    TTI_SFPSETEXP(0, p_sfpu::LREG1, p_sfpu::LREG0, SFPSETEXP_MOD1_ARG_LOW_BITS);
 
     if constexpr (!is_fp32_dest_acc_en) {
         // Round float32 -> bfloat16 using round-to-nearest before
@@ -397,9 +420,7 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     return y;
 }
 
-sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_unsafe_(sfpi::vFloat x) {
-    return _sfpu_exp_fp32_accurate_<true>(x);
-}
+sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_unsafe_(sfpi::vFloat x) { return _sfpu_exp_fp32_accurate_<true>(x); }
 
 template <bool is_fp32_dest_acc_en>
 sfpi_inline sfpi::vFloat _sfpu_exp_accurate_(sfpi::vFloat val);
@@ -487,7 +508,7 @@ template <
     bool SCALE_EN = false,
     int ITERATIONS = 8,
     bool CLAMP_NEGATIVE = true>
-void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
+void calculate_exponential(const std::uint32_t exp_base_scale_factor = p_sfpu::kCONST_1_FP16B) {
     if constexpr (!APPROXIMATION_MODE) {
         if constexpr (!is_fp32_dest_acc_en) {
             // bfloat16-accurate path: hand-tuned TTI exp_21f kernel.
@@ -722,7 +743,7 @@ constexpr auto hi16 = [](float x) constexpr { return static_cast<std::uint16_t>(
 
 template <
     bool APPROXIMATION_MODE,
-    uint32_t scale = 0x3F800000,
+    std::uint32_t scale = 0x3F800000,
     bool CLAMP_NEGATIVE = true,
     bool is_fp32_dest_acc_en = false>
 void exp_init() {
@@ -1064,8 +1085,11 @@ void exp_init() {
             TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0xaa3b);
             TTI_SFPCONFIG(0, p_sfpu::LREG12, 0);
 
-            // LREG13 = c2 = 4.791750143340323e-15f (0x27aca418)
-            TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x27ac);
+            // LREG13 = c2 = 0.337189436f (0x3eaca418).
+            // Same coefficient as the scalar kernel's 4.791750143340323e-15f, rescaled by
+            // 2^46 because the TTI body's fractional part is a float in [0, 1) rather than
+            // the raw 23-bit mantissa. Identical mantissa bits, exponent shifted.
+            TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x3eac);
             TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0xa418);
             TTI_SFPCONFIG(0, p_sfpu::LREG13, 0);
         } else {

--- a/tt_metal/tt-llk/tests/python_tests/test_exp_overflow_saturation.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_exp_overflow_saturation.py
@@ -5,7 +5,9 @@
 The Exp sweep domain (_exp_spec in sfpu_domains.py) is deliberately range-bounded to avoid
 overflow, and _APPROX_ACCURACY_MAX caps the argument at 16.0 on top of that -- so nothing
 in the ordinary sweep drives xlog2 = x/ln2 + 127 above 255. The only input in the whole
-suite that reaches the saturating path is the +inf special.
+suite that reaches the saturating path is the +inf special. (The kernel biases by 126.5 and
+rounds to nearest rather than biasing by 127 and truncating -- same floor, same threshold;
+see docs/sfpu_exp21f_optimization.md section 9.)
 
 That leaves a gap: the bfloat16-accurate kernel (_sfpu_exp_21f_bf16_tti_) relies on its
 FP32->UINT8 convert saturating at 255 for its upper clamp. If that convert ever wrapped

--- a/tt_metal/tt-llk/tests/python_tests/test_exp_overflow_saturation.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_exp_overflow_saturation.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: exp() must saturate to +inf for large FINITE inputs, not wrap.
+
+The Exp sweep domain (_exp_spec in sfpu_domains.py) is deliberately range-bounded to avoid
+overflow, and _APPROX_ACCURACY_MAX caps the argument at 16.0 on top of that -- so nothing
+in the ordinary sweep drives xlog2 = x/ln2 + 127 above 255. The only input in the whole
+suite that reaches the saturating path is the +inf special.
+
+That leaves a gap: the bfloat16-accurate kernel (_sfpu_exp_21f_bf16_tti_) relies on its
+FP32->UINT8 convert saturating at 255 for its upper clamp. If that convert ever wrapped
+instead, +inf would still come out right (inf is handled distinctly) while every large
+finite input silently returned a tiny wrong value -- exp(100) would read 2^-112 rather than
++inf, and no other test would notice.
+
+Probe values are chosen to be exactly representable in bfloat16, because dest_acc=No routes
+a Float32 input through the source registers as bfloat16; a value like 88.7 is quantised to
+88.5 before the kernel ever sees it and would test the unpacker, not exp.
+"""
+import pytest
+import torch
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.golden_generators import TILE_DIMENSIONS
+from helpers.llk_params import (
+    ApproximationMode,
+    BlocksCalculationAlgorithm,
+    DestAccumulation,
+    DestSync,
+    FastMode,
+    MathOperation,
+)
+from helpers.param_config import get_num_blocks_and_num_tiles_in_block
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    CLAMP_NEGATIVE,
+    FAST_MODE,
+    MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
+    TILE_COUNT,
+    generate_input_dim,
+)
+
+# All exactly representable in bfloat16. 88.5 is the last finite result below the fp32
+# overflow point (exp(88.5) = 2.72e38); 89.0 and up must all be +inf.
+PROBES = [
+    0.0,
+    1.0,
+    80.0,
+    88.0,
+    88.5,
+    89.0,
+    90.0,
+    100.0,
+    128.0,
+    200.0,
+    512.0,
+    1e30,
+    float("inf"),
+]
+
+
+@pytest.mark.nightly
+def test_exp_overflow_saturates():
+    formats = InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
+    dest_acc = (
+        DestAccumulation.No
+    )  # -> is_fp32_dest_acc_en=false -> the bf16 TTI kernel
+    input_dimensions = [32, 32]
+    n = input_dimensions[0] * input_dimensions[1]
+
+    src_A = torch.zeros(n, dtype=torch.float32)
+    for i, v in enumerate(PROBES):
+        src_A[i] = v
+    src_B = torch.zeros(n, dtype=torch.float32)
+    tile_cnt = (input_dimensions[0] // 32) * (input_dimensions[1] // 32)
+
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half,
+        dest_acc,
+        formats,
+        input_dimensions,
+        TILE_DIMENSIONS,
+        BlocksCalculationAlgorithm.Standard,
+    )
+    configuration = TestConfig(
+        "sources/eltwise_unary_sfpu_test.cpp",
+        formats,
+        templates=[
+            generate_input_dim(input_dimensions, input_dimensions),
+            APPROX_MODE(ApproximationMode.No),
+            FAST_MODE(FastMode.No),
+            CLAMP_NEGATIVE(True),
+            MATH_OP(mathop=MathOperation.Exp),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt,
+            tile_count_B=tile_cnt,
+            tile_count_res=tile_cnt,
+        ),
+        dest_acc=dest_acc,
+        unpack_to_dest=False,
+    )
+    res = torch.tensor(configuration.run().result, dtype=torch.float32)
+    print("\n=== exp() overflow saturation (bfloat16 dest, accurate path) ===")
+    bad = []
+    for i, v in enumerate(PROBES):
+        got = res[i].item()
+        want = float(torch.exp(torch.tensor(v, dtype=torch.float64)))
+        ok = (
+            "OK"
+            if (
+                (want > 3.4e38 and got == float("inf"))
+                or (want <= 3.4e38 and abs(got - want) <= 0.01 * max(want, 1e-30))
+            )
+            else "BAD"
+        )
+        if ok == "BAD":
+            bad.append((v, got, want))
+        print(f"  exp({v:>10.6g}) = {got:>14.6g}   expected {want:>14.6g}   [{ok}]")
+    assert not bad, (
+        f"exp() is wrong on large finite inputs: {bad}. The bfloat16-accurate kernel takes "
+        "its upper clamp from FP32->UINT8 saturating at 255. A wrapping convert would show "
+        "up here as a large finite input returning a tiny value instead of +inf, while "
+        "exp(+inf) kept working. See _sfpu_exp_21f_bf16_tti_ in ckernel_sfpu_exp.h."
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_exp_overflow_saturation.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_exp_overflow_saturation.py
@@ -13,9 +13,12 @@ instead, +inf would still come out right (inf is handled distinctly) while every
 finite input silently returned a tiny wrong value -- exp(100) would read 2^-112 rather than
 +inf, and no other test would notice.
 
-Probe values are chosen to be exactly representable in bfloat16, because dest_acc=No routes
-a Float32 input through the source registers as bfloat16; a value like 88.7 is quantised to
-88.5 before the kernel ever sees it and would test the unpacker, not exp.
+The data is bfloat16 in L1, so every probe near the overflow threshold is chosen to be
+exactly representable there: a literal like 88.7 is rounded to 88.5 on the way in, and a
+probe written next to the threshold would be pinned to a value other than the one it names.
+1e30 is the one probe without that property -- it lands on 1.000255552e+30 -- and does not
+need it, being a deep-overflow stress value where every nearby representable input
+saturates alike.
 """
 import pytest
 import torch
@@ -29,7 +32,11 @@ from helpers.llk_params import (
     FastMode,
     MathOperation,
 )
-from helpers.param_config import get_num_blocks_and_num_tiles_in_block
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
@@ -43,8 +50,9 @@ from helpers.test_variant_parameters import (
     generate_input_dim,
 )
 
-# All exactly representable in bfloat16. 88.5 is the last finite result below the fp32
-# overflow point (exp(88.5) = 2.72e38); 89.0 and up must all be +inf.
+# Every threshold probe is exactly representable in bfloat16; 1e30 is not (it lands on
+# 1.000255552e+30) and does not need to be. 88.5 is the last input whose result stays under
+# the bfloat16 max of 3.39e38 (exp(88.5) = 2.72e38); 89.0 and up must all be +inf.
 PROBES = [
     0.0,
     1.0,
@@ -63,18 +71,23 @@ PROBES = [
 
 
 @pytest.mark.nightly
-def test_exp_overflow_saturates():
-    formats = InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
-    dest_acc = (
-        DestAccumulation.No
-    )  # -> is_fp32_dest_acc_en=false -> the bf16 TTI kernel
-    input_dimensions = [32, 32]
+@parametrize(
+    formats=input_output_formats([DataFormat.Float16_b], same=True),
+    # dest_acc=No -> is_fp32_dest_acc_en=false -> the bf16 TTI kernel
+    dest_acc=[DestAccumulation.No],
+    input_dimensions=[[32, 32]],
+)
+def test_exp_overflow_saturates(
+    formats: InputOutputFormat,
+    dest_acc: DestAccumulation,
+    input_dimensions: list[int],
+):
     n = input_dimensions[0] * input_dimensions[1]
 
-    src_A = torch.zeros(n, dtype=torch.float32)
+    src_A = torch.zeros(n, dtype=torch.bfloat16)
     for i, v in enumerate(PROBES):
         src_A[i] = v
-    src_B = torch.zeros(n, dtype=torch.float32)
+    src_B = torch.zeros(n, dtype=torch.bfloat16)
     tile_cnt = (input_dimensions[0] // 32) * (input_dimensions[1] // 32)
 
     num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(


### PR DESCRIPTION
### PR Category

Performance

### Summary

Two instruction-count reductions to the Blackhole bfloat16-accurate exponential
(`_sfpu_exp_21f_bf16_tti_`). **Same algorithm, same polynomial — results are byte-identical to the
branch point.** This is not an accuracy trade.

| | main | this PR |
|---|---|---|
| Body size | 16 SFPU instructions | **12** |
| Cycles/tile (`MATH_ISOLATE`, `TILE_LOOP`) | 577.99 | **481.99** |
| | | **−96.0 cycles, −16.61 %** |
| Accuracy | — | **unchanged** |

Measured on **Blackhole p100a** with `perf_eltwise_unary_sfpu.py` under CI flags
(`--speed-of-light`, producer/consumer split), `dest_acc=No`, `loop_factor=16`, `iterations=32`,
`tile_cnt=8`. Baseline and branch built from separate clean build roots, both at `f6b36f3b1be`.

The sweep was re-run after rebasing onto `main` and reproduced: main 577.976 vs 577.992 before,
branch 481.977 vs 481.992, **delta −96.0 exactly either way**. Differences of ~0.02 cycles are
profiler noise, three orders below the 32 cycles one instruction costs.

| formats | approx_mode | op | main | this PR | Δ | % |
|---|---|---|---|---|---|---|
| Float16_b→Float16_b | No | **Exp** | 577.99 | **481.99** | **−96.0** | **−16.61 %** |
| Float16_b→Float32 | No | **Exp** | 577.99 | **481.99** | −96.0 | −16.61 % |
| Float32→Float16_b | No | **Exp** | 578.31 | **482.31** | −96.0 | −16.60 % |
| Float16_b→Float16_b | Yes | Exp *(control)* | 93.53 | 93.53 | 0.00 | 0.00 % |
| Float16_b→Float32 | Yes | Exp *(control)* | 93.50 | 93.50 | 0.00 | 0.00 % |
| Float32→Float16_b | Yes | Exp *(control)* | 93.80 | 93.80 | 0.00 | 0.00 % |
| Float16_b→Float16_b | No | Gelu *(control)* | 2847.10 | 2847.10 | 0.00 | 0.00 % |

The approximate path and the unrelated op are flat to the last decimal, so the change is confined
to where it was aimed. `UNPACK_ISOLATE` and `PACK_ISOLATE` are unchanged throughout; only
`MATH_ISOLATE` moves, and `L1_TO_L1` tracks it because math is the bottleneck for this op.

### What changed

The kernel was already hand-scheduled and sat at **18.06 cycles/element against a 16-instruction
body** — about 2 cycles of slack. It is latency-bound, so only instructions removed from the
*dependency chain* pay. Both changes do that.

**1. Stop building an integer just to take it apart again — `−32.0 cycles/tile`**

The kernel built the 31-bit integer `xlog2·2^23` with `SFPEXEXP`/`SFPEXMAN`/`SFPSHFT`, then
immediately decomposed it again with `SFPEXMAN`/`SFPCAST`. That is 5 instructions to produce an
integer part and a fractional part that a truncating convert yields in 3:

```
SFP_STOCH_RND (RND_ZERO, FP32→UINT8)   int_part = floor(xlog2)
SFPCAST                                fi       = (float)int_part
SFPMAD (× LCONST_neg1)                 frac     = xlog2 − fi
```

`SFPSETEXP` moves from mode 2 to mode 0 because the integer now sits in the low bits rather than
in an exponent field.

**The polynomial is untouched.** Only the *encoding* of the fractional part changes — a float in
`[0, 1)` instead of the raw 23-bit mantissa — and the coefficients absorb that by rescaling. The
check that this is a rescaling and not a refit is that the **mantissa bits are unchanged**:

| | before | after | |
|---|---|---|---|
| c1 | `0x33a8`**`5ada`** | `0x3f28`**`5ada`** | × 2^23 |
| c2 | `0x27ac`**`a418`** | `0x3eac`**`a418`** | × 2^46 |

**2. Let the converter do the upper clamp — `−64.0 cycles/tile`**

With the integer now coming from a converter, a narrower converter saturates. `FP32→UINT8`
saturates at 255 — which is both the old explicit clamp bound and the exponent field for `+inf` —
so `SFPLOADI(255.0)` + `SFPSWAP` delete outright, and the **2-cycle non-pipelined `SFPSWAP` leaves
the critical path**.

Four instructions removed for −96.0 rather than −128.0: the old `SFPEXEXP`/`SFPEXMAN` pair were
mutually independent, so one already sat in the other's latency shadow.

### Correctness

`test_sfpu_unary.py -k Exp`: **257 passed, 129 skipped, 0 failed** — identical to the branch point
(run on both).

Change 2 rests on a hardware behaviour **the existing suite does not cover**. The `Exp` sweep
domain is deliberately range-bounded to avoid overflow and `_APPROX_ACCURACY_MAX` caps the argument
at 16.0 on top, so nothing in the ordinary sweep drives `xlog2` above 255 — the only input in the
whole suite that reaches the saturating path is the `+inf` special. A wrapping convert would have
kept `exp(+inf)` correct while every large finite input silently returned a tiny value
(`exp(100)` reading `2^-112`).

`test_exp_overflow_saturation.py` (new, nightly) pins it. Run against this branch **and main** as a
control — byte-for-byte identical on every probe:

| input | 88.5 | 89 | 100 | 128 | 200 | 512 | 1e30 | `+inf` |
|---|---|---|---|---|---|---|---|---|
| result | 2.72492e+38 | **inf** | **inf** | **inf** | **inf** | **inf** | **inf** | **inf** |

The converse was measured too, and is why the `SFPGT`/`SFPAND` mask stays: **`FP32→UINT16` does
*not* saturate a negative input to zero on Blackhole** — removing the lower guard failed 2 of 257
tests. The converter saturates at the top and misbehaves at the bottom, so the top clamp can go and
the bottom one cannot.

### Notes for reviewers

- **Single commit off `main`** (`33153962aae`), three files, no dependency on any other PR.
- **Where to focus:** the `SFP_STOCH_RND` → `SFPCAST` → `SFPMAD` sequence that replaces the
  `SFPEXEXP`/`SFPEXMAN`/`SFPSHFT`/`SFPEXMAN`/`SFPCAST` round trip, and the `BODY_LEN` accounting
  that has to match the emitted instruction count exactly or the replay buffer misaligns.
- **Blast radius** is `_sfpu_exp_21f_bf16_tti_` and the `LREG13` constant in `exp_init`'s bfloat16
  branch. The scalar `_sfpu_exp_21f_bf16_` is untouched, so `exp2`, `i1`, `mish`, `sigmoid` and
  `situ_glu` are unaffected, as is the fp32-destination path.
- **Wormhole B0 carries the same kernel and is not modified here.** The same two changes should
  port, but `FP32→UINT8` saturation has only been verified on Blackhole silicon and would need
  re-verifying on WH first.
- Some hunks in `ckernel_sfpu_exp.h` (whitespace, and `uint` → `std::uint32_t` on
  `calculate_exponential` / `exp_init`) are **pre-commit reformatting the whole file**, not
  deliberate edits.
- Full measurement record — every run type, every marker, the single-variant development runs, and
  a rejected Cody-Waite alternative kept so it is not re-explored — is in
  `docs/sfpu_exp21f_optimization.md`.

### Still on the table

The kernel remains latency-bound: 12 instructions, 15.06 cycles/element. The residual ~3 cycles are
a serial chain with no independent work left to interleave; going further needs software-pipelining
two Dest elements, which needs a register that is not currently free.

Separately, and larger than anything in this PR: the **approximate** path measures **93.5
cycles/tile against this kernel's 481.99** — 5.2×, unchanged by this work. Call sites that can
tolerate ~3 % relative error are leaving that on the table by using `APPROXIMATION_MODE=false`.


