### PR TITLE
fix(sfpu): sqrt/rsqrt handle -0.0 per IEEE 754

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -77,7 +77,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
     }
 
     if constexpr (!FAST_APPROX) {
-        v_if(x < 0.0f) { y = std::numeric_limits<float>::quiet_NaN(); }
+        v_if(x < 0.0f && sfpi::as<sfpi::vUInt>(x) != 0x80000000u) { y = std::numeric_limits<float>::quiet_NaN(); }
         v_endif;
     }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sqrt.h
@@ -76,7 +76,7 @@ sfpi_inline sfpi::vFloat _calculate_sqrt_body_(const sfpi::vFloat x) {
         }
     }
     if constexpr (!FAST_APPROX) {
-        v_if(x < 0.0F) {
+        v_if(x < 0.0F && sfpi::as<sfpi::vUInt>(x) != 0x80000000u) {
             y = std::numeric_limits<float>::quiet_NaN();  // returns nan for fp32 and inf for bf16
         }
         v_endif;


### PR DESCRIPTION
## Summary
Fixes #53975

`sqrt(-0.0)` returns NaN and `rsqrt(-0.0)` returns NaN instead of -0.0 and -inf.

## Root cause
The `x < 0` guard in `ckernel_sfpu_sqrt.h` uses sign-bit comparison, which treats -0.0 (bit pattern 0x80000000) as negative. IEEE 754 places -0.0 in the domain of sqrt/rsqrt.

## Fix
Exclude -0.0 from the NaN guard: `x < 0.0F && sfpi::as<sfpi::vUInt>(x) != 0x80000000u`. This lets -0.0 pass through to produce the correct signed-zero result (-0.0 for sqrt, -inf for rsqrt).

Applied to both wormhole_b0 and blackhole (identical logic).