### PR TITLE
fix(sfpu): div_int32 INT32_MIN divisor spurious quotient

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -96,7 +96,7 @@ sfpi_inline void calculate_div_int32_body(
         q -= 1;
         r += b;
     }
-    v_elseif(r >= b) {
+    v_elseif(sfpi::as<sfpi::vUInt>(r) >= sfpi::as<sfpi::vUInt>(b)) {
         q += 1;
         r -= b;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -137,7 +137,7 @@ sfpi_inline void calculate_div_int32_body(
         q -= 1;
         r += b;
     }
-    v_elseif(r >= b) {
+    v_elseif(sfpi::as<sfpi::vUInt>(r) >= sfpi::as<sfpi::vUInt>(b)) {
         q += 1;
         r -= b;
     }


### PR DESCRIPTION
## Summary
Fixes #54326

`ttnn.div` int32 with `rounding_mode="trunc"` or `"floor"` returns wrong results when divisor is INT32_MIN:
| call | kernel | torch |
|---|---|---|
| div(1, INT32_MIN, trunc) | -1 | 0 |
| div(65536, INT32_MIN, trunc) | -1 | 0 |
| div(-6, INT32_MIN, trunc) | 1 | 0 |

## Root cause
`abs(INT32_MIN)` = 0x80000000, which is negative as signed int32. The `v_elseif(r >= b)` remainder correction uses signed comparison, so it fires unconditionally for this divisor, adding a spurious `q += 1`.

## Fix
Use unsigned comparison: `sfpi::as<sfpi::vUInt>(r) >= sfpi::as<sfpi::vUInt>(b)`. This correctly handles the INT32_MIN magnitude without affecting other divisors.

Applied to both wormhole_b0 and blackhole floor variants.