### PR TITLE
[Models CI] Migrate the Galaxy Wan2.2 integration tests to tier 1 Models unit CI

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -358,7 +358,7 @@ models:
     bh_p300: 8
     bh_quietbox_2: 42
   unit_tier1:
-    wh_llmbox: 140
+    wh_llmbox: 150
     wh_n150: 110
     wh_galaxy: 240
     wh_galaxy_perf: 60

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -360,7 +360,7 @@ models:
   unit_tier1:
     wh_llmbox: 140
     wh_n150: 110
-    wh_galaxy: 275
+    wh_galaxy: 240
     wh_galaxy_perf: 60
     bh_p150: 20
     bh_quietbox_2: 390

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -360,7 +360,7 @@ models:
   unit_tier1:
     wh_llmbox: 140
     wh_n150: 110
-    wh_galaxy: 235
+    wh_galaxy: 275
     wh_galaxy_perf: 60
     bh_p150: 20
     bh_quietbox_2: 390

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -393,7 +393,6 @@ models:
     bh_p300: 20
     bh_quietbox_2: 80
   demo:
-    wh_galaxy_perf: 125
     bh_galaxy: 470
     bh_sc1: 488
     bh_sc1_high_power: 166

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -41,7 +41,6 @@ on:
           - all
           - deepseek_decode
           - deepseek_unit_tests
-          - wan22
 
   schedule:
     # Run daily at 1 AM UTC
@@ -100,18 +99,3 @@ jobs:
       model: deepseek_unit_tests
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
       job-prefix: "[DeepSeek Unit Tests] "
-
-  wan22-tests:
-    name: "Wan 2.2 Tests"
-    needs: [build-artifact]
-    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'wan22' || github.event_name == 'schedule' }}
-    secrets: inherit
-    uses: ./.github/workflows/demo-sp-release-impl.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: wh_galaxy_perf
-      model: wan22
-      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
-      job-prefix: "[Wan2.2] "

--- a/.github/workflows/galaxy-integration-tests.yaml
+++ b/.github/workflows/galaxy-integration-tests.yaml
@@ -11,7 +11,6 @@ on:
         options:
           - all
           - unit
-          - wan22
       platform:
         required: false
         type: choice

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -47,7 +47,6 @@ on:
           - all
           - llama3
           - unit
-          - wan22
         default: "disabled"
       galaxy-e2e:
         description: "Galaxy e2e tests: all, one suite (see tests/pipeline_reorg/galaxy_e2e_tests.yaml ids), or disabled"

--- a/.github/workflows/silencer.lock.yml
+++ b/.github/workflows/silencer.lock.yml
@@ -1145,8 +1145,7 @@ jobs:
                         "description": "Select model to test",
                         "enum": [
                           "all",
-                          "unit",
-                          "wan22"
+                          "unit"
                         ],
                         "type": "string"
                       },

--- a/.github/workflows/silencer.lock.yml
+++ b/.github/workflows/silencer.lock.yml
@@ -1667,7 +1667,6 @@ jobs:
                         "description": "Select model to test",
                         "enum": [
                           "all",
-                          "dits",
                           "tttv2 modules",
                           "qwen3_vl"
                         ],
@@ -1838,6 +1837,7 @@ jobs:
                           "gemma-4-26b-a4b",
                           "gemma-4-31b",
                           "dit-common",
+                          "dit-encoders",
                           "wan-2.2-t2v",
                           "wan-2.2-i2v",
                           "llama3.3-70b-galaxy",

--- a/.github/workflows/test-command.lock.yml
+++ b/.github/workflows/test-command.lock.yml
@@ -953,8 +953,7 @@ jobs:
                           "unit",
                           "fabric",
                           "multiprocess",
-                          "distributed-ops",
-                          "tttv2"
+                          "distributed-ops"
                         ],
                         "type": "string"
                       },
@@ -1399,7 +1398,6 @@ jobs:
                         "description": "Select model to test",
                         "enum": [
                           "all",
-                          "dits",
                           "tttv2 modules",
                           "qwen3_vl"
                         ],
@@ -1697,6 +1695,7 @@ jobs:
                           "gemma-4-26b-a4b",
                           "gemma-4-31b",
                           "dit-common",
+                          "dit-encoders",
                           "wan-2.2-t2v",
                           "wan-2.2-i2v",
                           "llama3.3-70b-galaxy",

--- a/.github/workflows/test-command.lock.yml
+++ b/.github/workflows/test-command.lock.yml
@@ -1004,8 +1004,7 @@ jobs:
                         "description": "Select model to test",
                         "enum": [
                           "all",
-                          "unit",
-                          "wan22"
+                          "unit"
                         ],
                         "type": "string"
                       },

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -156,32 +156,3 @@
       timeout: 15
   owner_id: U03PUAKE719 # Miguel Tairum
   team: models
-
-# ============================================================================
-# Wan 2.2 Tests (Galaxy)
-# ============================================================================
-
-- name: Galaxy Wan2.2 demo tests
-  cmd: |
-    export TT_DIT_CACHE_DIR=/tmp/TT_DIT_CACHE NO_PROMPT=1 VBENCH_CACHE_DIR=/mnt/MLPerf/vbench TORCH_HOME=/mnt/MLPerf/vbench/torch_hub
-    pytest models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py -k "wh_4x8sp1tp0 and resolution_720p" --timeout 1500
-  model: wan22
-  skus:
-    wh_galaxy_perf:
-      timeout: 20
-  owner_id: U06UEFWB4P9
-  team: models
-
-- name: Galaxy DiT Wan2.2 model perf tests
-  cmd: |
-    export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-    pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "wh_4x8sp1tp0 and resolution_720p and t2v" --timeout=1200
-  model: wan22
-  skus:
-    wh_galaxy_perf:
-      timeout: 25
-  owner_id: U06UEFWB4P9 # Colman Glagovich
-  team: models
-  arch: wormhole_b0
-  save-perf-data: true
-  model-type: Wan2.2

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -185,12 +185,3 @@
   arch: wormhole_b0
   save-perf-data: true
   model-type: Wan2.2
-
-- name: Galaxy Wan2.2 integration tests
-  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
-  model: wan22
-  skus:
-    wh_galaxy_perf:
-      timeout: 40
-  owner_id: U06UEFWB4P9 # Colman Glagovich
-  team: models

--- a/tests/pipeline_reorg/galaxy_integration_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_integration_tests.yaml
@@ -18,12 +18,3 @@
       timeout: 50
   owner_id: U07D5N7QL4U # Joseph Chu
   team: ttnn
-
-- name: Galaxy Wan2.2 integration tests
-  cmd: ./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
-  model: wan22
-  skus:
-    wh_galaxy:
-      timeout: 40
-  owner_id: U06UEFWB4P9 # Colman Glagovich
-  team: ttnn

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1314,11 +1314,14 @@
     unset TT_METAL_WATCHER  # blocked by #50886
     unset HF_HUB_OFFLINE
     export NO_PROMPT=1 VBENCH_CACHE_DIR=/mnt/MLPerf/vbench TORCH_HOME=/mnt/MLPerf/vbench/torch_hub
+    export TT_DIT_CACHE_DIR=/tmp/TT_DIT_CACHE
     pytest --timeout 1000 models/tt_dit/tests/models/wan2_2/test_rope.py
     pytest --timeout 1000 models/tt_dit/tests/models/wan2_2/test_attention_wan.py
     pytest --maxfail 10 --timeout 10000  models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py -k "not f32 and not 720p and not f81"
     pytest --maxfail 10 --timeout 10000  models/tt_dit/tests/models/wan2_2/test_transformer_wan.py -k "not 720p"
     pytest --maxfail 10 --timeout 10000  models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+    pytest --timeout 1000 models/tt_dit/tests/encoders/umt5/test_umt5.py -k "wh_glx"
+    pytest --timeout 1000 models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding -k "wh_glx"
   model: wan-2.2-t2v
   model_family: Wan
   skus:
@@ -1326,7 +1329,7 @@
     #   timeout: 150
     #   tier: 1
     wh_galaxy:
-      timeout: 150
+      timeout: 190
       tier: 1
     bh_quietbox_2:
       timeout: 105

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1329,7 +1329,7 @@
     #   timeout: 150
     #   tier: 1
     wh_galaxy:
-      timeout: 190
+      timeout: 155
       tier: 1
     bh_quietbox_2:
       timeout: 105

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -9,11 +9,6 @@ run_tg_tests() {
     pytest tests/ttnn/distributed/test_multidevice_TG.py --timeout=900 ; fail+=$?
     pytest tests/ttnn/unit_tests/base_functionality/test_multi_device_trace_TG.py --timeout=900 ; fail+=$?
 
-  elif [[ "$1" == "wan22" ]]; then # Wan2.2 I2V and T2V
-    echo "LOG_METAL: running Wan2.2 run_tg_frequent_tests"
-    export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-    pytest models/tt_dit/tests/encoders/umt5/test_umt5.py -k "wh_glx" ; fail+=$?
-    pytest models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding  -k "wh_glx" ; fail+=$?
 
   else
     echo "LOG_METAL: Unknown model type: $1"


### PR DESCRIPTION
### Ticket

N/A — CI pipeline migration, continuation of #53911, #54184, #54306, #54324 and #54443.

### Problem description

`Galaxy Wan2.2 integration tests` was the only model work in `(Galaxy) integration tests`. Its registry entry says `team: ttnn`, but its owner is the models-side Wan owner and its content is entirely `models/tt_dit`. Like every entry in that pipeline it delegates to a script, so the registry `cmd` tells you nothing:

```
./tests/scripts/tg/run_tg_frequent_tests.sh --model wan22
```

which is, in the script:

```
export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
pytest models/tt_dit/tests/encoders/umt5/test_umt5.py -k "wh_glx"
pytest models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding -k "wh_glx"
```

Two Wan-specific targets, both pinned to the Wormhole Galaxy parametrisation.

### Destination: the existing Wan2.2 unit entry

Both calls join the tier-1 **`TT-DiT Wan2.2-T2V-A14B unit tests`** entry, which already runs on `wh_galaxy`:

| | Before | After |
|---|---|---|
| `wh_galaxy` | 150 min, 5 pytest calls | 190 min, 7 pytest calls |
| `bh_quietbox_2` | 105 min, unchanged | 105 min, unchanged |

On `bh_quietbox_2` both new calls request 32 devices against 4 available and skip, so that leg is unaffected. That entry has **no `--cov` gate**, so the coverage-threshold failure mode from #54443 does not arise here. It already `unset HF_HUB_OFFLINE`, which the UMT5 encoder needs to resolve the Wan2.2 checkpoint; `TT_DIT_CACHE_DIR` is added, which the source job set and this entry did not.

### Why not `dit-common`

That was the obvious-looking host — `test_embeddings.py` lives under `models/tt_dit/tests/unit/`, which `dit-common` sweeps. It does not work:

- `dit-common`'s `cmd` is a bare directory sweep with no `-k`, and one `cmd` applies to every SKU an entry declares. Adding `wh_galaxy` would run all 78 tests across 15 files there.
- The only way to narrow it, `-k wh_glx`, would deselect everything on `wh_n150` and `bh_quietbox_2` and destroy that entry's existing coverage.

Same structural wall as the Wan `-k` problem in #54306 and the `--cov` problem in #54443: an entry's `cmd` cannot vary per SKU.

### Coverage: what this actually moves

Worth being precise, because `dit-common` looks like it already covers half of this and does not.

**`encoders/umt5/test_umt5.py`** — 6 cases (2 test functions × 3 mesh ids):

| Case | Devices | Covered today | In tiered CI |
|---|---|---|---|
| `t3k` | 8 | `t3k_dits_tests` (T3K unit pipeline) | ✗ |
| `wh_glx` | 32 | this job → **migrated here** | ✗ → ✓ |
| `bh_glx` | 32 | nobody | ✗ |

**`test_embeddings.py::test_wan_time_text_image_embedding`** — 3 cases (one shape × 3 mesh ids):

| `dit-common` SKU | Devices | `t3k` (8) | `wh_glx` (32) | `bh_glx` (32) |
|---|---|---|---|---|
| `wh_n150` | 1 | skips | skips | skips |
| `bh_quietbox_2` | 4 | skips | skips | skips |

So `dit-common` sweeps the file but every case of this test skips on both of its SKUs — effective coverage is zero, not partial. `test_embedding` in the same file carries the identical parametrisation and is equally dark there; six other tests in the file use small meshes and do run, so `dit-common` genuinely covers most of the file, just not the two multi-device tests.

**Out of scope by design, as agreed:** UMT5's `t3k` case stays in `t3k_dits_tests` for a later PR, and the `bh_glx` cases of both tests remain uncovered everywhere. This is a migration, not a coverage expansion.

### Source side

The entry is removed from `galaxy_integration_tests.yaml`, the `wan22` branch from `run_tg_frequent_tests.sh`, and the `wan22` option from both the `(Galaxy) integration tests` dispatch enum and the `galaxy-integration` input of `pipeline-select-galaxy.yaml`.

`galaxy-integration-tests` is dispatchable from both agentic workflows, so both generated locks were regenerated with `gh aw compile` v0.86.2, each a single enum line:

```diff
 # silencer.lock.yml and test-command.lock.yml
-                          "unit",
-                          "wan22"
+                          "unit"
```

The `test-command` half was missed in the first pass and caught in review: `/test` would have offered `wan22` and then failed when GitHub rejected the dispatch.

The pipeline itself stays, for its remaining `Galaxy unit/distributed integration tests` job (`team: ttnn`, three ttnn distributed/trace suites).

### Also in scope: retiring the Wan2.2 group from demo-SP release

`run_tg_frequent_tests.sh --model wan22` had a second caller — `demo_sp_release_tests.yaml` — which would have hit the script's `Unknown model type` path and returned 1, breaking a green daily job. Caught in review.

Investigating that turned up more than a dangling caller. All three `wan22` entries in that pipeline were examined; the two that were not the integration entry had **never been running anything**:

| Entry | `-k` filter | Real param id | Status |
|---|---|---|---|
| `Galaxy Wan2.2 demo tests` | `wh_4x8sp1tp0 and resolution_720p` | `4x8sp1tp0nl4_ring_is_fsdp1` | **exit 5** |
| `Galaxy DiT Wan2.2 model perf tests` | `wh_4x8sp1tp0 and resolution_720p and t2v` | `wh_4x8_sp1tp0` | **exit 5** |

A missing underscore, and `-k` is substring matching, so neither matched. Exit code 5 is pytest's "no tests were collected", reproduced on every scheduled run — most recently `33033903449`, where the integration entry was the only one of the three that passed.

Both are already covered in tier 1 e2e (`models_e2e_tests.yaml`, `wh_galaxy_perf`) with working filters, the same timeouts of 1500 and 1200, the same env, plus the 480p case. The one thing that looked like a real loss was `save-perf-data: true` — the only user of that flag in any registry, driving an SFTP benchmark upload. It is not a loss: `models-e2e-tests-impl.yaml:222-241` performs the identical save and upload with the same secrets and batchfile, unconditionally rather than behind a flag. So the working tier entry publishes what the broken one never could.

Removed: both entries, the now-empty `wan22-tests` job and its `workflow_dispatch` option, and `models.demo.wh_galaxy_perf: 125`, which no registry on the `demo` key uses any more (`demo_sp_release` and `blaze_models_prefill` are the only two, and neither touches that SKU).

**Left alone:** `tracy: true` in that workflow's build step, whose comment cites the deleted Wan perf test. No remaining entry has any profiler marker, so it can probably go, but that is a build-config change for a separate PR.

### Budget

| Team / pipeline / SKU | Was | Now | Used |
|---|---|---|---|
| `models.unit_tier1.wh_galaxy` | 235 | 240 | 235 |
| `models.demo.wh_galaxy_perf` | 125 | removed | — |

The Wan unit entry goes 150 → 155. The source job was granted 40 minutes for these two tests, which is what the first revision copied; the run below measured them at **1m22s** (68.37s + 13.55s), so +5 is the measured number rather than the inherited one.

`ttnn.integration.wh_galaxy` is left at 100 with 50 now used; that stanza still serves the remaining ttnn job.

Verified with the CI check itself: `models_unit_tests.yaml` passes at unit tiers 1–3, and `demo_sp_release_tests.yaml` and `blaze_models_prefill_tests.yaml` both still pass on the `demo` key after the budget line was dropped.

### Note on the `team` field

The source entry was labelled `team: ttnn` while being models work. That matters because `team` decides which budget stanza `verify_time_budget.py` charges and who gets paged on failure. Migrating it into a `team: models` entry resolves the mislabel as a side effect rather than needing a separate relabel step.

### Testing

Both legs dispatched and passing.

**`wh_galaxy`** — [run 32988247164](https://github.com/tenstorrent/tt-metal/actions/runs/32988247164), job `98241457937`, success in 2h10m. The two migrated calls are the final two pytest summaries:

```
2 passed, 4 deselected in 68.37s   <- test_umt5.py -k "wh_glx"
1 passed, 2 deselected in 13.55s   <- test_embeddings.py::test_wan_time_text_image_embedding -k "wh_glx"
```

Selected params confirmed as `test_umt5_embeddings[...-wh_glx-...]` and `test_umt5_encoder[...-wh_glx-...]`. The `-k` filter is load-bearing rather than cosmetic: `wh_glx` and `bh_glx` are both `(4, 8)` and differ only in `num_links` (4 vs 2), so without it the `bh_glx` variant would also run on a WH Galaxy.

**`bh_quietbox_2`** — [run 32988263807](https://github.com/tenstorrent/tt-metal/actions/runs/32988263807), job `98243255997`, success:

```
2 skipped, 4 deselected in 2.04s
1 skipped, 2 deselected in 1.87s
SKIPPED test_umt5.py:83  Requested more devices (32) than available (4). Test not applicable for machine
SKIPPED test_embeddings.py:520  Requested more devices (32) than available (4).
```

Collection is non-empty and the skip happens at fixture setup, so there is no pytest exit-5 risk on that leg.

Both runs are on `9b6d89608`, the first commit. Everything since is the grant trim, a rebase, the demo-SP removals and the lock recompile — none of which touch the two migrated pytest calls or the entry's `cmd`, so they are not re-verified by a fresh 2h Galaxy run.

### Checklist

- [x] (Tier 1) Models Unit Tests — `model: wan-2.2-t2v`, `sku: wh_galaxy (WH Galaxy)` — both calls run and pass
- [x] (Tier 1) Models Unit Tests — `model: wan-2.2-t2v`, `sku: bh_quietbox_2 (BH QB2)` — both calls skip on device count
- [x] `gh aw compile` clean for silencer and test-command; a merge with #54569 recompiles idempotently
- [ ] (Galaxy) integration tests — dispatch to confirm the removed `wan22` option left the pipeline valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/migrate-galaxy-wan-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/migrate-galaxy-wan-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/migrate-galaxy-wan-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/migrate-galaxy-wan-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/migrate-galaxy-wan-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/migrate-galaxy-wan-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/migrate-galaxy-wan-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/migrate-galaxy-wan-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/migrate-galaxy-wan-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/migrate-galaxy-wan-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/migrate-galaxy-wan-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/migrate-galaxy-wan-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/migrate-galaxy-wan-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/migrate-galaxy-wan-integration)