### PR TITLE
hc: surface failed self-heal reboot and its error on JIRA ticket + comment

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -395,6 +395,8 @@ def main() -> int:
     # between the deployments: it drives Slurm (scontrol reboot + requeue), which
     # orchestration has no equivalent for, so there we say so and ticket instead.
     restart_count = slurm_restart_count()
+    # Set only when self-heal tried but couldn't reboot/requeue; surfaced on the ticket.
+    reboot_failure: str | None = None
     if effective_code != 0 and args.reboot_on_failure and launch_mode != "slurm":
         log.warning(
             "--reboot-on-failure is not supported in %s launch mode (reboot-and-requeue "
@@ -431,10 +433,14 @@ def main() -> int:
             upload_csv_sftp(pre_reboot_csv, sftp_user, sftp_host, log_dir=log_dir, launch_mode=launch_mode)
         if args.cleanup and pre_reboot_csv:
             remove_path(tempfile.gettempdir(), pre_reboot_csv)
-        if reboot_and_requeue(node, slurm_job_id):
+        reboot_failure = reboot_and_requeue(node, slurm_job_id)
+        if reboot_failure is None:
             log.info("Reboot armed and job requeued; exiting so the node reboots and reruns")
             return effective_code
-        log.warning("Reboot/requeue could not be issued; proceeding to JIRA ticketing")
+        log.error(
+            "Self-heal reboot FAILED (%s); node was NOT rebooted or requeued, " "proceeding to JIRA ticketing",
+            reboot_failure,
+        )
 
     # JIRA ticket creation (failure only)
     ticket_key = None
@@ -479,6 +485,7 @@ def main() -> int:
                         test_output=full_output,
                         attachment_names=attachment_names,
                         restart_count=restart_count,
+                        reboot_failure=reboot_failure,
                         grafana_base_url=args.grafana_base_url,
                     )
                 )
@@ -511,6 +518,7 @@ def main() -> int:
                     telemetry_summary=prom_output,
                     attachment_names=attachment_names,
                     restart_count=restart_count,
+                    reboot_failure=reboot_failure,
                     grafana_base_url=args.grafana_base_url,
                 )
                 if ticket_key:

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/jira_client.py
@@ -32,6 +32,7 @@ def _build_failure_body(
     test_output: str,
     attachment_names: list[str] | None = None,
     restart_count: int = 0,
+    reboot_failure: str | None = None,
     grafana_base_url: str = "",
 ) -> str:
     """Build the shared failure detail block used by both a new ticket's
@@ -43,6 +44,14 @@ def _build_failure_body(
     reboot_line = ""
     if restart_count > 0:
         reboot_line = f"*Reboot recovery:* failure persisted after {restart_count} reboot(s)\n"
+
+    # A failed self-heal reboot means the run never got its clean rerun; flag it
+    # with the error so it isn't read as a normal single-run failure.
+    reboot_failure_line = ""
+    if reboot_failure:
+        reboot_failure_line = (
+            f"*Self-heal reboot: FAILED* - node was NOT rebooted or requeued. " f"Reason: {{{{{reboot_failure}}}}}\n"
+        )
 
     telemetry_section = ""
     if telemetry_summary:
@@ -64,6 +73,7 @@ def _build_failure_body(
         f"*Slurm Job ID:* {slurm_job_id}\n"
         f"*Exit Code:* {exit_code}\n"
         f"{reboot_line}"
+        f"{reboot_failure_line}"
         f"*TT-SMI Version:* {versions['tt_smi']}\n"
         f"*TT-KMD Version:* {versions['tt_kmd']}\n"
         f"*Firmware Version:* {versions['fw_bundle']}\n"
@@ -221,6 +231,7 @@ def create_jira_ticket(
     telemetry_summary: str = "",
     attachment_names: list[str] | None = None,
     restart_count: int = 0,
+    reboot_failure: str | None = None,
     grafana_base_url: str = "",
 ) -> str | None:
     """Create a JIRA ticket for a failed health check. Returns ticket key or None."""
@@ -234,6 +245,7 @@ def create_jira_ticket(
         test_output=test_output,
         attachment_names=attachment_names,
         restart_count=restart_count,
+        reboot_failure=reboot_failure,
         grafana_base_url=grafana_base_url,
     )
 

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/node_recovery.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/node_recovery.py
@@ -40,12 +40,15 @@ def should_reboot(*, exit_code: int, enabled: bool, slurm_job_id: str, restart_c
     return exit_code != 0 and enabled and slurm_job_id != "unknown" and restart_count < cap
 
 
-def reboot_and_requeue(node: str, slurm_job_id: str) -> bool:
+def reboot_and_requeue(node: str, slurm_job_id: str) -> str | None:
     """Arm a reboot (`scontrol reboot ASAP nextstate=RESUME` drains then
     auto-resumes the node) and `scontrol requeue` the job. The caller must return
     immediately without blocking: an earlier version slept and wedged the node at
     ALLOCATED+DRAIN+REBOOT_REQUESTED. Reboot needs sudo; `-n` fails fast so the
     caller can fall through to ticketing.
+
+    Returns ``None`` on success, else a short failure reason (e.g.
+    ``scontrol: command not found``) so a failed reboot isn't a silent no-op.
     """
     commands = (
         [
@@ -61,20 +64,19 @@ def reboot_and_requeue(node: str, slurm_job_id: str) -> bool:
         ["scontrol", "requeue", slurm_job_id],
     )
     for cmd in commands:
-        log.info("Running `%s` ...", " ".join(cmd))
+        printable = " ".join(cmd)
+        log.info("Running `%s` ...", printable)
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         # Any spawn failure (scontrol absent, sudo not executable) has to stay
         # non-fatal: crashing here would lose the JIRA ticket for a real failure.
         except (OSError, subprocess.TimeoutExpired) as exc:
-            log.warning("Could not run `%s`: %s", " ".join(cmd), exc)
-            return False
+            reason = f"`{printable}` could not run: {exc}"
+            log.warning(reason)
+            return reason
         if result.returncode != 0:
-            log.warning(
-                "`%s` failed (rc=%d): %s",
-                " ".join(cmd),
-                result.returncode,
-                (result.stderr or result.stdout).strip(),
-            )
-            return False
-    return True
+            detail = (result.stderr or result.stdout).strip()
+            reason = f"`{printable}` failed (rc={result.returncode}): {detail}"
+            log.warning(reason)
+            return reason
+    return None


### PR DESCRIPTION
### PR Category
Feature

### Summary
When self-heal reboot fails (e.g. `scontrol` missing since the harness moved into the container), the failure was a silent WARNING and the ticket looked like a normal single-run failure. This makes it loud: the reboot helper now returns the failure reason, the runner logs it at ERROR, and the JIRA ticket + recurring comment show `*Self-heal reboot: FAILED* - ... Reason: {{<error>}}`.

Tested here, look comment: https://tenstorrent.atlassian.net/browse/DCAMP-1493?focusedCommentId=650548

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-reboot-fail-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/hc-reboot-fail-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-reboot-fail-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/hc-reboot-fail-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/hc-reboot-fail-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/hc-reboot-fail-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/hc-reboot-fail-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/hc-reboot-fail-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/hc-reboot-fail-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/hc-reboot-fail-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/hc-reboot-fail-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/hc-reboot-fail-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/hc-reboot-fail-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/hc-reboot-fail-signal)