### PR TITLE
Fix SFPU binary broadcast runtime dest API compile failure

### DIFF
--- a/tt_metal/hw/inc/api/compute/sfpu_binary_bcast.h
+++ b/tt_metal/hw/inc/api/compute/sfpu_binary_bcast.h
@@ -75,10 +75,11 @@ ALWI void sfpu_mul_bcast_col_init() { sfpu_bcast_col_init(); }
 // `_llk_math_eltwise_sfpu_start_(0)` / `_llk_math_eltwise_sfpu_done_()` brackets
 // the standalone helper used to set up by hand, plus the dst-bound LLK_ASSERTs in
 // `_sfpu_binary_check_`.
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void sfpu_sub_bcast_col(uint32_t dst_data_idx, uint32_t dst_col_vec_idx) {
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
-        DST_ACCUM_MODE,
+        is_fp32_dest_acc_en,
         _calculate_sfpu_binary_bcast_full_tile_,
         (ckernel::BinaryOp::SUB, ckernel::BroadcastType::COL),
         dst_data_idx,
@@ -87,10 +88,11 @@ ALWI void sfpu_sub_bcast_col(uint32_t dst_data_idx, uint32_t dst_col_vec_idx) {
         VectorMode::None)));
 }
 
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void sfpu_add_bcast_col(uint32_t dst_data_idx, uint32_t dst_col_vec_idx) {
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
-        DST_ACCUM_MODE,
+        is_fp32_dest_acc_en,
         _calculate_sfpu_binary_bcast_full_tile_,
         (ckernel::BinaryOp::ADD, ckernel::BroadcastType::COL),
         dst_data_idx,
@@ -99,10 +101,11 @@ ALWI void sfpu_add_bcast_col(uint32_t dst_data_idx, uint32_t dst_col_vec_idx) {
         VectorMode::None)));
 }
 
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void sfpu_mul_bcast_col(uint32_t dst_data_idx, uint32_t dst_col_vec_idx) {
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
-        DST_ACCUM_MODE,
+        is_fp32_dest_acc_en,
         _calculate_sfpu_binary_bcast_full_tile_,
         (ckernel::BinaryOp::MUL, ckernel::BroadcastType::COL),
         dst_data_idx,
@@ -163,10 +166,11 @@ ALWI void sfpu_mul_bcast_row_init() { sfpu_bcast_row_init(); }
  * | dst_row_vec_idx  | The index of the row-vector tile in DST (row 0 is broadcast)        | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void sfpu_sub_bcast_row(uint32_t dst_data_idx, uint32_t dst_row_vec_idx) {
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
-        DST_ACCUM_MODE,
+        is_fp32_dest_acc_en,
         _calculate_sfpu_binary_bcast_full_tile_,
         (ckernel::BinaryOp::SUB, ckernel::BroadcastType::ROW),
         dst_data_idx,
@@ -175,10 +179,11 @@ ALWI void sfpu_sub_bcast_row(uint32_t dst_data_idx, uint32_t dst_row_vec_idx) {
         VectorMode::None)));
 }
 
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void sfpu_add_bcast_row(uint32_t dst_data_idx, uint32_t dst_row_vec_idx) {
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
-        DST_ACCUM_MODE,
+        is_fp32_dest_acc_en,
         _calculate_sfpu_binary_bcast_full_tile_,
         (ckernel::BinaryOp::ADD, ckernel::BroadcastType::ROW),
         dst_data_idx,
@@ -187,10 +192,11 @@ ALWI void sfpu_add_bcast_row(uint32_t dst_data_idx, uint32_t dst_row_vec_idx) {
         VectorMode::None)));
 }
 
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void sfpu_mul_bcast_row(uint32_t dst_data_idx, uint32_t dst_row_vec_idx) {
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
-        DST_ACCUM_MODE,
+        is_fp32_dest_acc_en,
         _calculate_sfpu_binary_bcast_full_tile_,
         (ckernel::BinaryOp::MUL, ckernel::BroadcastType::ROW),
         dst_data_idx,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The `SfpuBinaryBcast` LLK tests were failing during JIT compilation after the runtime dest switching change added an `is_fp32_dest_acc_en` template parameter to the unified `sfpu_bcast` API. The unified wrapper passed that parameter to the row/column ADD/SUB/MUL helpers, but those helpers were still plain functions, so the compiler parsed the calls as invalid comparison expressions instead of template calls. This change makes the six concrete broadcast helpers templated on `is_fp32_dest_acc_en` and forwards that value into `SFPU_BINARY_CALL`, matching the surrounding compute API pattern and preserving the default `DST_ACCUM_MODE` behavior for existing callers. Verified the 12 previously failing `SfpuBinaryBcast` FP32/BF16 row/column ADD/SUB/MUL variants pass on WH ttsim.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/sfpu-bcast-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/sfpu-bcast-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/sfpu-bcast-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/sfpu-bcast-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/sfpu-bcast-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/sfpu-bcast-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/sfpu-bcast-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/sfpu-bcast-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/sfpu-bcast-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/sfpu-bcast-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/sfpu-bcast-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/sfpu-bcast-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/sfpu-bcast-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/sfpu-bcast-api)