### PR TITLE
ci: fix reduce helper sanity failures

### DIFF
--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -247,7 +247,7 @@
   owner_id: U085GDCAZTN # Pavle Josipovic
 
 - name: "ttnn reduce group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/kernel_lib/reduce -xv -m "not disable_fast_runtime_mode"'
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce -xv -m "not disable_fast_runtime_mode"'
   skus:
     wh_n300_civ2:
       timeout: 40

--- a/tests/ttnn/unit_tests/kernel_lib/reduce/test_reduce_helpers.py
+++ b/tests/ttnn/unit_tests/kernel_lib/reduce/test_reduce_helpers.py
@@ -377,7 +377,8 @@ def _compute_config(case: ReduceCase) -> ttnn.ComputeConfigDescriptor:
         dst_full_sync_en=False,
     )
     if case.input_dtype == "fp32" and case.fp32_mode == "Accurate":
-        unpack_modes = [ttnn.UnpackToDestMode.Default] * 32
+        # Host descriptors use the maximum CB count so this vector covers both Wormhole (32) and Blackhole (64).
+        unpack_modes = [ttnn.UnpackToDestMode.Default] * 64
         unpack_modes[CB_INPUT] = ttnn.UnpackToDestMode.UnpackToDestFp32
         if case.calls > 1:
             unpack_modes[CB_ACCUMULATOR] = ttnn.UnpackToDestMode.UnpackToDestFp32


### PR DESCRIPTION
• ## Summary

  - Size the FP32 unpack-mode table for the 64-CB host maximum, fixing Blackhole reduce-helper failures while remaining compatible with Wormhole.
  - Remove duplicate reduce-helper execution from the TTNN reduce group; the suite remains covered by the LLK helper group.

  ## Testing

  WH/BH sanity passed ([https://github.com/tenstorrent/tt-metal/actions/runs/32962980365](https://github.com/tenstorrent/tt-metal/actions/runs/32962980365)) with 41 successful jobs and no failures.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=malimpic/fix_sanity_failiures)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:malimpic/fix_sanity_failiures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=malimpic/fix_sanity_failiures)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:malimpic/fix_sanity_failiures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=malimpic/fix_sanity_failiures)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:malimpic/fix_sanity_failiures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=malimpic/fix_sanity_failiures)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:malimpic/fix_sanity_failiures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=malimpic/fix_sanity_failiures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:malimpic/fix_sanity_failiures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=malimpic/fix_sanity_failiures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:malimpic/fix_sanity_failiures)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=malimpic/fix_sanity_failiures)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:malimpic/fix_sanity_failiures)