### PR TITLE
Fix for Sanity pipeline subdevice usage with slow dispatch

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -16,7 +16,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp, asser
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
-from models.common.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole, skip_for_slow_dispatch
 
 
 def _data_gen_div_scalar_input(input_shapes, low, high, device, divisor):
@@ -1074,6 +1074,7 @@ def test_situ_glu_sub_core_grids_rejects_interleaved_l1(device, expect_error, vi
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="situ_glu builds on softcap, which is Blackhole only")
+@skip_for_slow_dispatch("sub device managers are unsupported with slow dispatch")
 def test_situ_glu_requires_cores_when_sub_devices_loaded(device, expect_error):
     shape = torch.Size([1, 1, 32, 32])
     grid = device.compute_with_storage_grid_size()


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/54422

### Problem description

`test_situ_glu_requires_cores_when_sub_devices_loaded` calls
`load_sub_device_manager()`, which TT_FATALs without fast dispatch. The ttsim
leg of ttnn sanity runs under `TT_METAL_SLOW_DISPATCH_MODE=1` with `-x`, so it
fails the whole eltwise group.

### What's changed

Added `@skip_for_slow_dispatch(...)`, the guard the neighbouring sub-device
eltwise tests already carry. Blackhole fast-dispatch coverage unchanged.

### CI

Sanity: https://github.com/tenstorrent/tt-metal/actions/runs/32967206353

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/situ-glu-subdev-test-slow-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/situ-glu-subdev-test-slow-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/situ-glu-subdev-test-slow-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/situ-glu-subdev-test-slow-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/situ-glu-subdev-test-slow-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/situ-glu-subdev-test-slow-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/situ-glu-subdev-test-slow-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/situ-glu-subdev-test-slow-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/situ-glu-subdev-test-slow-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/situ-glu-subdev-test-slow-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/situ-glu-subdev-test-slow-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/situ-glu-subdev-test-slow-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/situ-glu-subdev-test-slow-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/situ-glu-subdev-test-slow-dispatch)