### PR TITLE
[Fabric] Make first-level ACK link-symmetric

### DIFF
--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1077,18 +1077,26 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     const bool vc0_is_terminal_or_source_only_after_trim =
         vc0_trim_fast_path_info_.has_value() && vc0_trim_fast_path_info_->terminal_or_source_only;
     const bool base_enable_deadlock_avoidance = fabric_context.need_deadlock_avoidance_support(this->direction_);
+    const bool peer_enable_deadlock_avoidance =
+        remote_routing_direction.has_value() &&
+        fabric_context.need_deadlock_avoidance_support(
+            control_plane.routing_direction_to_eth_direction(remote_routing_direction.value()));
+    // First-level ACK is a bidirectional link protocol. Inter-mesh links may join different logical directions
+    // (for example NORTH to WEST), so both endpoints must enable it whenever either endpoint uses bubble flow.
+    const bool link_requires_first_level_ack_vc0 = base_enable_deadlock_avoidance || peer_enable_deadlock_avoidance;
     const bool final_enable_deadlock_avoidance =
         base_enable_deadlock_avoidance && !vc0_is_terminal_or_source_only_after_trim;
-    const bool final_enable_first_level_ack_vc0 = final_enable_deadlock_avoidance;
     // Preserve the existing explicit single-sender behavior, allow the same
     // fast path when trimming collapses a wider VC0 router to the worker-only
     // shape, and optionally enable a terminal-only speedy receiver when the
     // host has already proven that the exact peer on this link is the
     // matching worker-only source router.
-    const bool enable_speedy_vc0 = vc0_speedy_path_enabled(
-        actual_sender_channels_vc0,
-        base_enable_deadlock_avoidance,
-        vc0_trim_fast_path_info_.value_or(Vc0TrimFastPathInfo{}));
+    const bool enable_speedy_vc0 =
+        !link_requires_first_level_ack_vc0 && vc0_speedy_path_enabled(
+                                                  actual_sender_channels_vc0,
+                                                  base_enable_deadlock_avoidance,
+                                                  vc0_trim_fast_path_info_.value_or(Vc0TrimFastPathInfo{}));
+    const bool final_enable_first_level_ack_vc0 = link_requires_first_level_ack_vc0;
 
     // ===== Build named compile-time args (all non-pool/channel-mapping args) =====
     std::unordered_map<std::string, uint32_t> named_args;


### PR DESCRIPTION
#### Summary

- make first-level ACK enablement symmetric across both endpoints of a fabric link
- derive the peer endpoint's logical routing direction and enable link-level ACK when either endpoint requires bubble flow
- keep deadlock avoidance local to each endpoint and disable the speedy VC0 path whenever the link requires first-level ACK

#### Problem

First-level ACK was enabled from only the local router's logical direction. An inter-mesh physical link can connect endpoints with different logical directions (for example, NORTH to WEST). Under `FABRIC_2D_TORUS_Y`, the NORTH endpoint requires bubble flow while the WEST endpoint does not, so the two endpoints compiled with different first-level ACK behavior for the same bidirectional link. Credits eventually drained and the 2x2 fully multi-mesh pipeline hung.

Related reproduction context: https://github.com/tenstorrent/tt-blaze/issues/3126



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkodkani/fix-fabric-link-symmetric-first-level-ack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkodkani/fix-fabric-link-symmetric-first-level-ack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkodkani/fix-fabric-link-symmetric-first-level-ack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkodkani/fix-fabric-link-symmetric-first-level-ack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkodkani/fix-fabric-link-symmetric-first-level-ack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkodkani/fix-fabric-link-symmetric-first-level-ack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkodkani/fix-fabric-link-symmetric-first-level-ack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkodkani/fix-fabric-link-symmetric-first-level-ack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkodkani/fix-fabric-link-symmetric-first-level-ack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkodkani/fix-fabric-link-symmetric-first-level-ack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkodkani/fix-fabric-link-symmetric-first-level-ack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkodkani/fix-fabric-link-symmetric-first-level-ack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkodkani/fix-fabric-link-symmetric-first-level-ack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkodkani/fix-fabric-link-symmetric-first-level-ack)