### PR TITLE
[Feature] - Generic reduce: H-axis split for TILE inputs on sum/mean

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -205,6 +205,59 @@ def test_rm_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
     )
 
 
+# Tall-H TILE reduces: Ht >= 32 splits the H reduce into ROW_MAJOR FP32 partials collapsed by a
+# second stage. Post-commit covers the shape matrix at keepdim=False; the very tall Wt=1 cases and
+# the keepdim variants live here.
+@pytest.mark.parametrize("reduce_op", ["mean", "sum"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("keepdim", [False, True])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 3136, 144),  # EfficientNetB0 global-pool; Wt=5, split fills the grid
+        (1, 1, 12544, 32),  # very tall, Wt=1 — the split takes this from 1 core to the whole grid
+        (1, 1, 51264, 32),  # the shape from the issue; deepest per-slice accumulation here
+        (1, 1, 3216, 128),  # non-aligned H → trailing slices past the end (identity pad)
+        (1, 1, 3136, 145),  # non-aligned W → last-tile clamp in the RM writer
+    ],
+)
+def test_tile_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
+    """H reduce on tall TILE input — stage 1 keeps the tiled reader/compute and emits ROW_MAJOR FP32
+    partials; stage 2 is the dense RM H collapse."""
+    if dtype == ttnn.bfloat16 and shape[2] >= 12544:
+        pytest.skip("bf16 accumulation-limited at this H; covered by the FP32 variant")
+    torch.manual_seed(0)
+    torch_dtype = torch.float32 if dtype == ttnn.float32 else torch.bfloat16
+    torch_input = torch.rand(shape, dtype=torch_dtype)
+    torch_op = torch.mean if reduce_op == "mean" else torch.sum
+    torch_ref = torch_op(torch_input.float(), dim=-2, keepdim=keepdim).to(torch_dtype)
+
+    tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_op = ttnn.mean if reduce_op == "mean" else ttnn.sum
+    tt_output = ttnn_op(tt_input, dim=-2, keepdim=keepdim)
+    # A TILE input keeps TILE output: stage 1's ROW_MAJOR partials must not leak out as the op's
+    # natural layout the way they do on the RM path.
+    assert tt_output.layout == ttnn.TILE_LAYOUT
+
+    if dtype == ttnn.float32:
+        # Only mean has an accurate fp32 SFPU reduce; sum goes through the TF32-truncating FPU.
+        rtol = 0.002 if reduce_op == "mean" else 0.004
+        pcc_threshold, atol, frobenius_threshold = 0.999, 1e-3, 0.003
+    else:
+        # See the RM variant above: reducing torch.rand leaves the output near-constant, so bf16
+        # quantization dominates the variance PCC measures. Relative error carries the check.
+        pcc_threshold, rtol, atol, frobenius_threshold = 0.97, 0.01, 0.02, 0.005
+    assert_numeric_metrics(
+        torch_ref,
+        ttnn.to_torch(tt_output),
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+        check_ulp=False,
+    )
+
+
 # Partials are always ROW_MAJOR, so output_layout only selects what the final combine stage emits —
 # orthogonal to dtype, so bfloat16 alone covers it.
 @pytest.mark.parametrize("reduce_op", ["mean", "sum"])

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -222,8 +222,7 @@ def test_rm_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
     ],
 )
 def test_tile_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
-    """H reduce on tall TILE input — stage 1 keeps the tiled reader/compute and emits ROW_MAJOR FP32
-    partials; stage 2 is the dense RM H collapse."""
+    """H reduce on tall TILE input — tiled stage 1, RM stage 2."""
     if dtype == ttnn.bfloat16 and shape[2] >= 12544:
         pytest.skip("bf16 accumulation-limited at this H; covered by the FP32 variant")
     torch.manual_seed(0)
@@ -235,8 +234,8 @@ def test_tile_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
     tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn_op = ttnn.mean if reduce_op == "mean" else ttnn.sum
     tt_output = ttnn_op(tt_input, dim=-2, keepdim=keepdim)
-    # A TILE input keeps TILE output: stage 1's ROW_MAJOR partials must not leak out as the op's
-    # natural layout the way they do on the RM path.
+    # No output_layout: TILE in must still produce TILE. Stage 1 writes ROW_MAJOR partials so
+    # each core can own a slice-row; that layout is intermediate and must not become the result.
     assert tt_output.layout == ttnn.TILE_LAYOUT
 
     if dtype == ttnn.float32:
@@ -254,6 +253,47 @@ def test_tile_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
         rtol=rtol,
         atol=atol,
         frobenius_threshold=frobenius_threshold,
+        check_ulp=False,
+    )
+
+
+# Block-float takes the same split (whole-tile I/O). Per-column scale keeps the reduced row from
+# collapsing to a constant that PCC cannot score.
+@pytest.mark.parametrize("reduce_op", ["mean", "sum"])
+@pytest.mark.parametrize("keepdim", [False, True])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 12544, 32),  # EfficientNetB0 SE global-pool; Wt=1, un-split this is a single core
+        (1, 1, 3136, 96),  # EfficientNetB0 SE global-pool; Wt=3
+        (1, 1, 3216, 128),  # non-aligned H → trailing slices past the end (identity pad)
+    ],
+)
+def test_tile_reduce_h_axis_split_block_float(device, reduce_op, keepdim, shape):
+    """H reduce on tall block-float TILE input — same two stages, block-float in and out."""
+    torch.manual_seed(0)
+    torch_input = torch.rand(shape, dtype=torch.bfloat16) * torch.linspace(0.25, 4.0, shape[-1], dtype=torch.bfloat16)
+
+    tt_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+    # Reference from the round-tripped input: against the pre-quantization tensor this would be
+    # measuring from_torch, not the reduce.
+    torch_op = torch.mean if reduce_op == "mean" else torch.sum
+    torch_ref = torch_op(ttnn.to_torch(tt_input).float(), dim=-2, keepdim=keepdim)
+
+    ttnn_op = ttnn.mean if reduce_op == "mean" else ttnn.sum
+    tt_output = ttnn_op(tt_input, dim=-2, keepdim=keepdim)
+    assert tt_output.dtype == ttnn.bfloat8_b
+    assert tt_output.layout == ttnn.TILE_LAYOUT
+
+    # Tolerances are set by the bfloat8_b pack of the result, not by the split: stage 1 accumulates
+    # in FP32, so the error here is at or below the un-split path's.
+    assert_numeric_metrics(
+        torch_ref,
+        ttnn.to_torch(tt_output).float(),
+        pcc_threshold=0.999,
+        rtol=0.02,
+        atol=0.02,
+        frobenius_threshold=0.01,
         check_ulp=False,
     )
 

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduce.py
@@ -189,9 +189,10 @@ def test_rm_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
     assert tt_output.layout == ttnn.ROW_MAJOR_LAYOUT
 
     if dtype == ttnn.float32:
-        # Only mean has an accurate fp32 SFPU reduce; sum goes through the TF32-truncating FPU.
-        rtol = 0.002 if reduce_op == "mean" else 0.004
-        pcc_threshold, atol, frobenius_threshold = 0.999, 1e-3, 0.003
+        # Accurate FP32 uses SFPU; Quasar has no SFPU reduce LLKs and uses the tf32 FPU bound.
+        fpu = device.arch() == ttnn.device.Arch.QUASAR
+        rtol, atol = (0.004, 1e-3) if fpu else (1e-5, 1e-5)
+        pcc_threshold, frobenius_threshold = 0.999, 0.003
     else:
         pcc_threshold, rtol, atol, frobenius_threshold = 0.97, 0.01, 0.02, 0.005
     assert_numeric_metrics(
@@ -205,7 +206,7 @@ def test_rm_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
     )
 
 
-# Tall-H TILE reduces: Ht >= 32 splits the H reduce into ROW_MAJOR FP32 partials collapsed by a
+# Tall-H TILE reduces: Ht >= 20 splits the H reduce into ROW_MAJOR FP32 partials collapsed by a
 # second stage. Post-commit covers the shape matrix at keepdim=False; the very tall Wt=1 cases and
 # the keepdim variants live here.
 @pytest.mark.parametrize("reduce_op", ["mean", "sum"])
@@ -239,9 +240,10 @@ def test_tile_reduce_h_axis_split(device, reduce_op, dtype, keepdim, shape):
     assert tt_output.layout == ttnn.TILE_LAYOUT
 
     if dtype == ttnn.float32:
-        # Only mean has an accurate fp32 SFPU reduce; sum goes through the TF32-truncating FPU.
-        rtol = 0.002 if reduce_op == "mean" else 0.004
-        pcc_threshold, atol, frobenius_threshold = 0.999, 1e-3, 0.003
+        # Accurate FP32 uses SFPU; Quasar has no SFPU reduce LLKs and uses the tf32 FPU bound.
+        fpu = device.arch() == ttnn.device.Arch.QUASAR
+        rtol, atol = (0.004, 1e-3) if fpu else (1e-5, 1e-5)
+        pcc_threshold, frobenius_threshold = 0.999, 0.003
     else:
         # See the RM variant above: reducing torch.rand leaves the output near-constant, so bf16
         # quantization dominates the variance PCC measures. Relative error carries the check.

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -751,6 +751,132 @@ def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, ou
     )
 
 
+def _tile_split_metrics(dtype, reduce_op, fast_and_approximate_mode):
+    if dtype == ttnn.float32:
+        # Only mean has an accurate fp32 SFPU reduce; the FPU path truncates to TF32, roughly
+        # doubling the relative error at these depths.
+        rtol = 0.002 if (reduce_op == "mean" and not fast_and_approximate_mode) else 0.004
+        return dict(pcc_threshold=0.999, rtol=rtol, atol=1e-3, frobenius_threshold=0.003, check_ulp=False)
+    # For bf16 the observed relative error saturates at ~0.008 for every shape below, which is the
+    # output dtype's own quantization step (2^-7) and not reduce error: stage 1 accumulates into
+    # FP32 partials either way, and only the final pack is bf16.
+    #
+    # The bf16 PCC threshold is loose for a structural reason, not because the results are: reducing
+    # torch.rand over thousands of rows concentrates the output around a constant (mean lands at
+    # 0.5 +/- 0.005), and bf16's step at that magnitude is 0.0039 -- the quantization noise is the
+    # same size as the signal PCC correlates against, so a bit-perfect kernel scores ~0.978.
+    # Switching the input to randn fixes PCC and breaks relative error instead (results pass through
+    # zero, so max rtol exceeds 1 even in fp32). Relative error and Frobenius stay tight and carry
+    # the check here; 0.97 matches the bf16 threshold the nightly RM split test uses for the same
+    # reason.
+    return dict(pcc_threshold=0.97, rtol=0.01, atol=0.01, frobenius_threshold=0.004, check_ulp=False)
+
+
+# Shapes that take the TILE H-axis split: Ht >= 32 (the TILE threshold) and NC*Wt below the core
+# count, so the un-split path would leave most of the grid idle. All of them also have
+# num_h_slices * slice_Ht > Ht on both a 64-core WH and a 130-core BH grid, so the reader's
+# past-the-end slices (identity zeros) are exercised too.
+_TILE_H_SPLIT_SHAPES = [
+    (1, 1, 3136, 144),  # EfficientNetB0 global-pool; Ht=98, Wt=5
+    (1, 1, 3216, 128),  # Ht=101, non-aligned H
+    (1, 1, 1064, 256),  # Ht=34, wide Wt=8, near the threshold, non-aligned H
+    (2, 3, 1024, 40),  # NC=6, Ht=32 — exactly at the threshold
+    (1, 1, 3136, 145),  # non-aligned W → the RM writer's last-tile clamp
+]
+
+
+@pytest.mark.parametrize("reduce_op", ["mean", "sum"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("fast_and_approximate_mode", [False, True])
+@pytest.mark.parametrize(
+    "output_layout", [None, ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], ids=["default", "rm", "tile"]
+)
+@pytest.mark.parametrize("shape", _TILE_H_SPLIT_SHAPES)
+def test_tile_reduce_h_axis_split(device, reduce_op, dtype, fast_and_approximate_mode, output_layout, shape):
+    """H reduce on tall TILE input — stage 1 keeps the tiled reader/compute but emits ROW_MAJOR FP32
+    partials, stage 2 is the dense RM H collapse."""
+    if fast_and_approximate_mode and reduce_op != "mean":
+        pytest.skip("fast_and_approximate_mode only affects mean")
+    torch.manual_seed(0)
+    torch_input = torch.rand(shape, dtype=_torch_dtype(dtype))
+    torch_ref = _golden(torch_input, reduce_op, dim=-2, keepdim=False)
+
+    tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    assert tt_input.layout == ttnn.TILE_LAYOUT
+
+    ttnn_op = _OPS[reduce_op][1]
+    op_kwargs = {"dim": -2, "keepdim": False, "output_layout": output_layout}
+    if reduce_op == "mean":
+        op_kwargs["fast_and_approximate_mode"] = fast_and_approximate_mode
+    tt_output = ttnn_op(tt_input, **op_kwargs)
+    # A TILE input defaults to TILE output: stage 1's ROW_MAJOR partials must not leak out as the
+    # op's natural layout the way they do on the RM path.
+    assert tt_output.layout == (output_layout or ttnn.TILE_LAYOUT)
+    output = ttnn.to_torch(tt_output)
+
+    assert_numeric_metrics(torch_ref, output, **_tile_split_metrics(dtype, reduce_op, fast_and_approximate_mode))
+
+
+@pytest.mark.parametrize("reduce_op", ["mean", "sum"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("shape", _TILE_H_SPLIT_SHAPES)
+def test_tile_reduce_h_axis_split_padding_poisoned(device, reduce_op, dtype, shape):
+    """Same shapes with the implicit tile padding pre-filled with a large negative value.
+
+    The reduce re-zeroes implicit padding itself (fill_implicit_tile_padding in
+    generic_reductions.cpp), so what this pins down is that the split path does not bypass that
+    fill — not the reader's past-the-end slices, which are covered by the shapes themselves.
+    """
+    torch.manual_seed(0)
+    torch_input = torch.rand(shape, dtype=_torch_dtype(dtype))
+    torch_ref = _golden(torch_input, reduce_op, dim=-2, keepdim=False)
+
+    tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_input = ttnn.fill_implicit_tile_padding(tt_input, -42.0)
+
+    tt_output = _OPS[reduce_op][1](tt_input, dim=-2, keepdim=False)
+    assert tt_output.layout == ttnn.TILE_LAYOUT
+    output = ttnn.to_torch(tt_output)
+
+    assert_numeric_metrics(torch_ref, output, **_tile_split_metrics(dtype, reduce_op, False))
+
+
+@pytest.mark.parametrize("reduce_op", ["mean", "sum"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize(
+    "shape_or_grid_width",
+    [
+        (1, 1, 256, 64),  # Ht=8, far below either split threshold
+        (1, 1, 512, 32),  # Ht=16: splits under the RM threshold, must not under the TILE one (32)
+        "grid_wide",  # Ht=32 (above the threshold) but NC*Wt == grid_cores, so there is nothing to fill
+    ],
+)
+def test_tile_reduce_h_no_split_unchanged(device, reduce_op, dtype, shape_or_grid_width):
+    """Shapes the TILE H-axis split must decline. Regression cover for the un-split reader branch,
+    whose compile-time arg layout shifted when the split slots were added."""
+    if shape_or_grid_width == "grid_wide":
+        grid = device.compute_with_storage_grid_size()
+        # W = 32 * grid_cores makes Wt == grid_cores, so col_groups >= grid_cores whatever the part
+        # is harvested down to. Do not hardcode a width: a literal that starves a 64-core Wormhole
+        # still splits on a 130-core Blackhole.
+        shape = (1, 1, 1024, 32 * grid.x * grid.y)
+        if dtype == ttnn.float32:
+            pytest.skip("grid-wide shape is only run in bfloat16 to keep the tensor small")
+    else:
+        shape = shape_or_grid_width
+
+    torch.manual_seed(0)
+    torch_input = torch.rand(shape, dtype=_torch_dtype(dtype))
+    torch_ref = _golden(torch_input, reduce_op, dim=-2, keepdim=False)
+
+    tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = _OPS[reduce_op][1](tt_input, dim=-2, keepdim=False)
+    assert tt_output.layout == ttnn.TILE_LAYOUT
+    output = ttnn.to_torch(tt_output)
+
+    assert_numeric_metrics(torch_ref, output, **_tile_split_metrics(dtype, reduce_op, False))
+
+
 # Block-float formats only exist in TILE layout: an RM output would have to widen to BFLOAT16, so
 # sum/mean reject the request instead of silently changing the dtype.
 @pytest.mark.parametrize("reduce_op", ["mean", "sum"])

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -751,50 +751,26 @@ def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, ou
     )
 
 
-def _tile_split_metrics(dtype, reduce_op, fast_and_approximate_mode):
-    if dtype == ttnn.float32:
-        # Only mean has an accurate fp32 SFPU reduce; the FPU path truncates to TF32, roughly
-        # doubling the relative error at these depths.
-        rtol = 0.002 if (reduce_op == "mean" and not fast_and_approximate_mode) else 0.004
-        return dict(pcc_threshold=0.999, rtol=rtol, atol=1e-3, frobenius_threshold=0.003, check_ulp=False)
-    # For bf16 the observed relative error saturates at ~0.008 for every shape below, which is the
-    # output dtype's own quantization step (2^-7) and not reduce error: stage 1 accumulates into
-    # FP32 partials either way, and only the final pack is bf16.
-    #
-    # The bf16 PCC threshold is loose for a structural reason, not because the results are: reducing
-    # torch.rand over thousands of rows concentrates the output around a constant (mean lands at
-    # 0.5 +/- 0.005), and bf16's step at that magnitude is 0.0039 -- the quantization noise is the
-    # same size as the signal PCC correlates against, so a bit-perfect kernel scores ~0.978.
-    # Switching the input to randn fixes PCC and breaks relative error instead (results pass through
-    # zero, so max rtol exceeds 1 even in fp32). Relative error and Frobenius stay tight and carry
-    # the check here; 0.97 matches the bf16 threshold the nightly RM split test uses for the same
-    # reason.
-    return dict(pcc_threshold=0.97, rtol=0.01, atol=0.01, frobenius_threshold=0.004, check_ulp=False)
-
-
-# Shapes that take the TILE H-axis split: Ht >= 32 (the TILE threshold) and NC*Wt below the core
-# count, so the un-split path would leave most of the grid idle. All of them also have
-# num_h_slices * slice_Ht > Ht on both a 64-core WH and a 130-core BH grid, so the reader's
-# past-the-end slices (identity zeros) are exercised too.
-_TILE_H_SPLIT_SHAPES = [
-    (1, 1, 3136, 144),  # EfficientNetB0 global-pool; Ht=98, Wt=5
-    (1, 1, 3216, 128),  # Ht=101, non-aligned H
-    (1, 1, 1064, 256),  # Ht=34, wide Wt=8, near the threshold, non-aligned H
-    (2, 3, 1024, 40),  # NC=6, Ht=32 — exactly at the threshold
-    (1, 1, 3136, 145),  # non-aligned W → the RM writer's last-tile clamp
-]
-
-
 @pytest.mark.parametrize("reduce_op", ["mean", "sum"])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("fast_and_approximate_mode", [False, True])
 @pytest.mark.parametrize(
     "output_layout", [None, ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], ids=["default", "rm", "tile"]
 )
-@pytest.mark.parametrize("shape", _TILE_H_SPLIT_SHAPES)
+# Shapes that take the split: Ht above k_min_ht_for_split_tile with NC*Wt below the core count.
+# All also have num_h_slices * slice_Ht > Ht, exercising the reader's past-the-end slices.
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 3136, 144),  # EfficientNetB0 global-pool; Ht=98, Wt=5
+        (1, 1, 3216, 128),  # Ht=101, non-aligned H
+        (1, 1, 1064, 256),  # Ht=34, wide Wt=8, near the threshold, non-aligned H
+        (2, 3, 1024, 40),  # NC=6, Ht=32 — exactly at the threshold
+        (1, 1, 3136, 145),  # non-aligned W → the RM writer's last-tile clamp
+    ],
+)
 def test_tile_reduce_h_axis_split(device, reduce_op, dtype, fast_and_approximate_mode, output_layout, shape):
-    """H reduce on tall TILE input — stage 1 keeps the tiled reader/compute but emits ROW_MAJOR FP32
-    partials, stage 2 is the dense RM H collapse."""
+    """H reduce on tall TILE input — tiled stage 1, RM stage 2. TILE input defaults to TILE output."""
     if fast_and_approximate_mode and reduce_op != "mean":
         pytest.skip("fast_and_approximate_mode only affects mean")
     torch.manual_seed(0)
@@ -803,6 +779,7 @@ def test_tile_reduce_h_axis_split(device, reduce_op, dtype, fast_and_approximate
 
     tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
     assert tt_input.layout == ttnn.TILE_LAYOUT
+    tt_input = ttnn.fill_implicit_tile_padding(tt_input, -42.0)
 
     ttnn_op = _OPS[reduce_op][1]
     op_kwargs = {"dim": -2, "keepdim": False, "output_layout": output_layout}
@@ -814,67 +791,13 @@ def test_tile_reduce_h_axis_split(device, reduce_op, dtype, fast_and_approximate
     assert tt_output.layout == (output_layout or ttnn.TILE_LAYOUT)
     output = ttnn.to_torch(tt_output)
 
-    assert_numeric_metrics(torch_ref, output, **_tile_split_metrics(dtype, reduce_op, fast_and_approximate_mode))
-
-
-@pytest.mark.parametrize("reduce_op", ["mean", "sum"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
-@pytest.mark.parametrize("shape", _TILE_H_SPLIT_SHAPES)
-def test_tile_reduce_h_axis_split_padding_poisoned(device, reduce_op, dtype, shape):
-    """Same shapes with the implicit tile padding pre-filled with a large negative value.
-
-    The reduce re-zeroes implicit padding itself (fill_implicit_tile_padding in
-    generic_reductions.cpp), so what this pins down is that the split path does not bypass that
-    fill — not the reader's past-the-end slices, which are covered by the shapes themselves.
-    """
-    torch.manual_seed(0)
-    torch_input = torch.rand(shape, dtype=_torch_dtype(dtype))
-    torch_ref = _golden(torch_input, reduce_op, dim=-2, keepdim=False)
-
-    tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
-    tt_input = ttnn.fill_implicit_tile_padding(tt_input, -42.0)
-
-    tt_output = _OPS[reduce_op][1](tt_input, dim=-2, keepdim=False)
-    assert tt_output.layout == ttnn.TILE_LAYOUT
-    output = ttnn.to_torch(tt_output)
-
-    assert_numeric_metrics(torch_ref, output, **_tile_split_metrics(dtype, reduce_op, False))
-
-
-@pytest.mark.parametrize("reduce_op", ["mean", "sum"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
-@pytest.mark.parametrize(
-    "shape_or_grid_width",
-    [
-        (1, 1, 256, 64),  # Ht=8, far below either split threshold
-        (1, 1, 512, 32),  # Ht=16: splits under the RM threshold, must not under the TILE one (32)
-        "grid_wide",  # Ht=32 (above the threshold) but NC*Wt == grid_cores, so there is nothing to fill
-    ],
-)
-def test_tile_reduce_h_no_split_unchanged(device, reduce_op, dtype, shape_or_grid_width):
-    """Shapes the TILE H-axis split must decline. Regression cover for the un-split reader branch,
-    whose compile-time arg layout shifted when the split slots were added."""
-    if shape_or_grid_width == "grid_wide":
-        grid = device.compute_with_storage_grid_size()
-        # W = 32 * grid_cores makes Wt == grid_cores, so col_groups >= grid_cores whatever the part
-        # is harvested down to. Do not hardcode a width: a literal that starves a 64-core Wormhole
-        # still splits on a 130-core Blackhole.
-        shape = (1, 1, 1024, 32 * grid.x * grid.y)
-        if dtype == ttnn.float32:
-            pytest.skip("grid-wide shape is only run in bfloat16 to keep the tensor small")
+    if dtype == ttnn.float32:
+        # Only mean has an accurate fp32 SFPU reduce; the FPU path truncates to TF32, doubling rtol.
+        rtol = 0.002 if (reduce_op == "mean" and not fast_and_approximate_mode) else 0.004
+        metrics = dict(pcc_threshold=0.999, rtol=rtol, atol=1e-3, frobenius_threshold=0.003)
     else:
-        shape = shape_or_grid_width
-
-    torch.manual_seed(0)
-    torch_input = torch.rand(shape, dtype=_torch_dtype(dtype))
-    torch_ref = _golden(torch_input, reduce_op, dim=-2, keepdim=False)
-
-    tt_input = ttnn.from_torch(torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
-    tt_output = _OPS[reduce_op][1](tt_input, dim=-2, keepdim=False)
-    assert tt_output.layout == ttnn.TILE_LAYOUT
-    output = ttnn.to_torch(tt_output)
-
-    assert_numeric_metrics(torch_ref, output, **_tile_split_metrics(dtype, reduce_op, False))
+        metrics = dict(pcc_threshold=0.97, rtol=0.01, atol=0.01, frobenius_threshold=0.004)
+    assert_numeric_metrics(torch_ref, output, check_ulp=False, **metrics)
 
 
 # Block-float formats only exist in TILE layout: an RM output would have to widen to BFLOAT16, so

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -737,23 +737,27 @@ def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, ou
     assert tt_output.layout == (output_layout or ttnn.ROW_MAJOR_LAYOUT)
     output = ttnn.to_torch(tt_output)
 
-    # Accurate SFPU (full fp32) vs FPU (tf32 truncation). The FPU path roughly doubles the relative
-    # error at these depths; Quasar has no SFPU reduce LLKs, so it always takes the FPU bound.
-    rtol = 0.004 if fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR else 0.0011
+    # Accurate FP32 uses SFPU; fast mode and Quasar use the tf32 FPU bound.
+    fpu = fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR
+    rtol, atol = (0.004, 1e-3) if fpu else (1e-5, 1e-5)
     assert_numeric_metrics(
         torch_ref,
         output,
         pcc_threshold=0.999,
         rtol=rtol,
-        atol=1e-3,
+        atol=atol,
         frobenius_threshold=0.003,
         check_ulp=False,
     )
 
 
 @pytest.mark.parametrize("reduce_op", ["mean", "sum"])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
-@pytest.mark.parametrize("fast_and_approximate_mode", [False, True])
+# Engine selection applies only to FLOAT32.
+@pytest.mark.parametrize(
+    "dtype, fast_and_approximate_mode",
+    [(ttnn.bfloat16, False), (ttnn.float32, False), (ttnn.float32, True)],
+    ids=["bf16", "fp32_sfpu", "fp32_fpu"],
+)
 @pytest.mark.parametrize(
     "output_layout", [None, ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT], ids=["default", "rm", "tile"]
 )
@@ -765,14 +769,12 @@ def test_rm_reduce_h_axis_split(device, reduce_op, fast_and_approximate_mode, ou
         (1, 1, 3136, 144),  # EfficientNetB0 global-pool; Ht=98, Wt=5
         (1, 1, 3216, 128),  # Ht=101, non-aligned H
         (1, 1, 1064, 256),  # Ht=34, wide Wt=8, near the threshold, non-aligned H
-        (2, 3, 1024, 40),  # NC=6, Ht=32 — exactly at the threshold
+        (2, 3, 1024, 40),  # NC=6, Ht=32
         (1, 1, 3136, 145),  # non-aligned W → the RM writer's last-tile clamp
     ],
 )
 def test_tile_reduce_h_axis_split(device, reduce_op, dtype, fast_and_approximate_mode, output_layout, shape):
     """H reduce on tall TILE input — tiled stage 1, RM stage 2. TILE input defaults to TILE output."""
-    if fast_and_approximate_mode and reduce_op != "mean":
-        pytest.skip("fast_and_approximate_mode only affects mean")
     torch.manual_seed(0)
     torch_input = torch.rand(shape, dtype=_torch_dtype(dtype))
     torch_ref = _golden(torch_input, reduce_op, dim=-2, keepdim=False)
@@ -782,9 +784,12 @@ def test_tile_reduce_h_axis_split(device, reduce_op, dtype, fast_and_approximate
     tt_input = ttnn.fill_implicit_tile_padding(tt_input, -42.0)
 
     ttnn_op = _OPS[reduce_op][1]
-    op_kwargs = {"dim": -2, "keepdim": False, "output_layout": output_layout}
-    if reduce_op == "mean":
-        op_kwargs["fast_and_approximate_mode"] = fast_and_approximate_mode
+    op_kwargs = {
+        "dim": -2,
+        "keepdim": False,
+        "output_layout": output_layout,
+        "fast_and_approximate_mode": fast_and_approximate_mode,
+    }
     tt_output = ttnn_op(tt_input, **op_kwargs)
     # A TILE input defaults to TILE output: stage 1's ROW_MAJOR partials must not leak out as the
     # op's natural layout the way they do on the RM path.
@@ -792,9 +797,10 @@ def test_tile_reduce_h_axis_split(device, reduce_op, dtype, fast_and_approximate
     output = ttnn.to_torch(tt_output)
 
     if dtype == ttnn.float32:
-        # Only mean has an accurate fp32 SFPU reduce; the FPU path truncates to TF32, doubling rtol.
-        rtol = 0.002 if (reduce_op == "mean" and not fast_and_approximate_mode) else 0.004
-        metrics = dict(pcc_threshold=0.999, rtol=rtol, atol=1e-3, frobenius_threshold=0.003)
+        # Accurate FP32 uses SFPU; fast mode and Quasar use the tf32 FPU bound.
+        fpu = fast_and_approximate_mode or device.arch() == ttnn.device.Arch.QUASAR
+        rtol, atol = (0.004, 1e-3) if fpu else (1e-5, 1e-5)
+        metrics = dict(pcc_threshold=0.999, rtol=rtol, atol=atol, frobenius_threshold=0.003)
     else:
         metrics = dict(pcc_threshold=0.97, rtol=0.01, atol=0.01, frobenius_threshold=0.004)
     assert_numeric_metrics(torch_ref, output, check_ulp=False, **metrics)

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -17,6 +17,12 @@
 #include <ttnn/tensor/layout/page_config.hpp>
 
 namespace ttnn::prim {
+namespace {
+// tt::datum_size throws for block-float rather than returning a size. Bfp8_b is the only
+// block-float format the op admits, so it is the only one that reaches here.
+bool block_float_format(tt::DataFormat df) { return df == tt::DataFormat::Bfp8_b; }
+}  // namespace
+
 RmPlan make_rm_plan(
     const tt::tt_metal::Shape& padded_shape,
     const tt::tt_metal::Shape& logical_shape,
@@ -49,10 +55,10 @@ RmPlan make_rm_plan(
         plan.ht_tiles_per_chunk = std::clamp(plan.Ht_rm, 1u, k_rm_max_tiles_per_chunk);
     }
 
-    // The RM dense path is gated to BF16/FP32 at validate_rm_preconditions;
-    // so the unpacked-format byte sizes are always well-defined here.
-    plan.src_datum_size = tt::datum_size(src_cb_data_format);
-    plan.dst_datum_size = tt::datum_size(dst_cb_data_format);
+    // Block-float has no per-datum size. RM staging and the writer stride never see it here:
+    // RM input is BF16/FP32, and block-float output is TILE-only.
+    plan.src_datum_size = block_float_format(src_cb_data_format) ? 0 : tt::datum_size(src_cb_data_format);
+    plan.dst_datum_size = block_float_format(dst_cb_data_format) ? 0 : tt::datum_size(dst_cb_data_format);
     plan.chunk_row_bytes = plan.wt_tiles_per_chunk * tile_width * plan.src_datum_size;
     // One CB page = one logical RM row (chunk-wide). The compute kernel uses
     // compute_kernel_lib::tilize, whose asymmetric mode requires one input page per row so each

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -63,18 +63,8 @@ void kernel_main() {
     auto tensor_accessor = TensorAccessor(tensor::src);
 
     if constexpr (num_h_slices > 1) {
-        //
-        // === H-axis split ===
-        //
-        // Each work unit is a (nc, slice, wt) triple of the (N, C, num_h_slices, W) result, laid out
-        // wt-fastest then slice then nc — the same ordering writer_reduce_rm_scalar.cpp recovers from
-        // its start_output_tile_id. col_start_tile_id carries the global work-unit id
-        // (curr_col_in_batch is unused), so the tile ids come out in closed form rather than from an
-        // incremental walk.
-        //
-        // The (j over the slice's H, k over the W-chunk) nesting matches the un-split path, so the
-        // tile order the compute kernel sees still lines up with its DEST_AUTO_LIMIT chunking.
-        //
+        // Work units are (nc, slice, wt) in wt-fastest order. col_start_tile_id is the global id
+        // (curr_col_in_batch unused). Nesting matches the un-split DEST_AUTO_LIMIT chunking.
         const uint32_t work_start = col_start_tile_id;
         for (uint32_t i = 0; i < num_cols; i += row_chunk) {
             const uint32_t chunk_end = std::min(i + row_chunk, num_cols);
@@ -96,8 +86,7 @@ void kernel_main() {
                             {.offset_bytes = 0});
                         noc.async_read_barrier();
                     } else {
-                        // slice_Ht is rounded up, so the trailing slices can run past the end of the
-                        // reduction axis. Push the SUM identity instead of reading out of bounds.
+                        // slice_Ht is rounded up; pad past Ht with the SUM identity.
                         dataflow_kernel_lib::zero_tile(dfb_in0);
                     }
                     dfb_in0.push_back(onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp"
 
 void kernel_main() {
     // Start id in column major order. This should be the start of a column.
@@ -26,6 +27,11 @@ void kernel_main() {
     constexpr bool use_welford = get_arg(args::use_welford) != 0;
     constexpr auto fp32_mode = get_arg(args::enable_fp32_sfpu) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
     constexpr uint32_t tiles_per_batch = get_arg(args::tiles_per_batch);
+    // H-axis split geometry: the reduction axis is cut into `num_h_slices` slices of `slice_Ht` tiles
+    // each, and the work units become (nc, slice, wt) triples over a (N, C, num_h_slices, W) result.
+    // {1, Ht} is the un-split reduce.
+    constexpr auto num_h_slices = get_arg(args::num_h_slices);
+    constexpr auto slice_Ht = get_arg(args::slice_Ht);
 
     // Welford must process one column at a time because the SFPU can only maintain
     // a single running mean/M2 state. DEST_AUTO_LIMIT interleaves multiple columns
@@ -55,6 +61,51 @@ void kernel_main() {
     dataflow_kernel_lib::prepare_reduce_scaler<dfb::scaler, REDUCE_OP, REDUCE_DIM>(scaler_f);
 
     auto tensor_accessor = TensorAccessor(tensor::src);
+
+    if constexpr (num_h_slices > 1) {
+        //
+        // === H-axis split ===
+        //
+        // Each work unit is a (nc, slice, wt) triple of the (N, C, num_h_slices, W) result, laid out
+        // wt-fastest then slice then nc — the same ordering writer_reduce_rm_scalar.cpp recovers from
+        // its start_output_tile_id. col_start_tile_id carries the global work-unit id
+        // (curr_col_in_batch is unused), so the tile ids come out in closed form rather than from an
+        // incremental walk.
+        //
+        // The (j over the slice's H, k over the W-chunk) nesting matches the un-split path, so the
+        // tile order the compute kernel sees still lines up with its DEST_AUTO_LIMIT chunking.
+        //
+        const uint32_t work_start = col_start_tile_id;
+        for (uint32_t i = 0; i < num_cols; i += row_chunk) {
+            const uint32_t chunk_end = std::min(i + row_chunk, num_cols);
+            for (uint32_t j = 0; j < slice_Ht; ++j) {
+                for (uint32_t k = i; k < chunk_end; ++k) {
+                    const uint32_t id = work_start + k;
+                    const uint32_t wt = id % Wt;
+                    const uint32_t slice = (id / Wt) % num_h_slices;
+                    const uint32_t nc = id / (Wt * num_h_slices);
+                    const uint32_t ht = slice * slice_Ht + j;
+
+                    dfb_in0.reserve_back(onetile);
+                    if (ht < Ht) {
+                        noc.async_read(
+                            tensor_accessor,
+                            dfb_in0,
+                            tile_bytes,
+                            {.page_id = nc * HtWt + ht * Wt + wt},
+                            {.offset_bytes = 0});
+                        noc.async_read_barrier();
+                    } else {
+                        // slice_Ht is rounded up, so the trailing slices can run past the end of the
+                        // reduction axis. Push the SUM identity instead of reading out of bounds.
+                        dataflow_kernel_lib::zero_tile(dfb_in0);
+                    }
+                    dfb_in0.push_back(onetile);
+                }
+            }
+        }
+        return;
+    }
 
     uint32_t w = curr_col_in_batch;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -11,7 +11,6 @@
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_common.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"
-#include "ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp"
 
 void kernel_main() {
     // Start id in column major order. This should be the start of a column.
@@ -65,7 +64,14 @@ void kernel_main() {
     if constexpr (num_h_slices > 1) {
         // Work units are (nc, slice, wt) in wt-fastest order. col_start_tile_id is the global id
         // (curr_col_in_batch unused). Nesting matches the un-split DEST_AUTO_LIMIT chunking.
+        //
+        // Reads batch along the whole (i, j, k) stream rather than the k loop alone: the split sizes
+        // num_cols to fill the grid, so a core usually owns one column and its consecutive reads run
+        // down the slice's H. Only the trailing push is short, so every full reserve stays aligned to
+        // tiles_per_batch and none straddles the buffer wrap.
         const uint32_t work_start = col_start_tile_id;
+        uint32_t filled = 0;
+        bool padded = false;
         for (uint32_t i = 0; i < num_cols; i += row_chunk) {
             const uint32_t chunk_end = std::min(i + row_chunk, num_cols);
             for (uint32_t j = 0; j < slice_Ht; ++j) {
@@ -76,22 +82,40 @@ void kernel_main() {
                     const uint32_t nc = id / (Wt * num_h_slices);
                     const uint32_t ht = slice * slice_Ht + j;
 
-                    dfb_in0.reserve_back(onetile);
+                    if (filled == 0) {
+                        dfb_in0.reserve_back(tiles_per_batch);
+                    }
                     if (ht < Ht) {
                         noc.async_read(
                             tensor_accessor,
                             dfb_in0,
                             tile_bytes,
                             {.page_id = nc * HtWt + ht * Wt + wt},
-                            {.offset_bytes = 0});
-                        noc.async_read_barrier();
+                            {.offset_bytes = filled * tile_bytes});
                     } else {
                         // slice_Ht is rounded up; pad past Ht with the SUM identity.
-                        dataflow_kernel_lib::zero_tile(dfb_in0);
+                        noc.async_write_zeros(dfb_in0, tile_bytes, {.offset_bytes = filled * tile_bytes});
+                        padded = true;
                     }
-                    dfb_in0.push_back(onetile);
+
+                    if (++filled == tiles_per_batch) {
+                        noc.async_read_barrier();
+                        if (padded) {
+                            noc.write_zeros_l1_barrier();
+                        }
+                        dfb_in0.push_back(tiles_per_batch);
+                        filled = 0;
+                        padded = false;
+                    }
                 }
             }
+        }
+        if (filled > 0) {
+            noc.async_read_barrier();
+            if (padded) {
+                noc.write_zeros_l1_barrier();
+            }
+            dfb_in0.push_back(filled);
         }
         return;
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -87,27 +87,16 @@ Tensor reduce_min(
         true);
 }
 
-// --- H-axis split tuning knobs. Both are per-path; the RM values reproduce merged behavior. ---
-//
-// (1) Don't split at all below this many tiles on the reduction axis: the extra dispatch and the
-// partials round trip cost more than the added parallelism buys. The RM path stages row pages
-// through compute_kernel_lib::tilize (one CB page per logical row), so its per-tile cost is higher
-// and it breaks even sooner; the TILE path async_reads whole tiles, so its un-split baseline is
-// already cheap and the split must clear a higher bar.
+// Minimum H tiles required to take the H-axis split.
 static constexpr uint32_t k_min_ht_for_split_rm = 16;    // ~H >= 512 rows
-static constexpr uint32_t k_min_ht_for_split_tile = 32;  // ~H >= 1024 rows
+static constexpr uint32_t k_min_ht_for_split_tile = 20;  // ~H >= 640 rows
 
-// (2) Never split so finely that one core reduces fewer than this many tiles. Every extra slice
-// adds a row to the partials and a work unit to stage 2, so past some point thinner slices stop
-// paying back. 1 == "as thin as needed to fill the grid", which is exactly today's behavior since
-// slices_at_min_work then degenerates to Ht. Raising it trades cores for per-core work.
-static constexpr uint32_t k_min_ht_per_slice_rm = 1;    // merged behavior - do not change
-static constexpr uint32_t k_min_ht_per_slice_tile = 1;  // deliberately neutral; tune from here
+static constexpr uint32_t k_min_ht_per_slice_rm = 1;
+static constexpr uint32_t k_min_ht_per_slice_tile = 1;
 
-// Number of H-axis slices to split the reduction into. 1 means "don't split".
-// `min_ht_per_slice` is a floor on tiles-per-slice, so it can only reduce the slice count below the
-// grid-filling value: oversubscribing the grid would add partial rows and stage-2 work without
-// adding parallelism.
+// H-axis slice count; 1 leaves the reduce un-split.
+// Fill the grid, but never so thinly that a slice has fewer than min_ht_per_slice tiles. Extra
+// slices past that would add partial rows and stage-2 work without more parallelism.
 static uint32_t compute_h_slices(
     uint32_t col_groups, uint32_t Ht, uint32_t grid_cores, uint32_t min_ht_for_split, uint32_t min_ht_per_slice) {
     if (col_groups == 0 || col_groups >= grid_cores || Ht < min_ht_for_split) {
@@ -364,9 +353,7 @@ Tensor reduce(
     }
 
     // H-axis split: the un-split RM-H path uses only NC*Wt cores, so tall-H shapes starve the grid.
-    // Split the reduction axis into S segments — stage 1 → (N,C,S,W) FP32 partials, stage 2 →
-    // collapse the slice axis with the user scaler and final dtype. Sum over H is the sum of the
-    // per-slice sums, so mean's 1/N applies once, in stage 2.
+    // Stage 1 emits (N,C,S,W) FP32 partials; stage 2 collapses the slice axis with the user scaler.
     if (use_rm_dense_h) {
         const auto& logical = input_tensor.logical_shape();
         const auto& padded = input_tensor.padded_shape();
@@ -421,24 +408,22 @@ Tensor reduce(
         }
     }
 
-    // Same H-axis split for TILE input: the un-split tiled H path also parallelizes only over
-    // NC*Wt columns. Stage 1 keeps the tiled reader + reduce.cpp but emits (N,C,S,W) FP32
-    // ROW_MAJOR partials — a TILE partial would put up to TILE_HEIGHT slices inside one page,
-    // which independent cores cannot write. Stage 2 is then the same RM dense H collapse the
-    // ROW_MAJOR split already uses.
+    // Same split for TILE input: un-split also parallelizes only over NC*Wt. Stage 1 keeps the
+    // tiled reader/compute but emits ROW_MAJOR FP32 partials — a TILE partial would pack slices
+    // into one page. Stage 2 is the RM dense H collapse. Block-float rides along as whole tiles.
     if (prepared_input.layout() == tt::tt_metal::Layout::TILE && reduce_dim == tt::tt_metal::ReduceOpDim::H &&
         (reduce_math == tt::tt_metal::ReduceOpMath::AVG || reduce_math == tt::tt_metal::ReduceOpMath::SUM) && !negate &&
         both_interleaved && !prepared_input.shard_spec().has_value() && prepared_input.logical_shape().rank() == 4 &&
         (prepared_input.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
-         prepared_input.dtype() == tt::tt_metal::DataType::FLOAT32)) {
+         prepared_input.dtype() == tt::tt_metal::DataType::FLOAT32 ||
+         tt::tt_metal::is_block_float(prepared_input.dtype()))) {
         const auto& logical = prepared_input.logical_shape();
         const auto& padded = prepared_input.padded_shape();
         const uint32_t tile_h = prepared_input.tensor_spec().tile().get_height();
         const uint32_t tile_w = prepared_input.tensor_spec().tile().get_width();
         const uint32_t NC = logical[0] * logical[1];
         const uint32_t Wt = (padded[3] + tile_w - 1) / tile_w;
-        // Derived from the padded H, matching the factory's Ht: the reader's overhang guard
-        // (ht >= Ht) indexes real tiles, so host and kernel must agree on the tile count.
+        // Padded H, matching the factory's Ht so the reader's ht >= Ht guard indexes real tiles.
         const uint32_t Ht = (padded[2] + tile_h - 1) / tile_h;
         const uint32_t col_groups = NC * Wt;  // cores the un-split path would use
 
@@ -449,7 +434,7 @@ Tensor reduce(
             compute_h_slices(col_groups, Ht, grid_cores, k_min_ht_for_split_tile, k_min_ht_per_slice_tile);
 
         if (num_h_slices >= 2) {
-            // Stage 1: tiled H reduce, S slices, unit scaler, ROW_MAJOR FP32 partials.
+            // Stage 1: tiled H reduce, unit scaler, ROW_MAJOR FP32 partials.
             const Tensor partials = ttnn::prim::reduce(
                 prepared_input,
                 tt::tt_metal::ReduceOpMath::SUM,
@@ -467,8 +452,7 @@ Tensor reduce(
                 /*num_h_slices=*/num_h_slices,
                 /*output_layout=*/tt::tt_metal::Layout::ROW_MAJOR);
 
-            // Stage 2: collapse the slice axis with the user scaler and final dtype. TILE input
-            // defaults to TILE output; only an explicit ROW_MAJOR request changes that.
+            // Stage 2: collapse the slice axis. TILE in defaults to TILE out.
             return ttnn::prim::reduce(
                 partials,
                 tt::tt_metal::ReduceOpMath::SUM,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp"
 #include "ttnn/operations/reduction/generic/device/common.hpp"
 
+#include <algorithm>
 #include <optional>
 #include <string>
 
@@ -84,6 +85,37 @@ Tensor reduce_min(
         compute_kernel_config,
         sub_core_grids,
         true);
+}
+
+// --- H-axis split tuning knobs. Both are per-path; the RM values reproduce merged behavior. ---
+//
+// (1) Don't split at all below this many tiles on the reduction axis: the extra dispatch and the
+// partials round trip cost more than the added parallelism buys. The RM path stages row pages
+// through compute_kernel_lib::tilize (one CB page per logical row), so its per-tile cost is higher
+// and it breaks even sooner; the TILE path async_reads whole tiles, so its un-split baseline is
+// already cheap and the split must clear a higher bar.
+static constexpr uint32_t k_min_ht_for_split_rm = 16;    // ~H >= 512 rows
+static constexpr uint32_t k_min_ht_for_split_tile = 32;  // ~H >= 1024 rows
+
+// (2) Never split so finely that one core reduces fewer than this many tiles. Every extra slice
+// adds a row to the partials and a work unit to stage 2, so past some point thinner slices stop
+// paying back. 1 == "as thin as needed to fill the grid", which is exactly today's behavior since
+// slices_at_min_work then degenerates to Ht. Raising it trades cores for per-core work.
+static constexpr uint32_t k_min_ht_per_slice_rm = 1;    // merged behavior - do not change
+static constexpr uint32_t k_min_ht_per_slice_tile = 1;  // deliberately neutral; tune from here
+
+// Number of H-axis slices to split the reduction into. 1 means "don't split".
+// `min_ht_per_slice` is a floor on tiles-per-slice, so it can only reduce the slice count below the
+// grid-filling value: oversubscribing the grid would add partial rows and stage-2 work without
+// adding parallelism.
+static uint32_t compute_h_slices(
+    uint32_t col_groups, uint32_t Ht, uint32_t grid_cores, uint32_t min_ht_for_split, uint32_t min_ht_per_slice) {
+    if (col_groups == 0 || col_groups >= grid_cores || Ht < min_ht_for_split) {
+        return 1;
+    }
+    const uint32_t slices_to_fill_grid = grid_cores / col_groups;  // slices that keep the grid filled
+    const uint32_t slices_at_min_work = Ht / min_ht_per_slice;     // floor => slice_Ht >= min_ht_per_slice
+    return std::max(std::min(slices_to_fill_grid, slices_at_min_work), 1u);
 }
 
 Tensor reduce(
@@ -348,14 +380,8 @@ Tensor reduce(
         const auto grid = input_tensor.device()->compute_with_storage_grid_size();
         const uint32_t grid_cores = sub_core_grids.has_value() ? sub_core_grids->num_cores() : (grid.x * grid.y);
 
-        // Splitting an Ht_rm below this costs more (extra dispatch + rounding) than it gains.
-        constexpr uint32_t k_min_ht_for_split = 16;  // ~H >= 512 rows
-        uint32_t num_h_slices = 1;
-        if (col_groups > 0 && col_groups < grid_cores && Ht_rm >= k_min_ht_for_split) {
-            const uint32_t slices_to_fill_grid = grid_cores / col_groups;  // slices that keep the grid filled
-            num_h_slices =
-                (slices_to_fill_grid < Ht_rm) ? slices_to_fill_grid : Ht_rm;  // never more slices than H tiles
-        }
+        const uint32_t num_h_slices =
+            compute_h_slices(col_groups, Ht_rm, grid_cores, k_min_ht_for_split_rm, k_min_ht_per_slice_rm);
 
         if (num_h_slices >= 2) {
             // Stage 1 emits ROW_MAJOR partials; only stage 2 honors the requested layout.
@@ -392,6 +418,74 @@ Tensor reduce(
                 /*use_sfpu_reduce=*/use_sfpu_fp32_reduce,
                 /*num_h_slices=*/1,
                 /*output_layout=*/rm_dense_out_layout);
+        }
+    }
+
+    // Same H-axis split for TILE input: the un-split tiled H path also parallelizes only over
+    // NC*Wt columns. Stage 1 keeps the tiled reader + reduce.cpp but emits (N,C,S,W) FP32
+    // ROW_MAJOR partials — a TILE partial would put up to TILE_HEIGHT slices inside one page,
+    // which independent cores cannot write. Stage 2 is then the same RM dense H collapse the
+    // ROW_MAJOR split already uses.
+    if (prepared_input.layout() == tt::tt_metal::Layout::TILE && reduce_dim == tt::tt_metal::ReduceOpDim::H &&
+        (reduce_math == tt::tt_metal::ReduceOpMath::AVG || reduce_math == tt::tt_metal::ReduceOpMath::SUM) && !negate &&
+        both_interleaved && !prepared_input.shard_spec().has_value() && prepared_input.logical_shape().rank() == 4 &&
+        (prepared_input.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
+         prepared_input.dtype() == tt::tt_metal::DataType::FLOAT32)) {
+        const auto& logical = prepared_input.logical_shape();
+        const auto& padded = prepared_input.padded_shape();
+        const uint32_t tile_h = prepared_input.tensor_spec().tile().get_height();
+        const uint32_t tile_w = prepared_input.tensor_spec().tile().get_width();
+        const uint32_t NC = logical[0] * logical[1];
+        const uint32_t Wt = (padded[3] + tile_w - 1) / tile_w;
+        // Derived from the padded H, matching the factory's Ht: the reader's overhang guard
+        // (ht >= Ht) indexes real tiles, so host and kernel must agree on the tile count.
+        const uint32_t Ht = (padded[2] + tile_h - 1) / tile_h;
+        const uint32_t col_groups = NC * Wt;  // cores the un-split path would use
+
+        const auto grid = prepared_input.device()->compute_with_storage_grid_size();
+        const uint32_t grid_cores = sub_core_grids.has_value() ? sub_core_grids->num_cores() : (grid.x * grid.y);
+
+        const uint32_t num_h_slices =
+            compute_h_slices(col_groups, Ht, grid_cores, k_min_ht_for_split_tile, k_min_ht_per_slice_tile);
+
+        if (num_h_slices >= 2) {
+            // Stage 1: tiled H reduce, S slices, unit scaler, ROW_MAJOR FP32 partials.
+            const Tensor partials = ttnn::prim::reduce(
+                prepared_input,
+                tt::tt_metal::ReduceOpMath::SUM,
+                tt::tt_metal::ReduceOpDim::H,
+                /*scaler=*/1.0f,
+                output_mem_config,
+                tt::tt_metal::DataType::FLOAT32,
+                config,
+                sub_core_grids,
+                /*negate=*/false,
+                /*post_mul_scaler=*/1.0f,
+                /*row_major_w_dense_path=*/false,
+                /*row_major_h_dense_path=*/false,
+                /*use_sfpu_reduce=*/use_sfpu_fp32_mean,
+                /*num_h_slices=*/num_h_slices,
+                /*output_layout=*/tt::tt_metal::Layout::ROW_MAJOR);
+
+            // Stage 2: collapse the slice axis with the user scaler and final dtype. TILE input
+            // defaults to TILE output; only an explicit ROW_MAJOR request changes that.
+            return ttnn::prim::reduce(
+                partials,
+                tt::tt_metal::ReduceOpMath::SUM,
+                tt::tt_metal::ReduceOpDim::H,
+                reduce_scaler,
+                output_mem_config,
+                output_dtype.value_or(input_tensor.dtype()),
+                config,
+                sub_core_grids,
+                /*negate=*/false,
+                /*post_mul_scaler=*/post_mul,
+                /*row_major_w_dense_path=*/false,
+                /*row_major_h_dense_path=*/true,
+                /*use_sfpu_reduce=*/use_sfpu_fp32_mean,
+                /*num_h_slices=*/1,
+                /*output_layout=*/output_layout == tt::tt_metal::Layout::ROW_MAJOR ? tt::tt_metal::Layout::ROW_MAJOR
+                                                                                   : tt::tt_metal::Layout::TILE);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -10,6 +10,8 @@
 #include <optional>
 #include <string>
 
+#include <tt-metalium/math.hpp>
+
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/eltwise/unary_backward/unary_backward.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
@@ -422,9 +424,9 @@ Tensor reduce(
         const uint32_t tile_h = prepared_input.tensor_spec().tile().get_height();
         const uint32_t tile_w = prepared_input.tensor_spec().tile().get_width();
         const uint32_t NC = logical[0] * logical[1];
-        const uint32_t Wt = (padded[3] + tile_w - 1) / tile_w;
+        const uint32_t Wt = tt::div_up(padded[3], tile_w);
         // Padded H, matching the factory's Ht so the reader's ht >= Ht guard indexes real tiles.
-        const uint32_t Ht = (padded[2] + tile_h - 1) / tile_h;
+        const uint32_t Ht = tt::div_up(padded[2], tile_h);
         const uint32_t col_groups = NC * Wt;  // cores the un-split path would use
 
         const auto grid = prepared_input.device()->compute_with_storage_grid_size();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -450,25 +450,34 @@ Tensor reduce(
                 /*post_mul_scaler=*/1.0f,
                 /*row_major_w_dense_path=*/false,
                 /*row_major_h_dense_path=*/false,
-                /*use_sfpu_reduce=*/use_sfpu_fp32_mean,
+                /*use_sfpu_reduce=*/use_sfpu_fp32_reduce,
                 /*num_h_slices=*/num_h_slices,
                 /*output_layout=*/tt::tt_metal::Layout::ROW_MAJOR);
+
+            // Stage 2 folds FP32 partials on SFPU even if stage 1 used the FPU; FPU would round each to tf32.
+            // Scaler vs post-mul follows the partial dtype: SFPU ignores the scaler CB.
+            const bool s2_use_sfpu = !tt::tt_metal::is_block_float(input_tensor.dtype()) && arch != tt::ARCH::QUASAR &&
+                                     config.fp32_dest_acc_en;
+            const bool s2_post_mul =
+                ttnn::prim::requires_post_mul(tt::tt_metal::ReduceOpMath::SUM, partials.dtype(), scaler, s2_use_sfpu);
+            const float s2_scaler = s2_post_mul ? 1.0f : scaler;
+            const float s2_mul = s2_post_mul ? scaler : 1.0f;
 
             // Stage 2: collapse the slice axis. TILE in defaults to TILE out.
             return ttnn::prim::reduce(
                 partials,
                 tt::tt_metal::ReduceOpMath::SUM,
                 tt::tt_metal::ReduceOpDim::H,
-                reduce_scaler,
+                s2_scaler,
                 output_mem_config,
                 output_dtype.value_or(input_tensor.dtype()),
                 config,
                 sub_core_grids,
                 /*negate=*/false,
-                /*post_mul_scaler=*/post_mul,
+                /*post_mul_scaler=*/s2_mul,
                 /*row_major_w_dense_path=*/false,
                 /*row_major_h_dense_path=*/true,
-                /*use_sfpu_reduce=*/use_sfpu_fp32_mean,
+                /*use_sfpu_reduce=*/s2_use_sfpu,
                 /*num_h_slices=*/1,
                 /*output_layout=*/output_layout == tt::tt_metal::Layout::ROW_MAJOR ? tt::tt_metal::Layout::ROW_MAJOR
                                                                                    : tt::tt_metal::Layout::TILE);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -41,9 +41,24 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         !(operation_attributes.row_major_w_dense_path && operation_attributes.row_major_h_dense_path),
         "Only one of row_major_w_dense_path / row_major_h_dense_path may be set");
     TT_FATAL(operation_attributes.num_h_slices >= 1, "num_h_slices must be >= 1");
+    // Stage 1 of the TILE H-axis split: tiled input and compute, but ROW_MAJOR SUM partials so the
+    // per-slice results land one row per page (a TILE partial would share a page across slices).
+    // `dim` must be constrained too: compute_output_specs sizes output_shape[2] from num_h_slices,
+    // so a W or HW reduce with num_h_slices > 1 would silently produce a mis-shaped result.
+    // num_h_slices > 1 is part of the predicate: it is what makes the factory pick the RM writer,
+    // so without it an un-split tiled reduce could ask for ROW_MAJOR output that nothing emits.
+    const bool tile_h_split = tensor_args.layout() == Layout::TILE && operation_attributes.num_h_slices > 1 &&
+                              operation_attributes.dim == tt::tt_metal::ReduceOpDim::H &&
+                              operation_attributes.output_layout == Layout::ROW_MAJOR &&
+                              operation_attributes.math_op == tt::tt_metal::ReduceOpMath::SUM;
     TT_FATAL(
-        operation_attributes.num_h_slices == 1 || operation_attributes.row_major_h_dense_path,
-        "num_h_slices > 1 (H-axis split) is only supported on the row-major H dense path");
+        operation_attributes.num_h_slices == 1 || operation_attributes.row_major_h_dense_path || tile_h_split,
+        "num_h_slices > 1 (H-axis split) requires the row-major H dense path, or a TILE H-reduce "
+        "emitting ROW_MAJOR SUM partials (got layout {}, dim {}, output_layout {}, math_op {})",
+        tensor_args.layout(),
+        operation_attributes.dim,
+        operation_attributes.output_layout,
+        operation_attributes.math_op);
     if (operation_attributes.row_major_w_dense_path || operation_attributes.row_major_h_dense_path) {
         const auto expected_dim =
             operation_attributes.row_major_w_dense_path ? tt::tt_metal::ReduceOpDim::W : tt::tt_metal::ReduceOpDim::H;
@@ -95,9 +110,25 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
     } else {
         TT_FATAL((tensor_args.layout() == Layout::TILE), "Inputs to reduce must be tilized");
         TT_FATAL(
-            operation_attributes.output_layout == Layout::TILE,
+            operation_attributes.output_layout == Layout::TILE || tile_h_split,
             "Tilized reduce paths only emit TILE output, got {}",
             operation_attributes.output_layout);
+        if (tile_h_split) {
+            // The RM writer this path borrows extracts datums with get_tilized_idx at a fixed
+            // datum_bytes stride, and make_rm_plan's tt::datum_size throws for block-float, so the
+            // dtypes the tilized branch otherwise admits (BFLOAT8_B / UINT32 / INT32) are excluded.
+            TT_FATAL(
+                tensor_args.dtype() == DataType::BFLOAT16 || tensor_args.dtype() == DataType::FLOAT32,
+                "TILE H-axis split only supports BFLOAT16 and FLOAT32 input, got {}",
+                tensor_args.dtype());
+            TT_FATAL(
+                tensor_args.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+                    operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "TILE H-axis split requires interleaved input and output memory layouts (input {}, output {})",
+                static_cast<int>(tensor_args.memory_config().memory_layout()),
+                static_cast<int>(operation_attributes.output_mem_config.memory_layout()));
+            TT_FATAL(!operation_attributes.negate, "TILE H-axis split does not support negate (min-reduce)");
+        }
         // INT32 MIN/MAX/SUM is supported via the SFPU reduce path (format deduced from the input CB
         // in compute_kernel_lib::reduce). See common.hpp.
         const bool is_int32_sfpu_reduce = use_sfpu_reduce_path(tensor_args.dtype(), operation_attributes.math_op);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -41,12 +41,14 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         !(operation_attributes.row_major_w_dense_path && operation_attributes.row_major_h_dense_path),
         "Only one of row_major_w_dense_path / row_major_h_dense_path may be set");
     TT_FATAL(operation_attributes.num_h_slices >= 1, "num_h_slices must be >= 1");
-    // Stage 1 of the TILE H-axis split: tiled input and compute, but ROW_MAJOR SUM partials so the
-    // per-slice results land one row per page (a TILE partial would share a page across slices).
-    // `dim` must be constrained too: compute_output_specs sizes output_shape[2] from num_h_slices,
-    // so a W or HW reduce with num_h_slices > 1 would silently produce a mis-shaped result.
-    // num_h_slices > 1 is part of the predicate: it is what makes the factory pick the RM writer,
-    // so without it an un-split tiled reduce could ask for ROW_MAJOR output that nothing emits.
+    TT_FATAL(
+        operation_attributes.output_layout == Layout::TILE || !is_block_float(operation_attributes.output_dtype),
+        "Block-float output is TILE-only, got output_layout {} with dtype {}",
+        operation_attributes.output_layout,
+        operation_attributes.output_dtype);
+    // TILE H-axis split stage 1: tiled compute, ROW_MAJOR SUM partials (one row per slice).
+    // dim must be H: compute_output_specs sizes H from num_h_slices. num_h_slices > 1 is what
+    // makes the factory pick the RM writer.
     const bool tile_h_split = tensor_args.layout() == Layout::TILE && operation_attributes.num_h_slices > 1 &&
                               operation_attributes.dim == tt::tt_metal::ReduceOpDim::H &&
                               operation_attributes.output_layout == Layout::ROW_MAJOR &&
@@ -114,12 +116,10 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
             "Tilized reduce paths only emit TILE output, got {}",
             operation_attributes.output_layout);
         if (tile_h_split) {
-            // The RM writer this path borrows extracts datums with get_tilized_idx at a fixed
-            // datum_bytes stride, and make_rm_plan's tt::datum_size throws for block-float, so the
-            // dtypes the tilized branch otherwise admits (BFLOAT8_B / UINT32 / INT32) are excluded.
             TT_FATAL(
-                tensor_args.dtype() == DataType::BFLOAT16 || tensor_args.dtype() == DataType::FLOAT32,
-                "TILE H-axis split only supports BFLOAT16 and FLOAT32 input, got {}",
+                tensor_args.dtype() == DataType::BFLOAT16 || tensor_args.dtype() == DataType::FLOAT32 ||
+                    is_block_float(tensor_args.dtype()),
+                "TILE H-axis split only supports BFLOAT16, FLOAT32 and block-float input, got {}",
                 tensor_args.dtype());
             TT_FATAL(
                 tensor_args.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED &&

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation_types.hpp
@@ -37,8 +37,7 @@ struct ReduceParams {
     // Accurate fp32: route Float32 through the SFPU (full fp32); set from
     // fast_and_approximate_mode=False on sum/mean/max/min.
     bool use_sfpu_reduce{false};
-    // Number of contiguous H segments to reduce independently (RM-H dense path; 1 = no split).
-    // Spreads a tall-H reduce over more cores, yielding a (N, C, num_h_slices, W) partial.
+    // Contiguous H segments reduced independently (1 = no split). RM-H dense path and TILE split stage 1.
     uint32_t num_h_slices{1};
     // Physical layout the op must produce: TILE on the tilized paths, ROW_MAJOR on the dense RM
     // ones, or TILE from RM-H when num_h_slices == 1.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -66,10 +66,20 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
 
     // Populate the RM-only locals (chunk sizes, page bytes, padding identity, datum sizes) into
     // a single struct so the per-site formulas don't drift between this factory and the W one.
-    // tt::datum_size(...) inside make_rm_plan throws for block-float formats; guard the call
-    // behind rm_path since validate_rm_preconditions already gates the RM branch to BF16/FP32.
+    // tt::datum_size(...) inside make_rm_plan throws for block-float formats, so only populate it on
+    // paths already gated to BF16/FP32: validate_rm_preconditions for the RM path, and the
+    // tile_h_split fatals in validate_on_program_cache_miss for the TILE H-axis split below.
+    //
+    // TILE H-axis split: the tiled reader and reduce.cpp over `num_h_slices` slices, but ROW_MAJOR
+    // partials written by the RM writer (one row per slice), so it needs the plan too.
+    // use_width_sharding is excluded here and not only on the host: the sharded branch below
+    // reassigns all_cores and the per-core column counts *after* num_cols is computed, and its
+    // runtime args ignore slices entirely, so a direct ttnn::prim::reduce call must not be able to
+    // reach that combination.
+    const bool tile_h_split = !rm_path && !use_width_sharding && operation_attributes.num_h_slices > 1;
+
     RmPlan plan{};
-    if (rm_path) {
+    if (rm_path || tile_h_split) {
         plan = make_rm_plan(
             shape,
             logical_shape,
@@ -82,16 +92,22 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
     }
 
     // H-axis split geometry: every slice reduces a uniform `slice_Ht` tiles, the last one's overhang
-    // past Ht_rm identity-padded by the reader. Clamped to Ht_rm so no slice is empty.
-    const uint32_t num_h_slices = rm_path ? std::min(std::max(operation_attributes.num_h_slices, 1u), plan.Ht_rm) : 1;
-    const uint32_t slice_Ht = rm_path ? tt::div_up(plan.Ht_rm, num_h_slices) : 0;
+    // past the end of the reduction axis identity-padded by the reader. The RM path counts H tiles
+    // from the logical H (plan.Ht_rm); the tiled path from the padded H (Ht), matching the tile ids
+    // its reader indexes. Clamped so no slice is empty.
+    const uint32_t Ht_for_split = rm_path ? plan.Ht_rm : Ht;
+    const uint32_t num_h_slices =
+        (rm_path || tile_h_split) ? std::min(std::max(operation_attributes.num_h_slices, 1u), Ht_for_split) : 1;
+    const uint32_t slice_Ht =
+        rm_path ? tt::div_up(plan.Ht_rm, num_h_slices) : (tile_h_split ? tt::div_up(Ht, num_h_slices) : 0);
     // compute_output_specs sizes the output's H from the unclamped attribute, so the clamp above must
-    // be a no-op; the host already bounds num_h_slices by Ht_rm.
+    // be a no-op; the host already bounds num_h_slices by the H tile count.
     TT_FATAL(
-        !rm_path || operation_attributes.num_h_slices <= plan.Ht_rm,
-        "Reduce H (dense RM): num_h_slices {} exceeds Ht_rm {}; the output spec and the kernels would disagree",
+        !(rm_path || tile_h_split) || operation_attributes.num_h_slices <= Ht_for_split,
+        "Reduce H: num_h_slices {} exceeds the reduction-axis tile count {}; the output spec and the "
+        "kernels would disagree",
         operation_attributes.num_h_slices,
-        plan.Ht_rm);
+        Ht_for_split);
 
     uint32_t chunk_size = use_width_sharding ? 1 : ttnn::get_dest_reg_count(operation_attributes.compute_kernel_config);
 
@@ -458,6 +474,9 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             {"use_welford", 0u},
             {"enable_fp32_sfpu", fp32_sfpu_reduce ? 1u : 0u},
             {"tiles_per_batch", reader_tiles_per_batch},
+            // {1, Ht} is the un-split reduce, which the reader handles with its incremental tile walk.
+            {"num_h_slices", tile_h_split ? num_h_slices : 1u},
+            {"slice_Ht", tile_h_split ? slice_Ht : Ht},
         };
         reader_rta_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols"};
         // Pass DEST config so reader can compute DEST_AUTO_LIMIT
@@ -498,10 +517,11 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
     Group<TensorBinding> writer_tensor_bindings;
     KernelSpec::CompilerOptions::Defines writer_defines;
 
-    if (rm_path) {
+    if (rm_path || tile_h_split) {
         writer_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp";
         // One writer for both layouts; tile_output picks whole-tile pages over (nc, slice) RM pages.
+        // The TILE split always emits ROW_MAJOR partials, so tile_output is false there.
         writer_ct_args =
             build_rm_writer_ct_args(plan, operation_attributes.output_layout == Layout::TILE, num_h_slices);
         writer_rta_names = {"rt_count", "rt_start"};
@@ -661,7 +681,8 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             };
         } else {
             ct_args = {
-                {"Ht", Ht},
+                // Per-slice H under the H-axis split.
+                {"Ht", tile_h_split ? slice_Ht : Ht},
                 {"Wt", group_compute_Wt},
                 {"NC", group_compute_NC},
                 // packed fp32 user scalar (only used if REDUCE_POST_MUL is set)
@@ -847,20 +868,36 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             } else {
                 TT_THROW("Core not in specified core ranges");
             }
-            AddRuntimeArgsForNode(
-                reader_run_args.runtime_arg_values,
-                core,
-                {{"col_start_tile_id", (num_cols_read / Wt * HtWt) + (num_cols_read % Wt)},
-                 {"curr_col_in_batch", num_cols_read % Wt},
-                 {"num_cols", num_cols_per_core}});
+            if (tile_h_split) {
+                // The split reader decomposes (nc, slice, wt) from the global work-unit id itself,
+                // so col_start_tile_id carries that id and curr_col_in_batch is unused. Its ROW_MAJOR
+                // partials leave through the RM writer, which names its per-core span rt_count/rt_start.
+                AddRuntimeArgsForNode(
+                    reader_run_args.runtime_arg_values,
+                    core,
+                    {{"col_start_tile_id", num_cols_read},
+                     {"curr_col_in_batch", 0u},
+                     {"num_cols", num_cols_per_core}});
+                AddRuntimeArgsForNode(
+                    writer_run_args.runtime_arg_values,
+                    core,
+                    {{"rt_count", num_cols_per_core}, {"rt_start", num_cols_read}});
+            } else {
+                AddRuntimeArgsForNode(
+                    reader_run_args.runtime_arg_values,
+                    core,
+                    {{"col_start_tile_id", (num_cols_read / Wt * HtWt) + (num_cols_read % Wt)},
+                     {"curr_col_in_batch", num_cols_read % Wt},
+                     {"num_cols", num_cols_per_core}});
 
-            AddRuntimeArgsForNode(
-                writer_run_args.runtime_arg_values,
-                core,
-                {// number of tiles to write
-                 {"num_pages", num_cols_per_core},
-                 // output tile start index
-                 {"start_id", num_cols_read}});
+                AddRuntimeArgsForNode(
+                    writer_run_args.runtime_arg_values,
+                    core,
+                    {// number of tiles to write
+                     {"num_pages", num_cols_per_core},
+                     // output tile start index
+                     {"start_id", num_cols_read}});
+            }
             num_cols_read += num_cols_per_core;
             if (i == num_cores - 1) {
                 TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -66,16 +66,8 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
 
     // Populate the RM-only locals (chunk sizes, page bytes, padding identity, datum sizes) into
     // a single struct so the per-site formulas don't drift between this factory and the W one.
-    // tt::datum_size(...) inside make_rm_plan throws for block-float formats, so only populate it on
-    // paths already gated to BF16/FP32: validate_rm_preconditions for the RM path, and the
-    // tile_h_split fatals in validate_on_program_cache_miss for the TILE H-axis split below.
-    //
-    // TILE H-axis split: the tiled reader and reduce.cpp over `num_h_slices` slices, but ROW_MAJOR
-    // partials written by the RM writer (one row per slice), so it needs the plan too.
-    // use_width_sharding is excluded here and not only on the host: the sharded branch below
-    // reassigns all_cores and the per-core column counts *after* num_cols is computed, and its
-    // runtime args ignore slices entirely, so a direct ttnn::prim::reduce call must not be able to
-    // reach that combination.
+    // TILE H-axis split uses the RM writer for ROW_MAJOR partials, so it needs the plan too.
+    // Width-sharding is excluded: that branch reassigns cores after num_cols and ignores slices.
     const bool tile_h_split = !rm_path && !use_width_sharding && operation_attributes.num_h_slices > 1;
 
     RmPlan plan{};
@@ -91,17 +83,14 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             ReduceOpDim::H);
     }
 
-    // H-axis split geometry: every slice reduces a uniform `slice_Ht` tiles, the last one's overhang
-    // past the end of the reduction axis identity-padded by the reader. The RM path counts H tiles
-    // from the logical H (plan.Ht_rm); the tiled path from the padded H (Ht), matching the tile ids
-    // its reader indexes. Clamped so no slice is empty.
+    // Uniform slice_Ht; the last slice's overhang is identity-padded. RM counts logical H tiles,
+    // TILE counts padded H so the ids match the reader.
     const uint32_t Ht_for_split = rm_path ? plan.Ht_rm : Ht;
     const uint32_t num_h_slices =
         (rm_path || tile_h_split) ? std::min(std::max(operation_attributes.num_h_slices, 1u), Ht_for_split) : 1;
     const uint32_t slice_Ht =
         rm_path ? tt::div_up(plan.Ht_rm, num_h_slices) : (tile_h_split ? tt::div_up(Ht, num_h_slices) : 0);
-    // compute_output_specs sizes the output's H from the unclamped attribute, so the clamp above must
-    // be a no-op; the host already bounds num_h_slices by the H tile count.
+    // Host already bounds num_h_slices; the clamp must be a no-op so output spec and kernels agree.
     TT_FATAL(
         !(rm_path || tile_h_split) || operation_attributes.num_h_slices <= Ht_for_split,
         "Reduce H: num_h_slices {} exceeds the reduction-axis tile count {}; the output spec and the "
@@ -474,7 +463,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             {"use_welford", 0u},
             {"enable_fp32_sfpu", fp32_sfpu_reduce ? 1u : 0u},
             {"tiles_per_batch", reader_tiles_per_batch},
-            // {1, Ht} is the un-split reduce, which the reader handles with its incremental tile walk.
+            // {1, Ht} is the un-split reduce.
             {"num_h_slices", tile_h_split ? num_h_slices : 1u},
             {"slice_Ht", tile_h_split ? slice_Ht : Ht},
         };
@@ -520,8 +509,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
     if (rm_path || tile_h_split) {
         writer_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp";
-        // One writer for both layouts; tile_output picks whole-tile pages over (nc, slice) RM pages.
-        // The TILE split always emits ROW_MAJOR partials, so tile_output is false there.
+        // One writer for both layouts. TILE split always emits ROW_MAJOR partials.
         writer_ct_args =
             build_rm_writer_ct_args(plan, operation_attributes.output_layout == Layout::TILE, num_h_slices);
         writer_rta_names = {"rt_count", "rt_start"};
@@ -869,9 +857,8 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
                 TT_THROW("Core not in specified core ranges");
             }
             if (tile_h_split) {
-                // The split reader decomposes (nc, slice, wt) from the global work-unit id itself,
-                // so col_start_tile_id carries that id and curr_col_in_batch is unused. Its ROW_MAJOR
-                // partials leave through the RM writer, which names its per-core span rt_count/rt_start.
+                // Split reader takes the global work-unit id; curr_col_in_batch unused.
+                // RM writer names the same span rt_count/rt_start.
                 AddRuntimeArgsForNode(
                     reader_run_args.runtime_arg_values,
                     core,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -566,13 +566,11 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
         [&](auto& compute_cfg) {
             compute_cfg.sfpu_precision_mode = Precision::Precise;  // legacy math_approx_mode = false
             if (fp32_sfpu_reduce) {
-                // Legacy: unpack_to_dest_mode[src0_cb_index] = UnpackToDestFp32 — unpacks the reduce
-                // input straight into the fp32 DEST, bypassing the SrcA tf32 truncation. The RM
-                // path's chunk accumulator (legacy c_5) gets the same treatment so partials
-                // round-trip in fp32.
+                // Unpack FP32 inputs, RM rows, and partials to DEST so SrcA does not truncate them to tf32.
                 compute_cfg.unpack_modes.emplace(IN_DFB, UnpackMode::UnpackToDest);
                 if (rm_path) {
                     compute_cfg.unpack_modes.emplace(ACC_DFB, UnpackMode::UnpackToDest);
+                    compute_cfg.unpack_modes.emplace(RM_DFB, UnpackMode::UnpackToDest);
                 }
             }
             // Legacy left every other entry at Default (= UnpackToSrc). Metal 2.0 nonetheless requires an

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -155,11 +155,15 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
     const TensorParamName INPUT_TENSOR{"input"};
     const TensorParamName OUTPUT_TENSOR{"output"};
 
-    // The column reader batches a dest chunk; a core that owns fewer columns stays unbatched.
+    // The column reader batches a dest chunk; a core that owns fewer columns stays unbatched. The
+    // H-axis split has one column per core, so it batches down the slice instead — but those tiles
+    // feed a single accumulator, so the batch costs compute the chance to start on each tile as it
+    // lands. That trade only pays while the reads dominate, which fp32 input is too slow to do.
     const uint32_t min_cols_per_core = num_cols_per_core_group_2 == 0
                                            ? num_cols_per_core_group_1
                                            : std::min(num_cols_per_core_group_1, num_cols_per_core_group_2);
-    const uint32_t reader_tiles_per_batch = min_cols_per_core < chunk_size ? 1u : chunk_size;
+    const bool batch_down_slice = tile_h_split && src0_cb_data_format != tt::DataFormat::Float32;
+    const uint32_t reader_tiles_per_batch = (batch_down_slice || min_cols_per_core >= chunk_size) ? chunk_size : 1u;
 
     ProgramSpec spec;
     spec.name = rm_path ? "reduce_multi_core_h_dense_rm"

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -323,6 +323,9 @@ WelfordReduceDeviceOperation::WelfordReduceProgramFactory::create_program_artifa
             {"enable_fp32_sfpu", 0u},
             // Welford is compute-bound: batching the reader's tiles measures flat, so it stays off.
             {"tiles_per_batch", 1u},
+            // Welford never splits the H axis; {1, Ht} selects the reader's un-split path.
+            {"num_h_slices", 1u},
+            {"slice_Ht", Ht},
         };
         reader_rta_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols"};
     } else {


### PR DESCRIPTION
### PR Category
Feature — H-axis reduce split for TILE inputs (`sum`/`mean`), issue [#52922](https://github.com/tenstorrent/tt-metal/issues/52922)

## Summary

Generic reduce now splits the H axis on TILE inputs.

An H reduce parallelizes only over output tile columns — `num_cols = NC * Wt` — so a narrow-W tensor starves the grid however tall it is. `(1, 1, 51264, 32)` gives `NC * Wt == 1`: one work unit, one core, 51264 rows serialized. A tall-H TILE reduce now segments the reduction axis into `S` slices and collapses them in a second stage:

- **Stage 1** keeps the tiled reader and `reduce.cpp` and reduces `S` slices independently into `(N, C, S, W)` FP32 partials with a unit scaler. The partials are ROW_MAJOR: a TILE partial would put up to `TILE_HEIGHT` slices inside one page, which independent cores cannot write.
- **Stage 2** is the dense RM H collapse — it sums the slice axis and applies the user scaler and the final dtype. Sum over H is the sum of the per-slice sums, so mean's `1/N` applies once, in stage 2. The partials are FP32, so stage 2 folds them on the SFPU whenever `fp32_dest_acc_en` allows it, even when stage 1 ran on the FPU — the FPU would round every partial to tf32.
- **Layout is unchanged from the caller's view** — a TILE input still yields a TILE output, and only an explicit `output_layout=ROW_MAJOR` changes that. The intermediate partials never surface.

Covers `dim=-2` on rank-4, interleaved, unsharded tensors in BFLOAT16, FLOAT32 and block-float-8b. `min`/`max` are excluded by the `AVG`/`SUM` math gate, and `min` again by the no-negate one since it lowers to `-max(-x)`; **the mechanism applies to them, and the tiled side is the only place it can, but that is left for a follow-up PR.**

`compute_h_slices` is now shared. The tiled path splits at `Ht >= 20`, the RM path at `Ht >= 16`; both keep a per-slice floor of 1.

## Changes Made

**common.cpp** — `make_rm_plan` leaves block-float datum sizes at 0 instead of throwing. RM staging and the writer's datum stride never see that format here.

**reduce_op.cpp** — `compute_h_slices` takes per-path `min_ht_for_split` / `min_ht_per_slice`. New TILE split branch after the RM one; its `Ht` is the padded H so it matches the factory and the reader's overhang guard. Both stages forward `use_sfpu_fp32_reduce`, so an FP32 `sum` keeps the accurate engine; stage 2 selects its engine from the partial dtype and re-derives scaler vs post-mul from it.

**reduce_op_device_operation.cpp** — `num_h_slices > 1` also admits a TILE H-reduce that emits ROW_MAJOR SUM partials (`dim == H` is required because output H is `num_h_slices`). Fatals on non-BF16/FP32/block-float, non-interleaved I/O, and negate. Block-float output is TILE-only.

**reader_unary_transpose_wh_universal_input_cols_partitioned.cpp** — `num_h_slices` / `slice_Ht`; `{1, Ht}` keeps the un-split walk. The split loop indexes `(nc, slice, wt)` from the global work-unit id and pads past `Ht` with the SUM identity.

**reduce_op_multi_core_h_program_factory.cpp** — `tile_h_split` excludes width-sharding (that branch ignores slices). The split uses the RM writer for the partials, `Ht = slice_Ht` on compute, and the global work-unit id on the reader. The RM input CB also unpacks to DEST under `fp32_sfpu_reduce`, so stage 2's partials are not truncated to tf32.

**welford_reduce_program_factory.cpp** — `{num_h_slices = 1, slice_Ht = Ht}`. Welford never splits.

## Tests

**test_row_major_reduce.py** (post-commit)

- `test_tile_reduce_h_axis_split` — five shapes that take the split, across `sum`/`mean`, `output_layout` in `{None, ROW_MAJOR, TILE}`, and `(dtype, fast_and_approximate_mode)` paired as `bf16` / `fp32_sfpu` / `fp32_fpu`, since the mode only selects an engine for FP32. 90 cases. Asserts TILE in defaults to TILE out. FP32 bounds follow the engine: SFPU at `rtol = atol = 1e-5`, the tf32 FPU at `0.004 / 1e-3`.


**test_reduce.py** (nightly)

- `test_tile_reduce_h_axis_split` — the very tall `Wt=1` shapes (12544, and 51264 from the issue) plus `keepdim`. BF16 skipped at `H >= 12544`; FP32 covers those.
- `test_tile_reduce_h_axis_split_block_float` — `bfloat8_b` in and out. Reference is the round-tripped input so the check is the reduce, not `from_torch`.

## Performance
**Wormhole n300, 8×8 = 64-core grid. `ttnn.mean(dim=-2, keepdim=True)`, TILE in / TILE out, Tracy device kernel duration, 5 timed iterations.**
<!DOCTYPE html>
<!DOCTYPE html>
<!DOCTYPE html>
Shape | Ht | dtype / mode | cores before | cores after (s1+s2) | slices | No-split TILE (µs) | Split s1+s2 (µs) | Speedup
-- | -- | -- | -- | -- | -- | -- | -- | --
51264×32 (issue shape) | 1602 | bf16 | 1 | 64+1 | 64 | 816.8 | 29.5 (18.1+11.3) | 27.73×
  |   | bf8_b | 1 | 64+1 | 64 | 758.5 | 20.9 (10.5+10.4) | 36.28×
  |   | fp32 FPU | 1 | 64+1 | 64 | 949.1 | 46.9 (35.4+11.5) | 20.25×
  |   | fp32 SFPU | 1 | 64+1 | 64 | 949.8 | 47.2 (35.8+11.4) | 20.12×
12544×32 (nightly) | 392 | bf16 | 1 | 64+1 | 64 | 200.7 | 17.4 (6.1+11.3) | 11.51×
  |   | bf8_b | 1 | 64+1 | 64 | 185.8 | 14.6 (4.2+10.4) | 12.69×
  |   | fp32 FPU | 1 | 64+1 | 64 | 233.5 | 21.6 (10.2+11.5) | 10.79×
  |   | fp32 SFPU | 1 | 64+1 | 64 | 234.2 | 22.1 (10.6+11.6) | 10.58×
8192×256 | 256 | bf16 | 8 | 64+8 | 8 | 152.8 | 31.5 (22.8+8.7) | 4.85×
  |   | bf8_b | 8 | 64+8 | 8 | 129.2 | 20.4 (12.4+8.1) | 6.33×
  |   | fp32 FPU | 8 | 64+8 | 8 | 202.0 | 52.1 (42.6+9.5) | 3.88×
  |   | fp32 SFPU | 8 | 64+8 | 8 | 200.6 | 52.6 (43.0+9.6) | 3.81×
4096×1024 (Wt=32, 2 slices) | 128 | bf16 | 32 | 64+32 | 2 | 81.6 | 52.1 (42.5+9.6) | 1.57×
  |   | bf8_b | 32 | 64+32 | 2 | 66.6 | 30.4 (22.5+7.9) | 2.19×
  |   | fp32 FPU | 32 | 64+32 | 2 | 112.5 | 93.3 (83.5+9.8) | 1.21×
  |   | fp32 SFPU | 32 | 64+32 | 2 | 112.2 | 93.0 (83.1+9.9) | 1.21×
3216×128 | 101 | bf16 | 4 | 64+4 | 16 | 55.9 | 15.0 (6.2+8.8) | 3.72×
  |   | bf8_b | 4 | 64+4 | 16 | 49.7 | 12.6 (4.3+8.3) | 3.96×
  |   | fp32 FPU | 4 | 64+4 | 16 | 67.8 | 19.6 (10.5+9.1) | 3.45×
  |   | fp32 SFPU | 4 | 64+4 | 16 | 69.2 | 20.0 (10.9+9.1) | 3.47×
3136×2048 (Wt fills grid) | 98 | bf16 | 64 | 64 | – | 65.8 | 66.1 | no split
  |   | bf8_b | 64 | 64 | – | 56.4 | 58.1 | no split
  |   | fp32 FPU | 64 | 64 | – | 125.8 | 125.8 | no split
  |   | fp32 SFPU | 64 | 64 | – | 126.5 | 125.8 | no split
3136×145 | 98 | bf16 | 5 | 60+5 | 12 | 55.4 | 15.9 (7.2+8.7) | 3.48×
  |   | fp32 FPU | 5 | 60+5 | 12 | 69.5 | 21.6 (12.5+9.1) | 3.23×
  |   | fp32 SFPU | 5 | 60+5 | 12 | 69.7 | 22.2 (13.1+9.1) | 3.14×
3136×144 (EfficientNetB0) | 98 | bf16 | 5 | 60+5 | 12 | 55.4 | 15.8 (7.1+8.8) | 3.50×
  |   | fp32 FPU | 5 | 60+5 | 12 | 68.9 | 21.7 (12.6+9.1) | 3.17×
  |   | fp32 SFPU | 5 | 60+5 | 12 | 70.2 | 21.9 (12.8+9.1) | 3.21×
2048×512 (Wt=16, 4 slices) | 64 | bf16 | 16 | 64+16 | 4 | 41.5 | 21.0 (12.4+8.6) | 1.97×
  |   | fp32 FPU | 16 | 64+16 | 4 | 53.4 | 31.4 (22.4+9.0) | 1.70×
  |   | fp32 SFPU | 16 | 64+16 | 4 | 54.2 | 32.1 (23.0+9.1) | 1.69×
1064×256 | 34 | bf16 | 8 | 64+8 | 8 | 22.0 | 13.7 (5.0+8.7) | 1.61×
  |   | fp32 FPU | 8 | 64+8 | 8 | 29.5 | 17.3 (8.1+9.2) | 1.70×
  |   | fp32 SFPU | 8 | 64+8 | 8 | 29.8 | 17.6 (8.4+9.2) | 1.69×
1024×40 (N2C3) | 32 | bf16 | 12 | 60+12 | 5 | 20.2 | 14.2 (5.7+8.4) | 1.43×
  |   | fp32 FPU | 12 | 60+12 | 5 | 28.0 | 18.9 (10.0+8.9) | 1.49×
  |   | fp32 SFPU | 12 | 60+12 | 5 | 28.5 | 19.5 (10.6+8.9) | 1.46×
1024×32 (N2C3) | 32 | bf16 | 6 | 60+6 | 10 | 19.4 | 12.9 (4.3+8.6) | 1.50×
  |   | fp32 FPU | 6 | 60+6 | 10 | 25.2 | 18.3 (9.2+9.1) | 1.38×
  |   | fp32 SFPU | 6 | 60+6 | 10 | 25.6 | 18.6 (9.6+9.1) | 1.37×
1024×32 (N8C8, NC fills grid) | 32 | bf16 | 64 | 64 | – | 26.2 | 26.1 | no split
  |   | fp32 FPU | 64 | 64 | – | 50.1 | 49.2 | no split
  |   | fp32 SFPU | 64 | 64 | – | 50.0 | 49.8 | no split
1000×32 (H not tile-aligned) | 32 | bf16 | 1 | 32+1 | 32 | 17.4 | 11.6 (2.4+9.2) | 1.50×
  |   | fp32 FPU | 1 | 32+1 | 32 | 20.6 | 12.6 (3.2+9.4) | 1.63×
  |   | fp32 SFPU | 1 | 32+1 | 32 | 21.3 | 12.8 (3.4+9.4) | 1.67×
992×144 | 31 | bf16 | 5 | 60+5 | 12 | 18.5 | 12.3 (3.5+8.7) | 1.51×
  |   | fp32 FPU | 5 | 60+5 | 12 | 23.4 | 14.6 (5.5+9.1) | 1.60×
  |   | fp32 SFPU | 5 | 60+5 | 12 | 24.0 | 15.0 (5.9+9.1) | 1.60×
992×32 | 31 | bf16 | 1 | 31+1 | 31 | 17.0 | 11.4 (2.3+9.2) | 1.49×
  |   | fp32 FPU | 1 | 31+1 | 31 | 20.1 | 12.3 (3.0+9.3) | 1.63×
  |   | fp32 SFPU | 1 | 31+1 | 31 | 20.7 | 12.5 (3.2+9.3) | 1.65×
800×32 | 25 | bf16 | 1 | 25+1 | 25 | 14.1 | 11.3 (2.4+8.9) | 1.25×
  |   | fp32 FPU | 1 | 25+1 | 25 | 16.6 | 12.0 (3.0+9.1) | 1.38×
  |   | fp32 SFPU | 1 | 25+1 | 25 | 17.3 | 12.4 (3.2+9.2) | 1.39×
768×128 | 24 | bf16 | 4 | 64+4 | 16 | 14.7 | 12.0 (3.1+8.9) | 1.23×
  |   | fp32 FPU | 4 | 64+4 | 16 | 18.2 | 13.4 (4.3+9.1) | 1.36×
  |   | fp32 SFPU | 4 | 64+4 | 16 | 18.7 | 14.0 (4.9+9.1) | 1.34×
640×144 | 20 | bf16 | 5 | 60+5 | 12 | 12.5 | 11.8 (3.1+8.7) | 1.06×
  |   | fp32 FPU | 5 | 60+5 | 12 | 16.0 | 13.6 (4.5+9.1) | 1.17×
  |   | fp32 SFPU | 5 | 60+5 | 12 | 16.7 | 14.1 (5.0+9.1) | 1.19×
640×32 | 20 | bf16 | 1 | 20+1 | 20 | 11.5 | 10.9 (2.2+8.7) | 1.06×
  |   | fp32 FPU | 1 | 20+1 | 20 | 13.6 | 11.7 (2.8+8.8) | 1.17×
  |   | fp32 SFPU | 1 | 20+1 | 20 | 14.4 | 11.9 (3.1+8.9) | 1.21×
608×32 (Ht=19, below gate) | 19 | bf16 | 1 | 1 | – | 11.0 | 10.8 | no split
  |   | fp32 FPU | 1 | 1 | – | 12.9 | 13.1 | no split
  |   | fp32 SFPU | 1 | 1 | – | 13.6 | 13.7 | no split





### Perf improvement in EfficientNetB0 model.

<!DOCTYPE html>
reduce Avgpool (bfloat8_b) | Main | PR | Speedup
-- | -- | -- | --
(1,1,12544,32) | 140.2 µs (1 core) | 3.4 (64 cores) + 9.8 (1 core) = 13.2 µs | 10.6×
(1,1,3136,96) | 35.4 µs (3 cores) | 2.8 (63 cores) + 8.0 (3 cores) = 10.9 µs | 3.2×
model total kernel time | 4230.5 µs | 4055.0 µs | 1.043× (4.2% less)



**EfficientNetB0** perf improved to 245 sample/sec</span></p>
### Accuracy 
<!DOCTYPE html>
<!DOCTYPE html>
Shape | Ht | dtype / mode | slices | main max rel err | split max rel err | main ULP-off | split ULP-off
-- | -- | -- | -- | -- | -- | -- | --
51264×32 | 1602 | bf16 | 64 | 5.793e-03 | 3.802e-03 | 29 | 0
  |   | fp32 FPU | 64 | 8.193e-04 | 6.532e-04 | 32 | 32
  |   | fp32 SFPU | 64 | 2.459e-07 | 1.041e-07 | 23 | 11
12544×32 | 392 | bf16 | 64 | 4.878e-03 | 3.427e-03 | 5 | 0
  |   | fp32 FPU | 64 | 1.082e-03 | 6.586e-04 | 32 | 32
  |   | fp32 SFPU | 64 | 1.463e-07 | 1.039e-07 | 18 | 16
8192×256 | 256 | bf16 | 8 | 3.869e-03 | 3.869e-03 | 0 | 0
  |   | fp32 FPU | 8 | 6.600e-04 | 6.633e-04 | 256 | 256
  |   | fp32 SFPU | 8 | 1.646e-07 | 1.207e-07 | 103 | 78
4096×1024 | 128 | bf16 | 2 | 3.883e-03 | 3.883e-03 | 0 | 0
  |   | fp32 FPU | 2 | 6.675e-04 | 6.682e-04 | 1024 | 1024
  |   | fp32 SFPU | 2 | 1.664e-07 | 1.415e-07 | 396 | 338
3216×128 | 101 | bf16 | 16 | 3.911e-03 | 3.847e-03 | 5 | 0
  |   | fp32 FPU | 16 | 8.806e-04 | 6.683e-04 | 128 | 128
  |   | fp32 SFPU | 16 | 1.630e-07 | 1.168e-07 | 60 | 55
3136×145 | 98 | bf16 | 12 | 5.008e-03 | 3.860e-03 | 32 | 0
  |   | fp32 FPU | 12 | 1.092e-03 | 6.661e-04 | 145 | 145
  |   | fp32 SFPU | 12 | 1.719e-07 | 1.421e-07 | 65 | 48
3136×144 | 98 | bf16 | 12 | 4.822e-03 | 3.878e-03 | 32 | 0
  |   | fp32 FPU | 12 | 1.091e-03 | 6.704e-04 | 144 | 144
  |   | fp32 SFPU | 12 | 1.456e-07 | 1.373e-07 | 59 | 50
2048×512 | 64 | bf16 | 4 | 3.867e-03 | 3.867e-03 | 0 | 0
  |   | bf8_b | 4 | 1.184e-02 | 1.148e-02 | n/a | n/a
  |   | fp32 FPU | 4 | 6.770e-04 | 6.774e-04 | 512 | 512
  |   | fp32 SFPU | 4 | 1.381e-07 | 1.375e-07 | 187 | 166
1064×256 | 34 | bf16 | 8 | 5.123e-03 | 3.887e-03 | 57 | 0
  |   | fp32 FPU | 8 | 6.824e-04 | 6.913e-04 | 256 | 256
  |   | fp32 SFPU | 8 | 1.667e-07 | 1.553e-07 | 126 | 124
1024×40 (N2C3) | 32 | bf16 | 5 | 3.882e-03 | 3.882e-03 | 0 | 0
  |   | fp32 FPU | 5 | 6.829e-04 | 6.830e-04 | 240 | 240
  |   | fp32 SFPU | 5 | 1.581e-07 | 1.247e-07 | 95 | 85
1024×32 (N2C3) | 32 | bf16 | 10 | 3.827e-03 | 3.827e-03 | 0 | 0
  |   | fp32 FPU | 10 | 6.831e-04 | 6.832e-04 | 192 | 192
  |   | fp32 SFPU | 10 | 1.291e-07 | 1.329e-07 | 65 | 61
1000×32 | 32 | bf16 | 32 | 4.355e-03 | 3.423e-03 | 6 | 0
  |   | fp32 FPU | 32 | 1.308e-03 | 6.785e-04 | 32 | 32
  |   | fp32 SFPU | 32 | 1.503e-07 | 1.503e-07 | 20 | 20
992×144 | 31 | bf16 | 12 | 4.632e-03 | 3.736e-03 | 27 | 0
  |   | fp32 FPU | 12 | 6.924e-04 | 6.821e-04 | 144 | 144
  |   | fp32 SFPU | 12 | 1.214e-07 | 1.318e-07 | 52 | 69
992×32 | 31 | bf16 | 31 | 3.675e-03 | 3.675e-03 | 2 | 1
  |   | fp32 FPU | 31 | 6.914e-04 | 6.840e-04 | 32 | 32
  |   | fp32 SFPU | 31 | 1.202e-07 | 1.473e-07 | 14 | 19
800×32 | 25 | bf16 | 25 | 8.655e-03 | 3.882e-03 | 31 | 0
  |   | fp32 FPU | 25 | 1.382e-03 | 6.751e-04 | 32 | 32
  |   | fp32 SFPU | 25 | 1.156e-07 | 1.269e-07 | 17 | 15
768×128 | 24 | bf16 | 16 | 7.652e-03 | 3.790e-03 | 102 | 0
  |   | fp32 FPU | 16 | 9.595e-04 | 7.032e-04 | 128 | 128
  |   | fp32 SFPU | 16 | 1.504e-07 | 1.468e-07 | 51 | 59
640×1024 | 20 | bf16 | 2 | 7.716e-03 | 3.847e-03 | 775 | 0
  |   | bf8_b | 2 | 1.151e-02 | 1.116e-02 | n/a | n/a
  |   | fp32 FPU | 2 | 9.921e-04 | 7.033e-04 | 1024 | 1024
  |   | fp32 SFPU | 2 | 1.548e-07 | 1.915e-07 | 441 | 434




### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/52922_tile_h_axis_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/52922_tile_h_axis_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/52922_tile_h_axis_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/52922_tile_h_axis_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/52922_tile_h_axis_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/52922_tile_h_axis_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/52922_tile_h_axis_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/52922_tile_h_axis_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/52922_tile_h_axis_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/52922_tile_h_axis_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/52922_tile_h_axis_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/52922_tile_h_axis_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/52922_tile_h_axis_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/52922_tile_h_axis_split)