### PR TITLE
[Bug fix] clamp: use an infinity, not FLT_MAX, for an omitted bound

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_clamp_open_bound.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_clamp_open_bound.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for ttnn.clamp with an omitted bound.
+
+`torch.clamp(x, min=m)` is documented as `torch.maximum(x, m)` — there is no upper bound.
+Before this fix the host substituted `FLT_MAX` for the omitted side, so `clamp(+inf, min=0)`
+returned `3.4028235e+38` where torch returns `+inf`. This asserts the fixed contract on
+float32 for the three inputs that reveal the sentinel: `+inf`, `-inf`, and `FLT_MAX` itself.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+
+def _tt(x, device):
+    return ttnn.from_torch(x, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+
+def _one(x, device):
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded.view(-1)[0] = x
+    tt = ttnn.from_torch(padded, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    return tt
+
+
+@pytest.mark.parametrize(
+    "x, min_v, max_v, expected",
+    [
+        (float("inf"), 0.0, None, float("inf")),
+        (float("inf"), -1.0, None, float("inf")),
+        (float("-inf"), None, 0.0, float("-inf")),
+        (float("-inf"), None, 1.0, float("-inf")),
+        # FLT_MAX is the old sentinel; with the omitted upper bound now +inf,
+        # clamp(FLT_MAX, min=0) should pass FLT_MAX through unchanged.
+        (torch.finfo(torch.float32).max, 0.0, None, torch.finfo(torch.float32).max),
+    ],
+)
+def test_clamp_open_bound_float32(device, x, min_v, max_v, expected):
+    """clamp with one bound omitted must not clip ±inf or FLT_MAX."""
+    got_scalar = ttnn.to_torch(ttnn.clamp(_one(x, device), min=min_v, max=max_v)).view(-1)[0].item()
+    assert got_scalar == expected, f"clamp({x}, min={min_v}, max={max_v}) = {got_scalar}, expected {expected}"
+
+
+def test_clamp_open_bound_matches_tensor_overload(device):
+    """The scalar-bound and tensor-bound overloads of ttnn.clamp must agree on finite input and ±inf."""
+    x = torch.tensor([[1.0, -2.0, float("inf"), float("-inf"), 3.0]] + [[0.0] * 5] * 31 * 32, dtype=torch.float32).view(
+        1, 1, 32, 32
+    )[:, :, :1, :5]
+    # Pad to a full 32x32 tile of zeros with the interesting row at [0, 0, 0, :5]
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded[0, 0, 0, :5] = x.view(-1)[:5]
+
+    tx = ttnn.from_torch(padded, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    zero_tensor = ttnn.from_torch(torch.zeros_like(padded), dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    got_scalar = ttnn.to_torch(ttnn.clamp(tx, min=0.0))
+    got_tensor = ttnn.to_torch(ttnn.clamp(tx, min=zero_tensor))
+    ref = torch.clamp(padded, min=0.0)
+
+    # Both overloads must equal torch, exactly, on the five special values in row 0.
+    for i, v in enumerate(padded[0, 0, 0, :5].tolist()):
+        assert (
+            got_scalar[0, 0, 0, i].item() == ref[0, 0, 0, i].item()
+        ), f"scalar overload at {v}: {got_scalar[0, 0, 0, i].item()} != torch {ref[0, 0, 0, i].item()}"
+        assert (
+            got_tensor[0, 0, 0, i].item() == ref[0, 0, 0, i].item()
+        ), f"tensor overload at {v}: {got_tensor[0, 0, 0, i].item()} != torch {ref[0, 0, 0, i].item()}"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -210,8 +210,15 @@ Tensor clamp(
                             : 16775716;  // max_val and min_val will be updated once unary infra supports int32 scalar.
         return ttnn::clamp_tss(a, min_val, max_val, output_mem_config, output_tensor);
     }  // All scalars are float (or null)
-    float min_val = min.has_value() ? std::get<float>(min.value()) : std::numeric_limits<float>::lowest();
-    float max_val = max.has_value() ? std::get<float>(max.value()) : std::numeric_limits<float>::max();
+    // Omitted bounds must not be substituted with a finite sentinel: on float32 that turns
+    // `clamp(+inf, min=m)` into `FLT_MAX` (3.4028235e38) where `torch.clamp` returns `+inf`.
+    // ±inf compares correctly against every finite operand under the kernel's sign-magnitude
+    // ordering (|inf| = 0x7F800000 is above every finite |v|), so passing ±inf preserves
+    // torch's contract: `clamp(x, min=m)` is `maximum(x, m)` and `clamp(x, max=M)` is
+    // `minimum(x, M)` when the other bound is None. NaN is not addressed here — the kernel's
+    // two SFPSWAP instructions lose it in either sentinel, tracked separately in #51470.
+    float min_val = min.has_value() ? std::get<float>(min.value()) : -std::numeric_limits<float>::infinity();
+    float max_val = max.has_value() ? std::get<float>(max.value()) : std::numeric_limits<float>::infinity();
     return ttnn::clamp_tss(a, min_val, max_val, output_mem_config, output_tensor);
 }
 


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #51498.

`torch.clamp(x, min=m)` is documented equivalent to `torch.maximum(x, m)` — there is no upper bound. The scalar-bound overload of `ttnn::clamp` (`unary_composite_op.cpp`) substituted `FLT_MAX` for the omitted side and passed it into `clamp_tss`, so an infinity came back as the largest finite float. The tensor-bound overload in the same function uses `where(ge(a, min), a, min)` and never had the problem, so **the two overloads of one public op disagreed on the same input**.

The substitution becomes the identity it was meant to be:

```
std::numeric_limits<float>::lowest() -> -std::numeric_limits<float>::infinity()
std::numeric_limits<float>::max()    -> +std::numeric_limits<float>::infinity()
```

`±inf` compares correctly against every finite operand under the kernel's sign-magnitude ordering — `|inf| = 0x7F800000` sits above every finite `|v|` — so the kernel path is untouched.

## Accuracy

N300 at `141fbea49c5`, one tile, against `torch.clamp`:

| | input | bound | main | this branch | torch |
|---|---|---|---|---|---|
| float32 | `+inf` | `min=0` | **3.4028234663852886e+38** | **`inf`** | `inf` |
| float32 | `-inf` | `max=0` | **-3.4028234663852886e+38** | **`-inf`** | `-inf` |
| bfloat16 | `+inf` | `min=0` | **3.3895313892515355e+38** | **`inf`** | `inf` |
| bfloat16 | `-inf` | `max=0` | **-3.3895313892515355e+38** | **`-inf`** | `-inf` |

What must not move does not. The bound that is supplied was never affected — `clamp(+inf, max=0)` returns `0.0` on both branches in both dtypes — and a finite input near the top of the range is unchanged: `clamp(3e38, min=0)` returns `3.0000000054977558e+38` on both branches in float32.

bfloat16 was already `+inf` at the sentinel in some paths, since `FLT_MAX` rounds up to `+inf` when the packer rounds to nearest; the rows above show it was not in this one.

## Cost

Host-side only: two words in the scalar-bound overload. No kernel change, no dispatch change, no per-call cost.

## Tests

`test_clamp_open_bound.py` asserts three things: that `clamp(±inf, min/max=m)` with the other bound omitted returns `±inf`, matching `torch.clamp`; that `clamp(FLT_MAX, min=0)` passes through unchanged rather than being clipped at value; and that the scalar-bound and tensor-bound overloads produce identical output on the same input, `±inf` included.

## Not covered

- **The int32 scalar path.** The `±16775716` sentinel at `:207-210` is left alone; extending it to `INT32_MIN`/`INT32_MAX` needs the integer `SFPSWAP` verified over the full range, which is a kernel-side question and not a host-side substitution.
- **NaN.** `clamp` loses NaN through the kernel's two `SFPSWAP` instructions whatever the sentinel is. That is a separate defect with its own upstream report; it is not touched here.

## Environment

* OS: Ubuntu 22.04
* Version of software: tt-metal `141fbea49c5`
* Hardware: N300 and P300
