### PR TITLE
tt_transformers: align resumed prefill offsets and reserve their traces

### DIFF
--- a/models/common/tests/test_resume_offset_alignment.py
+++ b/models/common/tests/test_resume_offset_alignment.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Host-only tests for the resumed-prefill offset alignment in
+``models.tt_transformers.tt.generator.Generator``.
+
+A resumed prefill (prefix caching, or a prompt split across engine steps) hands
+the traced chunked SDPA a ``chunk_start_idx``. That op reads the wrong prefix
+instead of raising when the offset is not a multiple of the ``q_chunk_size`` its
+program was captured with, so the offset is floored to
+``lcm(block_size, q_chunk_size)`` before use.
+
+These are pure functions of ``(num_cached, seq_len, block_size, q_chunk_size)``.
+The tests bind the real methods to a stub so they run without a device.
+"""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from models.tt_transformers.tt.common import get_padded_prefill_len
+from models.tt_transformers.tt.generator import Generator
+
+# The buckets Llama-3.1-8B traces on T3K, and the ceiling warmup applies to them.
+TRACED_BUCKETS = (128, 1024, 2048, 4096, 8192)
+CAPPED_WARMUP_SEQ_LEN = 131072
+
+
+def _q_chunk_size(seq_len):
+    """The rule ``ModelArgs.get_attn_sdpa_prefill_program_config`` applies at chunk_start_idx=0."""
+    return 256 if seq_len >= 2048 else 64
+
+
+class _StubModelArgs:
+    def __init__(self, q_chunk_size_fn=_q_chunk_size):
+        self._q_chunk_size_fn = q_chunk_size_fn
+        self.capped_warmup_seq_len = CAPPED_WARMUP_SEQ_LEN
+
+    def get_attn_sdpa_program_config(self, mode, seq_len, chunk_start_idx, _unused):
+        return SimpleNamespace(q_chunk_size=self._q_chunk_size_fn(seq_len))
+
+
+class _StubModelArgsNoProgramConfig:
+    """A model whose args cannot describe the pin, e.g. Gemma4ModelArgs."""
+
+    def __init__(self):
+        self.capped_warmup_seq_len = CAPPED_WARMUP_SEQ_LEN
+
+
+class _StubGenerator:
+    """Borrows the real methods so the tests exercise shipped code, not a copy."""
+
+    _traced_sdpa_q_chunk_size = Generator._traced_sdpa_q_chunk_size
+    _resume_offset_alignment = Generator._resume_offset_alignment
+    _assert_uniform_resume_alignment = Generator._assert_uniform_resume_alignment
+    _align_resume_offsets = Generator._align_resume_offsets
+    # Read off the class a staticmethod is a plain function, which would rebind here.
+    _resumed_warmup_prompt_len = staticmethod(Generator._resumed_warmup_prompt_len)
+
+    def __init__(self, block_size, model_args=None, model_capabilities=None):
+        args = model_args if model_args is not None else [_StubModelArgs()]
+        self.model_args = args
+        self.data_parallel = len(args)
+        self.model_capabilities = model_capabilities or {}
+        self._block_size = block_size
+
+    def _paged_prefill_block_size(self, _kv_cache):
+        return self._block_size
+
+    def align(self, num_cached_per_user, prompt_lens):
+        # kv_cache only has to be non-None: _paged_prefill_block_size is stubbed.
+        return self._align_resume_offsets(num_cached_per_user, prompt_lens, kv_cache=[object()])
+
+
+@pytest.mark.parametrize("block_size", [32, 64, 128, 256])
+@pytest.mark.parametrize("bucket", TRACED_BUCKETS)
+def test_alignment_is_lcm_of_block_size_and_pin(block_size, bucket):
+    gen = _StubGenerator(block_size)
+    alignment = gen._resume_offset_alignment(bucket, block_size)
+    expected = math.lcm(block_size, _q_chunk_size(bucket))
+    assert alignment == expected
+    assert alignment % block_size == 0, "paged ops need the page-table slice to land on a block"
+    assert alignment % _q_chunk_size(bucket) == 0, "the traced SDPA program pins this q_chunk_size"
+
+
+def test_zero_offset_short_circuits_without_consulting_the_alignment():
+    """An ordinary prefill passes a zero-filled start_pos and must not need an alignment."""
+    gen = _StubGenerator(64, model_args=[_StubModelArgsNoProgramConfig()], model_capabilities={})
+    assert gen.align([0, 0], [1024, 4096]) == [0, 0]
+
+
+def test_undeclarable_alignment_raises_on_a_real_resume(expect_error):
+    gen = _StubGenerator(64, model_args=[_StubModelArgsNoProgramConfig()], model_capabilities={})
+    with expect_error(ValueError, "resumed_prefill_token_alignment"):
+        gen.align([128], [4096])
+
+
+def test_declared_alignment_is_used_when_the_pin_cannot_be_derived():
+    """Gemma 4's case: chunked_prefill_sdpa pins 128 and the model args cannot say so."""
+    gen = _StubGenerator(
+        64,
+        model_args=[_StubModelArgsNoProgramConfig()],
+        model_capabilities={"resumed_prefill_token_alignment": 128},
+    )
+    assert gen.align([200], [4096]) == [128]
+
+
+def test_already_aligned_offset_is_unchanged():
+    gen = _StubGenerator(64)
+    # 4096 pins 256; 512 is already a multiple of lcm(64, 256) = 256.
+    assert gen.align([512], [8192]) == [512]
+
+
+def test_settle_loop_takes_the_second_hop():
+    """One pass is not enough: flooring lengthens the suffix, which can raise the pin.
+
+    block_size 32, seq_len 1120, start_pos 100. A single pass floors 100 against the
+    suffix at offset 96, whose padded length is 1024 and pins 64, giving 64. The
+    longer suffix at offset 64 pads to 2048 and pins 256, so the offset must settle
+    lower still.
+    """
+    gen = _StubGenerator(32)
+    (settled,) = gen.align([100], [1120])
+    assert settled == 0
+    # The result is a fixed point: re-running does not move it.
+    assert gen.align([settled], [1120]) == [settled]
+
+
+def test_settled_offset_is_a_fixed_point_across_the_bucket_range():
+    gen = _StubGenerator(64)
+    for seq_len in (200, 1120, 2100, 4500, 9000):
+        for start_pos in range(0, seq_len, 37):
+            (settled,) = gen.align([start_pos], [seq_len])
+            assert 0 <= settled <= start_pos, "flooring never raises the offset"
+            assert gen.align([settled], [seq_len]) == [settled], "not a fixed point"
+
+
+def test_each_user_is_aligned_independently():
+    gen = _StubGenerator(64)
+    assert gen.align([0, 100, 512], [1024, 1120, 8192]) == [0, 0, 512]
+
+
+@pytest.mark.parametrize("block_size", [64, 128, 256, 1024])
+@pytest.mark.parametrize("bucket", TRACED_BUCKETS)
+def test_resumed_warmup_prompt_reaches_the_intended_bucket(block_size, bucket):
+    """Regression for the block_size >= 128 startup failure.
+
+    Spanning the bucket alone gave a suffix of ``bucket - num_cached``, which is 0 at
+    block_size 128 and negative at 256, so warmup tripped
+    ``assert 0 <= num_cached < seq_len`` and the server never started.
+    """
+    gen = _StubGenerator(block_size)
+    num_cached = gen._resume_offset_alignment(bucket, block_size)
+    total_seq_len = gen._resumed_warmup_prompt_len(bucket, num_cached, CAPPED_WARMUP_SEQ_LEN)
+    suffix = total_seq_len - num_cached
+
+    assert suffix > 0, "a resumed warmup with no suffix has nothing to prefill"
+    assert get_padded_prefill_len(suffix) == bucket, "the captured trace would be for another bucket"
+    assert 0 <= num_cached < total_seq_len, "would trip the guard in _prefill_forward_text_impl"
+
+
+def test_resumed_warmup_prompt_respects_the_warmup_ceiling():
+    """When the ceiling equals the bucket the prompt is capped, and the suffix still fits."""
+    gen = _StubGenerator(64)
+    bucket = 8192
+    num_cached = gen._resume_offset_alignment(bucket, 64)
+    total_seq_len = gen._resumed_warmup_prompt_len(bucket, num_cached, capped_warmup_seq_len=bucket)
+    assert total_seq_len == bucket
+    assert get_padded_prefill_len(total_seq_len - num_cached) == bucket
+
+
+def test_heterogeneous_replicas_are_rejected_rather_than_silently_aligned_to_replica_zero(expect_error):
+    replica_0 = _StubModelArgs()
+    replica_1 = _StubModelArgs(q_chunk_size_fn=lambda seq_len: 512)
+    gen = _StubGenerator(64, model_args=[replica_0, replica_1])
+    with expect_error(AssertionError, "replica 1"):
+        gen.align([300], [4096])

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -1495,6 +1495,11 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": False,
+        # Gemma4ModelArgs exposes no get_attn_sdpa_program_config, so the resume
+        # offset alignment cannot be derived. chunked_prefill_sdpa pins
+        # q_chunk_size=128 and documents that its base_offset must be a multiple
+        # of it.
+        "resumed_prefill_token_alignment": 128,
     }
 
     def __init__(self, *args, **kwargs):

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -1495,11 +1495,10 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": False,
-        # Gemma4ModelArgs exposes no get_attn_sdpa_program_config, so the resume
-        # offset alignment cannot be derived. chunked_prefill_sdpa pins
-        # q_chunk_size=128 and documents that its base_offset must be a multiple
-        # of it.
-        "resumed_prefill_token_alignment": 128,
+        # Gemma4ModelArgs exposes no get_attn_sdpa_program_config, so Generator
+        # cannot derive the resume offset alignment and must be told it. Same pin
+        # align_num_cached_tokens_to_sdpa applies locally.
+        "resumed_prefill_token_alignment": SDPA_CHUNK_ALIGN,
     }
 
     def __init__(self, *args, **kwargs):

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.demos.gemma4.tt.common import create_tt_model
 from models.demos.gemma4.tt.generator import (
+    SDPA_CHUNK_ALIGN,
     ChunkedPrefillPageTableGuardMixin,
     align_num_cached_tokens_to_sdpa,
     max_batched_prefill_users,
@@ -230,11 +231,10 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": os.environ.get("GEMMA4_SUPPORTS_ASYNC_DECODE", "1").lower() in ("1", "true", "yes"),
-        # Gemma4ModelArgs exposes no get_attn_sdpa_program_config, so the resume
-        # offset alignment cannot be derived. chunked_prefill_sdpa pins
-        # q_chunk_size=128 and documents that its base_offset must be a multiple
-        # of it.
-        "resumed_prefill_token_alignment": 128,
+        # Gemma4ModelArgs exposes no get_attn_sdpa_program_config, so Generator
+        # cannot derive the resume offset alignment and must be told it. Same pin
+        # align_num_cached_tokens_to_sdpa applies locally.
+        "resumed_prefill_token_alignment": SDPA_CHUNK_ALIGN,
         "supports_sample_on_device": True,
     }
 

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -230,6 +230,11 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": os.environ.get("GEMMA4_SUPPORTS_ASYNC_DECODE", "1").lower() in ("1", "true", "yes"),
+        # Gemma4ModelArgs exposes no get_attn_sdpa_program_config, so the resume
+        # offset alignment cannot be derived. chunked_prefill_sdpa pins
+        # q_chunk_size=128 and documents that its base_offset must be a multiple
+        # of it.
+        "resumed_prefill_token_alignment": 128,
         "supports_sample_on_device": True,
     }
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import os
 from collections import defaultdict
 
@@ -242,6 +243,58 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             skip_sequence_lengths=skip_sequence_lengths,
             sampling_parameters_sweeped=sampling_parameters_sweeped,
         )
+
+        # Only models that accept a nonzero ``start_pos`` can ever take the
+        # resumed path, so only they should reserve trace region for it.
+        if enable_trace and self.model_capabilities.get("supports_prefix_caching", False):
+            self._warmup_prefill_resumed_sweep(kv_cache=kv_cache)
+
+    def _warmup_prefill_resumed_sweep(self, kv_cache):
+        """Capture the resumed-prefill ("sp1") traces, batch 1, one per traced length.
+
+        The sweep above never passes ``start_pos``, so it only ever captures the
+        ``sp0`` half of the prefill trace key. A resumed prefill -- prefix caching,
+        or a prompt split across engine steps -- takes the ``sp1`` half, which
+        would otherwise be captured lazily on whichever request happens to resume
+        first, allocating trace region nobody sized for. Reserving them here makes
+        the requirement a function of configuration instead of traffic.
+
+        Mirrors the phase-2 warmup in
+        ``models/demos/llama3_70b_galaxy/tt/generator.py``.
+        """
+        if kv_cache is None or kv_cache[0] is None:
+            # Resumed prefill needs a page table, so there is nothing to capture.
+            return
+        block_size = self._paged_prefill_block_size(kv_cache[0])
+
+        for model_id in range(self.data_parallel):
+            model_args = self.model_args[model_id]
+            for prefill_seq_len in model_args.trace_prefill_supported_seq_lens:
+                if not model_args.can_enable_trace(prefill_seq_len):
+                    continue
+                # The offset a real request will be floored to for this length, so
+                # the captured program config is the one those replays need.
+                q_chunk = self._traced_sdpa_q_chunk_size(prefill_seq_len, model_id) or block_size
+                num_cached = math.lcm(block_size, int(q_chunk))
+                total_seq_len = num_cached + prefill_seq_len
+                if total_seq_len > model_args.max_seq_len:
+                    continue
+
+                num_blocks = num_blocks_in_seq(total_seq_len, block_size)
+                logger.info(
+                    f"Warming up resumed prefill for sequence length: {prefill_seq_len}, " f"num_cached: {num_cached}"
+                )
+                self.prefill_forward_text(
+                    tokens=torch.zeros(1, total_seq_len, dtype=torch.long),
+                    prompt_lens=torch.tensor([total_seq_len], dtype=torch.long),
+                    empty_slots=[0],
+                    page_table=torch.zeros(1, num_blocks, dtype=torch.int32),
+                    start_pos=[num_cached],
+                    kv_cache=kv_cache,
+                    enable_trace=True,
+                    model_id_warmup=model_id,
+                    sampling_params=None,
+                )
 
     def finalize_deferred_traces(self):
         """Record the decode trace that this call deferred.
@@ -948,6 +1001,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         assert len(num_cached_per_user) == len(
             prompt_lens
         ), f"start_pos length {len(num_cached_per_user)} != prompt_lens length {len(prompt_lens)}"
+        if start_pos is not None:
+            num_cached_per_user = self._align_resume_offsets(num_cached_per_user, prompt_lens, kv_cache)
+            # The per-user loop below re-reads the offset from ``start_pos``, so the
+            # aligned list has to replace it: otherwise the padded length computed
+            # here would not match the token slice the kernel receives.
+            start_pos = num_cached_per_user
         for i, (seq_len, num_cached) in enumerate(zip(prompt_lens, num_cached_per_user)):
             assert 0 <= num_cached < seq_len, f"user {i}: num_cached={num_cached} must be < seq_len={seq_len}"
         prefill_seq_lens = [
@@ -1388,6 +1447,60 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             return output_tokens, reformat_logprobs(output_log_probs, batch_size)
         else:
             return output_tensor
+
+    def _traced_sdpa_q_chunk_size(self, prefill_seq_len, model_id=0):
+        """q_chunk_size a traced prefill of this length is captured with, or None.
+
+        The traced path hands the op a ``chunk_start_idx`` device tensor that is
+        refreshed per replay, so the captured program config cannot be derived
+        from the offset. It is built with ``chunk_start_idx=0`` instead, which is
+        what this reproduces.
+        """
+        get_config = getattr(self.model_args[model_id], "get_attn_sdpa_program_config", None)
+        if get_config is None:
+            return None
+        try:
+            return get_config(Mode.PREFILL, prefill_seq_len, 0, None).q_chunk_size
+        except (AttributeError, TypeError, ValueError):
+            # A model whose program config this signature does not describe.
+            return None
+
+    def _align_resume_offsets(self, num_cached_per_user, prompt_lens, kv_cache):
+        """Floor each resume offset to what the paged ops and the traced SDPA need.
+
+        ``block_size`` covers the page-table slice the chunk's K/V is written
+        through: an offset off that multiple shifts every write by
+        ``chunk_start % block_size`` positions.
+
+        ``q_chunk_size`` covers the SDPA op, which requires ``chunk_start_idx`` to
+        be a multiple of the value its program was built with and answers from the
+        wrong prefix rather than raising when it is not. Under tracing that value
+        is pinned at capture, so it has to be satisfied by the offset.
+
+        Flooring recomputes at most ``alignment - 1`` tokens whose K/V is rewritten
+        identically into the same blocks, so it is semantically a no-op. Mirrors
+        the ``SDPA_CHUNK_ALIGN`` round-down in
+        ``models/demos/llama3_70b_galaxy/tt/generator.py``.
+        """
+        if kv_cache is None or kv_cache[0] is None:
+            # Non-paged prefill: there is no page table to slice.
+            return num_cached_per_user
+        block_size = self._paged_prefill_block_size(kv_cache[0])
+        aligned = []
+        for i, (num_cached, seq_len) in enumerate(zip(num_cached_per_user, prompt_lens)):
+            floored = (int(num_cached) // block_size) * block_size
+            # The pinned q_chunk_size depends on the padded length, which depends on
+            # the offset. Flooring further only lengthens the remaining span, and
+            # the pinned value never decreases with length, so one re-floor settles
+            # it.
+            q_chunk = self._traced_sdpa_q_chunk_size(get_padded_prefill_len(int(seq_len) - floored))
+            if q_chunk and q_chunk > block_size:
+                alignment = math.lcm(block_size, int(q_chunk))
+                floored = (int(num_cached) // alignment) * alignment
+            if floored != num_cached:
+                logger.debug(f"Resume offset alignment: user {i} start_pos {num_cached} -> {floored}")
+            aligned.append(floored)
+        return aligned
 
     def _paged_prefill_block_size(self, kv_cache):
         """Block size for chunked-prefill page-table padding/slicing.

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1522,6 +1522,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         block_size = self._paged_prefill_block_size(kv_cache[0])
         aligned = []
         for i, (num_cached, seq_len) in enumerate(zip(num_cached_per_user, prompt_lens)):
+            if int(num_cached) == 0:
+                # Not a resume. Callers pass a zero-filled start_pos for an
+                # ordinary prefill, so this is the common path and must not
+                # require the model to describe an alignment it never uses.
+                aligned.append(0)
+                continue
             floored = (int(num_cached) // block_size) * block_size
             # The alignment depends on the padded suffix length, which depends on
             # the offset, so it has to settle: flooring lengthens the suffix, a

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -32,6 +32,7 @@ from models.common.warmup import WarmupForwardMixin
 from models.tt_transformers.tt.common import (
     Mode,
     copy_host_to_device,
+    get_all_padded_prefill_lengths,
     get_block_size,
     get_max_prefill_chunk_size,
     get_padded_prefill_len,
@@ -245,8 +246,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         )
 
         # Only models that accept a nonzero ``start_pos`` can ever take the
-        # resumed path, so only they should reserve trace region for it.
-        if enable_trace and self.model_capabilities.get("supports_prefix_caching", False):
+        # resumed path, so only they should reserve trace region for it. Both
+        # prefix caching and a prompt split across engine steps produce one.
+        resumes_prefill = self.model_capabilities.get("supports_prefix_caching", False) or self.model_capabilities.get(
+            "supports_chunked_prefill", False
+        )
+        if enable_trace and resumes_prefill:
             self._warmup_prefill_resumed_sweep(kv_cache=kv_cache)
 
     def _warmup_prefill_resumed_sweep(self, kv_cache):
@@ -274,11 +279,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     continue
                 # The offset a real request will be floored to for this length, so
                 # the captured program config is the one those replays need.
-                q_chunk = self._traced_sdpa_q_chunk_size(prefill_seq_len, model_id) or block_size
-                num_cached = math.lcm(block_size, int(q_chunk))
-                total_seq_len = num_cached + prefill_seq_len
-                if total_seq_len > model_args.max_seq_len:
-                    continue
+                num_cached = self._resume_offset_alignment(prefill_seq_len, block_size, model_id)
+                # The prompt spans the bucket rather than the bucket plus the
+                # offset: adding to it would exceed max_seq_len for the largest
+                # bucket, skipping the trace a real request of that length uses.
+                # The suffix still pads back to this bucket because the offset is
+                # at most half of it.
+                total_seq_len = prefill_seq_len
+                assert (
+                    get_padded_prefill_len(total_seq_len - num_cached) == prefill_seq_len
+                ), f"warmup suffix {total_seq_len - num_cached} does not pad to bucket {prefill_seq_len}"
 
                 num_blocks = num_blocks_in_seq(total_seq_len, block_size)
                 logger.info(
@@ -1459,11 +1469,35 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         get_config = getattr(self.model_args[model_id], "get_attn_sdpa_program_config", None)
         if get_config is None:
             return None
-        try:
-            return get_config(Mode.PREFILL, prefill_seq_len, 0, None).q_chunk_size
-        except (AttributeError, TypeError, ValueError):
-            # A model whose program config this signature does not describe.
-            return None
+        # Deliberately unguarded: a model whose program config this signature does
+        # not describe must say so by not exposing the method. Swallowing the error
+        # here would drop back to block-only alignment and reinstate the wrong
+        # prefix reads this exists to prevent.
+        return get_config(Mode.PREFILL, prefill_seq_len, 0, None).q_chunk_size
+
+    def _resume_offset_alignment(self, prefill_seq_len, block_size, model_id=0):
+        """Multiple a resume offset must land on for this padded suffix length.
+
+        The paged ops need ``block_size``; the traced SDPA needs the q_chunk_size
+        its program was captured with. Their least common multiple satisfies both.
+
+        The q_chunk_size is taken from the model's own program config where it
+        exposes one, so a short suffix keeps its smaller alignment instead of
+        being rounded away. A model without one must declare
+        ``resumed_prefill_token_alignment``: there is no safe default, and
+        guessing block_size is what produces the silent wrong prefix.
+        """
+        q_chunk = self._traced_sdpa_q_chunk_size(prefill_seq_len, model_id)
+        if q_chunk is None:
+            q_chunk = self.model_capabilities.get("resumed_prefill_token_alignment")
+        if q_chunk is None:
+            raise ValueError(
+                f"{type(self).__name__} resumes a prefill but neither exposes "
+                "`get_attn_sdpa_program_config` on its model_args nor declares "
+                "`model_capabilities['resumed_prefill_token_alignment']`, so the "
+                "alignment its chunked-SDPA program requires cannot be determined."
+            )
+        return math.lcm(block_size, int(q_chunk))
 
     def _align_resume_offsets(self, num_cached_per_user, prompt_lens, kv_cache):
         """Floor each resume offset to what the paged ops and the traced SDPA need.
@@ -1489,14 +1523,22 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         aligned = []
         for i, (num_cached, seq_len) in enumerate(zip(num_cached_per_user, prompt_lens)):
             floored = (int(num_cached) // block_size) * block_size
-            # The pinned q_chunk_size depends on the padded length, which depends on
-            # the offset. Flooring further only lengthens the remaining span, and
-            # the pinned value never decreases with length, so one re-floor settles
-            # it.
-            q_chunk = self._traced_sdpa_q_chunk_size(get_padded_prefill_len(int(seq_len) - floored))
-            if q_chunk and q_chunk > block_size:
-                alignment = math.lcm(block_size, int(q_chunk))
-                floored = (int(num_cached) // alignment) * alignment
+            # The alignment depends on the padded suffix length, which depends on
+            # the offset, so it has to settle: flooring lengthens the suffix, a
+            # longer suffix can pin a larger q_chunk_size, and that can demand a
+            # smaller offset again. Both are monotonic and the q_chunk_size set is
+            # finite, so this terminates; the bound is a guard, not an expectation.
+            for _ in range(len(get_all_padded_prefill_lengths(int(seq_len))) + 1):
+                alignment = self._resume_offset_alignment(get_padded_prefill_len(int(seq_len) - floored), block_size)
+                settled = (int(num_cached) // alignment) * alignment
+                if settled == floored:
+                    break
+                floored = settled
+            else:
+                raise RuntimeError(
+                    f"user {i}: resume offset alignment did not settle for "
+                    f"start_pos={num_cached}, seq_len={seq_len}, block_size={block_size}"
+                )
             if floored != num_cached:
                 logger.debug(f"Resume offset alignment: user {i} start_pos {num_cached} -> {floored}")
             aligned.append(floored)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -173,9 +173,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self._defer_trace_recording = False
         self._pending_decode_trace = None
 
-    # Class-level capabilities (VLLM specific, to be overridden by subclasses)
+    # Class-level capabilities (VLLM specific, to be overridden by subclasses).
+    # A subclass dict replaces this one rather than merging into it, so a default
+    # of True would be claimed by every subclass that declares nothing at all.
     model_capabilities = {
-        "supports_prefix_caching": True,
+        "supports_prefix_caching": False,
     }
 
     def _any_trace_captured(self):
@@ -275,7 +277,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         for model_id in range(self.data_parallel):
             model_args = self.model_args[model_id]
             for prefill_seq_len in model_args.trace_prefill_supported_seq_lens:
-                if not model_args.can_enable_trace(prefill_seq_len):
+                # A nonzero probe: ``can_enable_trace`` reads this argument only to
+                # test it against zero, and a model that refuses a resumed prefill
+                # refuses it for every offset. The declaration alone is not enough,
+                # because the model args can reject what the capability allows.
+                if not model_args.can_enable_trace(prefill_seq_len, 1):
                     continue
                 # The offset a real request will be floored to for this length, so
                 # the captured program config is the one those replays need.

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -280,15 +280,20 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # The offset a real request will be floored to for this length, so
                 # the captured program config is the one those replays need.
                 num_cached = self._resume_offset_alignment(prefill_seq_len, block_size, model_id)
-                # The prompt spans the bucket rather than the bucket plus the
-                # offset: adding to it would exceed max_seq_len for the largest
-                # bucket, skipping the trace a real request of that length uses.
-                # The suffix still pads back to this bucket because the offset is
-                # at most half of it.
-                total_seq_len = prefill_seq_len
-                assert (
-                    get_padded_prefill_len(total_seq_len - num_cached) == prefill_seq_len
-                ), f"warmup suffix {total_seq_len - num_cached} does not pad to bucket {prefill_seq_len}"
+                # Only the suffix after the offset is padded into the bucket, so
+                # the prompt has to clear the offset by a full bucket to land on
+                # this key. ``capped_warmup_seq_len`` is the ceiling the rest of
+                # warmup uses: past it the call would be split into chunks and
+                # capture something else.
+                total_seq_len = min(num_cached + prefill_seq_len, model_args.capped_warmup_seq_len)
+                suffix = total_seq_len - num_cached
+                if suffix <= 0 or get_padded_prefill_len(suffix) != prefill_seq_len:
+                    logger.warning(
+                        f"Skipping resumed prefill warmup for sequence length {prefill_seq_len}: "
+                        f"offset {num_cached} leaves no suffix padding back to it within "
+                        f"{model_args.capped_warmup_seq_len} tokens. Its trace is captured on first use."
+                    )
+                    continue
 
                 num_blocks = num_blocks_in_seq(total_seq_len, block_size)
                 logger.info(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -291,7 +291,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # this key. ``capped_warmup_seq_len`` is the ceiling the rest of
                 # warmup uses: past it the call would be split into chunks and
                 # capture something else.
-                total_seq_len = min(num_cached + prefill_seq_len, model_args.capped_warmup_seq_len)
+                total_seq_len = self._resumed_warmup_prompt_len(
+                    prefill_seq_len, num_cached, model_args.capped_warmup_seq_len
+                )
                 suffix = total_seq_len - num_cached
                 if suffix <= 0 or get_padded_prefill_len(suffix) != prefill_seq_len:
                     logger.warning(
@@ -1510,6 +1512,23 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             )
         return math.lcm(block_size, int(q_chunk))
 
+    def _assert_uniform_resume_alignment(self, prefill_seq_len, block_size, expected):
+        """Replica 0's alignment stands for every replica. Fail if it stops doing so.
+
+        ``create_submeshes`` splits the mesh into submeshes of one shape, and
+        ``initialize_vllm_model`` builds every replica's ``ModelArgs`` from the same
+        arguments, so they all pin the same q_chunk_size. The per-user offsets are
+        therefore aligned once against replica 0 rather than per replica. Nothing in
+        the type system holds that, so check it instead of trusting it.
+        """
+        for model_id in range(1, self.data_parallel):
+            other = self._resume_offset_alignment(prefill_seq_len, block_size, model_id)
+            assert other == expected, (
+                f"replica {model_id} needs resume alignment {other} where replica 0 needs "
+                f"{expected} at padded length {prefill_seq_len}; offsets are aligned once "
+                "against replica 0 and would be wrong for this replica."
+            )
+
     def _align_resume_offsets(self, num_cached_per_user, prompt_lens, kv_cache):
         """Floor each resume offset to what the paged ops and the traced SDPA need.
 
@@ -1543,10 +1562,19 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # The alignment depends on the padded suffix length, which depends on
             # the offset, so it has to settle: flooring lengthens the suffix, a
             # longer suffix can pin a larger q_chunk_size, and that can demand a
-            # smaller offset again. Both are monotonic and the q_chunk_size set is
-            # finite, so this terminates; the bound is a guard, not an expectation.
+            # smaller offset again.
+            #
+            # The bound is exact, not generous. A pass that does not break must
+            # lower the offset, which lengthens the suffix, which moves it to a
+            # strictly higher padded bucket: an equal bucket would give an equal
+            # alignment and the pass would have broken. So the bucket count bounds
+            # the passes. It is a loose ceiling in practice, because
+            # get_attn_sdpa_prefill_program_config pins only 64 or 256 and two
+            # passes always suffice.
             for _ in range(len(get_all_padded_prefill_lengths(int(seq_len))) + 1):
-                alignment = self._resume_offset_alignment(get_padded_prefill_len(int(seq_len) - floored), block_size)
+                padded_suffix = get_padded_prefill_len(int(seq_len) - floored)
+                alignment = self._resume_offset_alignment(padded_suffix, block_size)
+                self._assert_uniform_resume_alignment(padded_suffix, block_size, alignment)
                 settled = (int(num_cached) // alignment) * alignment
                 if settled == floored:
                     break
@@ -1560,6 +1588,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 logger.debug(f"Resume offset alignment: user {i} start_pos {num_cached} -> {floored}")
             aligned.append(floored)
         return aligned
+
+    @staticmethod
+    def _resumed_warmup_prompt_len(prefill_seq_len, num_cached, capped_warmup_seq_len):
+        """Prompt length whose suffix after ``num_cached`` pads back to this bucket.
+
+        Only the suffix reaches the kernel, so the prompt has to clear the offset by
+        a full bucket. Spanning the bucket alone leaves no suffix at all once
+        ``block_size`` reaches the smallest traced length. ``capped_warmup_seq_len``
+        is the ceiling the rest of warmup uses: past it the call is split into chunks
+        and captures a different trace.
+        """
+        return min(num_cached + prefill_seq_len, capped_warmup_seq_len)
 
     def _paged_prefill_block_size(self, kv_cache):
         """Block size for chunked-prefill page-table padding/slicing.

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -308,8 +308,9 @@
   arch: arch-wormhole_b0
   tt-llama-text-ver: tt_transformers
   # Prefix-caching models reserve a traced resumed prefill per traced sequence
-  # length at warmup, which the 50 MB default does not cover (53 MB measured on
-  # T3K).
+  # length at warmup, which the 50 MB default does not cover: 53248000B measured
+  # on this SKU. 85 MB matches the T3K sampling-tests leg above rather than
+  # tracking the measurement, so the headroom absorbs a bucket set growing.
   tt-config: '{"fabric_config": "FABRIC_1D", "trace_region_size": 85000000}'
   multimodal: false
   additional-benchmark-args: "--random-prefix-len 128"
@@ -347,8 +348,11 @@
   mesh-device: P150x8
   arch: arch-blackhole
   tt-llama-text-ver: tt_transformers
-  # See the prefix-caching leg: warmup now reserves a traced resumed prefill per
-  # traced sequence length, above the 50 MB default.
+  # See the prefix-caching leg: warmup reserves a traced resumed prefill per
+  # traced sequence length, above the 50 MB default. Carried over from the T3K
+  # measurement, not measured on Blackhole. Reserving at warmup means a value
+  # that is too small fails at server startup rather than mid-run, so this is
+  # loud if it is wrong.
   tt-config: '{"trace_region_size": 85000000}'
   additional-server-args: "--data_parallel_size 8 --async-scheduling"
   structured-output: true
@@ -367,8 +371,11 @@
   benchmark-timeout: 5
   mesh-device: TG
   arch: arch-wormhole_b0
-  # See the prefix-caching leg: warmup now reserves a traced resumed prefill per
-  # traced sequence length, above the 50 MB default.
+  # See the prefix-caching leg: warmup reserves a traced resumed prefill per
+  # traced sequence length, above the 50 MB default. Carried over from the T3K
+  # measurement, not measured on Galaxy. Reserving at warmup means a value that
+  # is too small fails at server startup rather than mid-run, so this is loud if
+  # it is wrong.
   tt-config: '{"fabric_config": "FABRIC_1D_RING", "sample_on_device_mode": "all", "trace_region_size": 85000000}'
   tt-llama-text-ver: tt_transformers
   additional-server-args: "--data_parallel_size 4 --async-scheduling"

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -307,7 +307,10 @@
   mesh-device: T3K
   arch: arch-wormhole_b0
   tt-llama-text-ver: tt_transformers
-  tt-config: '{"fabric_config": "FABRIC_1D"}'
+  # Prefix-caching models reserve a traced resumed prefill per traced sequence
+  # length at warmup, which the 50 MB default does not cover (53 MB measured on
+  # T3K).
+  tt-config: '{"fabric_config": "FABRIC_1D", "trace_region_size": 85000000}'
   multimodal: false
   additional-benchmark-args: "--random-prefix-len 128"
   additional-server-args: "--async-scheduling"
@@ -344,6 +347,9 @@
   mesh-device: P150x8
   arch: arch-blackhole
   tt-llama-text-ver: tt_transformers
+  # See the prefix-caching leg: warmup now reserves a traced resumed prefill per
+  # traced sequence length, above the 50 MB default.
+  tt-config: '{"trace_region_size": 85000000}'
   additional-server-args: "--data_parallel_size 8 --async-scheduling"
   structured-output: true
   sampling-tests: true
@@ -361,7 +367,9 @@
   benchmark-timeout: 5
   mesh-device: TG
   arch: arch-wormhole_b0
-  tt-config: '{"fabric_config": "FABRIC_1D_RING", "sample_on_device_mode": "all"}'
+  # See the prefix-caching leg: warmup now reserves a traced resumed prefill per
+  # traced sequence length, above the 50 MB default.
+  tt-config: '{"fabric_config": "FABRIC_1D_RING", "sample_on_device_mode": "all", "trace_region_size": 85000000}'
   tt-llama-text-ver: tt_transformers
   additional-server-args: "--data_parallel_size 4 --async-scheduling"
   structured-output: true


### PR DESCRIPTION
Fixes a silent wrong-answer bug in traced prefill with automatic prefix caching,
and stops the traces it needs from being allocated behind the operator's back.

Independent of, and a prerequisite for,
[tenstorrent/tt-metal#54302](https://github.com/tenstorrent/tt-metal/pull/54302)
(chunked prefill), which makes the same code path far busier.

## The bug

`tenstorrent/tt-metal#43165` made resumed prefill traceable by passing
`chunk_start_idx` to `ttnn.transformer.chunked_scaled_dot_product_attention` as a
`ttnn.Tensor` that is refreshed on every replay. The captured program config
therefore cannot be derived from the offset, so
`models/tt_transformers/tt/attention.py` builds it with `chunk_start_idx=0`:

| padded length of the resumed span | `q_chunk_size` the traced program is pinned to |
|---|---|
| `< 2048` | 64 |
| `>= 2048` | 256 |

`ttnn.transformer.chunked_scaled_dot_product_attention` requires
`chunk_start_idx` to be a multiple of the `q_chunk_size` its program was built
with. It reads the wrong prefix rather than raising when it is not.

Automatic prefix caching hands `Generator.prefill_forward_text` a `start_pos`
that is a multiple of the paged KV `block_size` (64), which need not be a
multiple of 256. So a cache hit whose remaining span reaches 2048 tokens can land
on an offset the captured program cannot honour, and the request answers from the
wrong prefix.

A full-prompt repeat never hits it, because the remaining span is tiny and the
pin is 64. It needs a partial prefix overlap followed by enough new tokens.

## Measurement

T3K, `meta-llama/Llama-3.1-8B-Instruct`, tracing on, automatic prefix caching on.
Two prompts share a prefix carrying a passphrase, then diverge for ~2300 tokens so
the second request's resumed padded length is 4096. Sweeping the shared prefix
length across every residue mod 256:

| | recall |
|---|---|
| before | **13/40** |
| after | **40/40** |

Failures are the shared prefix being read back as unrelated text, never an error.

## Changes

`models/tt_transformers/tt/generator.py`:

- `_align_resume_offsets` floors each `num_cached_tokens` to
  `math.lcm(block_size, q_chunk_size)`, iterating until the offset stops
  changing. It has to iterate: flooring lengthens the suffix, a longer suffix can
  pin a larger `q_chunk_size`, and that can demand a smaller offset again. With
  `block_size` 32, `seq_len` 1120 and `start_pos` 100 a single pass settles on 64
  against a pin of 256. Flooring recomputes at most `alignment - 1` tokens whose
  K/V is rewritten identically into the same blocks, so it is semantically a
  no-op.
- `_resume_offset_alignment` takes the pin from the model's own
  `get_attn_sdpa_program_config`, so a short cache hit on a short suffix keeps its
  64-token alignment and is not rounded away. A model whose `model_args` exposes
  no such method must declare
  `model_capabilities['resumed_prefill_token_alignment']`; the generator raises
  rather than fall back to block-only alignment, which is the wrong-prefix bug
  itself. `Gemma4ModelArgs` is that case, so both Gemma 4 generator classes
  declare `SDPA_CHUNK_ALIGN`, the same 128 that `align_num_cached_tokens_to_sdpa`
  already applies locally.
- `_warmup_prefill_resumed_sweep` captures the resumed ("sp1") prefill traces at
  warmup, batch 1, one per traced sequence length, at the offset a real request
  will be floored to. The warmup prompt is the offset plus a full bucket, capped
  at `capped_warmup_seq_len`, so the suffix padded into the bucket is the bucket
  itself. Spanning only the bucket leaves no suffix at all once `block_size`
  reaches the smallest traced length of 128. Gated on the model declaring
  `supports_prefix_caching` or `supports_chunked_prefill`.

Both mirror `models/demos/llama3_70b_galaxy/tt/generator.py`, which has paired a
`SDPA_CHUNK_ALIGN` round-down with a phase-2 resumed-prefill warmup since
`tenstorrent/tt-metal#35904`. `models/tt_transformers` took the tracing half of
that design without either.

## Why the warmup matters

`Generator.warmup_model_prefill` never passed a `start_pos`, so it only ever
captured the `sp0` half of the prefill trace key
`f"{prefill_seq_len}_{model_id}_{batch_size}_{use_start_pos}"`. Every `sp1` key
was captured lazily by whichever request happened to resume first, allocating
trace region at serving time that nothing had sized for. That is how a server
gets a fatal `TT_FATAL @ mesh_trace.cpp:82 ... only 50000000B is allocated for
trace region` mid-benchmark rather than at startup.

Reserving them makes the requirement a function of configuration instead of
traffic. Measured on T3K with `Llama-3.1-8B-Instruct`: 53248000B, against the
50000000B default. The three `Llama-3.1-8B-Instruct` legs still on that default
(`(prefix caching) [wh_llmbox]`, `with sampling-tests [bh_loudbox]`,
`DP=4 [wh_galaxy_perf]`) get an explicit `trace_region_size` of 85000000, the
value the sibling `with sampling-tests [wh_llmbox]` leg already uses.

Models that declare neither `supports_prefix_caching` nor
`supports_chunked_prefill` capture nothing extra at warmup, so their trace region
is unchanged. That covers Gemma 3, GPT-OSS, Mistral 3, Mllama and the Qwen VL
bridges, including the ones on a 28467200-byte region. Gemma 4 overrides
`warmup_model_prefill` in both its generator classes and is not reached.

The gate decides what to reserve, not what can happen. A model reaches
`_align_resume_offsets` on any nonzero `start_pos`, whatever it declares, which is
why the alignment has to be derivable or declared for every model that can resume
and not only for the ones warmed here.

Gemma 4 is the case in point. The plugin surfaces a chunked-prefill continuation as
a nonzero `start_pos`
([`model_runner.py:1159`](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/src/vllm_tt_plugin/model_runner.py#L1159):
`input_positions = num_computed_tokens_cpu[req_indices]`), and the Gemma 4 legs run
`enable_chunked_prefill=True` with `max_num_batched_tokens=2496`. Any prompt past
that budget resumes at an offset that is not a multiple of 128, through the
fall-through `super().prefill_forward_text(..., start_pos=start_pos)` in
`models/demos/gemma4/tt/generator.py`. Its declaration is load-bearing, not
defensive hardening.

## Validation

https://github.com/tenstorrent/tt-metal/actions/runs/33065341377

Default `block_size` 64:

- Partial-prefix-hit sweep, 40 shared-prefix lengths: 13/40 before, 40/40 after.
- Whole-prompt repeat at 2000/3000/4000/6000 words, cold and cached: 8/8 before
  and after (this shape was never broken; included to show no regression).
- Warmup reserves exactly 5 resumed traces, at `num_cached` 64 for the 128 and
  1024 buckets and 256 for 2048, 4096 and 8192, matching the pinned
  `q_chunk_size` per length.
- With the 50000000B default the server now fails at startup rather than
  mid-serving, which is the intended consequence of reserving the traces.

`--block_size 128`, where the resume offset `lcm(block_size, q_chunk_size)`
reaches the smallest traced bucket and the warmup prompt has to clear it:

| | prompt spanning the bucket | prompt of offset plus a bucket |
|---|---|---|
| 128 bucket | `AssertionError: user 0: num_cached=128 must be < seq_len=128` | warms at `num_cached` 128 |
| server | `EngineCore failed to start` | `Application startup complete` |
| resumed traces reserved | 0 | 5, at `num_cached` 128/128/256/256/256 |
| partial-prefix-hit sweep | never ran | 40/40 |

## Known gap

Prefill warmup prepares each trace variant while earlier traces are already live,
against the invariant `_prepare_trace_prefill` documents. The existing sp0 sweep
already does this, so it is pre-existing rather than introduced here, and fixing
it changes behaviour beyond this PR. Tracked in
https://github.com/tenstorrent/tt-metal/issues/54441.

No CI leg runs a non-default `block_size`, so the `--block_size 128` results above
come from manual runs. Because the resumed traces are reserved at warmup, a
regression there fails at server startup rather than silently, so it stays loud.

The 53248000B measurement is T3K only. `bh_loudbox` and `wh_galaxy_perf` take the
same 85000000 without their own measurement. Because the traces are now reserved
at warmup, an undersized region fails at startup rather than mid-serving, so a
wrong value is loud.

## AI assistance

Written with AI assistance (Claude). Every line is to be reviewed and defended by
the human submitter.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/traced-apc-alignment-and-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/traced-apc-alignment-and-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/traced-apc-alignment-and-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/traced-apc-alignment-and-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/traced-apc-alignment-and-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/traced-apc-alignment-and-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/traced-apc-alignment-and-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/traced-apc-alignment-and-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/traced-apc-alignment-and-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/traced-apc-alignment-and-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/traced-apc-alignment-and-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/traced-apc-alignment-and-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/traced-apc-alignment-and-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/traced-apc-alignment-and-warmup)


