### PR TITLE
fix: enable numeric_stable=true by default in all softmax entry points

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
@@ -79,7 +79,7 @@ Tensor scale_mask_softmax_in_place(
     const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
     bool is_causal_mask = false,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    bool numeric_stable = false);
+    bool numeric_stable = true);
 
 /**
  * @brief Specialized in-place operation for causal masked softmax with height-width dimension constraints.
@@ -101,6 +101,6 @@ Tensor scale_causal_mask_hw_dims_softmax_in_place(
     const std::optional<const Tensor>& mask = std::nullopt,
     const SoftmaxProgramConfig& program_config = SoftmaxDefaultProgramConfig{},
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
-    bool numeric_stable = false);
+    bool numeric_stable = true);
 
 }  // namespace ttnn


### PR DESCRIPTION
## Summary

Fixes #52131

The four blocking tickets (#28531, #28525, #28509, #28500) that prevented enabling numeric_stable=true in softmax entry points are all CLOSED. However, two of the four excepted softmax entry points still default to numeric_stable=false, causing all-zeros output above |x| ~85.

## Changes

Changed default from false to true in:
- scale_mask_softmax_in_place (softmax.hpp:82)
- scale_causal_mask_hw_dims_softmax_in_place (softmax.hpp:104)

The other three entry points (softmax, scale_mask_softmax, softmax_in_place) already default to true.

## Rationale

Per issue #52131, the softmax operation returns all zeros for input values above |x| ~85 when numeric_stable=false. The blocking tickets that previously prevented this change have all been resolved. Enabling numeric_stable=true by default prevents overflow via the standard technique of subtracting the max before applying exp().

## Test plan

- Existing softmax tests should pass with the new default
- Verify that attention softmax operations no longer return zeros for large input values
- The numeric_stable=true path is already implemented and tested in the program factories