### PR TITLE
[Bug fix] ttnn.div int32 (trunc/floor): exclude the INT32_MIN magnitude word from the final comparison (WH/BH)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -869,6 +869,15 @@ def test_div_edge_cases(rounding_mode, device):
         (2147483647, 1073741823),
         (1073741823, -2147483647),
         (1073741824, -2147483647),
+        # INT32_MIN divisor: its magnitude word 0x80000000 reads as negative in
+        # the final r >= b comparison, injecting a spurious quotient increment.
+        (1, -2147483648),
+        (6, -2147483648),
+        (65536, -2147483648),
+        (1000000, -2147483648),
+        (2097153, -2147483648),
+        (2147483647, -2147483648),
+        (-2147483647, -2147483648),
     ]
 
     numerators, denominators = zip(*pairs)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -96,7 +96,11 @@ sfpi_inline void calculate_div_int32_body(
         q -= 1;
         r += b;
     }
-    v_elseif(r >= b) {
+    // When the divisor is INT32_MIN, its magnitude word is 0x80000000, which
+    // this signed comparison reads as negative -- making it unconditionally
+    // true and injecting a spurious quotient increment. The true magnitude
+    // 2**31 can never be reached by r here, so exclude that word entirely.
+    v_elseif(r >= b && b != (-2147483647 - 1)) {
         q += 1;
         r -= b;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -137,7 +137,12 @@ sfpi_inline void calculate_div_int32_body(
         q -= 1;
         r += b;
     }
-    v_elseif(r >= b) {
+    // When the divisor is INT32_MIN, its magnitude word is 0x80000000, which
+    // this signed comparison reads as negative -- making it unconditionally
+    // true and injecting a spurious quotient increment (e.g. div(1,
+    // INT32_MIN) returned -1 instead of 0). The true magnitude 2**31 can
+    // never be reached by r here, so exclude that word entirely.
+    v_elseif(r >= b && b != (-2147483647 - 1)) {
         q += 1;
         r -= b;
     }


### PR DESCRIPTION
Fixes #54326.

### Problem
With divisor INT32_MIN, `b = sfpi::abs(b_s)` keeps the magnitude word `0x80000000`. The final normalization `v_elseif(r >= b)` compares signed, reads that word as `-2147483648`, and is unconditionally true -- every lane takes a spurious `q += 1; r -= b;`, so `div(1, INT32_MIN, trunc)` returns `-1` instead of `0` (WH and BH).

### Fix
Exclude the poisoned word from the comparison on both architectures:

```c
v_elseif(r >= b && b != (-2147483647 - 1)) { ... }
```

The true magnitude 2**31 is unreachable by `r` at this point, so skipping the increment for that lane is exactly correct; all other divisors take the identical path as before.

### Validation

Cycle-faithful Python emulation of the Wormhole datapath (sfpi convert/exman/SFPMAD semantics; the emulation reproduces main bit-exactly on ~1200 randomized non-pathological pairs):

| sweep | before | after |
|---|---:|---:|
| divisor INT32_MIN, 258 cases | 128 wrong | **0** |
| dividend INT32_MIN sweeps (adjacent defect, untouched) | 0 | 0 |
| 800 randomized sanity pairs | 0 | 0 |

Device coverage for the affected class added to `test_div_edge_cases` (both rounding modes run on WH/BH CI).

### Related
Independent of #51476 / PR #54325 (dividend-side residual conversion); the two patches touch different hunks of the same files and compose cleanly.
