### PR TITLE
[Bug fix] pow_bw: the gradient of a negative base is n*x^(n-1), not +inf

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -260,17 +260,36 @@ std::vector<std::optional<Tensor>> pow_bw(
         return grad_tensor;
     }
 
-    Tensor power_input = ttnn::pow(input, std::fabs(exponent - 1.0f), output_mem_config);
+    // d/dx x^n = n * x^(n-1). ttnn::pow evaluates exp(y * log(x)), which is NaN
+    // for x < 0 even when the true power is well defined, so compute the
+    // magnitude on |x| and carry the sign explicitly: for an integral exponent,
+    // x^(n-1) = |x|^(n-1-odd) * x^odd (the |x| power is even, hence exact), and
+    // for a non-integral exponent the gradient at x < 0 is NaN (as in torch),
+    // never +inf. x = 0 needs no special case: |0|^(n-1) already gives the
+    // correct 0 / 1 / inf for n > 1 / n == 1 / n < 1.
+    const float exp_m1 = exponent - 1.0f;
+    const bool integral_exponent = std::nearbyint(exponent) == exponent;
+    const bool odd_power = integral_exponent && std::fmod(std::fabs(exp_m1), 2.0f) == 1.0f;
+    Tensor abs_input = ttnn::abs(input, output_mem_config);
+    Tensor power_input =
+        ttnn::pow(abs_input, odd_power ? std::fabs(exp_m1) - 1.0f : std::fabs(exp_m1), output_mem_config);
+    abs_input.deallocate();
+    if (odd_power) {
+        power_input = ttnn::multiply(power_input, input, std::nullopt, output_mem_config);
+    }
     if (exponent < 1.0f) {
         power_input = ttnn::reciprocal(power_input, output_mem_config);
     }
 
     Tensor result = ttnn::multiply(power_input, exponent, std::nullopt, output_mem_config);
     power_input.deallocate();
-    Tensor final_result = ttnn::multiply(result, grad, std::nullopt, output_mem_config);
+    if (integral_exponent) {
+        ttnn::multiply(result, grad, std::nullopt, output_mem_config, input_grad);
+    } else {
+        Tensor final_result = ttnn::multiply(result, grad, std::nullopt, output_mem_config);
+        where(ttnn::ltz(input), std::nanf(""), final_result, output_mem_config, input_grad);
+    }
     result.deallocate();
-    // Handle negative inputs by returning infinity
-    where(ttnn::lez(input), std::numeric_limits<float>::infinity(), final_result, output_mem_config, input_grad);
     grad_tensor.emplace_back(input_grad);
     return grad_tensor;
 }


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #54439.

`d/dx x^n = n * x^(n-1)`, which is finite for every finite base. `pow_bw` returned `+inf` for **every** negative base instead. The old code formed the power as `exp((n-1) * log(x))`, `log` of a negative is NaN, and a `where(lez(input), +inf, ...)` painted over the NaN — so the guard was not handling an edge case, it was hiding the fact that the formulation could not evaluate half its domain.

The magnitude now comes from `|x|` with the `|x|` power kept even, and the sign from `x` itself when `n-1` is odd. A non-integral exponent gives NaN at `x < 0`, as torch does. `x = 0` falls out with no special case.

## Accuracy

Every one of the 65536 bfloat16 patterns as the base, `grad = 1`, classified against `torch.autograd` in float64. **N300 at `141fbea49c5` and P300 at `04cf22f7ee`.**

Negative bases returning `+inf` — the defect:

| exponent | negative bases | base | this branch |
|---|---|---|---|
| 2.0 | 32639 | **32639** | **128** |
| 3.0 | 32639 | **32639** | **8300** |
| 1.0 | 32639 | **32639** | **0** |

**The survivors are true overflow, not the defect.** `n * x^(n-1)` leaves bfloat16's range at `3.39e38`: at `e = 3, x = -1e30` torch gives `3e60`, so `inf` is the correct answer. At `e = 1` the gradient is the constant 1 and nothing can overflow, which is why that row reaches zero.

Exact agreement with torch over the same sweep, N300:

| exponent | base | this branch |
|---|---|---|
| 2.0 | 32384 / 65280 | **64770 / 65280** |
| 3.0 | 632 / 65280 | 1266 / 65280 |
| 1.0 | 32639 / 65280 | **65280 / 65280** |

Spot values, both machines: `pow_bw(-2, 2) = -4.0` (was `+inf`), `pow_bw(-2, 3) = 12.0`, `pow_bw(-2, 1) = 1.0`, `pow_bw(2, 2) = 4.0` unchanged. float32 boundary set at `e = 2`: `-1 -> -2.0` exact, `-normal_min -> -2 * 2^-126` exact, `-max_finite -> -inf` (true overflow), `±0 -> 0`.

**No positive base moves**, at any exponent, on either machine. P300's classification counted 0 words where the base build was closer to torch than this branch, at every exponent measured.

## Cost

| | | base | this branch |
|---|---|---|---|
| dispatches, `e = 2` | | 5 | 5 |
| dispatches, `e = 3` | | 5 | 4 |
| dispatches, `e = 2.5` | | 5 | 6 |
| wall clock, 1 tile bfloat16, P300 | | 95.1 us | 91.9 us |

The parity multiply replaces the `lez` and `where` pair, so the common integral case is a wash on dispatch count and slightly faster in wall clock. An even `n-1` needs no sign fix at all, which is where `e = 3` saves one. A non-integral exponent pays one more for the `ltz` and the NaN `where` that torch's semantics require.

## Tests

`test_pow_bw_negative_base.py`: the three integral exponents against `torch.autograd` over a negative, a positive and a zero base in both dtypes, plus the non-integral case asserted to be non-finite at a negative base. The negative-base cases fail on the base commit with `+inf`.

## Not covered

- **NaN bases.** They stay on the usual bfloat16 NaN-to-inf collapse in both builds; 255 words classify as "neither" on that account. A bfloat16 DST cannot carry a NaN, so this is not reachable from here.
- **The `e = 2.5` row.** Non-integral exponents give NaN at a negative base, which bfloat16 reports as `inf`. Correct in float32, unrepresentable in bfloat16, unchanged by this PR.
- **`bfloat8_b` and the sharded paths.**
- The wall clock and the dispatch counts are P300. The accuracy sweep is both machines.
