### PR TITLE
[Test Only] Increase Blackhole experimental L2 timeout to 40 minutes

### DIFF
--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -96,7 +96,7 @@
     bh_p100:
       timeout: 60
     bh_p150b_civ2:
-      timeout: 35
+      timeout: 40
   owner_id: U080FKG7KEU # Utku Aydonat
   team: ttnn
   category: experimental


### PR DESCRIPTION
### PR Category

Test Only

### Summary

- The Blackhole P150 L2 nightly experimental job has no remaining headroom. The latest successful scheduled `main` job used 34:59 of its 35:00 timeout.
- Adding new KDA layer-op coverage is blocked because the current suite already reaches the cap before more tests are added.

This PR raises only `ttnn nightly experimental tests (blackhole) [bh_p150b_civ2]` from 35 to 40 minutes. It does not change test selection or coverage. At the observed 34:59 high-water mark, the new limit provides 5:01 (14.3%) headroom.

Evidence: scheduled-main [run 32815515451 / job 97705026437](https://github.com/tenstorrent/tt-metal/actions/runs/32815515451/job/97705026437), commit `de9a9b2cd018b9864f6eacf19b37a5fca3fe6bbf`.

### Test plan

- CI configuration validation only; do not trigger the Blackhole L2 workload while this PR remains draft.