### PR TITLE
[Bug fix] Skip situ_glu sub-device test under slow dispatch

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -16,7 +16,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, asser
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
-from models.common.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole, is_slow_dispatch
 
 
 def _data_gen_div_scalar_input(input_shapes, low, high, device, divisor):
@@ -1074,6 +1074,7 @@ def test_situ_glu_sub_core_grids_rejects_interleaved_l1(device, expect_error, vi
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
+@pytest.mark.skipif(is_slow_dispatch(), reason="sub-device managers are unsupported with slow dispatch")
 def test_situ_glu_requires_cores_when_sub_devices_loaded(device, expect_error):
     shape = torch.Size([1, 1, 32, 32])
     grid = device.compute_with_storage_grid_size()


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

`ttnn eltwise group 2 [sim_bh_p150]` is red on main. One test fails:

`tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py::test_situ_glu_requires_cores_when_sub_devices_loaded`

```
RuntimeError: TT_FATAL @ tt_metal/impl/sub_device/sub_device_manager_tracker.cpp:102
  tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()
  info: Using sub device managers is unsupported with slow dispatch
```

It dies at `device.load_sub_device_manager(manager)` during setup, before ever reaching the `expect_error` assertion it exists to make.

**Cause.** The ttsim SKU setup exports `TT_METAL_SLOW_DISPATCH_MODE=1`, and sub-device managers hard-require fast dispatch. The test's only guard is `@pytest.mark.skipif(not is_blackhole(), ...)` — and `sim_bh_p150` *is* blackhole as far as that check is concerned, so the guard passes and the test runs.

**First failing commit** is `3900b5ea46` ([#54149](https://github.com/tenstorrent/tt-metal/pull/54149)), which added the test. Bisect on main, all `Sanity tests (push) SKUs[WH,Sim]`:

| commit | time (UTC) | result |
|---|---|---|
| `728777dc4d` | 06:40 | success — last green |
| `3900b5ea46` | 07:42 | **failure** — added the test |
| `58342a6f63` | 08:10 | failure |

Both failures are on run attempt 3, so it is deterministic rather than flaky.

### What this changes

Guards the test on dispatch mode:

```python
@pytest.mark.skipif(is_slow_dispatch(), reason="sub-device managers are unsupported with slow dispatch")
```

`is_slow_dispatch()` already exists in `models.common.utility_functions`, which this file already imports `is_blackhole` from, so the change is one decorator plus one name on the existing import.

### Why not the ttsim skip list

`tests/pipeline_reorg/ttsim-skip-list.yaml` means "does not work on TTSim", and its entries are simulator defects and job-level timeouts. This is neither — it is a product constraint. The same test fails identically on silicon with `TT_METAL_SLOW_DISPATCH_MODE=1`, so naming the real condition keeps the test running everywhere it is actually valid and does not misattribute the cause to the simulator.

### Notes for reviewers

- This is the only test in the file that touches sub-devices, so nothing else needs the guard.
- The test's coverage is unchanged on every fast-dispatch SKU; it is skipped only where it could never have run.
- @pmilojevicTT for awareness, as the author of #54149.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-situ-glu-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswinmcw/fix-situ-glu-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-situ-glu-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aswinmcw/fix-situ-glu-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswinmcw/fix-situ-glu-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswinmcw/fix-situ-glu-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aswinmcw/fix-situ-glu-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aswinmcw/fix-situ-glu-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswinmcw/fix-situ-glu-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswinmcw/fix-situ-glu-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswinmcw/fix-situ-glu-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswinmcw/fix-situ-glu-slow-dispatch-skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswinmcw/fix-situ-glu-slow-dispatch-skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswinmcw/fix-situ-glu-slow-dispatch-skip)