### PR TITLE
Mistral-Small-4-119B prefill: regrouped history + cleanup

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -385,7 +385,17 @@ models:
   demo:
     wh_galaxy_perf: 125
     bh_galaxy: 470
-    bh_sc1: 488
+
+    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840).
+    # 488 -> 595: the seven Mistral-Small-4-119B entries add 110 min (479 -> 589). Five are sized
+    # from measured test time on run 32793561151 plus runner setup, not from a margin; the block
+    # and transformer rows are left generous until CI reports their own times. 6 min headroom.
+
+    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840).
+    # 488 -> 585: the six Mistral-Small-4-119B entries add 100 min, plus 2 on the shared KV cache
+    # table entry it now rides (479 -> 581). Sized from measured test time on run 32793561151
+    # plus runner setup, not from a flat margin. 4 min headroom.
+    bh_sc1: 585
     bh_sc1_high_power: 166
     wh_n150: 500
     wh_n150_civ2: 300

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -15,7 +15,8 @@ on:
           glm_moe, glm_prefill_block, hca_chunked, hca_perf, high_bw_all_gather_perf,
           k3_mla, k3_mla_perf, k3_mla_trace, kimi_chunked, kimi_chunked_padded, kimi_dflash,
           kimi_k3_moe, kimi_k3_moe_perf, kimi_mla, kimi_moe, kimi_prefill_block,
-          kv_cache_table, minimax_prefill_kv_pcc, minimax_prefill_perf, mla,
+          kv_cache_table, minimax_prefill_kv_pcc, minimax_prefill_perf, mistral4_mla, mistral4_mla_chunked, mistral4_moe, mistral4_moe_ops,
+          mistral4_prefill_block, mistral4_prefill_transformer, mla,
           mla_chunked, moe_gate, prefill_block, prefill_block_determinism,
           prefill_runner, prefill_runner_kv_pcc, prefill_transformer_determinism,
           ring_joint_sdpa_perf.

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -254,6 +254,15 @@ class PrefillModelAdapter(ABC):
     def reference_moe_cls(self) -> Optional[type]:
         return None
 
+    @property
+    def reference_rotary_cls(self) -> Optional[type]:
+        """Rope module a standalone reference attention needs its ``(cos, sin)`` from.
+
+        Only needed for references from transformers >= 5, which compute rope at the MODEL level and
+        pass ``position_embeddings`` down, so an attention used on its own has to be handed them.
+        The vendored DeepSeek/Kimi references build rope internally and leave this None."""
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Model registry

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -211,6 +211,12 @@ class PrefillModelAdapter(ABC):
     # This variant's OWN golden MLA-trace dirs (each holding mla_io/ + kv_cache/), for the
     # MLA-level trace tests; one per user, cycled. Empty = no trace was ever recorded for it.
     mla_trace_defaults: tuple[str, ...] = ()
+    # Use ``config_builder`` for pretrained tests too, instead of AutoConfig on the checkpoint. Set
+    # True when the checkpoint's config loads but says something the TT stack would misread.
+    config_builder_overrides_checkpoint: bool = False
+    # Checkpoint stores routed experts stacked (one `mlp.experts.gate_up_proj` of [n_experts, ...])
+    # rather than per-expert. The pretrained fixture cannot split that, so it loads attention only.
+    packed_expert_checkpoint: bool = False
     # Whether the tokenizer needs trust_remote_code=True (custom tokenizer code shipped in the repo,
     # e.g. Kimi's tiktoken-backed BBPE). DeepSeek-V3 uses a stock fast tokenizer, so it turns this off
     # to avoid the flat-config trust_remote_code import path that otherwise breaks its load.
@@ -284,6 +290,8 @@ ADAPTER_PATHS = {
     "kimi_k2_6": "models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6:KimiK26Adapter",
     # Kimi-K2.7: same architecture as K2.6, new checkpoint (adapters/kimi_k2_7.py).
     "kimi_k2_7": "models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_7:KimiK27Adapter",
+    # Mistral-Small-4-119B: dense MLA + MoE; config hand-built (transformers 5.x rope_parameters).
+    "mistral_small_4": "models.demos.deepseek_v3_d_p.tt.runners.adapters.mistral_small_4:MistralSmall4Adapter",
     "minimax_m3": "models.demos.minimax_m3.tt.runners.adapters.minimax_m3:MiniMaxM3PrefillAdapter",
     # GPT-OSS-120B: GQA (not MLA) + attention sinks + sliding/full alternation + EP MoE.
     "gpt_oss_d_p": "models.demos.gpt_oss_d_p.tt.runners.adapters.gpt_oss:GptOssPrefillAdapter",

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -215,7 +215,8 @@ class PrefillModelAdapter(ABC):
     # True when the checkpoint's config loads but says something the TT stack would misread.
     config_builder_overrides_checkpoint: bool = False
     # Checkpoint stores routed experts stacked (one `mlp.experts.gate_up_proj` of [n_experts, ...])
-    # rather than per-expert. The pretrained fixture cannot split that, so it loads attention only.
+    # rather than per-expert. Unread: the fixture splits both layouts. Setting it would mean
+    # loading attention only.
     packed_expert_checkpoint: bool = False
     # Whether the tokenizer needs trust_remote_code=True (custom tokenizer code shipped in the repo,
     # e.g. Kimi's tiktoken-backed BBPE). DeepSeek-V3 uses a stock fast tokenizer, so it turns this off

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -214,10 +214,6 @@ class PrefillModelAdapter(ABC):
     # Use ``config_builder`` for pretrained tests too, instead of AutoConfig on the checkpoint. Set
     # True when the checkpoint's config loads but says something the TT stack would misread.
     config_builder_overrides_checkpoint: bool = False
-    # Checkpoint stores routed experts stacked (one `mlp.experts.gate_up_proj` of [n_experts, ...])
-    # rather than per-expert. Unread: the fixture splits both layouts. Setting it would mean
-    # loading attention only.
-    packed_expert_checkpoint: bool = False
     # Whether the tokenizer needs trust_remote_code=True (custom tokenizer code shipped in the repo,
     # e.g. Kimi's tiktoken-backed BBPE). DeepSeek-V3 uses a stock fast tokenizer, so it turns this off
     # to avoid the flat-config trust_remote_code import path that otherwise breaks its load.

--- a/models/demos/deepseek_v3_d_p/README.md
+++ b/models/demos/deepseek_v3_d_p/README.md
@@ -13,7 +13,7 @@ model, see
 
 ## Environment Variables
 
-- **`PREFILL_MODEL`** — Which model adapter the runner / producers use (`deepseek_v3_d_p` | `kimi_k2_6` | `kimi_k2_7` | …). Defaults to `kimi_k2_7`. Replaces the former `PREFILL_MODEL_VARIANT`.
+- **`PREFILL_MODEL`** — Which model adapter the runner / producers use (`deepseek_v3_d_p` | `deepseek_v32` | `glm_5_1` | `glm_5_2` | `kimi_k2_6` | `kimi_k2_7` | `minimax_m3` | `gpt_oss_d_p` | `mistral_small_4`). Defaults to `kimi_k2_7`. Replaces the former `PREFILL_MODEL_VARIANT`.
 
 - **`DEEPSEEK_V3_HF_MODEL`** — Path to DeepSeek-R1-0528 weights directory. Falls back to `models/demos/deepseek_v3/reference/` then `/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528`.
 - **`TT_DS_PREFILL_TTNN_CACHE`** — Directory for cached TTNN weight tensors (`.tensorbin` files). First run writes cache, subsequent runs load directly. Defaults to `{model_path}/tensor_cache_{arch}_{num_devices}dev/`.

--- a/models/demos/deepseek_v3_d_p/reference/mistral_small_4_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/mistral_small_4_config.py
@@ -27,8 +27,6 @@ is exactly 1.0 for every position below 8192 and steps up at each 8192-token bou
 against an HF reference are only meaningful at or below 8192 until ttMLA implements it.
 """
 
-import types
-
 
 class MistralSmall4Config:
     """Mistral-Small-4-119B model dimensions (text_config)."""
@@ -77,25 +75,31 @@ class MistralSmall4Config:
     ROPE_SCALING_BETA_SLOW = 1.0
     ROPE_SCALING_MSCALE = 1.0
     ROPE_SCALING_MSCALE_ALL_DIM = 1.0
+    # partial_rotary_factor; sizes rope at 0.5 * head_dim = 64
+    ROPE_PARTIAL_ROTARY_FACTOR = 0.5
     LLAMA4_SCALING_BETA = 0.1  # llama_4_scaling_beta; no ttMLA equivalent (see module docstring)
 
     # Misc read by the test fixtures / reference construction
     INITIALIZER_RANGE = 0.02
     ATTENTION_BIAS = False
+    MLP_BIAS = False
     ATTENTION_DROPOUT = 0.0
 
 
 def mistral4_hf_config(max_seq: int = 8192):
     """HF-attribute-style config the unified ttMLA reads (Mistral 4 dims, DeepSeek field names).
 
-    Hand-built rather than read via ``AutoConfig``: the checkpoint's config exposes
+    Values are stated here rather than read via ``AutoConfig``: the checkpoint's config exposes
     ``rope_parameters`` (with ``rope_theta`` nested inside it) where ttMLA and the vendored DeepSeek
     reference want a top-level ``rope_theta`` plus a DeepSeek-shaped ``rope_scaling`` dict, and its
     ``quantization_config`` sits on the outer (multimodal) config, so unwrapping to ``text_config``
     drops it and the fp8 loader would refuse the tensors.
+
+    A real ``Mistral4Config``, not a namespace: ``PreTrainedModel.__init__`` rejects anything else,
+    which would cost every random-weight row. The DeepSeek-named extras survive as attributes.
     """
     C = MistralSmall4Config
-    return types.SimpleNamespace(
+    fields = dict(
         vocab_size=C.VOCAB_SIZE,
         hidden_size=C.EMB_SIZE,
         intermediate_size=C.INTERMEDIATE_SIZE,
@@ -117,6 +121,7 @@ def mistral4_hf_config(max_seq: int = 8192):
         rope_theta=float(C.ROPE_THETA),
         rope_interleave=C.ROPE_INTERLEAVE,
         attention_bias=C.ATTENTION_BIAS,
+        mlp_bias=C.MLP_BIAS,
         attention_dropout=C.ATTENTION_DROPOUT,
         initializer_range=C.INITIALIZER_RANGE,
         hidden_act="silu",
@@ -133,6 +138,11 @@ def mistral4_hf_config(max_seq: int = 8192):
             "beta_slow": C.ROPE_SCALING_BETA_SLOW,
             "mscale": C.ROPE_SCALING_MSCALE,
             "mscale_all_dim": C.ROPE_SCALING_MSCALE_ALL_DIM,
+            # Sizes rope at 0.5 * head_dim = 64. Omitting it spans the full 128, and the reference
+            # then hands apply_rotary_pos_emb a cos twice as wide as the rope half of q.
+            "partial_rotary_factor": C.ROPE_PARTIAL_ROTARY_FACTOR,
+            # Drives get_llama_4_attn_scale, exactly 1.0 below 8192 (see the module KNOWN GAP).
+            "llama_4_scaling_beta": C.LLAMA4_SCALING_BETA,
         },
         # MoE structure read by the MoE path and the pretrained cache-build path.
         first_k_dense_replace=C.NUM_DENSE_LAYERS,
@@ -152,3 +162,10 @@ def mistral4_hf_config(max_seq: int = 8192):
             "weight_block_size": None,
         },
     )
+    from transformers.models.mistral4.configuration_mistral4 import Mistral4Config
+
+    cfg = Mistral4Config(**fields)
+    # Mistral4Config folds rope_theta into rope_parameters -- that rename is the whole reason this
+    # function exists -- so put it back where rope.py reads it. Not a property, so setattr sticks.
+    cfg.rope_theta = fields["rope_theta"]
+    return cfg

--- a/models/demos/deepseek_v3_d_p/reference/mistral_small_4_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/mistral_small_4_config.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Mistral-Small-4-119B Model Configuration (text tower only).
+
+Single source of truth for model dimension constants.
+Values from HuggingFace config.json for mistralai/Mistral-Small-4-119B-2603 (text_config);
+the vision tower (Pixtral) and the multimodal projector are ignored for text-only prefill.
+
+Mistral 4 is an MLA + MoE model, so it rides the shared ttMLA / ttMoE path, but it is not a
+DeepSeek-schema checkpoint. ``mistral4_hf_config`` translates it into the field names the shared
+device code reads:
+
+1. ``rope_parameters`` -> ``rope_scaling`` (transformers 5.x renamed the block; ttMLA subscripts
+   ``hf_config.rope_scaling[...]`` with no defaults), and ``rope_theta`` moves out of it up to the
+   top level, where ttMLA reads it. ``factor = 128`` still drives the YaRN frequency interpolation.
+2. ``mla_disable_yarn_mscale = True``. HF's Mistral4Attention uses a plain ``qk_head_dim ** -0.5``,
+   whereas ``tt/mla/mla.py`` and ``reference/mla_reference.py`` otherwise derive a YaRN mscale
+   correction from ``factor`` and square it into the softmax scale. Both sides would inflate it
+   identically, so PCC stays green while the model is wrong: the flag is not safe to drop.
+
+KNOWN GAP (not expressible in config): Mistral also scales queries by a position-dependent
+``get_llama_4_attn_scale`` = 1 + 0.1*ln(1 + floor(pos / 8192)), for which ttMLA has no equivalent. It
+is exactly 1.0 for every position below 8192 and steps up at each 8192-token boundary, so comparisons
+against an HF reference are only meaningful at or below 8192 until ttMLA implements it.
+"""
+
+import types
+
+
+class MistralSmall4Config:
+    """Mistral-Small-4-119B model dimensions (text_config)."""
+
+    # Core dimensions
+    EMB_SIZE = 4096  # hidden_size
+    FABRIC_PAYLOAD_SIZE = EMB_SIZE  # max fabric packet payload; must stay in sync with migration code
+    MOE_INTERMEDIATE_SIZE = 2048  # MoE FFN hidden dimension (also the shared expert's)
+    INTERMEDIATE_SIZE = 12288  # Dense FFN hidden dimension; unused - NUM_DENSE_LAYERS is 0
+
+    # MoE configuration
+    NUM_ROUTED_EXPERTS = 128  # n_routed_experts
+    NUM_EXPERTS_PER_TOKEN = 4  # num_experts_per_tok
+    NUM_SHARED_EXPERTS = 1  # n_shared_experts
+    NUM_EXPERT_GROUPS = 1  # n_group
+    NUM_LIMITED_GROUPS = 1  # topk_group
+    ROUTE_SCALE = 1.0  # routed_scaling_factor
+    NORM_TOPK_PROB = True  # norm_topk_prob
+
+    # Model architecture
+    NUM_LAYERS = 36  # num_hidden_layers
+    NUM_DENSE_LAYERS = 0  # first_k_dense_replace - every layer is MoE
+    VOCAB_SIZE = 131072
+    MAX_POSITION_EMBEDDINGS = 1048576
+
+    # MLA dimensions
+    NUM_ATTENTION_HEADS = 32
+    NUM_KEY_VALUE_HEADS = 32
+    Q_LORA_RANK = 1024
+    KV_LORA_RANK = 256
+    QK_NOPE_HEAD_DIM = 64
+    QK_ROPE_HEAD_DIM = 64
+    QK_HEAD_DIM = 128  # qk_nope_head_dim + qk_rope_head_dim; == head_dim
+    V_HEAD_DIM = 128
+
+    # Norm / RoPE
+    RMS_NORM_EPS = 1e-06
+    ROPE_THETA = 10000.0  # nested under rope_parameters in config.json
+    ROPE_INTERLEAVE = True  # Mistral rotates interleaved pairs, matching ttMLA's own layout
+
+    # YaRN scaling, as stated in config.json rope_parameters. The MSCALE values are passed through
+    # verbatim; mla_disable_yarn_mscale suppresses the mscale softmax correction - see module docstring.
+    ROPE_SCALING_FACTOR = 128.0
+    ROPE_SCALING_ORIGINAL_MAX_POSITION_EMBEDDINGS = 8192
+    ROPE_SCALING_BETA_FAST = 32.0
+    ROPE_SCALING_BETA_SLOW = 1.0
+    ROPE_SCALING_MSCALE = 1.0
+    ROPE_SCALING_MSCALE_ALL_DIM = 1.0
+    LLAMA4_SCALING_BETA = 0.1  # llama_4_scaling_beta; no ttMLA equivalent (see module docstring)
+
+    # Misc read by the test fixtures / reference construction
+    INITIALIZER_RANGE = 0.02
+    ATTENTION_BIAS = False
+    ATTENTION_DROPOUT = 0.0
+
+
+def mistral4_hf_config(max_seq: int = 8192):
+    """HF-attribute-style config the unified ttMLA reads (Mistral 4 dims, DeepSeek field names).
+
+    Hand-built rather than read via ``AutoConfig``: the checkpoint's config exposes
+    ``rope_parameters`` (with ``rope_theta`` nested inside it) where ttMLA and the vendored DeepSeek
+    reference want a top-level ``rope_theta`` plus a DeepSeek-shaped ``rope_scaling`` dict, and its
+    ``quantization_config`` sits on the outer (multimodal) config, so unwrapping to ``text_config``
+    drops it and the fp8 loader would refuse the tensors.
+    """
+    C = MistralSmall4Config
+    return types.SimpleNamespace(
+        vocab_size=C.VOCAB_SIZE,
+        hidden_size=C.EMB_SIZE,
+        intermediate_size=C.INTERMEDIATE_SIZE,
+        moe_intermediate_size=C.MOE_INTERMEDIATE_SIZE,
+        num_hidden_layers=C.NUM_LAYERS,
+        num_attention_heads=C.NUM_ATTENTION_HEADS,
+        num_key_value_heads=C.NUM_KEY_VALUE_HEADS,
+        kv_lora_rank=C.KV_LORA_RANK,
+        q_lora_rank=C.Q_LORA_RANK,
+        qk_nope_head_dim=C.QK_NOPE_HEAD_DIM,
+        qk_rope_head_dim=C.QK_ROPE_HEAD_DIM,
+        qk_head_dim=C.QK_HEAD_DIM,
+        v_head_dim=C.V_HEAD_DIM,
+        rms_norm_eps=C.RMS_NORM_EPS,
+        max_position_embeddings=C.MAX_POSITION_EMBEDDINGS,
+        # The runner / tests overwrite this per run; seed it so the rope tables are built consistently.
+        max_seq_len=max_seq,
+        # Lifted OUT of rope_parameters: rope.py reads hf_config.rope_theta at the top level.
+        rope_theta=float(C.ROPE_THETA),
+        rope_interleave=C.ROPE_INTERLEAVE,
+        attention_bias=C.ATTENTION_BIAS,
+        attention_dropout=C.ATTENTION_DROPOUT,
+        initializer_range=C.INITIALIZER_RANGE,
+        hidden_act="silu",
+        pretraining_tp=1,
+        # Mistral's softmax scale is a plain qk_head_dim ** -0.5 - see module docstring.
+        mla_disable_yarn_mscale=True,
+        # rope_parameters renamed to rope_scaling, with "type" retained for the reference's
+        # _init_rope dispatch.
+        rope_scaling={
+            "type": "yarn",
+            "factor": C.ROPE_SCALING_FACTOR,
+            "original_max_position_embeddings": C.ROPE_SCALING_ORIGINAL_MAX_POSITION_EMBEDDINGS,
+            "beta_fast": C.ROPE_SCALING_BETA_FAST,
+            "beta_slow": C.ROPE_SCALING_BETA_SLOW,
+            "mscale": C.ROPE_SCALING_MSCALE,
+            "mscale_all_dim": C.ROPE_SCALING_MSCALE_ALL_DIM,
+        },
+        # MoE structure read by the MoE path and the pretrained cache-build path.
+        first_k_dense_replace=C.NUM_DENSE_LAYERS,
+        n_routed_experts=C.NUM_ROUTED_EXPERTS,
+        n_shared_experts=C.NUM_SHARED_EXPERTS,
+        num_experts_per_tok=C.NUM_EXPERTS_PER_TOKEN,
+        n_group=C.NUM_EXPERT_GROUPS,
+        topk_group=C.NUM_LIMITED_GROUPS,
+        routed_scaling_factor=C.ROUTE_SCALE,
+        norm_topk_prob=C.NORM_TOPK_PROB,
+        # fp8 with weight_block_size null (per-tensor) rather than the [128,128] block scheme, so
+        # test_utils dispatches to the per-tensor dequant path.
+        quantization_config={
+            "quant_method": "fp8",
+            "activation_scheme": "static",
+            "dequantize": False,
+            "weight_block_size": None,
+        },
+    )

--- a/models/demos/deepseek_v3_d_p/reference/mla_reference.py
+++ b/models/demos/deepseek_v3_d_p/reference/mla_reference.py
@@ -43,6 +43,15 @@ class MLAReference(nn.Module):
         # forward() is overridden below to use memory-efficient F.scaled_dot_product_attention.
         self.attention = DeepseekV3Attention(config, layer_idx=layer_idx)
 
+        # Mistral Small 4 carries a full YaRN block but applies NO mscale to the softmax scale --
+        # `Mistral4Attention` sets `self.scaling = qk_head_dim ** -0.5` unconditionally and its
+        # rotary reports attention_scaling = 1.0. DeepseekV3Attention.__init__ folds mscale^2 in
+        # whenever `rope_scaling["mscale_all_dim"]` is truthy, which would make this reference
+        # disagree with the model it is standing in for (and with tt/mla/mla.py, which honours the
+        # same flag). Absent (-> False) on every other variant, so their scale is unchanged.
+        if bool(getattr(config, "mla_disable_yarn_mscale", False)):
+            self.attention.softmax_scale = (config.qk_nope_head_dim + config.qk_rope_head_dim) ** -0.5
+
         # Kimi-K3 deltas; both absent (-> False) on every other variant.
         self.use_nope = bool(getattr(config, "mla_use_nope", False))
         self.use_output_gate = bool(getattr(config, "mla_use_output_gate", False))

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -50,9 +50,17 @@ def cleanup_cache():
     ],
     indirect=["mesh_device", "device_params"],
 )
-# "k3" (not "kimi_k3") because pytest -k is substring-based. deepseek_v3_d_p is the historical
-# default of the `variant` fixture, so keeping it first preserves this test's original coverage.
-@pytest.mark.parametrize("variant", ["deepseek_v3_d_p", "kimi_k3"], indirect=True, ids=["dsv3", "k3"])
+# "k3" (not "kimi_k3") and "mistral4" (not "mistral_small_4") because pytest -k is substring-based.
+# deepseek_v3_d_p is the historical default of the `variant` fixture, so keeping it first preserves
+# this test's original coverage.
+# mistral_small_4 resolves through the adapter's hand-built `mistral4_hf_config` rather than
+# AutoConfig, so it needs no checkpoint here — only the MLA dims the state_dict below is built from.
+@pytest.mark.parametrize(
+    "variant",
+    ["deepseek_v3_d_p", "kimi_k3", "mistral_small_4"],
+    indirect=True,
+    ids=["dsv3", "k3", "mistral4"],
+)
 def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only, variant):
     """Test: weights → cold cache → warm cache produce identical outputs.
 

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -163,7 +163,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
     # === Path 2: Cold Cache (build + load) ===
     init_checker(CACHE_DIR)
     assert not TtMoe.check_cache_complete(
-        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip
+        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip, routed_expert_weights_dtype=ttnn.bfloat16
     ), "Cache should be empty before build"
 
     logger.info(f"Building cache to {CACHE_DIR}...")
@@ -186,7 +186,7 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
 
     init_checker(CACHE_DIR)
     assert TtMoe.check_cache_complete(
-        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip
+        CACHE_DIR, layer_idx=0, experts_per_chip=experts_per_chip, routed_expert_weights_dtype=ttnn.bfloat16
     ), "Cache should be complete after build"
 
     logger.info("Path 2: Creating TtMoe from cold cache...")

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -207,7 +207,7 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
     # === Path 2: Cold Cache ===
     init_checker(CACHE_DIR)
     assert not TtRoutedExpert.check_cache_complete(
-        CACHE_DIR, "routed_expert", experts_per_chip
+        CACHE_DIR, "routed_expert", experts_per_chip, weights_dtype
     ), "Cache should be empty before build"
 
     logger.info(f"Building cache to {CACHE_DIR}")
@@ -225,7 +225,7 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
 
     init_checker(CACHE_DIR)
     assert TtRoutedExpert.check_cache_complete(
-        CACHE_DIR, "routed_expert", experts_per_chip
+        CACHE_DIR, "routed_expert", experts_per_chip, weights_dtype
     ), "Cache should be complete after build"
 
     profiler.start("cold_load")
@@ -289,3 +289,54 @@ def test_routed_expert_weights_cold_warm_cache(mesh_device, device_params):
 
     assert passed_cold, f"Cold cache mismatch: PCC={pcc_cold}"
     assert passed_warm, f"Warm cache mismatch: PCC={pcc_warm}"
+
+
+# Host-only, pure filename logic. as_tensor stamps the requested dtype into the tensorbin name, so a
+# cache built at bfloat4_b must read as INCOMPLETE for a bfloat8_b request -- otherwise the empty
+# placeholder is loaded as the weights and the model reports a cache hit while running on nothing.
+# Same reasoning as TtIndexer.check_cache_complete.
+def _touch_expert_bin(cache_dir, prefix, local_idx, proj, dtype, layout=ttnn.TILE_LAYOUT):
+    # Reproduce the exact name as_tensor writes: core.py appends `_dtype_{dtype.name}_layout_{layout.name}`.
+    (cache_dir / f"{prefix}.local_{local_idx}_{proj}_dtype_{dtype.name}_layout_{layout.name}.tensorbin").touch()
+
+
+def test_routed_expert_check_cache_complete_is_dtype_aware(tmp_path):
+    from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
+
+    prefix, experts_per_chip = "routed_expert", 2
+
+    def write(dtype):
+        for f in tmp_path.glob("*.tensorbin"):
+            f.unlink()
+        for idx in range(experts_per_chip):
+            for proj in ("gate", "up", "down"):
+                _touch_expert_bin(tmp_path, prefix, idx, proj, dtype)
+        init_checker(tmp_path)  # re-scan: the checker caches the directory listing
+
+    # A complete bf4 cache is complete for bf4 ...
+    write(ttnn.bfloat4_b)
+    assert TtRoutedExpert.check_cache_complete(
+        tmp_path, prefix, experts_per_chip, ttnn.bfloat4_b
+    ), "bfloat4_b cache must be complete for a bfloat4_b request"
+
+    # ... and NOT for bf8, which is the whole point: the bf8 tensorbins do not exist.
+    assert not TtRoutedExpert.check_cache_complete(
+        tmp_path, prefix, experts_per_chip, ttnn.bfloat8_b
+    ), "bfloat4_b-only cache must fail a bfloat8_b completeness check"
+
+    # A superset cache (both dtypes on disk, as a regenerated cache carries) satisfies either.
+    for idx in range(experts_per_chip):
+        for proj in ("gate", "up", "down"):
+            _touch_expert_bin(tmp_path, prefix, idx, proj, ttnn.bfloat8_b)
+    init_checker(tmp_path)
+    for dtype in (ttnn.bfloat4_b, ttnn.bfloat8_b):
+        assert TtRoutedExpert.check_cache_complete(
+            tmp_path, prefix, experts_per_chip, dtype
+        ), f"superset cache must stay complete for {dtype.name}"
+
+    # One missing projection at the requested dtype is still incomplete.
+    (tmp_path / f"{prefix}.local_1_down_dtype_{ttnn.bfloat8_b.name}_layout_{ttnn.TILE_LAYOUT.name}.tensorbin").unlink()
+    init_checker(tmp_path)
+    assert not TtRoutedExpert.check_cache_complete(
+        tmp_path, prefix, experts_per_chip, ttnn.bfloat8_b
+    ), "a missing projection at the requested dtype must read as incomplete"

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -743,11 +743,19 @@ def model_path(variant) -> Path:
 
 
 @pytest.fixture
-def hf_config(model_path):
+def hf_config(variant, model_path):
     """
     Load HF config for testing.
     Returns None if model path doesn't exist (weights not available).
+
+    `config_builder_overrides_checkpoint` means the adapter's config is authoritative even though
+    the checkpoint's own loads: transformers 5.x nests rope_theta inside rope_parameters, so an
+    AutoConfig-derived config lacks attributes ttMLA reads as plain ones. `config_only` already goes
+    through the builder, and this path has to agree with it -- otherwise the two fixtures hand out
+    different configs for one checkpoint and only the tests using the second one fail.
     """
+    if getattr(variant, "config_builder_overrides_checkpoint", False) and variant.config_builder is not None:
+        return variant.config_builder()
     return _resolve_hf_config(str(model_path))
 
 

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -54,7 +54,7 @@ from models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k3 import KimiK3Adapt
 
 TEST_VARIANTS["kimi_k3"] = KimiK3Adapter()
 from models.demos.deepseek_v3_d_p.utils.test_utils import convert_state_dict, detect_language_model_prefix
-from models.demos.deepseek_v3_d_p.utils.transformer_helpers import download_infinitebench_subset
+from models.demos.deepseek_v3_d_p.utils.transformer_helpers import download_infinitebench_subset, extract_routed_experts
 
 # Shared production-policy params for prefill block + transformer tests. LoudBox executes canonical
 # 2x4 Fabric2D and one 4x2 axis-order diagnostic; Galaxy production executes only 8x4 TorusXY.
@@ -612,7 +612,14 @@ def _unwrap_multimodal_config(cfg):
     """
     if hasattr(cfg, "text_config") and hasattr(cfg.text_config, "hidden_size"):
         logger.info(f"Unwrapping multimodal wrapper config (inner model_type={cfg.text_config.model_type})")
+        # `quantization_config` describes the CHECKPOINT, so HF puts it on the outer wrapper only and
+        # the unwrap drops it. convert_state_dict then falls to passthrough and raises on the first
+        # float8 tensor ("config has no `quantization_config`"). Carry the genuine one across rather
+        # than reconstructing it, so modules_to_not_convert / dequantize survive.
+        outer_quant = getattr(cfg, "quantization_config", None)
         cfg = cfg.text_config
+        if getattr(cfg, "quantization_config", None) is None and outer_quant is not None:
+            cfg.quantization_config = outer_quant
     return cfg
 
 
@@ -972,18 +979,20 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
                 "down_proj": layer_dequant["mlp.down_proj.weight"],
             }
         else:
+            # Both lookups have to tolerate the two checkpoint shapes this repo already sees, the same
+            # way load_and_compute_layer_by_layer does: a router with no auxiliary correction bias
+            # (Mistral -- zeros are the identity for it), and stacked+fused expert tensors instead of
+            # per-expert keys. extract_routed_experts owns the second, including the gate/up split
+            # order, which is not inferable and is wrong-but-plausible if guessed.
+            gate_weight = layer_dequant["mlp.gate.weight"]
             layer_dict["gate_weights"] = {
-                "weight": layer_dequant["mlp.gate.weight"],
-                "e_score_correction_bias": layer_dequant["mlp.gate.e_score_correction_bias"],
+                "weight": gate_weight,
+                "e_score_correction_bias": layer_dequant.get(
+                    "mlp.gate.e_score_correction_bias",
+                    torch.zeros(gate_weight.shape[0], dtype=torch.float32),
+                ),
             }
-            layer_dict["routed_expert_weights"] = [
-                {
-                    "gate_proj": layer_dequant[f"mlp.experts.{j}.gate_proj.weight"],
-                    "up_proj": layer_dequant[f"mlp.experts.{j}.up_proj.weight"],
-                    "down_proj": layer_dequant[f"mlp.experts.{j}.down_proj.weight"],
-                }
-                for j in range(n_routed)
-            ]
+            layer_dict["routed_expert_weights"] = extract_routed_experts(layer_dequant, n_routed)
             layer_dict["shared_expert_weights"] = {
                 "gate_proj": layer_dequant["mlp.shared_experts.gate_proj.weight"],
                 "up_proj": layer_dequant["mlp.shared_experts.up_proj.weight"],

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -26,6 +26,7 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import fabric_to_device_params
@@ -374,6 +375,10 @@ COMBINE_MODELS = [
     ("dsv4_pro", DeepSeekV4ProConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
     ("dsv4_flash", DeepSeekV4FlashConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
     ("gptoss_120b", GptOss120BConfig, True, SINGLE_GLX_AND_PROXY_MESHES),
+    # Mistral-Small-4-119B: 128 experts top-4 over a 4096 emb, the same expert/topk pair as
+    # gptoss_120b, so _model_scaledown_for_combine hits its max() floors on the smaller proxy
+    # meshes (top-k cannot scale below 2, experts below the chip count) rather than dividing freely.
+    ("mistral4", MistralSmall4Config, True, SINGLE_GLX_AND_PROXY_MESHES),
 ]
 
 

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
@@ -23,6 +23,7 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
@@ -456,6 +457,9 @@ DISPATCH_MODELS = [
     ("dsv4_pro", DeepSeekV4ProConfig, True),
     ("dsv4_flash", DeepSeekV4FlashConfig, True),
     ("gptoss_120b", GptOss120BConfig, True),
+    # Mistral-Small-4-119B routes only 128 experts top-4 (vs 256-384 top-8 above), so the // 16 pcc
+    # param lands at 8 experts — the same floor gptoss_120b already exercises.
+    ("mistral4", MistralSmall4Config, True),
 ]
 
 # Models whose dispatch supports the fp8-compression path (fp8 input + per-token scale tail). Their

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
@@ -24,6 +24,7 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.reduce import TorchReduceModule
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_y_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
@@ -259,6 +260,10 @@ REDUCE_MODELS = [
     ("dsv4_pro", DeepSeekV4ProConfig, True),
     ("dsv4_flash", DeepSeekV4FlashConfig, True),
     ("gptoss_120b", GptOss120BConfig, True),
+    # Mistral-Small-4-119B: emb_dim 4096, topk 4. Top-4 is the smallest topk here that the mesh-4x2
+    # mapper can still shard across the two dispatch groups (2 each) — top-1 needs the linear-4
+    # mesh, which is why it has its own test above.
+    ("mistral4", MistralSmall4Config, True),
 ]
 
 

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
@@ -24,6 +24,7 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_y_device_params
@@ -382,6 +383,9 @@ DISPATCH_COMBINE_MODELS = [
     ("dsv4_pro", DeepSeekV4ProConfig, True),
     ("dsv4_flash", DeepSeekV4FlashConfig, True),
     ("gptoss_120b", GptOss120BConfig, True),
+    # Mistral-Small-4-119B. Only emb_dim (4096) is model-dependent here; its 128 routed experts
+    # land on the same // 4 count as gptoss_120b (32), well inside the fixed capacity tuning above.
+    ("mistral4", MistralSmall4Config, True),
 ]
 
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
     torus_x_device_params,
@@ -64,6 +65,10 @@ def random_weights(config, emb_dim: int, vocab_size: int, dtype: torch.dtype):
         # fmt: off
         pytest.param(32, 1024, 10240, True, id="small"),
         pytest.param(3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.VOCAB_SIZE, False, id="full-no-pcc"),
+        # Mistral-Small-4-119B: emb 4096 / vocab 131072, the opposite aspect ratio to DeepSeek's
+        # 7168 x 129280. seq_len is TILE_SIZE because the PCC check only runs at that length, so a
+        # longer row would skip; this is the only row that checks PCC at a real model's dimensions.
+        pytest.param(ttnn.TILE_SIZE, MistralSmall4Config.EMB_SIZE, MistralSmall4Config.VOCAB_SIZE, True, id="mistral4"),
         # fmt: on
     ],
 )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -17,7 +17,12 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -27,8 +32,9 @@ from tests.ttnn.utils_for_testing import comp_pcc
     "isl_per_chip, vocab_size, emb_dim",
     [
         (3200, DeepSeekV3Config.VOCAB_SIZE, DeepSeekV3Config.EMB_SIZE),
+        (3200, MistralSmall4Config.VOCAB_SIZE, MistralSmall4Config.EMB_SIZE),
     ],
-    ids=["deepseek_prefill_100K"],
+    ids=["deepseek_prefill_100K", "mistral4"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
@@ -44,6 +50,14 @@ from tests.ttnn.utils_for_testing import comp_pcc
             fabric2d_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-2x4",
+        ),
+        # The production shape. This test previously topped out at 2x4, so no model was covering
+        # the embedding at the mesh it actually runs on.
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -36,6 +36,15 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
             id="torus-x-1x4",
         ),
+        # TP=1. Regression row: ttnn.all_gather TT_FATALs when the cluster axis has length 1 rather
+        # than degenerating to a copy, so this module died on any single-column mesh. Nothing
+        # exercised that before, which is why it went unnoticed. One device, so it is nearly free.
+        pytest.param(
+            (1, 1),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 1), topology="linear"),
+            id="tp1",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -980,14 +980,7 @@ def test_kimi_k3_moe(
 # reference is a different class; the shared run_model body is unchanged.
 #
 # 640 x dgs 8 = 5120 tokens, matching the rest of the mistral4 suite. 128 experts at top-4 exercises
-# the unfused extract -> FFN -> insert path that DSv3/Kimi/GLM only cover at top-8. Random weights
-# only: the checkpoint stacks the routed experts, so the pretrained fixture loads attention alone.
-#
-# The [reference_output] check sits at its threshold by construction, for two reasons that are both
-# about routing rather than device numerics: Mistral's router scores with softmax while the device op
-# only knows sigmoid, and the fixture emits an e_score_correction_bias that the device consumes but
-# Mistral's router does not have. Together those cap this comparison near 0.977, against the
-# moe_pcc_threshold of 0.971. A miss here is far more likely to be routing than arithmetic.
+# the unfused extract -> FFN -> insert path that DSv3/Kimi/GLM only cover at top-8.
 @pytest.mark.parametrize(
     (
         "seq_len_per_chip, emb_dim, hidden_dim, num_routed_experts, num_experts_per_tok, "

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -27,6 +27,7 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SILU, ACTIVATION_SITU
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
@@ -139,6 +140,7 @@ def run_model(
     it to run the forward inside a real-time-profiler window (see
     ``tests/perf/test_kimi_k3_moe_perf.py``) so the measured region is the forward alone --
     the constructor's one-time weight tilize/typecast stays outside it.
+
     """
     if routed_activation not in _TORCH_ROUTED_ACTIVATION or routed_activation not in _UPSTREAM_ACT:
         raise ValueError(f"no torch reference for {routed_activation}; supported: {list(_TORCH_ROUTED_ACTIVATION)}")
@@ -971,4 +973,84 @@ def test_kimi_k3_moe(
         rms_norm_eps=KimiK3Config.RMS_NORM_EPS,
         final_output_pcc=0.965,
         routed_activation=ROUTED_EXPERT_ACTIVATION_BY_NAME[KimiK3Config.ROUTED_EXPERT_ACTIVATION],
+    )
+
+
+# Mistral-Small-4-119B MoE. Own test function rather than a row on test_ds_moe because the upstream
+# reference is a different class; the shared run_model body is unchanged.
+#
+# 640 x dgs 8 = 5120 tokens, matching the rest of the mistral4 suite. 128 experts at top-4 exercises
+# the unfused extract -> FFN -> insert path that DSv3/Kimi/GLM only cover at top-8. Random weights
+# only: the checkpoint stacks the routed experts, so the pretrained fixture loads attention alone.
+#
+# The [reference_output] check sits at its threshold by construction, for two reasons that are both
+# about routing rather than device numerics: Mistral's router scores with softmax while the device op
+# only knows sigmoid, and the fixture emits an e_score_correction_bias that the device consumes but
+# Mistral's router does not have. Together those cap this comparison near 0.977, against the
+# moe_pcc_threshold of 0.971. A miss here is far more likely to be routing than arithmetic.
+@pytest.mark.parametrize(
+    (
+        "seq_len_per_chip, emb_dim, hidden_dim, num_routed_experts, num_experts_per_tok, "
+        "dispatch_buffer_capacity_factor, gate_fallback_mode, run_pcc_check"
+    ),
+    [
+        # fmt: off
+        pytest.param( 640, MistralSmall4Config.EMB_SIZE, MistralSmall4Config.MOE_INTERMEDIATE_SIZE, MistralSmall4Config.NUM_ROUTED_EXPERTS, MistralSmall4Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Mistral-Small-4 requires Blackhole"), pytest.mark.timeout(0)], id="mistral4-5k-pcc"),
+        # fmt: on
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links",
+    [
+        pytest.param(
+            (8, 4),
+            # fabric2d, not torus_xy, and deliberately unlike the sibling 8x4 rows: measured on CI run
+            # 32567382271, every torus_xy mistral4 case SKIPPED ("Galaxy TorusXY ... requires an
+            # explicit ring/ring descriptor and a cabling-certified allocation"), and a skipped leg
+            # reports green. FABRIC_2D is what this test ran under on ssalice/mistral4-119b-prefill,
+            # where it genuinely passed on CI. Revert once bh_sc1 is ring-cabled.
+            fabric2d_device_params(
+                fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE,
+            ),
+            2 if is_blackhole() else 1,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="fabric2d-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["mistral_small_4"], indirect=True, ids=["mistral4"])
+def test_mistral4_moe(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    seq_len_per_chip,
+    emb_dim,
+    hidden_dim,
+    num_routed_experts,
+    num_experts_per_tok,
+    dispatch_buffer_capacity_factor,
+    run_pcc_check,
+    num_links,
+    gate_fallback_mode,
+    request,
+):
+    topology = per_axis_topology(device_params["fabric_config"])
+    run_model(
+        variant,
+        config_only,
+        mesh_device,
+        device_params,
+        seq_len_per_chip,
+        emb_dim,
+        hidden_dim,
+        num_routed_experts,
+        num_experts_per_tok,
+        dispatch_buffer_capacity_factor,
+        run_pcc_check,
+        num_links,
+        topology,
+        gate_fallback_mode,
+        request,
     )

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -11,6 +11,7 @@ bundled reference return `None` and the comparison is skipped at the call
 site.
 """
 
+import inspect
 from copy import copy, deepcopy
 from typing import Optional
 
@@ -119,14 +120,32 @@ def run_reference_mla(
     attn.load_state_dict(weights, strict=False)
     attn = attn.eval().to(torch.bfloat16)
     causal = torch.triu(torch.full((q_len, q_len), float("-inf"), dtype=hidden_states.dtype), diagonal=1)
-    with torch.no_grad():
-        out = attn(
-            hidden_states=hidden_states,
-            attention_mask=causal[None, None],
-            position_ids=position_ids,
-            past_key_value=None,
-            use_cache=False,
+    # Bind by signature: vendored DeepSeek/Kimi attentions take `past_key_value` and derive rope
+    # internally; transformers >= 5 takes `past_key_values` and requires `position_embeddings`. The
+    # wrong cache name lands silently in **kwargs and captures no KV.
+    fwd_params = inspect.signature(attn.forward).parameters
+    kwargs = {
+        "hidden_states": hidden_states,
+        "attention_mask": causal[None, None],
+        "position_ids": position_ids,
+        "use_cache": False,
+    }
+    kwargs["past_key_values" if "past_key_values" in fwd_params else "past_key_value"] = None
+    if "position_embeddings" in fwd_params:
+        rotary_cls = getattr(variant, "reference_rotary_cls", None)
+        assert rotary_cls is not None, (
+            f"{type(attn).__name__} requires position_embeddings but {variant.name!r} exposes no "
+            "reference_rotary_cls to build (cos, sin) from"
         )
+        # Built from the CONFIG, not from the model: a reference instantiated in bf16 carries a bf16
+        # `inv_freq` buffer, and .float() cannot recover the lost bits. The resulting ~4.4e-4
+        # frequency error is a phase error that grows with position.
+        rotary = rotary_cls(config=config).float()
+        with torch.no_grad():
+            cos, sin = rotary(hidden_states.float(), position_ids)
+            kwargs["position_embeddings"] = (cos.to(hidden_states.dtype), sin.to(hidden_states.dtype))
+    with torch.no_grad():
+        out = attn(**kwargs)
     # DeepseekV3Attention returns (out, attn_weights, past_kv); Kimi-K3's KimiMLAAttention returns a
     # bare tensor (upstream shape). Accept either.
     return out[0] if isinstance(out, tuple) else out

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -160,16 +160,26 @@ def _pack_reference_moe_state_dict(moe, gate_weights, routed_expert_weights, sha
     """
     sd = {
         "gate.weight": gate_weights["weight"],
-        "gate.e_score_correction_bias": gate_weights["e_score_correction_bias"],
         "shared_experts.gate_proj.weight": shared_expert_weights["gate_proj"],
         "shared_experts.up_proj.weight": shared_expert_weights["up_proj"],
         "shared_experts.down_proj.weight": shared_expert_weights["down_proj"],
     }
-    src = ("gate_proj", "up_proj", "down_proj")
-    dst = ("w1", "w3", "w2") if hasattr(moe.experts[0], "w1") else src
-    for i, w in enumerate(routed_expert_weights):
-        for proj, name in zip(src, dst):
-            sd[f"experts.{i}.{name}.weight"] = w[proj]
+    # Softmax-router models (Mistral) have no correction bias; a strict load rejects the extra key.
+    if hasattr(getattr(moe, "gate", None), "e_score_correction_bias"):
+        sd["gate.e_score_correction_bias"] = gate_weights["e_score_correction_bias"]
+    if hasattr(moe.experts, "gate_up_proj"):
+        # Stacked experts (Mistral): one [n_experts, 2 * moe_intermediate, hidden] tensor with gate
+        # in the first half and up in the second, plus [n_experts, hidden, moe_intermediate] down.
+        sd["experts.gate_up_proj"] = torch.stack(
+            [torch.cat([w["gate_proj"], w["up_proj"]], dim=0) for w in routed_expert_weights]
+        )
+        sd["experts.down_proj"] = torch.stack([w["down_proj"] for w in routed_expert_weights])
+    else:
+        src = ("gate_proj", "up_proj", "down_proj")
+        dst = ("w1", "w3", "w2") if hasattr(moe.experts[0], "w1") else src
+        for i, w in enumerate(routed_expert_weights):
+            for proj, name in zip(src, dst):
+                sd[f"experts.{i}.{name}.weight"] = w[proj]
     if hasattr(moe, "routed_expert_down_proj"):
         sd["routed_expert_down_proj.weight"] = latent_weights["down_proj"]
         sd["routed_expert_up_proj.weight"] = latent_weights["up_proj"]

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -994,3 +994,134 @@ def test_glm52_kv_cache_table(
         chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
         assert_equal(chunk_torch, tt_kvpe_cache_torch[:, :, position:pos_end, :])
     logger.info(f"[glm52] kvpe-cache (config {KVPE_CONFIG_ID}, bf16 RM) readback verified over {seq_len} tokens")
+
+
+# sp x tp -- Mistral-Small-4-119B (dense MLA, no DSA indexer) KV chunk address table.
+# Follows test_kimi_kv_cache_table (the dense-MLA, single-config template) rather than the GLM ones:
+# those reach into mla_tt._indexer and build a 2-config table for the sparse index-key cache, which
+# Mistral 4 has no equivalent of (resolve_has_indexer is False for its config).
+#
+# The point of the test is the NARROWER kvpe row: kv_lora_rank(256) + qk_rope_head_dim(64) = 320, vs
+# 512 + 64 = 576 for DeepSeek/Kimi. 320 is 10 tiles of 32, so a 32-token DRAM-bank chunk is 10 bfp8
+# tiles, not 18 -- every byte size below is derived from the config rather than copied. The cache is
+# TP-replicated (init_kvpe_cache stamps PlacementReplicate), so the 320 row is never split across the
+# 4 TP columns -- 320/4 = 80 would not be tile-aligned.
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(8, 4)],
+    ids=["8x4"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    ids=["line"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [5 * 1024], ids=["seq5k"])
+@pytest.mark.parametrize("variant", ["mistral_small_4"], indirect=True, ids=["mistral4"])
+@pytest.mark.skipif(not is_blackhole(), reason="Mistral-Small-4 requires Blackhole")
+@pytest.mark.timeout(0)
+def test_mistral4_kv_cache_table(
+    mesh_device,
+    seq_len,
+    variant,
+    random_weights,
+    device_params,
+):
+    """
+    Readback test for the Mistral-Small-4-119B (non-balanced / sequential) KV chunk address table.
+
+    Runs one dense Mistral 4 MLA layer with random weights (SP=8 on axis 0, TP=4 on axis 1) to fill a
+    sequentially laid-out KVPE cache, builds the table with create_kv_chunk_address_table_kimi, then
+    reads every 32-token chunk back through the table and checks it against the gathered cache. The
+    sequential gather is already position-continuous, so no chunk reorder is needed.
+    """
+    config, weights = random_weights
+
+    assert config.num_attention_heads == 32, f"Not Mistral 4 config: {config.num_attention_heads} heads"
+
+    logger.info(f"model={variant.name} num_heads={config.num_attention_heads} hidden={config.hidden_size}")
+
+    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
+    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+
+    sp_axis = 0
+    tp_axis = 1
+    mesh_shape = list(mesh_device.shape)
+    config.max_seq_len = seq_len
+
+    # Test forward pass comparison
+    logger.info("=" * 80)
+    logger.info(f"Testing forward pass comparison (seq_len={seq_len})")
+    logger.info("=" * 80)
+
+    # Initialize KVPE cache
+    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 320
+    assert kvpe_cache_head_dim == 320, f"expected a 320-wide Mistral 4 kvpe row, got {kvpe_cache_head_dim}"
+
+    num_kvpe_cache_layers = 1
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_kvpe_cache_layers,
+    )
+
+    # Create and populate KV chunk address table using utility function.
+    # Derived, not the 19584 the 576-wide models use: a [1, 1, 32, 320] bfp8 chunk is 10 tiles and a
+    # 32x32 bfp8 tile is 1024 data + 64 exponent bytes (cf. GLM's 128-wide index cache: 4 * 1088).
+    CHUNK_SIZE_BYTES = (kvpe_cache_head_dim // 32) * 1088  # [1, 1, 32, 320] bfp8 = 10 tiles = 10880
+    lookup_table_config = ttnn.experimental.disaggregation.KvChunkAddressTableConfig()
+    lookup_table_config.num_layers = num_kvpe_cache_layers
+    lookup_table_config.max_sequence_length = seq_len
+    lookup_table_config.num_slots = 1
+    lookup_table_config.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+    lookup_table_config.chunk_size_bytes = CHUNK_SIZE_BYTES
+
+    lookup_table = create_kv_chunk_address_table_kimi(
+        config=lookup_table_config,
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        kvpe_cache=tt_kvpe_cache.storage,
+        chunk_size_bytes=CHUNK_SIZE_BYTES,
+    )
+
+    # Run MLA inference using utility function
+    # Fill the single cache layer with the actual kv cache
+    run_mla_inference(
+        config=config,
+        weights=weights,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=False,
+        topology=topology,
+        tt_kvpe_cache=tt_kvpe_cache,
+    )
+
+    tt_kvpe_cache_torch = ttnn.to_torch(
+        tt_kvpe_cache.storage,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)
+
+    # remember layer0 results
+    tt_kvpe_cache_torch_layer0 = tt_kvpe_cache_torch[:1, :1, :, :]
+
+    # Walk every chunk in layer 0, read it back via the address table, and compare
+    # against the corresponding 32-token slice of the gathered cache.
+    chunk_shape = [1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, kvpe_cache_head_dim]
+    for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+        raw_bytes = lookup_table.read_device_chunk(layer=0, position=position, slot=0)
+        chunk_tt = ttnn.experimental.disaggregation.tensor_from_bfp8_bytes(raw_bytes, chunk_shape)
+        chunk_torch = ttnn.to_torch(chunk_tt).to(torch.bfloat16)
+        expected_chunk = tt_kvpe_cache_torch_layer0[:, :, position : position + NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, :]
+        assert_equal(chunk_torch, expected_chunk)
+    logger.info(f"[mistral4] kvpe-cache (320-wide bfp8) address-table readback verified over {seq_len} tokens")

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -500,8 +500,8 @@ def test_kimi_mla(
 # every axis Kimi sweeps is pinned here to ONE value unless it changes the number being measured.
 #   mesh_device        (8, 4) only. Production SP-axis shape for this box; a (2, 4) PCC is not a
 #                      production-shape result, and the TTNN weight cache is keyed on device count.
-#   device_params      line (FABRIC_1D) only. ring / fabric2d are transport topologies; they do not
-#                      change the MLA math, so they cannot earn their runtime before a first number.
+#   device_params      fabric2d only. FABRIC_1D is not in CI_ALLOWED_FABRICS for BH galaxy (8,4), so
+#                      pinning it skips the row; TorusXY needs a certified cabling descriptor.
 #   use_pretrained     random only. This row measures the MLA math, which the random-weight path
 #                      exercises identically; the pretrained checkpoint is covered by the chunked
 #                      rows below and by the transformer row.
@@ -523,11 +523,11 @@ def test_kimi_mla(
     "device_params",
     [
         {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
         },
     ],
-    ids=["line"],
+    ids=["fabric2d"],
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False], ids=["random"])

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -496,6 +496,76 @@ def test_kimi_mla(
     )
 
 
+# sp x tp -- Mistral Small 4 bringup. Copied from test_kimi_mla above and deliberately narrowed;
+# every axis Kimi sweeps is pinned here to ONE value unless it changes the number being measured.
+#   mesh_device        (8, 4) only. Production SP-axis shape for this box; a (2, 4) PCC is not a
+#                      production-shape result, and the TTNN weight cache is keyed on device count.
+#   device_params      line (FABRIC_1D) only. ring / fabric2d are transport topologies; they do not
+#                      change the MLA math, so they cannot earn their runtime before a first number.
+#   use_pretrained     random only. This row measures the MLA math, which the random-weight path
+#                      exercises identically; the pretrained checkpoint is covered by the chunked
+#                      rows below and by the transformer row.
+#   seq_len            5k only. 25k roughly quadruples the host reference's attention cost for no
+#                      extra coverage of the config fields under test.
+#   skip_host_comparison  check_pcc only. skip_check does the device work and computes NO PCC; the
+#                      gate for this step IS the PCC, so that case would be a silent zero-signal run.
+#   is_balanced        sequential only, as Kimi.
+# scale_down_sl stays swept (2 cases): it is the one axis that changes the seq_len actually run
+# (max_sl 5120 vs scaled_sl (5120//32)*8 = 1280), which exercises different padding/rotation paths.
+#
+# NOT WIRED ON PURPOSE: reference_attention_cls. run_reference_mla returns None for a variant with
+# no reference (reference_runners.py:63), so the [reference_output] PCC is skipped and the three
+# gate PCCs below still come from create_mla_reference -- the vendored DeepSeek MLA, which is
+# variant-independent. Whether that vendored reference is the right truth for Mistral is a separate
+# question and is deliberately NOT settled by this test.
+@pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+        },
+    ],
+    ids=["line"],
+    indirect=True,
+)
+@pytest.mark.parametrize("use_pretrained", [False], ids=["random"])
+@pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
+@pytest.mark.parametrize("seq_len", [5 * 1024], ids=["seq5k"])
+@pytest.mark.parametrize("skip_host_comparison", [False], ids=["check_pcc"])
+@pytest.mark.parametrize("is_balanced", [False], ids=["sequential"])
+@pytest.mark.parametrize("variant", ["mistral_small_4"], indirect=True, ids=["mistral"])
+@pytest.mark.skipif(not is_blackhole(), reason="Mistral Small 4 bringup targets the Blackhole galaxy")
+@pytest.mark.timeout(0)
+def test_mistral_small4_mla(
+    use_pretrained,
+    request,
+    mesh_device,
+    seq_len,
+    skip_host_comparison,
+    scale_down_sl,
+    is_balanced,
+    is_ci_env,
+    is_ci_v2_env,
+    device_params,
+    variant,
+):
+    run_model(
+        variant,
+        use_pretrained,
+        request,
+        mesh_device,
+        seq_len,
+        skip_host_comparison,
+        scale_down_sl,
+        is_balanced,
+        is_ci_env,
+        is_ci_v2_env,
+        device_params,
+    )
+
+
 # ---------------------------------------------------------------------------------------------------
 # Unified chunked-prefill driver. One loop (preload -> N iters of write+rope+ring_mla -> compare)
 # parametrized by where the prefix/reference come from. See test_mla_chunked_prefill below.
@@ -954,11 +1024,13 @@ _CHUNKED_SCENARIOS = (
 @pytest.mark.parametrize("kwargs", [kw for _, kw in _CHUNKED_SCENARIOS], ids=[sid for sid, _ in _CHUNKED_SCENARIOS])
 @pytest.mark.parametrize(
     "variant",
-    ["deepseek_v3_d_p", "kimi_k2_6", "kimi_k3"],
+    ["deepseek_v3_d_p", "kimi_k2_6", "kimi_k3", "mistral_small_4"],
     indirect=True,
     # "k3", not "kimi_k3": pytest -k is substring-based, so a "kimi_k3" id would silently widen every
     # existing `-k kimi` selector (CI yaml, tests/perf/test_mla_perf.py) to include K3.
-    ids=["dsv3", "kimi", "k3"],
+    # "mistral4" matches the transformer/block rows' id, so one `-k mistral4` selects this model
+    # across all three; `-k mistral` still finds it, and no other variant here shares the prefix.
+    ids=["dsv3", "kimi", "k3", "mistral4"],
 )
 @pytest.mark.parametrize("use_metadata_tensor", [False, True], ids=["scalar", "metadata"])
 @pytest.mark.parametrize("determinism_check", [False, True], ids=["no_determinism", "with_determinism"])
@@ -996,6 +1068,23 @@ def test_mla_chunked_prefill(
     # Incidental, not a K3 guarantee; re-enable when K3 has a runtime that actually feeds metadata.
     if variant.name == "kimi_k3" and use_metadata_tensor:
         pytest.skip("kimi_k3 has no runtime, so the metadata (device-scalar) path is unreachable for it")
+    # No K3 checkpoint is reachable, so no GPU trace was ever recorded for it. _run_chunked_prefill
+    # already asserts on supports_pretrained, but only once a trace root is configured -- so on a box
+    # with MLA_CHUNKED_TRACE_DIR set these cases would hard-fail instead of being cleanly out of
+    # scope. Skip up front; the assert stays as the backstop for any future supports_pretrained=False
+    # variant and for the silent K2.6-trace-substitution it was written to catch.
+    if variant.name == "kimi_k3" and reference == "trace":
+        pytest.skip("kimi_k3 has no reachable checkpoint, so no GPU trace exists for it")
+    # Same reason as K3's: the variant-unqualified CI selectors for this test would otherwise run
+    # Mistral on Wormhole T3K, where it has never been brought up.
+    if variant.name == "mistral_small_4" and not is_blackhole():
+        pytest.skip("mistral_small_4 is validated on Blackhole only")
+    # No GPU trace has ever been recorded for Mistral and none is required for CI; 'cpu' and 'func'
+    # cover all 13 scenarios between them. Skipped up front for K3's reason: the supports_pretrained
+    # assert inside _run_chunked_prefill only fires once a trace root is configured, so on a box with
+    # MLA_CHUNKED_TRACE_DIR set these would hard-fail instead of reading as out of scope.
+    if variant.name == "mistral_small_4" and reference == "trace":
+        pytest.skip("no GPU trace recorded for mistral_small_4; cpu and func cover all 13 scenarios")
     # Opt into real weights on the cpu path when the variant's checkpoint env var is set. The "trace"
     # path already forces pretrained; "func" is ref-less so weights don't matter. The pretrained
     # fixture skips the test if the env var is set but the checkpoint is incomplete.

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -496,28 +496,17 @@ def test_kimi_mla(
     )
 
 
-# sp x tp -- Mistral Small 4 bringup. Copied from test_kimi_mla above and deliberately narrowed;
-# every axis Kimi sweeps is pinned here to ONE value unless it changes the number being measured.
-#   mesh_device        (8, 4) only. Production SP-axis shape for this box; a (2, 4) PCC is not a
-#                      production-shape result, and the TTNN weight cache is keyed on device count.
-#   device_params      fabric2d only. FABRIC_1D is not in CI_ALLOWED_FABRICS for BH galaxy (8,4), so
-#                      pinning it skips the row; TorusXY needs a certified cabling descriptor.
-#   use_pretrained     random only. This row measures the MLA math, which the random-weight path
-#                      exercises identically; the pretrained checkpoint is covered by the chunked
-#                      rows below and by the transformer row.
-#   seq_len            5k only. 25k roughly quadruples the host reference's attention cost for no
-#                      extra coverage of the config fields under test.
-#   skip_host_comparison  check_pcc only. skip_check does the device work and computes NO PCC; the
-#                      gate for this step IS the PCC, so that case would be a silent zero-signal run.
-#   is_balanced        sequential only, as Kimi.
-# scale_down_sl stays swept (2 cases): it is the one axis that changes the seq_len actually run
-# (max_sl 5120 vs scaled_sl (5120//32)*8 = 1280), which exercises different padding/rotation paths.
+# sp x tp -- Mistral Small 4 bringup. Copied from test_kimi_mla and deliberately narrowed: every axis
+# Kimi sweeps is pinned to one value unless it changes the number being measured. Two pins are not
+# obvious -- fabric2d because FABRIC_1D is not in CI_ALLOWED_FABRICS for BH galaxy (8,4) and TorusXY
+# needs a certified cabling descriptor, and 8x4 because the TTNN weight cache is keyed on device
+# count. scale_down_sl stays swept: it is the one axis that changes the seq_len actually run
+# (5120 vs 1280), exercising different padding/rotation paths.
 #
-# NOT WIRED ON PURPOSE: reference_attention_cls. run_reference_mla returns None for a variant with
-# no reference (reference_runners.py:63), so the [reference_output] PCC is skipped and the three
-# gate PCCs below still come from create_mla_reference -- the vendored DeepSeek MLA, which is
-# variant-independent. Whether that vendored reference is the right truth for Mistral is a separate
-# question and is deliberately NOT settled by this test.
+# NOT WIRED ON PURPOSE: reference_attention_cls. run_reference_mla returns None for a variant with no
+# reference, so the [reference_output] PCC is skipped and the gate PCCs come from create_mla_reference
+# -- the vendored DeepSeek MLA. Whether that is the right truth for Mistral is deliberately not
+# settled here.
 @pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
@@ -1059,32 +1048,22 @@ def test_mla_chunked_prefill(
     variant.pretrained_mla_layer. Its rotation scenarios still matter: rotation comes from the
     block-cyclic cache write and the causal offset, not from RoPE."""
     # Per-variant, not module-level: two CI selectors for this test are variant-unqualified, so
-    # without this a kimi_k3 case would run on Wormhole T3K where it has never been validated.
-    if variant.name == "kimi_k3" and not is_blackhole():
-        pytest.skip("kimi_k3 is validated on Blackhole only")
+    # without this these would run on Wormhole T3K, where neither has been validated.
+    if variant.name in ("kimi_k3", "mistral_small_4") and not is_blackhole():
+        pytest.skip(f"{variant.name} is validated on Blackhole only")
     # The metadata contract serves the trace-safe runtime (inbound_socket_service_sync feeds forward
     # tt_metadata directly). K3 has no runtime -- build_runtime/allocate_kv_cache deliberately raise
     # -- so the path is unreachable for it and passes only via the shared arch-agnostic ttMLA.forward.
     # Incidental, not a K3 guarantee; re-enable when K3 has a runtime that actually feeds metadata.
     if variant.name == "kimi_k3" and use_metadata_tensor:
         pytest.skip("kimi_k3 has no runtime, so the metadata (device-scalar) path is unreachable for it")
-    # No K3 checkpoint is reachable, so no GPU trace was ever recorded for it. _run_chunked_prefill
-    # already asserts on supports_pretrained, but only once a trace root is configured -- so on a box
-    # with MLA_CHUNKED_TRACE_DIR set these cases would hard-fail instead of being cleanly out of
-    # scope. Skip up front; the assert stays as the backstop for any future supports_pretrained=False
-    # variant and for the silent K2.6-trace-substitution it was written to catch.
-    if variant.name == "kimi_k3" and reference == "trace":
-        pytest.skip("kimi_k3 has no reachable checkpoint, so no GPU trace exists for it")
-    # Same reason as K3's: the variant-unqualified CI selectors for this test would otherwise run
-    # Mistral on Wormhole T3K, where it has never been brought up.
-    if variant.name == "mistral_small_4" and not is_blackhole():
-        pytest.skip("mistral_small_4 is validated on Blackhole only")
-    # No GPU trace has ever been recorded for Mistral and none is required for CI; 'cpu' and 'func'
-    # cover all 13 scenarios between them. Skipped up front for K3's reason: the supports_pretrained
-    # assert inside _run_chunked_prefill only fires once a trace root is configured, so on a box with
-    # MLA_CHUNKED_TRACE_DIR set these would hard-fail instead of reading as out of scope.
-    if variant.name == "mistral_small_4" and reference == "trace":
-        pytest.skip("no GPU trace recorded for mistral_small_4; cpu and func cover all 13 scenarios")
+    # Neither has a recorded GPU trace: K3's checkpoint is unreachable, Mistral's was never recorded
+    # ('cpu' and 'func' cover all 13 scenarios). Skipped up front because _run_chunked_prefill's
+    # supports_pretrained assert only fires once a trace root is configured, so with
+    # MLA_CHUNKED_TRACE_DIR set these would hard-fail instead of reading as out of scope. That assert
+    # stays as the backstop for the silent K2.6-trace-substitution it was written to catch.
+    if variant.name in ("kimi_k3", "mistral_small_4") and reference == "trace":
+        pytest.skip(f"no GPU trace recorded for {variant.name}")
     # Opt into real weights on the cpu path when the variant's checkpoint env var is set. The "trace"
     # path already forces pretrained; "func" is ref-less so weights don't matter. The pretrained
     # fixture skips the test if the env var is set but the checkpoint is incomplete.

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -23,7 +23,7 @@ from loguru import logger
 from transformers import DynamicCache
 
 import ttnn
-from models.common.utility_functions import hf_cache_layer_kv, is_blackhole, profiler
+from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3.demo.demo import load_prompts_from_json
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import pretrained_mla_weights
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
@@ -55,9 +55,11 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     PROMPT_5K_PATH,
     PROMPT_25K_PATH,
     create_hf_model,
+    decoder_layer_kwargs,
     extract_layer_state_dict,
     get_4d_causal_mask,
     load_and_compute_layer_by_layer,
+    reference_kvpe_for_layer,
     tokenize_prompt_to_isl,
 )
 
@@ -285,18 +287,18 @@ def run_model(
             position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
             attention_mask = get_4d_causal_mask(torch.ones(1, isl_total), causal_only=True).to(torch.bfloat16)
             ref_cache = DynamicCache()
+            # Bound to the layer's own signature, and reused below for the KVPE line.
+            layer_kwargs = decoder_layer_kwargs(
+                hf_model.layers[layer_idx], hf_model, torch_input, attention_mask, position_ids, ref_cache
+            )
             with torch.no_grad():
-                layer_out = hf_model.layers[layer_idx](
-                    torch_input,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
-                    past_key_value=ref_cache,
-                    use_cache=True,
-                )
-                torch_output = layer_out[0]
+                layer_out = hf_model.layers[layer_idx](torch_input, **layer_kwargs)
+                torch_output = layer_out[0] if isinstance(layer_out, (tuple, list)) else layer_out
             logger.info(f"Torch reference output shape: {torch_output.shape}")
             if ref_cache is not None:
-                ref_kvpe = hf_cache_layer_kv(ref_cache, layer_idx)[0]
+                ref_kvpe = reference_kvpe_for_layer(
+                    hf_model.layers[layer_idx], layer_idx, torch_input, layer_kwargs, ref_cache, config
+                )
                 logger.info(f"Reference KVPE shape: {ref_kvpe.shape}")
             profiler.end("torch_reference")
 

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -30,6 +30,7 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.reference.glm_5_1 import glm_decoder_layer_reference
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import load_moe_weights_from_hf
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     fabric2d_device_params,
@@ -79,6 +80,10 @@ class PrefillBlockThresholds:
 
 DSV3_THRESHOLDS = PrefillBlockThresholds()
 KIMI_THRESHOLDS = PrefillBlockThresholds(moe_gate_host=0.950)
+# Mistral runs GPT_DEVICE, and the selector above only special-cases GateComputeMode.DEVICE, so every
+# other device gate lands on `moe_gate_host` -- the same reason Kimi tunes that field rather than
+# moe_gate_device. Floor set just under the measured 0.990894 (pcc-prompt_5k, mesh-8x4, CHUNK=5120).
+MISTRAL4_THRESHOLDS = PrefillBlockThresholds(moe_gate_host=0.990)
 
 # Determinism: every iteration must be bit-identical to the iter-0 baseline (strict).
 DETERMINISM_PCC_THRESHOLD = 1.0
@@ -476,6 +481,49 @@ def run_model(
             _, pe_pcc = comp_pcc(ref_kvpe[:, :, :, kv_lora_rank:].float(), tt_kvpe[:, :, :, kv_lora_rank:].float())
             logger.info(f"KVPE cache KV part PCC: {kv_pcc:.6f} (threshold: {thresholds.kvpe_kv})")
             logger.info(f"KVPE cache PE part PCC: {pe_pcc:.6f} (threshold: {thresholds.kvpe_pe})")
+
+            # A single PCC over the whole tensor cannot say WHERE the error is, and the two failure
+            # shapes need different fixes: a uniform miss is precision/convention, a localised one is
+            # a boundary (last partial chunk, padding tail, final tile). Set KVPE_POSITION_BREAKDOWN=1
+            # to print per-band PCC. Diagnostic only -- off by default, asserts nothing.
+            if os.environ.get("KVPE_POSITION_BREAKDOWN"):
+                ref_pe = ref_kvpe[0, 0, :, kv_lora_rank:].float()
+                dev_pe = tt_kvpe[0, 0, :, kv_lora_rank:].float()
+                ref_kv = ref_kvpe[0, 0, :, :kv_lora_rank].float()
+                dev_kv = tt_kvpe[0, 0, :, :kv_lora_rank].float()
+                seq = ref_pe.shape[0]
+                sp = mesh_shape[sp_axis]
+                per_chip = seq // sp
+                logger.info(f"KVPE position breakdown: seq={seq} sp={sp} per_chip={per_chip} tile=32")
+                logger.info(f"{'band':>16} {'PE PCC':>10} {'KV PCC':>10} {'|ref|max':>10} {'|dev|max':>10}")
+                bands = [
+                    (i * per_chip, (i + 1) * per_chip, f"chip{i} {i*per_chip}-{(i+1)*per_chip}") for i in range(sp)
+                ]
+                # the last chip again, split fine: a tile- or tail-sized error hides inside a 640-row band
+                last = seq - per_chip
+                bands += [
+                    (last + k, min(last + k + 64, seq), f"  tail {last+k}-{min(last+k+64, seq)}")
+                    for k in range(0, per_chip, 128)
+                ]
+                for lo, hi, label in bands:
+                    if hi <= lo:
+                        continue
+                    p = comp_pcc(ref_pe[lo:hi], dev_pe[lo:hi], 0.0)[1]
+                    k = comp_pcc(ref_kv[lo:hi], dev_kv[lo:hi], 0.0)[1]
+                    logger.info(
+                        f"{label:>16} {float(p):>10.6f} {float(k):>10.6f} "
+                        f"{ref_pe[lo:hi].abs().max():>10.3f} {dev_pe[lo:hi].abs().max():>10.3f}"
+                    )
+                worst = min(
+                    range(sp),
+                    key=lambda i: float(
+                        comp_pcc(
+                            ref_pe[i * per_chip : (i + 1) * per_chip], dev_pe[i * per_chip : (i + 1) * per_chip], 0.0
+                        )[1]
+                    ),
+                )
+                logger.info(f"KVPE worst SP band: chip{worst} (rows {worst*per_chip}-{(worst+1)*per_chip})")
+
             assert kv_pcc > thresholds.kvpe_kv, f"KVPE KV PCC {kv_pcc:.6f} below threshold {thresholds.kvpe_kv}"
             assert pe_pcc > thresholds.kvpe_pe, f"KVPE PE PCC {pe_pcc:.6f} below threshold {thresholds.kvpe_pe}"
 
@@ -704,6 +752,103 @@ def test_kimi_prefill_block(
         determinism_check=determinism_check,
         num_iterations=num_iterations,
         thresholds=KIMI_THRESHOLDS,
+        use_pretrained=use_pretrained,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mistral Small 4 block test
+# ---------------------------------------------------------------------------
+# Two rows differ from the Kimi test above, both forced by the config rather than chosen:
+#
+#   * NO "dense" row. text_config.first_k_dense_replace = 0, so all 36 layers are MoE and a dense
+#     block is a configuration this model never has. Kimi/DeepSeek run ("dense", None) because their
+#     first 1 / 3 layers really are dense.
+#   * GPT_DEVICE, not DEVICE_FP32. moe_grouped_topk.cpp's parse_score_func accepts only sigmoid and
+#     sqrtsoftplus, so the sigmoid device gate cannot express Mistral's softmax -> top-4 ->
+#     renormalize router. Running DEVICE_FP32 here would apply a sigmoid affinity and silently
+#     produce wrong routing weights -- no crash, and invisible to an MLA-only test.
+#
+# Random weights only for now: the adapter carries supports_pretrained=False and no TTNN weight cache
+# has been populated, so a pretrained row would skip rather than fail. Add ("pretrained") once a cache
+# exists -- and check `passed` vs `skipped`, since a skip reads as success in the summary.
+@pytest.mark.parametrize(
+    "input_source, pcc_validation, isl_total, dispatch_buffer_capacity_factor",
+    [
+        ("random", False, 1024, 8),
+        ("random", False, 5 * 1024, 8),
+        ("prompt_5k", True, 5 * 1024, 8),
+    ],
+    ids=["smoke-random", "perf-random-5k", "pcc-prompt_5k"],
+)
+@pytest.mark.parametrize(
+    "layer_type, gate_fallback_mode",
+    [("moe", GateComputeMode.GPT_DEVICE)],
+    ids=["moe_gate_gpt"],
+)
+@pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links",
+    [
+        pytest.param(
+            (8, 4),
+            fabric2d_device_params(fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE),
+            2,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="fabric2d-mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["mistral_small_4"], indirect=True, ids=["mistral"])
+@pytest.mark.parametrize("determinism_check", [False, True], ids=["no_determinism", "with_determinism"])
+@pytest.mark.parametrize("num_iterations", [1, 2, 5], ids=["iter1", "iter2", "iter5"])
+@pytest.mark.skipif(not is_blackhole(), reason="Mistral Small 4 targets the Blackhole galaxy")
+@pytest.mark.timeout(900)
+@pytest.mark.parametrize("use_pretrained", [False], ids=["random"])
+def test_mistral4_prefill_block(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    is_balanced,
+    isl_total,
+    dispatch_buffer_capacity_factor,
+    layer_type,
+    gate_fallback_mode,
+    num_links,
+    pcc_validation,
+    input_source,
+    tokenizer,
+    is_ci_env,
+    is_ci_v2_env,
+    determinism_check,
+    num_iterations,
+    use_pretrained,
+    request,
+):
+    topology = per_axis_topology(device_params["fabric_config"])
+    run_model(
+        variant,
+        config_only,
+        mesh_device,
+        device_params,
+        is_balanced,
+        isl_total,
+        dispatch_buffer_capacity_factor,
+        layer_type,
+        gate_fallback_mode,
+        num_links,
+        topology,
+        pcc_validation,
+        input_source,
+        tokenizer,
+        request,
+        is_ci_env,
+        is_ci_v2_env,
+        determinism_check=determinism_check,
+        num_iterations=num_iterations,
+        thresholds=MISTRAL4_THRESHOLDS,
         use_pretrained=use_pretrained,
     )
 

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -61,6 +61,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     load_and_compute_layer_by_layer,
     load_debug_trace,
     load_reference_cache,
+    mla_kvpe_width,
     save_reference_cache,
     slice_debug_trace,
     slice_non_padded,
@@ -255,7 +256,10 @@ def run_model(
         n_routed_experts=n_routed_experts,
         padding_side=padding_side,
     )
-    ref_cache_exists = check_reference_cache_exists(variant, cache_key) if (pcc_validation and trace is None) else False
+    # A cache written before the compressed-line fix holds expanded per-head keys, and without the
+    # width check still reports as reusable.
+    kvpe_width = mla_kvpe_width(config)
+    ref_cache_exists = pcc_validation and trace is None and check_reference_cache_exists(variant, cache_key, kvpe_width)
 
     logger.info(
         f"Cache status: TTNN={ttnn_cache_complete}, Trace={'YES' if trace else 'NO'}, Reference={ref_cache_exists}"

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -29,7 +29,6 @@ from pathlib import Path
 import pytest
 import torch
 from loguru import logger
-from transformers import PreTrainedConfig
 
 import ttnn
 from conftest import is_galaxy
@@ -38,14 +37,13 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
@@ -1301,21 +1299,18 @@ MISTRAL4_THRESHOLDS = PrefillTransformerThresholds(
 )
 @pytest.mark.parametrize("determinism_check", [False], ids=["no_determinism"])
 @pytest.mark.parametrize("num_iterations", [1], ids=["iter1"])
+# FABRIC_1D is not in CI_ALLOWED_FABRICS for BLACKHOLE_GALAXY (8,4), so pinning it here skips the
+# whole row on this hardware. fabric2d is the allowed non-torus option; TorusXY needs a certified
+# cabling descriptor.
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            fabric2d_device_params(fabric_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="fabric2d-mesh-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1334,7 +1329,6 @@ def test_mistral4_prefill_transformer(
     n_routed_experts,
     gate_fallback_mode,
     num_links,
-    topology,
     pcc_validation,
     determinism_check,
     num_iterations,
@@ -1348,18 +1342,12 @@ def test_mistral4_prefill_transformer(
     tokenizer,
     request,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     # The random path holds every layer at once (~6.5 GB per MoE layer here, plus the state-dict
     # copy), so a deep random model would peak near this shared box's RAM. Depth is covered by the
     # pretrained rows, which load and free one layer at a time.
     if not use_pretrained and num_layers > 2:
         pytest.skip(f"random weights at {num_layers} layers would need ~{num_layers * 6.5:.0f} GB of host RAM")
-
-    # Random weights mean building the reference model from the config, and transformers refuses a
-    # config that is not a PreTrainedConfig. A variant whose config_builder hand-builds a namespace
-    # (config_builder_overrides_checkpoint) has no random-weight path at all as a result; the
-    # pretrained rows cover the same ground, so skip rather than fail inside transformers.
-    if not use_pretrained and not isinstance(config_only, PreTrainedConfig):
-        pytest.skip(f"{variant.name}: config_builder returns {type(config_only).__name__}, not a PreTrainedConfig")
 
     run_model(
         variant,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -23,17 +23,20 @@ import gc
 import json
 import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 import torch
 from loguru import logger
+from transformers import PreTrainedConfig
 
 import ttnn
 from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
@@ -42,6 +45,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
@@ -69,6 +73,36 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
 )
 from tests.ttnn.utils_for_testing import comp_pcc
 
+
+@dataclass(frozen=True)
+class PrefillTransformerThresholds:
+    """Per-stage PCC bars, and which of the two scores gates them.
+
+    One scalar cannot serve every stage: a residual-stream layer, the normalised output and the two
+    halves of the KV cache line sit at different levels for reasons that are properties of the model,
+    not of the device. `metric="npcc"` gates the hidden-state stages on the RMS-normalised score
+    (see _compare_intermediate_pcc); the KV rows always gate on raw, to stay comparable with
+    test_prefill_block.
+    """
+
+    layer: float  # embed + per-layer residual stream
+    output: float  # norm / lm_head / logits
+    kvpe_kv: float
+    kvpe_pe: float
+    metric: str = "pcc"
+
+
+def _threshold_for(label: str, th: PrefillTransformerThresholds) -> tuple[float, bool]:
+    """(bar, gate_on_npcc) for one stage label."""
+    if label.endswith("_kvpe_kv"):
+        return th.kvpe_kv, False
+    if label.endswith("_kvpe_pe"):
+        return th.kvpe_pe, False
+    if label in ("norm", "lm_head", "logits"):
+        return th.output, th.metric == "npcc"
+    return th.layer, th.metric == "npcc"
+
+
 PCC_THRESHOLD = 0.99
 TRACE_PCC_THRESHOLD = 0.97
 TRACE_PCC_THRESHOLD_HOST = 0.96
@@ -86,7 +120,20 @@ SEQ_LEN_5K = 5120
 SEQ_LEN_25K = 25600
 
 
+def _token_normalized(t: torch.Tensor) -> torch.Tensor:
+    """Scale each token's row to unit RMS — the transform RMSNorm itself applies."""
+    t = t.float()
+    return t / t.pow(2).mean(dim=-1, keepdim=True).sqrt().clamp_min(1e-12)
+
+
 def _compare_intermediate_pcc(reference_items, tt_intermediates, number_of_non_padded_tokens, padding_side):
+    """Per-stage (label, pcc, npcc). npcc is the same PCC after per-token RMS normalisation.
+
+    Raw PCC over a whole hidden state is dominated by its largest channels. Where a model develops
+    massive activations (Mistral Small 4: absmax/rms ~150 by layer 30) that makes it a measurement of
+    a few hundred outlier channels rather than of the layer -- in both directions. npcc removes the
+    scale so every channel counts; which of the two gates is the caller's choice.
+    """
     pcc_results = []
     for label, ref_host in reference_items:
         # For lm_head TT only emits logits at the next-token position, not the full sequence.
@@ -95,35 +142,37 @@ def _compare_intermediate_pcc(reference_items, tt_intermediates, number_of_non_p
             tt_host = tt_intermediates.get("logits")
             if tt_host is None:
                 logger.error(f"{label:<20s}  Missing 'logits' single-position extract in TT intermediates")
-                pcc_results.append((label, -1.0))
+                pcc_results.append((label, -1.0, None))
                 continue
             last_token_idx = number_of_non_padded_tokens - 1 if padding_side == "right" else ref_host.shape[-2] - 1
             try:
-                ref_slice = ref_host.narrow(-2, last_token_idx, 1)
-                _, pcc = comp_pcc(ref_slice.float(), tt_host.float())
-                logger.debug(f"{label:<20s}  PCC = {pcc:.6f}")
-                pcc_results.append((label, pcc))
+                ref_slice = ref_host.narrow(-2, last_token_idx, 1).float()
+                tt_slice = tt_host.float()
+                _, pcc = comp_pcc(ref_slice, tt_slice)
+                _, npcc = comp_pcc(_token_normalized(ref_slice), _token_normalized(tt_slice))
+                logger.debug(f"{label:<20s}  PCC = {pcc:.6f}  nPCC = {npcc:.6f}")
+                pcc_results.append((label, pcc, npcc))
             except Exception as e:
                 logger.error(f"{label:<20s}  PCC comparison failed: {e}")
-                pcc_results.append((label, -1.0))
+                pcc_results.append((label, -1.0, None))
             continue
 
         if label not in tt_intermediates:
             logger.error(f"{label:<20s}  Missing from TT intermediates")
-            pcc_results.append((label, -1.0))
+            pcc_results.append((label, -1.0, None))
             continue
 
         tt_host = tt_intermediates[label]
         try:
-            _, pcc = comp_pcc(
-                slice_non_padded(ref_host, number_of_non_padded_tokens, padding_side).float(),
-                slice_non_padded(tt_host, number_of_non_padded_tokens, padding_side).float(),
-            )
-            logger.debug(f"{label:<20s}  PCC = {pcc:.6f}")
-            pcc_results.append((label, pcc))
+            ref_slice = slice_non_padded(ref_host, number_of_non_padded_tokens, padding_side).float()
+            tt_slice = slice_non_padded(tt_host, number_of_non_padded_tokens, padding_side).float()
+            _, pcc = comp_pcc(ref_slice, tt_slice)
+            _, npcc = comp_pcc(_token_normalized(ref_slice), _token_normalized(tt_slice))
+            logger.debug(f"{label:<20s}  PCC = {pcc:.6f}  nPCC = {npcc:.6f}")
+            pcc_results.append((label, pcc, npcc))
         except Exception as e:
             logger.error(f"{label:<20s}  PCC comparison failed: {e}")
-            pcc_results.append((label, -1.0))
+            pcc_results.append((label, -1.0, None))
     return pcc_results
 
 
@@ -152,6 +201,7 @@ def run_model(
     is_ci_v2_env,
     tokenizer,
     request,
+    thresholds: PrefillTransformerThresholds | None = None,
 ):
     torch.manual_seed(42)
 
@@ -515,13 +565,15 @@ def run_model(
             if baseline_logits is not None and isinstance(tt_intermediates.get("logits"), torch.Tensor):
                 try:
                     _, lp = comp_pcc(baseline_logits.float(), tt_intermediates["logits"].float())
-                    iter_pcc.append(("logits", lp))
+                    iter_pcc.append(("logits", lp, None))
                 except Exception as e:
                     logger.error(f"logits PCC comparison failed: {e}")
-                    iter_pcc.append(("logits", -1.0))
-            iter_pcc.append(("first_token_id", 1.0 if first_token_id == baseline_first_token_id else -1.0))
+                    iter_pcc.append(("logits", -1.0, None))
+            iter_pcc.append(("first_token_id", 1.0 if first_token_id == baseline_first_token_id else -1.0, None))
             logger.info(f"\n--- Determinism iter {i} vs iter0 ---")
-            for label, pcc in iter_pcc:
+            # Determinism compares TT against TT, so raw PCC is the right score: the two tensors are
+            # in the same units and normalising would hide a scale-only divergence.
+            for label, pcc, _ in iter_pcc:
                 status = "PASS" if pcc >= threshold else ("FAIL" if pcc >= 0 else "ERROR")
                 logger.info(f"{label:<20s}  {pcc:>10.6f}  {status:>8s}")
                 if pcc < threshold:
@@ -621,7 +673,11 @@ def run_model(
             threshold = 0.985
         else:
             threshold = PCC_THRESHOLD  # 0.99
-        logger.info(f"PCC threshold: {threshold} (ref_source={'trace' if trace else 'host'})")
+        # No explicit tiers -> one bar for every stage, gated on raw PCC (unchanged behaviour).
+        th = thresholds or PrefillTransformerThresholds(
+            layer=threshold, output=threshold, kvpe_kv=threshold, kvpe_pe=threshold
+        )
+        logger.info(f"PCC thresholds: {th} (ref_source={'trace' if trace else 'host'})")
 
         # --- Load reference snapshots (priority: trace > cache > already computed) ---
         pcc_results = []
@@ -678,13 +734,13 @@ def run_model(
                         ).float(),
                     )
                     logger.info(f"{label:<20s}  KV PCC = {kv_pcc:.6f}, PE PCC = {pe_pcc:.6f}")
-                    pcc_results.append((f"{label}_kv", kv_pcc))
-                    pcc_results.append((f"{label}_pe", pe_pcc))
+                    pcc_results.append((f"{label}_kv", kv_pcc, None))
+                    pcc_results.append((f"{label}_pe", pe_pcc, None))
 
                 except Exception as e:
                     logger.error(f"{label:<20s}  KVPE PCC comparison failed: {e}")
-                    pcc_results.append((f"{label}_kv", -1.0))
-                    pcc_results.append((f"{label}_pe", -1.0))
+                    pcc_results.append((f"{label}_kv", -1.0, None))
+                    pcc_results.append((f"{label}_pe", -1.0, None))
 
         # --- Logits PCC check (last-token logits vs trace reference) ---
         # Trace logits / next-token are products of the full traced model. They are
@@ -694,12 +750,15 @@ def run_model(
         trace_full_model = trace is not None and not trace_sliced and num_layers == trace.metadata.get("n_layers")
         if trace_full_model and trace.logits is not None and "logits" in tt_intermediates:
             try:
-                _, logits_pcc = comp_pcc(trace.logits.float(), tt_intermediates["logits"].float())
-                logger.info(f"{'logits':<20s}  PCC = {logits_pcc:.6f}")
-                pcc_results.append(("logits", logits_pcc))
+                ref_logits = trace.logits.float()
+                tt_logits = tt_intermediates["logits"].float()
+                _, logits_pcc = comp_pcc(ref_logits, tt_logits)
+                _, logits_npcc = comp_pcc(_token_normalized(ref_logits), _token_normalized(tt_logits))
+                logger.info(f"{'logits':<20s}  PCC = {logits_pcc:.6f}  nPCC = {logits_npcc:.6f}")
+                pcc_results.append(("logits", logits_pcc, logits_npcc))
             except Exception as e:
                 logger.error(f"{'logits':<20s}  PCC comparison failed: {e}")
-                pcc_results.append(("logits", -1.0))
+                pcc_results.append(("logits", -1.0, None))
         elif trace is not None and not trace_full_model:
             reason = (
                 "trace sliced to a shorter isl (full-sequence logits/next-token invalid)"
@@ -711,16 +770,20 @@ def run_model(
         profiler.end("pcc_validation")
 
         # --- Summary table ---
-        logger.info(f"\n{'='*50}")
-        logger.info(f"{'Stage':<20s}  {'PCC':>10s}  {'Status':>8s}")
-        logger.info(f"{'-'*50}")
+        logger.info(f"\n{'='*72}")
+        logger.info(f"{'Stage':<20s}  {'PCC':>10s}  {'nPCC':>10s}  {'bar':>8s}  {'Status':>8s}")
+        logger.info(f"{'-'*72}")
         failures = []
-        for label, pcc in pcc_results:
-            status = "PASS" if pcc >= threshold else ("FAIL" if pcc >= 0 else "ERROR")
-            logger.info(f"{label:<20s}  {pcc:>10.6f}  {status:>8s}")
-            if pcc < threshold:
-                failures.append((label, pcc))
-        logger.info(f"{'='*50}")
+        for label, pcc, npcc in pcc_results:
+            bar, gate_on_npcc = _threshold_for(label, th)
+            # The gated score is the one in `bar`'s units; the other is reported for context only.
+            score = npcc if (gate_on_npcc and npcc is not None) else pcc
+            status = "PASS" if score >= bar else ("FAIL" if score >= 0 else "ERROR")
+            npcc_s = f"{npcc:>10.6f}" if npcc is not None else f"{'-':>10s}"
+            logger.info(f"{label:<20s}  {pcc:>10.6f}  {npcc_s}  {bar:>8.4f}  {status:>8s}")
+            if score < bar:
+                failures.append((label, score))
+        logger.info(f"{'='*72}")
 
         # --- First token info ---
         tok = tokenizer
@@ -732,13 +795,22 @@ def run_model(
 
         # First-token cross-check against the reference
         # (skipped for a sliced trace: its next_token_id is the full sequence's, not the prefix's)
-        if trace is not None and not trace_sliced and num_layers == trace.metadata.get("n_layers"):
-            token_match = check_first_token_match(trace, trace_dir, first_token_id, first_token_prob)
+        # Both references hold an ARGMAX, so compare TT's argmax, not `first_token_id` -- that is a
+        # temperature-sampled draw, and on a flat distribution the two are unrelated (at isl 5120 with
+        # random ids the sampler returned a token of probability 0.0% against a 17.1% argmax).
+        _tt_logits = tt_intermediates.get("logits") if tt_intermediates else None
+        tt_argmax = int(_tt_logits.float().flatten().argmax().item()) if _tt_logits is not None else first_token_id
+        if input_source == "random":
+            # Uniform random ids are not language: the next-token distribution is near-flat, so token
+            # equality carries no signal either way. The PCC stages still cover this input.
+            logger.info("Skipping first-token equality for random token ids")
+        elif trace is not None and not trace_sliced and num_layers == trace.metadata.get("n_layers"):
+            token_match = check_first_token_match(trace, trace_dir, tt_argmax, first_token_prob)
             if token_match is False:
                 failures.append(("first_token_match", -1.0))
         elif trace is None and num_layers == config.num_hidden_layers:
             hf_match = check_first_token_match_host_ref(
-                ref_snapshots, number_of_non_padded_tokens, padding_side, first_token_id, tok
+                ref_snapshots, number_of_non_padded_tokens, padding_side, tt_argmax, tok
             )
             if hf_match is False:
                 failures.append(("first_token_match", -1.0))
@@ -797,7 +869,7 @@ def run_model(
         output_pcc = {}
         kvpe_kv_pcc = {}
         kvpe_pe_pcc = {}
-        for label, pcc in pcc_results:
+        for label, pcc, _ in pcc_results:
             if "_kv" in label:
                 kvpe_kv_pcc[label] = pcc
             elif "_pe" in label:
@@ -815,9 +887,9 @@ def run_model(
             "n_routed_experts": n_routed_experts,
             "capacity_factor": dispatch_buffer_capacity_factor,
             "gate_fallback_mode": gate_fallback_mode,
-            "threshold": threshold,
+            "threshold": th.layer,
         }
-        write_pcc_summary(summary_result, threshold=threshold)
+        write_pcc_summary(summary_result, threshold=th.layer)
         # PCC plots are opt-in (TT_PREFILL_PCC_PLOTS=1). generate_pcc_plots renders a PNG into trace_dir,
         # which for a pinned golden is a read-only shared mount (/mnt/models/...) -> PermissionError. Off by
         # default so trace-backed runs don't crash on artifact write; still skipped under GitHub Actions.
@@ -826,7 +898,7 @@ def run_model(
 
     # Deferred PCC failure check (after timing report)
     if pcc_validation and has_pcc_failures:
-        pytest.fail(f"PCC below {threshold} at: {pcc_failure_msg}")
+        pytest.fail(f"PCC below its stage bar ({th}) at: {pcc_failure_msg}")
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="Requires Blackhole.")
@@ -1163,4 +1235,156 @@ def test_glm_prefill_transformer(
         is_ci_v2_env,
         tokenizer,
         request,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mistral Small 4
+# ---------------------------------------------------------------------------
+# Each bar sits ~0.01 under the worst stage measured by the 36L/isl-1024 row (2026-08-21; minima
+# layer_19 0.9210, norm 0.9581, layer_16 kv 0.8346 / pe 0.9792). They are FLOORS -- the device tracks
+# the reference to a bounded discrepancy rather than diverging, so a floor catches a regression that
+# an aspirational 0.99 could only park as xfail. metric="npcc" because raw PCC on this model measures
+# a few hundred outlier channels (see _compare_intermediate_pcc): it reads 0.17 at layer_32 where the
+# normalised score reads 0.936, and the model matches the reference's next token exactly.
+MISTRAL4_THRESHOLDS = PrefillTransformerThresholds(
+    layer=0.91,
+    output=0.95,
+    kvpe_kv=0.82,
+    kvpe_pe=0.97,
+    metric="npcc",
+)
+
+
+# Two deviations from the sibling rows, both forced by the config:
+#   * no dense stage -- first_k_dense_replace = 0, so all 36 layers are MoE.
+#   * GPT_DEVICE -- moe_grouped_topk.cpp's parse_score_func takes only sigmoid/sqrtsoftplus, so the
+#     sigmoid device gate cannot express softmax -> top-4 -> renormalise. DEVICE_FP32 would apply a
+#     sigmoid affinity and produce wrong routing weights without failing.
+# The PCC case needs supports_pretrained on the adapter; until then it skips at run_model.
+@pytest.mark.skipif(not is_blackhole(), reason="Mistral Small 4 targets the Blackhole galaxy")
+@pytest.mark.parametrize("tokenizer", ["right"], indirect=True, ids=["right_pad"])
+@pytest.mark.parametrize("temperature", [[0.5]], ids=["temp_sweep"])
+@pytest.mark.parametrize("return_kv_cache", [True], ids=["kv_cache"])
+@pytest.mark.parametrize(
+    "input_source, pcc_validation, use_pretrained",
+    [
+        ("random", False, False),
+        ("json_prompts", True, True),
+        # PROMPT_1K_PATH holds ~1080 tokens, so at isl 5120 the json row compares 1080 real positions
+        # and pads the rest -- it exercises the wider per-chip geometry but never a position past
+        # ~1080. Random token ids fill every position with a valid mask, which is what puts the rope
+        # phase at position 5119 under test (the fp32-rope bug read 0.9995 at 512 and 0.956 at 5120).
+        ("random", True, True),
+    ],
+    ids=["smoke-random-random", "pcc-json_prompts-pretrained", "pcc-random-pretrained"],
+)
+@pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
+@pytest.mark.parametrize(
+    "isl_total, dispatch_buffer_capacity_factor",
+    [(SEQ_LEN_1K, 8), (SEQ_LEN_5K, 8)],
+    ids=["1k", "5k"],
+)
+# 2 layers is the wiring check; 36 is the model. Nothing between the two tests anything new.
+@pytest.mark.parametrize(
+    "num_layers",
+    [
+        2,
+        pytest.param(36, marks=pytest.mark.skipif(not is_galaxy(), reason="Full 36-layer prefill only on Galaxy")),
+    ],
+    ids=["2_layers", "36_layers"],
+)
+@pytest.mark.parametrize(
+    "n_routed_experts, gate_fallback_mode",
+    [(MistralSmall4Config.NUM_ROUTED_EXPERTS, GateComputeMode.GPT_DEVICE)],
+    ids=["e128_gpt_device"],
+)
+@pytest.mark.parametrize("determinism_check", [False], ids=["no_determinism"])
+@pytest.mark.parametrize("num_iterations", [1], ids=["iter1"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(
+                    max_payload_size=MistralSmall4Config.FABRIC_PAYLOAD_SIZE
+                ),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["mistral_small_4"], indirect=True, ids=["mistral4"])
+@pytest.mark.timeout(0)
+def test_mistral4_prefill_transformer(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    is_balanced,
+    isl_total,
+    dispatch_buffer_capacity_factor,
+    num_layers,
+    n_routed_experts,
+    gate_fallback_mode,
+    num_links,
+    topology,
+    pcc_validation,
+    determinism_check,
+    num_iterations,
+    input_source,
+    use_pretrained,
+    return_kv_cache,
+    temperature,
+    weight_cache_path,
+    is_ci_env,
+    is_ci_v2_env,
+    tokenizer,
+    request,
+):
+    # The random path holds every layer at once (~6.5 GB per MoE layer here, plus the state-dict
+    # copy), so a deep random model would peak near this shared box's RAM. Depth is covered by the
+    # pretrained rows, which load and free one layer at a time.
+    if not use_pretrained and num_layers > 2:
+        pytest.skip(f"random weights at {num_layers} layers would need ~{num_layers * 6.5:.0f} GB of host RAM")
+
+    # Random weights mean building the reference model from the config, and transformers refuses a
+    # config that is not a PreTrainedConfig. A variant whose config_builder hand-builds a namespace
+    # (config_builder_overrides_checkpoint) has no random-weight path at all as a result; the
+    # pretrained rows cover the same ground, so skip rather than fail inside transformers.
+    if not use_pretrained and not isinstance(config_only, PreTrainedConfig):
+        pytest.skip(f"{variant.name}: config_builder returns {type(config_only).__name__}, not a PreTrainedConfig")
+
+    run_model(
+        variant,
+        config_only,
+        mesh_device,
+        device_params,
+        is_balanced,
+        isl_total,
+        dispatch_buffer_capacity_factor,
+        num_layers,
+        n_routed_experts,
+        gate_fallback_mode,
+        num_links,
+        topology,
+        pcc_validation,
+        determinism_check,
+        num_iterations,
+        input_source,
+        use_pretrained,
+        return_kv_cache,
+        temperature,
+        weight_cache_path,
+        is_ci_env,
+        is_ci_v2_env,
+        tokenizer,
+        request,
+        thresholds=MISTRAL4_THRESHOLDS,
     )

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_shared_prefill_fixes.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_shared_prefill_fixes.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only regression tests for the shared prefill fixes. No device, no weights, milliseconds.
+
+Each test fails on the code as it stood before its named commit. Both bugs are silent -- they produce
+a plausible wrong number rather than an error -- so each test also asserts that the *pre-fix*
+behaviour is detectably wrong, otherwise the test could pass for the wrong reason.
+"""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.mla.mla import ttMLA
+from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
+    decoder_layer_kwargs,
+    layer_wants_position_embeddings,
+    reference_position_embeddings,
+    reference_rope,
+)
+
+
+def test_reference_rope_is_fp32_even_when_the_model_is_bf16():
+    """Guards `fix(mla): build the reference rope from the config, not the model`.
+
+    A reference instantiated in bf16 carries a bf16 ``inv_freq`` BUFFER, and ``.float()`` cannot
+    recover bits already gone (0.75 where the true value is 0.7498942). The residue is a
+    per-dimension frequency error, i.e. a phase error that grows LINEARLY with position -- harmless
+    at short prompts, ruinous at long ones. Rebuilding from the config in fp32 is the only fix.
+    """
+    transformers = pytest.importorskip("transformers")
+    from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
+
+    cfg = transformers.LlamaConfig(
+        hidden_size=256, num_attention_heads=4, num_hidden_layers=1, rope_theta=10000.0, max_position_embeddings=65536
+    )
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = cfg
+            self.rotary_emb = LlamaRotaryEmbedding(config=cfg)
+
+    model = _Model().to(torch.bfloat16)  # what create_hf_model does
+    assert model.rotary_emb.inv_freq.dtype == torch.bfloat16, "precondition: the buffer must be bf16"
+
+    # Far enough out that a ~4.4e-4 relative frequency error is visible. The error is proportional to
+    # position, so a short prompt would hide it -- which is exactly how this survived.
+    pos = torch.tensor([[40000]], dtype=torch.long)
+    hidden = torch.zeros(1, 1, cfg.hidden_size, dtype=torch.bfloat16)
+
+    cos_fix, sin_fix = reference_rope(model, hidden, pos)
+
+    # Ground truth: an independently constructed fp32 table.
+    gt = LlamaRotaryEmbedding(config=cfg).float()
+    with torch.no_grad():
+        cos_gt, sin_gt = gt(torch.zeros(1, 1, cfg.hidden_size), pos)
+
+    err_fix = max((cos_fix - cos_gt).abs().max().item(), (sin_fix - sin_gt).abs().max().item())
+    assert err_fix < 1e-5, f"reference_rope should match an fp32 table; max err {err_fix:.2e}"
+
+    # The pre-fix path, asserted to be detectably wrong so this test cannot pass vacuously.
+    old = deepcopy(model.rotary_emb).float()
+    with torch.no_grad():
+        cos_old, sin_old = old(torch.zeros(1, 1, cfg.hidden_size), pos)
+    err_old = max((cos_old - cos_gt).abs().max().item(), (sin_old - sin_gt).abs().max().item())
+    assert err_old > 1e-3, (
+        f"the deepcopy(bf16).float() path should be visibly wrong at position {pos.item()} "
+        f"(got {err_old:.2e}); if this fires, the test has stopped discriminating"
+    )
+
+
+@pytest.mark.parametrize(
+    "in0_block_w, kt, fits",
+    [
+        # DeepSeek's tuning: Kt = 7168/4/32 = 56, and 56 % 14 == 0.
+        (14, 56, True),
+        # The same tuned row reached by a model whose Kt is 32 (hidden 4096 / tp 4 / 32). 32 % 14 != 0,
+        # so the matmul TT_FATALs: "Kt (32) must be divisible by in0_block_w (14)".
+        (14, 32, False),
+        (8, 32, True),
+        # Kt = 64 (tp 2) divides by 8, so the config is ACCEPTED -- the guard's known gap: another
+        # model's tiling then applies silently. Pinned here so a future change to that behaviour is
+        # a deliberate decision rather than a surprise.
+        (8, 64, True),
+    ],
+)
+def test_tuned_matmul_cfg_is_rejected_when_block_width_does_not_divide_k(in0_block_w, kt, fits):
+    """Guards `perf(mla): guard tuned matmul configs against the wrong K`.
+
+    `MLA_MATMUL_CONFIG` is keyed on (weight_name, seq_len_local) and knows nothing about the
+    variant's dimensions, so a config tuned for one model is applied to another with a different K.
+    Rejecting a non-dividing block width degrades to the generic program config -- untuned, so
+    possibly slower -- instead of dying.
+    """
+    stub = SimpleNamespace(q_a_proj_weight=SimpleNamespace(shape=(kt * ttnn.TILE_SIZE, 1024)))
+    cfg = {"program_config": SimpleNamespace(in0_block_w=in0_block_w)}
+    assert ttMLA._cfg_fits_weight(stub, cfg, "q_a_proj") is fits
+
+
+def test_tuned_matmul_cfg_kept_when_there_is_nothing_to_check_against():
+    """A config with no in0_block_w, or a weight that is absent, must not be rejected."""
+    stub = SimpleNamespace(q_a_proj_weight=SimpleNamespace(shape=(1024, 1024)))
+    assert ttMLA._cfg_fits_weight(stub, {"program_config": SimpleNamespace()}, "q_a_proj") is True
+    assert ttMLA._cfg_fits_weight(SimpleNamespace(), {"program_config": SimpleNamespace(in0_block_w=14)}, "q_a_proj")
+
+
+class _OldStyleLayer(torch.nn.Module):
+    """A vendored DeepSeek/Kimi/GLM-shaped layer: singular cache kwarg, rope computed internally."""
+
+    def forward(self, hidden_states, attention_mask=None, position_ids=None, past_key_value=None, use_cache=True):
+        raise AssertionError("not called")
+
+
+class _NewStyleLayer(torch.nn.Module):
+    """A transformers-5.x layer: plural cache kwarg, and rope must be handed in."""
+
+    def forward(
+        self, hidden_states, attention_mask=None, position_ids=None, past_key_values=None, position_embeddings=None
+    ):
+        raise AssertionError("not called")
+
+
+def test_a_layer_that_computes_rope_internally_needs_no_rotary_emb(expect_error):
+    """Guards the DeepSeek regression: an unconditional rope build breaks references that never
+    wanted one.
+
+    A transformers-5.x layer requires the caller to pass ``(cos, sin)``; a vendored layer such as
+    DeepSeekV3's computes rope from ``position_ids`` itself and its model exposes no top-level
+    ``rotary_emb``. Building the table for everything asserted with
+    "DeepseekV3Model exposes no rotary_emb to build rope from" on precisely the models that did not
+    need it, so the predicate must come from the layer's SIGNATURE, not from the model's attributes.
+    """
+
+    old_layer, new_layer = _OldStyleLayer(), _NewStyleLayer()
+    assert layer_wants_position_embeddings(old_layer) is False
+    assert layer_wants_position_embeddings(new_layer) is True
+
+    # A model with NO rotary_emb, as DeepSeekV3Model has none. Binding kwargs for the old-style
+    # layer must not reach reference_rope at all -- if it does, the assert there fires.
+    class _ModelWithoutRotary(torch.nn.Module):
+        pass
+
+    kwargs = decoder_layer_kwargs(
+        old_layer,
+        _ModelWithoutRotary(),
+        torch.zeros(1, 4, 8),
+        None,
+        torch.arange(4).unsqueeze(0),
+        None,
+    )
+    assert "position_embeddings" not in kwargs, "an old-style layer must not be handed position_embeddings"
+
+    # The regression itself: the run-level hoist must return None here, not raise. Before the fix it
+    # called reference_rope unconditionally and died on the missing rotary_emb.
+    model = _ModelWithoutRotary()
+    model.layers = [old_layer]
+    assert reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1) is None
+
+    # ...and a layer that DOES want them still gets a table built (here: absent rotary -> loud).
+    model.layers = [new_layer]
+    with expect_error(AssertionError, "exposes no rotary_emb"):
+        reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1)
+
+
+def test_old_style_layer_kwargs_match_the_explicit_call_they_replaced():
+    """`decoder_layer_kwargs` now binds the reference call in test_prefill_block for EVERY model, so
+    on a vendored layer it must still reproduce the explicit call it replaced -- a silent drift here
+    moves the reference those models' PCC rows are judged against.
+    """
+    cache = object()
+    mask = torch.zeros(1, 1, 4, 4)
+    pos = torch.arange(4).unsqueeze(0)
+    kwargs = decoder_layer_kwargs(_OldStyleLayer(), None, torch.zeros(1, 4, 8), mask, pos, cache)
+
+    assert set(kwargs) == {"attention_mask", "position_ids", "past_key_value", "use_cache"}
+    assert kwargs["past_key_value"] is cache, "the vendored layers take the SINGULAR cache kwarg"
+    assert kwargs["use_cache"] is True
+    assert kwargs["attention_mask"] is mask and kwargs["position_ids"] is pos
+
+    # The plural branch, which nothing else covers: a transformers-5.x layer must get the cache under
+    # `past_key_values`, or the KV lands in **kwargs and is silently never captured.
+    plural = decoder_layer_kwargs(
+        _NewStyleLayer(), None, torch.zeros(1, 4, 8), mask, pos, cache, position_embeddings=(mask, mask)
+    )
+    assert "past_key_values" in plural and plural["past_key_values"] is cache

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -378,8 +378,14 @@ class ttMLA:
         rope_scaling = getattr(config, "rope_scaling", None) or {}
         rope_factor = rope_scaling.get("factor")
 
+        # Not every YaRN model folds the mscale amplitude into the softmax scale. Mistral Small 4
+        # carries a full YaRN block (factor=128) but its own implementation uses the bare
+        # qk_head_dim**-0.5 and reports attention_scaling = 1.0, so no mscale is applied anywhere.
+        # Applying DeepSeek's correction anyway multiplies the attention logits by mscale^2 (2.2058
+        # at factor=128): no crash, just a wrong softmax temperature. Absent (-> False) on every
+        # other variant, so those paths are byte-identical.
         self.scale = self.qk_head_dim**-0.5
-        if rope_factor is not None and rope_factor > 1.0:
+        if rope_factor is not None and rope_factor > 1.0 and not getattr(config, "mla_disable_yarn_mscale", False):
             mscale = rope_scaling["mscale"]
             mscale = 0.1 * mscale * math.log(rope_factor) + 1.0
             self.scale = self.scale * mscale * mscale

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -715,7 +715,43 @@ class ttMLA:
         Returns None when no tuned config applies (caller falls back to defaults)."""
         if not is_blackhole():
             return None
-        return self._select_cfg(self.mm_configs[weight_name].get(seq_len_local))
+        cfg = self._select_cfg(self.mm_configs[weight_name].get(seq_len_local))
+        if cfg is not None and not self._cfg_fits_weight(cfg, weight_name):
+            return None
+        return cfg
+
+    def _cfg_fits_weight(self, cfg: dict, weight_name: str) -> bool:
+        """Reject a tuned config whose in0_block_w does not divide THIS weight's Kt.
+
+        The tuned table is keyed on (weight_name, seq_len_local) only -- nothing about the variant's
+        dimensions -- so a config tuned for one model is silently applied to another with a different
+        K. That is fatal when the block width does not divide: Mistral Small 4 at seq_len_local 3200
+        (= 25600/8, i.e. the 25k production ISL) picks up a config with in0_block_w=14, which suits
+        DeepSeek's Kt of 56 (hidden 7168 / tp 4 / 32) but not Mistral's 32, and the matmul asserts:
+
+            TT_FATAL: MatmulMultiCoreReuseMultiCastProgramConfig: Kt (32) must be divisible by
+                      in0_block_w (14)
+
+        Falling back to the default program config keeps such a model running (untuned, so possibly
+        slower) instead of dying. Note the crash is the LUCKY case: where the block width happens to
+        divide, another model's tuning is applied silently and nobody finds out. The real fix is to
+        key the table on the variant or on the actual (K, N); this is the guard until then.
+        """
+        pc = cfg.get("program_config")
+        in0_block_w = getattr(pc, "in0_block_w", None)
+        weight = getattr(self, f"{weight_name}_weight", None)
+        if in0_block_w is None or weight is None:
+            return True  # nothing to check against; keep the tuned config
+        # Weights are [K, N]; only the K dim participates in the in0 block tiling.
+        kt = weight.shape[-2] // ttnn.TILE_SIZE
+        if kt % in0_block_w == 0:
+            return True
+        logger.warning(
+            f"[ttMLA] tuned matmul config for '{weight_name}' has in0_block_w={in0_block_w}, which does "
+            f"not divide this model's Kt={kt} — falling back to the default program config. The tuned "
+            f"table is keyed on (weight, seq_len) only, so it is another variant's tuning."
+        )
+        return False
 
     def _get_act_mem_config(self, weight_name: str, seq_len_local: int) -> ttnn.MemoryConfig:
         """Memory config for the activation (in0) feeding this weight's matmul, as tuned in the mm

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -35,6 +35,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 
 # Four similarly-named dimensions, shown for Kimi-K3, the only variant where all four differ:
 #
@@ -73,16 +74,24 @@ class TtMoe(LightweightModule):
         experts_per_chip: int,
         use_latent_moe: bool = False,
         latent_use_norm: bool = True,
+        routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     ) -> bool:
         """Check if MoE cache is complete (gate + routed experts + shared expert [+ latent proj]).
 
         ``use_latent_moe`` must be passed for Kimi-K3, otherwise a cache missing the latent
         projections would be reported complete and __init__ would then fail loading them.
+
+        routed_expert_weights_dtype: dtype the routed experts were/will be BUILT at.
+        as_tensor stamps it into the tensorbin filename, so the completeness check must pin the
+        same value it will later request -- otherwise a stale cache at another dtype reports
+        complete and the empty placeholder is loaded as the weights.
         """
         prefix = f"layer_{layer_idx}"
         if not TtMoEGatePrefill.check_cache_complete(cache_path, f"{prefix}.gate"):
             return False
-        if not TtRoutedExpert.check_cache_complete(cache_path, f"{prefix}.routed_expert", experts_per_chip):
+        if not TtRoutedExpert.check_cache_complete(
+            cache_path, f"{prefix}.routed_expert", experts_per_chip, routed_expert_weights_dtype
+        ):
             return False
         if not TtSharedExpert.check_cache_complete(cache_path, f"{prefix}.shared_expert"):
             return False
@@ -198,7 +207,7 @@ class TtMoe(LightweightModule):
         routed_expert_weights: list[dict] = None,
         shared_expert_weights: dict = None,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         routed_expert_activation=ttnn.RoutedExpertActivation.Silu,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -23,6 +23,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 
 # Model configs are torch-only and so name their activation as a string; this is the one place
 # that maps those names onto the kernel enum. Keys match the HF ``hidden_act`` spelling.
@@ -49,15 +50,33 @@ COMPUTE_KERNEL_CONFIG_LOFI = ttnn.WormholeComputeKernelConfig(
 
 class TtRoutedExpert(LightweightModule):
     @staticmethod
-    def check_cache_complete(cache_path: Path, cache_name_prefix: str, experts_per_chip: int) -> bool:
-        """Check if all routed expert weight cache files exist."""
+    def check_cache_complete(
+        cache_path: Path,
+        cache_name_prefix: str,
+        experts_per_chip: int,
+        weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
+    ) -> bool:
+        """True iff every routed-expert tensorbin exists AT `weights_dtype`.
+
+        The glob pins ``_dtype_{name}_`` because as_tensor encodes the dtype in the filename
+        (`..._dtype_BFLOAT4_B_layout_TILE.tensorbin`). A dtype-blind glob accepts a stale
+        bfloat4_b cache for a bfloat8_b request, reports complete, and then cache-only
+        construction finds no matching file and dumps the EMPTY PLACEHOLDER as the weights --
+        random experts, plausible-looking text, and a PCC number that means nothing. Same
+        reasoning and same fix as TtIndexer.check_cache_complete; the routed experts are where
+        it actually bites, because their dtype is the one people vary.
+
+        The default matches the routed-expert default (bfloat4_b) so existing callers are
+        unaffected; any caller that builds at a different dtype must pass the same value here.
+        """
         from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import pattern_exists
 
+        dtype_name = weights_dtype.name
         for local_expert_idx in range(experts_per_chip):
             for proj in ["gate", "up", "down"]:
-                pattern = f"{cache_name_prefix}.local_{local_expert_idx}_{proj}*.tensorbin"
-                if not pattern_exists(pattern, "RoutedExpert"):
-                    logger.debug(f"TTNN cache missing: {cache_name_prefix}.local_{local_expert_idx}_{proj}")
+                stem = f"{cache_name_prefix}.local_{local_expert_idx}_{proj}"
+                if not pattern_exists(f"{stem}_dtype_{dtype_name}_*.tensorbin", "RoutedExpert"):
+                    logger.debug(f"TTNN cache missing: {stem} ({dtype_name})")
                     return False
         return True
 
@@ -264,7 +283,7 @@ class TtRoutedExpert(LightweightModule):
         torch_weights: list[dict] = None,
         torch_biases: list[dict] = None,
         activations_dtype=ttnn.bfloat8_b,
-        weights_dtype=ttnn.bfloat4_b,
+        weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_LOFI,
         weight_cache_path: Optional[Path] = None,
         cache_name_prefix: Optional[str] = None,

--- a/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
+++ b/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
@@ -200,6 +200,19 @@ Same roles as the DSV3 names above:
 
 ---
 
+## Mistral variant equivalents (only if you run the `mistral_small_4` variant)
+
+Same roles again:
+
+- `DEEPSEEK_V3_HF_MODEL` → `MISTRAL4_HF_MODEL`
+- `TT_DS_PREFILL_TTNN_CACHE` → `TT_MISTRAL4_PREFILL_TTNN_CACHE`
+- `TT_DS_PREFILL_HOST_REF_CACHE` → `TT_MISTRAL4_PREFILL_HOST_REF_CACHE`
+- `DEEPSEEK_V3_MLA_REF_CACHE` → `MISTRAL4_MLA_REF_CACHE`
+
+`TT_MISTRAL4_PREFILL_TTNN_CACHE` has no default — point it at a writable directory of your own.
+
+---
+
 ## NOT used by this test
 
 A large `PREFILL_*` family exists in this module

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
@@ -31,7 +31,9 @@ class MistralSmall4Adapter(MLAPrefillAdapter):
     # No shared prefill TTNN cache exists for Mistral yet; set PREFILL_TTNN_CACHE (serving) or
     # TT_MISTRAL4_PREFILL_TTNN_CACHE (tests) to a writable dir.
     ttnn_cache_default = ""
-    default_gate_mode = "DEVICE_FP32"  # single expert group (n_group = 1)
+    # softmax -> top-4 -> renormalise. moe_grouped_topk's parse_score_func takes only sigmoid /
+    # sqrtsoftplus, so the sigmoid gate applies a wrong affinity silently whatever the grouping.
+    default_gate_mode = "GPT_DEVICE"
     prefill_trace_default = None  # no golden trace recorded yet; pass one via PREFILL_TRACE_DIR
 
     # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL. Routing
@@ -69,15 +71,19 @@ class MistralSmall4Adapter(MLAPrefillAdapter):
     # outer (multimodal) config, so the unwrap to text_config drops it and the loader would refuse
     # the fp8 tensors. mistral4_hf_config also fixes the softmax-scale convention (see that module).
     config_builder_overrides_checkpoint = True
-    # Routed experts are stacked: `mlp.experts.gate_up_proj` is one [128, 4096, 4096] fp8 tensor, not
-    # per-expert gate_proj/up_proj. The pretrained fixture therefore loads attention only.
-    packed_expert_checkpoint = True
+    # packed_expert_checkpoint deliberately unset: the fixture splits the stacked experts now
+    # (extract_routed_experts), and setting it would silently load attention only.
     mla_pcc_threshold = 0.995
     moe_pcc_threshold = 0.971
     prefill_trace_layout = "single_file"
 
     # --- CPU reference ---------------------------------------------------------------------------
-    # No reference_* classes are wired: transformers' Mistral4Attention needs the precomputed
-    # `position_embeddings` that run_reference_mla does not pass, and Mistral's plain-softmax router
-    # with stacked experts does not match the state dict run_reference_moe expects. Leaving these
-    # None makes those comparisons skip rather than error; MLA is still checked against MLAReference.
+    # Model class only -- create_hf_model needs it for every random-weight row, and rope is computed
+    # at model level so the standalone-attention problem does not arise. attention / moe stay
+    # unwired: run_reference_mla does not pass position_embeddings, and run_reference_moe expects a
+    # different state dict. Those two comparisons skip rather than error.
+    @property
+    def reference_model_cls(self):
+        from transformers.models.mistral4.modeling_mistral4 import Mistral4Model
+
+        return Mistral4Model

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
@@ -83,6 +83,14 @@ class MistralSmall4Adapter(MLAPrefillAdapter):
     # unwired: run_reference_mla does not pass position_embeddings, and run_reference_moe expects a
     # different state dict. Those two comparisons skip rather than error.
     @property
+    def reference_moe_cls(self):
+        """Upstream MoE, used by run_reference_moe. Imported lazily: conftest imports every adapter
+        at collection time and transformers is expensive."""
+        from transformers.models.mistral4.modeling_mistral4 import Mistral4MoE
+
+        return Mistral4MoE
+
+    @property
     def reference_model_cls(self):
         from transformers.models.mistral4.modeling_mistral4 import Mistral4Model
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Mistral-Small-4-119B prefill adapter.
+
+Dense MLA + MoE, the same family as DeepSeek-V3 / Kimi, so it subclasses ``MLAPrefillAdapter`` and
+inherits the serving path. Its config is hand-built by ``mistral4_hf_config`` rather than read via
+``AutoConfig``: the checkpoint's config uses transformers 5.x field names and does not express the
+softmax-scale convention Mistral actually uses (see ``reference/mistral_small_4_config.py``).
+
+Like Kimi it has a single expert group (``n_group = 1``) with a device gate, so the MoE routing
+all-gather's semaphores go to L1_SMALL.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+from models.demos.deepseek_v3_d_p.reference.mistral_small_4_config import MistralSmall4Config, mistral4_hf_config
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
+
+
+class MistralSmall4Adapter(MLAPrefillAdapter):
+    # --- identity & runner defaults ---
+    name = "mistral_small_4"
+    model_config = MistralSmall4Config
+    # Config is hand-built (see load_hf_config); point PREFILL_HF_MODEL / MISTRAL4_HF_MODEL at the
+    # checkpoint for weights.
+    hf_model_default = ""
+    # No shared prefill TTNN cache exists for Mistral yet; set PREFILL_TTNN_CACHE (serving) or
+    # TT_MISTRAL4_PREFILL_TTNN_CACHE (tests) to a writable dir.
+    ttnn_cache_default = ""
+    default_gate_mode = "DEVICE_FP32"  # single expert group (n_group = 1)
+    prefill_trace_default = None  # no golden trace recorded yet; pass one via PREFILL_TRACE_DIR
+
+    # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL. Routing
+    # consumes 512 B; leave 256 B for MLA high-bandwidth-gather semaphores.
+    l1_small_size = 768
+    routing_use_l1_small_for_semaphores = True
+
+    def load_hf_config(self):
+        """Return the hand-built HF-attribute config. The runner overwrites ``max_seq_len`` after;
+        seed the builder with it so the rope tables are consistent."""
+        max_seq = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 8192))
+        return mistral4_hf_config(max_seq=max_seq)
+
+    @property
+    def config_builder(self) -> Callable:
+        """Tests resolve the config through this; serving goes through ``load_hf_config``. Both hand
+        off to ``mistral4_hf_config``."""
+        return mistral4_hf_config
+
+    # --- test metadata (HF download coordinates + PCC thresholds) ---
+    hf_repo_id = "mistralai/Mistral-Small-4-119B-2603"
+    env_var = "MISTRAL4_HF_MODEL"
+    ref_cache_env = "TT_MISTRAL4_PREFILL_HOST_REF_CACHE"
+    mla_ref_cache_env = "MISTRAL4_MLA_REF_CACHE"
+    ttnn_cache_env = "TT_MISTRAL4_PREFILL_TTNN_CACHE"
+    # Stock fast tokenizer + a natively-registered model_type, so neither trust_remote_code nor the
+    # flat-config copy is needed.
+    tokenizer_trust_remote_code = False
+    needs_flat_config_dir = False
+    # The checkpoint is fp8 with a per-tensor static scheme (weight_block_size null, a scalar
+    # weight_scale_inv) rather than the [128,128] block scheme, so it dequantizes through
+    # test_utils.is_per_tensor_fp8.
+    supports_pretrained = True
+    # AutoConfig can load this checkpoint but is the wrong source: quantization_config lives on the
+    # outer (multimodal) config, so the unwrap to text_config drops it and the loader would refuse
+    # the fp8 tensors. mistral4_hf_config also fixes the softmax-scale convention (see that module).
+    config_builder_overrides_checkpoint = True
+    # Routed experts are stacked: `mlp.experts.gate_up_proj` is one [128, 4096, 4096] fp8 tensor, not
+    # per-expert gate_proj/up_proj. The pretrained fixture therefore loads attention only.
+    packed_expert_checkpoint = True
+    mla_pcc_threshold = 0.995
+    moe_pcc_threshold = 0.971
+    prefill_trace_layout = "single_file"
+
+    # --- CPU reference ---------------------------------------------------------------------------
+    # No reference_* classes are wired: transformers' Mistral4Attention needs the precomputed
+    # `position_embeddings` that run_reference_mla does not pass, and Mistral's plain-softmax router
+    # with stacked experts does not match the state dict run_reference_moe expects. Leaving these
+    # None makes those comparisons skip rather than error; MLA is still checked against MLAReference.

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mistral_small_4.py
@@ -71,17 +71,13 @@ class MistralSmall4Adapter(MLAPrefillAdapter):
     # outer (multimodal) config, so the unwrap to text_config drops it and the loader would refuse
     # the fp8 tensors. mistral4_hf_config also fixes the softmax-scale convention (see that module).
     config_builder_overrides_checkpoint = True
-    # packed_expert_checkpoint deliberately unset: the fixture splits the stacked experts now
-    # (extract_routed_experts), and setting it would silently load attention only.
     mla_pcc_threshold = 0.995
     moe_pcc_threshold = 0.971
     prefill_trace_layout = "single_file"
 
     # --- CPU reference ---------------------------------------------------------------------------
-    # Model class only -- create_hf_model needs it for every random-weight row, and rope is computed
-    # at model level so the standalone-attention problem does not arise. attention / moe stay
-    # unwired: run_reference_mla does not pass position_embeddings, and run_reference_moe expects a
-    # different state dict. Those two comparisons skip rather than error.
+    # attention stays unwired: run_reference_mla does not pass position_embeddings, so that one
+    # comparison skips rather than errors. The model and MoE classes are wired below.
     @property
     def reference_moe_cls(self):
         """Upstream MoE, used by run_reference_moe. Imported lazily: conftest imports every adapter

--- a/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
@@ -11,6 +11,13 @@ producer validate device KV against a reference generated for that exact prompt.
 
 MLA models only (DeepSeek / Kimi): the golden is the compressed KVPE
 ``[seq, KV_LORA_RANK + QK_ROPE_HEAD_DIM]`` per layer.
+
+It also writes ``hidden_states/layer_N.safetensors`` and ``n_layers``, which is what the per-layer
+PCC tests read (``load_debug_trace``'s "per-layer format"); ``--no-hidden-states`` writes the
+producer's subset alone. One caveat this cannot fix: the reference here is the same torch/HF path
+those tests would otherwise compare against, so a golden from this script gives plumbing and
+per-layer localisation, NOT independence from the reference implementation. Only a trace recorded
+from a different implementation (vLLM) does that.
 """
 
 import argparse
@@ -53,11 +60,26 @@ def _resolve_model_path(variant) -> Path:
     )
 
 
-def _load_config(model_path: Path, isl: int):
-    config = AutoConfig.from_pretrained(str(model_path), trust_remote_code=True)
-    # Kimi ships a multimodal wrapper; the MLA reference wants the text sub-config.
-    if hasattr(config, "text_config") and hasattr(config.text_config, "hidden_size"):
-        config = config.text_config
+def _load_config(variant, model_path: Path, isl: int):
+    """The config the reference forward runs on.
+
+    Prefers the variant's ``config_builder`` -- the same hook ``conftest._resolve_config_only`` uses
+    -- so a variant needing normalization gets it here too. Without this, the golden is generated
+    from a raw AutoConfig: Mistral Small 4 then has no ``rope_theta`` (AttributeError in rope setup)
+    and, worse, no ``mla_disable_yarn_mscale``, so the reference would bake DeepSeek's mscale**2 =
+    2.2058 softmax scale into the golden -- a wrong golden that every downstream comparison agrees
+    with. Variants without a builder (DeepSeek, Kimi) take the AutoConfig path exactly as before.
+    """
+    builder = variant.config_builder
+    if builder is not None:
+        # Zero-arg by protocol (same as conftest); the builder resolves the checkpoint from
+        # PREFILL_HF_MODEL, i.e. the dir _resolve_model_path already validated.
+        config = builder()
+    else:
+        config = AutoConfig.from_pretrained(str(model_path), trust_remote_code=True)
+        # Kimi ships a multimodal wrapper; the MLA reference wants the text sub-config.
+        if hasattr(config, "text_config") and hasattr(config.text_config, "hidden_size"):
+            config = config.text_config
     config = deepcopy(config)
     # AutoConfig does not populate this; the reference forward path expects it set.
     config.max_seq_len = isl
@@ -103,25 +125,83 @@ def _meta_pe_to_hf(pe: torch.Tensor) -> torch.Tensor:
     return torch.cat([pe[:, 0::2], pe[:, 1::2]], dim=-1)
 
 
-def write_trace_dir(out_dir: Path, token_ids: torch.Tensor, ref_kvpe_list, kv_lora_rank: int) -> Path:
+def write_trace_dir(
+    out_dir: Path,
+    token_ids: torch.Tensor,
+    ref_kvpe_list,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int | None = None,
+    ref_snapshots=None,
+    num_layers: int | None = None,
+    num_real_tokens: int | None = None,
+) -> Path:
+    """Write ``kv_cache/`` always, and ``hidden_states/`` when ``ref_snapshots`` is given.
+
+    The producer validates device KV against ``kv_cache/`` alone. The per-layer PCC tests read
+    decoder outputs from ``hidden_states/layer_i.safetensors`` and take the layer count from
+    ``metadata["n_layers"]``, so a dir written without snapshots serves the producer and makes
+    ``load_debug_trace`` raise on the missing file -- loud, which is the point.
+    """
     out_dir = Path(out_dir)
     (out_dir / "kv_cache").mkdir(parents=True, exist_ok=True)
-    (out_dir / "metadata.json").write_text(json.dumps({"token_ids": token_ids[0].tolist()}))
 
     for i, kvpe in enumerate(ref_kvpe_list):
-        # ref_kvpe_list[i] is the HF DynamicCache key cache for the layer, [1, 1, seq, head_dim].
+        # ref_kvpe_list[i] is the layer's compressed MLA line, [1, 1, seq, kv_lora_rank + rope].
         t = kvpe
         while t.dim() > 2:
             t = t[0]
         t = t.to(torch.float32)
+        # A reference that cached expanded per-head keys arrives here as [seq, head_dim]; the nope
+        # slice would clamp, `pe` would come out empty, and the golden would be quietly the wrong
+        # width. reference_kvpe_for_layer derives the compressed line, so this only fires if that
+        # stops happening -- but it fails silently if unchecked.
+        if qk_rope_head_dim is not None and t.shape[-1] != kv_lora_rank + qk_rope_head_dim:
+            raise SystemExit(
+                f"layer {i}: reference KVPE width {t.shape[-1]} != {kv_lora_rank} + {qk_rope_head_dim}; "
+                "this is not the compressed MLA line the device caches"
+            )
         nope = t[:, :kv_lora_rank]  # compared directly by the producer, written as-is
         pe = _meta_pe_to_hf(t[:, kv_lora_rank:])
         row = torch.cat([nope, pe], dim=-1).contiguous()
         save_file({f"kv_post_transform_layer_{i}": row}, str(out_dir / "kv_cache" / f"layer_{i}.safetensors"))
+
+    meta = {"token_ids": token_ids[0].tolist()}
+    if num_real_tokens is not None:
+        meta["num_real_tokens"] = int(num_real_tokens)
+
+    if ref_snapshots is not None:
+        # ref_snapshots is [embed, layer_0..layer_{n-1}, norm, lm_head]; layer i is at 1 + i.
+        # fp32 like the kv rows above: the snapshots are fp32 and a bf16 golden would put its own
+        # rounding into every PCC (visible on the near-1.0 early layers). Costs ~3 GB at 36L/isl 5120.
+        n = num_layers if num_layers is not None else len(ref_snapshots) - 3
+        (out_dir / "hidden_states").mkdir(parents=True, exist_ok=True)
+        for i in range(n):
+            t = ref_snapshots[1 + i]
+            while t.dim() > 2:
+                t = t[0]
+            save_file(
+                {f"decoder_output_layer_{i}": t.to(torch.float32).contiguous()},
+                str(out_dir / "hidden_states" / f"layer_{i}.safetensors"),
+            )
+        meta["n_layers"] = n
+
+        # The reference's own next token, for the consumer's first-token check. Taken at the last
+        # REAL position: this generator forces right padding, so the final rows are pad tokens whose
+        # argmax is not the model's next token.
+        logits = ref_snapshots[-1]
+        while logits.dim() > 2:
+            logits = logits[0]
+        last_real = (num_real_tokens or logits.shape[0]) - 1
+        meta["next_token_id"] = int(logits[last_real].float().argmax().item())
+        meta["next_token_position"] = last_real
+
+    (out_dir / "metadata.json").write_text(json.dumps(meta))
     return out_dir
 
 
-def generate(model: str, prompt_text: str, isl: int, num_layers: int, out_dir: Path) -> Path:
+def generate(
+    model: str, prompt_text: str, isl: int, num_layers: int, out_dir: Path, hidden_states: bool = True
+) -> Path:
     variant = get_adapter(model)
     # Sparse/DSA models also keep an index-key cache (config 1); the producer's validation reads its
     # golden from the trace dir, but this generator writes only the KVPE cache — so reject them loudly
@@ -129,7 +209,7 @@ def generate(model: str, prompt_text: str, isl: int, num_layers: int, out_dir: P
     if hasattr(variant.model_config, "INDEX_HEAD_DIM"):
         raise SystemExit(f"{model} is a sparse/DSA model; prompt-trace generation supports dense-KVPE MLA only")
     model_path = _resolve_model_path(variant)
-    config = _load_config(model_path, isl)
+    config = _load_config(variant, model_path, isl)
     tokenizer = AutoTokenizer.from_pretrained(
         str(model_path), use_fast=True, trust_remote_code=variant.tokenizer_trust_remote_code
     )
@@ -153,9 +233,20 @@ def generate(model: str, prompt_text: str, isl: int, num_layers: int, out_dir: P
         seq_len=isl,
     )
 
-    kv_lora_rank = variant.model_config.KV_LORA_RANK
-    out = write_trace_dir(out_dir, token_ids, result.ref_kvpe_list, kv_lora_rank)
-    logger.success(f"[gen-trace] wrote {num_layers}-layer golden trace to {out}")
+    out = write_trace_dir(
+        out_dir,
+        token_ids,
+        result.ref_kvpe_list,
+        variant.model_config.KV_LORA_RANK,
+        qk_rope_head_dim=variant.model_config.QK_ROPE_HEAD_DIM,
+        ref_snapshots=result.ref_snapshots if hidden_states else None,
+        num_layers=num_layers,
+        num_real_tokens=int(attention_mask.sum()),
+    )
+    logger.success(
+        f"[gen-trace] wrote {num_layers}-layer golden trace to {out} "
+        f"(hidden_states={'yes' if hidden_states else 'no'})"
+    )
     return out
 
 
@@ -167,10 +258,15 @@ def main() -> None:
     p.add_argument("--isl", type=int, default=int(os.environ.get("PREFILL_MAX_SEQ_LEN", "1024")))
     p.add_argument("--num-layers", type=int, default=int(os.environ.get("PREFILL_NUM_LAYERS", "2")))
     p.add_argument("--out", required=True, help="output trace dir")
+    p.add_argument(
+        "--no-hidden-states",
+        action="store_true",
+        help="write kv_cache/ only (enough for the producer; the per-layer PCC tests need the rest)",
+    )
     args = p.parse_args()
 
     prompt_text = _load_prompt_text(args.prompt, args.prompt_file)
-    out = generate(args.model, prompt_text, args.isl, args.num_layers, Path(args.out))
+    out = generate(args.model, prompt_text, args.isl, args.num_layers, Path(args.out), not args.no_hidden_states)
     # last stdout line: the trace dir, for a caller to capture
     print(str(out))
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/manifests/mistral4.json
+++ b/models/demos/deepseek_v3_d_p/tt/runners/manifests/mistral4.json
@@ -2,6 +2,6 @@
   "env": {
     "PREFILL_MODEL": "mistral_small_4",
     "PREFILL_NUM_LAYERS": "36",
-    "PREFILL_GATE_FALLBACK_MODE": "DEVICE_FP32"
+    "PREFILL_GATE_FALLBACK_MODE": "GPT_DEVICE"
   }
 }

--- a/models/demos/deepseek_v3_d_p/tt/runners/manifests/mistral4.json
+++ b/models/demos/deepseek_v3_d_p/tt/runners/manifests/mistral4.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "PREFILL_MODEL": "mistral_small_4",
+    "PREFILL_NUM_LAYERS": "36",
+    "PREFILL_GATE_FALLBACK_MODE": "DEVICE_FP32"
+  }
+}

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -269,46 +269,65 @@ class TtDistributedRmsNorm(LightweightModule):
         )
         logger.debug(f"Pre-all-gather stats shape: {tt_stats.shape}")
 
-        # Step 2: Gather stats across cluster_axis. high_bw_all_gather requires topology metadata
-        # for every mesh axis through cluster_axis. Pipeline-parallel runners may expose a 1D tensor
-        # distribution on a 2D mesh, so preserve the general all_gather path for those tensors.
-        use_high_bw_all_gather = _supports_high_bw_all_gather(tt_stats, self.cluster_axis)
-        if use_high_bw_all_gather:
-            # high_bw_all_gather writes into a caller-provided DRAM tensor, so allocate its
-            # fixed-shape output once and reuse it across forwards.
-            if self._gathered_stats is None:
-                gathered_shape = list(tt_stats.shape)
-                gathered_shape[3] *= self.mesh_device.shape[self.cluster_axis]
-                self._gathered_stats = ttnn.empty(
-                    gathered_shape,
-                    dtype=tt_stats.dtype,
-                    layout=tt_stats.layout,
-                    device=self.mesh_device,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-            tt_gathered_stats = ttnn.experimental.high_bw_all_gather(
-                tt_stats,
-                dim=3,
-                output_tensor=self._gathered_stats,
-                cluster_axis=self.cluster_axis,
-                num_links=self.num_links,
-            )
+        # Step 2: Gather stats across cluster_axis.
+        #
+        # TP=1 is handled before choosing a gather at all: ttnn.all_gather TT_FATALs at
+        # num_devices == 1 rather than degenerating to a copy, and with no TP split each device
+        # already holds the full hidden dim, so its local sum(x^2) IS the global statistic. Kept as a
+        # pass-through into rms_norm_post_all_gather rather than switching to a plain ttnn.rms_norm,
+        # so the TP=1 path cannot drift numerically from the TP>1 one.
+        #
+        # Stays False on the TP=1 and fallback paths, which own their gathered tensor; only
+        # high_bw_all_gather writes into the reused self._gathered_stats buffer, which step 3 must
+        # NOT deallocate. At TP=1 the "gathered" tensor aliases tt_stats -- freshly allocated by
+        # rms_norm_pre_all_gather this forward -- so letting step 3 free it is both correct and the
+        # reason the branch below does not free it itself.
+        use_high_bw_all_gather = False
+        if self.mesh_device.shape[self.cluster_axis] == 1:
+            tt_gathered_stats = tt_stats  # aliased; freed once by step 3, after it is used
+            logger.debug("cluster_axis length 1 (TP=1): skipping the stats all-gather (identity)")
         else:
-            logger.debug(
-                f"Falling back to all_gather: tensor topology does not represent cluster_axis={self.cluster_axis}"
-            )
-            all_gather_kwargs = {
-                "input_tensor": tt_stats,
-                "dim": 3,
-                "cluster_axis": self.cluster_axis,
-                "num_links": self.num_links,
-                "topology": self.topology,
-            }
-            if self.stats_memcfg is not None:
-                all_gather_kwargs["memory_config"] = self.stats_memcfg
-            tt_gathered_stats = ttnn.all_gather(**all_gather_kwargs)
-        ttnn.deallocate(tt_stats)
-        logger.debug(f"Gathered stats shape: {tt_gathered_stats.shape}")
+            # high_bw_all_gather requires topology metadata for every mesh axis through
+            # cluster_axis. Pipeline-parallel runners may expose a 1D tensor distribution on a 2D
+            # mesh, so preserve the general all_gather path for those tensors.
+            use_high_bw_all_gather = _supports_high_bw_all_gather(tt_stats, self.cluster_axis)
+            if use_high_bw_all_gather:
+                # high_bw_all_gather writes into a caller-provided DRAM tensor, so allocate its
+                # fixed-shape output once and reuse it across forwards.
+                if self._gathered_stats is None:
+                    gathered_shape = list(tt_stats.shape)
+                    gathered_shape[3] *= self.mesh_device.shape[self.cluster_axis]
+                    self._gathered_stats = ttnn.empty(
+                        gathered_shape,
+                        dtype=tt_stats.dtype,
+                        layout=tt_stats.layout,
+                        device=self.mesh_device,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+                tt_gathered_stats = ttnn.experimental.high_bw_all_gather(
+                    tt_stats,
+                    dim=3,
+                    output_tensor=self._gathered_stats,
+                    cluster_axis=self.cluster_axis,
+                    num_links=self.num_links,
+                )
+            else:
+                logger.debug(
+                    f"Falling back to all_gather: tensor topology does not represent cluster_axis={self.cluster_axis}"
+                )
+                all_gather_kwargs = {
+                    "input_tensor": tt_stats,
+                    "dim": 3,
+                    "cluster_axis": self.cluster_axis,
+                    "num_links": self.num_links,
+                    "topology": self.topology,
+                }
+                if self.stats_memcfg is not None:
+                    all_gather_kwargs["memory_config"] = self.stats_memcfg
+                tt_gathered_stats = ttnn.all_gather(**all_gather_kwargs)
+            # Only safe once a gather actually produced a NEW tensor; at TP=1 the two alias.
+            ttnn.deallocate(tt_stats)
+            logger.debug(f"Gathered stats shape: {tt_gathered_stats.shape}")
 
         # Step 3: Post-all-gather - normalize using gathered global stats
         tt_output = ttnn.rms_norm_post_all_gather(

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -19,6 +19,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
 
 # Optional per-layer MLA-vs-FFN host timing (rough ratio only). Gated by TT_PREFILL_BLOCK_TIMING=1.
@@ -75,12 +76,18 @@ class TtPrefillBlock(LightweightModule):
         experts_per_chip: int = 8,
         *,
         model_cfg: type | None = None,
+        routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     ) -> bool:
         """Check if block cache is complete (norms + MLA + FFN/MoE).
 
         ``model_cfg`` is optional but MUST be passed for a LatentMoE model (Kimi-K3): without it this
         cannot know to look for the latent-projection cache files, and would report a cache that is
         missing them as complete. Left optional so existing callers are unaffected.
+
+        routed_expert_weights_dtype: dtype the routed experts were/will be BUILT at.
+        as_tensor stamps it into the tensorbin filename, so the completeness check must pin the
+        same value it will later request -- otherwise a stale cache at another dtype reports
+        complete and the empty placeholder is loaded as the weights.
         """
         prefix = f"layer_{layer_idx}"
 
@@ -102,6 +109,7 @@ class TtPrefillBlock(LightweightModule):
                 use_latent_moe=getattr(model_cfg, "ROUTED_EXPERT_HIDDEN_SIZE", None)
                 not in (None, getattr(model_cfg, "EMB_SIZE", None)),
                 latent_use_norm=getattr(model_cfg, "LATENT_MOE_USE_NORM", True),
+                routed_expert_weights_dtype=routed_expert_weights_dtype,
             ):
                 return False
 
@@ -123,7 +131,7 @@ class TtPrefillBlock(LightweightModule):
         tp_axis: int = 1,
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         kv_only: bool = False,
@@ -242,7 +250,7 @@ class TtPrefillBlock(LightweightModule):
         is_balanced: bool = False,
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         weight_cache_path: Optional[Path] = None,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -20,6 +20,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.runners.input_prep import prepare_prefill_input_tensor
 from models.demos.deepseek_v3_d_p.tt.runners.kv_caches import MlaKvCaches
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, allocate_dflash_kv_cache
 from models.demos.deepseek_v3_d_p.utils.sub_device_trace import SubDeviceTraceController
 
@@ -42,7 +43,7 @@ class TtPrefillRuntimeConfig:
     capacity_factor: int = 2
     gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL
     routed_expert_activations_dtype: ttnn.DataType = ttnn.bfloat8_b
-    routed_expert_weights_dtype: ttnn.DataType = ttnn.bfloat4_b
+    routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
     shared_expert_activations_dtype: ttnn.DataType = ttnn.bfloat16
     shared_expert_weights_dtype: ttnn.DataType = ttnn.bfloat8_b
     weight_cache_path: Optional[Path] = None
@@ -184,6 +185,9 @@ class TtPrefillRuntime:
                 # to look for the latent-projection cache files and would call an incomplete cache
                 # complete. model_cfg is already in hand two lines up.
                 model_cfg=model_cfg,
+                # Must be the dtype the experts will be BUILT at, or a cache at another dtype
+                # reports complete and the placeholder is loaded as the weights.
+                routed_expert_weights_dtype=self.config.routed_expert_weights_dtype,
             ):
                 logger.info(f"TTNN weight cache complete at {self.config.weight_cache_path}; loading from disk")
             else:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -29,6 +29,7 @@ from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistribute
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TopologyArg, TtPrefillBlock
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
 
@@ -56,6 +57,7 @@ class TtPrefillTransformer(LightweightModule):
         is_last_rank: bool = True,
         kv_only_last_layer: bool = False,
         model_cfg: type | None = None,
+        routed_expert_weights_dtype: ttnn.DataType = DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     ) -> bool:
         """
         Top-level cache completeness check for the full transformer.
@@ -71,6 +73,10 @@ class TtPrefillTransformer(LightweightModule):
             first_layer_idx: Global index of this instance's first layer. Non-zero
                 for a pipeline-parallel rank owning a layer slice; block cache keys
                 are global, so dense/MoE selection must use the global index.
+            routed_expert_weights_dtype: dtype the routed experts were/will be BUILT at.
+                as_tensor stamps it into the tensorbin filename, so the completeness check must
+                pin the same value it will later request -- otherwise a stale cache at another
+                dtype reports complete and the empty placeholder is loaded as the weights.
             is_first_rank / is_last_rank: a pipeline-parallel rank builds the
                 embedding only on the first rank and the final norm + LM head only
                 on the last, so check only the weights it actually loads. Both True
@@ -99,7 +105,12 @@ class TtPrefillTransformer(LightweightModule):
             layer_idx = first_layer_idx + local_idx
             is_dense = layer_idx < first_k_dense
             if not TtPrefillBlock.check_cache_complete(
-                cache_path, layer_idx, is_dense, experts_per_chip, model_cfg=model_cfg
+                cache_path,
+                layer_idx,
+                is_dense,
+                experts_per_chip,
+                model_cfg=model_cfg,
+                routed_expert_weights_dtype=routed_expert_weights_dtype,
             ):
                 return False
 
@@ -131,7 +142,7 @@ class TtPrefillTransformer(LightweightModule):
         padding_side: str = "right",
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
-        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         weight_cache_path: Optional[Path] = None,

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -47,14 +47,24 @@ def _ref_cache_key(config, weights, hidden_2d) -> str:
         multi-user run two users can share the same total_len while having different inputs. Keying on
         length alone would hand user 1 user 0's reference and silently corrupt its PCC.
       * config -- num_attention_heads changes the absorbed-Q head split even at identical weight
-        shapes; the NoPE / output-gate flags and rope_scaling change the math outright.
+        shapes; the NoPE / output-gate flags and rope_scaling change the math outright, and
+        mla_disable_yarn_mscale changes the softmax scale by mscale**2 (2.2058 for Mistral at
+        factor=128). Any field added here that moves the reference MUST be added to the hash below --
+        omitting one serves a stale reference against a changed device and reads as a device bug.
 
     Hashing the full tensors costs ~2 s at the 56320-token production shape, against a ~7 min
     reference. Content-addressing also makes the key collision-free across variants, so one shared
     cache dir is safe.
     """
     h = hashlib.sha1()
-    for field in ("num_attention_heads", "rms_norm_eps", "mla_use_nope", "mla_use_output_gate", "rope_scaling"):
+    for field in (
+        "num_attention_heads",
+        "rms_norm_eps",
+        "mla_use_nope",
+        "mla_use_output_gate",
+        "mla_disable_yarn_mscale",
+        "rope_scaling",
+    ):
         h.update(f"{field}={getattr(config, field, None)!r}".encode())
     _hash_tensor(h, "hidden", hidden_2d)
     for name in sorted(weights):

--- a/models/demos/deepseek_v3_d_p/utils/expert_dtypes.py
+++ b/models/demos/deepseek_v3_d_p/utils/expert_dtypes.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""The default routed-expert weight dtype, in one place.
+
+`routed_expert_weights_dtype=ttnn.bfloat4_b` used to be spelled as a literal default in six places
+(TtMoe, TtPrefillBlock x2, TtPrefillTransformer, TtPrefillRuntime, and the layer-by-layer loader).
+A/B-ing expert precision therefore meant editing six defaults and hoping none was missed -- and
+missing one is not a crash, it is a weight cache BUILT at one dtype and CHECKED at another, which
+loads the empty placeholder as the weights and produces plausible output with a meaningless PCC.
+
+One constant, so the build and the completeness check cannot disagree. Callers that want a different
+precision pass `routed_expert_weights_dtype` explicitly.
+"""
+
+import ttnn
+
+DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE = ttnn.bfloat4_b

--- a/models/demos/deepseek_v3_d_p/utils/test_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_utils.py
@@ -349,6 +349,63 @@ def _dequantize_pack_quantized_state_dict(
     return out
 
 
+def is_per_tensor_fp8(quantization_config: Any) -> bool:
+    """True for fp8 checkpoints scaled per tensor rather than per [128,128] block.
+
+    Signature is ``quant_method == "fp8"`` with **no** ``weight_block_size`` (Mistral Small 4 ships
+    `null`). The block-wise dequantizer cannot express this: it asserts
+    ``tensor.ndim == inv_scale.ndim`` and a block shape of matching rank, and per-tensor scales are
+    rank-0 scalars (dense) or ``[E, 1, 1]`` (stacked experts).
+    """
+    if not isinstance(quantization_config, dict):
+        return False
+    if quantization_config.get("quant_method") != "fp8":
+        return False
+    return not quantization_config.get("weight_block_size")
+
+
+def _dequantize_per_tensor_fp8_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    dtype: torch.dtype = torch.bfloat16,
+) -> dict[str, torch.Tensor]:
+    """Dequantize per-tensor fp8 weights: ``w = w_fp8.float() * scale_inv``.
+
+    Handles both scale ranks the format uses, with one expression, because torch broadcasting
+    already does the right thing:
+
+      * dense weights -- rank-0 scalar scale against an ``[out, in]`` weight;
+      * stacked experts -- ``[E, 1, 1]`` scale against an ``[E, out, in]`` weight, i.e. one scale
+        per expert.
+
+    ``*_activation_scale`` entries are inputs to a static activation-quantization scheme, not weight
+    scales; they are dropped rather than emitted as weights.
+    """
+    out: dict[str, torch.Tensor] = {}
+    n_dequantized = 0
+    for name in sorted(state_dict.keys()):
+        if name.endswith("_scale_inv") or name.endswith("activation_scale"):
+            continue
+        tensor = state_dict[name]
+        if tensor is None:
+            raise ValueError(f"Expected tensor {name} to exist in state_dict but it was None")
+        scale = state_dict.get(f"{name}_scale_inv")
+        if scale is None:
+            if tensor.dtype == torch.float8_e4m3fn:
+                raise ValueError(f"Found float8 tensor '{name}' without matching inverse scale '{name}_scale_inv'.")
+            out[name] = tensor.to(dtype).contiguous() if tensor.is_floating_point() else tensor.clone()
+            continue
+        if scale.ndim not in (0, tensor.ndim):
+            raise ValueError(
+                f"per-tensor fp8 scale for '{name}' has ndim {scale.ndim}; expected 0 (one scale per "
+                f"tensor) or {tensor.ndim} (one per leading slice), tensor shape {tuple(tensor.shape)}"
+            )
+        out[name] = (tensor.float() * scale.float()).to(dtype).contiguous()
+        n_dequantized += 1
+    if n_dequantized:
+        logger.info(f"per-tensor fp8: dequantized {n_dequantized} weight tensor(s)")
+    return out
+
+
 def dequantize_state_dict(
     state_dict: Mapping[str, torch.Tensor],
     hf_config: Any,
@@ -356,13 +413,15 @@ def dequantize_state_dict(
 ) -> dict[str, torch.Tensor]:
     """Dequantize an HF (sub-)state_dict for the d_p pipeline.
 
-    Kimi K2.6's compressed-tensors pack-quantized INT4 weights are dequantized locally; every
-    other checkpoint (DeepSeek fp8 block-wise) is delegated unchanged to the shared deepseek_v3
-    dequantizer.
+    Three schemes are in play: Kimi K2.6's compressed-tensors pack-quantized INT4, Mistral Small 4's
+    per-tensor fp8, and DeepSeek's block-wise fp8 (delegated unchanged to the shared deepseek_v3
+    dequantizer).
     """
     quant_cfg = _get_quantization_config_dict(hf_config)
     if is_pack_quantized_int4(quant_cfg):
         return _dequantize_pack_quantized_state_dict(state_dict, quant_cfg, dtype=dtype)
+    if is_per_tensor_fp8(quant_cfg):
+        return _dequantize_per_tensor_fp8_state_dict(state_dict, dtype=dtype)
     return _fp8_dequantize_state_dict(state_dict, hf_config, dtype)
 
 
@@ -442,3 +501,16 @@ def convert_state_dict(
         "quantized; dequantizing weights."
     )
     return dequantize_state_dict(state_dict, hf_config, dtype)
+
+
+def token_normalized(t: torch.Tensor) -> torch.Tensor:
+    """Per-token RMS-normalized copy: each position's feature vector divided by its own RMS.
+
+    Raw PCC on late-layer hidden states of a model with massive activations (an attention-sink
+    effect: a few channels carry values orders of magnitude larger than the rest) is dominated by
+    those channels and measures almost nothing about the other thousands. Normalizing PER TOKEN --
+    not globally -- makes the metric insensitive to them while still catching a genuine regression,
+    because a real error moves the whole feature vector rather than rescaling it.
+    """
+    x = t.float()
+    return x / x.pow(2).mean(dim=-1, keepdim=True).clamp_min(1e-12).sqrt()

--- a/models/demos/deepseek_v3_d_p/utils/test_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_utils.py
@@ -501,16 +501,3 @@ def convert_state_dict(
         "quantized; dequantizing weights."
     )
     return dequantize_state_dict(state_dict, hf_config, dtype)
-
-
-def token_normalized(t: torch.Tensor) -> torch.Tensor:
-    """Per-token RMS-normalized copy: each position's feature vector divided by its own RMS.
-
-    Raw PCC on late-layer hidden states of a model with massive activations (an attention-sink
-    effect: a few channels carry values orders of magnitude larger than the rest) is dominated by
-    those channels and measures almost nothing about the other thousands. Normalizing PER TOKEN --
-    not globally -- makes the metric insensitive to them while still catching a genuine regression,
-    because a real error moves the whole feature vector rather than rescaling it.
-    """
-    x = t.float()
-    return x / x.pow(2).mean(dim=-1, keepdim=True).clamp_min(1e-12).sqrt()

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -387,6 +387,64 @@ def reference_kvpe_for_layer(hf_layer, layer_idx, layer_input, layer_kwargs, ref
     return derive_mla_kvpe(hf_layer, layer_input, layer_kwargs.get("position_embeddings"), config)
 
 
+def extract_routed_experts(full_sd, n_routed=None, prefix="", hf_layer=None):
+    """Per-expert {gate_proj, up_proj, down_proj} for one layer, from either expert weight layout.
+
+    Two layouts exist in the wild and the TT side wants the same thing from both:
+
+    * **per-expert** (DeepSeek-V3 / Kimi / GLM) -- ``mlp.experts.{j}.{gate,up,down}_proj.weight``,
+      each a 2-D ``[out, in]`` tensor.
+    * **stacked + fused** (Mistral Small 4, GPT-OSS family) -- one 3-D tensor per projection, with
+      gate and up concatenated along the output dim:
+      ``mlp.experts.gate_up_proj`` ``[E, 2*moe_intermediate, hidden]`` and
+      ``mlp.experts.down_proj``    ``[E, hidden, moe_intermediate]``.
+
+    The split is contiguous halves, gate first -- ``Mistral4NaiveMoe.forward`` does
+    ``linear(x, gate_up_proj[e]).chunk(2, dim=-1)`` and uses the first result as the gate. Read off
+    the modeling code rather than inferred, because getting it backwards swaps SwiGLU's branches and
+    produces plausible output with bad PCC.
+
+    The layer-by-layer pretrained loader passes an unprefixed single-layer state_dict; the whole-model
+    path passes the full dict with a ``layers.{i}.`` prefix. Same two layouts either way.
+    """
+    stacked_gate_up = full_sd.get(f"{prefix}mlp.experts.gate_up_proj")
+    if stacked_gate_up is None:
+        # Per-expert layout only. Resolved HERE, not at the call site: for a stacked-layout model
+        # `hf_layer.mlp.experts` is a single module with no __len__ (Mistral4NaiveMoe), so asking for
+        # its length eagerly is a TypeError on exactly the variants that take the branch below.
+        if n_routed is None:
+            n_routed = len(hf_layer.mlp.experts)
+        return [
+            {
+                "gate_proj": full_sd[f"{prefix}mlp.experts.{j}.gate_proj.weight"],
+                "up_proj": full_sd[f"{prefix}mlp.experts.{j}.up_proj.weight"],
+                "down_proj": full_sd[f"{prefix}mlp.experts.{j}.down_proj.weight"],
+            }
+            for j in range(n_routed)
+        ]
+
+    stacked_down = full_sd[f"{prefix}mlp.experts.down_proj"]
+    num_experts, two_i, _hidden = stacked_gate_up.shape
+    if n_routed is not None:
+        assert num_experts == n_routed, f"stacked experts {num_experts} != n_routed_experts {n_routed}"
+    assert two_i % 2 == 0, f"fused gate_up out-dim {two_i} is not even"
+    inter = two_i // 2
+    assert (
+        stacked_down.shape[0] == num_experts
+    ), f"expert-count mismatch: gate_up {num_experts} vs down {stacked_down.shape[0]}"
+    assert (
+        stacked_down.shape[2] == inter
+    ), f"down_proj in-dim {stacked_down.shape[2]} != moe_intermediate {inter} implied by gate_up"
+    return [
+        {
+            "gate_proj": stacked_gate_up[j, :inter, :],
+            "up_proj": stacked_gate_up[j, inter:, :],
+            "down_proj": stacked_down[j],
+        }
+        for j in range(num_experts)
+    ]
+
+
 def extract_layer_state_dict(variant, full_sd, layer_idx, hf_layer):
     """Extract one layer's weights from HF state_dict into TtPrefillBlock format."""
     prefix = f"layers.{layer_idx}."
@@ -407,18 +465,18 @@ def extract_layer_state_dict(variant, full_sd, layer_idx, hf_layer):
     }
 
     if is_moe:
+        gate_weight = full_sd[f"{prefix}mlp.gate.weight"]
+        # Models whose router has no auxiliary-loss-free correction bias (Mistral Small 4: a plain
+        # softmax top-k router, `Mistral4TopkRouter` holds only `weight`) get zeros. The TT gate
+        # always carries a bias tensor, and zero is its identity in every path that reads it --
+        # top-k on (logits + bias) and the sigmoid/noaux_tc affinity alike -- so this is exact, not a
+        # placeholder. DeepSeek/Kimi/GLM are unaffected: their bias is present and used.
+        bias_key = f"{prefix}mlp.gate.e_score_correction_bias"
         layer_sd["gate_weights"] = {
-            "weight": full_sd[f"{prefix}mlp.gate.weight"],
-            "e_score_correction_bias": full_sd[f"{prefix}mlp.gate.e_score_correction_bias"],
+            "weight": gate_weight,
+            "e_score_correction_bias": full_sd.get(bias_key, torch.zeros(gate_weight.shape[0], dtype=torch.float32)),
         }
-        layer_sd["routed_expert_weights"] = [
-            {
-                "gate_proj": full_sd[f"{prefix}mlp.experts.{j}.gate_proj.weight"],
-                "up_proj": full_sd[f"{prefix}mlp.experts.{j}.up_proj.weight"],
-                "down_proj": full_sd[f"{prefix}mlp.experts.{j}.down_proj.weight"],
-            }
-            for j in range(len(hf_layer.mlp.experts))
-        ]
+        layer_sd["routed_expert_weights"] = extract_routed_experts(full_sd, prefix=prefix, hf_layer=hf_layer)
         layer_sd["shared_expert_weights"] = {
             "gate_proj": full_sd[f"{prefix}mlp.shared_experts.gate_proj.weight"],
             "up_proj": full_sd[f"{prefix}mlp.shared_experts.up_proj.weight"],
@@ -834,18 +892,18 @@ def load_and_compute_layer_by_layer(
                     "down_proj": layer_dequant["mlp.down_proj.weight"],
                 }
             else:
+                # Same two checkpoint-shape variations the random-weight path handles in
+                # `extract_layer_state_dict`: a router with no auxiliary correction bias (zeros are
+                # the identity for it), and stacked+fused expert tensors instead of per-expert keys.
+                gate_weight = layer_dequant["mlp.gate.weight"]
                 layer_dict["gate_weights"] = {
-                    "weight": layer_dequant["mlp.gate.weight"],
-                    "e_score_correction_bias": layer_dequant["mlp.gate.e_score_correction_bias"],
+                    "weight": gate_weight,
+                    "e_score_correction_bias": layer_dequant.get(
+                        "mlp.gate.e_score_correction_bias",
+                        torch.zeros(gate_weight.shape[0], dtype=torch.float32),
+                    ),
                 }
-                layer_dict["routed_expert_weights"] = [
-                    {
-                        "gate_proj": layer_dequant[f"mlp.experts.{j}.gate_proj.weight"],
-                        "up_proj": layer_dequant[f"mlp.experts.{j}.up_proj.weight"],
-                        "down_proj": layer_dequant[f"mlp.experts.{j}.down_proj.weight"],
-                    }
-                    for j in range(n_routed)
-                ]
+                layer_dict["routed_expert_weights"] = extract_routed_experts(layer_dequant, n_routed)
                 layer_dict["shared_expert_weights"] = {
                     "gate_proj": layer_dequant["mlp.shared_experts.gate_proj.weight"],
                     "up_proj": layer_dequant["mlp.shared_experts.up_proj.weight"],

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -13,6 +13,7 @@ Provides:
 """
 
 import gc
+import inspect
 import json
 import os
 from copy import deepcopy
@@ -34,6 +35,7 @@ except ImportError:
     from transformers.modeling_utils import no_init_weights
 
 import ttnn
+from models.demos.deepseek_v3_d_p.utils.expert_dtypes import DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE
 
 
 @dataclass
@@ -211,6 +213,178 @@ def create_hf_model(variant, config, num_layers, n_routed_experts=None):
 
     model = variant.reference_model_cls(test_config)
     return model.eval().to(torch.bfloat16)
+
+
+def reference_rope(hf_model, hidden_states, position_ids):
+    """The reference ``(cos, sin)``, built in fp32 from the CONFIG rather than copied from the model.
+
+    A reference instantiated in bf16 carries a bf16 ``inv_freq`` buffer and ``.float()`` cannot
+    recover the lost bits; the resulting ~4.4e-4 frequency error is a phase error that grows with
+    position. Depends only on the positions, so build it once per run.
+    """
+    rotary = getattr(hf_model, "rotary_emb", None)
+    assert rotary is not None, f"{type(hf_model).__name__} exposes no rotary_emb to build rope from"
+    # Check the signature rather than catching: a bare `except` would also swallow a genuine
+    # construction failure and silently fall back to the bf16 buffer this function exists to avoid.
+    rotary_cls = type(rotary)
+    if "config" in inspect.signature(rotary_cls.__init__).parameters:
+        rotary_f32 = rotary_cls(config=hf_model.config).float()
+    else:  # a rotary that predates `config=`; the bf16 buffer is then unavoidable
+        rotary_f32 = deepcopy(rotary).float()
+    # `forward` reads this tensor only for device and dtype (transformers 5.12), so pass a view --
+    # a full fp32 copy of the hidden states is ~251 MB at seq 15360.
+    probe = hidden_states[:1, :1].float()
+    with torch.no_grad():
+        return rotary_f32(probe, position_ids)
+
+
+def layer_wants_position_embeddings(hf_layer) -> bool:
+    """Does this reference decoder layer take ``position_embeddings``?
+
+    The predicate that decides whether a rope table has to be built at all. Layers differ across
+    transformers generations: a transformers-5.x layer (e.g. Mistral4) REQUIRES the caller to pass
+    ``(cos, sin)``, while an older or vendored layer (e.g. DeepSeekV3) computes rope internally from
+    ``position_ids`` and exposes no top-level ``rotary_emb`` to build one from. Asking the signature
+    keeps both working; assuming either shape breaks the other.
+    """
+    return "position_embeddings" in inspect.signature(hf_layer.forward).parameters
+
+
+def reference_position_embeddings(hf_model, hidden_states, position_ids, num_layers: int):
+    """The reference rope table for a whole run, or ``None`` when no layer takes one.
+
+    Built once: it depends only on the positions, and building per layer would construct a rotary
+    module and a full fp32 copy of the hidden states each time (~251 MB at seq 15360).
+
+    Returns None rather than raising for a reference whose layers compute rope internally --
+    DeepSeekV3's vendored layer does, and its model exposes no top-level ``rotary_emb``, so asking
+    unconditionally asserted on exactly the models that never needed a table.
+    """
+    if not num_layers or not layer_wants_position_embeddings(hf_model.layers[0]):
+        return None
+    return reference_rope(hf_model, hidden_states, position_ids)
+
+
+def decoder_layer_kwargs(
+    hf_layer, hf_model, hidden_states, attention_mask, position_ids, cache, use_cache=True, position_embeddings=None
+):
+    """Keyword arguments for calling one reference decoder layer, bound to ITS OWN signature.
+
+    Reference layers differ across transformers generations and getting it wrong fails in two
+    distinct ways, neither of which points at the cause:
+
+      * the cache kwarg is ``past_key_value`` on the vendored DeepSeek/Kimi layers and
+        ``past_key_values`` on transformers >= 5. The wrong name lands silently in ``**kwargs``, so
+        no KV is ever captured and a later cache comparison comes up empty or mis-shaped;
+      * transformers >= 5 moved rope to the MODEL level and made ``position_embeddings`` required, so
+        omitting it raises ``TypeError: cannot unpack non-iterable NoneType`` from inside attention.
+
+    Pass ``position_embeddings`` from ``reference_rope`` -- it depends only on the positions, so
+    building it per layer is wasted work. Omitted, it is built here for this one call.
+    """
+    params = inspect.signature(hf_layer.forward).parameters
+    kwargs = {
+        "attention_mask": attention_mask,
+        "position_ids": position_ids,
+        "use_cache": use_cache,
+    }
+    kwargs["past_key_values" if "past_key_values" in params else "past_key_value"] = cache
+    if "position_embeddings" in params:  # == layer_wants_position_embeddings(hf_layer)
+        cos, sin = (
+            position_embeddings
+            if position_embeddings is not None
+            else reference_rope(hf_model, hidden_states, position_ids)
+        )
+        kwargs["position_embeddings"] = (cos.to(hidden_states.dtype), sin.to(hidden_states.dtype))
+    return kwargs
+
+
+def derive_mla_kvpe(hf_layer, hidden_states, position_embeddings, config):
+    """Compressed MLA KV line [b, 1, seq, kv_lora_rank + qk_rope_head_dim] from a decoder layer.
+
+    For references that cache expanded per-head keys rather than the MLA latent. Mirrors what
+    MLAReference caches: ``kv_a_layernorm(latent)`` concatenated with the ROPE-rotated pe part,
+    computed with the layer's own weights and its own rope convention.
+
+    Call this while the layer's weights are still loaded -- the layer-by-layer reference frees
+    them right after the forward.
+    """
+    import sys
+
+    from models.demos.deepseek_v3_d_p.tt.mla.rope import interleaved_to_halfsplit_perm
+
+    attn = hf_layer.self_attn
+    kv_lora_rank, rope_dim = config.kv_lora_rank, config.qk_rope_head_dim
+    with torch.no_grad():
+        # fp32: accumulating the norm + projection in bf16 costs ~2e-3 of PCC against the device's
+        # own KVPE, enough to fail a 0.999 bar with nothing actually wrong.
+        norm_f = deepcopy(hf_layer.input_layernorm).float()
+        proj_f = deepcopy(attn.kv_a_proj_with_mqa).float()
+        kv_norm_f = deepcopy(attn.kv_a_layernorm).float()
+        normed = norm_f(hidden_states.float())
+        compressed = proj_f(normed)
+        latent, k_pe = torch.split(compressed, [kv_lora_rank, rope_dim], dim=-1)
+        bsz, seq_len = hidden_states.shape[0], hidden_states.shape[1]
+        k_nope = kv_norm_f(latent).view(bsz, 1, seq_len, kv_lora_rank)
+        k_pe = k_pe.view(bsz, 1, seq_len, rope_dim)
+
+        assert position_embeddings is not None, "need (cos, sin) to rotate the pe part"
+        cos, sin = (c.float() for c in position_embeddings)
+        # Use the layer's OWN rope convention, resolved from the attention's own module rather than
+        # any one variant's: Mistral sets rope_interleave=True and applies
+        # apply_rotary_pos_emb_interleave; getting this wrong silently rotates the wrong pairs.
+        attn_module = sys.modules[type(attn).__module__]
+        fn_name = (
+            "apply_rotary_pos_emb_interleave" if getattr(config, "rope_interleave", False) else "apply_rotary_pos_emb"
+        )
+        _apply = getattr(attn_module, fn_name, None)
+        assert _apply is not None, f"{attn_module.__name__} exposes no {fn_name} to rotate the pe part"
+        _q_unused, k_pe = _apply(k_pe, k_pe, cos, sin)
+
+        # The rotated pe is in the HF half-split basis; MLAReference and the device both store the
+        # Meta-interleaved one. The permutation between them cancels in q.k, which is why attention
+        # output PCC is ~1.0 either way while the stored pe compares at ~0.03 without it.
+        perm = torch.argsort(interleaved_to_halfsplit_perm(rope_dim))
+        k_pe = k_pe[..., perm]
+
+        kvpe = k_pe.new_empty(bsz, 1, seq_len, kv_lora_rank + rope_dim)
+        kvpe[:, :, :, :kv_lora_rank] = k_nope
+        kvpe[:, :, :, kv_lora_rank:] = k_pe
+    return kvpe
+
+
+def mla_kvpe_width(config) -> int | None:
+    """Width of the row the device caches per token: kv_lora_rank + qk_rope_head_dim.
+
+    None when the config is not MLA, so callers can skip a layout check that does not apply.
+    """
+    kv, rope = getattr(config, "kv_lora_rank", None), getattr(config, "qk_rope_head_dim", None)
+    return None if kv is None or rope is None else kv + rope
+
+
+def reference_kvpe_for_layer(hf_layer, layer_idx, layer_input, layer_kwargs, ref_cache, config):
+    """This layer's reference KVPE in the layout the DEVICE stores: [b, 1, seq, kv_lora_rank + pe].
+
+    A vendored MLAReference caches that line directly, so it is used as-is. A stock transformers
+    attention (`Mistral4Attention`) caches EXPANDED per-head keys -- [b, n_heads, seq, head_dim] --
+    which does not correspond to the device's latent cache in rank OR width. Comparing the two does
+    not merely fail, it fails *quietly*: a `[..., :kv_lora_rank]` slice of a 128-wide last dim just
+    clamps to 128, and what reaches comp_pcc is a shape error rather than a number. Derive the
+    latent from the layer's own modules in that case.
+    """
+    width = mla_kvpe_width(config)
+    cached = hf_cache_layer_kv(ref_cache, layer_idx)[0]
+    if width is None:
+        return cached  # not an MLA config; nothing to derive
+    if cached is not None and cached.shape[-1] == width:
+        return cached
+    if layer_idx == 0:
+        logger.info(
+            f"Reference caches expanded KV (last dim "
+            f"{None if cached is None else cached.shape[-1]} != {width}); "
+            "deriving the compressed MLA KVPE line from each layer instead"
+        )
+    return derive_mla_kvpe(hf_layer, layer_input, layer_kwargs.get("position_embeddings"), config)
 
 
 def extract_layer_state_dict(variant, full_sd, layer_idx, hf_layer):
@@ -448,7 +622,7 @@ def load_and_compute_layer_by_layer(
     tp_axis: int = 1,
     gate_fallback_mode=None,
     routed_expert_activations_dtype=ttnn.bfloat8_b,
-    routed_expert_weights_dtype=ttnn.bfloat4_b,
+    routed_expert_weights_dtype=DEFAULT_ROUTED_EXPERT_WEIGHTS_DTYPE,
     shared_expert_activations_dtype=ttnn.bfloat16,
     shared_expert_weights_dtype=ttnn.bfloat8_b,
     causal_only=True,
@@ -507,7 +681,7 @@ def load_and_compute_layer_by_layer(
 
     # Initialize outputs
     ref_snapshots = [] if compute_reference else None
-    ref_kvpe_list = None
+    ref_kvpe_list = [] if compute_reference else None
     ref_cache = None
 
     # Create hf_model only if computing reference
@@ -568,6 +742,16 @@ def load_and_compute_layer_by_layer(
     first_k_dense = config.first_k_dense_replace
     n_routed = config.n_routed_experts
 
+    # Once for the whole reference: identical across layers, and each build would otherwise construct
+    # a rotary module and a full fp32 copy of the hidden states.
+    #
+    # Only when a layer actually takes position_embeddings. A vendored reference such as DeepSeekV3
+    # computes rope internally and exposes no top-level rotary_emb, so building this unconditionally
+    # asserts on exactly the models that never needed it.
+    ref_position_embeddings = (
+        reference_position_embeddings(hf_model, h_ref, position_ids, num_layers) if compute_reference else None
+    )
+
     for i in range(num_layers):
         logger.info(f"Processing layer {i}/{num_layers}...")
 
@@ -578,16 +762,30 @@ def load_and_compute_layer_by_layer(
             layer_with_prefix = {f"layers.{i}.{k}": v for k, v in layer_dequant.items()}
             hf_model.load_state_dict(layer_with_prefix, strict=False)
 
+            layer_input = h_ref
+            layer_kwargs = decoder_layer_kwargs(
+                hf_model.layers[i],
+                hf_model,
+                h_ref,
+                attention_mask,
+                position_ids,
+                ref_cache,
+                position_embeddings=ref_position_embeddings,
+            )
             with torch.no_grad():
-                layer_out = hf_model.layers[i](
-                    h_ref,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
-                    past_key_value=ref_cache,
-                    use_cache=True,
-                )
-                h_ref = layer_out[0]
+                layer_out = hf_model.layers[i](layer_input, **layer_kwargs)
+                h_ref = layer_out[0] if isinstance(layer_out, (tuple, list)) else layer_out
             ref_snapshots.append(h_ref)
+
+            # Capture the reference KVPE *here*, while this layer's weights are still loaded: they
+            # are freed a few lines below, and for a stock attention the line has to be derived from
+            # them (see reference_kvpe_for_layer). Doing it after the loop -- which is what the
+            # earlier `hf_cache_layer_kv` one-liner did -- can only read back the cache, which for
+            # Mistral holds per-head keys and made all 72 per-layer KVPE rows unusable.
+            ref_kvpe_list.append(
+                reference_kvpe_for_layer(hf_model.layers[i], i, layer_input, layer_kwargs, ref_cache, config)
+            )
+            del layer_input, layer_kwargs
 
             # Clear layer weights from hf_model
             for param in hf_model.layers[i].parameters():
@@ -683,10 +881,6 @@ def load_and_compute_layer_by_layer(
         gc.collect()
         _log_memory(f"After layer {i} cleared")
         logger.debug(f"Layer {i} processed, cache cleared")
-
-    # Extract KVPE if computed reference
-    if compute_reference:
-        ref_kvpe_list = [hf_cache_layer_kv(ref_cache, i)[0] for i in range(num_layers)]
 
     # --- Process Norm ---
     logger.info("Processing norm...")
@@ -788,9 +982,39 @@ def _ref_cache_dir(variant) -> Path:
     return Path(os.environ.get(env, f"/tmp/{variant.name}_transformer_ref_cache"))
 
 
-def check_reference_cache_exists(variant, cache_key: ReferenceCacheKey) -> bool:
+def _ref_cache_kvpe_width(cache_path: Path) -> int | None:
+    """Last-dim width of the first stored KVPE entry, or None if it cannot be determined."""
+    try:
+        try:
+            cached = torch.load(cache_path, weights_only=True, mmap=True)
+        except (RuntimeError, TypeError):  # not zipfile-serialized, or older torch without mmap
+            cached = torch.load(cache_path, weights_only=True)
+        kvpe = cached.get("ref_kvpe_list")
+        return None if not kvpe else kvpe[0].shape[-1]
+    except Exception as e:  # a cache we cannot read is handled by the normal load path
+        logger.debug(f"Could not inspect KVPE width of {cache_path}: {e}")
+        return None
+
+
+def check_reference_cache_exists(variant, cache_key: ReferenceCacheKey, expected_kvpe_width: int | None = None) -> bool:
+    """Whether a reusable reference cache exists for `cache_key`.
+
+    `expected_kvpe_width` (kv_lora_rank + qk_rope_head_dim) additionally rejects a file whose
+    stored KVPE predates `reference_kvpe_for_layer` -- i.e. holds expanded per-head keys instead of
+    the compressed MLA line. ReferenceCacheKey covers everything that changes reference *values*
+    but nothing about their *layout*, so without this a stale file is reused silently and every
+    per-layer KVPE row errors out. Treated as a miss, which recomputes the reference (~6 s/layer).
+    """
     cache_path = _ref_cache_dir(variant) / f"{cache_key}.pt"
     exists = cache_path.exists()
+    if exists and expected_kvpe_width is not None:
+        stale = _ref_cache_kvpe_width(cache_path)
+        if stale is not None and stale != expected_kvpe_width:
+            logger.warning(
+                f"Reference cache {cache_path.name} stores KVPE of width {stale}, expected "
+                f"{expected_kvpe_width} (pre-compressed-line format) -- recomputing the reference"
+            )
+            return False
     if exists:
         logger.info(f"Reference cache found: {cache_path}")
     else:

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -448,7 +448,10 @@ def extract_routed_experts(full_sd, n_routed=None, prefix="", hf_layer=None):
 def extract_layer_state_dict(variant, full_sd, layer_idx, hf_layer):
     """Extract one layer's weights from HF state_dict into TtPrefillBlock format."""
     prefix = f"layers.{layer_idx}."
-    is_moe = isinstance(hf_layer.mlp, variant.reference_moe_cls)
+    # reference_moe_cls is optional -- left None to skip the MoE reference comparison -- so fall back
+    # to the structural test: a MoE FFN has .experts, a dense one does not.
+    moe_cls = variant.reference_moe_cls
+    is_moe = isinstance(hf_layer.mlp, moe_cls) if moe_cls is not None else hasattr(hf_layer.mlp, "experts")
 
     layer_sd = {
         "attn_norm_weight": full_sd[f"{prefix}input_layernorm.weight"],

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -196,7 +196,7 @@
   team: models
   sp_config: sc1
 
-- name: "KV cache table accuracy (DeepSeek-V3-671B, Kimi-K2.6-1T, GLM-5.2-744B)"
+- name: "KV cache table accuracy (DeepSeek-V3-671B, Kimi-K2.6-1T, GLM-5.2-744B, Mistral-Small-4-119B)"
   fabric_profile: torus_xy
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/DeepSeek-R1-0528-fp8-4236a6af/
@@ -213,12 +213,13 @@
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_mock -k "torus-xy" -vvv --tb=short
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_glm52_kv_cache_table -k "torus-xy-8x4" -vvv --tb=short
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_dflash_kv_cache_mock -k "seq5k and 1user and 2layers" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_mistral4_kv_cache_table -vvv --tb=short
     '
   test_type: kv_cache_table
   test_group: module
   skus:
     bh_sc1:
-      timeout: 10
+      timeout: 12
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -952,5 +953,119 @@
       # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build will exceed this.
       timeout: 35
   owner_id: U08ECJQ848G # Viacheslav Melnykov
+  team: models
+  sp_config: sc1
+- name: "Mistral-Small-4-119B MLA accuracy 5k, 25k"
+  cmd: |
+    export MISTRAL4_HF_MODEL=/mnt/models/Mistral-Small-4-119B-2603
+    export MISTRAL4_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/mistral_small_4_119b_mla_ref_cache
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mistral_small4_mla -vvv --tb=short
+    '
+  test_type: mistral4_mla
+  test_group: module
+  skus:
+    bh_sc1:
+      # measured 73 s of tests on run 32793561151, plus runner setup
+      timeout: 11
+  owner_id: U08GEEEEC75 # ssalice
+  team: models
+  sp_config: sc1
+
+- name: "Mistral-Small-4-119B MLA chunked accuracy 5k@5k, 25k@5k"
+  fabric_profile: torus_xy
+  cmd: |
+    export MISTRAL4_HF_MODEL=/mnt/models/Mistral-Small-4-119B-2603
+    export MISTRAL4_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/mistral_small_4_119b_mla_ref_cache
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "mistral4 and cpu and scalar and no_determinism and torus-xy-8x4" -vvv --tb=short
+    '
+  test_type: mistral4_mla_chunked
+  test_group: module
+  skus:
+    bh_sc1:
+      # 13 scenarios (verified by --collect-only). Measured: all 13 pass in 1260 s (21 min) on run
+      # 32786508251, but the job still timed out at 30 because the box's setup runs before them.
+      # measured 1164 s (19.4 min) for all 13 scenarios, plus runner setup;
+      # 30 was not enough when the same leg ran 21 min, so this keeps a real margin
+      timeout: 32
+  owner_id: U08GEEEEC75 # ssalice
+  team: models
+  sp_config: sc1
+
+- name: "Mistral-Small-4-119B MoE dispatch, combine, reduce accuracy"
+  fabric_profile: torus_xy
+  cmd: |
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -k "mistral4-perf_no_pcc and 8x4" -vvv --tb=short
+    '
+  test_type: mistral4_moe_ops
+  test_group: module
+  skus:
+    bh_sc1:
+      # 16 cases across the four op files (verified by --collect-only). Measured 12 min; +15%.
+      # mesh_configs' only marker-carrying 8x4 row is fabric2d-torus-xy-8x4-2link, so this leg
+      # measured 86 s for 4 passed + 12 skipped, plus runner setup
+      timeout: 11
+  owner_id: U08GEEEEC75 # ssalice
+  team: models
+  sp_config: sc1
+
+- name: "Mistral-Small-4-119B prefill block accuracy 5k"
+  cmd: |
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_mistral4_prefill_block -vvv --tb=short
+    '
+  test_type: mistral4_prefill_block
+  test_group: module
+  skus:
+    bh_sc1:
+      # the row here is the shared-harness one (smoke, perf, pcc x determinism x
+      # iterations), not the 4-case row this number was measured against -- left generous until CI
+      # reports its own time
+      timeout: 14
+  owner_id: U08GEEEEC75 # ssalice
+  team: models
+  sp_config: sc1
+
+- name: "Mistral-Small-4-119B MoE accuracy 5k"
+  cmd: |
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_mistral4_moe -vvv --tb=short
+    '
+  test_type: mistral4_moe
+  test_group: module
+  skus:
+    bh_sc1:
+      # measured 144 s of tests, plus runner setup
+      timeout: 12
+  owner_id: U08GEEEEC75 # ssalice
+  team: models
+  sp_config: sc1
+
+- name: "Mistral-Small-4-119B prefill transformer accuracy 5k"
+  cmd: |
+    export MISTRAL4_HF_MODEL=/mnt/models/Mistral-Small-4-119B-2603
+    export TT_MISTRAL4_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/mistral_small_4_host_ref_cache
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_mistral4_prefill_transformer -k "36_layers and 5k and pcc and random and not json" -vvv --tb=short
+    '
+  test_type: mistral4_prefill_transformer
+  test_group: module
+  skus:
+    bh_sc1:
+      # Full-model PCC gated per stage on npcc, heavier than the 5.4 min smoke row it replaces.
+      # full-model PCC, never yet completed on CI -- generous until it reports a time
+      timeout: 20
+  owner_id: U08GEEEEC75 # ssalice
   team: models
   sp_config: sc1


### PR DESCRIPTION
Draft for comparison only — **not for merge**.

The `kmabee/mistral4-prefill-base` history (30 commits) regrouped into 9 by what the diffs actually
touch, with original authorship kept. The cleanup pass is the 10th, deliberately separate.

| # | Author | Commit |
|---|--------|--------|
| 1 | Kyle Mabee | `fix(prefill)`: shared MLA, MoE and norm fixes |
| 2 | Kyle Mabee | `feat(mistral4)`: weight handling and reference scale |
| 3 | ssaliceTT | `feat(mistral4)`: config, adapter, and variant wiring |
| 4 | Alina Khan | `feat(prefill)`: per-layer hidden states and quantized multimodal config loading |
| 5 | Alina Khan | `test(mistral4)`: MLA, chunked prefill and full-transformer rows |
| 6 | Alina Khan | `fix(mistral4)`: config, MoE gate and reference model wiring |
| 7 | Alina Khan | `test(mistral4)`: fabric, decoder block and smoke row updates |
| 8 | ssaliceTT | `test(mistral4)`: MoE, KV cache, op unit, MLA cache and LM head rows |
| 9 | ssaliceTT | `ci(mistral4)`: prefill test stages |
| 10 | ssaliceTT | `refactor(mistral4)`: drop dead code and duplicated guards |

Commits 1-9 reproduce `kmabee/mistral4-prefill-base` exactly — same tree, only the history is grouped.

**What commit 10 changes** (5 files, +23/-72):

- merged the duplicated `kimi_k3` / `mistral_small_4` Blackhole and no-GPU-trace skips in
  `test_mla_chunked_prefill` — each was written twice with the same rationale (27 -> 17 lines)
- removed `token_normalized` from `test_utils.py` — zero readers; `test_prefill_transformer.py` has
  its own copy
- removed `packed_expert_checkpoint` from `adapter.py` — branch-added, zero readers after its only
  setter was dropped
- corrected a comment claiming the MoE reference was unwired (it is wired), and one attributing a
  Mistral-specific meaning to the shared gate-recall target
- trimmed two over-long comment blocks, keeping the load-bearing notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)