### PR TITLE
[sweeps] Drop the stale traced topk indices tensor when it needs 32-bit indices

### DIFF
--- a/tests/sweep_framework/sweeps/model_traced/topk_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/topk_model_traced.py
@@ -192,7 +192,19 @@ def run(
         # vectors without one instead of aborting at the TT_FATAL. The values are unaffected
         # either way -- the kernel generates identical indices itself.
         dim_is_last = dim_val in (-1, len(shape) - 1)
-        if idx_shape != shape or not dim_is_last:
+        # ttnn.topk now also honours the supplied tensor's index width (#54168): a UINT16
+        # indices tensor is rejected once 32-bit indices are required -- reduced dim above
+        # 65535, or a float32 input. The traced Llama 3.x configs carry a UINT16 indices
+        # tensor at width 65536 from that same retired sampling code, so drop it for the
+        # same reason rather than aborting at the TT_FATAL. Dropping is also the only
+        # correct replay now that the tensor is honoured: the traced values are not
+        # recorded, so the placeholder we would pass (all zeros) would come back as the
+        # op's indices output and disagree with the torch golden.
+        reduced_w = shape[dim_val if dim_val != -1 else len(shape) - 1]
+        padded_reduced_w = ((reduced_w + 31) // 32) * 32
+        idx_needs_32_bit = padded_reduced_w > 65535 or input_a_dtype == ttnn.float32
+        idx_is_16_bit = indices_tensor_info.get("dtype") == ttnn.uint16
+        if idx_shape != shape or not dim_is_last or (idx_is_16_bit and idx_needs_32_bit):
             indices_tensor_info = None
     if indices_tensor_info and indices_tensor_info["shape"] is not None:
         idx_dtype = indices_tensor_info.get("dtype") or ttnn.uint16


### PR DESCRIPTION
### Problem

Eight traced Llama 3.1/3.3 `topk` configs abort in lead-model runs:

```
TT_FATAL topk_device_operation.cpp:243:
  Optional indices tensor must be the same width as the output indices dtype
  DataType::UINT32, got: DataType::UINT16
```

All eight are width **65536** with a UINT16 indices tensor. They passed until `91cde4c2245` (#54168) began honouring the supplied tensor's index width — a UINT16 tensor is now rejected once 32-bit indices are required (reduced dim above 65535, or a float32 input).

### Fix

The module already drops a stale traced indices tensor when its shape or reduction dim no longer matches what `ttnn.topk` accepts (#52928) — those specs come from retired sampling code that production no longer uses. These configs are the same class, so this extends that guard instead of adding a parallel one.

Dropping is also the only *correct* replay now that the tensor is honoured: traced tensor **values are not recorded**, so the placeholder the module builds (`torch.zeros`) would be returned as the op's indices output and disagree with the torch golden. The generated indices are identical to what the op produces itself.

### Verification

- Guard fires on exactly the **8 affected config hashes**; the other **40** traced indices tensors are untouched.
- All 8 pass at **PCC 1.0** on a 1x2 mesh.

Note this validates the drop path produces correct results; avoiding the abort is guaranteed by construction, since no indices tensor is passed and the dtype validation cannot run.

### Scope

This is the sweeps-side fix. Whether `ttnn.topk` should accept UINT16 labels at width 65536 — the largest index, 65535, fits UINT16 exactly, and a supplied tensor holds arbitrary labels rather than positions — is a separate question for the topk owners.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-topk-stale-traced-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-topk-stale-traced-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-topk-stale-traced-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-topk-stale-traced-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-topk-stale-traced-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-topk-stale-traced-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-topk-stale-traced-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-topk-stale-traced-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-topk-stale-traced-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-topk-stale-traced-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-topk-stale-traced-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-topk-stale-traced-indices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-topk-stale-traced-indices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-topk-stale-traced-indices)