### PR TITLE
[Cleanup] Reducing `MeshDevice::get_devices` usage

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -25,11 +25,10 @@
 using namespace tt::tt_metal;
 namespace unit_tests::test_l1_banking_allocator {
 
-uint64_t get_alloc_limit(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto* device = mesh_device->get_devices()[0];
+uint64_t get_alloc_limit(distributed::MeshDevice& mesh_device) {
     const metal_SocDescriptor& soc_desc =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-    uint32_t l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(mesh_device.get_device_ids()[0]);
+    uint32_t l1_unreserved_base = mesh_device.allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const uint32_t interleaved_l1_bank_size = soc_desc.worker_l1_size - l1_unreserved_base;
     return interleaved_l1_bank_size;
 }
@@ -38,11 +37,11 @@ uint64_t get_alloc_limit(const std::shared_ptr<distributed::MeshDevice>& mesh_de
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceSingleCardBufferFixture, TestL1BuffersAllocatedTopDown) {
+TEST_F(UnitMeshFixture, TestL1BuffersAllocatedTopDown) {
     std::vector<uint32_t> alloc_sizes = {32 * 1024, 64 * 1024, 128 * 1024};
     size_t total_size_bytes = 0;
 
-    uint64_t alloc_limit = unit_tests::test_l1_banking_allocator::get_alloc_limit(this->devices_[0]);
+    uint64_t alloc_limit = unit_tests::test_l1_banking_allocator::get_alloc_limit(this->device());
 
     std::vector<std::shared_ptr<distributed::MeshBuffer>> buffers;
     int alloc_size_idx = 0;
@@ -56,20 +55,19 @@ TEST_F(MeshDeviceSingleCardBufferFixture, TestL1BuffersAllocatedTopDown) {
         distributed::DeviceLocalBufferConfig local_config{.page_size = buffer_size, .buffer_type = BufferType::L1};
         distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
         std::shared_ptr<distributed::MeshBuffer> buffer =
-            distributed::MeshBuffer::create(buffer_config, local_config, this->devices_[0].get());
+            distributed::MeshBuffer::create(buffer_config, local_config, &this->device());
         buffers.emplace_back(std::move(buffer));
         total_buffer_size += buffer_size;
-        EXPECT_EQ(buffers.back()->address(), this->devices_[0]->l1_size_per_core() - total_buffer_size);
+        EXPECT_EQ(buffers.back()->address(), this->device().l1_size_per_core() - total_buffer_size);
     }
     buffers.clear();
 }
 
-TEST_F(MeshDeviceSingleCardBufferFixture, TestL1BuffersDoNotGrowBeyondBankSize) {
-    uint64_t alloc_limit = unit_tests::test_l1_banking_allocator::get_alloc_limit(this->devices_[0]);
+TEST_F(UnitMeshFixture, TestL1BuffersDoNotGrowBeyondBankSize) {
+    uint64_t alloc_limit = unit_tests::test_l1_banking_allocator::get_alloc_limit(this->device());
     distributed::DeviceLocalBufferConfig local_config{.page_size = alloc_limit + 64, .buffer_type = BufferType::L1};
     distributed::ReplicatedBufferConfig buffer_config{.size = alloc_limit + 64};
-    EXPECT_ANY_THROW(
-        auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, this->devices_[0].get()));
+    EXPECT_ANY_THROW(auto buffer = distributed::MeshBuffer::create(buffer_config, local_config, &this->device()));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -62,7 +62,6 @@ struct LiveTcSnapshot {
 
 inline LiveTcSnapshot read_live_tcs(
     distributed::MeshDevice& unit_mesh, const CoreCoord& logical_core, uint32_t neo_id) {
-    IDevice* device = unit_mesh.get_devices()[0];
     const auto& hal = MetalContext::instance().hal();
     const uint32_t base = hal.get_neo_tile_counters_base_addr() + neo_id * hal.get_neo_tile_counters_stride();
     const uint32_t size = hal.get_neo_tile_counters_size();
@@ -71,21 +70,21 @@ inline LiveTcSnapshot read_live_tcs(
     // Same offset as NEO_REGS_*_SPACE_AVAILABLE.
     constexpr uint32_t space_available_offset = 0x0000000Cu;
     const uint32_t num_counters = size != 0 ? static_cast<uint32_t>(::dfb::NUM_TILE_COUNTERS_PER_TENSIX) : 0u;
-    const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
+    const CoreCoord virtual_core = unit_mesh.worker_core_from_logical_core(logical_core);
 
     LiveTcSnapshot snap;
     snap.capacity.reserve(num_counters);
     snap.tiles_available.reserve(num_counters);
     snap.space_available.reserve(num_counters);
     auto& cluster = MetalContext::instance().get_cluster();
+    const auto device_id = unit_mesh.get_device_ids()[0];
     for (uint32_t i = 0; i < num_counters; i++) {
         const uint32_t tc_base = base + i * size;
-        snap.capacity.push_back(
-            cluster.read_core(device->id(), virtual_core, tc_base + cap_offset, sizeof(uint32_t))[0]);
+        snap.capacity.push_back(cluster.read_core(device_id, virtual_core, tc_base + cap_offset, sizeof(uint32_t))[0]);
         snap.tiles_available.push_back(
-            cluster.read_core(device->id(), virtual_core, tc_base + tiles_available_offset, sizeof(uint32_t))[0]);
+            cluster.read_core(device_id, virtual_core, tc_base + tiles_available_offset, sizeof(uint32_t))[0]);
         snap.space_available.push_back(
-            cluster.read_core(device->id(), virtual_core, tc_base + space_available_offset, sizeof(uint32_t))[0]);
+            cluster.read_core(device_id, virtual_core, tc_base + space_available_offset, sizeof(uint32_t))[0]);
     }
     return snap;
 }

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -97,7 +97,7 @@ TEST_F(UnitMeshFixture, Semaphore_OutsideRegion_NoViolation) {
 // check: the JIT patch pass's semaphore-provenance rules (S1 inline / S2
 // store-then-cast) route these casts through __emule_sem_l1_to_ptr. Exercises
 // both forms through the real JIT pipeline.
-TEST_F(MeshDeviceFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
+TEST_F(UnitMeshFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
     CoreCoord logical_core = {0, 0};
@@ -127,7 +127,7 @@ TEST_F(MeshDeviceFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
 
     // Must NOT abort.
-    LaunchProgram(*this->devices_.at(0), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -138,10 +138,9 @@ TEST_F(MeshDeviceFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
 // LOCAL semaphore word as its NOC source — emule's noc_semaphore_set_remote
 // must translate that source via the sanctioned-semaphore path, not the
 // checked chokepoint, or the API itself trips the Illegal-Semaphore check.
-TEST_F(MeshDeviceFixture, Semaphore_RelayUnicast_NoViolation) {
+TEST_F(UnitMeshFixture, Semaphore_RelayUnicast_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord sender_core = {0, 0};
     CoreCoord receiver_core = {1, 0};
     CoreRange both_cores(sender_core, receiver_core);
@@ -184,11 +183,11 @@ TEST_F(MeshDeviceFixture, Semaphore_RelayUnicast_NoViolation) {
         receiver_core,
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {dst_sem_id}});
-    CoreCoord rx_virtual = device->worker_core_from_logical_core(receiver_core);
+    CoreCoord rx_virtual = this->device().worker_core_from_logical_core(receiver_core);
     SetRuntimeArgs(program, sender_kernel, sender_core, {rx_virtual.x, rx_virtual.y});
 
     // Must NOT abort (and must not hang: the relay's value wakes the waiter).
-    LaunchProgram(*this->devices_.at(0), std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -199,10 +198,9 @@ TEST_F(MeshDeviceFixture, Semaphore_RelayUnicast_NoViolation) {
 // wanders out of the reserved region falls through to the full check chain and
 // must still die (here: Out-of-Bounds Write — well above the unreserved base,
 // inside no allocated tensor).
-TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
+TEST_F(UnitMeshFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
     uint32_t sem_id = CreateSemaphore(program, logical_core, /*initial_value=*/0);
@@ -210,7 +208,7 @@ TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
     auto buf = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = 1024},
         {.page_size = 1024, .buffer_type = BufferType::L1},
-        this->devices_.at(0).get());
+        &this->device());
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"
@@ -229,8 +227,7 @@ TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
 
     EXPECT_DEATH(
-        LaunchProgram(*this->devices_.at(0), std::move(program), /*wait_until_cores_done=*/true),
-        ".*Out-of-Bounds Write.*");
+        LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true), ".*Out-of-Bounds Write.*");
     ::unsetenv("TT_METAL_EMULE_ASAN");
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_mesh_workload_factories_hw.cpp
@@ -52,8 +52,7 @@ protected:
             return;
         }
         auto mesh_device = devices_.at(0);
-        IDevice* device = mesh_device->get_devices()[0];
-        if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
+        if (mesh_device->arch() != tt::ARCH::WORMHOLE_B0 && mesh_device->arch() != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
         }
     }
@@ -67,8 +66,7 @@ protected:
             return;
         }
         auto mesh_device = devices_.at(0);
-        IDevice* device = mesh_device->get_devices()[0];
-        if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
+        if (mesh_device->arch() != tt::ARCH::WORMHOLE_B0 && mesh_device->arch() != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
         }
     }
@@ -81,8 +79,7 @@ protected:
         if (this->IsSkipped()) {
             return;
         }
-        IDevice* device = mesh_device_->get_devices().at(0);
-        if (device->arch() != tt::ARCH::WORMHOLE_B0 && device->arch() != tt::ARCH::BLACKHOLE) {
+        if (mesh_device_->arch() != tt::ARCH::WORMHOLE_B0 && mesh_device_->arch() != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
         }
     }

--- a/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/conv_hardcoded/test_conv_hardcoded.cpp
@@ -31,14 +31,13 @@ struct ConvConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ConvConfig& test_config) {
+bool run_dm(distributed::MeshDevice& mesh_device, const ConvConfig& test_config) {
     // Program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device.mesh_command_queue();
 
     // Kernels
     auto receiver_kernel = CreateKernel(
@@ -58,7 +57,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const C
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Launch program using slow dispatch
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids()[0]);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -66,11 +65,8 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const C
 }
 }  // namespace unit_tests::dm::conv_hardcoded
 
-TEST_F(MeshDeviceFixture, TensixDataMovementConvActHalo3x3) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::BLACKHOLE) {
+TEST_F(UnitMeshFixture, TensixDataMovementConvActHalo3x3) {
+    if (this->device().arch() != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
@@ -135,14 +131,11 @@ TEST_F(MeshDeviceFixture, TensixDataMovementConvActHalo3x3) {
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
-TEST_F(MeshDeviceFixture, TensixDataMovementConvActHalo3x3Smaller) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::BLACKHOLE) {
+TEST_F(UnitMeshFixture, TensixDataMovementConvActHalo3x3Smaller) {
+    if (this->device().arch() != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
@@ -207,14 +200,11 @@ TEST_F(MeshDeviceFixture, TensixDataMovementConvActHalo3x3Smaller) {
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
-TEST_F(MeshDeviceFixture, TensixDataMovementConvHaloGather) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::BLACKHOLE) {
+TEST_F(UnitMeshFixture, TensixDataMovementConvHaloGather) {
+    if (this->device().arch() != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
@@ -272,7 +262,7 @@ TEST_F(MeshDeviceFixture, TensixDataMovementConvHaloGather) {
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/deinterleave_hardcoded/test_deinterleave_hardcoded.cpp
@@ -30,14 +30,13 @@ struct DeinterleaveConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const DeinterleaveConfig& test_config) {
+bool run_dm(distributed::MeshDevice& mesh_device, const DeinterleaveConfig& test_config) {
     // Program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device.mesh_command_queue();
 
     for (int k = 0; k < test_config.dest_core_set.size(); k++) {
         // Kernels
@@ -59,7 +58,7 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const D
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Launch program using slow dispatch
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids()[0]);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -67,11 +66,8 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const D
 }
 }  // namespace unit_tests::dm::deinterleave_hardcoded
 
-TEST_F(MeshDeviceFixture, TensixDataMovementDeinterleaveSingleCore) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::WORMHOLE_B0) {
+TEST_F(UnitMeshFixture, TensixDataMovementDeinterleaveSingleCore) {
+    if (this->device().arch() != ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Skipping test for non-WH architecture";
     }
 
@@ -134,15 +130,12 @@ TEST_F(MeshDeviceFixture, TensixDataMovementDeinterleaveSingleCore) {
             .noc_id = noc_id};
 
         // Run
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
     }
 }
 
-TEST_F(MeshDeviceFixture, TensixDataMovementDeinterleaveMultiCore) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::WORMHOLE_B0) {
+TEST_F(UnitMeshFixture, TensixDataMovementDeinterleaveMultiCore) {
+    if (this->device().arch() != ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Skipping test for non-WH architecture";
     }
 
@@ -229,7 +222,7 @@ TEST_F(MeshDeviceFixture, TensixDataMovementDeinterleaveMultiCore) {
             .noc_id = noc_id};
 
         // Run
-        EXPECT_TRUE(run_dm(mesh_device, test_config));
+        EXPECT_TRUE(run_dm(this->device(), test_config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/reshard_hardcoded/test_reshard_hardcoded.cpp
@@ -31,14 +31,13 @@ struct ReshardConfig {
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ReshardConfig& test_config) {
+bool run_dm(distributed::MeshDevice& mesh_device, const ReshardConfig& test_config) {
     // Program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    auto& cq = mesh_device->mesh_command_queue();
-    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device.mesh_command_queue();
 
     // Kernels
     auto receiver_kernel = CreateKernel(
@@ -60,18 +59,15 @@ bool run_dm(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const R
     workload.add_program(device_range, std::move(program));
 
     // Launch program using slow dispatch
-    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    MetalContext::instance().get_cluster().l1_barrier(mesh_device.get_device_ids()[0]);
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     return true;
 }
 }  // namespace unit_tests::dm::reshard_hardcoded
 
-TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::BLACKHOLE) {
+TEST_F(UnitMeshFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
+    if (this->device().arch() != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
@@ -136,14 +132,11 @@ TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketSmallSizes) {
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
-TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::BLACKHOLE) {
+TEST_F(UnitMeshFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
+    if (this->device().arch() != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
@@ -228,14 +221,11 @@ TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketMedSizes) {
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
-TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::BLACKHOLE) {
+TEST_F(UnitMeshFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes) {
+    if (this->device().arch() != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
@@ -318,14 +308,11 @@ TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketManyCoresSizes
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
-TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToManyCoresSizes) {
-    auto mesh_device = devices_.at(0);
-    auto arch_ = mesh_device->arch();
-
-    if (arch_ != ARCH::BLACKHOLE) {
+TEST_F(UnitMeshFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToManyCoresSizes) {
+    if (this->device().arch() != ARCH::BLACKHOLE) {
         GTEST_SKIP() << "Skipping test for non-BH architecture";
     }
 
@@ -405,7 +392,7 @@ TEST_F(MeshDeviceFixture, TensixDataMovementReshardHardcodedPacketSmallCoresToMa
     };
 
     // Run
-    EXPECT_TRUE(run_dm(mesh_device, test_config));
+    EXPECT_TRUE(run_dm(this->device(), test_config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -65,10 +65,9 @@ protected:
         auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
         for (auto& [device_id, device] : id_to_device_) {
             for (const auto& logical_core : device->get_devices()[0]->get_inactive_ethernet_cores()) {
-                CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
-                    device->get_devices()[0]->id(), logical_core, CoreType::ETH);
-                cluster.assert_risc_reset_at_core(
-                    tt_cxy_pair(device->get_devices()[0]->id(), virtual_core), tt::umd::RiscType::ALL);
+                CoreCoord virtual_core =
+                    cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::ETH);
+                cluster.assert_risc_reset_at_core(tt_cxy_pair(device_id, virtual_core), tt::umd::RiscType::ALL);
             }
         }
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
@@ -191,13 +191,12 @@ TEST_F(DevicePrintCheckpointTest, CheckpointLoopAndDumpDest) {
 static void run_global_checkpoint(
     DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     using namespace dp_ckpt;
-    auto* device = mesh_device->get_devices()[0];
     size_t tile_size = tt::tile_size(FMT);
     size_t buf_sz = NUM_TILES * tile_size;
 
     CoreCoord core0 = {0, 0}, core1 = {0, 1};
     CoreRange cores(core0, core1);
-    CoreCoord barrier_coord = device->worker_core_from_logical_core(core0);
+    CoreCoord barrier_coord = mesh_device->worker_core_from_logical_core(core0);
 
     distributed::MeshWorkload workload;
     auto zero = distributed::MeshCoordinate(0, 0);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
@@ -125,7 +125,7 @@ void RunFilteringTest(
         << log;
 
     for (const auto& mesh_device : all_devices) {
-        auto [row, col] = GetGlobalCoord(mesh_device->get_devices()[0]->id());
+        auto [row, col] = GetGlobalCoord(mesh_device->get_device_ids()[0]);
         if (std::make_pair(row, col) == fixture->target_coord) {
             continue;
         }
@@ -140,7 +140,7 @@ void RunFilteringTest(
 void RunAllChipsVerificationTest(
     DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     constexpr auto kDprint = tt::llrt::RunTimeDebugFeatureDprint;
-    ChipId chip_id = mesh_device->get_devices()[0]->id();
+    ChipId chip_id = mesh_device->get_device_ids()[0];
     auto [row, col] = GetGlobalCoord(chip_id);
 
     auto workload = BuildMeshCoordWorkload(mesh_device);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
@@ -32,14 +32,13 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
 void RunTest(DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto* device = mesh_device->get_devices()[0];
-
     // This tests prints only on a single core
     CoreCoord xy_start = {0, 0};
     CoreCoord xy_end = {0, 0};
 
     // Run the program, use a large delay for the last print to emulate a long-running kernel.
-    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
+    const auto device_id = mesh_device->get_device_ids()[0];
+    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
     uint32_t delay_cycles = clk_mhz * 4000000;  // 4 seconds
     const std::vector<uint32_t> args = {delay_cycles, xy_start.x, xy_start.y};
     fixture->RunProgram(mesh_device, "tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp", args);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
@@ -38,7 +38,7 @@ void UpdateGoldenOutput(
     const std::string& risc) {
     // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
     // by machine. CoreCoord::str() formats as "x-y".
-    const std::string& device_core_risc = std::to_string(mesh_device->get_devices()[0]->id()) + ":?-?:" + risc + ": ";
+    const std::string& device_core_risc = std::to_string(mesh_device->get_device_ids()[0]) + ":?-?:" + risc + ": ";
 
     const std::string& output_line_all_riscs = device_core_risc + "Printing on a RISC.";
     golden_output.push_back(output_line_all_riscs);
@@ -181,10 +181,8 @@ TEST_F(DevicePrintFixture, TensixActiveEthTestPrintPrependDeviceCoreRisc) {
         tt::llrt::RunTimeDebugFeatureDprint, true);
     for (auto& mesh_device : this->devices_) {
         if (mesh_device->get_devices()[0]->get_active_ethernet_cores(true).empty()) {
-            log_info(
-                tt::LogTest,
-                "Skipping device {} due to no active ethernet cores...",
-                mesh_device->get_devices()[0]->id());
+            const auto device_id = mesh_device->get_device_ids()[0];
+            log_info(tt::LogTest, "Skipping device {} due to no active ethernet cores...", device_id);
             continue;
         }
         this->RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_mcast_wrap_around.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_mcast_wrap_around.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include "debug_tools_fixture.hpp"
 #include "impl/context/metal_context.hpp"
+#include "mesh_device.hpp"
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/distributed.hpp>
@@ -42,8 +43,8 @@ void DoHostMcastWrite(ChipId chip_id, CoreCoord core_start, CoreCoord core_end) 
 }  // namespace
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Down) {
-    auto* device = this->devices_[0]->get_devices()[0];
-    ChipId chip_id = device->id();
+    distributed::MeshDevice* device = this->devices_[0].get();
+    ChipId chip_id = device->get_device_ids()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.y < 2) {
@@ -59,8 +60,8 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Down) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Up) {
-    auto* device = this->devices_[0]->get_devices()[0];
-    ChipId chip_id = device->id();
+    distributed::MeshDevice* device = this->devices_[0].get();
+    ChipId chip_id = device->get_device_ids()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.y < 2) {
@@ -76,8 +77,8 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundY_Up) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Right) {
-    auto* device = this->devices_[0]->get_devices()[0];
-    ChipId chip_id = device->id();
+    distributed::MeshDevice* device = this->devices_[0].get();
+    ChipId chip_id = device->get_device_ids()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.x < 2) {
@@ -93,8 +94,8 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Right) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Left) {
-    auto* device = this->devices_[0]->get_devices()[0];
-    ChipId chip_id = device->id();
+    distributed::MeshDevice* device = this->devices_[0].get();
+    ChipId chip_id = device->get_device_ids()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.x < 2) {
@@ -110,8 +111,8 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundX_Left) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundXY_DownRight) {
-    auto* device = this->devices_[0]->get_devices()[0];
-    ChipId chip_id = device->id();
+    distributed::MeshDevice* device = this->devices_[0].get();
+    ChipId chip_id = device->get_device_ids()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.x < 2 || grid.y < 2) {
@@ -127,8 +128,8 @@ TEST_F(MeshWatcherFixture, HostMcastWrapAroundXY_DownRight) {
 }
 
 TEST_F(MeshWatcherFixture, HostMcastWrapAroundXY_UpLeft) {
-    auto* device = this->devices_[0]->get_devices()[0];
-    ChipId chip_id = device->id();
+    distributed::MeshDevice* device = this->devices_[0].get();
+    ChipId chip_id = device->get_device_ids()[0];
     CoreCoord grid = device->compute_with_storage_grid_size();
 
     if (grid.x < 2 || grid.y < 2) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -41,7 +41,6 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
     const auto& hal = MetalContext::instance().hal();
     const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     // Watcher pause kernels use Metal 2.0 on all architectures.
@@ -59,7 +58,8 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     }
 
     // Write runtime args
-    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
+    const auto device_id = mesh_device->get_device_ids()[0];
+    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
     uint32_t delay_cycles = clk_mhz * 500000;  // .5 seconds
     std::vector<experimental::KernelSpec> kernel_specs;
     std::vector<experimental::KernelSpecName> kernel_names;
@@ -134,7 +134,7 @@ void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::Mes
     vector<std::string> expected_strings;
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
-            CoreCoord virtual_core = device->worker_core_from_logical_core({x, y});
+            CoreCoord virtual_core = mesh_device->worker_core_from_logical_core({x, y});
             uint32_t num_processors =
                 is_quasar ? hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 0)  // DMs only
                           : hal.get_num_risc_processors(HalProgrammableCoreType::TENSIX);      // all 5

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -210,9 +210,8 @@ void RunMultiWriterTest(MeshWatcherFixture* fixture, const std::shared_ptr<distr
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto* device = mesh_device->get_devices()[0];
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    const bool is_quasar = device->arch() == tt::ARCH::QUASAR;
+    const bool is_quasar = mesh_device->arch() == tt::ARCH::QUASAR;
     CoreCoord logical_core{0, 0};
     constexpr const char* kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp";
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -825,14 +825,13 @@ void RunTestIEth(
 
 // Run tests for host-side sanitization (uses functions that are from watcher_server.hpp).
 void CheckHostSanitization(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    auto* device = mesh_device->get_devices()[0];
     // Try reading from a core that doesn't exist
     constexpr CoreCoord core = {99, 99};
     uint64_t addr = 0;
     uint32_t sz_bytes = 4;
     try {
-        [[maybe_unused]] auto data =
-            tt::tt_metal::MetalContext::instance().get_cluster().read_core(device->id(), core, addr, sz_bytes);
+        [[maybe_unused]] auto data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            mesh_device->get_device_ids()[0], core, addr, sz_bytes);
     } catch (std::runtime_error& e) {
         const std::string expected = fmt::format("Host watcher: bad {} NOC coord {}\n", "read", core.str());
         const std::string error = std::string(e.what());

--- a/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_galaxy_cluster_api.cpp
@@ -71,8 +71,7 @@ TEST_F(GalaxyFixture, Initialize) {
 // which shelf a particular Galaxy chip is on.
 TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        const ChipId device_id = device->id();
+        const ChipId device_id = mesh_device->get_device_ids()[0];
         if (is_galaxy_device(device_id)) {
             std::unordered_map<ChipId, uint32_t> connected_devices_to_num_links_found;
             const std::unordered_set<CoreCoord>& active_ethernet_cores =
@@ -108,8 +107,7 @@ TEST_F(TGFixture, ActiveEthValidateNumLinksBetweenAdjacentGalaxyChips) {
 // and that each Galaxy chip links to at most one MMIO chip
 TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        const ChipId device_id = device->id();
+        const ChipId device_id = mesh_device->get_device_ids()[0];
         const std::unordered_set<ChipId>& connected_device_ids = get_ethernet_connected_device_ids(device_id);
         if (is_galaxy_device(device_id)) {
             uint32_t num_mmio_chips_that_curr_chip_is_linked_to = 0;
@@ -144,8 +142,7 @@ TEST_F(GalaxyFixture, DISABLED_ActiveEthValidateLinksBetweenMMIOAndGalaxyChips) 
 // Validate that all galaxy chips are unharvested
 TEST_F(GalaxyFixture, ValidateAllGalaxyChipsAreUnharvested) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        const ChipId device_id = device->id();
+        const ChipId device_id = mesh_device->get_device_ids()[0];
         if (is_galaxy_device(device_id)) {
             const uint32_t harvest_mask =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
@@ -158,8 +155,7 @@ TEST_F(GalaxyFixture, ValidateAllGalaxyChipsAreUnharvested) {
 // Validate that all MMIO chips have a single row harvested
 TEST_F(GalaxyFixture, DISABLED_ValidateAllMMIOChipsHaveSingleRowHarvested) {
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        const ChipId device_id = device->id();
+        const ChipId device_id = mesh_device->get_device_ids()[0];
         if (!is_galaxy_device(device_id)) {
             uint32_t num_rows_harvested = 0;
             uint32_t harvest_mask = tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
@@ -190,8 +186,7 @@ TEST_F(TGFixture, ValidateChipBoardTypes) {
     uint32_t num_n150_chips = 0;
     uint32_t num_galaxy_chips = 0;
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        const ChipId device_id = device->id();
+        const ChipId device_id = mesh_device->get_device_ids()[0];
         if (is_galaxy_device(device_id)) {
             num_galaxy_chips++;
         } else if (is_n150_device(device_id)) {

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -98,7 +98,7 @@ TEST_F(AnyDispatchSimulatorFixture, QuasarStaticTlbReadWrite) {
     constexpr uint32_t value32 = 0xDEADBEEF;
 
     for (auto& mesh_device : this->devices_) {
-        const ChipId chip_id = mesh_device->get_devices()[0]->id();
+        const ChipId chip_id = mesh_device->get_device_ids()[0];
         const auto& sdesc = cluster.get_soc_desc(chip_id);
 
         const std::vector<tt::umd::CoreCoord> tensix_cores =

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -465,7 +465,6 @@ void stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
     srand(config.seed);
 
     auto device_coord = distributed::MeshCoordinate(0, 0);
-    auto* device = mesh_device->get_devices()[0];
 
     for (const bool cq_write : {true, false}) {
         for (const bool cq_read : {true, false}) {
@@ -503,10 +502,11 @@ void stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
                     distributed::WriteShard(cq, buf, src, device_coord, false);
                 } else {
                     local_test_functions::WriteToUnitMeshBuffer(mesh_device, test_config, src, buf, std::nullopt);
+                    const auto device_id = mesh_device->get_device_ids()[0];
                     if (buftype == BufferType::DRAM) {
-                        tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
+                        tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device_id);
                     } else {
-                        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+                        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device_id);
                     }
                 }
 
@@ -1642,11 +1642,11 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForDra
 
 TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     auto mesh_device = this->device_;
-    auto* device = mesh_device->get_devices()[0];
     uint32_t page_size = 2048;
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
+    const auto device_id = mesh_device->get_device_ids()[0];
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
     uint32_t command_queue_size =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_host_channel_size(device->id(), channel);
+        tt::tt_metal::MetalContext::instance().get_cluster().get_host_channel_size(device_id, channel);
     uint32_t num_pages = command_queue_size / page_size;
 
     TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -41,6 +41,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
     CoreRangeSet sharded_cores_2 = CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})});
 
     auto mesh_device = devices_[0];
+    const auto device_id = mesh_device->get_device_ids()[0];
     auto sub_device_manager_1 = mesh_device->create_sub_device_manager({sub_device_1}, local_l1_size);
     auto sub_device_manager_2 = mesh_device->create_sub_device_manager({sub_device_1, sub_device_2}, local_l1_size);
     DeviceAddr l1_unreserved_base = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
@@ -115,7 +116,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
     auto input_1_it = input_1.begin();
     for (const auto& physical_core : physical_cores_1) {
         auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            mesh_device->get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
+            device_id, physical_core, buffer_1->address(), page_size_1);
         EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
         input_1_it += page_size_1 / sizeof(uint32_t);
     }
@@ -140,7 +141,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
     auto input_2_it = input_2.begin();
     for (const auto& physical_core : physical_cores_2) {
         auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            mesh_device->get_devices()[0]->id(), physical_core, buffer_3->address(), page_size_2);
+            device_id, physical_core, buffer_3->address(), page_size_2);
         EXPECT_TRUE(std::equal(input_2_it, input_2_it + page_size_2 / sizeof(uint32_t), readback.begin()));
         input_2_it += page_size_2 / sizeof(uint32_t);
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_device/test_enqueue_read_write_core.cpp
@@ -22,11 +22,11 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicReadWriteL1) {
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
 
     for (const auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
         const CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(logical_core);
 
-        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        const distributed::MeshCoordinate device_coord =
+            mesh_device->get_view().find_device(mesh_device->get_device_ids()[0]);
         const distributed::DeviceMemoryAddress device_memory_address = {
             device_coord, virtual_core, reinterpret_cast<DeviceAddr>(address)};
         fd_cq.enqueue_write_shard_to_core(
@@ -52,10 +52,10 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicReadL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
-        const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(device->id(), virtual_core, src_data, address);
-        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        const CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(logical_core);
+        const auto device_id = mesh_device->get_device_ids()[0];
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(device_id, virtual_core, src_data, address);
+        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
         const distributed::DeviceMemoryAddress device_memory_address = {
             device_coord, virtual_core, reinterpret_cast<DeviceAddr>(address)};
 
@@ -79,9 +79,9 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicWriteL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
-        const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        const CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(logical_core);
+        const auto device_id = mesh_device->get_device_ids()[0];
+        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
         const distributed::DeviceMemoryAddress device_memory_address = {
             device_coord, virtual_core, reinterpret_cast<DeviceAddr>(address)};
         fd_cq.enqueue_write_shard_to_core(
@@ -90,7 +90,7 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestBasicWriteL1) {
         distributed::Finish(mesh_device->mesh_command_queue());
 
         const std::vector<uint32_t> dst_data = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            device->id(), virtual_core, address, num_elements * sizeof(uint32_t));
+            device_id, virtual_core, address, num_elements * sizeof(uint32_t));
 
         EXPECT_EQ(src_data, dst_data);
     }
@@ -109,9 +109,9 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestInvalidReadWriteAddressL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
-        const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        const CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(logical_core);
+        const auto device_id = mesh_device->get_device_ids()[0];
+        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
         const distributed::DeviceMemoryAddress device_memory_address = {
             device_coord, virtual_core, reinterpret_cast<DeviceAddr>(address)};
         EXPECT_THROW(
@@ -135,11 +135,11 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteMultipleCoresL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
-        for (uint32_t core_x = 0; core_x < device->compute_with_storage_grid_size().x; ++core_x) {
-            for (uint32_t core_y = 0; core_y < device->compute_with_storage_grid_size().y; ++core_y) {
-                const CoreCoord core = device->worker_core_from_logical_core({core_x, core_y});
-                const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        for (uint32_t core_x = 0; core_x < mesh_device->compute_with_storage_grid_size().x; ++core_x) {
+            for (uint32_t core_y = 0; core_y < mesh_device->compute_with_storage_grid_size().y; ++core_y) {
+                const CoreCoord core = mesh_device->worker_core_from_logical_core({core_x, core_y});
+                const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
                 const distributed::DeviceMemoryAddress device_memory_address = {
                     device_coord, core, reinterpret_cast<DeviceAddr>(address)};
                 fd_cq.enqueue_write_shard_to_core(
@@ -148,13 +148,13 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteMultipleCoresL1) {
         }
 
         std::vector<std::vector<uint32_t>> all_cores_dst_data(
-            device->compute_with_storage_grid_size().x * device->compute_with_storage_grid_size().y,
+            mesh_device->compute_with_storage_grid_size().x * mesh_device->compute_with_storage_grid_size().y,
             std::vector<uint32_t>(num_elements, 0));
         uint32_t i = 0;
-        for (uint32_t core_x = 0; core_x < device->compute_with_storage_grid_size().x; ++core_x) {
-            for (uint32_t core_y = 0; core_y < device->compute_with_storage_grid_size().y; ++core_y) {
-                const CoreCoord core = device->worker_core_from_logical_core({core_x, core_y});
-                const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        for (uint32_t core_x = 0; core_x < mesh_device->compute_with_storage_grid_size().x; ++core_x) {
+            for (uint32_t core_y = 0; core_y < mesh_device->compute_with_storage_grid_size().y; ++core_y) {
+                const CoreCoord core = mesh_device->worker_core_from_logical_core({core_x, core_y});
+                const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
                 const distributed::DeviceMemoryAddress device_memory_address = {
                     device_coord, core, reinterpret_cast<DeviceAddr>(address)};
                 fd_cq.enqueue_read_shard_from_core(
@@ -179,9 +179,9 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteZeroElementsL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
-        const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        const CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(logical_core);
+        const auto device_id = mesh_device->get_device_ids()[0];
+        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
         const distributed::DeviceMemoryAddress device_memory_address = {
             device_coord, virtual_core, reinterpret_cast<DeviceAddr>(address)};
         fd_cq.enqueue_write_shard_to_core(device_memory_address, src_data.data(), 0, false);
@@ -206,9 +206,9 @@ TEST_F(UnitMeshCQSingleCardSharedFixture, TensixTestReadWriteEntireL1) {
 
     for (const auto& mesh_device : this->devices_) {
         auto& fd_cq = dynamic_cast<distributed::FDMeshCommandQueue&>(mesh_device->mesh_command_queue());
-        auto* device = mesh_device->get_devices()[0];
-        const CoreCoord virtual_core = device->worker_core_from_logical_core(logical_core);
-        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
+        const CoreCoord virtual_core = mesh_device->worker_core_from_logical_core(logical_core);
+        const auto device_id = mesh_device->get_device_ids()[0];
+        const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device_id);
         const distributed::DeviceMemoryAddress device_memory_address = {
             device_coord, virtual_core, reinterpret_cast<DeviceAddr>(address)};
         fd_cq.enqueue_write_shard_to_core(device_memory_address, src_data.data(), size, true);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -232,7 +232,6 @@ void test_dummy_EnqueueProgram_with_runtime_args(
     distributed::MeshCoordinate zero_coord = distributed::MeshCoordinate::zero_coordinate(mesh_device->shape().dims());
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program;
-    auto* device = mesh_device->get_devices()[0];
     auto eth_noc_xy = mesh_device->ethernet_core_from_logical_core(eth_core_coord);
 
     constexpr uint32_t num_runtime_args0 = 9;
@@ -270,7 +269,7 @@ void test_dummy_EnqueueProgram_with_runtime_args(
     Finish(cq);
 
     vector<uint32_t> dummy_kernel0_args_readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        device->id(),
+        mesh_device->get_device_ids()[0],
         eth_noc_xy,
         MetalContext::instance().hal().get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED),
@@ -907,15 +906,15 @@ void test_basic_dispatch_functions(const std::shared_ptr<distributed::MeshDevice
     constexpr uint32_t k_LoopPerDev = 100;
 
     DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-    auto* device = mesh_device->get_devices()[0];
     log_info(tt::LogTest, "Running On Device {} CQ{}", mesh_device->id(), cq_id);
+    const auto device_id = mesh_device->get_device_ids()[0];
 
     // Alternate write patterns
     std::vector<uint32_t> src_data_1(k_DataSize / sizeof(uint32_t));
     std::vector<uint32_t> src_data_2(k_DataSize / sizeof(uint32_t));
     for (int i = 0; i < k_DataSize / sizeof(uint32_t); ++i) {
-        src_data_1[i] = (device->id() + rand()) * 0xdeadbeef;
-        src_data_2[i] = (device->id() + rand()) * 0xabcd1234;
+        src_data_1[i] = (device_id + rand()) * 0xdeadbeef;
+        src_data_2[i] = (device_id + rand()) * 0xabcd1234;
     }
     distributed::DeviceLocalBufferConfig l1_buffer_config{.page_size = k_PageSize, .buffer_type = BufferType::L1};
     distributed::DeviceLocalBufferConfig dram_buffer_config{.page_size = k_PageSize, .buffer_type = BufferType::DRAM};

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "mesh_dispatch_fixture.hpp"
+#include "device_fixture.hpp"
 
 #include <chrono>
 #include <cstdint>
@@ -15,16 +15,15 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
+#include "impl/program/program_impl.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 // Tests dataflow through CBs at indices 0, 8, 16, ... and topmost CB
 // Validates data integrity: DRAM -> Reader -> CB -> Writer -> DRAM (src == dst)
-TEST_F(MeshDispatchFixture, DataflowCb) {
-    auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
-    if (dev->arch() == ARCH::QUASAR) {
+TEST_F(UnitMeshAnyDispatchFixture, DataflowCb) {
+    if (this->device().arch() == ARCH::QUASAR) {
         GTEST_SKIP() << "Quasar does not support CBs, skipping test";
     }
     Program program = CreateProgram();
@@ -52,13 +51,13 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     const uint32_t num_tiles = tiles_to_transfer_per_cb * total_cbs;
     const uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = this->device().mesh_command_queue();
     distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
     distributed::ReplicatedBufferConfig global_config{.size = dram_buffer_size};
 
-    auto src_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
+    auto src_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, &this->device());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
-    auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, &this->device());
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     auto create_cb = [&](uint32_t cb_index) {
@@ -105,12 +104,7 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_cb});
     SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_cb});
 
-    // Execute
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    this->RunProgram(mesh_device, workload);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
@@ -119,8 +113,7 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     EXPECT_EQ(src_vec, result_vec);
 }
 
-TEST_F(MeshDispatchFixture, DataflowDfb) {
-    auto mesh_device = devices_[0];
+TEST_F(UnitMeshAnyDispatchFixture, DataflowDfb) {
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -141,13 +134,13 @@ TEST_F(MeshDispatchFixture, DataflowDfb) {
     const uint32_t num_tiles = tiles_to_transfer_per_dfb * total_dfbs;
     const uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = this->device().mesh_command_queue();
     distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
     distributed::ReplicatedBufferConfig global_config{.size = dram_buffer_size};
 
-    auto src_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
+    auto src_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, &this->device());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
-    auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, mesh_device.get());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(global_config, dram_config, &this->device());
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     tt_metal::experimental::dfb::DataflowBufferConfig dfb_config = {
@@ -201,12 +194,7 @@ TEST_F(MeshDispatchFixture, DataflowDfb) {
     SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_dfb});
     SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_dfb});
 
-    // Execute
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, std::move(program));
-    this->RunProgram(mesh_device, workload);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
@@ -59,7 +59,7 @@ void RunTest(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     // Write runtime args
     auto get_first_arg =
         [](const std::shared_ptr<distributed::MeshDevice>& mesh_device, CoreCoord& core, uint32_t multiplier) {
-            return (uint32_t)mesh_device->get_devices()[0]->id() + ((uint32_t)core.x * 10 * multiplier);
+            return (uint32_t)mesh_device->get_device_ids()[0] + ((uint32_t)core.x * 10 * multiplier);
         };
     auto get_second_arg = [](const std::shared_ptr<distributed::MeshDevice>& /*mesh_device*/,
                              CoreCoord& core,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -165,17 +165,18 @@ void test_sub_device_synchronization(distributed::MeshDevice* device) {
     std::vector<uint32_t> output_1;
     distributed::ReadShard(device->mesh_command_queue(), output_1, buffer_1, zero_coord, true);
     EXPECT_EQ(input_1, output_1);
+    const auto device_id = device->get_device_ids()[0];
     auto input_1_it = input_1.begin();
     for (const auto& physical_core : physical_cores_1) {
         auto readback = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            device->get_devices()[0]->id(), physical_core, buffer_1->address(), page_size_1);
+            device_id, physical_core, buffer_1->address(), page_size_1);
         EXPECT_TRUE(std::equal(input_1_it, input_1_it + page_size_1 / sizeof(uint32_t), readback.begin()));
         input_1_it += page_size_1 / sizeof(uint32_t);
     }
     auto sem_addr = global_semaphore.address();
     auto physical_syncer_core = device->worker_core_from_logical_core(syncer_core);
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-        device->get_devices()[0]->id(), physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
+        device_id, physical_syncer_core, std::vector<uint32_t>{1}, sem_addr);
 
     // Full synchronization
     device->reset_sub_device_stall_group();

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -72,9 +72,6 @@ bool chip_to_chip_dram_buffer_transfer(
     const DataMovementProcessor& processor) {
     bool pass = true;
 
-    auto* sender_device = sender_mesh_device->get_devices()[0];
-    auto* receiver_device = receiver_mesh_device->get_devices()[0];
-
     distributed::DeviceLocalBufferConfig sender_dram_config{
         .page_size = byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM, .bottom_up = false};
     distributed::ReplicatedBufferConfig sender_buffer_config{.size = byte_size};
@@ -99,9 +96,9 @@ bool chip_to_chip_dram_buffer_transfer(
         "and "
         "{} {}",
         byte_size,
-        sender_device->id(),
+        sender_mesh_device->get_device_ids()[0],
         input_dram_byte_address,
-        receiver_device->id(),
+        receiver_mesh_device->get_device_ids()[0],
         output_dram_byte_address,
         eth_sender_core.str(),
         eth_receiver_core.str(),
@@ -474,15 +471,15 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
     const auto& sender_mesh_device = devices_.at(0);
     const auto& receiver_mesh_device = devices_.at(1);
     auto* const sender_device = sender_mesh_device->get_devices()[0];
-    auto* const receiver_device = receiver_mesh_device->get_devices()[0];
+    const auto receiver_device_id = receiver_mesh_device->get_device_ids()[0];
     uint32_t MAX_BUFFER_SIZE =
         MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
 
-    if (sender_device->get_ethernet_sockets(receiver_device->id()).empty()) {
+    if (sender_device->get_ethernet_sockets(receiver_device_id).empty()) {
         GTEST_SKIP() << "No connected ethernet sockets";
     }
 
-    for (const auto& sender_eth_core : sender_device->get_ethernet_sockets(receiver_device->id())) {
+    for (const auto& sender_eth_core : sender_device->get_ethernet_sockets(receiver_device_id)) {
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
                 sender_device->id(), sender_eth_core)) {
             continue;
@@ -493,7 +490,7 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1)
             tt::LogTest,
             "Sending interleaved buffer from device {} to device {}, using eth core {} and {}",
             sender_device->id(),
-            receiver_device->id(),
+            receiver_device_id,
             sender_eth_core.str(),
             receiver_eth_core.str());
         BankedConfig test_config;
@@ -562,8 +559,8 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
     for (const auto& sender_mesh_device : devices_) {
         auto* const sender_device = sender_mesh_device->get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
-            if (sender_device->id() == receiver_device->id()) {
+            const auto receiver_device_id = receiver_mesh_device->get_device_ids()[0];
+            if (sender_device->id() == receiver_device_id) {
                 continue;
             }
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
@@ -572,7 +569,7 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                     continue;
                 }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
-                if (receiver_device->id() != device_id) {
+                if (receiver_device_id != device_id) {
                     continue;
                 }
                 const auto num_eriscs = tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
@@ -583,7 +580,7 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips
                         tt::LogTest,
                         "Sending interleaved buffer from device {} to device {}, using eth core {} and {}",
                         sender_device->id(),
-                        receiver_device->id(),
+                        receiver_device_id,
                         sender_eth_core.str(),
                         receiver_eth_core.str());
                     BankedConfig test_config = BankedConfig{
@@ -652,8 +649,8 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllCon
     for (const auto& sender_mesh_device : devices_) {
         auto* const sender_device = sender_mesh_device->get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
-            if (sender_device->id() >= receiver_device->id()) {
+            const auto receiver_device_id = receiver_mesh_device->get_device_ids()[0];
+            if (sender_device->id() >= receiver_device_id) {
                 continue;
             }
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
@@ -662,7 +659,7 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllCon
                     continue;
                 }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
-                if (receiver_device->id() != device_id) {
+                if (receiver_device_id != device_id) {
                     continue;
                 }
 
@@ -672,7 +669,7 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllCon
                         tt::LogTest,
                         "Sending dram buffer from device {} to device {}, using eth core {} DM{} and {}",
                         sender_device->id(),
-                        receiver_device->id(),
+                        receiver_device_id,
                         sender_eth_core.str(),
                         erisc_idx,
                         receiver_eth_core.str());
@@ -728,8 +725,8 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
     for (const auto& sender_mesh_device : devices_) {
         auto* const sender_device = sender_mesh_device->get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
-            if (sender_device->id() >= receiver_device->id()) {
+            const auto receiver_device_id = receiver_mesh_device->get_device_ids()[0];
+            if (sender_device->id() >= receiver_device_id) {
                 continue;
             }
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
@@ -738,7 +735,7 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                     continue;
                 }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
-                if (receiver_device->id() != device_id) {
+                if (receiver_device_id != device_id) {
                     continue;
                 }
 
@@ -748,7 +745,7 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuffe
                         tt::LogTest,
                         "Sending interleaved buffer from device {} to device {}, using eth core {} DM{} and {}",
                         sender_device->id(),
-                        receiver_device->id(),
+                        receiver_device_id,
                         sender_eth_core.str(),
                         erisc_idx,
                         receiver_eth_core.str());

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -489,7 +489,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
     auto* const device_0 = mesh_device_0->get_devices()[0];
-    auto* const device_1 = mesh_device_1->get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
         MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
@@ -501,7 +500,7 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip0ToChip1) {
             continue;
         }
         auto [device_id, receiver_core] = device_0->get_connected_ethernet_core(sender_core);
-        if (device_1->id() != device_id) {
+        if (mesh_device_1->get_device_ids()[0] != device_id) {
             continue;
         }
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
@@ -547,7 +546,6 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     const auto& mesh_device_0 = devices_.at(0);
     const auto& mesh_device_1 = devices_.at(1);
-    auto* const device_0 = mesh_device_0->get_devices()[0];
     auto* const device_1 = mesh_device_1->get_devices()[0];
 
     const size_t src_eth_l1_byte_address =
@@ -560,7 +558,7 @@ TEST_F(N300MeshDeviceFixture, ActiveEthKernelsDirectSendChip1ToChip0) {
             continue;
         }
         auto [device_id, receiver_core] = device_1->get_connected_ethernet_core(sender_core);
-        if (device_0->id() != device_id) {
+        if (mesh_device_0->get_device_ids()[0] != device_id) {
             continue;
         }
         ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
@@ -611,8 +609,7 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
     for (const auto& sender_mesh_device : devices_) {
         auto* const sender_device = sender_mesh_device->get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
-            if (sender_device->id() == receiver_device->id()) {
+            if (sender_device->id() == receiver_mesh_device->get_device_ids()[0]) {
                 continue;
             }
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
@@ -621,7 +618,7 @@ TEST_F(MeshDeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
                     continue;
                 }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
-                if (receiver_device->id() != device_id) {
+                if (receiver_mesh_device->get_device_ids()[0] != device_id) {
                     continue;
                 }
                 ASSERT_TRUE(unit_tests::erisc::direct_send::eth_direct_sender_receiver_kernels(
@@ -851,9 +848,8 @@ TEST_F(TwoMeshDeviceFixture, ActiveEthKernelsRandomDirectSendTests) {
 
         // gotcha: devices_ are mesh devices. Mesh device IDs are not the same as actual device IDs needed in the
         // cluster
-        auto* send_device = send_chip->get_devices()[0];
         if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
-                send_device->id(), sender_core)) {
+                send_chip->get_device_ids()[0], sender_core)) {
             continue;
         }
 
@@ -962,8 +958,7 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
     for (const auto& sender_mesh_device : devices_) {
         auto* const sender_device = sender_mesh_device->get_devices()[0];
         for (const auto& receiver_mesh_device : devices_) {
-            auto* const receiver_device = receiver_mesh_device->get_devices()[0];
-            if (sender_device->id() >= receiver_device->id()) {
+            if (sender_device->id() >= receiver_mesh_device->get_device_ids()[0]) {
                 continue;
             }
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
@@ -972,7 +967,7 @@ TEST_F(UnitMeshCQMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConnect
                     continue;
                 }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
-                if (receiver_device->id() != device_id) {
+                if (receiver_mesh_device->get_device_ids()[0] != device_id) {
                     continue;
                 }
                 for (uint32_t erisc_idx = 0; erisc_idx < num_eriscs; erisc_idx++) {

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -103,9 +103,9 @@ std::vector<std::shared_ptr<distributed::MeshDevice>> get_device_ring(
     std::vector<std::vector<int>> adj(mesh_devices.size(), std::vector<int>(mesh_devices.size(), 0));
     for (uint32_t i = 0; i < mesh_devices.size(); ++i) {
         const auto& mesh_device = mesh_devices[i];
-        auto* device = mesh_device->get_devices()[0];
         auto ethernet_connected_device_ids =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connected_device_ids(device->id());
+            tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connected_device_ids(
+                mesh_device->get_device_ids()[0]);
         for (const auto& connected_device_id : ethernet_connected_device_ids) {
             for (uint32_t j = 0; j < mesh_devices.size(); ++j) {
                 if (mesh_devices[j]->id() == connected_device_id) {
@@ -141,7 +141,6 @@ get_sender_receiver_cores(std::vector<std::shared_ptr<distributed::MeshDevice>> 
         const auto& first_mesh_device = device_ring[0];
         auto* first_device = first_mesh_device->get_devices()[0];
         const auto& second_mesh_device = device_ring[1];
-        auto* second_device = second_mesh_device->get_devices()[0];
         uint32_t i = 0;
         for (const auto& first_eth_core : first_device->get_active_ethernet_cores(true)) {
             if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
@@ -149,7 +148,7 @@ get_sender_receiver_cores(std::vector<std::shared_ptr<distributed::MeshDevice>> 
                 continue;
             }
             auto [device_id, second_eth_core] = first_device->get_connected_ethernet_core(first_eth_core);
-            if (second_device->id() == device_id) {
+            if (second_mesh_device->get_device_ids()[0] == device_id) {
                 std::shared_ptr<distributed::MeshDevice> sender_mesh_device, receiver_mesh_device;
                 CoreCoord sender_eth_core, receiver_eth_core;
                 if (i == 0) {
@@ -159,15 +158,13 @@ get_sender_receiver_cores(std::vector<std::shared_ptr<distributed::MeshDevice>> 
                     sender_mesh_device = second_mesh_device, receiver_mesh_device = first_mesh_device;
                     sender_eth_core = second_eth_core, receiver_eth_core = first_eth_core;
                 }
-                auto* sender_device = sender_mesh_device->get_devices()[0];
-                auto* receiver_device = receiver_mesh_device->get_devices()[0];
                 sender_receivers.push_back(
                     {sender_mesh_device, receiver_mesh_device, sender_eth_core, receiver_eth_core});
                 log_info(
                     tt::LogTest,
                     "Sender: {} Receiver: {} Sender Eth: {} Receiver Eth: {}",
-                    sender_device->id(),
-                    receiver_device->id(),
+                    sender_mesh_device->get_device_ids()[0],
+                    receiver_mesh_device->get_device_ids()[0],
                     sender_eth_core.str(),
                     receiver_eth_core.str());
                 if (i > 0) {
@@ -181,21 +178,20 @@ get_sender_receiver_cores(std::vector<std::shared_ptr<distributed::MeshDevice>> 
             const auto& sender_mesh_device = device_ring[i];
             auto* sender_device = sender_mesh_device->get_devices()[0];
             const auto& receiver_mesh_device = device_ring[i + 1];
-            auto* receiver_device = receiver_mesh_device->get_devices()[0];
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
                 if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
                         sender_device->id(), sender_eth_core)) {
                     continue;
                 }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
-                if (receiver_device->id() == device_id) {
+                if (receiver_mesh_device->get_device_ids()[0] == device_id) {
                     sender_receivers.push_back(
                         {sender_mesh_device, receiver_mesh_device, sender_eth_core, receiver_eth_core});
                     log_info(
                         tt::LogTest,
                         "Sender: {} Receiver: {} Sender Eth: {} Receiver Eth: {}",
                         sender_device->id(),
-                        receiver_device->id(),
+                        receiver_mesh_device->get_device_ids()[0],
                         sender_eth_core.str(),
                         receiver_eth_core.str());
                     break;
@@ -255,7 +251,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         auto& receiver_program = programs[receiver_device->id()];
         CoreCoord sender_receiver_core;
         for (const auto& sender_receiver : sender_receivers) {
-            if (std::get<1>(sender_receiver)->get_devices()[0]->id() == sender_device->id()) {
+            if (std::get<1>(sender_receiver)->get_device_ids()[0] == sender_device->id()) {
                 sender_receiver_core = sender_device->ethernet_core_from_logical_core(std::get<3>(sender_receiver));
             }
         }
@@ -302,7 +298,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         // Clear expected value at ethernet L1 address
         CoreCoord receiver_sender_core;
         for (const auto& sender_receiver : sender_receivers) {
-            if (std::get<0>(sender_receiver)->get_devices()[0]->id() == receiver_device->id()) {
+            if (std::get<0>(sender_receiver)->get_device_ids()[0] == receiver_device->id()) {
                 receiver_sender_core = receiver_device->ethernet_core_from_logical_core(std::get<2>(sender_receiver));
             }
         }
@@ -342,11 +338,10 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
     ths.reserve(sender_receivers.size());
     for (const auto& sender_receiver : sender_receivers) {
         const auto& device = std::get<0>(sender_receiver);
-        workloads[device->get_devices()[0]->id()].add_program(
-            device_range, std::move(programs[device->get_devices()[0]->id()]));
-        ths.emplace_back([&] {
-            distributed::EnqueueMeshWorkload(
-                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);
+        const auto device_id = device->get_device_ids()[0];
+        workloads[device_id].add_program(device_range, std::move(programs[device_id]));
+        ths.emplace_back([device, device_id, &workloads] {
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workloads[device_id], false);
         });
     }
     for (auto& th : ths) {
@@ -356,7 +351,7 @@ bool eth_direct_ring_gather_sender_receiver_kernels(
         const auto& device = std::get<0>(sender_receivers[i]);
         const auto& core = std::get<2>(sender_receivers[i]);
         auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-            device->get_devices()[0]->id(),
+            device->get_device_ids()[0],
             device->get_devices()[0]->ethernet_core_from_logical_core(core),
             src_eth_l1_byte_address,
             byte_size_per_device * sender_receivers.size());
@@ -405,6 +400,7 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
 
         const auto& device = std::get<0>(sender_receivers[i]);
         const auto& eth_sender_core = std::get<2>(sender_receivers[i]);
+        const auto device_id = device->get_device_ids()[0];
         CoreCoord eth_receiver_core;
         for (const auto& sender_receiver : sender_receivers) {
             if (std::get<1>(sender_receiver)->id() == device->id()) {
@@ -413,7 +409,7 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
             }
         }
 
-        auto& program = programs[device->get_devices()[0]->id()];
+        auto& program = programs[device_id];
 
         auto input_buffer = CreateBuffer(
             tt_metal::InterleavedBufferConfig{device->get_devices()[0], cfg.size_bytes, cfg.page_size_bytes, cfg.input_buffer_type});
@@ -454,13 +450,13 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
              (uint32_t)cfg.page_size_bytes,
              (uint32_t)sem_l1_byte_address});
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device->get_devices()[0]->id(),
+            device_id,
             device->get_devices()[0]->ethernet_core_from_logical_core(eth_sender_core),
             std::vector{INVALID},
             sem_l1_byte_address);
 
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
-            device->get_devices()[0]->id(),
+            device_id,
             device->get_devices()[0]->ethernet_core_from_logical_core(eth_receiver_core),
             std::vector{INVALID},
             sem_l1_byte_address);
@@ -499,11 +495,10 @@ bool eth_interleaved_ring_gather_sender_receiver_kernels(
     ths.reserve(sender_receivers.size());
     for (const auto& sender_receiver : sender_receivers) {
         const auto& device = std::get<0>(sender_receiver);
-        workloads[device->get_devices()[0]->id()].add_program(
-            device_range, std::move(programs[device->get_devices()[0]->id()]));
-        ths.emplace_back([&] {
-            distributed::EnqueueMeshWorkload(
-                device->mesh_command_queue(), workloads[device->get_devices()[0]->id()], false);
+        const auto device_id = device->get_device_ids()[0];
+        workloads[device_id].add_program(device_range, std::move(programs[device_id]));
+        ths.emplace_back([device, device_id, &workloads] {
+            distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workloads[device_id], false);
         });
     }
     for (auto& th : ths) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -398,7 +398,7 @@ int main(int argc, char** argv) {
                     uint32_t num_write_ptr_updates = write_size_bytes / (32 * 1024);
                     for (int i = 0; i < num_write_ptr_updates; i++) {
                         tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
-                            &val_to_write, tt_cxy_pair(device->get_devices()[0]->id(), physical_core), reg_addr);
+                            &val_to_write, tt_cxy_pair(device_id, physical_core), reg_addr);
                         reg_addr += sizeof(uint32_t);
                         num_reg_writes = (reg_addr - prefetch_q_base) / sizeof(uint32_t);
                         if (num_reg_writes == num_reg_entries) {
@@ -410,10 +410,7 @@ int main(int argc, char** argv) {
                 if (write_ptr_readback_interval > 0 and num_reg_writes == write_ptr_readback_interval) {
                     std::vector<std::uint32_t> read_hex_vec(1, 0);
                     tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-                        read_hex_vec.data(),
-                        sizeof(uint32_t),
-                        tt_cxy_pair(device->get_devices()[0]->id(), physical_core),
-                        reg_addr);
+                        read_hex_vec.data(), sizeof(uint32_t), tt_cxy_pair(device_id, physical_core), reg_addr);
                 }
 
                 host_write_ptr += write_size_bytes;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -220,7 +220,7 @@ int main(int argc, char** argv) {
     try {
         auto mesh_device = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(0 /*device_id*/);
         auto& cq = mesh_device->mesh_command_queue();
-        auto device_id = mesh_device->get_devices()[0]->id();
+        auto device_id = mesh_device->get_device_ids()[0];
 
         auto mesh_workload = tt::tt_metal::distributed::MeshWorkload();
         tt_metal::Program program = tt_metal::CreateProgram();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -110,7 +110,7 @@ struct SenderReceiverPair {
 tt_metal::distributed::MeshDevice* find_device_with_id(
     const std::vector<std::shared_ptr<tt_metal::distributed::MeshDevice>>& devices, ChipId chip_id) {
     for (const auto& device : devices) {
-        if (device->get_devices()[0]->id() == chip_id) {
+        if (device->get_device_ids()[0] == chip_id) {
             return device.get();
         }
     }
@@ -238,8 +238,9 @@ private:
         bool slow_dispath_mode = (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr);
 
         std::queue<ChipId> chip_q;
-        chip_q.push(this->devices[0]->get_devices()[0]->id());  // Start with the first device's chip ID
-        sender_chips.insert(this->devices[0]->get_devices()[0]->id());
+        const auto device_id = this->devices[0]->get_device_ids()[0];
+        chip_q.push(device_id);  // Start with the first device's chip ID
+        sender_chips.insert(device_id);
         std::unordered_set<ChipId> visited_chips;
 
         // Need sender and receiver chips to be disjoint because we profile wrt. sender and don't want devices to be out
@@ -275,10 +276,11 @@ private:
 
             // Handle other unconnected device clusters
             for (auto& device : this->devices) {
-                if (!visited_chips.contains(device->get_devices()[0]->id())) {
+                const auto device_id = device->get_device_ids()[0];
+                if (!visited_chips.contains(device_id)) {
                     // This device is not connected others visited above, mark it as a sender for its connected cluster
-                    chip_q.push(device->get_devices()[0]->id());
-                    sender_chips.insert(device->get_devices()[0]->id());
+                    chip_q.push(device_id);
+                    sender_chips.insert(device_id);
                     break;
                 }
             }
@@ -330,8 +332,9 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
     // Create a mapping from chip ID to vector index
     std::map<ChipId, size_t> chip_to_index;
     for (size_t i = 0; i < device_helper.devices.size(); i++) {
-        chip_to_index[device_helper.devices[i]->get_devices()[0]->id()] = i;
-        log_info(tt::LogTest, "Device {} index {}", device_helper.devices[i]->get_devices()[0]->id(), i);
+        const auto device_id = device_helper.devices[i]->get_device_ids()[0];
+        chip_to_index[device_id] = i;
+        log_info(tt::LogTest, "Device {} index {}", device_id, i);
     }
 
     uint32_t measurement_type = (uint32_t)(params.test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth);
@@ -438,8 +441,8 @@ void validation(
     auto* sender_device = find_device_with_id(device_helper.devices, link.sender.chip);
     auto* receiver_device = find_device_with_id(device_helper.devices, link.receiver.chip);
     TT_FATAL(
-        sender_device->get_devices()[0]->id() == link.sender.chip and
-            receiver_device->get_devices()[0]->id() == link.receiver.chip,
+        sender_device->get_device_ids()[0] == link.sender.chip and
+            receiver_device->get_device_ids()[0] == link.receiver.chip,
         "Mismatch between chips");
 
     auto sender_virtual =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     do {
         TT_FATAL(eth_sender_core_iter != eth_sender_core_iter_end, "No active ethernet core found for device 0");
-        if (cluster.is_ethernet_link_up(device_0->get_devices()[0]->id(), *eth_sender_core_iter)) {
+        if (cluster.is_ethernet_link_up(device_0->get_device_ids()[0], *eth_sender_core_iter)) {
             std::tie(device_id, eth_receiver_core) =
                 device_0->get_devices()[0]->get_connected_ethernet_core(*eth_sender_core_iter);
             eth_sender_core = *eth_sender_core_iter;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -679,7 +679,7 @@ BuiltProgram build_program(
         core_list.assign(full_order.begin() + off, full_order.begin() + off + want);
     }
     if (cfg.log_core_map) {
-        const auto did = mesh_device->get_devices()[0]->id();
+        const auto did = mesh_device->get_device_ids()[0];
         const auto& sd = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(did);
         for (const auto& c : core_list) {
             const auto p = sd.get_physical_tensix_core_from_logical(c);  // matches profiler core_x/core_y


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

We're going to hide `MeshDevice::get_devices` API in the impl and change the return type to `std::vector<Device*>` to clearly indicate that those are single devices and not mesh devices.

To reduce the blast radius of that change, first we eliminate ~100 unnecessary calls to `get_devices`, for example, where it's used only to get the underlying device ID.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-get-devices-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-get-devices-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-get-devices-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-get-devices-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-get-devices-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-get-devices-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-get-devices-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-get-devices-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-get-devices-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-get-devices-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-get-devices-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-get-devices-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-get-devices-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-get-devices-reduction)