### PR TITLE
Set explicit `O3` opt on Metal 2.0 ported compute kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_program_factory.cpp
@@ -164,7 +164,7 @@ ttnn::device_operation::ProgramArtifacts TypecastProgramFactory::create_program_
         return KernelSpec{
             .unique_id = id,
             .source = kComputeSource,
-            .compiler_options = {.defines = typecast_defines},
+            .compiler_options = {.defines = typecast_defines, .opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings =
                 {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
                  DFBBinding{
@@ -327,7 +327,8 @@ ttnn::device_operation::ProgramArtifacts TypecastSubgridProgramFactory::create_p
     const KernelSpec compute{
         .unique_id = COMPUTE,
         .source = kComputeSource,
-        .compiler_options = {.defines = make_typecast_defines(input_dtype, output_dtype)},
+        .compiler_options =
+            {.defines = make_typecast_defines(input_dtype, output_dtype), .opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
              DFBBinding{.dfb_spec_name = OUT_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}},

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -224,7 +224,7 @@ ttnn::device_operation::ProgramArtifacts TypecastRowMajorChunkedProgramFactory::
         return KernelSpec{
             .unique_id = id,
             .source = path,
-            .compiler_options = {.defines = unary_defines},
+            .compiler_options = {.defines = unary_defines, .opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings =
                 {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
                  DFBBinding{

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_sharded_program_factory.cpp
@@ -194,7 +194,7 @@ ttnn::device_operation::ProgramArtifacts TypecastShardedProgramFactory::create_p
     const KernelSpec compute{
         .unique_id = COMPUTE,
         .source = "ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp",
-        .compiler_options = {.defines = std::move(unary_defines)},
+        .compiler_options = {.defines = std::move(unary_defines), .opt_level = KernelBuildOptLevel::O3},
         // The output DFB has no other toucher — no writer kernel drains it, the borrowed output
         // buffer *is* the result — so compute binds it as both PRODUCER and CONSUMER (self-loop).
         .dfb_bindings =

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_program_factory.cpp
@@ -214,6 +214,7 @@ ttnn::device_operation::ProgramArtifacts CloneProgramFactory::create_program_art
             return KernelSpec{
                 .unique_id = unique_id,
                 .source = "ttnn/cpp/ttnn/operations/data_movement/clone/device/kernels/compute_kernel.cpp",
+                .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
                 .dfb_bindings =
                     {DFBBinding{
                          .dfb_spec_name = SRC, .accessor_name = "src", .endpoint_type = DFBEndpointType::CONSUMER},

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/rotary_embedding_indexed/device/rotary_embedding_indexed_device_operation.cpp
@@ -472,7 +472,7 @@ RotaryEmbeddingIndexedDeviceOperation::MeshWorkloadFactory::create_at(
     KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = kComputeSource,
-        .compiler_options = {.defines = reload_define},
+        .compiler_options = {.defines = reload_define, .opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {DFBBinding{
                  .dfb_spec_name = INPUT_DFB, .accessor_name = "input", .endpoint_type = DFBEndpointType::CONSUMER},

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/device/intimg_program_factory.cpp
@@ -158,6 +158,7 @@ ttnn::device_operation::ProgramArtifacts IntImgDeviceOperation::ProgramFactory::
     m2::KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = std::filesystem::path(KERNEL_PATHS[1]),
+        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {m2::DFBBinding{
                  .dfb_spec_name = START, .accessor_name = "start", .endpoint_type = m2::DFBEndpointType::CONSUMER},

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_prefill_sharded_program_factory.cpp
@@ -273,7 +273,7 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCorePrefillSha
     KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = kComputeSource,
-        .compiler_options = {.defines = reload_define},
+        .compiler_options = {.defines = reload_define, .opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {DFBBinding{
                  .dfb_spec_name = INPUT_DFB, .accessor_name = "input", .endpoint_type = DFBEndpointType::CONSUMER},

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_multi_core_program_factory.cpp
@@ -228,7 +228,7 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCore::create_p
     KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = kComputeSource,
-        .compiler_options = {.defines = reload_define},
+        .compiler_options = {.defines = reload_define, .opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {DFBBinding{
                  .dfb_spec_name = INPUT_DFB, .accessor_name = "input", .endpoint_type = DFBEndpointType::CONSUMER},

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_sharded_program_factory.cpp
@@ -161,6 +161,7 @@ ttnn::device_operation::ProgramArtifacts RotaryEmbeddingLlamaMultiCoreSharded::c
     KernelSpec compute_spec{
         .unique_id = COMPUTE,
         .source = kComputeShardedSource,
+        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings = compute_bindings,
         .compile_time_args = {{"Wt", head_dim_t}, {"Ht", n_heads_t}},
         .hw_config = compute_hw_config};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/device/moreh_abs_pow_program_factory.cpp
@@ -199,6 +199,7 @@ ttnn::device_operation::ProgramArtifacts MorehAbsPowOperation::MorehAbsPowProgra
     m2::KernelSpec compute{
         .unique_id = COMPUTE,
         .source = COMPUTE_KERNEL_PATH,
+        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {
                 m2::DFBBinding{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/device/moreh_dot_program_factory.cpp
@@ -124,7 +124,9 @@ ttnn::device_operation::ProgramArtifacts MorehDotOperation::ProgramFactory::crea
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source = COMPUTE_KERNEL_PATH,
-        .compiler_options = {.defines = {{"REDUCE_OP", "PoolType::SUM"}, {"REDUCE_DIM", "ReduceDim::REDUCE_ROW"}}},
+        .compiler_options =
+            {.defines = {{"REDUCE_OP", "PoolType::SUM"}, {"REDUCE_DIM", "ReduceDim::REDUCE_ROW"}},
+             .opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {
                 DFBBinding{.dfb_spec_name = IN0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::CONSUMER},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/moreh_dot_backward_program_factory.cpp
@@ -143,6 +143,7 @@ ttnn::device_operation::ProgramArtifacts MorehDotBackwardOperation::ProgramFacto
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source = COMPUTE_KERNEL_PATH,
+        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {
                 DFBBinding{.dfb_spec_name = IN0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::CONSUMER},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_program_factory.cpp
@@ -493,7 +493,7 @@ ttnn::device_operation::ProgramArtifacts MorehMatmulOperation::MultiCoreProgramF
         return KernelSpec{
             .unique_id = id,
             .source = compute_kernel_file,
-            .compiler_options = {.defines = compute_defines},
+            .compiler_options = {.defines = compute_defines, .opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings = compute_dfb_bindings,
             .compile_time_args = compute_args,
             // output_stride[8]

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/device/moreh_mean_backward_program_factory.cpp
@@ -220,7 +220,7 @@ MorehMeanBackwardOperation::MorehMeanBackwardProgramFactory::create_program_arti
         return KernelSpec{
             .unique_id = unique_id,
             .source = std::filesystem::path{COMPUTE_KERNEL_PATH},
-            .compiler_options = {.defines = compute_defines},
+            .compiler_options = {.defines = compute_defines, .opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings =
                 {DFBBinding{.dfb_spec_name = IN_DFB, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
                  DFBBinding{

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/device/moreh_norm_backward_program_factory.cpp
@@ -317,7 +317,7 @@ ProgramArtifacts MorehNormBackwardOperation::MorehNormBackwardProgramFactory::cr
         return m2::KernelSpec{
             .unique_id = id,
             .source = std::filesystem::path(COMPUTE_KERNEL_PATH),
-            .compiler_options = {.defines = compute_defines},
+            .compiler_options = {.defines = compute_defines, .opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings = compute_dfb_bindings(),
             .compile_time_args =
                 {{"num_output_tiles", num_cols_per_core_group},

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/device/moreh_sum_backward_program_factory.cpp
@@ -247,7 +247,7 @@ ttnn::device_operation::ProgramArtifacts MorehSumBackwardOperation::ProgramFacto
         return KernelSpec{
             .unique_id = id,
             .source = COMPUTE_KERNEL_PATH,
-            .compiler_options = {.defines = compute_defines},
+            .compiler_options = {.defines = compute_defines, .opt_level = KernelBuildOptLevel::O3},
             .dfb_bindings =
                 {DFBBinding{.dfb_spec_name = C0_IN, .accessor_name = "in0", .endpoint_type = DFBEndpointType::CONSUMER},
                  DFBBinding{


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #54450

Legacy `ComputeConfig` defaults compute kernels to **O3**, while Metal 2.0 `KernelSpec::CompilerOptions` defaults to **O2** for both DM and compute kernels. Several already-merged Metal 2.0 ports omitted an explicit `opt_level`, so their compute kernels were compiling at a lower optimization level than the legacy path.

This PR adds `.opt_level = KernelBuildOptLevel::O3` to compute `KernelSpec`s in 15 ported program factories (excluding `experimental/quasar/`):

- `copy/typecast` (3 factories)
- `data_movement/clone`
- `experimental/reduction/integral_image`
- `experimental/transformer/rotary_embedding_llama` (3 factories)
- `moreh/moreh_abs_pow`, `moreh_dot`, `moreh_dot_backward`, `moreh_matmul`, `moreh_mean_backward`, `moreh_norm_backward`, `moreh_sum_backward`

DM kernels are unchanged.

### Notes for reviewers
Mechanical one-liner (or two-liner) changes per compute `KernelSpec`. No functional logic changes beyond restoring the legacy compile optimization level.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/54450/metal2-fix-left-out-compute-O3-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/54450/metal2-fix-left-out-compute-O3-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/54450/metal2-fix-left-out-compute-O3-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/54450/metal2-fix-left-out-compute-O3-opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/54450/metal2-fix-left-out-compute-O3-opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/54450/metal2-fix-left-out-compute-O3-opt)