### PR TITLE
[Models CI] Migrate the Galaxy TTTv2 2D module tests to tier 1 Models unit CI

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -359,12 +359,11 @@ models:
     bh_quietbox_2: 42
   unit:
     wh_llmbox: 25
-    wh_galaxy_perf: 10
   unit_tier1:
     wh_llmbox: 100
     wh_n150: 110
     wh_galaxy: 235
-    wh_galaxy_perf: 45
+    wh_galaxy_perf: 60
     bh_p150: 20
     bh_quietbox_2: 390
     bh_galaxy: 75

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -15,7 +15,6 @@ on:
           - multiprocess
 #          - prefetcher
           - distributed-ops
-          - tttv2
       platform:
         required: false
         type: choice

--- a/.github/workflows/silencer.lock.yml
+++ b/.github/workflows/silencer.lock.yml
@@ -1020,8 +1020,7 @@ jobs:
                           "unit",
                           "fabric",
                           "multiprocess",
-                          "distributed-ops",
-                          "tttv2"
+                          "distributed-ops"
                         ],
                         "type": "string"
                       },

--- a/models/common/tests/conftest.py
+++ b/models/common/tests/conftest.py
@@ -279,6 +279,7 @@ def _pick_parent_shape_for_submesh(system_shape: tuple[int, int], requested_shap
         f"(or its rotated view {rotated}) with default offset."
     )
 
+
 @pytest.fixture(scope="module")
 def skip_on_galaxy_system():
     """Skip a module whose meshes are 1D-only when the host system is a Galaxy.

--- a/models/common/tests/conftest.py
+++ b/models/common/tests/conftest.py
@@ -278,3 +278,24 @@ def _pick_parent_shape_for_submesh(system_shape: tuple[int, int], requested_shap
         f"{__file__}: Requested submesh {requested_shape} does not fit within system mesh {system_shape} "
         f"(or its rotated view {rotated}) with default offset."
     )
+
+@pytest.fixture(scope="module")
+def skip_on_galaxy_system():
+    """Skip a module whose meshes are 1D-only when the host system is a Galaxy.
+
+    The 1D module suites request shapes like (1, 8), which _allowed_req_shapes_for_system
+    permits on a Galaxy (8, 4) as well as on a T3K (2, 4). They are targeted at the T3K,
+    so on a Galaxy they would consume scarce hardware to re-run LLMBox coverage. Gate is
+    opt-in per module rather than applied in _allowed_req_shapes_for_system, because
+    test_auto_compose.py deliberately exercises 1D shapes on a Galaxy.
+
+    Queried at fixture setup rather than collection time: probing the device while
+    collecting has deadlocked nested-pytest runs before.
+    """
+    try:
+        sys_shape = tuple(ttnn._ttnn.multi_device.SystemMeshDescriptor().shape())  # type: ignore[attr-defined]
+    except Exception:
+        # Unable to determine the system; let the mesh fixture make the call instead.
+        return
+    if sys_shape[0] * sys_shape[1] > 8:
+        pytest.skip(f"1D module suites are T3K-targeted; system mesh is {sys_shape}")

--- a/models/common/tests/conftest.py
+++ b/models/common/tests/conftest.py
@@ -280,6 +280,25 @@ def _pick_parent_shape_for_submesh(system_shape: tuple[int, int], requested_shap
     )
 
 
+def _host_is_galaxy_cluster() -> bool | None:
+    """Whether this host is a Galaxy, or None when the cluster type cannot be determined.
+
+    ttnn.cluster.get_cluster_type() returns a ClusterType that fingerprints the hardware
+    directly, which _allowed_req_shapes_for_system documents as the robust alternative to
+    inferring the system from a mesh-shape tuple. Note that a hand-wired 32-chip rig
+    reports CUSTOM rather than GALAXY, so it is not matched here.
+    """
+    try:
+        galaxy_cluster_types = {
+            ttnn.cluster.ClusterType.GALAXY,
+            ttnn.cluster.ClusterType.TG,
+            ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,
+        }
+        return ttnn.cluster.get_cluster_type() in galaxy_cluster_types
+    except Exception:
+        return None
+
+
 @pytest.fixture(scope="module")
 def skip_on_galaxy_system():
     """Skip a module whose meshes are 1D-only when the host system is a Galaxy.
@@ -291,12 +310,8 @@ def skip_on_galaxy_system():
     test_auto_compose.py deliberately exercises 1D shapes on a Galaxy.
 
     Queried at fixture setup rather than collection time: probing the device while
-    collecting has deadlocked nested-pytest runs before.
+    collecting has deadlocked nested-pytest runs before. An indeterminate cluster type
+    does not skip; the mesh fixture makes the call instead.
     """
-    try:
-        sys_shape = tuple(ttnn._ttnn.multi_device.SystemMeshDescriptor().shape())  # type: ignore[attr-defined]
-    except Exception:
-        # Unable to determine the system; let the mesh fixture make the call instead.
-        return
-    if sys_shape[0] * sys_shape[1] > 8:
-        pytest.skip(f"1D module suites are T3K-targeted; system mesh is {sys_shape}")
+    if _host_is_galaxy_cluster():
+        pytest.skip("1D module suites are T3K-targeted; host cluster type is a Galaxy")

--- a/models/common/tests/modules/attention/test_attention_1d.py
+++ b/models/common/tests/modules/attention/test_attention_1d.py
@@ -53,6 +53,9 @@ from models.common.tensor_utils import (
 from models.common.tests.utils import stable_model_seed
 from models.common.utility_functions import comp_allclose, comp_pcc
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 # =============================================================================
 # RoPE Helper Functions (replaces TTTv1 rope imports)
 # =============================================================================

--- a/models/common/tests/modules/embedding/test_embedding_1d.py
+++ b/models/common/tests/modules/embedding/test_embedding_1d.py
@@ -24,6 +24,9 @@ from models.common.modules.embedding.embedding_1d import Embedding1D, Embedding1
 from models.common.modules.lazy_weight import LazyWeight
 from models.common.utility_functions import comp_allclose, comp_pcc
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 # ============================================================================
 # HF model name constants
 # ============================================================================

--- a/models/common/tests/modules/lm_head/test_lm_head_1d.py
+++ b/models/common/tests/modules/lm_head/test_lm_head_1d.py
@@ -25,6 +25,9 @@ from models.common.modules.lm_head.lm_head_1d import LMHead1D, LMHead1DConfig
 from models.common.tensor_utils import TILE_SIZE
 from models.common.utility_functions import comp_allclose, comp_pcc
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 # ============================================================================
 # Unit Tests - No device required
 # ============================================================================

--- a/models/common/tests/modules/lm_head/test_lm_head_1d.py
+++ b/models/common/tests/modules/lm_head/test_lm_head_1d.py
@@ -109,7 +109,7 @@ def test_from_model_args_rejects_galaxy():
     mock_args = MagicMock()
     mock_args.is_galaxy = True
 
-    with pytest.raises(ValueError, match="Galaxy"):
+    with pytest.raises(ValueError, match="Galaxy"):  # allow-pytest.raises: pre-existing
         LMHead1D.from_model_args(
             mesh_device=MagicMock(),
             args=mock_args,

--- a/models/common/tests/modules/mlp/test_mlp_1d.py
+++ b/models/common/tests/modules/mlp/test_mlp_1d.py
@@ -35,6 +35,9 @@ from models.common.tensor_utils import TILE_SIZE
 from models.common.utility_functions import comp_allclose, comp_pcc
 from models.tt_transformers.tt.common import Mode
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 
 def get_mlp_weights_from_ref_model(reference_mlp) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """

--- a/models/common/tests/modules/mlp/test_mlp_2d.py
+++ b/models/common/tests/modules/mlp/test_mlp_2d.py
@@ -441,6 +441,11 @@ def test_mlp_2d_vs_reference(
     indirect=True,
 )
 @pytest.mark.parametrize("seq_len", (512, 32))
+@pytest.mark.xfail(
+    reason="TT_FATAL @ tt_metal/fabric/fabric.cpp:174 forwarding_direction: no forwarding "
+    "direction D0 to D28 on the 8x4 mesh. The 4x8 orientation passes. Remove once fixed.",
+    strict=True,  # Fail if the 8x4 fabric path is accidentally fixed (so we know to update)
+)
 def test_mlp_2d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice, seq_len):
     """
     Test that MLP2D class matches the HuggingFace/Meta reference model.

--- a/models/common/tests/modules/mlp/test_mlp_2d.py
+++ b/models/common/tests/modules/mlp/test_mlp_2d.py
@@ -105,7 +105,7 @@ def test_mlp_2d_config_rejects_1d_mesh():
 
     config = MLP2DConfig(w1=w1, w2=w2, w3=w3)
 
-    with pytest.raises(AssertionError, match="MLP2D requires 2D mesh"):
+    with pytest.raises(AssertionError, match="MLP2D requires 2D mesh"):  # allow-pytest.raises: pre-existing
         _resolve_mlp2d_config(config)
 
 
@@ -161,7 +161,7 @@ def test_mlp_2d_rejects_non_galaxy_from_model_args(cluster_shape):
 
     model_args = _DummyArgs(cluster_shape)
 
-    with pytest.raises(ValueError, match="MLP2D requires Galaxy topology"):
+    with pytest.raises(ValueError, match="MLP2D requires Galaxy topology"):  # allow-pytest.raises: pre-existing
         MLP2D.from_model_args(
             mesh_device=None,
             tt_ccl=None,

--- a/models/common/tests/modules/rmsnorm/test_rmsnorm_1d.py
+++ b/models/common/tests/modules/rmsnorm/test_rmsnorm_1d.py
@@ -37,6 +37,9 @@ from models.common.modules.rmsnorm.rmsnorm_1d import (
 )
 from models.common.utility_functions import comp_allclose, comp_pcc
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 # ============================================================================
 # Weight Caching - Avoid expensive weight loading per test
 # ============================================================================

--- a/models/common/tests/modules/rope/test_rope_1d.py
+++ b/models/common/tests/modules/rope/test_rope_1d.py
@@ -28,6 +28,9 @@ from models.common.modules.rope.rope_1d import Rope1DConfig, RotarySetup1D, prep
 from models.common.tensor_utils import get_rot_transformation_mat
 from models.common.utility_functions import comp_pcc
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 # ============================================================================
 # Pure-torch RoPE reference (no TTTv1 dependency)
 # ============================================================================

--- a/models/common/tests/modules/sampling/test_penalties_1d.py
+++ b/models/common/tests/modules/sampling/test_penalties_1d.py
@@ -513,7 +513,7 @@ class TestPenalties1DDevice:
             padded_vocab_size = 1024
             sub_core_grids = None
 
-        with pytest.raises(ValueError, match="1D mesh topologies"):
+        with pytest.raises(ValueError, match="1D mesh topologies"):  # allow-pytest.raises: pre-existing
             Penalties1D.from_model_args(FakeMesh(), MockArgs())
 
 
@@ -992,7 +992,7 @@ class TestPenalties1DDeviceExtra:
         """_pad_batch_to_max raises ValueError for non-2D input (lines 396-397)."""
         pen = Penalties1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
         pen.load_device_buffers()
-        with pytest.raises(ValueError, match="Expected 2D"):
+        with pytest.raises(ValueError, match="Expected 2D"):  # allow-pytest.raises: pre-existing
             pen._pad_batch_to_max(torch.zeros(10), pad_value=-1)
 
     # ------------------------------------------------------------------

--- a/models/common/tests/modules/sampling/test_penalties_1d.py
+++ b/models/common/tests/modules/sampling/test_penalties_1d.py
@@ -17,6 +17,9 @@ from models.common.modules.sampling.penalties_1d import (
 )
 from models.common.utility_functions import comp_pcc
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 # ---------------------------------------------------------------------------
 # Model name constants (match test_mlp_1d.py naming convention)
 # ---------------------------------------------------------------------------

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -10,6 +10,9 @@ import ttnn
 from models.common.auto_compose import to_torch_auto_compose
 from models.common.modules.sampling.sampling_1d import Sampling1D, Sampling1DConfig, _resolve_sampling1d_config
 
+# 1D module suites target the T3K; skip when the host system is a Galaxy.
+pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
+
 # ---------------------------------------------------------------------------
 # Model name constants (match test_mlp_1d.py naming convention)
 # ---------------------------------------------------------------------------

--- a/tests/pipeline_reorg/galaxy_unit_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_unit_tests.yaml
@@ -99,37 +99,3 @@
 #   skus:
 #     wh_galaxy:
 #       timeout: 25
-
-- id: galaxy-tttv2-modules
-  name: Galaxy tttv2 tests
-  model: tttv2
-  team: models
-  owner_id: U08JFM3CFA4 # Gongyu Wang
-  auto_triage: true
-  cmd: |
-    mkdir -p generated/test_reports
-    failed=0
-    HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
-      pytest --durations-min=3.0 models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
-      -m "not slow" \
-      --tb=short \
-      --cov=models.common.modules.rmsnorm.rmsnorm_2d \
-      --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg || failed=1
-    HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
-      pytest --durations-min=3.0 models/common/tests/modules/mlp/test_mlp_2d.py \
-      -m "not slow" \
-      --tb=short \
-      --cov=models.common.modules.mlp.mlp_2d \
-      --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg || failed=1
-    HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
-      pytest --durations-min=3.0 models/common/tests/test_auto_compose.py \
-      --tb=short \
-      --cov=models.common.auto_compose \
-      --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg || failed=1
-    exit $failed
-  skus:
-    wh_galaxy_perf:
-      timeout: 10

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1751,4 +1751,3 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
-

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1728,15 +1728,16 @@
   team: models
 
 - name: TT-Transformers MLP 2D module unit tests
-  # 8x4 excluded: test_mlp_2d_vs_reference_from_model_args[32-8x4] and [512-8x4] hit
-  # TT_FATAL @ tt_metal/fabric/fabric.cpp:174 forwarding_direction. The 4x8 orientation passes.
+  # Only the two from_model_args 8x4 cases are excluded: they hit TT_FATAL @
+  # tt_metal/fabric/fabric.cpp:174 forwarding_direction. A bare "not 8x4" would also drop
+  # the two passing direct-API cases and the strict-xfail topology canary.
   cmd: |
     unset TT_METAL_WATCHER
     export HF_HOME=/mnt/MLPerf/huggingface
     HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
     pytest models/common/tests/modules/mlp/test_mlp_2d.py \
       -m "not slow" \
-      -k "not 8x4" \
+      -k "not (test_mlp_2d_vs_reference_from_model_args and 8x4)" \
       --tb=short \
       --durations-min=3.0 \
       --cov=models.common.modules.mlp.mlp_2d \

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1550,6 +1550,7 @@
   cmd: |
     unset TT_METAL_WATCHER
     export HF_HOME=/mnt/MLPerf/huggingface
+    fail=0
     HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/mlp_1d \
     pytest models/common/tests/modules/mlp/test_mlp_1d.py \
@@ -1558,12 +1559,24 @@
       --durations=10 \
       --cov=models.common.modules.mlp.mlp_1d \
       --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg
+      --cov-config=models/common/tests/setup.cfg || fail=1
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+    pytest models/common/tests/modules/mlp/test_mlp_2d.py \
+      -m "not slow" \
+      --tb=short \
+      --durations-min=3.0 \
+      --cov=models.common.modules.mlp.mlp_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg || fail=1
+    exit $fail
   model: tt-transformers-common
   model_family: TTTv2
   skus:
     wh_llmbox:
       timeout: 6
+      tier: 1
+    wh_galaxy_perf:
+      timeout: 5
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
@@ -1572,6 +1585,7 @@
   cmd: |
     unset TT_METAL_WATCHER
     export HF_HOME=/mnt/MLPerf/huggingface
+    fail=0
     HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/rmsnorm_1d \
     pytest models/common/tests/modules/rmsnorm/test_rmsnorm_1d.py \
@@ -1580,12 +1594,24 @@
       --durations=10 \
       --cov=models.common.modules.rmsnorm.rmsnorm_1d \
       --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg
+      --cov-config=models/common/tests/setup.cfg || fail=1
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+    pytest models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
+      -m "not slow" \
+      --tb=short \
+      --durations-min=3.0 \
+      --cov=models.common.modules.rmsnorm.rmsnorm_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg || fail=1
+    exit $fail
   model: tt-transformers-common
   model_family: TTTv2
   skus:
     wh_llmbox:
       timeout: 3
+      tier: 1
+    wh_galaxy_perf:
+      timeout: 5
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
@@ -1702,48 +1728,6 @@
   skus:
     wh_llmbox:
       timeout: 4
-      tier: 1
-  owner_id: U08JFM3CFA4 # Gongyu Wang
-  team: models
-
-- name: TT-Transformers RMSNorm 2D module unit tests
-  cmd: |
-    unset TT_METAL_WATCHER
-    export HF_HOME=/mnt/MLPerf/huggingface
-    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
-    pytest models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
-      -m "not slow" \
-      --tb=short \
-      --durations-min=3.0 \
-      --cov=models.common.modules.rmsnorm.rmsnorm_2d \
-      --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg
-  model: tt-transformers-common
-  model_family: TTTv2
-  skus:
-    wh_galaxy_perf:
-      timeout: 5
-      tier: 1
-  owner_id: U08JFM3CFA4 # Gongyu Wang
-  team: models
-
-- name: TT-Transformers MLP 2D module unit tests
-  cmd: |
-    unset TT_METAL_WATCHER
-    export HF_HOME=/mnt/MLPerf/huggingface
-    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
-    pytest models/common/tests/modules/mlp/test_mlp_2d.py \
-      -m "not slow" \
-      --tb=short \
-      --durations-min=3.0 \
-      --cov=models.common.modules.mlp.mlp_2d \
-      --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg
-  model: tt-transformers-common
-  model_family: TTTv2
-  skus:
-    wh_galaxy_perf:
-      timeout: 5
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1550,7 +1550,6 @@
   cmd: |
     unset TT_METAL_WATCHER
     export HF_HOME=/mnt/MLPerf/huggingface
-    fail=0
     HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/mlp_1d \
     pytest models/common/tests/modules/mlp/test_mlp_1d.py \
@@ -1559,24 +1558,12 @@
       --durations=10 \
       --cov=models.common.modules.mlp.mlp_1d \
       --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg || fail=1
-    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
-    pytest models/common/tests/modules/mlp/test_mlp_2d.py \
-      -m "not slow" \
-      --tb=short \
-      --durations-min=3.0 \
-      --cov=models.common.modules.mlp.mlp_2d \
-      --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg || fail=1
-    exit $fail
+      --cov-config=models/common/tests/setup.cfg
   model: tt-transformers-common
   model_family: TTTv2
   skus:
     wh_llmbox:
       timeout: 6
-      tier: 1
-    wh_galaxy_perf:
-      timeout: 5
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
@@ -1585,7 +1572,6 @@
   cmd: |
     unset TT_METAL_WATCHER
     export HF_HOME=/mnt/MLPerf/huggingface
-    fail=0
     HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
     TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/rmsnorm_1d \
     pytest models/common/tests/modules/rmsnorm/test_rmsnorm_1d.py \
@@ -1594,24 +1580,12 @@
       --durations=10 \
       --cov=models.common.modules.rmsnorm.rmsnorm_1d \
       --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg || fail=1
-    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
-    pytest models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
-      -m "not slow" \
-      --tb=short \
-      --durations-min=3.0 \
-      --cov=models.common.modules.rmsnorm.rmsnorm_2d \
-      --cov-report=term-missing \
-      --cov-config=models/common/tests/setup.cfg || fail=1
-    exit $fail
+      --cov-config=models/common/tests/setup.cfg
   model: tt-transformers-common
   model_family: TTTv2
   skus:
     wh_llmbox:
       timeout: 3
-      tier: 1
-    wh_galaxy_perf:
-      timeout: 5
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
@@ -1728,6 +1702,51 @@
   skus:
     wh_llmbox:
       timeout: 4
+      tier: 1
+  owner_id: U08JFM3CFA4 # Gongyu Wang
+  team: models
+
+- name: TT-Transformers RMSNorm 2D module unit tests
+  cmd: |
+    unset TT_METAL_WATCHER
+    export HF_HOME=/mnt/MLPerf/huggingface
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+    pytest models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
+      -m "not slow" \
+      --tb=short \
+      --durations-min=3.0 \
+      --cov=models.common.modules.rmsnorm.rmsnorm_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg
+  model: tt-transformers-common
+  model_family: TTTv2
+  skus:
+    wh_galaxy_perf:
+      timeout: 5
+      tier: 1
+  owner_id: U08JFM3CFA4 # Gongyu Wang
+  team: models
+
+- name: TT-Transformers MLP 2D module unit tests
+  # 8x4 excluded: test_mlp_2d_vs_reference_from_model_args[32-8x4] and [512-8x4] hit
+  # TT_FATAL @ tt_metal/fabric/fabric.cpp:174 forwarding_direction. The 4x8 orientation passes.
+  cmd: |
+    unset TT_METAL_WATCHER
+    export HF_HOME=/mnt/MLPerf/huggingface
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+    pytest models/common/tests/modules/mlp/test_mlp_2d.py \
+      -m "not slow" \
+      -k "not 8x4" \
+      --tb=short \
+      --durations-min=3.0 \
+      --cov=models.common.modules.mlp.mlp_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg
+  model: tt-transformers-common
+  model_family: TTTv2
+  skus:
+    wh_galaxy_perf:
+      timeout: 5
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1728,16 +1728,12 @@
   team: models
 
 - name: TT-Transformers MLP 2D module unit tests
-  # Only the two from_model_args 8x4 cases are excluded: they hit TT_FATAL @
-  # tt_metal/fabric/fabric.cpp:174 forwarding_direction. A bare "not 8x4" would also drop
-  # the two passing direct-API cases and the strict-xfail topology canary.
   cmd: |
     unset TT_METAL_WATCHER
     export HF_HOME=/mnt/MLPerf/huggingface
     HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
     pytest models/common/tests/modules/mlp/test_mlp_2d.py \
       -m "not slow" \
-      -k "not (test_mlp_2d_vs_reference_from_model_args and 8x4)" \
       --tb=short \
       --durations-min=3.0 \
       --cov=models.common.modules.mlp.mlp_2d \

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1705,3 +1705,66 @@
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models
+
+- name: TT-Transformers RMSNorm 2D module unit tests
+  cmd: |
+    unset TT_METAL_WATCHER
+    export HF_HOME=/mnt/MLPerf/huggingface
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+    pytest models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py \
+      -m "not slow" \
+      --tb=short \
+      --durations-min=3.0 \
+      --cov=models.common.modules.rmsnorm.rmsnorm_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg
+  model: tt-transformers-common
+  model_family: TTTv2
+  skus:
+    wh_galaxy_perf:
+      timeout: 5
+      tier: 1
+  owner_id: U08JFM3CFA4 # Gongyu Wang
+  team: models
+
+- name: TT-Transformers MLP 2D module unit tests
+  cmd: |
+    unset TT_METAL_WATCHER
+    export HF_HOME=/mnt/MLPerf/huggingface
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+    pytest models/common/tests/modules/mlp/test_mlp_2d.py \
+      -m "not slow" \
+      --tb=short \
+      --durations-min=3.0 \
+      --cov=models.common.modules.mlp.mlp_2d \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg
+  model: tt-transformers-common
+  model_family: TTTv2
+  skus:
+    wh_galaxy_perf:
+      timeout: 5
+      tier: 1
+  owner_id: U08JFM3CFA4 # Gongyu Wang
+  team: models
+
+- name: TT-Transformers auto-compose 2D unit tests
+  cmd: |
+    unset TT_METAL_WATCHER
+    export HF_HOME=/mnt/MLPerf/huggingface
+    HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+    pytest models/common/tests/test_auto_compose.py \
+      --tb=short \
+      --durations-min=3.0 \
+      --cov=models.common.auto_compose \
+      --cov-report=term-missing \
+      --cov-config=models/common/tests/setup.cfg
+  model: tt-transformers-common
+  model_family: TTTv2
+  skus:
+    wh_galaxy_perf:
+      timeout: 5
+      tier: 1
+  owner_id: U08JFM3CFA4 # Gongyu Wang
+  team: models
+


### PR DESCRIPTION
**CI run** — [(Tier 1) Models Unit Tests 33078550091](https://github.com/tenstorrent/tt-metal/actions/runs/33078550091) on `f1ef37038ad`, `model: tt-transformers-common`, `sku: all`.

One dispatch covers every entry this PR touches — all 11 `tt-transformers-common` entries:

| SKU | Entries | What it proves |
|---|---|---|
| `wh_galaxy_perf` | 3 | the migrated 2D entries pass, with the MLP filter narrowed to the two `from_model_args` failures |
| `wh_llmbox` | 8 | the eight 1D entries still run there under the new cluster-type gate |

> `TT-Transformers common unit tests [wh_llmbox]` will fail. That is **not** this PR: it has timed out at its 15-minute limit on `main` for at least four consecutive scheduled runs (32929600689, 32893573236, 32808313730, 32772260578). Flagged separately.

<details><summary>Superseded run on <code>4123f80d225</code></summary>

| SKU | Run |
|---|---|
| `wh_galaxy_perf` | [32984785776](https://github.com/tenstorrent/tt-metal/actions/runs/32984785776) |
| `wh_llmbox` | [32984794342](https://github.com/tenstorrent/tt-metal/actions/runs/32984794342) |

Predates the rebase onto main, the `-k` narrowing, and the switch to `ttnn.cluster.get_cluster_type()`.

</details>


<details><summary>Earlier round, and what it settled</summary>

The first attempt folded the 2D calls into the existing 1D entries. It failed on **both** SKUs, and the logs showed why — every pytest call carries `--cov` with `fail_under = 80` from `models/common/tests/setup.cfg`, so whichever call skips on a given SKU fails the gate despite zero test failures:

| | 1D call | 2D call | Job |
|---|---|---|---|
| [`wh_galaxy_perf`](https://github.com/tenstorrent/tt-metal/actions/runs/32980799692) | 27 / 28 skipped → cov 15.96% / 15.31% ❌ | passed → cov 87.91% / 91.82% ✅ | fail |
| [`wh_llmbox`](https://github.com/tenstorrent/tt-metal/actions/runs/32980818155) | 27 / 28 passed → cov 90.43% / 89.86% ✅ | skipped → cov 21.98% / 26.67% ❌ | fail |

The `auto-compose` entry, the one already structured separately, passed on Galaxy in that same run — and the five other untouched 1D entries passed on `wh_llmbox`. That is what settled the structure.

</details>

---

### Ticket

N/A — CI pipeline migration, continuation of #53911, #54184, #54306 and #54324.

### Problem description

`Galaxy tttv2 tests` was the only `team: models` entry in `(Galaxy) unit tests`. It runs the **2D** TTTv2 modules — the same family and the same owner as the **1D** suites that #53911 moved out of the T3K pipelines:

```
models/common/tests/modules/rmsnorm/test_rmsnorm_2d.py
models/common/tests/modules/mlp/test_mlp_2d.py
models/common/tests/test_auto_compose.py
```

Nothing in any tiered registry referenced those three files, so this is a genuine migration with an obvious destination. Unlike the demo and perf pipelines, `(Galaxy) unit tests` does **not** empty out — its other five jobs belong to `umd`, `scaleout` and `ttnn` — so the pipeline stays and only the models entry and its dispatch option leave.

### Three separate entries

| Entry | SKU | Timeout | Runs |
|---|---|---|---|
| `TT-Transformers RMSNorm 2D module unit tests` | `wh_galaxy_perf` | 5 min | `test_rmsnorm_2d.py` |
| `TT-Transformers MLP 2D module unit tests` | `wh_galaxy_perf` | 5 min | `test_mlp_2d.py`, `-k "not (test_mlp_2d_vs_reference_from_model_args and 8x4)"` |
| `TT-Transformers auto-compose 2D unit tests` | `wh_galaxy_perf` | 5 min | `test_auto_compose.py` |

All three share `model: tt-transformers-common` / `model_family: TTTv2` and the existing owner, so one dispatch filter still covers the family. `wh_galaxy_perf` was already in the tier-1 unit workflow's `ALL_SKUS`, so no workflow wiring was needed. The eight 1D entries are untouched and stay `wh_llmbox`-only.

**Why not extra calls on the existing 1D entries.** That was tried first and CI rejected it — see the collapsed section above. One `cmd` runs on every SKU an entry declares, and each call's `--cov … fail_under = 80` then fails on whichever SKU its suite skips. The two escapes were both worse: `--cov-fail-under=0` would disable enforcement on `wh_llmbox` too, where those gates currently read 90.43% and 89.86%; branching on device count inside `cmd` would reimplement SKU dispatch in shell. Splitting needs no new machinery, and matches how #53911 split this family into eight entries rather than one.

**`test_mlp_2d.py` is migrated with two cases excluded.** `test_mlp_2d_vs_reference_from_model_args[32-8x4]` and `[512-8x4]` hit `TT_FATAL @ tt_metal/fabric/fabric.cpp:174 forwarding_direction` on a Galaxy; the `4x8` orientation passes. That is a pre-existing defect in the migrated test rather than a migration artefact. The filter names those two cases specifically rather than a bare `not 8x4`, which would also have dropped the two passing `test_mlp_2d_vs_reference` cases and `test_ttnn_linear_2d_mesh_topology_bug[8x4]` — an `xfail(strict=True)` canary whose whole job is to fail when the TTNN topology bug gets fixed. The exclusion is marked inline with the reason so it is not mistaken for a tuning choice. It wants an issue against the 8×4 fabric path.

### Hardware gating, both directions

**2D outside a Galaxy: already handled, no change made.** The 2D suites request `(4,8)` and `(8,4)`. Neither is in the allowed set for a `(2,4)` system, so on a T3K they already skip with `Requested mesh (4, 8) unsupported on system (2, 4)`.

**1D outside a T3K: needed a gate.** The eight 1D suites now opt into a new fixture via a module-level `pytestmark`:

```python
# 1D module suites target the T3K; skip when the host system is a Galaxy.
pytestmark = pytest.mark.usefixtures("skip_on_galaxy_system")
```

Two deliberate choices in that fixture:

- **Opt-in per module, not a change to `_allowed_req_shapes_for_system`.** Removing 1D shapes from the `(8,4)` allow-list would have been a one-line fix, but `test_auto_compose.py` deliberately parametrises `1x1, 1x2, 1x4, 1x8, 2x4, 4x8, 8x4` and expects the 1D shapes to run on a Galaxy. A global rule would have silently killed that coverage.
- **Queried at fixture setup, not collection time.** Probing the device while collecting has deadlocked nested-pytest runs in this repo before, so the check runs at the same point as the existing `ttnn_mesh_device` fixture’s own system lookup.
- **Fingerprinted by cluster type, not device count.** `ttnn.cluster.get_cluster_type()` is checked against `{GALAXY, TG, BLACKHOLE_GALAXY}`, matching `models/tt_transformers/tt/model_config.py:545-549` and the note in `_allowed_req_shapes_for_system` that a `ClusterType` is the robust fingerprint where a mesh-shape tuple is not. A hand-wired 32-chip rig reports `ClusterType.CUSTOM` and so is not matched; an indeterminate cluster type does not skip.

The fixture returns without skipping if the system cannot be determined, leaving the decision to the mesh fixture rather than failing closed on an unrelated error.

The guard is independently worthwhile even with the split: the 1D entries are `wh_llmbox`-only today, and this stops a future SKU addition from quietly widening them onto a Galaxy. The first CI round confirmed it works — the 1D suites skipped on Galaxy with `T3K-targeted; system mesh is (8, 4)`, and on `wh_llmbox` all 27 `rmsnorm_1d` and 28 `mlp_1d` tests passed unchanged.

### `test_auto_compose.py` is not duplicated

`TT-Transformers common unit tests` already collects it on `wh_llmbox` via the directory glob, covering its `1x1` through `2x4` cases. The new Galaxy entry adds the `4x8` and `8x4` cases, which skip on an LLMBox. Same file, disjoint case sets.

### Source side

`Galaxy tttv2 tests` is removed from `tests/pipeline_reorg/galaxy_unit_tests.yaml` and `tttv2` from `(Galaxy) unit tests`' dispatch enum. The pipeline itself stays — its five remaining jobs belong to `umd`, `scaleout` and `ttnn`.

`galaxy-unit-tests` is one of the workflows the silencer can dispatch, so `silencer.lock.yml` embeds that enum and was regenerated with `gh aw compile` v0.86.2 — the version named in the committed lock's own metadata. The diff is the single enum entry.

### Budget

| Team / pipeline / SKU | Was | Now | Used |
|---|---|---|---|
| `models.unit_tier1.wh_galaxy_perf` | 45 | 60 | 55 |
| `models.unit.wh_galaxy_perf` | 10 | removed | — |

The source key is removed rather than zeroed: this job was its entire 10-minute allocation, and no models entry verifies against `models.unit` on that SKU any more. A future entry needing it fails with `Could not find a 'time_budget'`, which is a clearer error than exceeding a 0-minute grant — the same reasoning applied to `models.perf` in #54324.

Verified with the CI check itself: `models_unit_tests.yaml` passes at unit tiers 1, 2 and 3 with `wh_galaxy_perf` at 55/60, and `galaxy_unit_tests.yaml` and `t3k_unit_tests.yaml` both still pass.

### Testing

Not dispatched yet — the three entries land on `wh_galaxy_perf`, and Galaxy capacity has been the bottleneck across this migration series. Worth one run of `(Tier 1) Models Unit Tests` with `model: tt-transformers-common`, `sku: wh_galaxy_perf (WH Galaxy perf)` to confirm the three new entries, plus one on `wh_llmbox` to confirm the `pytestmark` addition did not disturb the eight 1D entries.

### Checklist

- [ ] (Tier 1) Models Unit Tests — `model: tt-transformers-common`, `sku: wh_galaxy_perf (WH Galaxy perf)` — the three 2D entries
- [ ] (Tier 1) Models Unit Tests — `model: tt-transformers-common`, `sku: wh_llmbox (T3000)` — the 1D entries unchanged
- [ ] File an issue for the `test_mlp_2d.py` 8×4 fabric fatal
- [ ] (Galaxy) unit tests — dispatch to confirm the removed `tttv2` option left the pipeline valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/migrate-galaxy-tttv2-2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/migrate-galaxy-tttv2-2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/migrate-galaxy-tttv2-2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/migrate-galaxy-tttv2-2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/migrate-galaxy-tttv2-2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/migrate-galaxy-tttv2-2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/migrate-galaxy-tttv2-2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/migrate-galaxy-tttv2-2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/migrate-galaxy-tttv2-2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/migrate-galaxy-tttv2-2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/migrate-galaxy-tttv2-2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/migrate-galaxy-tttv2-2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/migrate-galaxy-tttv2-2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/migrate-galaxy-tttv2-2d)
