### PR TITLE
CI Cleanup: move T3K large DRAM dispatch tests from T3K e2e into the runtime unit pipeline

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -254,7 +254,7 @@ runtime:
   unit:
     wh_n150_civ2: 232
     wh_n300_civ2: 99
-    wh_llmbox: 20
+    wh_llmbox: 25
     bh_p150b_civ2: 214
     bh_p300: 69
     bh_p150b_civ2_viommu: 11

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -45,6 +45,14 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
+- name: runtime_t3k_dispatch_large_dram
+  cmd: ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='Large*.NIGHTLY_DRAMReadback/*'
+  skus:
+    wh_llmbox:
+      timeout: 15
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
 - name: runtime_rt_profiler
   cmd: ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='RealtimeProfiler*'
   skus:

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -41,14 +41,6 @@
   owner_id: U07D5N7QL4U # Joseph Chu
   team: scaleout
 
-- name: t3k_dispatch_unit_tests
-  cmd: build/test/tt_metal/unit_tests_dispatch --gtest_filter="Large*.NIGHTLY_DRAMReadback/*"
-  skus:
-    wh_llmbox:
-      timeout: 15
-  owner_id: U07R05K4WGJ # John Bauman
-  team: scaleout
-
 - name: t3k_fabric_stability_tests
   # Setting TT_METAL_OPERATION_TIMEOUT_SECONDS=0 to disable test timeouts and let the tests run to completion, as some of the stability tests can take a long time to complete.
   cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml


### PR DESCRIPTION
## Summary
- Move `t3k_dispatch_unit_tests` (`unit_tests_dispatch --gtest_filter='Large*.NIGHTLY_DRAMReadback/*'` on `wh_llmbox`) out of `t3k_e2e_tests.yaml` into `runtime_unit_tests.yaml` as `runtime_t3k_dispatch_large_dram`.
- This is runtime dispatch coverage that the single-card fast-dispatch job excludes via `*NIGHTLY_*`. Scaleout does not need it in the T3K e2e pipeline.
- Raise `runtime.unit.wh_llmbox` 20 → 25 so existing multi-CQ (5 min) plus this job (15 min) still has headroom.
- Leave fabric jobs in `t3k_e2e_tests.yaml` unchanged (`t3k_fabric_unit_tests`, `t3k_fabric_stability_tests`, `t3k_addrgen_write_tests`).

## Test plan
- [x] `verify_time_budget.py` on `runtime_unit_tests.yaml` (unit) and `t3k_e2e_tests.yaml` (e2e)
- [x] `prepare_test_matrix.py` for `wh_llmbox`: new job present in runtime; `t3k_dispatch_unit_tests` gone from T3K e2e
- [ ] Nightly `(Runtime) Unit Tests` on `wh_llmbox` runs `runtime_t3k_dispatch_large_dram`
- [ ] T3000 e2e no longer schedules `t3k_dispatch_unit_tests`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/move-t3k-dispatch-to-runtime)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/move-t3k-dispatch-to-runtime)