### PR TITLE
[Performance] Replace per-tile constant fills with scalar immediates in fp32 gelu_bw

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_tanh_fp32.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/gelu_bw/device/kernels/compute/eltwise_bw_gelu_tanh_fp32.cpp
@@ -18,6 +18,8 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/copy_dest_values.h"
 #include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_unary/rsub.h"
 #include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
@@ -35,6 +37,15 @@ void kernel_main() {
     constexpr float kTwoOverSqrtPi = 1.12837916709551257390f;  // 2/sqrt(pi)
     constexpr float kBeta = kSqrt2 * kTwoOverSqrtPi * 0.5f;
     constexpr float kKappa = 0.044715f;
+
+    // The scalar SFPU ops below take the operand as packed fp32 bits.
+    constexpr auto bits = [](float f) { return __builtin_bit_cast(uint32_t, f); };
+    constexpr uint32_t kKappaBits = bits(kKappa);
+    constexpr uint32_t kThreeKappaBits = bits(kKappa * 3.0f);
+    constexpr uint32_t kBetaBits = bits(kBeta);
+    constexpr uint32_t kHalfBetaBits = bits(kBeta / 2.0f);
+    constexpr uint32_t kOneBits = bits(1.0f);
+    constexpr uint32_t kHalfBits = bits(0.5f);
 
     unary_op_init_common(cb_grad_out, cb_grad_in);
     add_binary_tile_init();
@@ -57,16 +68,19 @@ void kernel_main() {
         square_tile(1);
         mul_binary_tile(1, 2, 1);
 
+        // Scalar immediates below replace "fill a whole tile with a constant, then do a
+        // tile-by-tile binary op against it". Same fp32 arithmetic, one op instead of two.
+
         // tile[1] = 0.044715 * x^3
-        fill_tile(3, kKappa);
-        mul_binary_tile(1, 3, 1);
+        binop_with_scalar_tile_init();
+        mul_unary_tile(1, kKappaBits);
 
         // tile[1] = x + 0.044715 * x^3
         add_binary_tile(1, 2, 1);
 
         // tile[1] = sqrt(2/π) * (x + 0.044715 * x^3)
-        fill_tile(3, kBeta);
-        mul_binary_tile(1, 3, 1);
+        binop_with_scalar_tile_init();
+        mul_unary_tile(1, kBetaBits);
 
         // tile[1] = tanh(sqrt(2/π) * (x + 0.044715 * x^3))
         tanh_tile_init();
@@ -74,27 +88,25 @@ void kernel_main() {
         COPY_DEST_VALUES(1, 0);  // copy tanh result to tile[0]
 
         // CDF term: tile[1] = 0.5 * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))
-        fill_tile(3, 1.0f);
-        add_binary_tile(1, 3, 1);
-        fill_tile(3, 0.5f);
-        mul_binary_tile(1, 3, 1);
+        binop_with_scalar_tile_init();
+        add_unary_tile(1, kOneBits);
+        mul_unary_tile(1, kHalfBits);
 
         // tile[0] = 1 - tanh^2
         square_tile(0);
-        fill_tile(3, 1.0f);
-        sub_binary_tile(3, 0, 0);
+        rsub_tile_init();
+        rsub_tile(0, kOneBits);
 
         // tile[2] = (1 + 0.134145 * x**2)
-        fill_tile(3, kKappa * 3.0f);
-        square_tile(2);            // x^2
-        mul_binary_tile(2, 3, 2);  // 0.134145 * x**2
-        fill_tile(3, 1.0f);
-        add_binary_tile(2, 3, 2);  // 1 + 0.134145 * x**2
+        square_tile(2);  // x^2
+        binop_with_scalar_tile_init();
+        mul_unary_tile(2, kThreeKappaBits);
+        add_unary_tile(2, kOneBits);
 
         // PDF term: tile[2] = 0.5 * sqrt(2/π) * (1 + 0.134145 * x^2) * (1 - tanh^2)
         mul_binary_tile(2, 0, 2);
-        fill_tile(3, kBeta / 2.0f);
-        mul_binary_tile(2, 3, 2);
+        binop_with_scalar_tile_init();
+        mul_unary_tile(2, kHalfBetaBits);
 
         // tile[0] is free now (tanh/sech² no longer needed): load grad_out.
         copy_tile(cb_grad_out, 0, 0);


### PR DESCRIPTION
### PR Category
Performance

### Summary

`ttnn.gelu_bw(..., approximate="tanh")` on float32 is up to **14.6% faster** with **bit-identical** output.

The fp32 compute kernel repeatedly filled an entire DST tile with a scalar constant just to do a tile-by-tile binary op against it:

```cpp
fill_tile(3, kKappa);
mul_binary_tile(1, 3, 1);
```

Each of those pairs is two full-tile SFPU passes to accomplish one multiply-by-constant. The SFPU already has scalar-immediate forms (`mul_unary_tile`, `add_unary_tile`, `rsub_tile`) that do it in one:

```cpp
binop_with_scalar_tile_init();
mul_unary_tile(1, kKappaBits);
```

All 8 `fill_tile` calls in the per-tile loop are gone, taking the kernel from ~29 SFPU ops per tile to ~21. The arithmetic is unchanged: the same fp32 constant, the same fp32 multiply, in the same order.

The immediates are derived from the existing `kBeta`/`kKappa` constants with a `constexpr __builtin_bit_cast` rather than hardcoded hex, so they cannot drift from the constants that document them.

### Performance

Blackhole p150b, float32, 20 invocations per case, device kernel duration per op:

| Tiles | Before | After | Change |
|---|---|---|---|
| 64 | 6,811 ns | 6,165 ns | **-9.5%** |
| 256 | 17,885 ns | 15,858 ns | **-11.3%** |
| 1024 | 48,540 ns | 41,864 ns | **-13.8%** |
| 4096 | 170,643 ns | 145,724 ns | **-14.6%** |
| 1024 (bfloat16, control) | 84,348 ns | 84,346 ns | -0.00% |

The bfloat16 control uses a different kernel that this PR does not touch; it staying flat confirms the delta is attributable to the changed kernel rather than run-to-run variance.

The gain grows with tile count because the saved work is per-tile and fixed kernel startup cost dilutes it at small shapes.

### Correctness

Output is **bit-identical** to the current kernel — not "within tolerance". Verified by comparing raw bit patterns (NaN-aware) across 6 shapes x 2 dtypes:

| Shape | Elements | Bit diffs |
|---|---|---|
| (1,1,32,32) | 1,024 | 0 |
| (1,1,64,96) | 6,144 | 0 |
| (1,1,37,53) *(not tile-aligned)* | 1,961 | 0 |
| (1,1,256,256) | 65,536 | 0 |
| (2,3,128,160) *(multi-batch)* | 122,880 | 0 |
| (1,1,512,512) | 262,144 | 0 |

Inputs spanned [-10, 10] to cover both saturated tanh tails and the near-zero region.

### Notes for reviewers

- **Scope is deliberately fp32-only.** I tried the same rewrite on the bfloat16 kernel (`eltwise_bw_gelu_tanh.cpp`) and it is **not** bit-exact — ~4.5% of elements differed. On that path DST is 16-bit, and `binop_with_scalar` rounds its write-back differently from `fill_tile` + `mul_binary_tile`. Passing bf16-rounded immediates made it worse, not better, which rules out the constant's precision as the cause. That kernel is left untouched.

- **Why `add_unary_tile`/`rsub_tile` are safe here but not on the bf16 kernel:** the fp32 kernel's `add_binary_tile`/`sub_binary_tile` calls take no rounding-mode template, whereas the bf16 kernel's are `add_binary_tile<BF16_ROUNDING_MODE>`. The scalar variants take no such template, so converting them is only equivalent on the fp32 path.

- `#include "api/compute/eltwise_unary/fill.h"` is now unused by this kernel. I left it in rather than risk perturbing transitive includes; happy to drop it if preferred.

- One `mul_binary_tile(2, 0, 2)` remains, multiplying two computed tiles rather than a constant. That one is genuinely a tile-by-tile multiply and is left as is.

- There are no existing `gelu_bw` unit tests, so bit-exactness against the previous kernel is the validation here. I can add a regression test if you'd like, though bit-comparison against the old kernel is arguably stronger than a tolerance-based one.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswinmcw/gelu-bw-fp32-scalar-immediates)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswinmcw/gelu-bw-fp32-scalar-immediates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aswinmcw/gelu-bw-fp32-scalar-immediates)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aswinmcw/gelu-bw-fp32-scalar-immediates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswinmcw/gelu-bw-fp32-scalar-immediates)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswinmcw/gelu-bw-fp32-scalar-immediates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aswinmcw/gelu-bw-fp32-scalar-immediates)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aswinmcw/gelu-bw-fp32-scalar-immediates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswinmcw/gelu-bw-fp32-scalar-immediates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswinmcw/gelu-bw-fp32-scalar-immediates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswinmcw/gelu-bw-fp32-scalar-immediates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswinmcw/gelu-bw-fp32-scalar-immediates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswinmcw/gelu-bw-fp32-scalar-immediates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswinmcw/gelu-bw-fp32-scalar-immediates)