### PR TITLE
Test Only: cut nightly fused test runtime via grid de-crossing and module-scoped device

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -239,8 +239,14 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
     dram_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
     fp32_enabled = dtype == ttnn.float32  # FP32 requires fp32_dest_acc_en
 
-    entries_before = device.num_program_cache_entries()
-    entries_after_first_run = None
+    # The device is module-scoped, so the cache arrives here already populated -- and every config
+    # this test runs is also a cell of test_layernorm_part_2_with_program_cache above, so the entry
+    # for it always pre-exists. Without clearing, the count below can never change and the assertion
+    # holds no matter what the program cache does. Clear it so the assertion measures this test's
+    # own compilation, per the cache-state guidance in conftest.py's _device_module_impl docstring.
+    # Note: clear_program_cache(), not disable_and_clear_program_cache() -- the latter turns caching
+    # off, so the second run would recompile and the entry count would never reach 1.
+    device.clear_program_cache()
 
     for i in range(2):
         if i > 0:
@@ -256,16 +262,10 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
         run_layernorm_part_2(
             inp_shape, n_devices, is_rmsnorm, dtype, dtype, device, gamma_beta_dtype=dtype, fp32_enabled=fp32_enabled
         )
-        if i == 0:
-            entries_after_first_run = device.num_program_cache_entries()
 
     assert (
-        entries_after_first_run - entries_before <= 1
-    ), f"First run added more than one program cache entry: {entries_before} -> {entries_after_first_run}"
-    assert device.num_program_cache_entries() == entries_after_first_run, (
-        f"Second identical run added a program cache entry: "
-        f"{entries_after_first_run} -> {device.num_program_cache_entries()}"
-    )
+        device.num_program_cache_entries() == 1
+    ), f"Program cache should have exactly one entry, got {device.num_program_cache_entries()}"
 
 
 @pytest.mark.parametrize("input_w", [17, 34, 63])

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -239,13 +239,7 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
     dram_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
     fp32_enabled = dtype == ttnn.float32  # FP32 requires fp32_dest_acc_en
 
-    # The device is module-scoped, so the cache arrives here already populated -- and every config
-    # this test runs is also a cell of test_layernorm_part_2_with_program_cache above, so the entry
-    # for it always pre-exists. Without clearing, the count below can never change and the assertion
-    # holds no matter what the program cache does. Clear it so the assertion measures this test's
-    # own compilation, per the cache-state guidance in conftest.py's _device_module_impl docstring.
-    # Note: clear_program_cache(), not disable_and_clear_program_cache() -- the latter turns caching
-    # off, so the second run would recompile and the entry count would never reach 1.
+    # Module-scoped device: clear first (not disable_and_clear, which turns caching off) or `== 1` is vacuous.
     device.clear_program_cache()
 
     for i in range(2):

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_post_allgather.py
@@ -17,6 +17,9 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     ttnn_layer_norm_post_all_gather,
 )
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
+
 
 def reference_layernorm(x, gamma, beta, epsilon, is_rmsnorm):
     if is_rmsnorm:
@@ -236,6 +239,9 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
     dram_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
     fp32_enabled = dtype == ttnn.float32  # FP32 requires fp32_dest_acc_en
 
+    entries_before = device.num_program_cache_entries()
+    entries_after_first_run = None
+
     for i in range(2):
         if i > 0:
             dummy_tensors.append(
@@ -250,9 +256,15 @@ def test_layernorm_part_2_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
         run_layernorm_part_2(
             inp_shape, n_devices, is_rmsnorm, dtype, dtype, device, gamma_beta_dtype=dtype, fp32_enabled=fp32_enabled
         )
+        if i == 0:
+            entries_after_first_run = device.num_program_cache_entries()
 
-    assert device.num_program_cache_entries() == 1, "Program cache should have only one entry" + str(
-        device.num_program_cache_entries()
+    assert (
+        entries_after_first_run - entries_before <= 1
+    ), f"First run added more than one program cache entry: {entries_before} -> {entries_after_first_run}"
+    assert device.num_program_cache_entries() == entries_after_first_run, (
+        f"Second identical run added a program cache entry: "
+        f"{entries_after_first_run} -> {device.num_program_cache_entries()}"
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -459,8 +459,14 @@ def test_layernorm_part_1_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
 
     dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
 
-    entries_before = device.num_program_cache_entries()
-    entries_after_first_run = None
+    # The device is module-scoped, so the cache arrives here already populated -- and every config
+    # this test runs is also a cell of test_layernorm_part_1_with_program_cache above, so the entry
+    # for it always pre-exists. Without clearing, the count below can never change and the assertion
+    # holds no matter what the program cache does. Clear it so the assertion measures this test's
+    # own compilation, per the cache-state guidance in conftest.py's _device_module_impl docstring.
+    # Note: clear_program_cache(), not disable_and_clear_program_cache() -- the latter turns caching
+    # off, so the second run would recompile and the entry count would never reach 1.
+    device.clear_program_cache()
 
     for i in range(2):
         if i > 0:
@@ -474,16 +480,10 @@ def test_layernorm_part_1_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
                 )
             )
         run_layernorm_part_1(inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, device)
-        if i == 0:
-            entries_after_first_run = device.num_program_cache_entries()
 
     assert (
-        entries_after_first_run - entries_before <= 1
-    ), f"First run added more than one program cache entry: {entries_before} -> {entries_after_first_run}"
-    assert device.num_program_cache_entries() == entries_after_first_run, (
-        f"Second identical run added a program cache entry: "
-        f"{entries_after_first_run} -> {device.num_program_cache_entries()}"
-    )
+        device.num_program_cache_entries() == 1
+    ), f"Program cache should have exactly one entry, got {device.num_program_cache_entries()}"
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -459,13 +459,7 @@ def test_layernorm_part_1_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
 
     dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
 
-    # The device is module-scoped, so the cache arrives here already populated -- and every config
-    # this test runs is also a cell of test_layernorm_part_1_with_program_cache above, so the entry
-    # for it always pre-exists. Without clearing, the count below can never change and the assertion
-    # holds no matter what the program cache does. Clear it so the assertion measures this test's
-    # own compilation, per the cache-state guidance in conftest.py's _device_module_impl docstring.
-    # Note: clear_program_cache(), not disable_and_clear_program_cache() -- the latter turns caching
-    # off, so the second run would recompile and the entry count would never reach 1.
+    # Module-scoped device: clear first (not disable_and_clear, which turns caching off) or `== 1` is vacuous.
     device.clear_program_cache()
 
     for i in range(2):

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_layernorm_pre_allgather.py
@@ -18,6 +18,8 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     ttnn_layer_norm_post_all_gather,
 )
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
 
 TEST_PADDING_VALUE = -42
 
@@ -457,6 +459,9 @@ def test_layernorm_part_1_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
 
     dram_memcfg = ttnn.DRAM_MEMORY_CONFIG
 
+    entries_before = device.num_program_cache_entries()
+    entries_after_first_run = None
+
     for i in range(2):
         if i > 0:
             dummy_tensors.append(
@@ -469,9 +474,15 @@ def test_layernorm_part_1_with_program_cache2(inp_shape, n_devices, is_rmsnorm, 
                 )
             )
         run_layernorm_part_1(inp_shape, n_devices, is_rmsnorm, input_dtype, output_dtype, device)
+        if i == 0:
+            entries_after_first_run = device.num_program_cache_entries()
 
-    assert device.num_program_cache_entries() == 1, "Program cache should have only one entry" + str(
-        device.num_program_cache_entries()
+    assert (
+        entries_after_first_run - entries_before <= 1
+    ), f"First run added more than one program cache entry: {entries_before} -> {entries_after_first_run}"
+    assert device.num_program_cache_entries() == entries_after_first_run, (
+        f"Second identical run added a program cache entry: "
+        f"{entries_after_first_run} -> {device.num_program_cache_entries()}"
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_rmsnorm_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_rmsnorm_allgather.py
@@ -13,6 +13,9 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     ttnn_rms_norm_post_all_gather,
 )
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
+
 
 def _run_distributed_rmsnorm_single_device(
     device,

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -163,7 +163,6 @@ def test_group_norm_DRAM_rejects_non_uniform_mcast_groups(device, expect_error):
         (1, 1152, 128, 128, 32, 2, 8, 4),
         (1, 512, 64, 64, 32, 1, 8, 8),  # SD 1.4 VAE
         (1, 512, 128, 128, 32, 1, 8, 8),  # SD 1.4 VAE
-        (1, 512, 256, 256, 32, 4, 8, 8),  # SD 1.4 VAE
         (1, 256, 256, 256, 32, 8, 8, 8),  # SD 1.4 VAE
         # sd35. 4 indicates the number of device.
         (1, 256 // 4, 256, 256, 32 // 4, 1, 8, 8),

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -172,13 +172,29 @@ _BF16_DISTRIBUTIONS = ("uniform_01", "normal", "wide_uniform")
 _FP32_DISTRIBUTIONS = ("normal", "wide_uniform", "centered_uniform")
 
 
-def _fuse_distribution_into_shapes(shapes, distributions):
+def _fuse_distribution_into_shapes(shapes, distributions, offset=0):
     """Return (h, w, desc, distribution) rows, rotating `distributions` across `shapes`."""
-    return [(h, w, desc, distributions[i % len(distributions)]) for i, (h, w, desc) in enumerate(shapes)]
+    return [(h, w, desc, distributions[(i + offset) % len(distributions)]) for i, (h, w, desc) in enumerate(shapes)]
 
 
 _SHAPES_BF16 = _fuse_distribution_into_shapes(_SHAPES, _BF16_DISTRIBUTIONS)
-_SHAPES_FP32 = _fuse_distribution_into_shapes(_SHAPES, _FP32_DISTRIBUTIONS)
+# The FP32 rotation is offset by one so the non-tile-aligned 37x41 shape does not land on
+# wide_uniform. That shape is the padding-contamination probe of this group: it is the only one
+# whose logical width is padded inside the reduction dim (41 -> 64, filled with PAD_VALUE by
+# _run_ttnn_layer_norm). A wide-range distribution inflates the near-zero atol enough to absorb the
+# error from normalizing over those padded columns -- the same reason the sharded tests below are
+# restricted to small-range distributions.
+_SHAPES_FP32 = _fuse_distribution_into_shapes(_SHAPES, _FP32_DISTRIBUTIONS, offset=1)
+
+# Guard the property the offset above buys, so that appending a shape to _build_layer_norm_shapes
+# shifts the rotation into a collection error rather than silently weakening padding coverage.
+_WIDE_RANGE_DISTRIBUTIONS = ("wide_uniform",)
+for _rows in (_SHAPES_BF16, _SHAPES_FP32):
+    _unguarded = [desc for _, w, desc, dist in _rows if w % 32 and dist in _WIDE_RANGE_DISTRIBUTIONS]
+    assert not _unguarded, (
+        f"Non-tile-aligned shape(s) {_unguarded} assigned a wide-range distribution, which inflates "
+        f"the near-zero atol enough to hide padding contamination. Adjust the rotation offset."
+    )
 
 _IDS_BF16 = [f"{desc}-{dist}" for _, _, desc, dist in _SHAPES_BF16]
 _IDS_FP32 = [f"{desc}-{dist}" for _, _, desc, dist in _SHAPES_FP32]

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -178,16 +178,11 @@ def _fuse_distribution_into_shapes(shapes, distributions, offset=0):
 
 
 _SHAPES_BF16 = _fuse_distribution_into_shapes(_SHAPES, _BF16_DISTRIBUTIONS)
-# The FP32 rotation is offset by one so the non-tile-aligned 37x41 shape does not land on
-# wide_uniform. That shape is the padding-contamination probe of this group: it is the only one
-# whose logical width is padded inside the reduction dim (41 -> 64, filled with PAD_VALUE by
-# _run_ttnn_layer_norm). A wide-range distribution inflates the near-zero atol enough to absorb the
-# error from normalizing over those padded columns -- the same reason the sharded tests below are
-# restricted to small-range distributions.
+# Offset so 37x41 (the only shape padded inside the reduction dim) avoids wide_uniform, whose
+# inflated near-zero atol would absorb padding contamination -- see the sharded tests below.
 _SHAPES_FP32 = _fuse_distribution_into_shapes(_SHAPES, _FP32_DISTRIBUTIONS, offset=1)
 
-# Guard the property the offset above buys, so that appending a shape to _build_layer_norm_shapes
-# shifts the rotation into a collection error rather than silently weakening padding coverage.
+# Fail at collection if a new shape shifts a padding probe onto wide_uniform.
 _WIDE_RANGE_DISTRIBUTIONS = ("wide_uniform",)
 for _rows in (_SHAPES_BF16, _SHAPES_FP32):
     _unguarded = [desc for _, w, desc, dist in _rows if w % 32 and dist in _WIDE_RANGE_DISTRIBUTIONS]

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -432,13 +432,9 @@ def _run_sharded_norm_ulp(device, norm, w, num_cores_w, distribution, dtype, use
     _assert_sharded_norm_ulp(golden, actual, dtype, f"ttnn.{norm} ULP (sharded)", spec, f"[{spec}]")
 
 
-# The sharded padding tests are restricted to small-range distributions. The near-zero atol
-# tolerance scales with the golden's value range, so a wide-range distribution (e.g. wide_uniform,
-# ±1e3) inflates the tolerance enough to absorb the error from normalizing over padded columns.
-# normal and centered_uniform both keep the range near unity, so PAD_VALUE-contaminated statistics
-# are caught either way -- the two are interchangeable for the property under test. They are
-# therefore rotated across the width axis rather than crossed with it, which keeps both
-# distributions exercised on every test while halving the case count.
+# The sharded padding tests are restricted to small-range distributions.
+# normal and centered_uniform are rotated across the width axis rather than crossed with it,
+# which keeps both distributions exercised on every test while halving the case count.
 _SHARDED_DISTRIBUTIONS = ("normal", "centered_uniform")
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -166,18 +166,7 @@ def _build_layer_norm_shapes():
 _SHAPES = _build_layer_norm_shapes()
 
 # ---------------------------------------------------------------------------
-# Input distribution: fused into the shape axis rather than crossed with it.
-#
-# The distribution only sets the numeric range of the generated input. It selects no kernel, no
-# reduction path and no threshold -- the ULP/atol caps are fixed per dtype, and the near-zero atol
-# scales with the golden's own range, so a wide-range distribution is self-normalizing. Crossing it
-# with the shape axis tripled the case count of these four characterization tests without reaching
-# a new code path.
-#
-# Rotating it across the shapes instead keeps every distribution on a third of the shapes, spanning
-# the W sweep, the H sweep, a square, the non-tile-aligned 37x41 and the 1x512 vector. Note that
-# adding a shape to _build_layer_norm_shapes shifts the assignment of every later shape; that is
-# fine for a characterization sweep, but it does mean the pairing is not stable across edits.
+# Input distribution: rotated across the shapes
 # ---------------------------------------------------------------------------
 _BF16_DISTRIBUTIONS = ("uniform_01", "normal", "wide_uniform")
 _FP32_DISTRIBUTIONS = ("normal", "wide_uniform", "centered_uniform")

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layer_norm_ulp.py
@@ -165,10 +165,38 @@ def _build_layer_norm_shapes():
 
 _SHAPES = _build_layer_norm_shapes()
 
+# ---------------------------------------------------------------------------
+# Input distribution: fused into the shape axis rather than crossed with it.
+#
+# The distribution only sets the numeric range of the generated input. It selects no kernel, no
+# reduction path and no threshold -- the ULP/atol caps are fixed per dtype, and the near-zero atol
+# scales with the golden's own range, so a wide-range distribution is self-normalizing. Crossing it
+# with the shape axis tripled the case count of these four characterization tests without reaching
+# a new code path.
+#
+# Rotating it across the shapes instead keeps every distribution on a third of the shapes, spanning
+# the W sweep, the H sweep, a square, the non-tile-aligned 37x41 and the 1x512 vector. Note that
+# adding a shape to _build_layer_norm_shapes shifts the assignment of every later shape; that is
+# fine for a characterization sweep, but it does mean the pairing is not stable across edits.
+# ---------------------------------------------------------------------------
+_BF16_DISTRIBUTIONS = ("uniform_01", "normal", "wide_uniform")
+_FP32_DISTRIBUTIONS = ("normal", "wide_uniform", "centered_uniform")
 
-@pytest.mark.parametrize("h, w, desc", _SHAPES, ids=[c[2] for c in _SHAPES])
+
+def _fuse_distribution_into_shapes(shapes, distributions):
+    """Return (h, w, desc, distribution) rows, rotating `distributions` across `shapes`."""
+    return [(h, w, desc, distributions[i % len(distributions)]) for i, (h, w, desc) in enumerate(shapes)]
+
+
+_SHAPES_BF16 = _fuse_distribution_into_shapes(_SHAPES, _BF16_DISTRIBUTIONS)
+_SHAPES_FP32 = _fuse_distribution_into_shapes(_SHAPES, _FP32_DISTRIBUTIONS)
+
+_IDS_BF16 = [f"{desc}-{dist}" for _, _, desc, dist in _SHAPES_BF16]
+_IDS_FP32 = [f"{desc}-{dist}" for _, _, desc, dist in _SHAPES_FP32]
+
+
+@pytest.mark.parametrize("h, w, desc, distribution", _SHAPES_BF16, ids=_IDS_BF16)
 @pytest.mark.parametrize("use_welford", [True, False])
-@pytest.mark.parametrize("distribution", ["uniform_01", "normal", "wide_uniform"])
 @pytest.mark.parametrize("fp32_dest_acc_en", [False, True], ids=["fp32_acc_off", "fp32_acc_on"])
 def test_layer_norm_ulp_bf16_no_weight_bias(device, h, w, desc, use_welford, distribution, fp32_dest_acc_en):
     """BF16 layer_norm ULP vs torch.nn.functional.layer_norm (no weight/bias).
@@ -202,9 +230,8 @@ def test_layer_norm_ulp_bf16_no_weight_bias(device, h, w, desc, use_welford, dis
     ), f"[BF16 no_wb {desc} use_welford={use_welford} dist={distribution} fp32_acc={fp32_dest_acc_en}] {msg}"
 
 
-@pytest.mark.parametrize("h, w, desc", _SHAPES, ids=[c[2] for c in _SHAPES])
+@pytest.mark.parametrize("h, w, desc, distribution", _SHAPES_BF16, ids=_IDS_BF16)
 @pytest.mark.parametrize("use_welford", [True, False])
-@pytest.mark.parametrize("distribution", ["uniform_01", "normal", "wide_uniform"])
 @pytest.mark.parametrize("wb_mode", ["wb", "weight_only", "bias_only"])
 @pytest.mark.parametrize("fp32_dest_acc_en", [False, True], ids=["fp32_acc_off", "fp32_acc_on"])
 def test_layer_norm_ulp_bf16_with_weight_bias(device, h, w, desc, use_welford, distribution, wb_mode, fp32_dest_acc_en):
@@ -265,9 +292,8 @@ _FP32_ULP_THRESHOLD = 2_500_000
 _FP32_NEAR_ZERO_ATOL_FRACTION = 0.004
 
 
-@pytest.mark.parametrize("h, w, desc", _SHAPES, ids=[c[2] for c in _SHAPES])
+@pytest.mark.parametrize("h, w, desc, distribution", _SHAPES_FP32, ids=_IDS_FP32)
 @pytest.mark.parametrize("use_welford", [True, False])
-@pytest.mark.parametrize("distribution", ["normal", "wide_uniform", "centered_uniform"])
 def test_layer_norm_ulp_fp32_no_weight_bias(device, h, w, desc, use_welford, distribution):
     """FP32 layer_norm ULP vs torch float32 golden (no weight/bias); fp32_dest_acc_en=True only."""
     torch.manual_seed(0)
@@ -290,9 +316,8 @@ def test_layer_norm_ulp_fp32_no_weight_bias(device, h, w, desc, use_welford, dis
     assert passed, f"[FP32 no_wb {desc} use_welford={use_welford} dist={distribution}] {msg}"
 
 
-@pytest.mark.parametrize("h, w, desc", _SHAPES, ids=[c[2] for c in _SHAPES])
+@pytest.mark.parametrize("h, w, desc, distribution", _SHAPES_FP32, ids=_IDS_FP32)
 @pytest.mark.parametrize("use_welford", [True, False])
-@pytest.mark.parametrize("distribution", ["normal", "wide_uniform", "centered_uniform"])
 @pytest.mark.parametrize("wb_mode", ["wb", "weight_only", "bias_only"])
 def test_layer_norm_ulp_fp32_with_weight_bias(device, h, w, desc, use_welford, distribution, wb_mode):
     """FP32 layer_norm ULP with weight/bias variants vs torch float32 golden; fp32_dest_acc_en=True only.
@@ -418,14 +443,27 @@ def _run_sharded_norm_ulp(device, norm, w, num_cores_w, distribution, dtype, use
     _assert_sharded_norm_ulp(golden, actual, dtype, f"ttnn.{norm} ULP (sharded)", spec, f"[{spec}]")
 
 
+# The sharded padding tests are restricted to small-range distributions. The near-zero atol
+# tolerance scales with the golden's value range, so a wide-range distribution (e.g. wide_uniform,
+# ±1e3) inflates the tolerance enough to absorb the error from normalizing over padded columns.
+# normal and centered_uniform both keep the range near unity, so PAD_VALUE-contaminated statistics
+# are caught either way -- the two are interchangeable for the property under test. They are
+# therefore rotated across the width axis rather than crossed with it, which keeps both
+# distributions exercised on every test while halving the case count.
+_SHARDED_DISTRIBUTIONS = ("normal", "centered_uniform")
+
+
+def _fuse_distribution_into_widths(widths):
+    """Return (w, distribution) rows, rotating _SHARDED_DISTRIBUTIONS across `widths`."""
+    return [(w, _SHARDED_DISTRIBUTIONS[i % len(_SHARDED_DISTRIBUTIONS)]) for i, w in enumerate(widths)]
+
+
 # Widths that are not multiples of the tile width (32), each on a single core so the
 # whole logical row plus its tile padding lives in one shard.
-@pytest.mark.parametrize("w", [40, 72, 200])
-# Restricted to small-range distributions. The near-zero atol tolerance scales with the
-# golden's value range, so a wide-range distribution (e.g. wide_uniform, ±1e3) inflates the
-# tolerance enough to absorb the error from normalizing over padded columns. normal and
-# centered_uniform keep the range near unity, so PAD_VALUE-contaminated statistics are caught.
-@pytest.mark.parametrize("distribution", ["normal", "centered_uniform"])
+_NON_TILE_ALIGNED_WIDTHS = _fuse_distribution_into_widths([40, 72, 200])
+
+
+@pytest.mark.parametrize("w, distribution", _NON_TILE_ALIGNED_WIDTHS)
 # Both reduction paths must normalize over the logical width: the Welford path (reciprocal LUT)
 # and the legacy reduce path (1/N reduction scaler).
 @pytest.mark.parametrize("use_welford", [True, False])
@@ -463,11 +501,9 @@ def test_layer_norm_ulp_sharded_tile_aligned_width_split_across_cores(device, us
 
 
 # Widths that are not multiples of the tile width (32), each on a single core so the
-# whole logical row plus its tile padding lives in one shard.
-@pytest.mark.parametrize("w", [40, 72, 200])
-# Restricted to small-range distributions for the same reason as the layer_norm sharded test: a
-# wide-range distribution inflates the near-zero atol tolerance enough to hide padding contamination.
-@pytest.mark.parametrize("distribution", ["normal", "centered_uniform"])
+# whole logical row plus its tile padding lives in one shard. The distribution is rotated across
+# the width axis for the same reason as the layer_norm sharded test above.
+@pytest.mark.parametrize("w, distribution", _NON_TILE_ALIGNED_WIDTHS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_ulp_sharded_non_tile_aligned_width(device, w, distribution, dtype):
     """Sharded rms_norm over a non-tile-aligned width vs torch golden, for BF16 and FP32 inputs.
@@ -494,8 +530,7 @@ def test_rms_norm_ulp_sharded_non_tile_aligned_width(device, w, distribution, dt
 # - Tiles 1 and 2 (columns 128-159 and 160-191) fully valid.
 # - Tile 3 (columns 192-223) partially valid (only 192-199 valid).
 # - Tile 4 (columns 224-255) fully padding.
-@pytest.mark.parametrize("w", [40, 72, 96, 200])
-@pytest.mark.parametrize("distribution", ["normal", "centered_uniform"])
+@pytest.mark.parametrize("w, distribution", _fuse_distribution_into_widths([40, 72, 96, 200]))
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_rms_norm_ulp_sharded_unevenly_split_width_across_cores(device, w, distribution, dtype):
     """Sharded rms_norm over a width split across two cores vs torch golden.
@@ -507,8 +542,7 @@ def test_rms_norm_ulp_sharded_unevenly_split_width_across_cores(device, w, distr
     _run_sharded_norm_ulp(device, "rmsnorm", w, num_cores_w=2, distribution=distribution, dtype=dtype)
 
 
-@pytest.mark.parametrize("w", [40, 72, 200])
-@pytest.mark.parametrize("distribution", ["normal", "centered_uniform"])
+@pytest.mark.parametrize("w, distribution", _NON_TILE_ALIGNED_WIDTHS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("norm", ["layernorm", "rmsnorm"])
 @pytest.mark.parametrize("num_cores_w", [1, 2])

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -12,7 +12,12 @@ import ttnn
 
 from models.common.utility_functions import torch2tt_tensor, run_for_blackhole
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
-from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_layer_norm, ttnn_rms_norm
+from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
+    ttnn_layer_norm,
+    ttnn_rms_norm,
+    MIX_PRECISION_TEST_IDS,
+    MIX_PRECISION_TEST_ID_NAMES,
+)
 
 TEST_PADDING_VALUE = -42
 
@@ -210,11 +215,6 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
     ],
 )
 @pytest.mark.parametrize(
-    "gamma_dtype",
-    (ttnn.bfloat16, ttnn.float32),
-    ids=["BFLOAT16", "FLOAT32"],
-)
-@pytest.mark.parametrize(
     "in_dtype",
     (
         ttnn.float32,
@@ -223,24 +223,8 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
     ),
     ids=["FLOAT32", "BFLOAT16", "BFLOAT8_B"],
 )
-@pytest.mark.parametrize(
-    "test_id",
-    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-    ids=[
-        "add_LN",
-        "add_LN_G",
-        "add_LN_GB",
-        "add_RMSN",
-        "add_RMSN_G",
-        "add_RMSN_GB",
-        "LN",
-        "LN_G",
-        "LN_GB",
-        "RMSN",
-        "RMSN_G",
-        "RMSN_GB",
-    ],
-)
+# gamma_dtype is fused into test_id instead of crossed with it -- see MIX_PRECISION_TEST_IDS.
+@pytest.mark.parametrize("test_id, gamma_dtype", MIX_PRECISION_TEST_IDS, ids=MIX_PRECISION_TEST_ID_NAMES)
 def test_layernorm_mix_precision(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device):
     torch.manual_seed(0)
     run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -226,7 +226,7 @@ def run_layernorm_mix_precision_tests(test_id, in_dtype, gamma_dtype, in0_mem_co
     ),
     ids=["FLOAT32", "BFLOAT16", "BFLOAT8_B"],
 )
-# gamma_dtype is fused into test_id instead of crossed with it -- see MIX_PRECISION_TEST_IDS.
+# gamma_dtype is fused into test_id -- see MIX_PRECISION_TEST_IDS.
 @pytest.mark.parametrize("test_id, gamma_dtype", MIX_PRECISION_TEST_IDS, ids=MIX_PRECISION_TEST_ID_NAMES)
 def test_layernorm_mix_precision(test_id, in_dtype, gamma_dtype, in0_mem_config, out_mem_config, device):
     torch.manual_seed(0)

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py
@@ -19,6 +19,9 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     MIX_PRECISION_TEST_ID_NAMES,
 )
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
+
 TEST_PADDING_VALUE = -42
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
@@ -14,6 +14,8 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     ttnn_layer_norm_in_place,
     ttnn_rms_norm_in_place,
+    MIX_PRECISION_TEST_IDS,
+    MIX_PRECISION_TEST_ID_NAMES,
 )
 
 
@@ -34,11 +36,6 @@ def rms_norm(x, dim, gamma, beta, eps):
     ],
 )
 @pytest.mark.parametrize(
-    "gamma_dtype",
-    (ttnn.bfloat16, ttnn.float32),
-    ids=["BFLOAT16", "FLOAT32"],
-)
-@pytest.mark.parametrize(
     "in_dtype",
     (
         ttnn.float32,
@@ -47,24 +44,8 @@ def rms_norm(x, dim, gamma, beta, eps):
     ),
     ids=["FLOAT32", "BFLOAT16", "BFLOAT8_B"],
 )
-@pytest.mark.parametrize(
-    "test_id",
-    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-    ids=[
-        "add_LN",
-        "add_LN_G",
-        "add_LN_GB",
-        "add_RMSN",
-        "add_RMSN_G",
-        "add_RMSN_GB",
-        "LN",
-        "LN_G",
-        "LN_GB",
-        "RMSN",
-        "RMSN_G",
-        "RMSN_GB",
-    ],
-)
+# gamma_dtype is fused into test_id instead of crossed with it -- see MIX_PRECISION_TEST_IDS.
+@pytest.mark.parametrize("test_id, gamma_dtype", MIX_PRECISION_TEST_IDS, ids=MIX_PRECISION_TEST_ID_NAMES)
 @pytest.mark.parametrize("width_padding", [False, True], ids=["no_padding", "padding"])
 def test_layernorm_sharded_mix_precision_rm(
     test_id, in_dtype, gamma_dtype, gamma_beta_mem_config, out_mem_config, device, width_padding
@@ -302,11 +283,6 @@ def test_layernorm_sharded_mix_precision_rm(
     ],
 )
 @pytest.mark.parametrize(
-    "gamma_dtype",
-    (ttnn.bfloat16, ttnn.float32),
-    ids=["BFLOAT16", "FLOAT32"],
-)
-@pytest.mark.parametrize(
     "in_dtype",
     (
         ttnn.float32,
@@ -323,24 +299,8 @@ def test_layernorm_sharded_mix_precision_rm(
         (512, 2048, 1),
     ],
 )
-@pytest.mark.parametrize(
-    "test_id",
-    (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
-    ids=[
-        "add_LN",
-        "add_LN_G",
-        "add_LN_GB",
-        "add_RMSN",
-        "add_RMSN_G",
-        "add_RMSN_GB",
-        "LN",
-        "LN_G",
-        "LN_GB",
-        "RMSN",
-        "RMSN_G",
-        "RMSN_GB",
-    ],
-)
+# gamma_dtype is fused into test_id instead of crossed with it -- see MIX_PRECISION_TEST_IDS.
+@pytest.mark.parametrize("test_id, gamma_dtype", MIX_PRECISION_TEST_IDS, ids=MIX_PRECISION_TEST_ID_NAMES)
 def test_layernorm_1d_sharded_mix_precision_rm(
     test_id, M, K, subblock_w, in_dtype, gamma_dtype, gamma_beta_mem_config, out_mem_config, shard_orientation, device
 ):

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm_sharded.py
@@ -18,6 +18,9 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     MIX_PRECISION_TEST_ID_NAMES,
 )
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
+
 
 def rms_norm(x, dim, gamma, beta, eps):
     return x * torch.rsqrt(x.pow(2).mean([-i for i in range(1, len(dim) + 1)], keepdim=True) + eps) * gamma + beta

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_rmsnorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_rmsnorm.py
@@ -20,6 +20,9 @@ from models.common.utility_functions import is_wormhole_b0
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_rms_norm
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
+
 TEST_PADDING_VALUE = -42
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_single_core_fused_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_single_core_fused_ops.py
@@ -12,6 +12,8 @@ from models.common.utility_functions import torch2tt_tensor
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_softmax_in_place, ttnn_layer_norm
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
 
 TEST_PADDING_VALUE = -42
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax.py
@@ -11,6 +11,9 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
 from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import ttnn_softmax
 from models.common.utility_functions import torch_random
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
+
 
 @pytest.mark.parametrize("shape", [[2, 10, 512, 8192]])
 def test_ttnn_softmax_sdxl_attention(device, shape):

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_interleaved.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_softmax_interleaved.py
@@ -23,6 +23,8 @@ from tests.ttnn.nightly.unit_tests.operations.fused.utility_functions import (
     ttnn_scale_mask_softmax_in_place,
 )
 
+# Module-scoped device: every test here shares one device configuration
+pytestmark = pytest.mark.use_module_device
 
 TEST_PADDING_VALUE = -42
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -2,18 +2,89 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""Determinism wrappers for the fused (norm / softmax) op tests.
+"""Shared helpers for the fused (norm / softmax) op tests.
 
-Each ``ttnn_<op>`` helper runs ``ttnn.<op>`` twice with the same inputs, asserts
-the two runs produce identical outputs, and returns the first one (a drop-in
-replacement for the original ``ttnn.<op>`` call).
+Determinism wrappers: each ``ttnn_<op>`` helper runs ``ttnn.<op>`` twice with the
+same inputs, asserts the two runs produce identical outputs, and returns the first
+one (a drop-in replacement for the original ``ttnn.<op>`` call).
 
 In-place ops mutate their input tensor, so the ``*_in_place`` helpers clone the
 input before each run to give both runs identical inputs.
+
+Also holds the shared ``test_id`` x gamma/beta dtype grid used by the mix-precision
+layernorm tests (see ``MIX_PRECISION_TEST_IDS``).
 """
 
 import torch
 import ttnn
+
+
+# ---------------------------------------------------------------------------
+# Shared test_id x gamma/beta dtype grid for the mix-precision layernorm tests.
+#
+# These tests used to cross a standalone ``gamma_dtype`` axis with ``test_id``, which doubled
+# every grid. The gamma/beta dtype is independent of every other axis in those grids:
+#
+#   * the gamma/beta CB data format is derived solely from the gamma/beta tensor dtype
+#     (sharded_layernorm_factory_helpers.cpp, layernorm_op_multi_core.cpp) -- it is never
+#     combined with the input dtype, the welford mode or the shard orientation;
+#   * it feeds only tile size and CB creation;
+#   * validation checks only that it is FLOAT32 or BFLOAT16 (layernorm_device_operation.cpp),
+#     with no cross-check against the input dtype;
+#   * the tolerances never branch on it.
+#
+# The reader-kernel switch ``use_row_major_kernel`` keys on gamma *layout*, not dtype, so a
+# ``gamma_layout`` axis does interact and must stay crossed where it appears. This is the same
+# de-crossing that #53549 applied to the axis under its ``gb_dtype`` name.
+#
+# The dtype is fused into ``test_id`` rather than pinned to a single value, alternating so both
+# formats appear in every {LN, RMSN} x {G, GB} x {residual, no residual} category:
+#
+#   test_id   0     1      2       3      4       5        6    7     8      9     10     11
+#   name      LN    LN_G   LN_GB   RMSN   RMSN_G  RMSN_GB  LN   LN_G  LN_GB  RMSN  RMSN_G RMSN_GB
+#             |<---------- residual (add_*) ---------->|   |<--------- no residual --------->|
+#   gamma     bf16  bf16   fp32    fp32   fp32    bf16     bf16 fp32  bf16   fp32  bf16   fp32
+#
+# ``test_id % 3 == 0`` (0, 3, 6, 9) passes no gamma/beta to the op at all, so its entry only
+# affects host-side tensor construction.
+# ---------------------------------------------------------------------------
+
+_MIX_PRECISION_TEST_ID_NAMES = (
+    "add_LN",
+    "add_LN_G",
+    "add_LN_GB",
+    "add_RMSN",
+    "add_RMSN_G",
+    "add_RMSN_GB",
+    "LN",
+    "LN_G",
+    "LN_GB",
+    "RMSN",
+    "RMSN_G",
+    "RMSN_GB",
+)
+
+_MIX_PRECISION_GAMMA_DTYPES = (
+    ttnn.bfloat16,  # 0  add_LN     (no gamma passed)
+    ttnn.bfloat16,  # 1  add_LN_G
+    ttnn.float32,  # 2  add_LN_GB
+    ttnn.float32,  # 3  add_RMSN   (no gamma passed)
+    ttnn.float32,  # 4  add_RMSN_G
+    ttnn.bfloat16,  # 5  add_RMSN_GB
+    ttnn.bfloat16,  # 6  LN        (no gamma passed)
+    ttnn.float32,  # 7  LN_G
+    ttnn.bfloat16,  # 8  LN_GB
+    ttnn.float32,  # 9  RMSN      (no gamma passed)
+    ttnn.bfloat16,  # 10 RMSN_G
+    ttnn.float32,  # 11 RMSN_GB
+)
+
+# Parametrize as ``"test_id, gamma_dtype"`` so the node id still names the dtype that ran.
+MIX_PRECISION_TEST_IDS = tuple(enumerate(_MIX_PRECISION_GAMMA_DTYPES))
+MIX_PRECISION_TEST_ID_NAMES = tuple(
+    f"{name}-{'gb_fp32' if dtype == ttnn.float32 else 'gb_bf16'}"
+    for name, dtype in zip(_MIX_PRECISION_TEST_ID_NAMES, _MIX_PRECISION_GAMMA_DTYPES)
+)
 
 
 def _run_twice(op, *args, **kwargs):

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -22,17 +22,14 @@ import ttnn
 # Shared test_id x gamma/beta dtype grid for the mix-precision layernorm tests.
 #
 # The dtype is fused into ``test_id``, alternating across the residual / no-residual pair so that
-# both formats appear in every {LN, RMSN} x {G, GB} category. Residual status is the axis that
-# carries the alternation, so it is not itself a category here -- each individual test_id runs
-# exactly one gamma/beta dtype:
+# both formats appear in every {LN, RMSN} x {G, GB} category (each test_id runs exactly one dtype):
 #
 #   test_id   0     1      2       3      4       5        6    7     8      9     10     11
 #   name      LN    LN_G   LN_GB   RMSN   RMSN_G  RMSN_GB  LN   LN_G  LN_GB  RMSN  RMSN_G RMSN_GB
 #             |<---------- residual (add_*) ---------->|   |<--------- no residual --------->|
 #   gamma     bf16  bf16   fp32    fp32   fp32    bf16     bf16 fp32  bf16   fp32  bf16   fp32
 #
-# Reading the pairs down the columns: LN_G is bf16 with residual / fp32 without, LN_GB is fp32 /
-# bf16, RMSN_G is fp32 / bf16, RMSN_GB is bf16 / fp32 -- both formats in each of the four.
+# Down the residual pairs: LN_G bf16/fp32, LN_GB fp32/bf16, RMSN_G fp32/bf16, RMSN_GB bf16/fp32.
 #
 # ---------------------------------------------------------------------------
 
@@ -68,12 +65,7 @@ _MIX_PRECISION_GAMMA_DTYPES = (
 
 
 def _mix_precision_id(name, dtype):
-    """Test id for one (test_id, gamma/beta dtype) pair.
-
-    The ``_G`` / ``_GB`` suffix in the name marks the cases that actually pass gamma (and beta) to
-    the op. The remaining four build the tensors but never pass them, so the fused dtype is inert
-    there -- they are labelled ``no_gb`` rather than advertising a dtype they do not exercise.
-    """
+    """Test id for one (test_id, dtype) pair; cases that never pass gamma/beta are labelled no_gb."""
     if not name.endswith(("_G", "_GB")):
         return f"{name}-no_gb"
     return f"{name}-{'gb_fp32' if dtype == ttnn.float32 else 'gb_bf16'}"

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -22,22 +22,7 @@ import ttnn
 # ---------------------------------------------------------------------------
 # Shared test_id x gamma/beta dtype grid for the mix-precision layernorm tests.
 #
-# These tests used to cross a standalone ``gamma_dtype`` axis with ``test_id``, which doubled
-# every grid. The gamma/beta dtype is independent of every other axis in those grids:
-#
-#   * the gamma/beta CB data format is derived solely from the gamma/beta tensor dtype
-#     (sharded_layernorm_factory_helpers.cpp, layernorm_op_multi_core.cpp) -- it is never
-#     combined with the input dtype, the welford mode or the shard orientation;
-#   * it feeds only tile size and CB creation;
-#   * validation checks only that it is FLOAT32 or BFLOAT16 (layernorm_device_operation.cpp),
-#     with no cross-check against the input dtype;
-#   * the tolerances never branch on it.
-#
-# The reader-kernel switch ``use_row_major_kernel`` keys on gamma *layout*, not dtype, so a
-# ``gamma_layout`` axis does interact and must stay crossed where it appears. This is the same
-# de-crossing that #53549 applied to the axis under its ``gb_dtype`` name.
-#
-# The dtype is fused into ``test_id`` rather than pinned to a single value, alternating so both
+# The dtype is fused into ``test_id``, alternating so both
 # formats appear in every {LN, RMSN} x {G, GB} x {residual, no residual} category:
 #
 #   test_id   0     1      2       3      4       5        6    7     8      9     10     11
@@ -45,8 +30,6 @@ import ttnn
 #             |<---------- residual (add_*) ---------->|   |<--------- no residual --------->|
 #   gamma     bf16  bf16   fp32    fp32   fp32    bf16     bf16 fp32  bf16   fp32  bf16   fp32
 #
-# ``test_id % 3 == 0`` (0, 3, 6, 9) passes no gamma/beta to the op at all, so its entry only
-# affects host-side tensor construction.
 # ---------------------------------------------------------------------------
 
 _MIX_PRECISION_TEST_ID_NAMES = (

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -18,17 +18,21 @@ layernorm tests (see ``MIX_PRECISION_TEST_IDS``).
 import torch
 import ttnn
 
-
 # ---------------------------------------------------------------------------
 # Shared test_id x gamma/beta dtype grid for the mix-precision layernorm tests.
 #
-# The dtype is fused into ``test_id``, alternating so both
-# formats appear in every {LN, RMSN} x {G, GB} x {residual, no residual} category:
+# The dtype is fused into ``test_id``, alternating across the residual / no-residual pair so that
+# both formats appear in every {LN, RMSN} x {G, GB} category. Residual status is the axis that
+# carries the alternation, so it is not itself a category here -- each individual test_id runs
+# exactly one gamma/beta dtype:
 #
 #   test_id   0     1      2       3      4       5        6    7     8      9     10     11
 #   name      LN    LN_G   LN_GB   RMSN   RMSN_G  RMSN_GB  LN   LN_G  LN_GB  RMSN  RMSN_G RMSN_GB
 #             |<---------- residual (add_*) ---------->|   |<--------- no residual --------->|
 #   gamma     bf16  bf16   fp32    fp32   fp32    bf16     bf16 fp32  bf16   fp32  bf16   fp32
+#
+# Reading the pairs down the columns: LN_G is bf16 with residual / fp32 without, LN_GB is fp32 /
+# bf16, RMSN_G is fp32 / bf16, RMSN_GB is bf16 / fp32 -- both formats in each of the four.
 #
 # ---------------------------------------------------------------------------
 
@@ -62,10 +66,22 @@ _MIX_PRECISION_GAMMA_DTYPES = (
     ttnn.float32,  # 11 RMSN_GB
 )
 
+
+def _mix_precision_id(name, dtype):
+    """Test id for one (test_id, gamma/beta dtype) pair.
+
+    The ``_G`` / ``_GB`` suffix in the name marks the cases that actually pass gamma (and beta) to
+    the op. The remaining four build the tensors but never pass them, so the fused dtype is inert
+    there -- they are labelled ``no_gb`` rather than advertising a dtype they do not exercise.
+    """
+    if not name.endswith(("_G", "_GB")):
+        return f"{name}-no_gb"
+    return f"{name}-{'gb_fp32' if dtype == ttnn.float32 else 'gb_bf16'}"
+
+
 MIX_PRECISION_TEST_IDS = tuple(enumerate(_MIX_PRECISION_GAMMA_DTYPES))
 MIX_PRECISION_TEST_ID_NAMES = tuple(
-    f"{name}-{'gb_fp32' if dtype == ttnn.float32 else 'gb_bf16'}"
-    for name, dtype in zip(_MIX_PRECISION_TEST_ID_NAMES, _MIX_PRECISION_GAMMA_DTYPES)
+    _mix_precision_id(name, dtype) for name, dtype in zip(_MIX_PRECISION_TEST_ID_NAMES, _MIX_PRECISION_GAMMA_DTYPES)
 )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/utility_functions.py
@@ -79,7 +79,6 @@ _MIX_PRECISION_GAMMA_DTYPES = (
     ttnn.float32,  # 11 RMSN_GB
 )
 
-# Parametrize as ``"test_id, gamma_dtype"`` so the node id still names the dtype that ran.
 MIX_PRECISION_TEST_IDS = tuple(enumerate(_MIX_PRECISION_GAMMA_DTYPES))
 MIX_PRECISION_TEST_ID_NAMES = tuple(
     f"{name}-{'gb_fp32' if dtype == ttnn.float32 else 'gb_bf16'}"


### PR DESCRIPTION
### PR Category

Test Only

### Summary

Relates to #53991, #53549.

`ops-unit-tests / ttnn nightly fused tests` has grown close to reaching the timeout. On `wh_n150_civ2` the pytest step now runs ~57 min against a 65 min declared timeout.

The suite is host-CPU-bound and non-test overhead is about 6% of the step. So the practical options are reducing the case count and the per-case fixed cost. This PR takes both.

**1. De-cross three redundant grid axes** (`2684 → 1872` collected cases, −30%)

| axis | where | argument |
|---|---|---|
| gamma/beta dtype | `test_layernorm.py`, `test_layernorm_sharded.py` (×2) | The op derives the gamma/beta CB data format solely from the gamma/beta tensor dtype (`sharded_layernorm_factory_helpers.cpp:60-65`, `layernorm_op_multi_core.cpp:152-155`). Not combined with input dtype, welford mode or orientation. For `test_id ∈ {0,3,6,9}` the tests build gamma/beta and never pass them to the op. Same axis #53549 de-crossed under its `gb_dtype` name. |
| input distribution | `test_layer_norm_ulp.py` (8 tests) | Only sets the numeric range of the generated input. Selects no kernel or accuracy threshold. |
| duplicate shape | `test_group_norm_DRAM.py` | SD 1.4 VAE's `(1, 512, 256, 256, 32, 4, 8, 8)` is byte-identical to the SDXL VAE entry above. |

The de-crossed axes are fused into an existing axis: each individual `test_id` therefore runs exactly one
gamma/beta dtype.

The PR preserves the `in_dtype × gamma/beta dtype` cross, which allows to validate unpacker reconfiguration — a problem caught during review of #53549:

| in_dtype | gamma/beta dtype | | surviving test_ids |
|---|---|---|---|
| `bfloat16` | `bfloat16` | same | `add_LN_G`, `add_RMSN_GB`, `LN_GB`, `RMSN_G` |
| `bfloat16` | `float32` | **mixed** | `add_LN_GB`, `add_RMSN_G`, `LN_G`, `RMSN_GB` |
| `bfloat8_b` | `bfloat16` | **mixed** | `add_LN_G`, `add_RMSN_GB`, `LN_GB`, `RMSN_G` |
| `bfloat8_b` | `float32` | **mixed** | `add_LN_GB`, `add_RMSN_G`, `LN_G`, `RMSN_GB` |
| `float32` | `bfloat16` | **mixed** | `add_LN_G`, `add_RMSN_GB`, `LN_GB`, `RMSN_G` |
| `float32` | `float32` | same | `add_LN_GB`, `add_RMSN_G`, `LN_G`, `RMSN_GB` |

The distribution rotates across the shape/width axis so each distribution still runs on a third of
the shapes.

What stays crossed: `in_dtype` — it drives `fp32_dest_acc_en`. `gamma_layout` — the `use_row_major_kernel` (`layernorm_op_multi_core.cpp:216`) depends on gamma layout. `shard_orientation` — selects a different reduction strategy via `should_use_two_stage_reduce`.

| file | before | after |
|---|---|---|
| `test_layernorm_sharded.py` | 588 | 300 |
| `test_layer_norm_ulp.py` | 750 | 268 |
| `test_layernorm.py` | 138 | 102 |
| `test_group_norm_DRAM.py` | 377 | 371 |

**2. Module-scoped device in 9 of the 12 remaining modules** (same change as #53991)

### Expected saving

~**14 min** on `wh_n150_civ2` (≈57 → ≈43 min), roughly a quarter of the step:
- grid de-crossing ≈ **11 min**
- module-scoped device ≈ **3 min** (de-crossing removed cases that would have paid the fixed cost)

### Notes for reviewers

Please focus on the coverage argument, since everything else is mechanical.

1. Is the gamma-dtype independence claim right?  For example, whether the dtype interacts with anything else in the operation;

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/cut-fused-nightly-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/cut-fused-nightly-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/cut-fused-nightly-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/cut-fused-nightly-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/cut-fused-nightly-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/cut-fused-nightly-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/cut-fused-nightly-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/cut-fused-nightly-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/cut-fused-nightly-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/cut-fused-nightly-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/cut-fused-nightly-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/cut-fused-nightly-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/cut-fused-nightly-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/cut-fused-nightly-runtime)
