### PR TITLE
Fix Llama graph tracing failures

### DIFF
--- a/models/experimental/llama32_1b_quasar/tests/demos/cleanup_utils.py
+++ b/models/experimental/llama32_1b_quasar/tests/demos/cleanup_utils.py
@@ -16,7 +16,7 @@ def cleanup_ttnn_value(value):
         return
 
     if isinstance(value, dict):
-        for nested_value in value.values():
+        for nested_value in list(value.values()):
             cleanup_ttnn_value(nested_value)
         return
 
@@ -47,7 +47,7 @@ def cleanup_object_graph(obj, seen=None):
         return
 
     if isinstance(obj, dict):
-        for value in obj.values():
+        for value in list(obj.values()):
             cleanup_object_graph(value, seen)
         return
 

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -11,6 +11,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 
 #include "attention_softmax/attention_softmax_nanobind.hpp"
 #include "concatenate_heads/concatenate_heads_nanobind.hpp"

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -347,6 +347,14 @@ def from_torch(
     import torch
     import numpy as np
 
+    if isinstance(tensor, torch.Tensor) and hasattr(tensor, "TRACEDTENSOR"):
+        # The graph tracer represents Torch inputs with a Tensor subclass. Keep that
+        # wrapper in the outer tracing layer for graph bookkeeping, but pass a plain
+        # Tensor to nanobind: ndarray_import cannot perform dtype conversion on the
+        # traced subclass.
+        with torch._C.DisableTorchFunctionSubclass():
+            tensor = tensor.as_subclass(torch.Tensor)
+
     if isinstance(tensor, np.ndarray):
         # We use bf16 as an intermediate type between types unsupported by ttnn (e.g., int64)
         # and types unsupported by Torch/NumPy (e.g., bfloat8).


### PR DESCRIPTION
### PR Category

Fixes https://github.com/tenstorrent/tt-metal/issues/53778

### Summary

Add missing nanobind string import, fix torch tensor subtype conversion error, use `list()` in the cleanup functions to avoid changing the dictionary while iterating over it. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=martemov/llama-graph-tracing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:martemov/llama-graph-tracing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=martemov/llama-graph-tracing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:martemov/llama-graph-tracing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=martemov/llama-graph-tracing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:martemov/llama-graph-tracing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=martemov/llama-graph-tracing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:martemov/llama-graph-tracing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=martemov/llama-graph-tracing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:martemov/llama-graph-tracing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=martemov/llama-graph-tracing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:martemov/llama-graph-tracing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=martemov/llama-graph-tracing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:martemov/llama-graph-tracing)