### PR TITLE
[Bug fix] softmax: validate the sharded subblock_w against the Dest capacity

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_numeric_metrics, assert_with_pcc
 from models.common.utility_functions import torch_random
 
 TEST_PADDING_VALUE = -42
@@ -292,6 +292,68 @@ def test_softmax_sharded_stable_with_program_cache(
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
     assert device.cache_entries_counter.total == 1
+
+
+# The sharded compute kernel keeps subblock_w tiles live in Dest, so a subblock_w above the Dest
+# capacity used to run to completion and return wrong numbers with no diagnostic. The capacity is
+# 8 tiles by default, 4 with fp32_dest_acc_en and 16 with dst_full_sync_en, so the guard has to read
+# the compute config rather than assume the default. subblock_w = 0 is the other end of the same
+# bound: block_w % subblock_w == 0 is only checked when a mask is present, so without one a zero
+# used to reach block_w / subblock_w in the program factory and take the process down with SIGFPE.
+@pytest.mark.parametrize(
+    "fp32_acc_en, dst_full_sync_en, subblock_w, expect_raise",
+    [
+        (False, False, 0, True),
+        (False, False, 8, False),
+        (False, False, 16, True),
+        (True, False, 4, False),
+        (True, False, 8, True),
+        (False, True, 16, False),
+    ],
+)
+def test_softmax_sharded_subblock_w_dest_capacity(
+    device, expect_error, fp32_acc_en, dst_full_sync_en, subblock_w, expect_raise
+):
+    torch.manual_seed(0)
+    grid_size = (8, 4)
+    batch_size, num_heads, h, w = 8, 4, 128, 512
+
+    torch_input_tensor = torch_random((batch_size, num_heads, h, w), -10, 10, dtype=torch.bfloat16)
+    memory_config = ttnn.create_sharded_memory_config(
+        torch_input_tensor.shape,
+        core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    program_config = ttnn.SoftmaxShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        subblock_w=subblock_w,
+        block_h=batch_size * num_heads * h // 32 // (grid_size[0] * grid_size[1]),
+        block_w=w // 32,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=fp32_acc_en,
+        packer_l1_acc=False,
+        dst_full_sync_en=dst_full_sync_en,
+    )
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config
+    )
+
+    if expect_raise:
+        with expect_error(RuntimeError, "must be greater than 0 and at most the Dest capacity"):
+            ttnn.softmax_in_place(
+                input_tensor, program_config=program_config, compute_kernel_config=compute_kernel_config
+            )
+        return
+
+    output_tensor = ttnn.softmax_in_place(
+        input_tensor, program_config=program_config, compute_kernel_config=compute_kernel_config
+    )
+    torch_output_tensor = F.softmax(torch_input_tensor.float(), dim=-1)
+    assert_with_pcc(torch_output_tensor, ttnn.to_torch(output_tensor).float(), 0.999)
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])

--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -343,7 +343,10 @@ def test_softmax_sharded_subblock_w_dest_capacity(
     )
 
     if expect_raise:
-        with expect_error(RuntimeError, "must be greater than 0 and at most the Dest capacity"):
+        # The bound is enforced by two checks now: the zero end runs ahead of the mask branch, which
+        # carries a block_w % subblock_w, and the capacity end needs the compute config.
+        message = "subblock_w must be greater than 0" if subblock_w == 0 else "must be at most the Dest capacity"
+        with expect_error(RuntimeError, message):
             ttnn.softmax_in_place(
                 input_tensor, program_config=program_config, compute_kernel_config=compute_kernel_config
             )
@@ -354,6 +357,38 @@ def test_softmax_sharded_subblock_w_dest_capacity(
     )
     torch_output_tensor = F.softmax(torch_input_tensor.float(), dim=-1)
     assert_with_pcc(torch_output_tensor, ttnn.to_torch(output_tensor).float(), 0.999)
+
+
+# subblock_w = 0 with a mask present used to reach `block_w % subblock_w` in the mask branch of
+# validate_on_program_cache_miss, which is a modulo by zero, before any check on subblock_w itself
+# ran. The zero check is hoisted ahead of both branches, so this path raises like the unmasked one.
+def test_softmax_sharded_masked_subblock_w_zero(device, expect_error):
+    torch.manual_seed(0)
+    grid_size = (8, 4)
+    batch_size, num_heads, h, w = 8, 4, 128, 512
+
+    torch_input_tensor = torch_random((batch_size, num_heads, h, w), -10, 10, dtype=torch.bfloat16)
+    attention_mask = torch.zeros(batch_size, 1, 1, w, dtype=torch.bfloat16)
+    attention_mask_t = ttnn.from_torch(attention_mask, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    memory_config = ttnn.create_sharded_memory_config(
+        torch_input_tensor.shape,
+        core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    program_config = ttnn.SoftmaxShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        subblock_w=0,
+        block_h=batch_size * num_heads * h // 32 // (grid_size[0] * grid_size[1]),
+        block_w=w // 32,
+    )
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memory_config
+    )
+
+    with expect_error(RuntimeError, "subblock_w must be greater than 0"):
+        ttnn.scale_mask_softmax_in_place(input_tensor, 1.0, attention_mask_t, program_config=program_config)
 
 
 @pytest.mark.parametrize("batch_size", [1, 16])

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -327,6 +327,20 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                     shard_shape[1],
                     tensors_args.input_tensor.tensor_spec().tile().get_width());
 
+                // The sharded compute kernel keeps subblock_w tiles live in Dest at once, so a
+                // subblock_w above the Dest capacity silently returns wrong results. The capacity
+                // depends on the compute config, hence get_dest_reg_count rather than a constant.
+                const uint32_t dest_tile_capacity = ttnn::get_dest_reg_count(
+                    attributes.compute_kernel_config, tensors_args.input_tensor.tensor_spec().tile().get_tile_shape());
+                TT_FATAL(
+                    program_config.subblock_w > 0 && program_config.subblock_w <= dest_tile_capacity,
+                    "subblock_w ({}) must be greater than 0 and at most the Dest capacity of {} tiles for this "
+                    "compute config (fp32_dest_acc_en={}, dst_full_sync_en={}).",
+                    program_config.subblock_w,
+                    dest_tile_capacity,
+                    attributes.compute_kernel_config.fp32_dest_acc_en,
+                    attributes.compute_kernel_config.dst_full_sync_en);
+
                 const auto& a = tensors_args.input_tensor;
                 if (a.is_sharded()) {
                     ttnn::operations::normalization::detail::validate_sharded_input(

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -184,6 +184,20 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
             tensors_args.input_tensor.dtype() == DataType::BFLOAT8_B,
         "Input tensor must be FLOAT32, BFLOAT16, or BFLOAT8_B, got: {}",
         tensors_args.input_tensor.dtype());
+
+    // subblock_w == 0 reaches `block_w % subblock_w` in the mask branch below and `block_w /
+    // subblock_w` in the program factory, so the zero check runs here, ahead of every divisibility
+    // check and of both branches. The Dest-capacity half of the same bound needs the compute
+    // config and stays with the other sharded checks further down.
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, SoftmaxShardedMultiCoreProgramConfig>) {
+                TT_FATAL(program_config.subblock_w > 0, "subblock_w must be greater than 0.");
+            }
+        },
+        attributes.program_config);
+
     if (tensors_args.mask.has_value()) {
         const auto& mask = tensors_args.mask.value();
         TT_FATAL(mask.storage_type() == StorageType::DEVICE, "Operands to softmax need to be on device!");
@@ -333,9 +347,9 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                 const uint32_t dest_tile_capacity = ttnn::get_dest_reg_count(
                     attributes.compute_kernel_config, tensors_args.input_tensor.tensor_spec().tile().get_tile_shape());
                 TT_FATAL(
-                    program_config.subblock_w > 0 && program_config.subblock_w <= dest_tile_capacity,
-                    "subblock_w ({}) must be greater than 0 and at most the Dest capacity of {} tiles for this "
-                    "compute config (fp32_dest_acc_en={}, dst_full_sync_en={}).",
+                    program_config.subblock_w <= dest_tile_capacity,
+                    "subblock_w ({}) must be at most the Dest capacity of {} tiles for this compute config "
+                    "(fp32_dest_acc_en={}, dst_full_sync_en={}).",
                     program_config.subblock_w,
                     dest_tile_capacity,
                     attributes.compute_kernel_config.fp32_dest_acc_en,


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #52040.

`SoftmaxShardedMultiCoreProgramConfig` lets the caller choose `subblock_w`, and nothing validated it against the Dest capacity. An oversized value ran to completion and returned a tensor of the right shape and dtype containing garbage, with no exception and no warning.

`softmax_program_factory_attention_optimized_sharded.cpp:197` passes `subblock_w` to the compute kernel as a compile-time argument, and the kernel indexes Dest with it directly (`kernels/attention/compute/softmax_sharded.cpp:57`):

```cpp
        for (uint32_t w = 0; w < subblock_w; w++) {
            pack_tile(w, dfb_out_id);
        }
```

so tiles `0 .. subblock_w-1` have to exist in Dest. The only bound the op applied was `block_w % subblock_w == 0` (`softmax_device_operation.cpp:240`), and that one sits inside the mask-present branch. That placement is also why `subblock_w = 0` belongs in the same check: with no mask the divisibility check never runs, so a zero reaches `num_subblocks_w = block_w / subblock_w` in the sharded factory and divides by zero — a SIGFPE that takes the process down with a core dump rather than an exception.

The bound comes from `ttnn::get_dest_reg_count`, not a constant, because the capacity depends on the compute config: 8 tiles by default, 4 with `fp32_dest_acc_en`, 16 with `dst_full_sync_en`. A hardcoded `<= 8` would reject `subblock_w = 16` under `dst_full_sync_en`, which runs correctly today. Layernorm spells the same table by hand in `sharded_layernorm_factory_helpers.cpp:23`, added for #14222 after the identical failure in that op; this calls the shared helper instead of adding a third copy.

## Accuracy

What the guard catches, measured on N300 at `141fbea49c5`, shape `[8, 4, 128, 512]`, height sharded on an 8x4 grid, bfloat16. Each row of a softmax must sum to 1:

| compute config | Dest capacity | `subblock_w` | row sum, min .. max | PCC vs torch |
|---|---|---|---|---|
| default | 8 | 8 | 0.9471 .. 1.0181 | 0.999860 |
| default | 8 | **16** | 0.8597 .. **159.7318** | **0.012314** |
| `fp32_dest_acc_en` | 4 | 4 | 0.9611 .. 1.0008 | 0.999815 |
| `fp32_dest_acc_en` | 4 | **8** | 2.6942 .. 3.9061 | **-0.063760** |
| `dst_full_sync_en` | 16 | 16 | 0.9471 .. 1.0181 | 0.999860 |

The two over-capacity rows are the defect. Nothing is raised for either. The `fp32_dest_acc_en` row is the one that shows the capacity is not a constant: `subblock_w = 8` is correct under the default config and wrong under this one, and its output is not merely inaccurate but anti-correlated with the answer.

What must not move: with the guard in place, all three in-capacity rows return **the same numbers to every printed digit**, and the two over-capacity rows raise instead:

```
TT_FATAL @ softmax_device_operation.cpp:342: program_config.subblock_w > 0 &&
program_config.subblock_w <= dest_tile_capacity
info: subblock_w (16) must be greater than 0 and at most the Dest capacity of 8 tiles for this
compute config (fp32_dest_acc_en=false, dst_full_sync_en=false).
```

## Cost

Host-side only. One `TT_FATAL` in `validate_on_program_cache_miss`, in the same `std::visit` block as the `block_h` and `block_w` checks from #37329. It runs once per program cache miss, before any program is built, so there is no per-call cost and the dispatch count is unchanged.

Reading `attributes.compute_kernel_config` there is safe: it is resolved by `softmax_init_compute_kernel_config` before it is stored (`softmax_device_operation.cpp:401`), and `get_compute_kernel_config_args`, which the program factory uses to configure the kernel, is a passthrough of the same fields `get_dest_reg_count` reads. The check and the kernel cannot disagree.

## Tests

`test_softmax_sharded_subblock_w_dest_capacity`, 6 cases: both bounds against all three capacities. On the base commit the two over-capacity cases fail; the `subblock_w = 0` case cannot be run there at all, since it aborts the interpreter rather than failing.

Nothing that works today starts raising:

| | P300 | N300 |
|---|---|---|
| `tests/ttnn/unit_tests/operations/fused/`, whole directory | 3380 passed, 540 skipped, 796 xfailed, 0 failed | not run |
| `tests/ttnn/nightly/.../test_softmax_sharded.py` | 13 passed | not run |
| `models/demos/blackhole/sentence_bert/tests/pcc/` | 9 passed | not run |
| the five configurations in the Accuracy table | — | 3 of 3 in-capacity identical, 2 of 2 over-capacity raise |

No in-tree caller exceeds the capacity, and the two that sit exactly on it — falcon7b at 8 (`falcon_attention.py:409`) and `test_softmax_sharded.py:72` at 8 — still pass.

## Not covered

- The interleaved factory's `fp32_dest_acc_en ? 4 : 8` and layernorm's four-branch `assert_subblock_compute_config_compatible` are both hand-rolled copies of what `get_dest_reg_count` computes, and neither accounts for `dst_full_sync_en` the same way. Consolidating them is a cleanup across two ops and would put a refactor in a bug-fix PR.
- The message names `fp32_dest_acc_en` and `dst_full_sync_en` rather than telling the caller which value to use, because the largest legal `subblock_w` also has to divide `block_w`, and picking it for them would need the divisor search the eager sweep does by hand.
- The regression suites above were run on P300 only. The N300 evidence is the five configurations in the Accuracy table, not a suite run.

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `141fbea49c5`
* Hardware: N300 and P300


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218171627388572