### PR TITLE
CI: kernel ccache diagnostics for basic.yaml (enabling it measures SLOWER — see results)

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -28,6 +28,10 @@ on:
         description: "Enable watcher"
         default: false
         type: boolean
+      enable-kernel-ccache:
+        description: 'Enable kernel ccache for JIT compilation at runtime'
+        default: false
+        type: boolean
       test-category:
         required: false
         type: string
@@ -105,7 +109,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          sparse-checkout: .github/actions/download-artifact-with-retry
+          sparse-checkout: |
+            .github/actions/download-artifact-with-retry
+            .github/scripts/ccache_log_filter.sh
           sparse-checkout-cone-mode: false
 
       - uses: ./.github/actions/download-artifact-with-retry
@@ -133,6 +139,42 @@ jobs:
           echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
           echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
           echo "TT_METAL_WATCHER_DISABLE_ETH=1" >> $GITHUB_ENV
+
+      # Kept byte-identical to the same step in smoke.yaml so the two stay diffable.
+      # Note this job declares no `environment:`, unlike smoke.yaml's, so
+      # secrets.REDIS_CCACHE_PASSWORD is empty here on every event -- as it already is for
+      # smoke on merge_group and pull_request, where its `mainline` environment does not
+      # apply either. The gate therefore reads the cache anonymously; see #<TBD>.
+      - name: Set up kernel ccache
+        if: ${{ inputs.enable-kernel-ccache == true && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        run: |
+          echo "Enabling TT Metal kernel ccache"
+          echo "CCACHE_COMPILERCHECK=content" >> $GITHUB_ENV
+          echo "CCACHE_REMOTE_ONLY=true" >> $GITHUB_ENV
+          echo "CCACHE_NOHASHDIR=true" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=3" >> $GITHUB_ENV
+          echo "CCACHE_LOGFILE=/tmp/ccache.log" >> $GITHUB_ENV
+          echo "CCACHE_BASEDIR=/work" >> $GITHUB_ENV
+          echo "TT_METAL_CCACHE_KERNEL_SUPPORT=1" >> $GITHUB_ENV
+          echo "CCACHE_TEMPDIR=/tmp/ccache" >> $GITHUB_ENV
+          mkdir -p /tmp/ccache
+          # Build Redis URL in bash so that the password is never embedded in a
+          # workflow input string (GHA does not pass secrets through string inputs
+          # to reusable workflows). This also ensures forks leave CCACHE_REMOTE_STORAGE
+          # unset — the step is guarded by the fork check above.
+          REDIS_USER="${{ vars.REDIS_CCACHE_USER }}"
+          REDIS_PASSWORD="${{ secrets.REDIS_CCACHE_PASSWORD }}"
+          REDIS_HOST="${{ vars.REDIS_CCACHE_HOST }}"
+          REDIS_PORT="${{ vars.REDIS_CCACHE_PORT }}"
+          REDIS_READONLY="${{ vars.REDIS_CCACHE_IS_READONLY }}"
+          CCACHE_REMOTE_STORAGE="redis://${REDIS_USER}:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}"
+          # ccache 4.13 bug: the read-only optional trips the write gate whenever
+          # it has *any* value — even false. Only append it when actually true.
+          if [ "${REDIS_READONLY}" = "true" ]; then
+            CCACHE_REMOTE_STORAGE="${CCACHE_REMOTE_STORAGE}|read-only=true"
+          fi
+          echo "CCACHE_REMOTE_STORAGE=${CCACHE_REMOTE_STORAGE}" >> $GITHUB_ENV
 
       - name: Run a test
         id: test
@@ -169,3 +211,29 @@ jobs:
         with:
           path: /work/test-reports/
           prefix: "test_reports_"
+
+      # Without this there is no way to tell a working cache from a broken one: a ccache
+      # miss is silent and just looks like normal compile time. The second block needs
+      # .github/scripts/ccache_log_filter.sh, which is why it is in the sparse-checkout above.
+      - name: Publish ccache summary
+        if: ${{ !cancelled() && inputs.enable-kernel-ccache == true }}
+        run: |
+          echo '<details><summary>CCache Summary (kernel)</summary>' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          ccache -s >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '</details>' >> $GITHUB_STEP_SUMMARY
+
+          # Surface remote storage stats and errors from the ccache log.
+          # Uses a filter script to avoid overflowing the 1024k step summary limit.
+          if [ -f /tmp/ccache.log ]; then
+            echo '<details><summary>CCache Remote Storage (kernel)</summary>' >> $GITHUB_STEP_SUMMARY
+            echo '' >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            "$GITHUB_WORKSPACE/.github/scripts/ccache_log_filter.sh" /tmp/ccache.log >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo '' >> $GITHUB_STEP_SUMMARY
+            echo '</details>' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -189,6 +189,36 @@ jobs:
           TT_LOGGER_LEVEL: warn
         run: ${{ matrix.test-group.cmd }}
 
+      # Emits to STDOUT, not just $GITHUB_STEP_SUMMARY, on purpose: summaries are not
+      # reachable from the REST API or `gh run view --log`, so a summary-only report means
+      # nobody can check the cache from a script or a terminal. remote_storage_error is the
+      # one that matters -- nonzero means the Redis connection or ACL is rejecting us and the
+      # cache is silently doing nothing, which otherwise just looks like normal compile time.
+      - name: Report kernel ccache stats
+        if: ${{ !cancelled() && inputs.enable-kernel-ccache == true }}
+        run: |
+          echo "=== kernel ccache remote storage ==="
+          # --print-stats is tab-separated and stable; -s is the human fallback for older ccache.
+          if ! ccache --print-stats 2>/dev/null | grep -E '^remote_storage_'; then
+            ccache -s || true
+          fi
+          echo "===================================="
+          hits=$(ccache --print-stats 2>/dev/null | awk -F'\t' '$1=="remote_storage_hit"{print $2}')
+          errs=$(ccache --print-stats 2>/dev/null | awk -F'\t' '$1=="remote_storage_error"{print $2}')
+          tmo=$(ccache --print-stats 2>/dev/null | awk -F'\t' '$1=="remote_storage_timeout"{print $2}')
+          echo "VERDICT: hits=${hits:-?} errors=${errs:-?} timeouts=${tmo:-?}"
+          if [ "${errs:-0}" != "0" ] || [ "${tmo:-0}" != "0" ]; then
+            echo "VERDICT: remote storage is erroring -- the cache is NOT being used."
+          elif [ "${hits:-0}" = "0" ]; then
+            echo "VERDICT: reachable but zero hits -- nothing is populating this cache for these kernels."
+          else
+            echo "VERDICT: cache is being hit."
+          fi
+          if [ -f /tmp/ccache.log ]; then
+            echo "=== remote storage detail (filtered) ==="
+            "$GITHUB_WORKSPACE/.github/scripts/ccache_log_filter.sh" /tmp/ccache.log || true
+          fi
+
       - name: workaround
         run: |
           # The test-reporting action runs git ls-files with no way to opt-out.

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -356,6 +356,12 @@ jobs:
             needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
         }}
     uses: ./.github/workflows/basic.yaml
+    # Required for kernel ccache: basic.yaml reads secrets.REDIS_CCACHE_PASSWORD to build the
+    # Redis URL, and a reusable workflow gets no custom secrets without this. Omitting it makes
+    # the password empty, which Redis rejects with "WRONGPASS invalid username-password pair"
+    # on every lookup -- measured at 1200 remote_storage_error / 0 hits, and a ~17% SLOWER test
+    # step than no cache at all, because CCACHE_REMOTE_ONLY leaves no local tier to fall back on.
+    secrets: inherit
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -362,6 +362,10 @@ jobs:
       enabled-skus: ALL_SKUS_IN_TESTS
       per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yaml
       product: tt-nn
+      # This job is the second-longest in the gate and its cost is almost entirely
+      # device-kernel JIT, so it benefits most from the shared kernel ccache that
+      # ttnn-smoke-tests already uses. runtime-basic-tests can opt in the same way.
+      enable-kernel-ccache: true
 
   ttnn-merge-gate-tests:
     needs: [build, find-changes]

--- a/tests/ttnn/unit_tests/gtests/test_reduction.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_reduction.cpp
@@ -1205,3 +1205,8 @@ TEST_F(ReductionSmoke, ManualSeedPerUserSeeds) {
 }
 
 }  // namespace ttnn::operations::reduction::test
+
+// TEMPORARY -- DROP BEFORE MERGE. Touch under tests/ttnn/** so find-changed-files.sh sets
+// tt-metalium-or-tt-nn-tests-changed, which is what gates ttnn-basic-tests in merge-gate.yaml.
+// A workflow-only diff flips none of those flags, so the job this PR modifies would otherwise
+// be skipped and the change would go unvalidated.


### PR DESCRIPTION
> **Draft, and the headline result is negative: kernel ccache as currently deployed makes `ttnn-basic-tests` ~14% SLOWER, not faster.** The diagnostics and the plumbing are worth keeping; the `enable-kernel-ccache: true` commit must not merge until the write side is solved. Details in *Results* below.

### Problem description

`basic.yaml` is the only test workflow without an `enable-kernel-ccache` input, so `ttnn-basic-tests` and `runtime-basic-tests` JIT-compile every device kernel cold on every run, while four sibling merge-gate jobs already consume the shared kernel ccache. `ttnn validation basic` is the second-longest job in the gate (10:50 on `wh_n150_civ2`, behind only `runtime validation smoke [wh_llmbox]` at 13:20) and its cost is almost entirely kernel JIT — per-test time runs from 17 ms to 6.5 s and tracks how many distinct programs a test compiles.

The hypothesis was that turning the cache on would speed up `MatmulSmoke`, `NormalizationSmoke` and `ReductionSmoke`, which are 44% of the binary. **Measured, it does the opposite.**

### Results

Three dispatches on this branch, same commit range, `ttnn validation basic [wh_n150_civ2]`:

| Run | Config | `Run a test` | `remote_storage_hit` | `error` |
|---|---|---|---|---|
| [32949883556](https://github.com/tenstorrent/tt-metal/actions/runs/32949883556) | ccache **off** (plumbing only) | **7:34** | — | — |
| [32952613628](https://github.com/tenstorrent/tt-metal/actions/runs/32952613628) | ccache on, no `secrets: inherit` | 8:50 | 0 | **1200** |
| [32956142223](https://github.com/tenstorrent/tt-metal/actions/runs/32956142223) | ccache on + `secrets: inherit` | 8:36 | 26 | 0 |

Per-suite, off → on-with-auth:

| Suite | ccache off | ccache on | Δ |
|---|---|---|---|
| `MatmulSmoke` | 33 151 ms | 39 457 ms | **+19%** |
| `NormalizationSmoke` | 70 100 ms | 80 851 ms | **+15%** |
| `ReductionSmoke` | 103 152 ms | 123 111 ms | **+19%** |
| whole binary | 449 041 ms | 511 172 ms | **+14%** |

Two distinct problems, in sequence.

**1. Auth was broken (fixed here).** Without `secrets: inherit` the Redis URL is built with an empty password and every lookup fails:

```
500x  Redis command failed: WRONGPASS invalid username-password pair or user is disabled.
500x  Marking remote storage backend for redis as failed
501x  Failed; falling back to running the real compiler
```

A reusable workflow gets no custom secrets unless inherited or passed. `smoke.yaml` works around this with `environment: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'mainline' || '' }}`, which resolves to `''` on `merge_group`, `pull_request` and `workflow_dispatch` — so **the existing `runtime-smoke-tests` and `ttnn-smoke-tests` jobs are hitting this same WRONGPASS in the merge gate today** and paying the failed-lookup penalty with zero cache benefit. It has gone unnoticed because their ccache diagnostics are summary-only. That is a separate bug worth its own fix; the one-line `secrets: inherit` on those two calls would do it.

**2. With auth fixed, the hit rate is ~2% — and that is the real blocker.**

| SKU | hits | misses | hit rate |
|---|---|---|---|
| `wh_n150_civ2` | 26 | 1174 | 2.2% |
| `bh_p150b_civ2_viommu` | 1 | 1176 | 0.08% |

`remote_storage_write` is **0** on every job, because `vars.REDIS_CCACHE_IS_READONLY` is `"true"` for every consumer in the repo, so `|read-only=true` is appended to every URL. Nothing in the gate populates the cache. The only writer can be push-to-main runs, where `smoke.yaml`'s `mainline` environment presumably overrides that variable — and those run the **smoke** suites, which compile a different kernel set than the **basic** suites. So `ttnn-basic-tests` finds almost none of its own kernels in the cache, and each of the ~1174 misses pays a Redis round-trip that the 26 hits do not repay.

That is why it is slower, and it is not something this PR can fix from the consumer side.

### What's changed

`.github/workflows/basic.yaml`:

1. `enable-kernel-ccache` input, mirroring `smoke.yaml:40-43`.
2. `Set up kernel ccache` step, in the same slot smoke uses (`Set up env vars for watcher` → ccache → `Run a test`).
3. `Publish ccache summary` step, plus the `.github/scripts/ccache_log_filter.sh` entry in the sparse-checkout it needs — `basic.yaml` only checked out `download-artifact-with-retry`, so the filter block would otherwise fail.
4. **`Report kernel ccache stats`** — new, not copied from smoke. Writes the `remote_storage_*` counters from `ccache --print-stats` to **stdout** plus a verdict line. Job summaries are not reachable from the REST API or `gh run view --log` (verified: no summary field on the jobs endpoint, and run artifacts hold only test/power reports), so a summary-only report cannot be checked from a terminal or a script. This step is what produced every number above, and it found the WRONGPASS on its first run. **Worth porting back to `smoke.yaml` regardless of what happens to the rest of this PR.**

Steps 2 and 3 are byte-identical to smoke's (verified by parsing both files and comparing the `if:` and `run:` strings), so the two stay diffable. `actionlint` — with shellcheck enabled — reports no new findings on either file.

`.github/workflows/merge-gate.yaml`: `enable-kernel-ccache: true` and `secrets: inherit` on `ttnn-basic-tests` only. `runtime-basic-tests` is untouched; it is metalium's job with its own tests yaml and gets the input for free once this lands.

### Recommendation

Split this:

- **Merge now, separately:** items 1–4 with the input left `false`. Zero behaviour change (validated — run 32949883556 is green on all four basic jobs and `"Enabling TT Metal kernel ccache"` appears 0 times, so the guard works), and it gives every future ccache question a CLI-readable answer.
- **Merge separately:** `secrets: inherit` on the two `smoke.yaml` calls in `merge-gate.yaml`. That removes a real, currently-active penalty from two jobs that already have ccache enabled.
- **Do not merge** `enable-kernel-ccache: true` for `ttnn-basic-tests` until something populates the cache with the kernels these suites compile. Concretely that means a writer for the basic kernel set — e.g. a push-to-main `ttnn-basic-tests` run with write access — after which the gate's read path would pay off. Until then this is a measured regression.

### Open questions for whoever owns the Redis

1. Which pipeline is intended to **write** to `redis-kernel-ccache`, given `REDIS_CCACHE_IS_READONLY` is `"true"` for every consumer in the repo? Is it overridden at `mainline` environment scope?
2. Should the basic suites' kernels be populated at all, or is the cache deliberately scoped to the smoke set?
3. Separately: `996x Failed to open inode cache /tmp/ccache/inode-cache-64.v3: No such file or directory` on every run — harmless but it suggests the local tier is misconfigured under `CCACHE_REMOTE_ONLY`.

### Test plan

- [x] `actionlint` (shellcheck enabled) — no new findings vs. baseline on either file
- [x] Copied steps verified byte-identical to `smoke.yaml`'s
- [x] Verdict shell logic tested locally against real `ccache 4.14 --print-stats`, all three branches
- [x] `ccache` confirmed present in the target image — `ttnn validation basic` (ASan) and `ttnn validation smoke` (TSan) run the identical container; only the debs differ
- [x] ccache **off** → all four basic jobs green, guard suppresses the step, no behaviour change
- [x] ccache **on**, no secrets → 1200 errors, 0 hits, +17% slower. Root cause identified.
- [x] ccache **on** + `secrets: inherit` → 0 errors, 26 hits, still +14% slower. Root cause identified.
- [ ] Blocked: a populating pipeline for the basic kernel set

`.github/workflows/basic.yaml` changes flip none of the `find-changed-files.sh` flags that gate `ttnn-basic-tests` (`tt-nn-changed` needs `ttnn/**`, the tests flag needs `tests/ttnn/**`), and `find-changes` is skipped entirely on `pull_request` — confirmed, the PR-event run on this branch has every test job `skipped`. So validation went via `workflow_dispatch`, and the branch carries a temporary comment in `tests/ttnn/unit_tests/gtests/test_reduction.cpp` purely to set `tt-metalium-or-tt-nn-tests-changed`. **Must be dropped before merge.**
