### PR TITLE
port(metal_2.0): data_movement/transpose 6-factory subset to Metal 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PORT_BRIEF.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PORT_BRIEF.md
@@ -1,0 +1,59 @@
+# Metal 2.0 Port Brief — `ttnn/cpp/ttnn/operations/data_movement/transpose`
+
+> **Scoped subset port.** The op is RED at op level — two of eight factories are gated
+> (`TransposeHCShardedProgramFactory`, `TransposeWHShardedRMProgramFactory`). This brief
+> covers the **clean six-factory subset only**; do **not** touch the two gated factories or
+> their kernels. Full record in `METAL2_PREPORT_AUDIT.md`.
+
+**In-scope factories (port these six):**
+`TransposeCNProgramFactory` · `TransposeHCRMProgramFactory` · `TransposeHCTiledInterleavedProgramFactory` · `TransposeHCTiledProgramFactory` · `TransposeWHProgramFactory` (tiled + row-major) · `TransposeWHShardedProgramFactory`
+
+**Out of scope (gated — leave on the descriptor path):**
+`TransposeHCShardedProgramFactory` · `TransposeWHShardedRMProgramFactory` — both use the shared device-op `get_dynamic_runtime_args` hook (`Runtime-args update`) and carry `Is safe to port? = no`.
+
+**Gates cleared (for the six):** Device 2.0 ✓ · Features ✓ · TTNN factory concept ✓ · Offset base pointers ✓ · TensorAccessor 3rd arg ✓
+
+**Recipe docs:** `de19c9df758 2026-07-22 docs(metal_2.0): route Gen1 porters away from the Quasar-uplift audit helper` *(carry this line into the port report's Provenance section)*
+
+## TTNN factory analysis
+
+These facts feed the port's TTNN ProgramFactory wiring (→ `ttnn_factory.md`); each of the six ports to `MetalV2FactoryConcept`. Carry them forward:
+
+- **Current concept:** `descriptor` (all six).
+- **Op-owned tensors:** none.
+- **Target concept:** `MetalV2FactoryConcept` (no op-owned tensors).
+- **Gate-cleared, confirmed absent** (each would have blocked the brief): custom hash · custom `override_runtime_arguments` · pybind `create_descriptor` — all `no`.
+- **Shared device-op coupling:** `get_dynamic_runtime_args` (declared in `transpose_hc_sharded_program_factory.cpp:432`) stays on `TransposeDeviceOperation`; it returns `{}` for these six factories and services only the two gated ones. Do not remove it while porting the subset.
+
+## Construct — to do
+
+**Tensor bindings** (per binding):
+
+- **CN / HC-RM / HC-Tiled-Interleaved / HC-Tiled / WH (tiled + RM)** — input and output are both **Case 1** (via `TensorAccessor`). Today they arrive through the `Buffer*`-binding form (`emplace_runtime_args(core, {tensor.buffer(), ...})`); express each as a `TensorParameter` / `TensorBinding`, kernel builds `TensorAccessor(tensor::name)`, and the `Buffer*` RTA drops out. Mechanical.
+- **WH-Sharded** — input CB `c_0` and output CB `c_16` are **borrowed-memory DFBs** (`.buffer = input/output ...buffer()`). Port via `DataflowBufferSpec::borrowed_from` a `TensorParameter`; these are **clean** (no Case-1/2 raw-pointer work).
+
+**TensorParameter relaxation:** none.
+
+**TensorAccessor 3rd arg:** none — every accessor is already 2-arg.
+
+**CB endpoints** (per `(CB, config)`):
+
+- **CN:** `c_0` → bind reader PRODUCER, writer CONSUMER (plain 1:1).
+- **HC-RM:** `c_0` → 1:1 (reader P, writer C).
+- **HC-Tiled-Interleaved:** `c_0` → 1:1 (reader P, writer C). `c_1` (padding, present only when `C % tile_height != 0`) → 1:1 (reader P, writer C).
+- **HC-Tiled:** `c_0` → 1:1 (reader P, donor unary writer C). `c_1` (scratch, present only when misaligned — e.g. Blackhole DRAM 64B) → **self-loop** (only the reader touches it, via `dfb_scratch.get_write_ptr()`; bind it PRODUCER **and** CONSUMER).
+- **WH (tiled):** `c_0` → 1:1 (reader P, compute C). `c_16` → 1:1 (compute P, donor unary writer C).
+- **WH (row-major):** `c_0` → 1:1 (reader P, compute C). `c_16` → 1:1 (compute P, writer C). `c_24` (im/tilize) → **self-loop** (produced and consumed within the compute kernel). **Drop dead CB `c_25` (im2)** — allocated at `transpose_wh_program_factory.cpp:203-213` (RM branch, marked `// TODO REMOVE`), referenced by no kernel in this factory (`c_25` is used only under `#ifdef SHARDED`, which this factory never sets). Remove the allocation.
+- **WH-Sharded:** `c_0` → 1:1 (donor reader P, compute C, borrowed). `c_16` → 1:1 (compute P, donor writer C, borrowed).
+
+No multi-binding CB anywhere in the subset.
+
+## Watch for
+
+- **CB endpoints (multi-binding):** none — no hidden second writer, no multi-reader. Nothing to hunt before binding.
+- **Cross-op / shared kernels — port the shared kernel as one unit:**
+  - `eltwise/unary/.../writer_unary_interleaved_start_id.cpp` (HC-Tiled + WH tiled writer) — broadly shared (~42 host files). Its CB→DFB / named-token rewrite must land for all co-borrowers together.
+  - `eltwise/unary/.../reader_unary_sharded.cpp` (WH-Sharded reader) — broadly shared (~17 host files).
+  - `data_movement/sharded/.../writer_unary_sharded.cpp` (WH-Sharded writer) — broadly shared (~15 host files).
+  - In-family helper `data_movement/common/kernels/common.hpp` (`noc_async_read_sharded`/`noc_async_write_sharded`/`fill_with_val`) — Device 2.0 signatures (`Noc&`, `TensorAccessor&`); passes cleanly with `tensor::name`-built accessors.
+- **RTA varargs:** none — name every runtime arg.

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PORT_PLAN.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PORT_PLAN.md
@@ -1,0 +1,301 @@
+# Port Plan — transpose (data_movement)
+
+Port plan for `ttnn/cpp/ttnn/operations/data_movement/transpose`, ported from the
+`ProgramDescriptorFactoryConcept` (`create_descriptor`) to Metal 2.0.
+Written during the inventory and planning steps; committed alongside the port for review.
+
+**Scope: the clean six-factory subset** the brief issues. The audit is RED at op level; the two
+sharded-RM factories are gated and stay on the legacy descriptor path.
+
+## Legacy Inventory
+
+### Legacy factory shape
+
+- Concept: `ProgramDescriptorFactoryConcept` — every one of the eight factories defines
+  `create_descriptor(...) -> ProgramDescriptor`. Methods live in per-factory structs already
+  (`program_factory_t` variant on `TransposeDeviceOperation`), so **not** the direct-descriptor
+  shape — no exception-3 restructuring needed.
+- Variants: 8 factories on one `TransposeDeviceOperation`. **In scope (6):** `TransposeCNProgramFactory`,
+  `TransposeHCRMProgramFactory`, `TransposeHCTiledInterleavedProgramFactory`,
+  `TransposeHCTiledProgramFactory`, `TransposeWHProgramFactory` (tiled **and** row-major, runtime-selected),
+  `TransposeWHShardedProgramFactory`.
+  **Out of scope (2, gated):** `TransposeHCShardedProgramFactory`, `TransposeWHShardedRMProgramFactory`.
+- Custom `compute_program_hash`: **none** — default reflection-based hash. Verified: no
+  `compute_program_hash`, no `attribute_values` / `to_hash` backdoor anywhere in the op.
+
+### Audit-vs-main divergence (recorded during inventory)
+
+The audit was written 2026-08-04; this port runs against `origin/main` @ `f6b36f3b1be` (2026-08-25).
+One material change landed in between:
+
+- **`get_dynamic_runtime_args` is gone from transpose.** Commit `383674438e5` ("Port transpose off
+  `get_dynamic_runtime_args` onto `override_runtime_arguments`", #52566) moved the two gated
+  factories onto `override_runtime_arguments`. The audit's gate rationale ("`Runtime-args update = yes`
+  via the device-op `get_dynamic_runtime_args` hook at `transpose_hc_sharded_program_factory.cpp:432`")
+  no longer describes the code.
+- **Consequence for scope: none.** `override_runtime_arguments` is declared *only* on the two gated
+  factories (`transpose_hc_sharded_program_factory.hpp:19`, `transpose_wh_sharded_rm_program_factory.hpp:19`).
+  The six in-scope factories have none, so they stay on the base `ProgramSpecFactoryConcept`; the
+  audit's target-concept decision still holds for the subset.
+- **Consequence for the gated two:** their second gate conjunct (`Is safe to port? = no`, the
+  readiness-sheet owner's correctness call) is untouched and is not mine to clear. If it ever clears,
+  they now route to `CustomProgramSpecFactoryConcept` (they carry an `override_runtime_arguments`),
+  **not** the base concept the audit recorded. Routed to the report.
+
+### Kernels
+
+| factory | unique_id | source | core_ranges | CTAs (positional) | CTAs (named) | RTAs | defines | opt_level | config |
+|---|---|---|---|---|---|---|---|---|---|
+| CN | reader | `…/transpose/…/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp` | `all_cores` | 0=`src0_cb_index`(0), 1=`src0->aligned_page_size()`, 2=`stick_size`, 3+=`TensorAccessorArgs(src0)` | — | `{src0_buffer, N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n}` | `CN_RM=1` iff row-major | absent → **O2** | `ReaderConfigDescriptor{}` |
+| CN | writer | `…/transpose/…/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp` | `all_cores` | 0=`src0_cb_index`(0), 1=`dst->aligned_page_size()`, 2=`stick_size`, 3+=`TensorAccessorArgs(dst)` | — | `{dst_buffer, num_pages_per_core, num_pages_read}` | `CN_RM=1` iff row-major | absent → **O2** | `WriterConfigDescriptor{}` |
+| HC-RM | reader | `…/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp` | `all_cores` | 0=`N`, 1=`H`, 2=`C`, 3=`stick_size`, 4=`src0->aligned_page_size()`, 5+=`TensorAccessorArgs(src0)` | — | `{input_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n}` | — | absent → **O2** | `ReaderConfigDescriptor{}` |
+| HC-RM | writer | `…/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp` | `all_cores` | 0=`src0_cb_index`(0), 1=`stick_size`, 2=`dst->aligned_page_size()`, 3+=`TensorAccessorArgs(dst)` | — | `{output_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write}` | — | absent → **O2** | `WriterConfigDescriptor{}` |
+| HC-Tiled-Intlv | reader | `…/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp` | `active_cores` | 0+=`TensorAccessorArgs(src)` only | `num_writes`, `padding_val_packed`, `needs_padding`, `swap_hw`=0, `H`=1, `W`=1, `accumulated_outer_dims`=1, `tile_height`=1, `tile_width`=1 | `{input_buffer, num_tiles_per_core, start_idx}` | — | absent → **O2** | `ReaderConfigDescriptor{}` |
+| HC-Tiled-Intlv | writer | `…/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp` | `active_cores` | 0=`element_size`, 1=`CBIndex::c_0`, 2=`C`, 3=`H`, 4=`W`, 5=`tile_shape[0]`, 6=`tile_shape[1]`, 7=`face_shape[0]`, 8=`face_shape[1]`, 9=`needs_padding`, 10+=`TensorAccessorArgs(dst)` | — | `{output_buffer, start_idx, end_idx, padded_start_idx, padded_end_idx}` | — | absent → **O2** | `WriterConfigDescriptor{}` |
+| HC-Tiled | reader | `…/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp` | `all_cores` | 0=`sub_tile_line_bytes`, 1=`is_float32`, 2=`alignment`, 3+=`TensorAccessorArgs(src0)` | — | `{input_buffer, Wt, H, Ct, HW_bytes, CHW_bytes, num_tiles_read, num_tiles_per_core, …, h, …, ct, …, …}` (14 values) | — | absent → **O2** | `ReaderConfigDescriptor{}` |
+| HC-Tiled | writer | **borrowed** `eltwise/unary/…/dataflow/writer_unary_interleaved_start_id.cpp` | `all_cores` | 0=`src0_cb_index`(0), 1+=`TensorAccessorArgs(dst)` | — | `{output_buffer, num_tiles_per_core, num_tiles_read}` | — | absent → **O2** | `WriterConfigDescriptor{}` |
+| WH (tiled) | reader | `…/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp` | `all_cores` | 0+=`TensorAccessorArgs(src0)` only | — | `{input_buffer, num_tiles_per_core, start_tile, h, w, Ht, Wt, HtWt}` | — | absent → **O2** | `ReaderConfigDescriptor{}` |
+| WH (tiled) | writer | **borrowed** `eltwise/unary/…/dataflow/writer_unary_interleaved_start_id.cpp` | `all_cores` | 0=`output_cb_index`(c_16), 1+=`TensorAccessorArgs(dst)` | — | `{output_buffer, num_tiles_per_core, num_tiles_read}` | — | absent → **O2** | `WriterConfigDescriptor{}` |
+| WH (tiled) | compute | `…/compute/transpose_wh.cpp` | `all_cores` | *(empty)* | — | `{num_tiles_per_core}` | — | absent → **O3** | `ComputeConfigDescriptor{fp32_dest_acc_en, unpack_to_dest_mode}` |
+| WH (RM) | reader | `…/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp` | `all_cores` | 0=`ht`,1..8 (see factory), 9+=`TensorAccessorArgs(src0)` | — | `{input_buffer, num_sticks_read, num_hw_blocks_per_core}` | — | absent → **O2** | `ReaderConfigDescriptor{}` |
+| WH (RM) | writer | `…/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp` | `all_cores` | 0=`output_cb_index`, 1..9 (see factory), 10+=`TensorAccessorArgs(dst)` | — | `{output_buffer, num_sticks_write, num_hw_blocks_per_core}` | — | absent → **O2** | `WriterConfigDescriptor{}` |
+| WH (RM) | compute | `…/compute/transpose_wh_rm.cpp` | `all_cores` | 0=`ht`, 1=`wt`, 2=`ht*wt` | — | `{num_hw_blocks_per_core}` | `DST_ACCUM_MODE=1` iff RM ∧ dtype∈{UINT32,INT32} | absent → **O3** | `ComputeConfigDescriptor{fp32_dest_acc_en, unpack_to_dest_mode}` |
+| WH-Sharded | reader | **borrowed** `eltwise/unary/…/dataflow/reader_unary_sharded.cpp` | `total_cores` | 0=`src0_cb_index`(c_0) | — | `{num_blocks}` (noop cores: 1 zero) | — | absent → **O2** | `ReaderConfigDescriptor{}` |
+| WH-Sharded | writer | **borrowed** `data_movement/sharded/…/dataflow/writer_unary_sharded.cpp` | `total_cores` | 0=`output_cb_index`(c_16) | — | `{num_blocks}` (noop cores: 1 zero) | — | absent → **O2** | `WriterConfigDescriptor{}` |
+| WH-Sharded | compute | `…/compute/transpose_wh_sharded.cpp` | `total_cores` | 0=`src0_cb_index`, 1=`output_cb_index` | — | `{num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts}` (noop cores: 5 zeros) | — | absent → **O3** | `ComputeConfigDescriptor{fp32_dest_acc_en, unpack_to_dest_mode}` |
+
+**`opt_level` — resolved, not literal.** No factory in the op sets `opt_level` at all (`grep -c opt_level`
+over all six factory `.cpp` files = 0). Under the descriptor API an absent field resolves as legacy does:
+**O2** for reader/writer descriptors, **O3** for every `ComputeConfigDescriptor`. The three compute
+kernels above therefore resolve to **O3** and each needs an explicit
+`compiler_options.opt_level = KernelBuildOptLevel::O3` on its `KernelSpec`, since Metal 2.0's
+`CompilerOptions` defaults to `O2` (`kernel_spec.hpp:116`).
+
+### CBs
+
+| factory | index | total_size | core_ranges | data_format | page_size | notes |
+|---|---|---|---|---|---|---|
+| CN | 0 | `2 * stick_size` | `all_cores` | `cb_data_format` | `stick_size` | |
+| HC-RM | 0 | `num_sticks * stick_size` | `all_cores` | `cb_data_format` | `stick_size` | |
+| HC-Tiled-Intlv | 0 | `2 * single_tile_size` | `active_cores` | `cb_data_format` | `single_tile_size` | |
+| HC-Tiled-Intlv | 1 | `max_padding_write * element_size` | `active_cores` | `cb_data_format` | same | **conditional** on `needs_padding` (`C % tile_h != 0`) |
+| HC-Tiled | 0 | `2 * single_tile_size` | `all_cores` | `cb_data_format` | `single_tile_size` | |
+| HC-Tiled | 1 | `alignment` | `all_cores` | `cb_data_format` | `alignment` | **conditional** on `misaligned` (`dst alignment > sub_tile_line_bytes`) |
+| WH | 0 | `num_input_tiles * src0_single_tile_size` | `all_cores` | `src0_cb_data_format` | `src0_single_tile_size` | `num_input_tiles = row_major ? wt*2 : 2` |
+| WH | 16 | `num_output_tiles * dst_single_tile_size` | `all_cores` | `dst_cb_data_format` | `dst_single_tile_size` | `num_output_tiles = row_major ? ht*2 : 2` |
+| WH | 24 | `ht*wt * src0_single_tile_size` | `all_cores` | `src0_cb_data_format` | `src0_single_tile_size` | **RM branch only** (tilize intermediate) |
+| WH | 25 | `ht * dst_single_tile_size` | `all_cores` | `dst_cb_data_format` | `dst_single_tile_size` | **RM branch only — DEAD, dropped** (see below) |
+| WH-Sharded | 0 | `num_tiles_per_shard * src0_single_tile_size` | `all_cores` (shard grid) | `src0_cb_data_format` | `src0_single_tile_size` | **borrowed** `.buffer = input_tensor.buffer()` |
+| WH-Sharded | 16 | `num_tiles_per_shard * dst_single_tile_size` | `total_cores` | `dst_cb_data_format` | `dst_single_tile_size` | **borrowed** `.buffer = output_tensor.buffer()` |
+
+No `GlobalCircularBuffer` anywhere. No aliased CBs (every `format_descriptors` list is single-element).
+
+### Semaphores
+
+none — the op declares no semaphores in any in-scope factory.
+
+### Tensor accessors
+
+| factory | host site | originating Tensor | RTA slot (host) |
+|---|---|---|---|
+| CN | reader / writer CTA tail | input / output | reader RTA 0, writer RTA 0 (`Buffer*` form) |
+| HC-RM | reader / writer CTA tail | input / output | reader RTA 0, writer RTA 0 |
+| HC-Tiled-Intlv | reader / writer CTA tail | input / output | reader RTA 0, writer RTA 0 |
+| HC-Tiled | reader / writer CTA tail | input / output | reader RTA 0, writer RTA 0 |
+| WH (both paths) | reader / writer CTA tail | input / output | reader RTA 0, writer RTA 0 |
+| WH-Sharded | — | input / output | **none** — addresses reach the kernels through the two borrowed CBs, not accessors |
+
+Every accessor is **2-arg** (`TensorAccessor(args, addr)`); no page-size third argument anywhere — matches
+the audit's TensorAccessor-3rd-arg GREEN.
+
+### Work split
+
+- CN: `split_work_to_cores(compute_with_storage_grid_size, num_tensor_pages)`
+- HC-RM: `split_work_to_cores(grid, NCH)`
+- HC-Tiled-Intlv: **two** `split_work_to_cores` calls — unpadded (`num_tensor_tiles`) and padded
+  (`padded_num_tensor_tiles`); `active_cores = num_cores > padded_num_cores ? all_cores : padded_all_cores`
+- HC-Tiled: `split_work_to_cores(grid, num_tensor_tiles)`
+- WH: `split_work_to_cores(grid, row_major ? NC : num_tensor_tiles)`
+- WH-Sharded: n/a — shard-spec driven; `grid_to_cores_with_noop(...)` over the full grid, with
+  zero-filled RTAs on the inactive (noop) cores
+
+None of the six emits **per-group CTAs**; the group distinction only ever reaches RTA values. So there is
+no multi-`KernelDescriptor` work-split multiplicity to preserve.
+
+### Shared kernels
+
+Established by `grep -rl <filename> ttnn/cpp/ttnn/operations/` and disambiguating the hits
+(the `experimental/quasar/` tree is excluded from consideration entirely and was not read).
+
+**Borrowed (live outside the transpose directory) — all three already have a `_metal2` fork on `main` → rung 1, reuse:**
+
+| kernel | bound by | fork on main | fork vocabulary (the constraint on my `KernelSpec`) |
+|---|---|---|---|
+| `eltwise/unary/…/writer_unary_interleaved_start_id.cpp` | HC-Tiled writer, WH-tiled writer (+~26 host files) | `…_metal2.cpp` ✓ | `dfb::out`, `tensor::dst`, `tensor::output`, `args::num_pages`, `args::start_id`; `#ifdef BACKWARDS`, `#ifdef OUT_SHARDED` |
+| `eltwise/unary/…/reader_unary_sharded.cpp` | WH-Sharded reader (+~11 host files) | `…_metal2.cpp` ✓ | `dfb::in`, `args::num_tiles_per_core` |
+| `data_movement/sharded/…/writer_unary_sharded.cpp` | WH-Sharded writer (+~11 host files) | `…_metal2.cpp` ✓ | `dfb::out`, `args::num_units` |
+
+**Lent (live in the transpose directory, bound by peer ops) — must NOT be converted in place:**
+
+| kernel | peer consumers | fork on main | rung |
+|---|---|---|---|
+| `compute/transpose_wh.cpp` | `nlp_create_qkv_heads`, `nlp_create_qkv_heads_boltz`, `nlp_create_qkv_heads_vit`, `split_query_key_value_and_split_heads` | `transpose_wh_metal2.cpp` ✓ (owned by **permute**) | **1 — reuse** if its vocabulary fits; else **2 — create a second fork** |
+| `compute/transpose_wh_sharded.cpp` | `create_qkv_heads`, `create_qkv_heads_from_separate_tensors`, `split_query_key_value_and_split_heads_sharded` | **none** | **2 — create the fork** beside the original + pointer comment |
+| `dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp` | *(none today — permute binds the `_metal2` fork, not this)* | `…_metal2.cpp` ✓ (owned by **permute**) | **1 — reuse** if vocabulary fits |
+
+All other transpose kernels are **transpose-only** and convert in place.
+
+### Flags — additions found during construction
+
+- **`transpose_wh_rm.cpp` is an INTRA-OP shared kernel — the brief missed it.** It is bound both by the
+  in-scope `TransposeWHProgramFactory` (compiled without `SHARDED`) and by the **gated**
+  `TransposeWHShardedRMProgramFactory` (compiled with `SHARDED=1`, and staying on the legacy path).
+  Converting it in place would break the gated factory at JIT time. Handled by forking to
+  `transpose_wh_rm_metal2.cpp` (non-sharded path only) with a pointer comment in the original.
+  A factory×kernel overlap check across all eight factories confirmed this is the **only** such
+  collision. Full write-up in the port report.
+
+### Flags
+
+- **Dead RTA (CN reader).** `reader_unary_transpose_cn_interleaved_start_id.cpp:16` reads
+  `C = get_arg_val<uint32_t>(2)` and never uses it. Preserved as a named RTA (a syntax swap does not
+  drop live plumbing); reported.
+- **Dead CTA slots (HC-RM).** The reader's slot 0 (`N`) and slot 4 (`aligned_page_size`) and the
+  writer's slot 2 (`aligned_page_size`) are emitted by the host and never read by the kernel
+  (`TensorAccessorArgs<5>` / `<3>` skip straight past them). Preserved as named CTAs; reported.
+- **Unreferenced kernel file.** `device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp` is
+  bound by no factory (dead code in the directory). Not audited, not touched.
+- **WH-Sharded DFB placement asymmetry.** Legacy allocates `c_0` on `all_cores` (the shard grid) but
+  `c_16` on `total_cores` (the full grid), while all three kernels run on `total_cores`. Metal 2.0 has no
+  `core_ranges` on `DataflowBufferSpec` — placement is derived from the kernel bindings — so the ported
+  `c_0` will be placed across `total_cores`. For a **borrowed** DFB whose backing tensor is sharded only
+  over `all_cores`, the noop cores have no shard to borrow. Flagged as the single most likely failure
+  point of this port; resolved at construction/verification, not assumed away.
+
+## TTNN ProgramFactory
+
+- **Concept (inherited from audit)**: `ProgramSpecFactoryConcept` (the brief's `MetalV2FactoryConcept`)
+  — re-confirmed against current `main`: none of the six in-scope factories declares an
+  `override_runtime_arguments`, so the base concept applies and
+  [Translating `override_runtime_arguments`] does not.
+- **Custom `compute_program_hash`**: none — leave the default reflection hash alone.
+- **Implementation notes**: each factory's `create_descriptor` becomes `create_program_artifacts`
+  returning `ttnn::device_operation::ProgramArtifacts`. The `program_factory_t` variant on
+  `TransposeDeviceOperation` will hold a **mix** of concepts (6 Metal 2.0, 2 legacy descriptor) — valid,
+  dispatched per-factory by `std::visit`. No pybind `create_descriptor` to remove (nanobind exposes only
+  the `transpose` free function), so device-op-class exceptions 1–3 all **do not apply**.
+
+## Planned Spec Shape
+
+Naming: DFB **spec** names are host-side identities (free choice); DFB **accessor** names are the
+kernel-facing `dfb::` tokens and are *fixed by the shared forks* where one is reused. No name contains
+`cb` in any casing.
+
+### CN
+- KernelSpecs: `READER`, `WRITER` (both DM)
+- DataflowBufferSpecs: `IN0` (entry_size=`stick_size`, num_entries=2)
+- TensorParameters: `INPUT` (accessor `src`), `OUTPUT` (accessor `dst`)
+- WorkUnitSpecs: one — {READER, WRITER} over `all_cores`
+- Semaphores / op-owned tensors: none
+
+### HC-RM
+- KernelSpecs: `READER`, `WRITER`
+- DataflowBufferSpecs: `IN0` (entry_size=`stick_size`, num_entries=`num_sticks`)
+- TensorParameters: `INPUT`, `OUTPUT`
+- WorkUnitSpecs: one over `all_cores`
+
+### HC-Tiled-Interleaved
+- KernelSpecs: `READER`, `WRITER`
+- DataflowBufferSpecs: `IN0`; `PAD` **conditional** on `needs_padding`
+- TensorParameters: `INPUT`, `OUTPUT`
+- WorkUnitSpecs: one over `active_cores`
+
+### HC-Tiled
+- KernelSpecs: `READER`, `WRITER` (writer = reused `writer_unary_interleaved_start_id_metal2.cpp`)
+- DataflowBufferSpecs: `IN0` (accessor **must be `out`** on the writer — the fork's vocabulary);
+  `SCRATCH` **conditional** on `misaligned`, **self-looped** (reader is its only toucher)
+- TensorParameters: `INPUT`, `OUTPUT` (writer's accessor name fixed by the fork: `dst`/`output`)
+- WorkUnitSpecs: one over `all_cores`
+
+### WH (one factory, two runtime-selected source sets — both convert together)
+- KernelSpecs: `READER`, `WRITER`, `COMPUTE` (sources chosen by `row_major`, as legacy does)
+- DataflowBufferSpecs: `IN0`, `OUT`; `IM` (c_24) **RM only**, **self-looped** (produced and consumed
+  inside the compute kernel). **`c_25` (im2): no spec — dead-CB drop.**
+- TensorParameters: `INPUT`, `OUTPUT`
+- WorkUnitSpecs: one over `all_cores`
+- `COMPUTE` gets `compiler_options.opt_level = O3`
+
+### WH-Sharded
+- KernelSpecs: `READER` (reused fork), `WRITER` (reused fork), `COMPUTE`
+- DataflowBufferSpecs: `IN0` `borrowed_from = INPUT`; `OUT` `borrowed_from = OUTPUT`
+- TensorParameters: `INPUT`, `OUTPUT`
+- WorkUnitSpecs: one over `total_cores`
+- `COMPUTE` gets `compiler_options.opt_level = O3`
+
+## Preserved Multiplicity
+
+**none — no work-split multiplicity in legacy.** Every factory emits exactly one `KernelDescriptor` per
+role; the two core groups differ only in RTA *values*, never in CTAs, so there is no per-group CTA to
+preserve and no reason to split a `KernelSpec`. (HC-Tiled-Interleaved runs two `split_work_to_cores`
+calls, but both feed RTA values on a single pair of kernels.)
+
+## Dropped Plumbing
+
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| CN reader CTA 0 / writer CTA 0 | `src0_cb_index` (0) | `DFBBinding{IN0, …}` |
+| CN reader CTA 3+ / writer CTA 3+ | `TensorAccessorArgs(*buf).append_to(...)` | `TensorBinding` + `TensorAccessor(tensor::…)` |
+| CN reader RTA 0 / writer RTA 0 | `Buffer*` in `emplace_runtime_args` | `TensorBinding` (auto base address) |
+| CN reader kernel `TensorAccessorArgs<3>()` | accessor-args chain | `TensorAccessor(tensor::src)` |
+| HC-RM reader kernel `constexpr auto dfb_in0 = tt::CBIndex::c_0` | **hardcoded magic CB index** | `dfb::in0` |
+| HC-RM writer CTA 0 | `src0_cb_index` | `DFBBinding{IN0, …}` |
+| HC-RM reader CTA 5+ / writer CTA 3+ | `TensorAccessorArgs` | `TensorBinding` |
+| HC-RM reader/writer RTA 0 | `Buffer*` | `TensorBinding` |
+| HC-Tiled-Intlv writer CTA 1 | `tt::CBIndex::c_0` (magic index) | `DFBBinding{IN0, …}` |
+| HC-Tiled-Intlv reader CTA 0+ / writer CTA 10+ | `TensorAccessorArgs` | `TensorBinding` |
+| HC-Tiled-Intlv reader/writer RTA 0 | `Buffer*` | `TensorBinding` |
+| HC-Tiled writer CTA 0 | `src0_cb_index` | `DFBBinding{IN0, accessor "out", CONSUMER}` |
+| HC-Tiled reader CTA 3+ / writer CTA 1+ | `TensorAccessorArgs` | `TensorBinding` |
+| HC-Tiled reader/writer RTA 0 | `Buffer*` | `TensorBinding` |
+| WH writer CTA 0 | `output_cb_index` (c_16) | `DFBBinding{OUT, …}` |
+| WH reader CTA tail / writer CTA tail | `TensorAccessorArgs` | `TensorBinding` |
+| WH reader/writer RTA 0 | `Buffer*` | `TensorBinding` |
+| WH RM branch, `transpose_wh_program_factory.cpp` c_25 block | dead `CBDescriptor` (im2) | **no spec — allocation dropped** |
+| WH-Sharded reader CTA 0 / writer CTA 0 / compute CTA 0,1 | `src0_cb_index`, `output_cb_index` | `DFBBinding`s |
+| WH-Sharded `.buffer = …buffer()` on both CBs | borrowed-memory CB | `DataflowBufferSpec::borrowed_from` |
+| **all six**, every remaining positional CTA | `get_compile_time_arg_val(N)` | named CTAs, `get_arg(args::…)` |
+| **all six**, every remaining positional RTA | `get_arg_val<uint32_t>(N)` | named RTAs, `get_arg(args::…)` |
+
+**Dead unread scalars — dropped, and reported as findings.** The HC-RM reader's `N` and both HC-RM
+kernels' `aligned_page_size` CTA slots (and the same on the WH row-major pair) are computed and shipped
+by the legacy host to slots each kernel's `TensorAccessorArgs<N>` boundary sits past — no kernel ever
+reads them. They are not re-emitted: an unread value carries no behavior (the same reasoning the
+dead-CB disposition uses), and keeping them would leave a named arg the kernel never references. The CN
+reader's unused `C` RTA is the one exception — that kernel *does* read it into a local, exactly as the
+legacy kernel did, so it is preserved verbatim.
+
+## Applied Patterns
+
+- **Sync-free / single-ended CB → self-loop DFB**: HC-Tiled `SCRATCH` (c_1) — only the reader touches it,
+  via `get_write_ptr()`; bound PRODUCER **and** CONSUMER on the reader.
+- **Self-loop DFB binding**: WH-RM `IM` (c_24) — produced and consumed inside the compute kernel.
+- **Conditional / optional DFB bindings**: HC-Tiled-Interleaved `PAD` (gated on `needs_padding`) and
+  HC-Tiled `SCRATCH` (gated on `misaligned`) — host binds conditionally, `KernelSpec::compiler_options.defines`
+  carries the flag, kernel `#ifdef`-gates both the alias and every use.
+- **Dead CB drop**: WH-RM `c_25` (im2) — no spec built, allocation removed.
+- **Borrowed-memory DFBs**: WH-Sharded `IN0` / `OUT` via `borrowed_from`.
+- **Porting a shared kernel**: rung 1 (reuse) for the three peer `_metal2` forks and permute's two
+  transpose forks; rung 2 (create) for `transpose_wh_sharded.cpp`.
+- **Multi-variant / runtime source selection**: WH factory selects tiled vs row-major sources at runtime;
+  both source sets convert together (atomic unit).
+
+## Deferred / Flagged
+
+- **Audit-vs-main divergence** on `get_dynamic_runtime_args` → `override_runtime_arguments` (detailed
+  above). Does not change the subset's scope or concept; routed to the report for the sheet owner.
+- **WH-Sharded borrowed `c_0` placement** across `total_cores` vs a shard grid of `all_cores` — the
+  open structural risk of this port (see Flags). **Resolved during construction:** accepted by the
+  validator with no spec change, and the sharded tests pass at baseline parity. See the port report.
+- **No multi-binding DFB anywhere.** Re-derived from the kernel-touch census rather than taken from the
+  brief: every DFB in the subset has either exactly one producer and one consumer on distinct kernels,
+  or a single toucher (self-loop). `allow_instance_multi_binding` is not set anywhere.

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PORT_REPORT.md
@@ -1,0 +1,291 @@
+# Port Report — transpose (data_movement)
+
+## Outcome
+
+`PORTED` — the six clean factories (`TransposeCNProgramFactory`, `TransposeHCRMProgramFactory`,
+`TransposeHCTiledInterleavedProgramFactory`, `TransposeHCTiledProgramFactory`,
+`TransposeWHProgramFactory` [tiled **and** row-major], `TransposeWHShardedProgramFactory`) converted to
+`ProgramSpecFactoryConcept`, built, and verified on device at exact parity with the pre-port baseline.
+The two gated factories (`TransposeHCShardedProgramFactory`, `TransposeWHShardedRMProgramFactory`) are
+untouched on the legacy descriptor path, as the audit scoped.
+
+## Verification
+
+Wormhole n150. Build via `./build_metal.sh --build-tests`; the Metal 2.0 legality checks were forced on
+in all 9 `skip_validation` sites and **proven live in the binary under test** — both markers present
+(`program_spec.cpp:2847`, `program_run_args.cpp:502`), firing 1656 times across the post-port run. The
+forcing scaffolding was reverted before commit and is absent from the diff.
+
+| | passed | failed | skipped |
+|---|---|---|---|
+| **Baseline** (pre-port, before any kernel edit) | 1075 | **0** | 75 |
+| **Post-port** | 1075 | **0** | 75 |
+
+Confirmed test set (agreed with the invoker before it was relied on) — transpose's own coverage plus
+every peer op affected by a shared kernel this port touched or reused:
+`misc/test_transpose.py`, `base_functionality/test_reshape_transpose.py`,
+`sweep_tests/tt_dnn/test_transpose.py`, `sweep_tests/tt_dnn/test_permute.py`,
+`misc/test_create_qkv_heads.py`, `misc/test_nlp_create_qkv_heads{,_boltz,_vit}.py`,
+`operations/transformers/test_transformer.py`.
+The peer-op files are in the set deliberately: `transpose_wh.cpp` and `transpose_wh_sharded.cpp` are
+lent to the qkv-heads ops, and permute owns two of the forks this port reuses.
+
+**Factory routing verified in the built library**, not inferred from the source: all six ported
+factories resolve to `ProgramSpecMeshWorkloadFactoryAdapter<...>` in
+`nm -C build_Release/lib/_ttnncpp.so`, and both gated factories resolve to neither adapter template.
+
+### Anti-pattern self-audit
+
+Each sweep reported as *hits / files scanned*; the op directory holds **47** `.cpp`/`.hpp` files and the
+diff-scoped sweeps saw **27**.
+
+| check | result |
+|---|---|
+| Buffer address / `Buffer*` in run-args | **0** / 47 |
+| `CBDescriptor` / `CircularBuffer` / `.cbs` / `ProgramDescriptor` in ported factories | **0** / 47 |
+| `TensorAccessorArgs` in ported kernels | **0** (2 survivors, both unbound legacy files — see Open items) |
+| Positional `compile_time_args` | **0** in ported factories (2 hits, both in the untouched gated factory) |
+| `get_vararg` / `compile_time_varargs` | **0** / 47 |
+| `.id` extraction at LLK call sites | **0** / 47 |
+| `allow_instance_multi_binding` | **0** / 47 — re-derived from the kernel-touch census; every DFB is 1P+1C or a single-toucher self-loop |
+| `TT_FATAL` / `TT_ASSERT` / `TT_THROW` census vs `$BASE` | **no delta** — every guard accounted for |
+| Ephemeral `.md` cited from code | **0** / 27 |
+| Forced-legality scaffolding in diff | **0** — no `tt_metal/impl` file, no marker string |
+| `opt_level` per compute `KernelSpec` | 2 compute specs exist (`transpose_wh`, `transpose_wh_sharded`); **both** set `O3` explicitly; the 4 DM-only factories correctly set none |
+
+**`cb`-name sweep — 8 hits, all attributed, none a leftover.** Six are `accessor_name` strings (and two
+comments naming them) that are **owned by reused `_metal2` forks** and therefore not renameable from
+this op: `cb_in0` / `cb_pad` (permute's padding-aware reader) and `cb_in` / `cb_out` (permute's
+`transpose_wh_metal2.cpp`). The remaining hits are in `transpose.cpp`, op-level host code this port did
+not touch. The one fork this port **authored** (`transpose_wh_sharded_metal2.cpp`) uses clean
+`dfb::in` / `dfb::out`. See the Friction entry on this sweep's tension with the fork-vocabulary rule.
+
+### Risk called out in the plan, and how it resolved
+
+The plan flagged the WH-Sharded borrowed input buffer as the port's most likely failure point: legacy
+allocated it on the shard grid (`all_cores`) while all three kernels run on the full grid
+(`total_cores`), and a Metal 2.0 `DataflowBufferSpec` has no `core_ranges` — placement is derived from
+the bindings, so the borrowed buffer is placed across `total_cores`. It resolved cleanly with no spec
+change: the validator accepted it and the sharded tests pass at baseline parity. Recorded because the
+reasoning is non-obvious and the next porter of a borrowed-DFB-on-a-subgrid op will hit the same
+question.
+
+## Provenance
+
+- **Recipe docs (this port):** `c1c4d4eceb0 2026-08-25 docs(metal_2.0): a run in flight freezes the kernel sources`
+  *(the recipe docs live only on the doc branch `vsureshTT/metal2-data_movement/transpose`; they are
+  not present on `origin/main`, so the command in the recipe prints nothing from a main-based checkout.
+  The line above is that branch's tip for the `metal_2.0/` doc tree.)*
+- **Audit docs (inherited):** `de19c9df758 2026-07-22 docs(metal_2.0): route Gen1 porters away from the Quasar-uplift audit helper`
+
+**Port base:** `origin/main` @ `f6b36f3b1be` (2026-08-25). Baseline established before the first kernel
+edit: **1075 passed / 0 failed / 75 skipped** over the confirmed test set (see Verification below).
+
+## TTNN ProgramFactory
+
+- **Concept realized:** `ProgramSpecFactoryConcept` on all six ported factories — matching the audit's
+  decision, re-confirmed against current `main` (none of the six carries an `override_runtime_arguments`,
+  so the custom concept does not apply and the recipe's translation step was skipped).
+  Verified in the built library rather than by reading: every one of the six resolves to
+  `ProgramSpecMeshWorkloadFactoryAdapter<...>` in `nm -C build_Release/lib/_ttnncpp.so`, and both gated
+  factories resolve to neither adapter template (they keep the descriptor shim).
+- **Custom `compute_program_hash`:** none — the op uses the default reflection hash, and it was not
+  touched. No `attribute_values` / `to_hash` backdoor either.
+- **Pybind entry points removed:** none. The nanobind module exposes only the `transpose` free
+  function, never `create_descriptor`, so none of the three device-op-class exceptions applied and
+  `transpose_device_operation.{hpp,cpp}`, `transpose.cpp` and `transpose_nanobind.cpp` are byte-identical
+  to `main`.
+- **`program_factory_t` variant:** left as-is. It now holds a **mix** — six factories on the Metal 2.0
+  concept and two on the legacy descriptor concept — which `std::visit` dispatches per factory. This
+  worked with no framework friction and is the thing that made a subset port shippable.
+- **Open items:** none blocking. The two gated factories re-audit separately (see Handoff point 1).
+
+## Handoff points
+
+### 1. Audit is stale on the gate rationale for the two blocked factories — and their target concept has changed
+
+*(→ readiness-sheet owner / TTNN PD-migration team)*
+
+The audit (2026-08-04) blocks `TransposeHCShardedProgramFactory` and `TransposeWHShardedRMProgramFactory`
+on two conjuncts, the first being `Runtime-args update == yes` via the device-op `get_dynamic_runtime_args`
+hook "declared at `transpose_hc_sharded_program_factory.cpp:432`".
+
+**That hook no longer exists in transpose.** Commit `383674438e5` ("Port transpose off
+`get_dynamic_runtime_args` onto `override_runtime_arguments`", #52566) removed it; `grep -rn
+get_dynamic_runtime_args ttnn/cpp/ttnn/operations/data_movement/transpose/` returns nothing on current main.
+
+Two consequences:
+
+- **For this port: none.** `override_runtime_arguments` is declared only on those same two factories
+  (`transpose_hc_sharded_program_factory.hpp:19`, `transpose_wh_sharded_rm_program_factory.hpp:19`), so the
+  six in-scope factories are unaffected and remain on the base `ProgramSpecFactoryConcept`.
+- **For the gated two, when their remaining gate clears:** they now carry an `override_runtime_arguments`
+  and therefore route to **`CustomProgramSpecFactoryConcept`**, not the `MetalV2FactoryConcept` (base) that
+  the audit recorded as their target. Whoever re-audits them needs the recipe's
+  "Translating `override_runtime_arguments`" step, which the current brief does not mention.
+
+The second conjunct (`Is safe to port? = no`, the readiness-sheet owner's correctness call) is unchanged
+and remains the live blocker. Not a porter-resolvable item; recorded so the sheet row can be refreshed.
+
+## Successes
+
+- **The shared-kernel Caution fired exactly as designed, on a case the brief had not listed.**
+  `transpose_wh_rm.cpp` looks transpose-private by path, and the instinct on a "convert the op's own
+  kernels in place" pass is to convert it. The recipe's *intra-op* shared-kernel bullet
+  (§Read this first, "Shared top-level entry point") is what prompted the factory×kernel overlap check
+  that found the gated factory compiling the same source with `SHARDED`. Cost of the check: one script.
+  Cost of skipping it: a JIT-time `'args' has not been declared` on the sharded-RM path, discovered
+  after the port looked green. Full write-up as Handoff point 4.
+
+- **The `opt_level` section's "grep it, don't eyeball it" instruction caught a real silent regression.**
+  Both compute-bearing factories (`transpose_wh`, `transpose_wh_sharded`) build their compute kernel
+  from a `ComputeConfigDescriptor` that never mentions `opt_level` — so nothing in the legacy source
+  reads as a setting, and nothing in the ported spec reads as missing. The resolved legacy level is
+  **O3**; a `KernelSpec` that stays silent gets **O2** (`kernel_spec.hpp:116`). Both now set
+  `KernelBuildOptLevel::O3` explicitly. This is a pure perf delta with no build, validator or test
+  signal — the section's framing of it as "an absent line, not a wrong value" is what made it findable.
+
+- **Forcing and *proving* the legality checks was worth the extra step.** The markers confirmed live
+  in both translation units (`program_spec.cpp:2847`, `program_run_args.cpp:502`) and fired ~960 times
+  across the baseline run, so every green result in this port was measured with validation on rather
+  than assumed to be.
+
+- **The header-first rule beat precedent-hunting.** `kernel_spec.hpp` settled in one read that
+  `DFBBinding::accessor_name` is *per binding*, not per DFB — which is what makes it legal for the
+  reused forks to keep their own token names while this op's own kernels use clean ones. Inferring that
+  from another port's code would have been guesswork.
+
+## Friction
+
+### Gaps
+
+- **The unity build makes anonymous-namespace spec constants collide across an op's factories, and the
+  recipe does not warn about it.** The natural way to write spec names — `const DFBSpecName IN0{"in0"};`
+  in the factory's anonymous namespace, as the migration guide's examples suggest — compiles fine per
+  file and then fails the moment a second factory in the same op does the same thing, because the op's
+  factory `.cpp`s are concatenated into one translation unit:
+  `error: redefinition of 'IN0'`. Every one of this op's six factories wanted the same handful of names
+  (`IN0`, `INPUT`, `OUTPUT`, `READER`, `WRITER`). Resolved by declaring the constants **function-locally**
+  inside `create_program_artifacts`, which is unambiguous and needs no per-factory prefixes. Worth one
+  line in the Construct section, since it hits every multi-factory op and the error arrives at the first
+  build after the *second* factory converts — far from the code that caused it.
+
+- **No guidance on what to do with a legacy CTA/RTA the kernel never reads.** This op had four
+  (the CN reader's `C`, the HC-RM reader's `N` and both kernels' `aligned_page_size`), all of them
+  values the host computes and ships to a slot the kernel's `TensorAccessorArgs<N>` boundary sits past.
+  They are not "dropped plumbing" (no Metal 2.0 primitive replaces them) and not a dead CB (the recipe's
+  one worked example of removing something inert). The choice matters because a named arg the kernel
+  never references leaves a host/kernel arg-set mismatch, which the Build section elsewhere tells you to
+  "reconcile". Resolved by emitting exactly what each kernel reads and reporting the rest as findings —
+  the same reasoning the dead-CB disposition uses (an unread value has no behavior). A sentence
+  extending the dead-CB rule to dead scalars would settle it.
+
+### Confusion
+
+- **"Reuse the existing `_metal2` fork" leaves the legacy original unreferenced, and the recipe does not
+  say whether that is the porter's problem.** After repointing the HC-Tiled-Interleaved reader at
+  permute's fork, `reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp` is bound by nothing in
+  the repo. Deleting it is outside a syntax-swap port's remit and risks a binding by a string this sweep
+  did not find; leaving it ships dead code. Left in place and recorded under Open items. The
+  shared-kernel Caution covers "which rung to take" thoroughly but is silent on the leftover.
+
+- **The `cb`-name sweep and the shared-fork vocabulary rule pull in opposite directions, and neither
+  cites the other.** The self-audit says expect **zero** `[Cc][Bb]_` hits across the op directory and
+  calls every hit "a real leftover". But three of the forks this port is told to reuse own token names
+  like `dfb::cb_in0` / `dfb::cb_pad` / `dfb::cb_in`, and conforming to them is mandatory — so a
+  correctly-executed port cannot reach zero. The sweep result for this op is documented under
+  Verification with each surviving hit attributed. Suggested fix: have the `cb`-sweep item say that hits
+  which are *accessor names owned by a reused fork* are expected, and must be attributed rather than
+  renamed.
+
+## Open items for downstream
+
+### Leftover from a rung-1 fork reuse
+
+`device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp` (the legacy
+original) is, after this port, **bound by nothing in the repo**: transpose's HC-Tiled-Interleaved
+factory was its last consumer and now binds permute's `_metal2` fork instead. It is a deletion
+candidate for the ops team. Not deleted here — removing a kernel source is outside a syntax-swap port,
+and a binding by some string this sweep did not match would fail only at JIT.
+
+The same directory already contains one pre-existing unreferenced kernel,
+`device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp` (the audit flagged it; bound by no
+factory before this port either). Both could go in one cleanup.
+
+### Findings — bugs / dead plumbing found while reading, deliberately NOT fixed
+
+Per the port's scope discipline these are preserved byte-for-behavior and reported rather than repaired.
+
+1. **Dead runtime arg — CN reader.** `kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp`
+   reads `C` (legacy RTA slot 2) and never uses it; the host computes and ships it for every core
+   (`transpose_cn_program_factory.cpp`, reader `emplace_runtime_args`). Preserved as a named RTA `C`.
+   Fix would be: drop the arg on both sides.
+
+2. **Dead compile-time args — HC-RM.** Three CTA slots are emitted by the host and never read by the
+   kernels, because each kernel's `TensorAccessorArgs<N>` boundary skips past them:
+   - reader slot 0 (`N`) and slot 4 (`src0_buffer->aligned_page_size()`) — the kernel's accessor args
+     start at `TensorAccessorArgs<5>()` and it reads only slots 1–3 (`H`, `C`, `stick_size`).
+   - writer slot 2 (`dst_buffer->aligned_page_size()`) — accessor args start at `TensorAccessorArgs<3>()`
+     and it reads only slots 0–1.
+
+   Preserved as named CTAs. Fix would be: drop all three on both sides.
+
+3. **Dead CB `c_25` (im2) — WH row-major path.** Allocated at `transpose_wh_program_factory.cpp` in the
+   row-major branch, carrying an existing `// TODO REMOVE`. Referenced by no kernel this factory binds:
+   `transpose_wh_rm.cpp` uses `c_25` as `cb_tilize` only under `#ifdef SHARDED`, a define set solely by
+   the *gated* `TransposeWHShardedRMProgramFactory`. **This one the port does act on** — a dead CB has no
+   behavior and a bindingless DFB is rejected by the validator, so the allocation is dropped (the
+   recipe's dead-CB disposition), not merely reported. Recorded here because it is a real L1 saving the
+   ops team may want to mirror into the gated factory's own path when that one ports.
+
+### Shared kernel touches
+
+Established by `grep -rl <filename> ttnn/cpp/ttnn/operations/` plus a factory-level overlap check
+between the six ported factories and the two gated ones. The `experimental/quasar/` tree was excluded
+from consideration and not read.
+
+**Rung 1 — reused an existing `_metal2` fork (no new file):**
+
+| fork reused | owner / other consumers | vocabulary this port had to conform to |
+|---|---|---|
+| `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_metal2.cpp` | eltwise/unary; ~26 host files bind the legacy original | `dfb::out`, `tensor::dst`, `args::num_pages`, `args::start_id` |
+| `eltwise/unary/device/kernels/dataflow/reader_unary_sharded_metal2.cpp` | eltwise/unary; ~11 host files bind the legacy original | `dfb::in`, `args::num_tiles_per_core` |
+| `data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_metal2.cpp` | data_movement/sharded; ~11 host files bind the legacy original | `dfb::out`, `args::num_units` |
+| `transpose/device/kernels/compute/transpose_wh_metal2.cpp` | created by the **permute** port; legacy original still bound by `nlp_create_qkv_heads{,_boltz,_vit}` and `split_query_key_value_and_split_heads` | `dfb::cb_in`, `dfb::cb_out`, `args::NHtWt` |
+| `transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware_metal2.cpp` | created by the **permute** port | `dfb::cb_in0`, `dfb::cb_pad`, `tensor::input`, `NEEDS_PADDING` define |
+
+**Rung 2 — created the fork (pointer comment landed in the legacy original):**
+
+| new fork | legacy original's remaining consumers |
+|---|---|
+| `transpose/device/kernels/compute/transpose_wh_sharded_metal2.cpp` | `create_qkv_heads`, `create_qkv_heads_from_separate_tensors`, `split_query_key_value_and_split_heads_sharded` — all still on the legacy host API |
+| `transpose/device/kernels/compute/transpose_wh_rm_metal2.cpp` | **`TransposeWHShardedRMProgramFactory` — this op's own gated factory** (see the finding below) |
+
+**In-place conversions** (verified transpose-only, bound by no peer op and by no gated factory):
+the CN reader/writer, the HC-RM reader/writer, the HC-Tiled reader, the HC-Tiled-Interleaved writer,
+and the three WH interleaved dataflow kernels.
+
+### 4. The brief's shared-kernel list missed an intra-op collision — `transpose_wh_rm.cpp`
+
+*(→ audit / brief authors; recipe's shared-kernel section)*
+
+The brief's "Cross-op / shared kernels" heads-up lists three **borrowed** kernels (the eltwise/unary and
+sharded donors) and nothing else. It does not flag `device/kernels/compute/transpose_wh_rm.cpp`, which is
+bound by **two factories on opposite sides of this port's scope line**:
+
+- `TransposeWHProgramFactory` (in scope) — compiles it **without** `SHARDED`
+- `TransposeWHShardedRMProgramFactory` (**gated**, stays on the legacy descriptor path) —
+  compiles it **with** `SHARDED=1` (`transpose_wh_sharded_rm_program_factory.cpp:222,236`)
+
+Converting it in place would have compiled Metal 2.0 `dfb::` / `args::` tokens into a kernel that a
+legacy `CreateKernel` path still builds, which emits no generated headers — the exact
+`'args' has not been declared` breakage the shared-kernel Caution exists to prevent, and it would have
+surfaced only at JIT time on the sharded-RM tests. Handled with rung 2: `transpose_wh_rm_metal2.cpp`
+carries the non-sharded path only, the legacy copy keeps the sharded path and gains a pointer comment.
+
+**Why the brief missed it:** its shared-kernel scan looks for kernels *outside* the op directory
+(borrowed) and for peer ops binding kernels *inside* it (lent). This one is neither — it is shared
+between two factories of the *same* op, separated only by a `#define`. The recipe does name this
+"intra-op" case, but the brief has no field for it, so a porter working from the brief alone would not
+see it. **Suggested audit change:** have the audit emit a per-op factory×kernel matrix and flag any
+kernel bound by both an in-scope and an out-of-scope factory.

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PREPORT_AUDIT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/METAL2_PREPORT_AUDIT.md
@@ -1,0 +1,155 @@
+# Metal 2.0 Audit Findings — `ttnn/cpp/ttnn/operations/data_movement/transpose`
+
+Single device-operation directory. One `DeviceOperation` with eight program factories:
+
+- **`TransposeDeviceOperation`** (`device/transpose_device_operation.{hpp,cpp}`)
+  - `TransposeCNProgramFactory` (`transpose_cn_program_factory.cpp`)
+  - `TransposeHCRMProgramFactory` (`transpose_hc_rm_program_factory.cpp`)
+  - `TransposeHCTiledInterleavedProgramFactory` (`transpose_hc_tiled_interleaved_program_factory.cpp`)
+  - `TransposeHCTiledProgramFactory` (`transpose_hc_tiled_program_factory.cpp`)
+  - `TransposeWHProgramFactory` (`transpose_wh_program_factory.cpp`) — handles both tiled and row-major
+  - `TransposeWHShardedProgramFactory` (`transpose_wh_sharded_program_factory.cpp`)
+  - `TransposeHCShardedProgramFactory` (`transpose_hc_sharded_program_factory.cpp`) — **gated**
+  - `TransposeWHShardedRMProgramFactory` (`transpose_wh_sharded_rm_program_factory.cpp`) — **gated**
+
+**Unreferenced kernel file (out of scope):** `device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp` is instantiated by no factory (dead code in the directory; the WH factory uses the `_start_id` variants). Its contents were not audited.
+
+**Scope:** TTNN op, Gen1 (WH/BH) target — within scope of `audit/metal2_audit.md`.
+
+**Recipe docs:** `de19c9df758 2026-07-22 docs(metal_2.0): route Gen1 porters away from the Quasar-uplift audit helper`
+
+## Status summary
+
+| Field | Value |
+|---|---|
+| **Op directory** | `ttnn/cpp/ttnn/operations/data_movement/transpose` |
+| **Overall** | **RED at op level; subset {CN, HC-RM, HC-Tiled-Interleaved, HC-Tiled, WH, WH-Sharded} is clear** |
+| **DOps / Factories** | `TransposeDeviceOperation` → 8 factories (6 clear, 2 gated) |
+| *Prereqs* — Device 2.0 (every kernel used) | **Yes (GREEN)** — all referenced own + donor kernels are Device 2.0 |
+| *Prereqs* — Cross-op escapes | Ok (workable) — 3 broadly-shared donor kernels + 1 in-family helper, all Device 2.0 |
+| *Feature Support* — overall | **GREEN** (all Appendix A entries N/A) |
+| *Feature Support* — Variadic-CTA | Ok (N/A) |
+| *TTNN Readiness* — `Is able to port?` (the gate) | **No for 2 factories** (`Runtime-args update` + `Is safe to port?`); **Yes for 6** |
+| *TTNN Readiness* — Concept (current) | `descriptor` (all 8) |
+| *TTNN Readiness* — Secretly SPMD | N/A (no `WorkloadDescriptor`) |
+| *TTNN Readiness* — Is safe to port? | `yes` (6 clean) / **`no` (HC-Sharded, WH-Sharded-RM → readiness-sheet owner)** |
+| *TTNN Readiness* — Custom hash | No (all) |
+| *TTNN Readiness* — Runtime-args update | No (6 clean) / **Yes (HC-Sharded, WH-Sharded-RM → `get_dynamic_runtime_args`)** |
+| *TTNN Readiness* — Pybind `create_descriptor` | No (function-only nanobind) |
+| *TTNN Readiness* — Op-owned tensors | No |
+| *TTNN Readiness* — Target concept | `MetalV2FactoryConcept` (no op-owned tensors) |
+| *Port work* — Offset base pointer | none (GREEN) — no host-folded offsets |
+| *Port work* — Tensor bindings | Case 1 (interleaved factories, in+out) / clean borrowed-DFB (WH-Sharded) |
+| *Port work* — TensorParameter relaxation | none |
+| *Port work* — TensorAccessor 3rd arg | none — every accessor is 2-arg |
+| *Port work* — CB endpoints | 1:1 (most) / self-loop (`c_1` scratch, `c_24` tilize) / **dead-CB drop (`c_25` in WH-RM)** |
+
+## Result
+
+**RED at op level; subset {CN, HC-RM, HC-Tiled-Interleaved, HC-Tiled, WH, WH-Sharded} is clear.**
+
+Two of the eight factories are blocked by the **TTNN factory-concept gate** (`Is able to port? == no`):
+
+- **`TransposeHCShardedProgramFactory`** and **`TransposeWHShardedRMProgramFactory`** each fail on **two** conjuncts:
+  - `Runtime-args update == yes` — both opt into the device-op-level `get_dynamic_runtime_args` fast-path hook (#48928). → **TTNN / ProgramDescriptor-migration team**; the gate lifts once the runtime-args-update infra ships in the Metal 2.0 path.
+  - `Is safe to port? == no` — the readiness-sheet owner's correctness call. → **readiness-sheet owner** (Diego); the buggy/at-risk PD-migration state must be reconciled before these two port.
+
+This is a **config-scoped gate**: the six non-`get_dynamic_runtime_args` factories clear every gate, so a **subset port of those six is available now**, and a brief is issued for them (`METAL2_PORT_BRIEF.md`). The two sharded RM factories re-audit once their gate conjuncts clear.
+
+**Coupling note for a subset port:** `get_dynamic_runtime_args` is declared once on the shared `TransposeDeviceOperation` (in `transpose_hc_sharded_program_factory.cpp:432`) and returns non-empty only for the two gated factories (returns `{}` for the other six — confirmed in code). Porting the six clean factories leaves the shared device op and its hook in place for the two that remain unported; this is expected for a subset port but should be carried as a heads-up.
+
+## Gate detail
+
+- **TTNN factory concept (`Is able to port?`):** RED at op level (config-scoped). Readiness-sheet `Concept = descriptor` for all 8, `Custom hash = no`, `Pybind descriptor = no`, `Smuggled pointer = no`. `Is able to port? = yes` for CN / HC-RM / HC-Tiled-Interleaved / HC-Tiled / WH / WH-Sharded; `= no` for HC-Sharded and WH-Sharded-RM (`Runtime-args update = yes` **and** `Is safe to port? = no`). **Cross-check (clean):** all factories define `create_descriptor()` returning `ProgramDescriptor` (`descriptor` ✓); no `compute_program_hash` override anywhere (`Custom hash = no` ✓); nanobind binds only the `transpose` free function, no `create_descriptor` (`Pybind = no` ✓); `get_dynamic_runtime_args` is defined and dispatches to exactly `TransposeHCShardedProgramFactory` + `TransposeWHShardedRMProgramFactory` (`transpose_hc_sharded_program_factory.cpp:432-456`), matching the sheet's two `Runtime-args update = yes` rows exactly. No `WorkloadDescriptor`/`create_mesh_workload`. Cross-column invariants hold (no op-owned tensors on a `descriptor` op). **Sheet is trustworthy.**
+- **Device 2.0 (every kernel used):** **GREEN.** Every referenced kernel — own and donor — uses Device 2.0 idioms: `Noc noc;`, `DataflowBuffer dfb(...)`, `TensorAccessor(args, addr)`, and object-method `dfb.get_read_ptr()` / `dfb.get_write_ptr()`. No Device 1.0 addr-gen (`InterleavedAddrGen`/`ShardedAddrGen`/`InterleavedPow2AddrGen*`), no raw `noc_async_read`/`noc_async_write`/`get_noc_addr_from_bank_id`, no raw sem addresses. The only CB free-function is `get_local_cb_interface(cb_id_out).fifo_page_size` in the eltwise/unary donor writer (`writer_unary_interleaved_start_id.cpp:19`) — **sanctioned** per the Green rule (not a holdover). Donor kernels checked: `eltwise/unary/.../writer_unary_interleaved_start_id.cpp`, `eltwise/unary/.../reader_unary_sharded.cpp`, `data_movement/sharded/.../writer_unary_sharded.cpp` — all Device 2.0. (Kernels for the two gated factories — `reader/writer_unary_transpose_hc_sharded_rm.cpp`, `reader/writer_unary_transpose_wh_sharded_rm.cpp` — are also Device 2.0, so Device 2.0 is not an additional blocker on them.)
+
+- **Feature compatibility:** every Appendix A entry is absent (all N/A — a clean scan).
+
+  | Feature | Status | Notes |
+  |---|---|---|
+  | GlobalCircularBuffer | N/A | no `GlobalCircularBuffer`/`CreateGlobalCircularBuffer` anywhere |
+  | CBDescriptor `address_offset` (non-zero) | N/A | The four `UpdateDynamicCircularBufferAddress` references are **comments** describing the standard borrowed-memory (`.buffer =`) re-application on cache hit, **not** a non-zero `address_offset` / `set_address_offset`. No Type-3 offset. |
+  | GlobalSemaphore | N/A | no semaphores of any kind in these kernels |
+  | Variable-count compile-time arguments (CTA varargs) | N/A | no runtime-varying CTA loop in any *referenced* kernel. (The one `get_compile_time_arg_val(src_args.next_compile_time_args_offset())` is a fixed accessor-args boundary in the **unreferenced** dead kernel `reader_unary_transpose_wh_interleaved.cpp`.) |
+
+- **CB endpoints (GATE-free):** classified per `(CB, config)` for the clean subset; all resolve without a flag. See Port-work summary. No multi-binding anywhere.
+- **Offset base pointers:** **GREEN.** No factory contains a `->address()` expression at all — bases reach kernels either via the **`Buffer*`-binding form** (`emplace_runtime_args(core, {input_tensor.buffer(), ...})`, framework auto-registers a `BufferBinding`; the kernel gets a clean `uint32_t` base it feeds to a `TensorAccessor`) or via **borrowed-memory CBs** (`.buffer = ...buffer()`). No host-folded `base + offset`. Kernel-side `dfb.get_write_ptr() + offset` arithmetic is L1-scratch addressing inside a CB, not a device-tensor base+offset fold; `TensorAccessor` `page_id`/`offset_bytes` are ordinary accessor addressing. Not present in the offset-base triage tables — consistent.
+- **TensorAccessor 3rd argument:** **GREEN.** Every `TensorAccessor(...)` construction across all referenced kernels is **2-arg** (`TensorAccessor(args, base_addr)`); no page-size 3rd argument is passed anywhere. Nothing to drop or gate. Not present in the 3rd-arg triage table — consistent.
+
+## Port-work summary  *(mirrors the brief; scoped to the clean 6-factory subset)*
+
+- **Tensor bindings** (per binding):
+  - **Interleaved factories** — CN / HC-RM / HC-Tiled-Interleaved / HC-Tiled / WH (tiled + RM): **input** and **output** are both **Case 1** (delivered today via the `Buffer*`-binding form, consumed through a `TensorAccessor`). Express each as `TensorParameter` / `TensorBinding`; kernel builds `TensorAccessor(tensor::name)`. Mechanical.
+  - **WH-Sharded**: input CB (`c_0`) and output CB (`c_16`) are **borrowed-memory DFBs** (`.buffer = input/output ...buffer()`) → **clean** (causal-link gate); port via `DataflowBufferSpec::borrowed_from`. No Case-1/2 work.
+- **TensorParameter relaxation:** none (`TensorParameter relaxation = none` on every row).
+- **TensorAccessor 3rd arg:** none — no sites.
+- **CB endpoints** (per `(CB, config)`):
+  - **CN:** `c_0` — 1:1 (reader P → writer C).
+  - **HC-RM:** `c_0` — 1:1 (reader P → writer C).
+  - **HC-Tiled-Interleaved:** `c_0` — 1:1 (reader P → writer C); `c_1` (padding) — 1:1 (reader P → writer C), **only when `needs_padding`** (`C % tile_height != 0`).
+  - **HC-Tiled:** `c_0` — 1:1 (reader P → donor unary writer C); `c_1` (scratch) — **self-loop** (touched only by the reader via `dfb_scratch.get_write_ptr()`), **only when `misaligned`** (`dst alignment > sub_tile_line_bytes`, e.g. Blackhole DRAM 64B).
+  - **WH (tiled):** `c_0` — 1:1 (reader P → compute C); `c_16` — 1:1 (compute P → donor unary writer C).
+  - **WH (row-major):** `c_0` — 1:1 (reader P → compute C); `c_16` — 1:1 (compute P → writer C); `c_24` (im / tilize) — **self-loop** (produced and consumed within the compute kernel); **`c_25` (im2) — DEAD-CB drop** (see below).
+  - **WH-Sharded:** `c_0` — 1:1 (donor reader P → compute C, borrowed); `c_16` — 1:1 (compute P → donor writer C, borrowed).
+  - **Dead-CB drop:** `c_25` (`im2`) allocated in `transpose_wh_program_factory.cpp:203-213` (row-major branch) is referenced by **no** kernel. `transpose_wh_rm.cpp` uses `c_25` as `cb_tilize` **only under `#ifdef SHARDED`** — a define set solely by the *gated* `TransposeWHShardedRMProgramFactory`, never by `TransposeWHProgramFactory`. In the WH factory's RM path `cb_tilize = c_24`, so `c_25` is unused. Corroborated by the factory's own `// TODO REMOVE` comment (line 202). **Confirmed dead → porter drops the allocation.**
+
+## Heads-ups  *(mirrors the brief)*
+
+- **CB endpoints (multi-binding shapes to watch):** none — no hidden second writer, no multi-reader, no ≥3-toucher CB in the clean subset.
+- **Cross-op / shared kernels (borrowed kernel files, port-together sets):**
+  - `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp` — donor writer for **HC-Tiled** (consumes `c_0`) and **WH tiled** (consumes `c_16`). **Broadly shared** (~42 host `.cpp` files reference it). Its Metal 2.0 rewrite (CB→DFB, named tokens) is a single change all co-borrowers adopt together.
+  - `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp` — donor reader for **WH-Sharded** (produces borrowed `c_0`). Broadly shared (~17 host files).
+  - `ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp` — donor writer for **WH-Sharded** (consumes borrowed `c_16`). Broadly shared (~15 host files).
+- **RTA varargs:** none in the clean subset — every referenced kernel reads a fixed set of distinctly-named args at constant indices (or a fixed `arg_idx++` run); no loop-indexed or data-selected reads.
+- **Shared device-op `get_dynamic_runtime_args` coupling:** the hook lives on the shared `TransposeDeviceOperation` and returns `{}` for the six clean factories; a subset port leaves it in place for the two gated factories.
+
+## Team-only
+
+### Out-of-directory coupling & donor shape
+
+**Op-level roll-up: ⚠ workable** — three broadly-shared donor kernel files (file-path instantiation) + one in-family function-call escape; all donors are Device 2.0, so nothing sequence-blocks beyond the standard port-together coupling.
+
+**Function-call escape:** the transpose dataflow kernels `#include "ttnn/operations/data_movement/common/kernels/common.hpp"` and call `tt::data_movement::common::noc_async_read_sharded` / `noc_async_write_sharded` / `fill_with_val` / `round_up`. This is an **in-family** (`data_movement/common`) shared helper pool. Signature shapes are Device 2.0 native — `(Noc& noc, uint32_t l1_addr, const TensorAccessor& s, ...)` (TensorAccessor Shape 1 ✓, `Noc&` ✓). No pre-Device-2.0 donor shapes → no Device 2.0 donor gate. Includes appear in: `reader_unary_transpose_cn...`, `reader/writer_unary_transpose_wh_interleaved_start_id_rm`, `reader_unary_transpose_hc_interleaved_tiled_padding_aware`, `reader_unary_transpose_hc_interleaved_partitioned_rm`, `writer_unary_transpose_hc_interleaved_start_id_rm`, `writer_unary_transpose_hc_interleaved_tiled_padding_aware`.
+
+**Borrowed kernel files (file-path instantiation):**
+
+| Kernel file | Owning family | Instantiated by transpose factory | Broadly shared? |
+|---|---|---|---|
+| `eltwise/unary/.../writer_unary_interleaved_start_id.cpp` | eltwise/unary (cross-family) | HC-Tiled, WH tiled | Yes — ~42 host `.cpp` files |
+| `eltwise/unary/.../reader_unary_sharded.cpp` | eltwise/unary (cross-family) | WH-Sharded | Yes — ~17 host `.cpp` files |
+| `data_movement/sharded/.../writer_unary_sharded.cpp` | data_movement/sharded (cross-op, same family) | WH-Sharded | Yes — ~15 host `.cpp` files |
+
+Each forms a Metal 2.0 port-together set with its co-borrowers; sequence the shared rewrite as one unit.
+
+### TTNN factory analysis (sheet-derived, with cross-check)
+
+- **Concept:** `descriptor` (all 8 factories) — verified in code (`create_descriptor` → `ProgramDescriptor`).
+- **Custom hash:** No — no `compute_program_hash` override in the op.
+- **Runtime-args update:** Yes for HC-Sharded + WH-Sharded-RM only (device-op `get_dynamic_runtime_args`, #48928); No for the other six.
+- **Pybind `create_descriptor`:** No — nanobind exposes only the `transpose` function.
+- **Op-owned tensors:** No.
+- **Target concept (cleared factories):** `MetalV2FactoryConcept` (no op-owned tensors).
+
+## Misc anomalies  *(team-only, non-gating)*
+
+- **Dead CB `c_25` (im2) in the WH factory RM path** — `transpose_wh_program_factory.cpp:203-213`, carries a `// TODO REMOVE` (line 202); no kernel references it. (Handled as a CB-endpoints dead-CB drop in the subset port; noted here for the ops team as a latent allocation waste.)
+- **Unreferenced kernel file** `device/kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp` — present in the directory but instantiated by no factory (dead code). Candidate for removal by the ops team.
+
+## Per-DeviceOperation attribution
+
+Single `TransposeDeviceOperation`; per-factory verdicts:
+
+| Factory | `Is able to port?` | Blocker (if any) |
+|---|---|---|
+| `TransposeCNProgramFactory` | yes | — (in clean subset) |
+| `TransposeHCRMProgramFactory` | yes | — (in clean subset) |
+| `TransposeHCTiledInterleavedProgramFactory` | yes | — (in clean subset) |
+| `TransposeHCTiledProgramFactory` | yes | — (in clean subset) |
+| `TransposeWHProgramFactory` | yes | — (in clean subset) |
+| `TransposeWHShardedProgramFactory` | yes | — (in clean subset) |
+| `TransposeHCShardedProgramFactory` | **no** | `Runtime-args update` (→ TTNN/PD-migration) + `Is safe to port? = no` (→ readiness-sheet owner) |
+| `TransposeWHShardedRMProgramFactory` | **no** | `Runtime-args update` (→ TTNN/PD-migration) + `Is safe to port? = no` (→ readiness-sheet owner) |
+
+## Recipe notes
+
+- **Device-op-level `get_dynamic_runtime_args` vs. per-factory gate attribution.** The `Runtime-args update` gate conjunct is described as a per-factory property, but the hook it keys on (`get_dynamic_runtime_args`) is necessarily declared once on the shared `DeviceOperation`. Here it dispatches on `select_program_factory` and returns non-empty for only 2 of 8 factories. The readiness sheet correctly scopes `Runtime-args update = yes` to those 2, and the cross-check ("grep the factory for `get_dynamic_runtime_args`") resolved cleanly once I read the hook *body* rather than just its presence. Worth an explicit line in the TTNN-factory-concept cross-check guidance: for a shared hook, verify *which factories it actually services*, not merely that the symbol exists — otherwise a naive grep would over-attribute the gate to all 8.

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+// A Metal 2.0 port of this kernel's non-sharded path exists alongside it as
+// transpose_wh_rm_metal2.cpp. Ops still on the legacy host API bind this copy (the sharded
+// path below is compiled only from here); ops on Metal 2.0 bind the fork. Keep the two in
+// sync when changing the shared compute logic.
+
 #include <cstdint>
 
 #include "api/compute/eltwise_unary/eltwise_unary.h"

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm_metal2.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of transpose_wh_rm.cpp (see the legacy copy alongside).
+// Compute logic is unchanged; resource access uses Metal 2.0 named handles:
+//   - c_0 / c_24 / c_16 (legacy magic CB indices) -> dfb::in0 / dfb::tilize / dfb::out
+//   - Ht / Wt / HtWt (legacy CTAs 0-2)            -> named compile-time args
+//   - num_hw_blocks_per_core (legacy RTA 0)       -> named RTA
+//
+// Forked (not modified in place) because the legacy copy is also bound by
+// TransposeWHShardedRMProgramFactory, which is still on the legacy host API and compiles
+// this source with SHARDED defined. Only the non-sharded path lives here: the fork is never
+// compiled with SHARDED, so carrying that branch would be dead code referencing buffers this
+// spec does not bind. The sharded variant — including its pack_untilize narrow-row path and
+// the yolov4/PCC note explaining the use_narrow_row conditions — remains in the legacy copy.
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/transpose.h"
+#include "api/compute/tilize.h"
+#include "api/compute/pack_untilize.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
+
+template <uint32_t Wt, uint32_t Ht, uint32_t HtWt, uint32_t dfb_out>
+ALWI void transpose_with_pack_untilize(uint32_t dfb_tilize, DataflowBuffer& dfb_out_buf) {
+    uint32_t tile_idx = 0;
+
+    transpose_init(dfb_tilize);
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(Ht);
+    constexpr uint32_t block_ct_dim = Ht / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = Ht;
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(dfb_out);
+    for (uint32_t w = 0; w < Wt; ++w) {
+        dfb_out_buf.reserve_back(Ht);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            tile_regs_acquire();
+            for (uint32_t h = 0; h < block_ct_dim; ++h) {
+                transpose_tile(dfb_tilize, tile_idx, h);
+                tile_idx += Wt;
+            }
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_untilize_dest<block_ct_dim, full_ct_dim>(dfb_out, 1, b);
+            tile_regs_release();
+        }
+        dfb_out_buf.push_back(Ht);
+
+        tile_idx = tile_idx - HtWt + 1;
+    }
+    pack_untilize_uninit(dfb_out);
+}
+
+void kernel_main() {
+    constexpr auto Ht = get_arg(args::Ht);
+    constexpr auto Wt = get_arg(args::Wt);
+    constexpr auto HtWt = get_arg(args::HtWt);
+
+    uint32_t num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
+
+    constexpr auto dfb_in = dfb::in0;
+    constexpr auto dfb_tilize = dfb::tilize;
+    constexpr auto dfb_out_idx = dfb::out;
+
+    DataflowBuffer dfb_tilize_buf(dfb_tilize);
+    DataflowBuffer dfb_out(dfb_out_idx);
+
+    unary_op_init_common(dfb_in, dfb_out_idx);
+
+    for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
+        // Tilize input (Ht rows × Wt tiles). Fp32Mode::Lossless keeps the full
+        // Float32 mantissa through tilization; the default Fast mode would
+        // collapse it to tf32 precision before the transpose ever runs.
+        compute_kernel_lib::tilize<
+            Wt,
+            dfb_in,
+            dfb_tilize,
+            compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+            compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+            compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+            compute_kernel_lib::tilize_config::Fp32Mode::Lossless>(Ht);
+
+        // transpose
+        dfb_tilize_buf.wait_front(HtWt);
+        transpose_with_pack_untilize<Wt, Ht, HtWt, dfb_out_idx>(dfb_tilize, dfb_out);
+
+        dfb_tilize_buf.pop_front(HtWt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp
@@ -2,6 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// A Metal 2.0 port of this kernel exists alongside it as transpose_wh_sharded_metal2.cpp.
+// Ops still on the legacy host API bind this copy; ops on Metal 2.0 bind the fork. Keep the
+// two in sync when changing the compute logic.
+
 #include <cstdint>
 
 #include "api/compute/compute_kernel_hw_startup.h"

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded_metal2.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of transpose_wh_sharded.cpp (see the legacy copy alongside).
+// Compute logic is unchanged; resource access uses Metal 2.0 named handles:
+//   - cb_id_in / cb_id_out (legacy CB-index CTAs) -> dfb::in / dfb::out
+//   - NHtWt / HtWt / N / Ht / Wt (legacy RTAs 0-4) -> named RTAs
+// Forked (not modified in place) because the legacy copy is still bound by the
+// create_qkv_heads, create_qkv_heads_from_separate_tensors and
+// split_query_key_value_and_split_heads_sharded ops, which are not on Metal 2.0.
+
+#include <cstdint>
+
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/transpose.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t NHtWt = get_arg(args::NHtWt);
+    uint32_t HtWt = get_arg(args::HtWt);
+    uint32_t N = get_arg(args::N);
+    uint32_t Ht = get_arg(args::Ht);
+    uint32_t Wt = get_arg(args::Wt);
+
+    constexpr auto dfb_in_id = dfb::in;
+    constexpr auto dfb_out_id = dfb::out;
+
+    compute_kernel_hw_startup(dfb_in_id, dfb_out_id);
+    transpose_init(dfb_in_id);
+
+    DataflowBuffer dfb_in(dfb_in_id);
+    DataflowBuffer dfb_out(dfb_out_id);
+
+    // transpose a row-major block:
+    // - uses reader_unary_transpose_wh
+    // - transpose_wh each tile
+
+    uint32_t tile_idx = 0;
+    uint32_t tile_idx_N = 0;
+
+    dfb_in.wait_front(NHtWt);
+    dfb_out.reserve_back(NHtWt);
+    for (uint32_t n = 0; n < N; ++n) {
+        tile_idx = tile_idx_N;
+        for (uint32_t w = 0; w < Wt; ++w) {
+            for (uint32_t h = 0; h < Ht; ++h) {
+                tile_regs_acquire();
+                transpose_tile(dfb_in_id, tile_idx, 0);
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, dfb_out_id);
+                tile_regs_release();
+                tile_idx += Wt;
+            }
+            tile_idx = tile_idx - HtWt + 1;
+        }
+        tile_idx_N += HtWt;
+    }
+    dfb_out.push_back(NHtWt);
+    dfb_in.pop_front(NHtWt);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -8,33 +8,31 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t N = get_arg_val<uint32_t>(1);
-    const uint32_t C = get_arg_val<uint32_t>(2);
-    const uint32_t HtWt = get_arg_val<uint32_t>(3);
-    const uint32_t batch_step = get_arg_val<uint32_t>(4);    // CHtWt - HtWt
-    const uint32_t channel_step = get_arg_val<uint32_t>(5);  // NCHtWt - HtWt
-    const uint32_t num_pages = get_arg_val<uint32_t>(6);
-    const uint32_t start_id = get_arg_val<uint32_t>(7);
-    uint32_t hw = get_arg_val<uint32_t>(8);
-    uint32_t n = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t HtWt = get_arg(args::HtWt);
+    const uint32_t batch_step = get_arg(args::batch_step);      // CHtWt - HtWt
+    const uint32_t channel_step = get_arg(args::channel_step);  // NCHtWt - HtWt
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+    uint32_t hw = get_arg(args::hw);
+    uint32_t n = get_arg(args::n);
 
-    constexpr uint32_t dfb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t read_size = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr auto page_size = get_arg(args::page_size);
+    constexpr auto read_size = get_arg(args::read_size);
 
     // ublocks size defined in tiles
     constexpr uint32_t onepage = 1;
 
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(tensor::src);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_id_in0);
+    DataflowBuffer dfb(dfb::in0);
 
-    // read a ublock of tiles from src to CB, and then push the ublock to unpacker
+    // read a ublock of tiles from src to DFB, and then push the ublock to unpacker
     uint32_t page_idx = start_id;
     for (uint32_t i = 0; i < num_pages; ++i) {
         dfb.reserve_back(onepage);
@@ -43,8 +41,8 @@ void kernel_main() {
         // RM-only: the helper splits a logical "row page" across multiple shards laterally
         // when the buffer is BLOCK/WIDTH-sharded. TILE-layout path below must keep the
         // original single-page transfer since each tile is one indivisible NOC unit.
-        const uint32_t cb_write_ptr = dfb.get_write_ptr();
-        tt::data_movement::common::noc_async_read_sharded(noc, cb_write_ptr, s, page_idx, 0, read_size);
+        const uint32_t dfb_write_ptr = dfb.get_write_ptr();
+        tt::data_movement::common::noc_async_read_sharded(noc, dfb_write_ptr, s, page_idx, 0, read_size);
 #else
         noc.async_read(s, dfb, page_size, {.page_id = page_idx}, {.offset_bytes = 0});
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
@@ -8,6 +8,7 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 using uint32_t = std::uint32_t;
 
@@ -16,42 +17,45 @@ inline uint32_t TADDR_FLOAT32(uint32_t ti) { return ti << 12; }
 inline uint32_t TADDR_BFLOAT16(uint32_t ti) { return ti << 11; }
 
 void kernel_main() {
-    uint32_t src0_addr = get_arg_val<uint32_t>(0);
-    uint32_t WT = get_arg_val<uint32_t>(1);
-    uint32_t H = get_arg_val<uint32_t>(2);
-    uint32_t CT = get_arg_val<uint32_t>(3);
-    uint32_t HW_bytes = get_arg_val<uint32_t>(4);
-    uint32_t CHW_bytes = get_arg_val<uint32_t>(5);
-    uint32_t start_id = get_arg_val<uint32_t>(6);
-    uint32_t num_tiles = get_arg_val<uint32_t>(7);
-    uint32_t batch_addr = get_arg_val<uint32_t>(8);
-    uint32_t h = get_arg_val<uint32_t>(9);
-    uint32_t htWT = get_arg_val<uint32_t>(10);
-    uint32_t ct = get_arg_val<uint32_t>(11);
-    uint32_t ctoffs = get_arg_val<uint32_t>(12);
-    uint32_t wt = get_arg_val<uint32_t>(13);
+    uint32_t WT = get_arg(args::WT);
+    uint32_t H = get_arg(args::H);
+    uint32_t CT = get_arg(args::CT);
+    uint32_t HW_bytes = get_arg(args::HW_bytes);
+    uint32_t CHW_bytes = get_arg(args::CHW_bytes);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t num_tiles = get_arg(args::num_tiles);
+    uint32_t batch_addr = get_arg(args::batch_addr);
+    uint32_t h = get_arg(args::h);
+    uint32_t htWT = get_arg(args::htWT);
+    uint32_t ct = get_arg(args::ct);
+    uint32_t ctoffs = get_arg(args::ctoffs);
+    uint32_t wt = get_arg(args::wt);
 
-    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(0);
-    constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(1);
-    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
-    constexpr bool MISALIGNED = ALIGNMENT > SUBTILE_LINE_BYTES;
+    constexpr auto SUBTILE_LINE_BYTES = get_arg(args::subtile_line_bytes);
+    constexpr auto FLOAT32_DTYPE = get_arg(args::float32_dtype);
+#ifdef MISALIGNED
+    constexpr auto ALIGNMENT = get_arg(args::alignment);
+#endif
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t dfb_id_in0 = 0;
 
     // The basic idea here is to iterate over output tiles (that will be over CT,WT) and H
     // this will generate a linearly incremented output address in the inner loop
     // we then reverse map this linear dest address to src address
 
-    const auto s0 = TensorAccessor(src_args, src0_addr);
+    const auto s0 = TensorAccessor(tensor::src);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_id_in0);
-    DataflowBuffer dfb_scratch(1);
+    DataflowBuffer dfb(dfb::in0);
 
-    uint32_t intermed_l1_scratch = MISALIGNED ? dfb_scratch.get_write_ptr() : 0;
+    // The scratch buffer exists only on the misaligned path, where a sub-tile line has to be
+    // staged through an alignment-sized landing area before being copied into the tile. It is
+    // bound (and this code compiled) only when the host saw dst alignment > sub-tile line bytes.
+#ifdef MISALIGNED
+    DataflowBuffer dfb_scratch(dfb::scratch);
+    uint32_t intermed_l1_scratch = dfb_scratch.get_write_ptr();
     volatile tt_l1_ptr uint8_t* intermed_l1_scratch_ptr = (volatile uint8_t*)intermed_l1_scratch;
+#endif
     for (uint32_t t = 0; t < num_tiles; t++) {
         auto h32 = (h & 31);
 
@@ -107,7 +111,8 @@ void kernel_main() {
                     rem = (bsrc_offs & 2047);
                 }
 
-                if constexpr (MISALIGNED) {
+#ifdef MISALIGNED
+                {
                     uint64_t banked_addr = s0.get_noc_addr(batch_itile, rem);
                     uint32_t banked_alignment = banked_addr % ALIGNMENT;
                     if (dest_tr0_l1 % ALIGNMENT != banked_alignment) {
@@ -132,7 +137,9 @@ void kernel_main() {
                             {.page_id = batch_itile, .offset_bytes = rem},
                             {.offset_bytes = 0});
                     }
-                } else {
+                }
+#else
+                {
                     CoreLocalMem<uint32_t> dst(dest_tr0_l1);
                     noc.async_read(
                         s0,
@@ -141,6 +148,7 @@ void kernel_main() {
                         {.page_id = batch_itile, .offset_bytes = rem},
                         {.offset_bytes = 0});
                 }
+#endif
 
                 // the output address is just linearly incremented
                 dest_tr0_l1 += SUBTILE_LINE_BYTES;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -8,43 +8,39 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(1);
-    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_id = get_arg_val<uint32_t>(3);
-    uint32_t curr_c = get_arg_val<uint32_t>(4);
-    uint32_t curr_h = get_arg_val<uint32_t>(5);
-    uint32_t curr_n = get_arg_val<uint32_t>(6);
+    uint32_t num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    uint32_t num_read_per_barrier = get_arg(args::num_read_per_barrier);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t curr_c = get_arg(args::curr_c);
+    uint32_t curr_h = get_arg(args::curr_h);
+    uint32_t curr_n = get_arg(args::curr_n);
 
-    constexpr uint32_t N = get_compile_time_arg_val(0);
-    constexpr uint32_t H = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(3);
+    constexpr auto H = get_arg(args::H);
+    constexpr auto C = get_arg(args::C);
+    constexpr auto W_size_bytes = get_arg(args::W_size_bytes);
 
     constexpr uint32_t CH = C * H;
 
-    constexpr auto dfb_in0 = tt::CBIndex::c_0;
-
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr auto src_args = TensorAccessorArgs<5>();
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(tensor::src);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_in0);
+    DataflowBuffer dfb(dfb::in0);
 
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
         dfb.reserve_back(num_read_per_barrier);
-        const uint32_t cb_write_ptr = dfb.get_write_ptr();
+        const uint32_t dfb_write_ptr = dfb.get_write_ptr();
         uint32_t l1_write_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
             // Restored native sharded multi-page split (see common.hpp helper).
             tt::data_movement::common::noc_async_read_sharded(
-                noc, cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
+                noc, dfb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
             l1_write_offset += stick_size_bytes;
 
             curr_c++;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
@@ -7,27 +7,23 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_tiles = get_arg_val<uint32_t>(1);
-    uint32_t start_id = get_arg_val<uint32_t>(2);
-    uint32_t start_ht = get_arg_val<uint32_t>(3);
-    uint32_t start_wt = get_arg_val<uint32_t>(4);
+    uint32_t num_tiles = get_arg(args::num_tiles);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t start_ht = get_arg(args::start_ht);
+    uint32_t start_wt = get_arg(args::start_wt);
 
-    uint32_t Ht = get_arg_val<uint32_t>(5);
-    uint32_t Wt = get_arg_val<uint32_t>(6);
-    uint32_t HtWt = get_arg_val<uint32_t>(7);
-
-    constexpr auto src_args = TensorAccessorArgs<0>();
-
-    constexpr uint32_t dfb_id_in0 = 0;
+    uint32_t Ht = get_arg(args::Ht);
+    uint32_t Wt = get_arg(args::Wt);
+    uint32_t HtWt = get_arg(args::HtWt);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
-    DataflowBuffer dfb(dfb_id_in0);
+    DataflowBuffer dfb(dfb::in0);
     const uint32_t tile_bytes = dfb.get_entry_size();
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(tensor::src);
 
     Noc noc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -8,30 +8,25 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
 
-    constexpr uint32_t Ht = get_compile_time_arg_val(0);
-    constexpr uint32_t H_per_tile = get_compile_time_arg_val(1);
-    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(2);
-    constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr uint32_t W = get_compile_time_arg_val(4);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(5);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(6);
-    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(7);
-    constexpr auto src_args = TensorAccessorArgs<9>();
-
-    constexpr auto dfb_in0 = tt::CBIndex::c_0;
+    constexpr auto Ht = get_arg(args::Ht);
+    constexpr auto H_per_tile = get_arg(args::H_per_tile);
+    constexpr auto H_per_tile_last = get_arg(args::H_per_tile_last);
+    constexpr auto Wt = get_arg(args::Wt);
+    constexpr auto W_size_bytes = get_arg(args::W_size_bytes);
+    constexpr auto l1_write_offset_bytes = get_arg(args::l1_write_offset_bytes);
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(tensor::src);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_in0);
+    DataflowBuffer dfb(dfb::in0);
 
     uint32_t i_stick = start_id;
 
@@ -44,12 +39,12 @@ void kernel_main() {
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t h = 0; h < Ht; ++h) {
             dfb.reserve_back(Wt);
-            const uint32_t cb_write_ptr = dfb.get_write_ptr();
+            const uint32_t dfb_write_ptr = dfb.get_write_ptr();
             uint32_t l1_write_offset = 0;
             uint32_t H_curr = h == Ht - 1 ? H_per_tile_last : H_per_tile;
             for (uint32_t h_datum = 0; h_datum < H_curr; ++h_datum) {
                 tt::data_movement::common::noc_async_read_sharded(
-                    noc, cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
+                    noc, dfb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
                 l1_write_offset += l1_write_offset_bytes;
                 i_stick += 1;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
@@ -6,23 +6,21 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_pages = get_arg_val<uint32_t>(1);
-    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t num_pages = get_arg(args::num_pages);
+    uint32_t start_id = get_arg(args::start_id);
 
-    constexpr uint32_t dfb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t write_size = get_compile_time_arg_val(2);
-    constexpr auto dst_args = TensorAccessorArgs<3>();
+    constexpr auto page_size = get_arg(args::page_size);
+    constexpr auto write_size = get_arg(args::write_size);
 
     constexpr uint32_t onepage = 1;
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(tensor::dst);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_id_out);
+    DataflowBuffer dfb(dfb::in0);
 
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {
@@ -30,8 +28,8 @@ void kernel_main() {
 #ifdef CN_RM
         // Restored native sharded multi-page split (see common.hpp helper).
         // RM-only: see reader kernel for rationale; TILE-layout below uses original API.
-        const uint32_t cb_read_ptr = dfb.get_read_ptr();
-        tt::data_movement::common::noc_async_write_sharded(noc, cb_read_ptr, s, i, 0, write_size);
+        const uint32_t dfb_read_ptr = dfb.get_read_ptr();
+        tt::data_movement::common::noc_async_write_sharded(noc, dfb_read_ptr, s, i, 0, write_size);
 #else
         noc.async_write(dfb, s, page_size, {.offset_bytes = 0}, {.page_id = i});
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -7,34 +7,32 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(1);
-    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_id = get_arg_val<uint32_t>(3);
+    uint32_t num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    uint32_t num_read_per_barrier = get_arg(args::num_read_per_barrier);
+    uint32_t start_id = get_arg(args::start_id);
 
-    constexpr uint32_t dfb_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(1);
+    constexpr auto W_size_bytes = get_arg(args::W_size_bytes);
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr auto dst_args = TensorAccessorArgs<3>();
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(tensor::dst);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_out0);
+    DataflowBuffer dfb(dfb::out0);
 
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {
         dfb.wait_front(num_read_per_barrier);
-        const uint32_t cb_read_ptr = dfb.get_read_ptr();
+        const uint32_t dfb_read_ptr = dfb.get_read_ptr();
         uint32_t l1_read_offset = 0;
 
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
             // Restored native sharded multi-page split (see common.hpp helper).
             tt::data_movement::common::noc_async_write_sharded(
-                noc, cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
+                noc, dfb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
             l1_read_offset += stick_size_bytes;
             i_stick += 1;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -8,27 +8,24 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Retrieve arguments
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_tile_idx = get_arg_val<uint32_t>(1);
-    uint32_t end_tile_idx = get_arg_val<uint32_t>(2);
-    uint32_t start_padding_tile_idx = get_arg_val<uint32_t>(3);
-    uint32_t end_padding_tile_idx = get_arg_val<uint32_t>(4);
+    uint32_t start_tile_idx = get_arg(args::start_tile_idx);
+    uint32_t end_tile_idx = get_arg(args::end_tile_idx);
+    uint32_t start_padding_tile_idx = get_arg(args::start_padding_tile_idx);
+    uint32_t end_padding_tile_idx = get_arg(args::end_padding_tile_idx);
 
     // Compile-time constants
-    constexpr uint32_t element_size = get_compile_time_arg_val(0);
-    constexpr uint32_t dfb_id_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t H = get_compile_time_arg_val(3);
-    constexpr uint32_t W = get_compile_time_arg_val(4);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(5);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(6);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(7);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(8);
-    constexpr bool needs_padding = get_compile_time_arg_val(9) == 1;
-    constexpr auto dst_args = TensorAccessorArgs<10>();
+    constexpr auto element_size = get_arg(args::element_size);
+    constexpr auto C = get_arg(args::C);
+    constexpr auto H = get_arg(args::H);
+    constexpr auto W = get_arg(args::W);
+    constexpr auto TILE_HEIGHT = get_arg(args::tile_height);
+    constexpr auto TILE_WIDTH = get_arg(args::tile_width);
+    constexpr auto FACE_HEIGHT = get_arg(args::face_height);
+    constexpr auto FACE_WIDTH = get_arg(args::face_width);
 
     // Derived compile-time constants
     constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
@@ -46,11 +43,10 @@ void kernel_main() {
     constexpr uint32_t SUBTILE_LINE_BYTES = FACE_WIDTH * element_size;
 
     // Initialize address generator
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(tensor::dst);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_id_out0);
-    DataflowBuffer dfb_padding(tt::CBIndex::c_1);
+    DataflowBuffer dfb(dfb::out0);
 
     // Calculate actual data height in the last tile
     constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;
@@ -162,7 +158,11 @@ void kernel_main() {
     }
 
     // add padding
-    if constexpr (needs_padding) {
+    // The padding buffer is bound (and this block compiled) only when the host determined the
+    // channel dim does not fill a whole tile; see the NEEDS_PADDING define on this kernel's spec.
+#ifdef NEEDS_PADDING
+    {
+        DataflowBuffer dfb_padding(dfb::pad);
         dfb_padding.wait_front(1);
 
         uint32_t l1_read_ptr = dfb_padding.get_read_ptr();
@@ -202,4 +202,5 @@ void kernel_main() {
         noc.async_write_barrier();
         dfb_padding.pop_front(1);
     }
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -7,30 +7,26 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
 
-    constexpr uint32_t dfb_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t H = get_compile_time_arg_val(2);
-    constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr uint32_t W_per_tile = get_compile_time_arg_val(4);
-    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(5);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(6);
-    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(7);
-    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(8);
+    constexpr auto Ht = get_arg(args::Ht);
+    constexpr auto Wt = get_arg(args::Wt);
+    constexpr auto W_per_tile = get_arg(args::W_per_tile);
+    constexpr auto W_per_tile_last = get_arg(args::W_per_tile_last);
+    constexpr auto H_size_bytes = get_arg(args::H_size_bytes);
+    constexpr auto l1_read_offset_bytes = get_arg(args::l1_read_offset_bytes);
 
     // single-tile ublocks
     const uint32_t stick_size_bytes = H_size_bytes;
 
-    constexpr auto dst_args = TensorAccessorArgs<10>();
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(tensor::dst);
 
     Noc noc;
-    DataflowBuffer dfb(dfb_out0);
+    DataflowBuffer dfb(dfb::out);
 
     uint32_t i_stick = start_id;
 
@@ -40,12 +36,12 @@ void kernel_main() {
     for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
         for (uint32_t w = 0; w < Wt; ++w) {
             dfb.wait_front(Ht);
-            const uint32_t cb_read_ptr = dfb.get_read_ptr();
+            const uint32_t dfb_read_ptr = dfb.get_read_ptr();
             uint32_t l1_read_offset = 0;
             uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
             for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
                 tt::data_movement::common::noc_async_write_sharded(
-                    noc, cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
+                    noc, dfb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
                 l1_read_offset += l1_read_offset_bytes;
                 i_stick += 1;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -4,37 +4,48 @@
 #include "transpose_cn_program_factory.hpp"
 #include "transpose_utils.hpp"
 
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
+
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_program_artifacts(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    // Spec-scope resource names. The DFB accessor names are the tokens the reader and writer
+    // kernels use (dfb::in0), so they are part of this factory's contract with its kernels.
+    // Declared function-locally: this op's factories share one translation unit in the unity
+    // build, so file-scope names would collide across them.
+    const DFBSpecName IN0{"in0"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+
     const auto& input_tensor = tensor_args.input;
+    const auto& input = input_tensor.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
     auto input_shape = input_tensor.padded_shape();
     bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_cn needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_cn needs to be allocated in a buffer on device!");
 
-    ProgramDescriptor desc;
-
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat dfb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t page_shape[2] = {TILE_WIDTH, TILE_HEIGHT};
     if (input_tensor.layout() == Layout::ROW_MAJOR) {
         page_shape[0] = 1;
         page_shape[1] = input_shape[-1];
     }
     uint32_t page_size = page_shape[0] * page_shape[1];
-    uint32_t stick_size = (row_major) ? page_shape[1] * input_tensor.element_size() : tt::tile_size(cb_data_format);
+    uint32_t stick_size = (row_major) ? page_shape[1] * input_tensor.element_size() : tt::tile_size(dfb_data_format);
 
     Buffer* src0_buffer = input_tensor.buffer();
     IDevice* device = input_tensor.device();
@@ -49,51 +60,68 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
     uint32_t num_input_pages = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_pages * stick_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size,
-        }}},
+
+    ProgramSpec spec{.name = "transpose_cn"};
+
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = IN0,
+        .entry_size = stick_size,
+        .num_entries = num_input_pages,
+        .data_format_metadata = dfb_data_format,
     });
 
-    KernelDescriptor::Defines reader_defines;
-    std::vector<uint32_t> reader_compile_time_args = {
-        static_cast<uint32_t>(src0_cb_index), src0_buffer->aligned_page_size(), stick_size};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelDescriptor::Defines writer_defines;
-    std::vector<uint32_t> writer_compile_time_args = {
-        static_cast<uint32_t>(src0_cb_index), dst_buffer->aligned_page_size(), stick_size};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = INPUT, .spec = input_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()});
 
+    KernelSpec::CompilerOptions::Defines reader_defines;
+    KernelSpec::CompilerOptions::Defines writer_defines;
     if (row_major) {
-        reader_defines.emplace_back("CN_RM", "1");
-        writer_defines.emplace_back("CN_RM", "1");
+        reader_defines.insert({"CN_RM", "1"});
+        writer_defines.insert({"CN_RM", "1"});
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_cn_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.defines = std::move(reader_defines);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // `read_size` / `write_size` drive the sharded multi-page split helper on the row-major path;
+    // `page_size` is the single-page NOC transfer size on the tile path. Both are emitted on both
+    // paths, matching the legacy kernels' unconditional compile-time reads.
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = READER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                  "reader_unary_transpose_cn_interleaved_start_id.cpp",
+        .compiler_options = {.defines = std::move(reader_defines)},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "in0",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
+        .compile_time_args = {{"page_size", src0_buffer->aligned_page_size()}, {"read_size", stick_size}},
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"N", "C", "HtWt", "batch_step", "channel_step", "num_pages", "start_id", "hw", "n"}},
+        .hw_config = create_reader_datamovement_config(device->arch()),
+    });
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_cn_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.defines = std::move(writer_defines);
-    writer_desc.config = WriterConfigDescriptor{};
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = WRITER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                  "writer_unary_transpose_cn_interleaved_start_id.cpp",
+        .compiler_options = {.defines = std::move(writer_defines)},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "in0",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
+        .compile_time_args = {{"page_size", dst_buffer->aligned_page_size()}, {"write_size", stick_size}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = create_writer_datamovement_config(device->arch()),
+    });
+
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "main",
+        .kernels = {READER, WRITER},
+        .target_nodes = all_cores,
+    });
 
     // Set runtime arguments for each core
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
@@ -105,9 +133,11 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     uint32_t batch_step = CHtWt - HtWt;
     uint32_t channel_step = NCHtWt - HtWt;
 
+    ProgramRunArgs run_args;
+    ProgramRunArgs::KernelRunArgs reader_run_args{.kernel = READER};
+    ProgramRunArgs::KernelRunArgs writer_run_args{.kernel = WRITER};
+
     auto cores = corerange_to_cores(all_cores, std::nullopt);
-    reader_desc.runtime_args.reserve(num_cores);
-    writer_desc.runtime_args.reserve(num_cores);
     uint32_t num_pages_read = 0;
     for (const auto& core : cores) {
         uint32_t num_pages_per_core;
@@ -124,17 +154,32 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
         uint32_t n = curr_c % N;
         uint32_t start_tile = num_pages_read + (curr_c * batch_step) - (curr_c / N * channel_step);
 
-        reader_desc.emplace_runtime_args(
-            core, {src0_buffer, N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
-        writer_desc.emplace_runtime_args(core, {dst_buffer, num_pages_per_core, num_pages_read});
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            core,
+            {{"N", N},
+             {"C", C},
+             {"HtWt", HtWt},
+             {"batch_step", batch_step},
+             {"channel_step", channel_step},
+             {"num_pages", num_pages_per_core},
+             {"start_id", start_tile},
+             {"hw", hw},
+             {"n", n}});
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            core,
+            {{"num_pages", num_pages_per_core}, {"start_id", num_pages_read}});
 
         num_pages_read += num_pages_per_core;
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    run_args.kernel_run_args.push_back(std::move(writer_run_args));
+    run_args.tensor_args.emplace(INPUT, input);
+    run_args.tensor_args.emplace(OUTPUT, output);
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.hpp
@@ -7,13 +7,14 @@
 
 #include "ttnn/device_operation.hpp"
 
+#include "ttnn/metal_v2_artifacts.hpp"
+
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeCNProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -4,37 +4,34 @@
 #include "transpose_hc_rm_program_factory.hpp"
 #include "transpose_utils.hpp"
 
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
+
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-logger/tt-logger.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 namespace {
 
-// Compute per-core runtime args (reader+writer) for HC RM transpose and append them to the
-// supplied KernelDescriptors. The traversal logic that advances (curr_c, curr_h, curr_n) was
+// Compute per-core runtime args (reader+writer) for HC RM transpose and add them to the
+// supplied KernelRunArgs. The traversal logic that advances (curr_c, curr_h, curr_n) was
 // previously shared between `create` and `override_runtime_arguments`; now it has a single home.
 void emit_runtime_args_hc_rm(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& writer_desc,
+    ProgramRunArgs::KernelRunArgs& reader_run_args,
+    ProgramRunArgs::KernelRunArgs& writer_run_args,
     const Tensor& input_tensor,
-    Tensor& output_tensor,
-    uint32_t num_cores,
     const CoreRangeSet& all_cores,
     const CoreRangeSet& core_group_1,
     uint32_t num_sticks_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_sticks_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
@@ -44,8 +41,6 @@ void emit_runtime_args_hc_rm(
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
 
     auto cores = corerange_to_cores(all_cores, std::nullopt);
-    reader_desc.runtime_args.reserve(num_cores);
-    writer_desc.runtime_args.reserve(num_cores);
 
     uint32_t curr_sticks_read = 0, curr_sticks_write = 0;
     for (const auto& core : cores) {
@@ -65,12 +60,22 @@ void emit_runtime_args_hc_rm(
             num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
         }
 
-        reader_desc.emplace_runtime_args(
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
             core,
-            {input_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
+            {{"num_sticks_per_core_read", num_sticks_per_core_read},
+             {"num_read_per_barrier", num_read_per_barrier},
+             {"start_id", curr_sticks_read},
+             {"curr_c", curr_c},
+             {"curr_h", curr_h},
+             {"curr_n", curr_n}});
 
-        writer_desc.emplace_runtime_args(
-            core, {output_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            core,
+            {{"num_sticks_per_core_read", num_sticks_per_core_read},
+             {"num_read_per_barrier", num_read_per_barrier},
+             {"start_id", curr_sticks_write}});
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -95,9 +100,19 @@ void emit_runtime_args_hc_rm(
 
 }  // namespace
 
-tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_program_artifacts(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    // Declared function-locally: this op's factories share one translation unit in the unity
+    // build, so file-scope names would collide across them.
+    const DFBSpecName IN0{"in0"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+
     const auto& input_tensor = tensor_args.input;
+    const auto& input = input_tensor.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
@@ -106,12 +121,10 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
     uint32_t NCH = N * C * H;
 
-    ProgramDescriptor desc;
-
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::DataFormat dfb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
     log_debug(tt::LogOp, "transpose_hc_rm");
-    log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
+    log_debug(tt::LogOp, "dfb_data_format: {}", dfb_data_format);
 
     IDevice* device = input_tensor.device();
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -122,8 +135,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
-
     auto num_sticks = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                 : num_sticks_per_core_group_2;
 
@@ -131,64 +142,79 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     uint32_t aligned_page = std::max(src0_buffer->aligned_page_size(), dst_buffer->aligned_page_size());
     auto stick_size = std::max(W * input_tensor.element_size(), aligned_page);
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_sticks * stick_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size,
-        }}},
+    ProgramSpec spec{.name = "transpose_hc_rm"};
+
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = IN0,
+        .entry_size = stick_size,
+        .num_entries = num_sticks,
+        .data_format_metadata = dfb_data_format,
     });
 
-    std::vector<uint32_t> reader_compile_time_args;
-    reader_compile_time_args.reserve(5);
-    reader_compile_time_args.push_back(N);
-    reader_compile_time_args.push_back(H);
-    reader_compile_time_args.push_back(C);
-    reader_compile_time_args.push_back(stick_size);
-    reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = INPUT, .spec = input_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()});
 
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
-    writer_compile_time_args.push_back(stick_size);
-    writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // The legacy factory also emitted `N` and an `aligned_page_size` on each kernel. Neither kernel
+    // ever read them (each one's TensorAccessorArgs boundary sat past those slots), so they carried
+    // no behavior and are not re-emitted here.
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = READER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                  "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp",
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "in0",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
+        .compile_time_args = {{"H", H}, {"C", C}, {"W_size_bytes", stick_size}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_sticks_per_core_read", "num_read_per_barrier", "start_id", "curr_c", "curr_h", "curr_n"}},
+        .hw_config = create_reader_datamovement_config(device->arch()),
+    });
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = WRITER,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                  "writer_unary_transpose_hc_interleaved_start_id_rm.cpp",
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "out0",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
+        .compile_time_args = {{"W_size_bytes", stick_size}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_sticks_per_core_read", "num_read_per_barrier", "start_id"}},
+        .hw_config = create_writer_datamovement_config(device->arch()),
+    });
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_hc_interleaved_start_id_rm.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "main",
+        .kernels = {READER, WRITER},
+        .target_nodes = all_cores,
+    });
+
+    ProgramRunArgs run_args;
+    ProgramRunArgs::KernelRunArgs reader_run_args{.kernel = READER};
+    ProgramRunArgs::KernelRunArgs writer_run_args{.kernel = WRITER};
 
     emit_runtime_args_hc_rm(
-        reader_desc,
-        writer_desc,
+        reader_run_args,
+        writer_run_args,
         input_tensor,
-        output_tensor,
-        num_cores,
         all_cores,
         core_group_1,
         num_sticks_per_core_group_1,
         core_group_2,
         num_sticks_per_core_group_2);
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    run_args.kernel_run_args.push_back(std::move(writer_run_args));
+    run_args.tensor_args.emplace(INPUT, input);
+    run_args.tensor_args.emplace(OUTPUT, output);
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.hpp
@@ -8,12 +8,12 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct TransposeHCRMProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -5,17 +5,17 @@
 #include "transpose_utils.hpp"
 
 #include "ttnn/operations/math.hpp"
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
@@ -28,10 +28,8 @@ namespace {
 // (start, end) pair from both. Writer also tracks the padded range; reader only
 // the unpadded count.
 void emit_runtime_args_hc_tiled_interleaved(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
+    ProgramRunArgs::KernelRunArgs& reader_run_args,
+    ProgramRunArgs::KernelRunArgs& writer_run_args,
     const CoreRangeSet& active_cores,
     const CoreRangeSet& core_group_1,
     uint32_t num_tiles_per_core_group_1,
@@ -41,9 +39,6 @@ void emit_runtime_args_hc_tiled_interleaved(
     uint32_t padded_num_tiles_per_core_group_1,
     const CoreRangeSet& padded_core_group_2,
     uint32_t padded_num_tiles_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-
     auto cores = corerange_to_cores(active_cores, std::nullopt);
 
     uint32_t start_idx = 0;
@@ -71,8 +66,15 @@ void emit_runtime_args_hc_tiled_interleaved(
         uint32_t end_idx = start_idx + num_tiles_per_core;
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
 
-        reader_desc.emplace_runtime_args(core, {input_buffer, num_tiles_per_core, start_idx});
-        writer_desc.emplace_runtime_args(core, {output_buffer, start_idx, end_idx, padded_start_idx, padded_end_idx});
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values, core, {{"num_tiles", num_tiles_per_core}, {"start_id", start_idx}});
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            core,
+            {{"start_tile_idx", start_idx},
+             {"end_tile_idx", end_idx},
+             {"start_padding_tile_idx", padded_start_idx},
+             {"end_padding_tile_idx", padded_end_idx}});
 
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;
@@ -81,26 +83,37 @@ void emit_runtime_args_hc_tiled_interleaved(
 
 }  // namespace
 
-tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFactory::create_program_artifacts(
     const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    // Declared function-locally: this op's factories share one translation unit in the unity
+    // build, so file-scope names would collide across them.
+    const DFBSpecName IN0{"in0"};
+    const DFBSpecName PAD{"pad"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+
     const auto& input_tensor = tensor_args.input;
+    const auto& input = input_tensor.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
     // pad_value is always defined at API level; padding is decided purely by shape
     const float pad_value = operation_attributes.pad_value;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
-    ProgramDescriptor desc;
     auto tile = input_tensor.tensor_spec().tile();
     auto tile_shape = tile.get_tile_shape();
     auto face_shape = tile.get_face_shape();
     uint32_t C = input_tensor.logical_shape()[1];
     bool needs_padding = (C % tile_shape[1] != 0);
 
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    tt::DataFormat dfb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(dfb_data_format);
 
-    auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+    IDevice* device = input_tensor.device();
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
 
     auto tile_hw = tile_shape[0] * tile_shape[1];
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / tile_hw;
@@ -120,33 +133,28 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
 
     CoreRangeSet active_cores = num_cores > padded_num_cores ? all_cores : padded_all_cores;
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t padding_cb_index = tt::CBIndex::c_1;
+    ProgramSpec spec{.name = "transpose_hc_tiled_interleaved"};
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = 2 * single_tile_size,
-        .core_ranges = active_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = IN0,
+        .entry_size = single_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = dfb_data_format,
     });
 
     auto max_padding_write = face_shape[0] * face_shape[1];
     if (needs_padding) {
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = max_padding_write * input_tensor.element_size(),
-            .core_ranges = active_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(padding_cb_index),
-                .data_format = cb_data_format,
-                .page_size = max_padding_write * input_tensor.element_size(),
-            }}},
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = PAD,
+            .entry_size = max_padding_write * input_tensor.element_size(),
+            .num_entries = 1,
+            .data_format_metadata = dfb_data_format,
         });
     }
 
-    Buffer* src_buffer = input_tensor.buffer();
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = INPUT, .spec = input_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()});
+
     uint32_t element_size = input_tensor.element_size();
     uint32_t padding_val_packed = 0;
     uint32_t num_writes = 0;
@@ -175,58 +183,96 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         }
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {};
-    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
-        {"num_writes", num_writes},
-        {"padding_val_packed", padding_val_packed},
-        {"needs_padding", needs_padding},
-        {"swap_hw", 0u},
-        {"H", 1u},
-        {"W", 1u},
-        {"accumulated_outer_dims", 1u},
-        {"tile_height", 1u},
-        {"tile_width", 1u},
+    // The reader is the shared Metal 2.0 fork that the permute op also binds; its binding
+    // vocabulary (dfb::cb_in0 / dfb::cb_pad / tensor::input, and the NEEDS_PADDING define that
+    // gates the padding buffer) is fixed by that kernel, so these accessor names conform to it.
+    KernelSpec::CompilerOptions::Defines reader_defines;
+    KernelSpec::CompilerOptions::Defines writer_defines;
+    if (needs_padding) {
+        reader_defines.insert({"NEEDS_PADDING", "1"});
+        writer_defines.insert({"NEEDS_PADDING", "1"});
+    }
+
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+            "reader_unary_transpose_hc_interleaved_tiled_padding_aware_metal2.cpp",
+        .compiler_options = {.defines = std::move(reader_defines)},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "cb_in0",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "input"}},
+        .compile_time_args =
+            {{"num_writes", num_writes},
+             {"padding_val_packed", padding_val_packed},
+             {"swap_hw", 0u},
+             {"H", 1u},
+             {"W", 1u},
+             {"accumulated_outer_dims", 1u},
+             {"tile_height", 1u},
+             {"tile_width", 1u}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
+        .hw_config = create_reader_datamovement_config(device->arch()),
     };
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = active_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+            "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp",
+        .compiler_options = {.defines = std::move(writer_defines)},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "out0",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
+        .compile_time_args =
+            {{"element_size", element_size},
+             {"C", C},
+             {"H", H},
+             {"W", W},
+             {"tile_height", tile_shape[0]},
+             {"tile_width", tile_shape[1]},
+             {"face_height", face_shape[0]},
+             {"face_width", face_shape[1]}},
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"start_tile_idx", "end_tile_idx", "start_padding_tile_idx", "end_padding_tile_idx"}},
+        .hw_config = create_writer_datamovement_config(device->arch()),
+    };
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    std::vector<uint32_t> writer_compile_time_args = {
-        element_size,
-        tt::CBIndex::c_0,
-        C,
-        H,
-        W,
-        tile_shape[0],
-        tile_shape[1],
-        face_shape[0],
-        face_shape[1],
-        static_cast<uint32_t>(needs_padding)};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    if (needs_padding) {
+        reader.dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = PAD,
+            .accessor_name = "cb_pad",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        });
+        writer.dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = PAD,
+            .accessor_name = "pad",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        });
+    }
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = active_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    spec.kernels.push_back(std::move(reader));
+    spec.kernels.push_back(std::move(writer));
+
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "main",
+        .kernels = {READER, WRITER},
+        .target_nodes = active_cores,
+    });
+
+    ProgramRunArgs run_args;
+    ProgramRunArgs::KernelRunArgs reader_run_args{.kernel = READER};
+    ProgramRunArgs::KernelRunArgs writer_run_args{.kernel = WRITER};
 
     emit_runtime_args_hc_tiled_interleaved(
-        reader_desc,
-        writer_desc,
-        input_tensor,
-        output_tensor,
+        reader_run_args,
+        writer_run_args,
         active_cores,
         core_group_1,
         num_tiles_per_core_group_1,
@@ -237,10 +283,12 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         padded_core_group_2,
         padded_num_tiles_per_core_group_2);
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    run_args.kernel_run_args.push_back(std::move(writer_run_args));
+    run_args.tensor_args.emplace(INPUT, input);
+    run_args.tensor_args.emplace(OUTPUT, output);
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
@@ -8,12 +8,12 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct TransposeHCTiledInterleavedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -3,94 +3,35 @@
 
 #include "transpose_hc_tiled_program_factory.hpp"
 
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
+
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-logger/tt-logger.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-namespace {
-
-void emit_runtime_args_hc_tiled(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    uint32_t num_cores,
-    const CoreRangeSet& all_cores,
-    const CoreRangeSet& core_group_1,
-    uint32_t num_tiles_per_core_group_1,
-    const CoreRangeSet& core_group_2,
-    uint32_t num_tiles_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
-
-    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
-    uint32_t HW = H * W;
-    uint32_t HW_bytes = HW * input_tensor.element_size();
-    uint32_t CHW_bytes = C * HW * input_tensor.element_size();
-
-    uint32_t Wt = W / TILE_WIDTH;
-    uint32_t Ct = C / TILE_HEIGHT;
-    uint32_t CtHWt = Ct * H * Wt;
-    uint32_t CtWt = Ct * Wt;
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    reader_desc.runtime_args.reserve(num_cores);
-    writer_desc.runtime_args.reserve(num_cores);
-
-    uint32_t num_tiles_read = 0;
-    for (const auto& core : cores) {
-        uint32_t num_tiles_per_core;
-
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
-
-        uint32_t h = num_tiles_read / CtWt % H;
-        uint32_t ct = num_tiles_read / Wt % Ct;
-
-        reader_desc.emplace_runtime_args(
-            core,
-            {input_buffer,
-             Wt,
-             H,
-             Ct,
-             HW_bytes,
-             CHW_bytes,
-             num_tiles_read,
-             num_tiles_per_core,
-             num_tiles_read / CtHWt * CHW_bytes,
-             h,
-             h / TILE_HEIGHT * Wt,
-             ct,
-             ct * TILE_HEIGHT * HW_bytes,
-             num_tiles_read % Wt});
-
-        writer_desc.emplace_runtime_args(core, {output_buffer, num_tiles_per_core, num_tiles_read});
-
-        num_tiles_read += num_tiles_per_core;
-    }
-}
-
-}  // namespace
-
-tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_program_artifacts(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    // Declared function-locally: this op's factories share one translation unit in the unity
+    // build, so file-scope names would collide across them.
+    const DFBSpecName IN0{"in0"};
+    const DFBSpecName SCRATCH{"scratch"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+
     const auto& input_tensor = tensor_args.input;
+    const auto& input = input_tensor.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
@@ -98,14 +39,12 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     uint32_t sub_tile_line_bytes = 16 * input_tensor.element_size();
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
 
-    ProgramDescriptor desc;
-
-    tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    tt::DataFormat dfb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(dfb_data_format);
 
     log_debug(tt::LogOp, "transpose_hc_tiled");
     log_debug(tt::LogOp, "sub_tile_line_bytes: {}", sub_tile_line_bytes);
-    log_debug(tt::LogOp, "cb_data_format: {}", cb_data_format);
+    log_debug(tt::LogOp, "dfb_data_format: {}", dfb_data_format);
     log_debug(tt::LogOp, "single_tile_size: {}", single_tile_size);
 
     IDevice* device = input_tensor.device();
@@ -117,88 +56,167 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
-    // check if we need to allocate a scratch buffer
-    // The kernel reads several 16 element face lines (32B for BFLOAT16) from different input tiles to form a single
-    // output tile, one output tile at a time Each face line is 32 bytes, so if our minimum read alignment is greater
-    // than that (64B for Blackhole) then we will have reads from unaligned face-lines into differently aligned
-    // destination face-lines
-    // TODO: noc_async_write only require 16B alignment for both DRAM and L1 for Blackhole, so instead of reading in
-    // face-lines from C tiles to form a single tile, we can load a single tile and then write out its face-lines to C
-    // tiles
     uint32_t alignment = dst_buffer->alignment();
     bool misaligned = alignment > sub_tile_line_bytes;
 
+    ProgramSpec spec{.name = "transpose_hc_tiled"};
+
     uint32_t num_input_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = IN0,
+        .entry_size = single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = dfb_data_format,
     });
 
-    // need some scratch memory here - if we need data from a misaligned address then we need to read from the
-    // nearest aligned address and then copy the data to the correct location
     if (misaligned) {
-        uint32_t src1_cb_index = 1;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = alignment,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(src1_cb_index),
-                .data_format = cb_data_format,
-                .page_size = alignment,
-            }}},
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = SCRATCH,
+            .entry_size = alignment,
+            .num_entries = 1,
+            .data_format_metadata = dfb_data_format,
         });
     }
 
-    Buffer* src0_buffer = input_tensor.buffer();
-    std::vector<uint32_t> reader_compile_time_args;
-    reader_compile_time_args.reserve(3);
-    reader_compile_time_args.push_back(sub_tile_line_bytes);
-    reader_compile_time_args.push_back(cb_data_format == tt::DataFormat::Float32 ? 1 : 0);
-    reader_compile_time_args.push_back(alignment);
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = INPUT, .spec = input_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()});
 
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    KernelSpec::CompilerOptions::Defines reader_defines;
+    if (misaligned) {
+        reader_defines.insert({"MISALIGNED", "1"});
+    }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_partitioned.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+            "reader_unary_transpose_hc_interleaved_partitioned.cpp",
+        .compiler_options = {.defines = std::move(reader_defines)},
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "in0",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"WT",
+                  "H",
+                  "CT",
+                  "HW_bytes",
+                  "CHW_bytes",
+                  "start_id",
+                  "num_tiles",
+                  "batch_addr",
+                  "h",
+                  "htWT",
+                  "ct",
+                  "ctoffs",
+                  "wt"}},
+        .hw_config = create_reader_datamovement_config(device->arch()),
+    };
+    reader.compile_time_args.insert({"subtile_line_bytes", sub_tile_line_bytes});
+    reader.compile_time_args.insert({"float32_dtype", dfb_data_format == tt::DataFormat::Float32 ? 1u : 0u});
+    if (misaligned) {
+        reader.compile_time_args.insert({"alignment", alignment});
+        // Only the reader touches the scratch buffer — it stages a NOC read there and copies
+        // out by hand — so it is both the producer and the consumer of that buffer.
+        reader.dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = SCRATCH,
+            .accessor_name = "scratch",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        });
+        reader.dfb_bindings.push_back(DFBBinding{
+            .dfb_spec_name = SCRATCH,
+            .accessor_name = "scratch",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        });
+    }
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // Shared Metal 2.0 writer from the eltwise/unary op; its binding vocabulary
+    // (dfb::out, tensor::dst) and named argument set are fixed by that kernel.
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+            "writer_unary_interleaved_start_id_metal2.cpp",
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "out",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = create_writer_datamovement_config(device->arch()),
+    };
 
-    emit_runtime_args_hc_tiled(
-        reader_desc,
-        writer_desc,
-        input_tensor,
-        output_tensor,
-        num_cores,
-        all_cores,
-        core_group_1,
-        num_tiles_per_core_group_1,
-        core_group_2,
-        num_tiles_per_core_group_2);
+    spec.kernels.push_back(std::move(reader));
+    spec.kernels.push_back(std::move(writer));
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "main",
+        .kernels = {READER, WRITER},
+        .target_nodes = all_cores,
+    });
 
-    return desc;
+    auto input_shape = input_tensor.padded_shape();
+    uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
+    uint32_t HW = H * W;
+    uint32_t HW_bytes = HW * input_tensor.element_size();
+    uint32_t CHW_bytes = C * HW * input_tensor.element_size();
+    uint32_t Wt = W / TILE_WIDTH;
+    uint32_t Ct = C / TILE_HEIGHT;
+    uint32_t CtHWt = Ct * H * Wt;
+    uint32_t CtWt = Ct * Wt;
+
+    ProgramRunArgs run_args;
+    ProgramRunArgs::KernelRunArgs reader_run_args{.kernel = READER};
+    ProgramRunArgs::KernelRunArgs writer_run_args{.kernel = WRITER};
+
+    auto cores = corerange_to_cores(all_cores, std::nullopt);
+    uint32_t num_tiles_read = 0;
+    for (const auto& core : cores) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        uint32_t h = num_tiles_read / CtWt % H;
+        uint32_t ct = num_tiles_read / Wt % Ct;
+
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values,
+            core,
+            {{"WT", Wt},
+             {"H", H},
+             {"CT", Ct},
+             {"HW_bytes", HW_bytes},
+             {"CHW_bytes", CHW_bytes},
+             {"start_id", num_tiles_read},
+             {"num_tiles", num_tiles_per_core},
+             {"batch_addr", num_tiles_read / CtHWt * CHW_bytes},
+             {"h", h},
+             {"htWT", h / TILE_HEIGHT * Wt},
+             {"ct", ct},
+             {"ctoffs", ct * TILE_HEIGHT * HW_bytes},
+             {"wt", num_tiles_read % Wt}});
+        AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values,
+            core,
+            {{"num_pages", num_tiles_per_core}, {"start_id", num_tiles_read}});
+
+        num_tiles_read += num_tiles_per_core;
+    }
+
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    run_args.kernel_run_args.push_back(std::move(writer_run_args));
+    run_args.tensor_args.emplace(INPUT, input);
+    run_args.tensor_args.emplace(OUTPUT, output);
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.hpp
@@ -8,12 +8,12 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct TransposeHCTiledProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -4,129 +4,36 @@
 #include "transpose_wh_program_factory.hpp"
 #include "transpose_utils.hpp"
 
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-namespace {
-
-void emit_runtime_args_wh_tiled(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& compute_desc,
-    KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    uint32_t num_cores,
-    const CoreRangeSet& all_cores,
-    const CoreRangeSet& core_group_1,
-    uint32_t num_tiles_per_core_group_1,
-    const CoreRangeSet& core_group_2,
-    uint32_t num_tiles_per_core_group_2) {
-    auto input_shape = input_tensor.padded_shape();
-
-    uint32_t W = input_shape[3], H = input_shape[2];
-
-    uint32_t Wt = W / TILE_WIDTH;
-    uint32_t Ht = H / TILE_HEIGHT;
-
-    auto HtWt = Ht * Wt;
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    reader_desc.runtime_args.reserve(num_cores);
-    compute_desc.runtime_args.reserve(num_cores);
-    writer_desc.runtime_args.reserve(num_cores);
-
-    uint32_t num_tiles_read = 0;
-    for (const auto& core : cores) {
-        uint32_t num_tiles_per_core;
-
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
-
-        uint32_t h = num_tiles_read % Ht;
-        uint32_t w = num_tiles_read / Ht % Wt;
-
-        reader_desc.emplace_runtime_args(
-            core,
-            {input_tensor.buffer(),
-             num_tiles_per_core,
-             tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
-             h,
-             w,
-             Ht,
-             Wt,
-             HtWt});
-
-        compute_desc.emplace_runtime_args(core, {num_tiles_per_core});
-
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, num_tiles_read});
-
-        num_tiles_read += num_tiles_per_core;
-    }
-}
-
-void emit_runtime_args_wh_rm(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& compute_desc,
-    KernelDescriptor& writer_desc,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    uint32_t num_cores,
-    const CoreRangeSet& all_cores,
-    const CoreRangeSet& core_group_1,
-    uint32_t num_hw_blocks_per_core_group_1,
-    const CoreRangeSet& core_group_2,
-    uint32_t num_hw_blocks_per_core_group_2) {
-    auto input_shape = input_tensor.logical_shape();
-
-    uint32_t W = input_shape[3], H = input_shape[2];
-
-    auto cores = corerange_to_cores(all_cores, std::nullopt);
-    reader_desc.runtime_args.reserve(num_cores);
-    compute_desc.runtime_args.reserve(num_cores);
-    writer_desc.runtime_args.reserve(num_cores);
-
-    uint32_t num_sticks_read = 0, num_sticks_write = 0;
-    for (const auto& core : cores) {
-        uint32_t num_hw_blocks_per_core;
-
-        if (core_group_1.contains(core)) {
-            num_hw_blocks_per_core = num_hw_blocks_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_hw_blocks_per_core = num_hw_blocks_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
-
-        reader_desc.emplace_runtime_args(core, {input_tensor.buffer(), num_sticks_read, num_hw_blocks_per_core});
-
-        compute_desc.emplace_runtime_args(core, {num_hw_blocks_per_core});
-
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_sticks_write, num_hw_blocks_per_core});
-
-        num_sticks_read += num_hw_blocks_per_core * H;
-        num_sticks_write += num_hw_blocks_per_core * W;
-    }
-}
-
-}  // namespace
-
-tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_program_artifacts(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    // Declared function-locally: this op's factories share one translation unit in the unity
+    // build, so file-scope names would collide across them.
+    const DFBSpecName IN0{"in0"};
+    const DFBSpecName OUT{"out"};
+    const DFBSpecName TILIZE{"tilize"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE{"compute"};
+
     const auto& input_tensor = tensor_args.input;
+    const auto& input = input_tensor.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
@@ -135,23 +42,19 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     uint32_t W = input_tensor.logical_shape()[3], H = input_tensor.logical_shape()[2];
     uint32_t NC = input_tensor.logical_shape()[1] * input_tensor.logical_shape()[0];
     bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
-
     uint32_t ht = (H + TILE_HEIGHT - 1) / TILE_HEIGHT;
     uint32_t wt = (W + TILE_WIDTH - 1) / TILE_WIDTH;
 
-    ProgramDescriptor desc;
+    tt::DataFormat src0_dfb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t src0_single_tile_size = tt::tile_size(src0_dfb_data_format);
+    tt::DataFormat dst_dfb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
+    uint32_t dst_single_tile_size = tt::tile_size(dst_dfb_data_format);
 
-    tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
-    tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
-    uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
-
-    Buffer* src0_buffer = input_tensor.buffer();
     IDevice* device = input_tensor.device();
 
-    bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32 ||
-                            src0_cb_data_format == tt::DataFormat::Int32 ||
-                            src0_cb_data_format == tt::DataFormat::UInt32;
+    bool fp32_dest_acc_en = src0_dfb_data_format == tt::DataFormat::Float32 ||
+                            src0_dfb_data_format == tt::DataFormat::Int32 ||
+                            src0_dfb_data_format == tt::DataFormat::UInt32;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
 
@@ -161,177 +64,270 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
+    ProgramSpec spec{.name = "transpose_wh"};
+
     uint32_t num_input_tiles = row_major ? wt * 2 : 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * src0_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = src0_single_tile_size,
-        }}},
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = IN0,
+        .entry_size = src0_single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = src0_dfb_data_format,
     });
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = row_major ? ht * 2 : 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * dst_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = dst_single_tile_size,
-        }}},
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = OUT,
+        .entry_size = dst_single_tile_size,
+        .num_entries = num_output_tiles,
+        .data_format_metadata = dst_dfb_data_format,
     });
 
     if (row_major) {
-        uint32_t im_cb_index = 24;
+        // Tilize intermediate: the compute kernel both fills it (tilize) and drains it
+        // (transpose), so it is self-looped onto that one kernel.
         uint32_t num_im_tiles = ht * wt;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = num_im_tiles * src0_single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(im_cb_index),
-                .data_format = src0_cb_data_format,
-                .page_size = src0_single_tile_size,
-            }}},
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = TILIZE,
+            .entry_size = src0_single_tile_size,
+            .num_entries = num_im_tiles,
+            .data_format_metadata = src0_dfb_data_format,
         });
-        // TODO REMOVE
-        uint32_t im2_cb_index = 25;
-        uint32_t num_im2_tiles = ht;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = num_im2_tiles * dst_single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(im2_cb_index),
-                .data_format = dst_cb_data_format,
-                .page_size = dst_single_tile_size,
-            }}},
-        });
+        // The legacy factory also allocated a second intermediate (c_25, "im2") on this path,
+        // carrying a TODO to remove it. No kernel this factory binds ever referenced it — the
+        // row-major compute kernel uses that index only under SHARDED, which only the sharded
+        // row-major factory defines — so it is not re-created here.
     }
 
-    std::vector<uint32_t> reader_compile_time_args;
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = INPUT, .spec = input_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()});
+
+    // ---- reader ----
+    KernelSpec reader{
+        .unique_id = READER,
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "in0",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
+        .hw_config = create_reader_datamovement_config(device->arch()),
+    };
     if (row_major) {
-        reader_compile_time_args.reserve(9);
-        reader_compile_time_args.push_back(ht);
-        reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
-        reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
-        reader_compile_time_args.push_back(wt);
-        reader_compile_time_args.push_back(W);
-        reader_compile_time_args.push_back(ht * wt);
-        reader_compile_time_args.push_back(W * input_tensor.element_size());
-        reader_compile_time_args.push_back(wt * input_tensor.element_size() * TILE_WIDTH);
-        reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
+        reader.source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+            "reader_unary_transpose_wh_interleaved_start_id_rm.cpp";
+        reader.compile_time_args = {
+            {"Ht", ht},
+            {"H_per_tile", H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT},
+            {"H_per_tile_last", H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT},
+            {"Wt", wt},
+            {"W_size_bytes", W * input_tensor.element_size()},
+            {"l1_write_offset_bytes", wt * input_tensor.element_size() * TILE_WIDTH}};
+        reader.runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_hw_blocks_per_core"}};
+    } else {
+        reader.source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+            "reader_unary_transpose_wh_interleaved_start_id.cpp";
+        reader.runtime_arg_schema = {
+            .runtime_arg_names = {"num_tiles", "start_id", "start_ht", "start_wt", "Ht", "Wt", "HtWt"}};
     }
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
 
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
+    // ---- writer ----
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .hw_config = create_writer_datamovement_config(device->arch()),
+    };
     if (row_major) {
-        writer_compile_time_args.push_back(ht);
-        writer_compile_time_args.push_back(H);
-        writer_compile_time_args.push_back(wt);
-        writer_compile_time_args.push_back(W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH);
-        writer_compile_time_args.push_back(W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH);
-        writer_compile_time_args.push_back(ht * wt);
-        writer_compile_time_args.push_back(H * output_tensor.element_size());
-        writer_compile_time_args.push_back(ht * output_tensor.element_size() * TILE_HEIGHT);
-        writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
-    }
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source = row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                                            "reader_unary_transpose_wh_interleaved_start_id_rm.cpp"
-                                          : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                                            "reader_unary_transpose_wh_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        row_major
-            ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-              "writer_unary_transpose_wh_interleaved_start_id_rm.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    std::vector<uint32_t> compute_kernel_args = {};
-    if (row_major) {
-        compute_kernel_args.reserve(3);
-        compute_kernel_args.push_back(ht);
-        compute_kernel_args.push_back(wt);
-        compute_kernel_args.push_back(ht * wt);
+        writer.source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+            "writer_unary_transpose_wh_interleaved_start_id_rm.cpp";
+        writer.dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT,
+            .accessor_name = "out",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }};
+        writer.tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}};
+        writer.compile_time_args = {
+            {"Ht", ht},
+            {"Wt", wt},
+            {"W_per_tile", W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH},
+            {"W_per_tile_last", W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH},
+            {"H_size_bytes", H * output_tensor.element_size()},
+            {"l1_read_offset_bytes", ht * output_tensor.element_size() * TILE_HEIGHT}};
+        writer.runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_hw_blocks_per_core"}};
+    } else {
+        // Shared Metal 2.0 writer from the eltwise/unary op; its binding vocabulary
+        // (dfb::out, tensor::dst) and named argument set are fixed by that kernel.
+        writer.source =
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/"
+            "writer_unary_interleaved_start_id_metal2.cpp";
+        writer.dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT,
+            .accessor_name = "out",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }};
+        writer.tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}};
+        writer.runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}};
     }
 
-    KernelDescriptor::Defines compute_defines;
+    // ---- compute ----
+    KernelSpec::CompilerOptions::Defines compute_defines;
     if (row_major && (input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::INT32)) {
-        compute_defines.emplace_back("DST_ACCUM_MODE", "1");
+        compute_defines.insert({"DST_ACCUM_MODE", "1"});
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (src0_cb_data_format == tt::DataFormat::Float32) {
-        // Keep the source CB in full Float32 on the unpack-to-dest path. In
-        // the row-major kernel, the tile-formatted intermediate (c_24) also
-        // feeds the transpose, so it needs the same treatment.
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+
+    // Legacy built a ComputeConfigDescriptor directly (no TTNN ComputeKernelConfig feeding it),
+    // setting only fp32_dest_acc_en and unpack_to_dest_mode; every other field kept its Metal
+    // default, which ComputeGen1Config reproduces.
+    ComputeGen1Config compute_hw{.enable_32_bit_dest = fp32_dest_acc_en};
+    if (src0_dfb_data_format == tt::DataFormat::Float32) {
+        compute_hw.unpack_modes.insert({IN0, UnpackMode::UnpackToDest});
         if (row_major) {
-            unpack_to_dest_mode[static_cast<std::size_t>(tt::CBIndex::c_24)] =
-                tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            compute_hw.unpack_modes.insert({TILIZE, UnpackMode::UnpackToDest});
         }
     }
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source =
-        row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp"
-                  : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = std::move(compute_kernel_args);
-    compute_desc.defines = std::move(compute_defines);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    KernelSpec compute{
+        .unique_id = COMPUTE,
+        // Legacy left opt_level unset on a ComputeConfigDescriptor, which resolves to O3;
+        // a Metal 2.0 KernelSpec defaults to O2, so the level is restated explicitly here.
+        .compiler_options = {.defines = std::move(compute_defines), .opt_level = KernelBuildOptLevel::O3},
+        .hw_config = compute_hw,
     };
-
     if (row_major) {
-        emit_runtime_args_wh_rm(
-            reader_desc,
-            compute_desc,
-            writer_desc,
-            input_tensor,
-            output_tensor,
-            num_cores,
-            all_cores,
-            core_group_1,
-            num_tiles_per_core_group_1,
-            core_group_2,
-            num_tiles_per_core_group_2);
+        compute.source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm_metal2.cpp";
+        compute.dfb_bindings = {
+            DFBBinding{
+                .dfb_spec_name = IN0,
+                .accessor_name = "in0",
+                .endpoint_type = DFBEndpointType::CONSUMER,
+            },
+            DFBBinding{
+                .dfb_spec_name = OUT,
+                .accessor_name = "out",
+                .endpoint_type = DFBEndpointType::PRODUCER,
+            },
+            // Self-loop: this kernel tilizes into the intermediate and transposes back out of it.
+            DFBBinding{
+                .dfb_spec_name = TILIZE,
+                .accessor_name = "tilize",
+                .endpoint_type = DFBEndpointType::PRODUCER,
+            },
+            DFBBinding{
+                .dfb_spec_name = TILIZE,
+                .accessor_name = "tilize",
+                .endpoint_type = DFBEndpointType::CONSUMER,
+            }};
+        compute.compile_time_args = {{"Ht", ht}, {"Wt", wt}, {"HtWt", ht * wt}};
+        compute.runtime_arg_schema = {.runtime_arg_names = {"num_hw_blocks_per_core"}};
     } else {
-        emit_runtime_args_wh_tiled(
-            reader_desc,
-            compute_desc,
-            writer_desc,
-            input_tensor,
-            output_tensor,
-            num_cores,
-            all_cores,
-            core_group_1,
-            num_tiles_per_core_group_1,
-            core_group_2,
-            num_tiles_per_core_group_2);
+        // Shared Metal 2.0 compute fork (the legacy copy alongside it is still bound by the
+        // qkv-heads ops); its binding vocabulary (dfb::cb_in / dfb::cb_out) is fixed by that kernel.
+        compute.source =
+            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_metal2.cpp";
+        compute.dfb_bindings = {
+            DFBBinding{
+                .dfb_spec_name = IN0,
+                .accessor_name = "cb_in",
+                .endpoint_type = DFBEndpointType::CONSUMER,
+            },
+            DFBBinding{
+                .dfb_spec_name = OUT,
+                .accessor_name = "cb_out",
+                .endpoint_type = DFBEndpointType::PRODUCER,
+            }};
+        compute.runtime_arg_schema = {.runtime_arg_names = {"NHtWt"}};
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    spec.kernels.push_back(std::move(reader));
+    spec.kernels.push_back(std::move(writer));
+    spec.kernels.push_back(std::move(compute));
 
-    return desc;
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "main",
+        .kernels = {READER, WRITER, COMPUTE},
+        .target_nodes = all_cores,
+    });
+
+    // ---- run args ----
+    ProgramRunArgs run_args;
+    ProgramRunArgs::KernelRunArgs reader_run_args{.kernel = READER};
+    ProgramRunArgs::KernelRunArgs writer_run_args{.kernel = WRITER};
+    ProgramRunArgs::KernelRunArgs compute_run_args{.kernel = COMPUTE};
+
+    auto cores = corerange_to_cores(all_cores, std::nullopt);
+
+    if (row_major) {
+        auto rm_shape = input_tensor.logical_shape();
+        uint32_t rm_W = rm_shape[3], rm_H = rm_shape[2];
+        uint32_t num_sticks_read = 0, num_sticks_write = 0;
+        for (const auto& core : cores) {
+            uint32_t num_hw_blocks_per_core;
+            if (core_group_1.contains(core)) {
+                num_hw_blocks_per_core = num_tiles_per_core_group_1;
+            } else if (core_group_2.contains(core)) {
+                num_hw_blocks_per_core = num_tiles_per_core_group_2;
+            } else {
+                TT_THROW("Core not in specified core ranges");
+            }
+            AddRuntimeArgsForNode(
+                reader_run_args.runtime_arg_values,
+                core,
+                {{"start_id", num_sticks_read}, {"num_hw_blocks_per_core", num_hw_blocks_per_core}});
+            AddRuntimeArgsForNode(
+                compute_run_args.runtime_arg_values, core, {{"num_hw_blocks_per_core", num_hw_blocks_per_core}});
+            AddRuntimeArgsForNode(
+                writer_run_args.runtime_arg_values,
+                core,
+                {{"start_id", num_sticks_write}, {"num_hw_blocks_per_core", num_hw_blocks_per_core}});
+            num_sticks_read += num_hw_blocks_per_core * rm_H;
+            num_sticks_write += num_hw_blocks_per_core * rm_W;
+        }
+    } else {
+        auto tiled_shape = input_tensor.padded_shape();
+        uint32_t tiled_W = tiled_shape[3], tiled_H = tiled_shape[2];
+        uint32_t Wt_t = tiled_W / TILE_WIDTH;
+        uint32_t Ht_t = tiled_H / TILE_HEIGHT;
+        auto HtWt = Ht_t * Wt_t;
+        uint32_t num_tiles_read = 0;
+        for (const auto& core : cores) {
+            uint32_t num_tiles_per_core;
+            if (core_group_1.contains(core)) {
+                num_tiles_per_core = num_tiles_per_core_group_1;
+            } else if (core_group_2.contains(core)) {
+                num_tiles_per_core = num_tiles_per_core_group_2;
+            } else {
+                TT_THROW("Core not in specified core ranges");
+            }
+            uint32_t h = num_tiles_read % Ht_t;
+            uint32_t w = num_tiles_read / Ht_t % Wt_t;
+            AddRuntimeArgsForNode(
+                reader_run_args.runtime_arg_values,
+                core,
+                {{"num_tiles", num_tiles_per_core},
+                 {"start_id", tt::round_down(num_tiles_read, HtWt) + (h * Wt_t) + w},
+                 {"start_ht", h},
+                 {"start_wt", w},
+                 {"Ht", Ht_t},
+                 {"Wt", Wt_t},
+                 {"HtWt", HtWt}});
+            AddRuntimeArgsForNode(compute_run_args.runtime_arg_values, core, {{"NHtWt", num_tiles_per_core}});
+            AddRuntimeArgsForNode(
+                writer_run_args.runtime_arg_values,
+                core,
+                {{"num_pages", num_tiles_per_core}, {"start_id", num_tiles_read}});
+            num_tiles_read += num_tiles_per_core;
+        }
+    }
+
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    run_args.kernel_run_args.push_back(std::move(writer_run_args));
+    run_args.kernel_run_args.push_back(std::move(compute_run_args));
+    run_args.tensor_args.emplace(INPUT, input);
+    run_args.tensor_args.emplace(OUTPUT, output);
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.hpp
@@ -8,12 +8,12 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct TransposeWHProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -3,38 +3,50 @@
 
 #include "transpose_wh_sharded_program_factory.hpp"
 
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
+
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-
 #include <algorithm>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::create_program_artifacts(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    // Declared function-locally: this op's factories share one translation unit in the unity
+    // build, so file-scope names would collide across them.
+    const DFBSpecName IN0{"in0"};
+    const DFBSpecName OUT{"out"};
+    const TensorParamName INPUT{"input"};
+    const TensorParamName OUTPUT{"output"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE{"compute"};
+
     const auto& input_tensor = tensor_args.input;
+    const auto& input = input_tensor.mesh_tensor();
+    const auto& output = output_tensor.mesh_tensor();
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
 
-    ProgramDescriptor desc;
-
-    tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
-    tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
-    uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
+    tt::DataFormat src0_dfb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t src0_single_tile_size = tt::tile_size(src0_dfb_data_format);
+    tt::DataFormat dst_dfb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
+    uint32_t dst_single_tile_size = tt::tile_size(dst_dfb_data_format);
 
     const auto tile = input_tensor.tensor_spec().tile();
     const uint32_t tile_hw = tile.get_tile_hw();
 
     IDevice* device = input_tensor.device();
 
-    bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32;
+    bool fp32_dest_acc_en = src0_dfb_data_format == tt::DataFormat::Float32;
+
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
@@ -42,126 +54,141 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
 
     auto shard_spec = input_tensor.shard_spec().value();
     bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-
     auto& all_cores = shard_spec.grid;
     uint32_t num_tiles_per_shard = shard_spec.numel() / tile_hw;
 
-    // Sharded CBs: total_size depends on num_tiles_per_shard which can vary across
-    // cache hits; .buffer triggers UpdateDynamicCircularBufferAddress. total_size
-    // is not in the program hash so the framework re-applies the combined update
-    // via apply_descriptor_runtime_args.
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t num_input_tiles = num_tiles_per_shard;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * src0_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = src0_single_tile_size,
-        }}},
-        .buffer = input_tensor.buffer(),
+    ProgramSpec spec{.name = "transpose_wh_sharded"};
+
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = INPUT, .spec = input_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = OUTPUT, .spec = output_tensor.tensor_spec()});
+
+    // Both buffers are built on the io tensors' own sharded L1 memory rather than on
+    // Program-lifetime storage, so the compute kernel transposes the resident shard in place.
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = IN0,
+        .entry_size = src0_single_tile_size,
+        .num_entries = num_tiles_per_shard,
+        .data_format_metadata = src0_dfb_data_format,
+        .borrowed_from = INPUT,
+    });
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = OUT,
+        .entry_size = dst_single_tile_size,
+        .num_entries = num_tiles_per_shard,
+        .data_format_metadata = dst_dfb_data_format,
+        .borrowed_from = OUTPUT,
     });
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = num_tiles_per_shard;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * dst_single_tile_size,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = dst_single_tile_size,
-        }}},
-        .buffer = output_tensor.buffer(),
+    // Reader and writer are shared Metal 2.0 forks owned by the eltwise/unary and
+    // data_movement/sharded ops; their binding vocabulary and named argument sets are fixed
+    // by those kernels.
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = READER,
+        .source = "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded_metal2.cpp",
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = IN0,
+            .accessor_name = "in",
+            .endpoint_type = DFBEndpointType::PRODUCER,
+        }},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
+        .hw_config = create_reader_datamovement_config(device->arch()),
     });
 
-    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    std::vector<uint32_t> compute_compile_time_args = {src0_cb_index, output_cb_index};
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_metal2.cpp",
+        .dfb_bindings = {DFBBinding{
+            .dfb_spec_name = OUT,
+            .accessor_name = "out",
+            .endpoint_type = DFBEndpointType::CONSUMER,
+        }},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_units"}},
+        .hw_config = create_writer_datamovement_config(device->arch()),
+    });
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = total_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = total_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (src0_cb_data_format == tt::DataFormat::Float32) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    // Legacy built a ComputeConfigDescriptor directly, setting only fp32_dest_acc_en and
+    // unpack_to_dest_mode; every other field kept its Metal default, which ComputeGen1Config
+    // reproduces.
+    ComputeGen1Config compute_hw{.enable_32_bit_dest = fp32_dest_acc_en};
+    if (src0_dfb_data_format == tt::DataFormat::Float32) {
+        compute_hw.unpack_modes.insert({IN0, UnpackMode::UnpackToDest});
     }
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = total_cores;
-    compute_desc.compile_time_args = std::move(compute_compile_time_args);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
-    };
+    spec.kernels.push_back(KernelSpec{
+        .unique_id = COMPUTE,
+        .source = "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/"
+                  "transpose_wh_sharded_metal2.cpp",
+        // Legacy left opt_level unset on a ComputeConfigDescriptor, which resolves to O3;
+        // a Metal 2.0 KernelSpec defaults to O2, so the level is restated explicitly here.
+        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
+        .dfb_bindings =
+            {DFBBinding{
+                 .dfb_spec_name = IN0,
+                 .accessor_name = "in",
+                 .endpoint_type = DFBEndpointType::CONSUMER,
+             },
+             DFBBinding{
+                 .dfb_spec_name = OUT,
+                 .accessor_name = "out",
+                 .endpoint_type = DFBEndpointType::PRODUCER,
+             }},
+        .runtime_arg_schema = {.runtime_arg_names = {"NHtWt", "HtWt", "N", "Ht", "Wt"}},
+        .hw_config = compute_hw,
+    });
+
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "main",
+        .kernels = {READER, WRITER, COMPUTE},
+        .target_nodes = total_cores,
+    });
 
     auto padded_shape = input_tensor.padded_shape();
     auto shard_shape = shard_spec.shape;
-
     uint32_t H = padded_shape[2];
     uint32_t Hs = shard_shape[0], Ws = shard_shape[1];
-
     uint32_t Hts = Hs / tile.get_height();
     uint32_t Wts = Ws / tile.get_width();
-
     uint32_t Ht = H / tile.get_height();
     uint32_t Ht_per_shard = std::min(Ht, Hts);
-
     uint32_t num_hw_blocks_per_shard = Hts > Ht ? Hts / Ht : 1;
-
     uint32_t HtWt_tile_size = Ht_per_shard * Wts;
     uint32_t num_blocks = num_hw_blocks_per_shard * HtWt_tile_size;
 
     auto bbox = all_cores.bounding_box();
     std::vector<CoreCoord> cores =
         grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
-
-    // Active shard cores get the real arg values; the trailing no-op cores keep the
-    // default-constructed slots (matching legacy std::fill behavior on cores.size()).
-    const std::vector<uint32_t> reader_rt = {num_blocks};
-    const std::vector<uint32_t> compute_rt = {num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts};
-    const std::vector<uint32_t> writer_rt = {num_blocks};
-
     const uint32_t num_active = all_cores.num_cores();
-    reader_desc.runtime_args.reserve(cores.size());
-    compute_desc.runtime_args.reserve(cores.size());
-    writer_desc.runtime_args.reserve(cores.size());
+
+    ProgramRunArgs run_args;
+    ProgramRunArgs::KernelRunArgs reader_run_args{.kernel = READER};
+    ProgramRunArgs::KernelRunArgs writer_run_args{.kernel = WRITER};
+    ProgramRunArgs::KernelRunArgs compute_run_args{.kernel = COMPUTE};
+
+    // Cores outside the shard grid still run the kernels; legacy handed them a zero-filled
+    // argument set so they fall straight through their loops, and that is preserved here.
     for (uint32_t i = 0; i < cores.size(); ++i) {
-        if (i < num_active) {
-            reader_desc.runtime_args.emplace_back(cores[i], reader_rt);
-            compute_desc.runtime_args.emplace_back(cores[i], compute_rt);
-            writer_desc.runtime_args.emplace_back(cores[i], writer_rt);
-        } else {
-            // No-op core: matches legacy std::vector<uint32_t>(1)/(5) zero-initialized rows.
-            reader_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
-            compute_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(5));
-            writer_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
-        }
+        const bool active = i < num_active;
+        AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values, cores[i], {{"num_tiles_per_core", active ? num_blocks : 0}});
+        AddRuntimeArgsForNode(writer_run_args.runtime_arg_values, cores[i], {{"num_units", active ? num_blocks : 0}});
+        AddRuntimeArgsForNode(
+            compute_run_args.runtime_arg_values,
+            cores[i],
+            {{"NHtWt", active ? num_blocks : 0},
+             {"HtWt", active ? HtWt_tile_size : 0},
+             {"N", active ? num_hw_blocks_per_shard : 0},
+             {"Ht", active ? Ht_per_shard : 0},
+             {"Wt", active ? Wts : 0}});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    run_args.kernel_run_args.push_back(std::move(writer_run_args));
+    run_args.kernel_run_args.push_back(std::move(compute_run_args));
+    run_args.tensor_args.emplace(INPUT, input);
+    run_args.tensor_args.emplace(OUTPUT, output);
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.hpp
@@ -8,12 +8,12 @@
 #include "ttnn/device_operation.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct TransposeWHShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 


### PR DESCRIPTION
## What

Ports the **six audit-cleared factories** of `TransposeDeviceOperation` from the legacy `ProgramDescriptor` API (`create_descriptor`) to Metal 2.0 `ProgramSpecFactoryConcept` (`create_program_artifacts`):

- `TransposeCNProgramFactory`
- `TransposeHCRMProgramFactory`
- `TransposeHCTiledInterleavedProgramFactory`
- `TransposeHCTiledProgramFactory`
- `TransposeWHProgramFactory` (tiled **and** row-major)
- `TransposeWHShardedProgramFactory`

The two gated factories (`TransposeHCShardedProgramFactory`, `TransposeWHShardedRMProgramFactory`) stay on the descriptor path — the pre-port audit is RED at op level for them. `program_factory_t` therefore holds a **mix** of concepts and `std::visit` dispatches per factory, which builds and runs correctly.

The diff is confined entirely to the op directory (29 files).

## Verification

Wormhole n150. Metal 2.0 legality checks were forced on at all 9 `skip_validation` sites and **proven live in the binary under test** (both `METAL2_CHECKS_FORCED` markers firing, 1656 hits across the run). The forcing scaffolding was reverted before commit — no `tt_metal/` file appears in the diff.

| | passed | failed | skipped |
|---|---|---|---|
| **Baseline** (pre-port, taken before the first kernel edit) | 1075 | **0** | 75 |
| **Post-port** | 1075 | **0** | 75 |

Test set covers transpose plus every peer op affected by a shared kernel this port touches or reuses: `misc/test_transpose.py`, `base_functionality/test_reshape_transpose.py`, `sweep_tests/tt_dnn/test_transpose.py`, `sweep_tests/tt_dnn/test_permute.py`, `misc/test_create_qkv_heads.py`, `misc/test_nlp_create_qkv_heads{,_boltz,_vit}.py`, `operations/transformers/test_transformer.py`.

Factory routing was verified in the built library rather than inferred: all six ported factories resolve to `ProgramSpecMeshWorkloadFactoryAdapter<...>` under `nm -C`, and both gated factories resolve to neither adapter template.

## Notable findings

**1. `transpose_wh_rm.cpp` is an intra-op shared kernel the audit brief did not flag.** It is bound both by the in-scope `TransposeWHProgramFactory` (compiled without `SHARDED`) and by the **gated** `TransposeWHShardedRMProgramFactory` (compiled with `SHARDED=1`). Converting it in place would have compiled `dfb::`/`args::` tokens into a source that a legacy `CreateKernel` path still builds — which emits no generated headers — surfacing as `'args' has not been declared` at JIT time, on the sharded-RM tests only, after the port otherwise looked green. Handled by forking to `transpose_wh_rm_metal2.cpp` (non-sharded path only) with a pointer comment in the legacy original. A factory×kernel overlap check across all eight factories confirmed this is the only such collision.

**2. The audit is stale on the gate rationale for the two blocked factories.** Commit `383674438e5` (#52566) moved transpose off `get_dynamic_runtime_args` onto `override_runtime_arguments`, so the audit's cited hook no longer exists. No effect on this port's scope — the six in-scope factories carry no override, so the base concept still applies — but when the gated two clear their remaining gate, they now route to `CustomProgramSpecFactoryConcept`, **not** the base concept the audit recorded.

**3. Both compute kernels would have silently dropped an optimization level.** Legacy resolves `O3` from an unset `ComputeConfigDescriptor` field; a Metal 2.0 `KernelSpec` defaults to `O2`. Both now set `KernelBuildOptLevel::O3` explicitly. No build, validator, or test signal would have caught this.

Dead plumbing found and deliberately **not** fixed (preserved and written up in the port report): an unused `C` RTA in the CN reader, and unread `aligned_page_size` CTA slots in HC-RM. The one exception is the dead `c_25` (im2) buffer on the WH row-major path — it carried an existing `// TODO REMOVE`, was bound by no kernel, and a bindingless DFB is rejected by the validator, so its allocation is dropped.

## Relationship to #50957

#50957 is an earlier port of the same six factories, made against a base that is now 312 commits behind `main` and whose report states it was never built or tested. This PR is a fresh port against current `main`, run through the current recipe, built and verified on device. **These two should not both land** — pick one and close the other.

## Artifacts

`METAL2_PREPORT_AUDIT.md`, `METAL2_PORT_BRIEF.md`, `METAL2_PORT_PLAN.md` and `METAL2_PORT_REPORT.md` are committed in the op directory for review. Per the porting workflow these are **vetting artifacts and must be deleted from the branch before the final merge** — they are not meant to reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-port-transpose-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/metal2-port-transpose-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/metal2-port-transpose-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/metal2-port-transpose-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/metal2-port-transpose-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/metal2-port-transpose-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/metal2-port-transpose-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/metal2-port-transpose-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/metal2-port-transpose-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/metal2-port-transpose-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/metal2-port-transpose-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/metal2-port-transpose-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/metal2-port-transpose-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/metal2-port-transpose-v2)