### PR TITLE
Add SQLite serializer to tt-triage

### DIFF
--- a/tools/tests/triage/test_sqlite_serializer.py
+++ b/tools/tests/triage/test_sqlite_serializer.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Unit tests for the SQLite output back end. These need no hardware - they feed
+# synthetic dataclasses through the serializer and query the result back.
+
+from dataclasses import dataclass
+import os
+import sqlite3
+import sys
+
+import pytest
+
+
+metal_home = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+triage_home = os.path.join(metal_home, "tools", "triage")
+sys.path.insert(0, triage_home)
+
+
+from sqlite_serializer import (
+    DIAGNOSTICS_TABLE,
+    SqliteSerializer,
+    _check_for_duplicates,
+    _check_row_widths,
+    _column_type,
+    _sql_value,
+    quote_identifier,
+)
+from triage import hex_serializer, recurse_field, triage_field
+
+
+@dataclass
+class Row:
+    name: str = triage_field("Kernel Name")
+    pc: "int | None" = triage_field("PC", hex_serializer)
+    rate: float = triage_field("Heartbeats/s")
+    enabled: bool = triage_field("Preload")
+
+
+@dataclass
+class Inner:
+    loc: str = triage_field("Loc")
+
+
+@dataclass
+class DuplicateLoc:
+    loc: str = triage_field("Loc")
+    inner: Inner = recurse_field()
+
+
+@dataclass
+class Narrow:
+    a: str = triage_field("A")
+
+
+@dataclass
+class Wide:
+    a: str = triage_field("A")
+    b: str = triage_field("B")
+
+
+def write(path, script_name, result, **kwargs):
+    """Serialize one result and return a connection to the finished database."""
+    serializer = SqliteSerializer(str(path), lambda: 0)
+    serializer.emit(
+        script_name=script_name,
+        execution_time="",
+        result=result,
+        failures=kwargs.get("failures", []),
+        warnings=kwargs.get("warnings", []),
+        script_failed=kwargs.get("script_failed", False),
+        failure_message=kwargs.get("failure_message"),
+        documentation=None,
+    )
+    serializer.close()
+    return sqlite3.connect(str(path))
+
+
+def test_quote_identifier_escapes_embedded_quote():
+    assert quote_identifier("Kernel Name") == '"Kernel Name"'
+    assert quote_identifier('we"ird') == '"we""ird"'
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([1, 2, 3], "INTEGER"),
+        ([1, None, 3], "INTEGER"),
+        ([1, 2.5], "REAL"),
+        ([1.5, 2.5], "REAL"),
+        (["a", "b"], "TEXT"),
+        ([1, "a"], "TEXT"),
+        ([None, None], "TEXT"),
+        ([True, False], "INTEGER"),
+    ],
+)
+def test_column_type(values, expected):
+    assert _column_type(values) == expected
+
+
+def test_sql_value_keeps_numbers_and_maps_none_to_null():
+    # The serialized form is what the field's serializer produced; the
+    # unserialized form is the attribute behind it.
+    assert _sql_value("0x1000", 4096) == 4096
+    assert _sql_value("2.5", 2.5) == 2.5
+    assert _sql_value("N/A", None) is None
+    assert _sql_value("matmul", "matmul") == "matmul"
+    # bool is an int subclass, so it stores as 0/1
+    assert _sql_value("True", True) == 1
+    assert _sql_value("False", False) == 0
+
+
+def test_sql_value_falls_back_to_string_past_int64():
+    too_big = 2**64 - 1
+    assert _sql_value(str(too_big), too_big) == str(too_big)
+    assert _sql_value(str(2**63 - 1), 2**63 - 1) == 2**63 - 1
+
+
+def test_check_for_duplicates():
+    _check_for_duplicates("demo.py", ["Dev", "Loc", "RiscV"])
+    with pytest.raises(ValueError, match="duplicate column 'Loc'"):  # allow-pytest.raises: no expect_error fixture
+        _check_for_duplicates("demo.py", ["Dev", "Loc", "Loc"])
+    # SQL column names are case insensitive, so these collide too
+    with pytest.raises(ValueError, match="differ only in case"):  # allow-pytest.raises: no expect_error fixture
+        _check_for_duplicates("demo.py", ["Dev", "Loc", "loc"])
+
+
+def test_check_row_widths():
+    _check_row_widths("demo.py", ["A", "B"], [["1", "2"], ["3", "4"]])
+    with pytest.raises(ValueError, match="row 1 has 1 values"):  # allow-pytest.raises: no expect_error fixture
+        _check_row_widths("demo.py", ["A", "B"], [["1", "2"], ["3"]])
+
+
+def test_round_trip_column_types_and_values(tmp_path):
+    con = write(
+        tmp_path / "t.db",
+        "dump_callstacks.py",
+        [Row("matmul", 0x1000, 9.5, True), Row("add", None, 0.5, False)],
+    )
+    schema = con.execute("SELECT sql FROM sqlite_master WHERE name='dump_callstacks'").fetchone()[0]
+    assert '"Kernel Name" TEXT' in schema
+    assert '"PC" INTEGER' in schema
+    assert '"Heartbeats/s" REAL' in schema
+    assert '"Preload" INTEGER' in schema
+
+    # A hex-serialized field stays numerically comparable, and NULL is NULL.
+    assert con.execute('SELECT count(*) FROM dump_callstacks WHERE "PC" > 4000').fetchone()[0] == 1
+    assert con.execute('SELECT count(*) FROM dump_callstacks WHERE "PC" IS NULL').fetchone()[0] == 1
+    assert con.execute('SELECT count(*) FROM dump_callstacks WHERE "Preload"').fetchone()[0] == 1
+    assert con.execute('SELECT printf(\'0x%X\', "PC") FROM dump_callstacks WHERE "PC" IS NOT NULL').fetchone() == (
+        "0x1000",
+    )
+
+
+def test_column_names_are_the_display_headers(tmp_path):
+    con = write(tmp_path / "t.db", "demo.py", [Row("matmul", 1, 1.0, True)])
+    names = [row[1] for row in con.execute("PRAGMA table_info(demo)")]
+    assert names == ["Kernel Name", "PC", "Heartbeats/s", "Preload"]
+
+
+def test_diagnostics_table_exists_even_when_empty(tmp_path):
+    con = write(tmp_path / "t.db", "demo.py", [Row("matmul", 1, 1.0, True)])
+    assert con.execute(f"SELECT count(*) FROM {quote_identifier(DIAGNOSTICS_TABLE)}").fetchone()[0] == 0
+
+
+def test_check_only_script_records_diagnostics_but_no_table(tmp_path):
+    con = write(
+        tmp_path / "t.db",
+        "check_noc_status.py",
+        None,
+        failures=["Device 0: tensix [1-1 (0,0)]: brisc: [error]NOC0 mismatch[/]"],
+        warnings=["Device 1: skipping"],
+    )
+    tables = [row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    assert tables == [DIAGNOSTICS_TABLE]
+    rows = con.execute(f'SELECT "Script", "Severity", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}').fetchall()
+    assert rows == [
+        ("check_noc_status.py", "failure", "Device 0: tensix [1-1 (0,0)]: brisc: NOC0 mismatch"),
+        ("check_noc_status.py", "warning", "Device 1: skipping"),
+    ]
+
+
+def test_failed_script_is_recorded_as_error(tmp_path):
+    con = write(
+        tmp_path / "t.db",
+        "dump_callstacks.py",
+        None,
+        script_failed=True,
+        failure_message="Skipped: dependency inspector_data.py failed.",
+    )
+    rows = con.execute(f'SELECT "Severity", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}').fetchall()
+    assert rows == [("error", "Skipped: dependency inspector_data.py failed.")]
+
+
+def test_duplicate_column_raises_through_emit(tmp_path):
+    with pytest.raises(ValueError, match="duplicate column 'Loc'"):  # allow-pytest.raises: no expect_error fixture
+        write(tmp_path / "t.db", "dump_fast_dispatch.py", [DuplicateLoc("1-1", Inner("1-1"))])
+
+
+def test_ragged_rows_raise_through_emit(tmp_path):
+    with pytest.raises(ValueError, match="values but the header has"):  # allow-pytest.raises: no expect_error fixture
+        write(tmp_path / "t.db", "demo.py", [Narrow("1"), Wide("2", "3")])
+
+
+def test_existing_database_is_not_reused(tmp_path):
+    path = tmp_path / "t.db"
+    write(path, "demo.py", [Row("matmul", 1, 1.0, True)])
+    with pytest.raises(FileExistsError):  # allow-pytest.raises: no expect_error fixture
+        SqliteSerializer(str(path), lambda: 0)
+    # the original database is left untouched
+    con = sqlite3.connect(str(path))
+    assert con.execute("SELECT count(*) FROM demo").fetchone()[0] == 1
+
+
+def test_multiple_scripts_share_one_database(tmp_path):
+    path = tmp_path / "t.db"
+    serializer = SqliteSerializer(str(path), lambda: 0)
+    for script in ("check_arc.py", "device_info.py"):
+        serializer.emit(script, "", [Row("matmul", 1, 1.0, True)], [], [], False, None, None)
+    serializer.close()
+    con = sqlite3.connect(str(path))
+    tables = sorted(row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'"))
+    assert tables == sorted(["check_arc", "device_info", DIAGNOSTICS_TABLE])

--- a/tools/tests/triage/test_sqlite_serializer.py
+++ b/tools/tests/triage/test_sqlite_serializer.py
@@ -213,6 +213,37 @@ def test_existing_database_is_not_reused(tmp_path):
     assert con.execute("SELECT count(*) FROM demo").fetchone()[0] == 1
 
 
+def test_record_diagnostics_without_a_result(tmp_path):
+    # main() prints skipped scripts and failed providers itself, so they arrive
+    # through record_diagnostics rather than emit.
+    path = tmp_path / "t.db"
+    serializer = SqliteSerializer(str(path), lambda: 0)
+    serializer.record_diagnostics("inspector_data.py", [], [], True, "Inspector unavailable")
+    serializer.record_diagnostics("dump_configuration.py", [], [], True, "Skipped: dependency failed.")
+    serializer.record_diagnostics("dispatcher_data.py", [], ["Device 0: no rank"], False, None)
+    serializer.close()
+
+    con = sqlite3.connect(str(path))
+    rows = con.execute(f'SELECT "Script", "Severity", "Message" FROM {quote_identifier(DIAGNOSTICS_TABLE)}').fetchall()
+    assert rows == [
+        ("inspector_data.py", "error", "Inspector unavailable"),
+        ("dump_configuration.py", "error", "Skipped: dependency failed."),
+        ("dispatcher_data.py", "warning", "Device 0: no rank"),
+    ]
+    # no script produced rows, so the only table is diagnostics
+    tables = [row[0] for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    assert tables == [DIAGNOSTICS_TABLE]
+
+
+def test_record_diagnostics_with_nothing_to_record(tmp_path):
+    path = tmp_path / "t.db"
+    serializer = SqliteSerializer(str(path), lambda: 0)
+    serializer.record_diagnostics("elfs_cache.py", [], [], False, None)
+    serializer.close()
+    con = sqlite3.connect(str(path))
+    assert con.execute(f"SELECT count(*) FROM {quote_identifier(DIAGNOSTICS_TABLE)}").fetchone()[0] == 0
+
+
 def test_multiple_scripts_share_one_database(tmp_path):
     path = tmp_path / "t.db"
     serializer = SqliteSerializer(str(path), lambda: 0)

--- a/tools/triage/check_eth_status.py
+++ b/tools/triage/check_eth_status.py
@@ -44,7 +44,6 @@ class EthCoreDefinitions:
 
 @dataclass
 class EthCoreCheckData:
-    location: OnChipCoordinate | None = triage_field("Loc")
     port_status: str | None = triage_field("Port Status")
     retrain_count: int | None = triage_field("Retrain Count")
     rx_link_up: str | None = triage_field("RX Link Up")
@@ -52,7 +51,6 @@ class EthCoreCheckData:
     mailbox: list[str] | None = triage_field("Mailbox")
 
     def __init__(self):
-        self.location = None
         self.port_status = None
         self.retrain_count = None
         self.rx_link_up = None
@@ -212,7 +210,7 @@ def get_eth_core_data(device: Device, location: OnChipCoordinate, context: Conte
 def run(args, context: Context):
     run_checks = get_run_checks(args, context)
     BLOCK_TYPES_TO_CHECK = ["active_eth"]
-    run_checks.run_per_block_check(
+    return run_checks.run_per_block_check(
         lambda location: get_eth_core_data(location.device, location, context), block_filter=BLOCK_TYPES_TO_CHECK
     )
 

--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -43,8 +43,6 @@ BLOCK_TYPES_TO_CHECK = ["tensix", "idle_eth"]
 
 @dataclass
 class DumpWaitGlobalsData:
-    location: OnChipCoordinate = triage_field("Loc")
-    risc_name: str = triage_field("Proc")
     kernel_name: str = triage_field("Kernel Name")
     worker_type: str | None = triage_field("worker_type")
     cq_id: int | None = triage_field("cq_id")
@@ -285,8 +283,6 @@ def read_wait_globals(
     core_info = multi_info.get_info_for_kernel(dispatcher_core_data.kernel_name) if multi_info else None
 
     return DumpWaitGlobalsData(
-        location=location,
-        risc_name=risc_name,
         kernel_name=dispatcher_core_data.kernel_name,
         last_wait_count=last_wait_count,
         last_wait_stream=last_wait_stream,

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -19,7 +19,7 @@ import io
 import os
 import textwrap
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, Callable, Iterable
 
 
@@ -27,6 +27,7 @@ from typing import Any, Callable, Iterable
 class TableData:
     columns: list[str]
     rows: list[list[str]]
+    unserialized_values: list[list[Any]] = field(default_factory=list)
 
 
 def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
@@ -61,7 +62,7 @@ def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
             elif "serialized_name" in metadata:
                 columns.append(metadata.get("serialized_name") or fld.name)
 
-    def collect_row(row: list[str], obj: Any, flds: Iterable[Any]) -> None:
+    def collect_row(row: list[str], unserialized: list[Any], obj: Any, flds: Iterable[Any]) -> None:
         for fld in flds:
             metadata = fld.metadata
             if metadata.get("verbose", 0) > verbose_level:
@@ -71,23 +72,30 @@ def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
             if metadata.get("recurse"):
                 value = getattr(obj, fld.name)
                 assert is_dataclass(value)
-                collect_row(row, value, fields(value))
+                collect_row(row, unserialized, value, fields(value))
             elif "additional_fields" in metadata:
                 assert all(hasattr(obj, af) for af in metadata["additional_fields"])
                 all_values = [getattr(obj, fld.name)]
                 all_values.extend(getattr(obj, af) for af in metadata["additional_fields"])
                 assert "serializer" in metadata, "Serializer must be provided for combined field."
-                row.append(metadata["serializer"](all_values))
+                combined = metadata["serializer"](all_values)
+                row.append(combined)
+                unserialized.append(combined)
             elif "serializer" in metadata:
-                row.append(metadata["serializer"](getattr(obj, fld.name)))
+                value = getattr(obj, fld.name)
+                row.append(metadata["serializer"](value))
+                unserialized.append(value)
 
     collect_header(result[0], fields(result[0]))
     rows: list[list[str]] = []
+    unserialized_values: list[list[Any]] = []
     for item in result:
         row: list[str] = []
-        collect_row(row, item, fields(item))
+        unserialized: list[Any] = []
+        collect_row(row, unserialized, item, fields(item))
         rows.append(row)
-    return TableData(columns=columns, rows=rows)
+        unserialized_values.append(unserialized)
+    return TableData(columns=columns, rows=rows, unserialized_values=unserialized_values)
 
 
 class OutputSerializer(ABC):
@@ -239,7 +247,7 @@ def _one_line(s: str) -> str:
     return s.replace("\n", "\\n").replace("\r", "\\r")
 
 
-def _strip_rich_markup(s: str) -> str:
+def strip_rich_markup(s: str) -> str:
     """Strip Rich markup tags (e.g. `[warning]...[/]`) from a string.
 
     Some script messages contain bracketed text that looks like markup but
@@ -267,7 +275,7 @@ class CsvSerializer(OutputSerializer):
         # Strip Rich markup (colour tags like `[blue]0x...[/]` embedded in cell
         # values), then escape embedded newlines so each record is exactly one
         # physical line.
-        self._sink.write_line(_one_line(_strip_rich_markup(line)))
+        self._sink.write_line(_one_line(strip_rich_markup(line)))
 
     def _print_csv_row(self, row: list[str]) -> None:
         buf = io.StringIO()

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -117,6 +117,16 @@ class OutputSerializer(ABC):
     ) -> None:
         pass
 
+    def record_diagnostics(
+        self,
+        script_name: str,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+    ) -> None:
+        pass
+
     def close(self) -> None:
         """Release any owned resources (e.g. file handles). Default is a no-op."""
         pass
@@ -360,6 +370,17 @@ class MultiSerializer(OutputSerializer):
                 failure_message=failure_message,
                 documentation=documentation,
             )
+
+    def record_diagnostics(
+        self,
+        script_name: str,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+    ) -> None:
+        for s in self._serializers:
+            s.record_diagnostics(script_name, failures, warnings, script_failed, failure_message)
 
     def close(self) -> None:
         for s in self._serializers:

--- a/tools/triage/sqlite_serializer.py
+++ b/tools/triage/sqlite_serializer.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SQLite output back end for tt-triage.
+
+Each script's output becomes one table, named after the script, with a row per
+result and a column per displayed field. Columns are INTEGER, REAL or TEXT,
+chosen from the values the script produced.
+
+A shared `diagnostics` table collects the check failures, warnings and script
+errors reported alongside those results.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import Any, Callable, Iterable
+
+from serializers import OutputSerializer, strip_rich_markup, extract_table_data
+
+
+def quote_identifier(name: str) -> str:
+    """Quote a table or column name, doubling any embedded quote.
+
+    Column names are the script's display headers verbatim, so they can contain
+    spaces, symbols or reserved words; quoting makes those legal.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _check_for_duplicates(script: str, headers: Iterable[str]) -> None:
+    """Raise if a script serializes two fields under the same column name."""
+    seen: dict[str, str] = {}
+    for header in headers:
+        previous = seen.get(header.lower())
+        if previous is not None:
+            detail = (
+                f"duplicate column {header!r}"
+                if previous == header
+                else f"columns {previous!r} and {header!r} differ only in case, which SQLite treats as one"
+            )
+            raise ValueError(f"{script}: {detail}. Drop the redundant triage_field.")
+        seen[header.lower()] = header
+
+
+def _check_row_widths(script: str, columns: list[str], rows: list[list[str]]) -> None:
+    """Raise if a row does not line up with the header."""
+    for index, row in enumerate(rows):
+        if len(row) != len(columns):
+            raise ValueError(
+                f"{script}: row {index} has {len(row)} values but the header has {len(columns)} "
+                f"columns. Return one dataclass type per result list."
+            )
+
+
+def _sql_value(serialized: Any, unserialized: Any) -> Any:
+    """Pick what gets stored for one cell: a number, or the serialized string.
+
+    Numbers stay numbers so they remain comparable - a `hex_serializer` field
+    would otherwise arrive as "0x1234" and `WHERE pc > 4096` could never work.
+    `bool` is an `int` subclass, so it stores as 0/1.
+    """
+    if unserialized is None:
+        return None
+    if isinstance(unserialized, int):
+        # SQLite's INTEGER is signed 64-bit and there is no wider type, so a
+        # value past that cannot be bound. Falling back to the string makes
+        # column declared as TEXT, which keeps it exact.
+        _INT64_MIN = -(2**63)
+        _INT64_MAX = 2**63 - 1
+        return unserialized if _INT64_MIN <= unserialized <= _INT64_MAX else serialized
+    if isinstance(unserialized, float):
+        return unserialized
+    return serialized
+
+
+def _column_type(values: Iterable[Any]) -> str:
+    """Choose the SQL type for a column from the values going into it.
+
+    INTEGER or REAL when every value is numeric, TEXT otherwise. NULLs are
+    skipped, since they fit any type.
+    """
+    seen_int = seen_float = False
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, int):
+            seen_int = True
+        elif isinstance(value, float):
+            seen_float = True
+        else:
+            return "TEXT"
+    if seen_float:
+        return "REAL"
+    return "INTEGER" if seen_int else "TEXT"
+
+
+DIAGNOSTICS_TABLE = "diagnostics"
+
+
+class SqliteSerializer(OutputSerializer):
+    """Writes each script's rows into a table named after the script."""
+
+    def __init__(self, path: str, verbose_level_getter: Callable[[], int]):
+        path = os.path.abspath(path)
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        if os.path.exists(path):
+            raise FileExistsError(f"{path} already exists - remove it or pass a different path")
+        self.path = path
+        self._verbose_getter = verbose_level_getter
+        self._con = sqlite3.connect(path)
+        # Created up front so it can always be queried, even on a clean run.
+        self._con.execute(
+            f"CREATE TABLE {quote_identifier(DIAGNOSTICS_TABLE)} "
+            f'("Script" TEXT NOT NULL, "Severity" TEXT NOT NULL, "Message" TEXT NOT NULL)'
+        )
+
+    def emit(
+        self,
+        script_name: str | None,
+        execution_time: str,
+        result: Any,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+        documentation: str | None,
+    ) -> None:
+        assert script_name is not None, "cannot serialize a result without a script name"
+        self._insert_diagnostics(script_name, failures, warnings, script_failed, failure_message)
+
+        table_data = extract_table_data(result, self._verbose_getter())
+        if table_data is None or not table_data.rows:
+            # Check-only scripts return nothing; their diagnostics are the output.
+            self._con.commit()
+            return
+        table = os.path.splitext(script_name)[0]
+        columns = table_data.columns
+        _check_for_duplicates(script_name, columns)
+        _check_row_widths(script_name, columns, table_data.rows)
+
+        rows: list[list[Any]] = []
+        for serialized, unserialized in zip(table_data.rows, table_data.unserialized_values):
+            # Strip the Rich markup some scripts embed in cell values.
+            rows.append(
+                [
+                    strip_rich_markup(value) if isinstance(value, str) else value
+                    for value in (_sql_value(text, original) for text, original in zip(serialized, unserialized))
+                ]
+            )
+
+        spec = ", ".join(f"{quote_identifier(c)} {_column_type(r[i] for r in rows)}" for i, c in enumerate(columns))
+        self._con.execute(f"CREATE TABLE IF NOT EXISTS {quote_identifier(table)} ({spec})")
+
+        names = ", ".join(quote_identifier(c) for c in columns)
+        marks = ", ".join("?" for _ in columns)
+        self._con.executemany(f"INSERT INTO {quote_identifier(table)} ({names}) VALUES ({marks})", rows)
+        self._con.commit()
+
+    def _insert_diagnostics(
+        self,
+        script_name: str,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+    ) -> None:
+        rows = [(script_name, "failure", message) for message in failures]
+        rows += [(script_name, "warning", message) for message in warnings]
+        if script_failed:
+            rows.append((script_name, "error", failure_message or "script failed"))
+        if not rows:
+            return
+        self._con.executemany(
+            f"INSERT INTO {quote_identifier(DIAGNOSTICS_TABLE)} VALUES (?, ?, ?)",
+            [(script, severity, strip_rich_markup(message)) for script, severity, message in rows],
+        )
+
+    def close(self) -> None:
+        try:
+            self._con.commit()
+        finally:
+            self._con.close()

--- a/tools/triage/sqlite_serializer.py
+++ b/tools/triage/sqlite_serializer.py
@@ -163,6 +163,17 @@ class SqliteSerializer(OutputSerializer):
         self._con.executemany(f"INSERT INTO {quote_identifier(table)} ({names}) VALUES ({marks})", rows)
         self._con.commit()
 
+    def record_diagnostics(
+        self,
+        script_name: str,
+        failures: list[str],
+        warnings: list[str],
+        script_failed: bool,
+        failure_message: str | None,
+    ) -> None:
+        self._insert_diagnostics(script_name, failures, warnings, script_failed, failure_message)
+        self._con.commit()
+
     def _insert_diagnostics(
         self,
         script_name: str,

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -28,7 +28,7 @@ Options:
     --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
     --llm-output                     Replace Rich tables on the console with a machine-readable report (CSV-formatted tables). Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
     --llm-output-path=<path>         Additionally write the machine-readable report to <path>. Can be combined with --llm-output; without it, Rich output still goes to the console.
-    --sqlite-output-path=<path>      Additionally write a SQLite database to <path>, with one table per script holding that script's rows.
+    --sqlite-output-path=<path>      Additionally write a SQLite database to <path>, with one table per script that returns non-empty tabular data; check-only output is stored in the diagnostics table.
 
 Description:
     Diagnoses Tenstorrent AI hardware by performing comprehensive health checks on ARC processors, NOC connectivity, L1 memory, and RISC-V cores.

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,7 +5,7 @@
 
 """
 Usage:
-    triage [--noc-id=<id>] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--print-elf-cache-stats] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>]
+    triage [--noc-id=<id>] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--print-elf-cache-stats] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>] [--sqlite-output-path=<path>]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
@@ -28,6 +28,7 @@ Options:
     --triage-summary-path=<path>     Write a triage summary file to the given path (used by CI for hang reports).
     --llm-output                     Replace Rich tables on the console with a machine-readable report (CSV-formatted tables). Easier and cheaper for LLMs (and grep/CI) to consume. Implies --disable-colors.
     --llm-output-path=<path>         Additionally write the machine-readable report to <path>. Can be combined with --llm-output; without it, Rich output still goes to the console.
+    --sqlite-output-path=<path>      Additionally write a SQLite database to <path>, with one table per script holding that script's rows.
 
 Description:
     Diagnoses Tenstorrent AI hardware by performing comprehensive health checks on ARC processors, NOC connectivity, L1 memory, and RISC-V cores.
@@ -629,6 +630,7 @@ def log_warning_risc(risc_name: str, location: OnChipCoordinate, message: str) -
 
 
 _output_serializer: Any = None
+_output_serializer_initialized = False
 
 
 def get_output_serializer() -> Any:
@@ -654,7 +656,17 @@ def init_output_serializer(args: ScriptArguments) -> None:
       --llm-output                      -> CsvSerializer on the console (replaces Rich)
       --llm-output-path=<path>          -> Rich on console + CsvSerializer to file
       --llm-output --llm-output-path=.. -> CsvSerializer on console + CsvSerializer to file
+
+    Builds once per process. `main()` calls this, and so does every
+    `run_script()`, so without the guard a `--run=` invocation would rebuild the
+    back ends per script - reopening `FileSink` with mode "w" and truncating the
+    report down to the last script alone.
     """
+    global _output_serializer_initialized
+    if _output_serializer_initialized:
+        return
+    _output_serializer_initialized = True
+
     from serializers import ConsoleSink, CsvSerializer, FileSink, MultiSerializer, RichSerializer
 
     console_sink = ConsoleSink(console)
@@ -672,6 +684,15 @@ def init_output_serializer(args: ScriptArguments) -> None:
             serializers.append(CsvSerializer(file_sink, get_verbose_level))
         except OSError as e:
             utils.WARN(f"Failed to open --llm-output-path={csv_path!r}: {e}. File output will be skipped.")
+
+    sqlite_path = utils.safe_path(args["--sqlite-output-path"])
+    if sqlite_path:
+        try:
+            from sqlite_serializer import SqliteSerializer
+
+            serializers.append(SqliteSerializer(sqlite_path, get_verbose_level))
+        except Exception as e:
+            utils.WARN(f"Failed to open --sqlite-output-path={sqlite_path!r}: {e}. SQLite output will be skipped.")
 
     set_output_serializer(serializers[0] if len(serializers) == 1 else MultiSerializer(serializers))
 

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -718,6 +718,24 @@ def serialize_result(script: TriageScript | None, result, execution_time: str = 
     )
 
 
+def record_diagnostics(script: TriageScript) -> None:
+    global FAILURE_CHECKS, WARNING_CHECKS
+    with FAILURE_CHECKS_LOCK:
+        failures = FAILURE_CHECKS
+        FAILURE_CHECKS = []
+    with WARNING_CHECKS_LOCK:
+        warnings = WARNING_CHECKS
+        WARNING_CHECKS = []
+
+    get_output_serializer().record_diagnostics(
+        script_name=script.name,
+        failures=failures,
+        warnings=warnings,
+        script_failed=script.failed,
+        failure_message=script.failure_message,
+    )
+
+
 def _enforce_dependencies(args: ScriptArguments) -> None:
     """Enforce approved `ttexalens` version unless skipped.
 
@@ -1015,6 +1033,7 @@ def main():
                     print()
                     utils.INFO(f"{script.name}:")
                     utils.WARN(f"  Skipping: dependency {failed_deps} failed")
+                    record_diagnostics(script)
                 else:
                     start_time = time()
                     result = script.run(args=args, context=context)
@@ -1033,6 +1052,7 @@ def main():
                             print()
                             utils.INFO(f"{script.name}{execution_time}:")
                             utils.INFO("  pass")
+                        record_diagnostics(script)
                     else:
                         start_time = time()
                         serialize_result(script, result, execution_time)


### PR DESCRIPTION
New optional argument to tt-triage: `--sqlite-output-path=<path>`.
It serializes output of all scripts into their table and also adds additional table `diagnostics` with all failure/warning/error messages.
Removing duplicated columns from output in `check_eth_status.py` and `dump_fast_dispatch.py` scripts.
Preventing multiple initialization of serializers when using `--run=` argument for multiple scripts.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/tt-triage-sqlite)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/tt-triage-sqlite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/tt-triage-sqlite)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/tt-triage-sqlite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/tt-triage-sqlite)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/tt-triage-sqlite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/tt-triage-sqlite)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/tt-triage-sqlite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/tt-triage-sqlite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/tt-triage-sqlite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/tt-triage-sqlite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/tt-triage-sqlite)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/tt-triage-sqlite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/tt-triage-sqlite)