### PR TITLE
fix(pad): use bit_cast for FLOAT32 pad value in single-core TILE factory (#54223)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -71,6 +71,8 @@ ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
         packed_pad_value = pad_value;
+    } else if (a.dtype() == DataType::FLOAT32) {
+        packed_pad_value = std::bit_cast<uint32_t>(pad_value);
     } else if (a.dtype() == DataType::UINT16) {
         packed_pad_value = pack_two_uint16_into_uint32({float_to_uint16(pad_value), float_to_uint16(pad_value)});
     } else {


### PR DESCRIPTION
## Summary

Fixes #54223

`PadTileCoreProgramFactory` (single-core TILE layout) packs FLOAT32 pad values as two bfloat16s via `pack_two_bfloat16_into_uint32`, producing incorrect fill values:

| Requested | Actual |
|-----------|--------|
| 7.0 | 7.0079193 |
| -3.0 | -3.0117340 |
| 0.0 | 0.0 (correct — identical in both formats) |

The multicore factory (`pad_tile_multicore_program_factory.cpp`) already handles FLOAT32 correctly with `std::bit_cast<uint32_t>(pad_value)`. This PR copies the same case to the single-core factory.

## Root Cause

The if/else chain in `pad_tile_program_factory.cpp` has explicit cases for INT32/UINT32 and UINT16 but falls through to bf16 packing for everything else, including FLOAT32. Since the kernel writes the packed uint32 into every 4-byte word of the pad tile, a FLOAT32 tile gets `(bf16(v) << 16) | bf16(v)` instead of the exact IEEE 754 bits.

## Fix

Add an explicit `DataType::FLOAT32` case using `std::bit_cast<uint32_t>`, matching the multicore factory.

## Testing

- Existing `test_pad_op` does not cover this factory path (no single-core FLOAT32 test)
- The fix is a direct port of proven logic from the multicore factory
- Zero functional change for non-FLOAT32 dtypes