### PR TITLE
Package the models/ tree as tt-metal-models for pip, apt, and dnf

### DIFF
--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -24,9 +24,14 @@ jobs:
     uses: ./.github/workflows/_test-wheels-impl.yaml
     with:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Independent of build-artifact: tt-metal-models is pure Python and needs no C++ build,
+  # so it runs in parallel rather than waiting on the wheel. It self-verifies via the
+  # import matrix.
+  build-models-wheel:
+    uses: ./.github/workflows/models-wheel.yaml
   publish-wheels:
     name: "Publish wheels to internal PyPI"
-    needs: [build-artifact, test-wheels]
+    needs: [build-artifact, test-wheels, build-models-wheel]
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for AWS OIDC
@@ -50,6 +55,15 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+          path: ./wheels
+
+      # Into the same directory: the publish step below globs *.whl, so the
+      # tt-metal-models wheel is picked up alongside ttnn. The .deb/.rpm in this artifact
+      # are not wheels and are ignored here.
+      - name: Download tt-metal-models artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build-models-wheel.outputs.artifact-name }}
           path: ./wheels
 
       - name: Publish wheels to internal PyPI

--- a/.github/workflows/models-wheel.yaml
+++ b/.github/workflows/models-wheel.yaml
@@ -139,3 +139,62 @@ jobs:
             dist/*.deb
             dist/*.rpm
           if-no-files-found: error
+
+  # The job above skips every entry point whose first import is `vllm` -- six of eleven
+  # at last count, including models.tt_transformers.tt.generator_vllm, the package's main
+  # reason to exist. A missing packaged module or data file *behind* that first import is
+  # invisible to it. This job supplies the consumer: the Tenstorrent vLLM fork built with
+  # the `empty` device target (no CUDA, no device -- the same recipe tt-model-manager's
+  # installer uses), plus its TT plugin, and requires the skipped entry points to import
+  # via --strict.
+  #
+  # The fork's `dev` branch is a moving target, so this leg can fail on fork-side churn
+  # with no change in this repository. That is accepted deliberately: these entry points
+  # exist to be loaded by that fork, so "the fork can no longer import our models" is
+  # release-blocking information, not noise. The failure log states which side broke.
+  import-matrix-strict:
+    name: "🐍 Import matrix vs vLLM fork (--strict)"
+    runs-on: ${{ inputs.runs-on || 'ubuntu-22.04' }}
+    timeout-minutes: 45
+    needs: build-models-wheel
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          # Only packaging/ is needed (import_matrix.py, build_wheel.py for
+          # --print-requirements); the wheel under test comes from the artifact.
+          sparse-checkout: packaging/tt-metal-models
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+
+      - name: Download the built wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build-models-wheel.outputs.artifact_name }}
+          path: dist
+
+      - name: Install the wheel and the Tenstorrent vLLM fork
+        run: |
+          python packaging/tt-metal-models/build_wheel.py --print-requirements > /tmp/models-requirements.txt
+          python -m venv /tmp/strictvenv
+          /tmp/strictvenv/bin/pip install --quiet --upgrade pip
+          /tmp/strictvenv/bin/pip install --quiet \
+            --extra-index-url https://download.pytorch.org/whl/cpu \
+            -r /tmp/models-requirements.txt
+          /tmp/strictvenv/bin/pip install --quiet ttnn
+          /tmp/strictvenv/bin/pip install --quiet --no-deps dist/tt_metal_models-*.whl
+
+          git clone --depth 1 -b dev https://github.com/tenstorrent/vllm /tmp/vllm
+          echo "vLLM fork at $(git -C /tmp/vllm rev-parse HEAD)"
+          # Tenstorrent has no CUDA: build vLLM with the `empty` device target and CPU
+          # torch; all compute runs through the TT out-of-tree platform. A plain install
+          # would default to VLLM_TARGET_DEVICE=cuda and fail on this runner.
+          VLLM_TARGET_DEVICE=empty /tmp/strictvenv/bin/pip install --quiet /tmp/vllm \
+            --extra-index-url https://download.pytorch.org/whl/cpu
+          /tmp/strictvenv/bin/pip install --quiet /tmp/vllm/plugins/vllm-tt-plugin
+
+      - name: Import matrix (--strict)
+        run: |
+          python packaging/tt-metal-models/import_matrix.py --python /tmp/strictvenv/bin/python --strict

--- a/.github/workflows/models-wheel.yaml
+++ b/.github/workflows/models-wheel.yaml
@@ -1,0 +1,129 @@
+name: "Build tt-metal-models wheel"
+
+# Builds the `tt-metal-models` distribution: the models/ Python tree, packaged so it can
+# be installed rather than cloned. See packaging/tt-metal-models/README.md.
+#
+# Deliberately separate from wheels.yaml. That workflow drives cibuildwheel to compile the
+# `ttnn` C++ extension inside a manylinux container; this artifact is pure Python
+# (py3-none-any) and needs none of that, so building it here keeps it off the critical
+# path of the expensive build and lets it run on a plain runner in about a minute.
+#
+# Version coupling: the wheel takes its version from the same setuptools-scm derivation
+# `ttnn` uses, so an artifact built from a given ref matches the `ttnn` wheel built from
+# that ref, and it declares `ttnn==<that version>`. Callers that need a specific version
+# (the release path) must pass `ref`.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to build from. Defaults to the triggering ref."
+        required: false
+        type: string
+      runs-on:
+        required: false
+        type: string
+        default: "ubuntu-22.04"
+      build-native-packages:
+        description: "Also build python3-tt-metal-models .deb and .rpm."
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      artifact-name:
+        value: ${{ jobs.build-models-wheel.outputs.artifact_name }}
+
+jobs:
+  build-models-wheel:
+    name: "🐍 Build tt-metal-models wheel"
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 20
+    outputs:
+      artifact_name: ${{ steps.artifact-name.outputs.name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          # setuptools-scm derives the version from the tag history, so a shallow clone
+          # without tags would silently produce the 0.0.0.dev0 fallback version.
+          fetch-depth: 0
+          fetch-tags: true
+          # The one submodule under models/ is intentionally NOT initialized: it is
+          # licensed under the Llama 2 Community License rather than Apache-2.0, so
+          # vendoring it into a published wheel is a licensing decision, not a build
+          # setting. See packaging/tt-metal-models/README.md.
+          submodules: false
+
+      # 3.11+ so build_wheel.py can use stdlib tomllib to read the repository's
+      # setuptools-scm configuration. The artifact itself is py3-none-any and supports
+      # 3.10 onwards regardless of which interpreter builds it.
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build setuptools setuptools-scm wheel
+
+      - name: Build the wheel
+        run: python packaging/tt-metal-models/build_wheel.py --output-dir dist
+
+      # .deb only. Debian's dist-packages path is version-independent, so an Ubuntu
+      # runner produces a correct package for every Debian/Ubuntu target. The .rpm is
+      # not built here: RPM distros use a version-qualified
+      # /usr/lib/python3.N/site-packages, N is resolved by the %{python3_sitelib} macro
+      # that only exists on those distros, and guessing it from an Ubuntu runner yields
+      # an rpm that installs cleanly and is then silently unimportable. Build it on the
+      # target distro (see packaging/tt-metal-models/README.md); build_native_packages.py
+      # refuses to guess rather than emit a broken package.
+      - name: Build python3-tt-metal-models (.deb)
+        if: ${{ inputs.build-native-packages }}
+        run: |
+          python packaging/tt-metal-models/build_native_packages.py \
+            --wheel dist/tt_metal_models-*.whl --output-dir dist --deb
+
+      # The gate. A wheel missing a package_data file, or pruned too far, still builds
+      # and still imports at the top level; it fails later at model construction. This
+      # imports every vLLM entry point in the tree against the built wheel, in a venv
+      # containing nothing but the wheel and its declared dependencies.
+      #
+      # The wheel is installed with --no-deps and its dependencies listed separately,
+      # because its `ttnn==<version>` pin refers to this exact build, which is not on any
+      # index until the ttnn wheel from this same commit is published. `ttnn` is
+      # therefore supplied here from the newest published release instead.
+      #
+      # That is an approximation, and a deliberate one: it is close enough to catch what
+      # this gate exists to catch -- missing package data, over-pruning, and undeclared
+      # dependencies, all of which surface as ModuleNotFoundError/FileNotFoundError
+      # regardless of the ttnn version. It does not verify API compatibility between
+      # models/ and the matching ttnn; that needs the two installed together, which
+      # happens after both are published.
+      - name: Import matrix
+        run: |
+          python packaging/tt-metal-models/build_wheel.py --print-requirements > /tmp/models-requirements.txt
+          python -m venv /tmp/matrixvenv
+          /tmp/matrixvenv/bin/pip install --quiet --upgrade pip
+          /tmp/matrixvenv/bin/pip install --quiet \
+            --extra-index-url https://download.pytorch.org/whl/cpu \
+            -r /tmp/models-requirements.txt
+          /tmp/matrixvenv/bin/pip install --quiet ttnn
+          /tmp/matrixvenv/bin/pip install --quiet --no-deps dist/tt_metal_models-*.whl
+          python packaging/tt-metal-models/import_matrix.py --python /tmp/matrixvenv/bin/python
+
+      - name: Compute artifact name
+        id: artifact-name
+        run: |
+          SANITIZED_REF=$(echo "${{ inputs.ref || github.ref_name }}" | tr '/' '-')
+          # Must NOT match `ttnn-dist-*`: package-and-release.yaml globs that pattern and
+          # uploads everything it finds to the `ttnn` PyPI project, whose trusted-publisher
+          # token would reject a differently-named distribution and fail the release.
+          echo "name=tt-metal-models-dist-${SANITIZED_REF}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ steps.artifact-name.outputs.name }}
+          path: |
+            dist/*.whl
+            dist/*.deb
+            dist/*.rpm
+          if-no-files-found: error

--- a/.github/workflows/models-wheel.yaml
+++ b/.github/workflows/models-wheel.yaml
@@ -32,11 +32,23 @@ on:
     outputs:
       artifact-name:
         value: ${{ jobs.build-models-wheel.outputs.artifact_name }}
+  # PR-time gate: the class of defect this catches -- an entry point importing from a
+  # pruned test directory, a data file missing from the wheel, an undeclared dependency
+  # -- is introduced by changes under models/, and is invisible there until the next
+  # scheduled wheel build. Runs on a plain runner in a few minutes; no C++ build.
+  pull_request:
+    paths:
+      - "models/**"
+      - "packaging/tt-metal-models/**"
+      - ".github/workflows/models-wheel.yaml"
+  workflow_dispatch:
 
 jobs:
   build-models-wheel:
     name: "🐍 Build tt-metal-models wheel"
-    runs-on: ${{ inputs.runs-on }}
+    # The `inputs` context is empty on pull_request/workflow_dispatch, so both
+    # expressions need a fallback matching the workflow_call defaults.
+    runs-on: ${{ inputs.runs-on || 'ubuntu-22.04' }}
     timeout-minutes: 20
     outputs:
       artifact_name: ${{ steps.artifact-name.outputs.name }}
@@ -76,7 +88,7 @@ jobs:
       # target distro (see packaging/tt-metal-models/README.md); build_native_packages.py
       # refuses to guess rather than emit a broken package.
       - name: Build python3-tt-metal-models (.deb)
-        if: ${{ inputs.build-native-packages }}
+        if: ${{ inputs.build-native-packages != false }}
         run: |
           python packaging/tt-metal-models/build_native_packages.py \
             --wheel dist/tt_metal_models-*.whl --output-dir dist --deb

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Publish to PyPI (Trusted Publishing)
         if: ${{ !inputs.dry-run }}
-        uses: pypa/gh-action-pypi-publish@ed0c539abdc6b55ad89f3ea7b8e96860a5ddef80 # v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
   # A separate job, not another file in the job above's dist/, because PyPI trusted
   # publishing issues a token scoped to a single project: the `pypi` environment's
@@ -282,7 +282,7 @@ jobs:
 
       - name: Publish to PyPI (Trusted Publishing)
         if: ${{ !inputs.dry-run }}
-        uses: pypa/gh-action-pypi-publish@ed0c539abdc6b55ad89f3ea7b8e96860a5ddef80 # v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
 
   create-changelog:
     needs: [create-tag, release-precheck]

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -162,6 +162,55 @@ jobs:
       is-release-candidate: ${{ needs.release-precheck.outputs.is-release-candidate }}
       tests-yaml-gist-url: ${{ inputs.tests-yaml-gist-url }}
 
+  # Built once, not inside build-test-publish's per-platform matrix: tt-metal-models is
+  # py3-none-any, so a per-platform build would produce identical wheels under one
+  # artifact name and collide on upload. Built from the release tag so it carries the
+  # same version as the ttnn wheel and its `ttnn==<version>` pin resolves.
+  build-models-wheel:
+    needs: create-tag
+    uses: ./.github/workflows/models-wheel.yaml
+    with:
+      # On a dry run the tag is calculated but never created, so checking it out would
+      # fail; build from the triggering ref instead. The version string differs from a
+      # real release in that case, which is correct -- a dry run is not a release.
+      ref: ${{ inputs.dry-run && github.ref || format('refs/tags/{0}', needs.create-tag.outputs.version) }}
+
+  publish-models-to-internal-pypi:
+    name: "Publish tt-metal-models to internal PyPI"
+    needs: [build-models-wheel, create-tag]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for AWS OIDC
+    if: ${{ github.ref == 'refs/heads/main' && !inputs.dry-run }}
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PYPI_ROLE }}
+          aws-region: ${{ secrets.PYPI_REGION }}
+
+      - name: Install s3pypi
+        run: pip install s3pypi
+
+      - name: Download tt-metal-models artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build-models-wheel.outputs.artifact-name }}
+          path: ./wheels
+
+      - name: Publish wheel to internal PyPI
+        run: |
+          found_wheel_files=$(find ./wheels -type f -name "*.whl" -exec realpath {} \;)
+          for wheel in $found_wheel_files; do
+            echo "Publishing wheel: $wheel"
+            s3pypi upload "$wheel" --put-root-index --bucket ${{ secrets.PYPI_BUCKET }}
+          done
+
   publish-to-pypi:
     needs: [build-test-publish, create-tag]
     runs-on: ubuntu-latest
@@ -196,7 +245,44 @@ jobs:
         if: ${{ !inputs.dry-run }}
         uses: pypa/gh-action-pypi-publish@ed0c539abdc6b55ad89f3ea7b8e96860a5ddef80 # v1.13.0
 
+  # A separate job, not another file in the job above's dist/, because PyPI trusted
+  # publishing issues a token scoped to a single project: the `pypi` environment's
+  # identity is bound to `ttnn` and would reject a `tt-metal-models` upload. This needs
+  # its own environment with its own trusted publisher registered on PyPI for the
+  # `tt-metal-models` project, pointing at this workflow and this environment name.
+  #
+  # For the same reason the artifact is named `tt-metal-models-dist-*` rather than
+  # `ttnn-dist-*`: the job above globs that pattern and would otherwise sweep this wheel
+  # into the ttnn upload.
+  publish-models-to-pypi:
+    needs: [build-models-wheel, create-tag]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v') || inputs.dry-run }}
+    environment:
+      name: pypi-models
+      url: https://pypi.org/project/tt-metal-models/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download tt-metal-models artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: tt-metal-models-dist-*
+          path: artifacts
+          merge-multiple: true
 
+      # Only the wheel goes to PyPI. The .deb/.rpm in the same artifact reach users via
+      # the GitHub release assets instead.
+      - name: Flatten into dist/
+        run: |
+          mkdir -p dist
+          find artifacts -type f -name '*.whl' -exec cp {} dist/ \;
+          ls -l dist
+
+      - name: Publish to PyPI (Trusted Publishing)
+        if: ${{ !inputs.dry-run }}
+        uses: pypa/gh-action-pypi-publish@ed0c539abdc6b55ad89f3ea7b8e96860a5ddef80 # v1.13.0
 
   create-changelog:
     needs: [create-tag, release-precheck]
@@ -423,13 +509,16 @@ jobs:
 
   # Candidate for breaking up
   create-and-upload-draft-release:
-    needs: [check-existing-release, create-tag]
+    # build-models-wheel is a dependency because its artifact is downloaded below and
+    # listed in the release assets, which are uploaded with fail_on_unmatched_files.
+    needs: [check-existing-release, create-tag, build-models-wheel]
     # May accidentally create two releases without restricting to 1 job
     concurrency: create_upload_draft_release
     runs-on: ubuntu-latest
     if: ${{ !cancelled() &&
             needs.check-existing-release.result == 'success' &&
             needs.check-existing-release.outputs.should-skip-release != 'true' &&
+            needs.build-models-wheel.result == 'success' &&
             github.run_attempt == '1'
         }}
     steps:
@@ -457,6 +546,15 @@ jobs:
         with:
           pattern: packages-*
           path: debian-packages
+          merge-multiple: true
+      # python3-tt-metal-models is pure Python and is built outside the CMake/CPack
+      # pipeline, so it arrives in its own artifact rather than under `packages-*`. Only
+      # the native packages go to the release; the wheel goes to PyPI.
+      - name: Download python3-tt-metal-models packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: tt-metal-models-dist-*
+          path: models-packages
           merge-multiple: true
       - name: Verify files for release (dry-run)
         if: ${{ inputs.dry-run }}
@@ -489,8 +587,15 @@ jobs:
             echo "✗ debian-packages directory not found"
           fi
           echo ""
+          echo "Checking for python3-tt-metal-models packages:"
+          if [ -d "models-packages" ]; then
+            find models-packages -name "*.deb" -exec bash -c 'for f in "$@"; do size=$(du -h "$f" | cut -f1); echo "  ✓ $f ($size)"; done' _ {} +
+          else
+            echo "✗ models-packages directory not found"
+          fi
+          echo ""
           echo "=== All files that would be uploaded to release ==="
-          ls -lh "${required_files[@]}" debian-packages/*.deb 2>/dev/null || echo "Some files are missing!"
+          ls -lh "${required_files[@]}" debian-packages/*.deb models-packages/*.deb 2>/dev/null || echo "Some files are missing!"
       - name: Create draft release with assets (skipped for dry run)
         if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) && !inputs.dry-run }}
         uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
@@ -508,6 +613,7 @@ jobs:
             models/docs/MODEL_UPDATES.md
             tt-metalium.tar.gz
             debian-packages/*.deb
+            models-packages/*.deb
           fail_on_unmatched_files: true
 
   convert-draft-to-prerelease:

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -461,6 +461,11 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
     secrets: inherit
 
+  # NOTE: tt-metal-models is deliberately NOT built here. This workflow runs as a
+  # per-platform matrix, and that artifact is py3-none-any -- building it per platform
+  # would produce identical wheels under one artifact name and collide on upload. It is
+  # built once in package-and-release.yaml instead.
+
   publish-wheels:
     name: "Publish wheels to internal PyPI"
     needs: build-artifact

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -119,8 +119,10 @@ the Tenstorrent vLLM plugin loads architectures from.
 > they take precedence when resolving bundled model parameters, so a stale value silently loads
 > configs from the wrong tree.
 
-See [`packaging/tt-metal-models/README.md`](packaging/tt-metal-models/README.md) for what the
-package contains, its known limitations, and how it is built.
+See [`packaging/tt-metal-models/README.md`](https://github.com/tenstorrent/tt-metal/blob/main/packaging/tt-metal-models/README.md)
+for what the package contains, its known limitations, and how it is built. (Absolute URL:
+this file is copied into the Sphinx docs tree, where a repository-relative link has no target
+and fails the docs build.)
 
 ---
 

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -83,21 +83,44 @@ All binaries support only Linux and distros with glibc 2.34 or newer.
   pip install ttnn
   ```
 
-#### Step 2. (For models users only) Set Up Environment for Models:
+#### Step 2. (For models users only) Install the Models:
 
-To try our pre-built models in [`tt-metal/models/`](https://github.com/tenstorrent/tt-metal/tree/main/models), you must:
+The `ttnn` wheel contains the runtime, but not the model implementations. Those live in
+[`tt-metal/models/`](https://github.com/tenstorrent/tt-metal/tree/main/models) and ship as a
+separate distribution, `tt-metal-models`, which provides the `models.*` Python namespace that
+the Tenstorrent vLLM plugin loads architectures from.
 
-  - Install their required dependencies
-  - Set appropriate environment variables
-  - Set the CPU performance governor to ensure high performance on the host
+- Install it at the **same version** as your `ttnn` — the two are built from one commit and
+  the coupling is exact, so `tt-metal-models` pins `ttnn` and a mismatch is an install error
+  rather than a failure deep inside model construction:
 
-- This is done by executing the following:
   ```sh
-  export PYTHONPATH=$(pwd)
-  pip install -r tt_metal/python_env/requirements-dev.txt
+  pip install tt-metal-models==$(python -c "import importlib.metadata as m; print(m.version('ttnn'))")
+  ```
+
+- For system Python and containers, the same tree is packaged as `python3-tt-metal-models`
+  (`.deb` and `.rpm` on the [release page](https://github.com/tenstorrent/tt-metal/releases)).
+  Note that it installs into the system Python and so is **not** visible inside a virtual
+  environment created without `--system-site-packages`; use the wheel there. `ttnn` itself must
+  still come from pip in either case — the `tt-nn` system package is the C++ library, and the
+  Python bindings ship only in the `ttnn` wheel.
+
+- Set the CPU performance governor for high performance on the host:
+
+  ```sh
   sudo apt-get install cpufrequtils
   sudo cpupower frequency-set -g performance
   ```
+
+> Working from a git checkout instead? Put the repository on `PYTHONPATH` (`export PYTHONPATH=$(pwd)`)
+> and install the development dependencies with `pip install -r tt_metal/python_env/requirements-dev.txt`.
+> This remains the path for model code that is not yet in a release. If you do this while
+> `tt-metal-models` is also installed, unset `TT_METAL_HOME` and `TT_METAL_RUNTIME_ROOT` first —
+> they take precedence when resolving bundled model parameters, so a stale value silently loads
+> configs from the wrong tree.
+
+See [`packaging/tt-metal-models/README.md`](packaging/tt-metal-models/README.md) for what the
+package contains, its known limitations, and how it is built.
 
 ---
 

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -9,7 +9,6 @@ import time
 from typing import Union
 
 import numpy as np
-import pytest
 import torch
 from loguru import logger
 from ttnn.device import Arch
@@ -567,6 +566,36 @@ def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
     return cal_pcc >= pcc, cal_pcc
 
 
+def assert_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
+    """
+    Assert that two PyTorch tensors are similar within a specified Pearson Correlation Coefficient (PCC) threshold.
+
+    This function compares two tensors using PCC, which measures the linear correlation between them.
+    It's particularly useful for floating-point comparisons where exact equality is not expected due to
+    numerical precision differences.
+
+    Args:
+        expected_pytorch_result (torch.Tensor): The expected reference tensor
+        actual_pytorch_result (torch.Tensor): The actual tensor to compare against the reference
+        pcc (float, optional): The minimum PCC threshold for the comparison to pass. Defaults to 0.9999.
+                              Values closer to 1.0 indicate stronger correlation.
+
+    Returns:
+        tuple: A tuple containing:
+            - pcc_passed (bool): True if the PCC check passed, False otherwise
+            - pcc_message (str): A message describing the PCC comparison result
+
+    Raises:
+        AssertionError: If the tensor shapes don't match or if the PCC is below the specified threshold
+    """
+    assert list(expected_pytorch_result.shape) == list(
+        actual_pytorch_result.shape
+    ), f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}"
+    pcc_passed, pcc_message = comp_pcc(expected_pytorch_result, actual_pytorch_result, pcc)
+    assert pcc_passed, pcc_message
+    return pcc_passed, pcc_message
+
+
 def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]:
     "Return Unit of Least Precision for each element of a given tensor"
 
@@ -1070,6 +1099,11 @@ def is_slow_dispatch():
 
 
 def ti_skip(condition, reason="Invalid test parameters"):
+    # Imported here rather than at module scope: this module is on the import path of
+    # essentially every model, including the vLLM serving entry points, and a top-level
+    # `import pytest` would make a test framework a hard runtime dependency of serving.
+    import pytest
+
     return pytest.mark.skipif(condition, reason="Skipping unsupported case: " + reason)
 
 

--- a/models/demos/bge_large_en/runner/performant_runner.py
+++ b/models/demos/bge_large_en/runner/performant_runner.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
+from models.common.utility_functions import assert_with_pcc
 from models.demos.bge_large_en.runner.performant_runner_infra import BGEPerformanceRunnerInfra
-from models.demos.wormhole.bge_large_en.tests.pcc.utils import assert_with_pcc
 
 
 class BGEPerformantRunner:

--- a/models/demos/bge_large_en/runner/performant_runner_infra.py
+++ b/models/demos/bge_large_en/runner/performant_runner_infra.py
@@ -8,11 +8,10 @@ from loguru import logger
 from ttnn.model_preprocessing import preprocess_model_parameters
 
 import ttnn
-from models.common.utility_functions import is_blackhole, is_wormhole_b0
+from models.common.utility_functions import assert_with_pcc, is_blackhole, is_wormhole_b0
 from models.demos.bge_large_en.common import load_torch_model
 from models.demos.bge_large_en.ttnn.ttnn_bge_model import TtnnBGEModel
 from models.demos.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
-from models.demos.wormhole.bge_large_en.tests.pcc.utils import assert_with_pcc
 
 if is_blackhole():
     from models.demos.blackhole.bge_large_en.ttnn.common import custom_preprocessor

--- a/models/demos/deepseek_v3_d_p/reference/dflash_prefill/LICENSE-MIT
+++ b/models/demos/deepseek_v3_d_p/reference/dflash_prefill/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Z Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/demos/wormhole/bge_large_en/tests/pcc/utils.py
+++ b/models/demos/wormhole/bge_large_en/tests/pcc/utils.py
@@ -2,7 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from models.common.utility_functions import comp_pcc
+# `assert_with_pcc` now lives in models.common.utility_functions, alongside the comp_pcc
+# it wraps. It was moved because the bge_large_en performant runners -- which are
+# serving code, not test code -- imported it from here, and that edge from a shipped
+# module into a test package makes the runners unimportable from the packaged
+# `tt-metal-models` distribution, which does not include test directories.
+#
+# Re-exported here so the pcc tests in this directory keep working unchanged.
+from models.common.utility_functions import assert_with_pcc
+
+__all__ = ["assert_with_pcc", "construct_pcc_assert_message"]
 
 
 def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorch_result):
@@ -10,33 +19,3 @@ def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorc
     messages.append(message)
     messages = [str(m) for m in messages]
     return "\n".join(messages)
-
-
-def assert_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
-    """
-    Assert that two PyTorch tensors are similar within a specified Pearson Correlation Coefficient (PCC) threshold.
-
-    This function compares two tensors using PCC, which measures the linear correlation between them.
-    It's particularly useful for floating-point comparisons where exact equality is not expected due to
-    numerical precision differences.
-
-    Args:
-        expected_pytorch_result (torch.Tensor): The expected reference tensor
-        actual_pytorch_result (torch.Tensor): The actual tensor to compare against the reference
-        pcc (float, optional): The minimum PCC threshold for the comparison to pass. Defaults to 0.9999.
-                              Values closer to 1.0 indicate stronger correlation.
-
-    Returns:
-        tuple: A tuple containing:
-            - pcc_passed (bool): True if the PCC check passed, False otherwise
-            - pcc_message (str): A message describing the PCC comparison result
-
-    Raises:
-        AssertionError: If the tensor shapes don't match or if the PCC is below the specified threshold
-    """
-    assert list(expected_pytorch_result.shape) == list(
-        actual_pytorch_result.shape
-    ), f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}"
-    pcc_passed, pcc_message = comp_pcc(expected_pytorch_result, actual_pytorch_result, pcc)
-    assert pcc_passed, construct_pcc_assert_message(pcc_message, expected_pytorch_result, actual_pytorch_result)
-    return pcc_passed, pcc_message

--- a/models/perf/benchmarking_utils.py
+++ b/models/perf/benchmarking_utils.py
@@ -11,12 +11,12 @@ from typing import List
 import pytz
 from loguru import logger
 
-# Decouple dependency of model tests on infra folder unless running in CI
+# The CI benchmark-data models live in the repository's infra/ tree, which exists in a
+# checkout but not in an installed models package. They are therefore imported inside the
+# IS_CI_ENV-guarded methods that use them, not here: a module-scope import would make any
+# environment with CI=true -- including CI jobs testing the installed package -- unable to
+# import every model that transitively pulls in this module.
 IS_CI_ENV = os.getenv("CI") == "true"
-if IS_CI_ENV:
-    from infra.data_collection.pydantic_models import BenchmarkMeasurement, PartialBenchmarkRun
-else:
-    logger.warning("Skipping import of pydantic_models for benchmarking since not running in CI environment")
 
 # Map tt-metal device names to unified names used in benchmark database
 UNIFIED_DEVICE_NAME_MAP = {
@@ -103,7 +103,7 @@ class BenchmarkProfiler:
 class BenchmarkData:
     def __init__(self):
         if IS_CI_ENV:
-            self.measure_data: List[BenchmarkMeasurement] = []
+            self.measure_data: List["BenchmarkMeasurement"] = []  # noqa: F821
             self.output_folder = "generated/benchmark_data/"
 
     def add_measurement(
@@ -123,6 +123,8 @@ class BenchmarkData:
             Measurement data contains records and attributes for each measurement performed at each iteration and each step of the benchmark run.
             The triad of fields (iteration, step_name, name) must be unique.
             """
+            from infra.data_collection.pydantic_models import BenchmarkMeasurement
+
             assert None not in [profiler, iteration, step_name, name, value], "Missing required fields"
             assert profiler.contains_step(
                 step_name, iteration
@@ -163,6 +165,8 @@ class BenchmarkData:
         training: bool = None,
     ):
         if IS_CI_ENV:  # no-op if not running in CI environment
+            from infra.data_collection.pydantic_models import PartialBenchmarkRun
+
             assert None not in [profiler, run_type, ml_model_name], "Missing required fields"
             assert profiler.contains_step("run"), "Run step not found in profiler"
 

--- a/models/tt_dit/reference/motif/LICENSE-MIT
+++ b/models/tt_dit/reference/motif/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Motif Technologies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -63,11 +63,37 @@ ACCURACY_DECODER_CONFIG_FILENAME = "accuracy_decoder_config.json"
 # Resolving these paths against the repo root makes LOCAL_LLAMA_PARAMS /
 # LOCAL_HF_PARAMS independent of the caller's current working directory, which
 # matters when tt-run scripts cd into an example directory before launching.
-_REPO_ROOT = Path(
-    os.environ.get("TT_METAL_RUNTIME_ROOT")
-    or os.environ.get("TT_METAL_HOME")
-    or str(Path(__file__).resolve().parents[3])
-)
+#
+# An environment-supplied root is only honored if it actually contains this package's
+# parameter directory. Once `models` is installed as a package (tt-metal-models) rather
+# than used from a checkout, a leftover TT_METAL_HOME pointing at an unrelated or older
+# tree would otherwise load model_params/ from *there* -- silently, with no version
+# check, and producing wrong configs rather than an error. The location of this file is
+# the only root guaranteed to match the code doing the loading, so it is the fallback.
+_PARAMS_DIRNAME = "models/tt_transformers/model_params"
+_INSTALLED_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _resolve_repo_root() -> Path:
+    for env_var in ("TT_METAL_RUNTIME_ROOT", "TT_METAL_HOME"):
+        value = os.environ.get(env_var)
+        if not value:
+            continue
+        candidate = Path(value)
+        if (candidate / _PARAMS_DIRNAME).is_dir():
+            return candidate
+        if (_INSTALLED_ROOT / _PARAMS_DIRNAME).is_dir():
+            logger.warning(
+                f"{env_var}={value} does not contain {_PARAMS_DIRNAME}; "
+                f"resolving bundled model parameters against {_INSTALLED_ROOT} instead. "
+                f"Unset {env_var} if you meant to use the installed models package."
+            )
+            return _INSTALLED_ROOT
+        return candidate
+    return _INSTALLED_ROOT
+
+
+_REPO_ROOT = _resolve_repo_root()
 
 
 class TensorGroup(Enum):

--- a/packaging/tt-metal-models/.gitignore
+++ b/packaging/tt-metal-models/.gitignore
@@ -1,0 +1,7 @@
+# The repository root .gitignore ignores `build_*` to keep build *output* directories
+# (build_Release, build_tt_metal_models, ...) out of the index. The two scripts below
+# match that pattern by name but are source, not output -- without these negations they
+# are silently dropped from commits, which is easy to miss because `git status` never
+# mentions them.
+!build_wheel.py
+!build_native_packages.py

--- a/packaging/tt-metal-models/MANIFEST.in
+++ b/packaging/tt-metal-models/MANIFEST.in
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Non-Python payload for the `tt-metal-models` distribution.
+#
+# This is the source of truth for data files. It is paired with
+# `include-package-data = true` in pyproject.toml: setuptools reads this list and
+# attaches each file to the deepest *discovered* package above it. That indirection is
+# what makes directories like `model_params/Llama-3.1-70B-Instruct/` work -- they contain
+# no .py, and their names are not valid Python identifiers, so they are not packages and
+# package-data globs cannot reach them.
+#
+# The `models/` tree staged here has already had test directories removed by
+# build_wheel.py; the excludes at the bottom are a second line of defence only.
+
+include README.md
+include LICENSE
+
+# --- Load-bearing configuration read at import or model-construction time -------------
+# Each of these is opened by name at runtime. Omitting any of them produces a wheel that
+# imports and then dies with FileNotFoundError. Confirmed loaders:
+#   models/tt_transformers/tt/prefetcher/prefetcher_config.yaml
+#       -> tt/prefetcher.py, module-level open() (fires on nearly every import)
+#   models/tt_transformers/model_params/**/*.json
+#       -> tt/model_config.py, LOCAL_LLAMA_PARAMS / LOCAL_HF_PARAMS
+#   models/model_targets.yaml            -> demos/utils/model_targets.py
+#   models/model_trace_region_sizes.yaml -> demos/utils/trace_region_sizes.py
+#   models/demos/gemma4/precision_overrides.json -> demos/gemma4/tt/precision.py
+recursive-include models *.json
+recursive-include models *.yaml
+recursive-include models *.textproto
+
+# --- Device kernel sources, JIT-compiled by the tt-metal runtime ----------------------
+# All of these currently live under models/demos/deepseek_v3_b1/. Note the glob is not
+# restricted to */kernels/* : two kernels sit directly beside their op.py
+# (micro_ops/eltwise_add/, fused_ops/moe_routed_expert/) and a kernels-only glob drops
+# them. See README.md "deepseek_v3_b1 kernels" for why shipping these is necessary but
+# not by itself sufficient.
+recursive-include models *.cpp
+recursive-include models *.h
+recursive-include models *.hpp
+
+# --- Small text payload (class/label lists, vocab-adjacent files) ---------------------
+recursive-include models *.txt
+recursive-include models *.names
+
+# Reference outputs for deepseek_v3's teacher-forcing demo. Resolved module-relative
+# (Path(__file__).with_name(...)), which is the one path style that still works from an
+# installed package -- so unlike the cwd-relative assets elsewhere in the tree, shipping
+# these actually makes the demo work.
+recursive-include models *.refpt
+
+# --- Third-party licence texts carried by vendored reference implementations ----------
+recursive-include models LICENSE*
+
+# --- Deliberately NOT shipped ---------------------------------------------------------
+# Sample media (~12 MB of .wav/.png/.jpg/.JPEG/.tif/.pdf) and ~1.4 MB of .md docs are
+# demo inputs and documentation, not runtime payload. Excluded by omission above; the
+# rules below only guard against a stray `recursive-include models *` being added later.
+global-exclude *.png *.jpg *.jpeg *.JPEG *.tif *.pdf *.svg *.wav
+global-exclude *.pth *.pkl *.ipynb
+global-exclude *.pyc *.pyo *.so *.dylib
+global-exclude .gitignore .gitmodules
+prune **/__pycache__

--- a/packaging/tt-metal-models/README.md
+++ b/packaging/tt-metal-models/README.md
@@ -71,6 +71,27 @@ release process that has made the decision to ship it.
 Until that decision is made, those two architectures are unsupported from the packaged
 artifact and should be documented as such.
 
+**Vendored third-party reference code — declared, not hidden.** Beyond the llama
+submodule, the tree vendors reference implementations under their upstream terms, and the
+wheel redistributes them. The wheel's `License-Expression` therefore declares
+`Apache-2.0 AND MIT AND LGPL-3.0-only AND LicenseRef-Kimi-K3`, and every governing text is
+enumerated as a `License-File` and embedded in the wheel's `dist-info/licenses/`:
+
+- **MIT** — the DeepSeek-V3 reference (`models/demos/deepseek_v3/reference/deepseek`),
+  Z Lab's dflash (`models/demos/deepseek_v3_d_p/reference/dflash_prefill`), Motif
+  (`models/tt_dit/reference/motif`), and nanoGPT
+  (`models/experimental/nanogpt/reference`).
+- **LGPL-3.0-only** — the EfficientDet reference
+  (`models/experimental/efficientdetd0/reference`), imported by that model's shipped
+  code, so it cannot be pruned without dropping the model. Redistribution of the
+  unmodified source with its license text is compliant, but a copyleft component in the
+  wheel is a policy decision reviewers should make consciously.
+- **LicenseRef-Kimi-K3** — `models/demos/deepseek_v3_d_p/reference/kimi_k3/attn_res`,
+  MIT plus a Model-as-a-Service restriction and an attribution condition; the governing
+  text is `LICENSE-Kimi-K3` in that folder.
+
+MANIFEST.in also ships each text inside the package, next to the code it covers.
+
 **deepseek_v3_b1 kernels.** The `.cpp` kernel sources are shipped, but the Python code
 refers to them by *repository-relative string literals*
 (`"models/demos/deepseek_v3_b1/micro_ops/persistent_loop/kernels/..."`), which the

--- a/packaging/tt-metal-models/README.md
+++ b/packaging/tt-metal-models/README.md
@@ -1,0 +1,166 @@
+<!--
+SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# tt-metal-models
+
+The tt-metal `models/` Python tree, packaged so it can be installed rather than cloned.
+
+`pip install ttnn` gives you the Tenstorrent runtime and its Python bindings, but not the
+model implementations that run on it — those live in the `models/` directory of the
+[tt-metal](https://github.com/tenstorrent/tt-metal) repository and, until now, were
+reachable only by cloning the repository and putting it on `PYTHONPATH`.
+
+That gap matters most for serving. The Tenstorrent vLLM plugin maps every registered
+architecture to a dotted path rooted at `models.`, so with no `models` tree importable,
+every model fails to load — and vLLM reports it only as
+`Model architectures [...] failed to be inspected`, which names neither the missing
+module nor the fix.
+
+```sh
+pip install tt-metal-models==<same version as your ttnn>
+```
+
+The import root stays `models`, so code that already imports
+`models.tt_transformers.tt.generator_vllm` keeps working unchanged.
+
+## Version coupling
+
+`tt-metal-models` and `ttnn` are built from the same commit and carry the same version
+string, and this package declares `ttnn==<that version>` as a hard requirement.
+
+The coupling is real but invisible in the source: `models/` contains no version asserts
+and no `ttnn.__version__` checks — it simply calls whatever `ttnn` is installed. A strict
+pin is the honest expression of that. It makes skew a resolver error at install time
+rather than an `AttributeError` deep inside model construction.
+
+## What is and is not in the package
+
+Shipped: every `.py` under `models/` outside test directories, plus the non-Python
+payload that is loaded by name at runtime — per-model parameter and decoder configs
+(`model_params/**/*.json`), the architecture and trace-region tables
+(`model_targets.yaml`, `model_trace_region_sizes.yaml`), the prefetcher configuration,
+and the device kernel sources under `models/demos/deepseek_v3_b1/`.
+
+Not shipped: test suites, ~12 MB of sample media (`.wav`, `.png`, `.jpg`), and
+documentation. See `MANIFEST.in`, which is the source of truth for the non-Python
+payload.
+
+### Known limitations
+
+These are properties of the `models/` tree as it stands, not of the packaging. Each one
+is a live upstream cleanup.
+
+**The llama reference submodule — needs a licensing decision before release.**
+`models/demos/t3000/llama2_70b/reference/llama` is a git submodule that is empty in a
+normal clone. When it is empty,
+`models.demos.t3000.llama2_70b.tt.generator_vllm` and
+`models.demos.llama3_70b_galaxy.tt.generator_vllm` are unimportable from the built wheel.
+Populating it before the build makes both import successfully — that is verified, not
+assumed.
+
+The obstacle is not technical. That submodule is Meta's llama repository, distributed
+under the **Llama 2 Community License**, not Apache-2.0. Vendoring it into a wheel that
+declares `License: Apache-2.0` and publishing it to a package index is a redistribution
+decision with licence consequences (attribution, carrying the agreement, the acceptable
+use policy, and the 700M-MAU clause). So `build_wheel.py` never populates it implicitly:
+it builds without it and warns. `--require-submodule` fails the build instead, for a
+release process that has made the decision to ship it.
+
+Until that decision is made, those two architectures are unsupported from the packaged
+artifact and should be documented as such.
+
+**deepseek_v3_b1 kernels.** The `.cpp` kernel sources are shipped, but the Python code
+refers to them by *repository-relative string literals*
+(`"models/demos/deepseek_v3_b1/micro_ops/persistent_loop/kernels/..."`), which the
+tt-metal C++ runtime resolves against its kernel search root, not against `__file__`.
+Shipping the files is necessary but not sufficient: those ops still require the search
+root to point at the installed tree. Until those paths are made `__file__`-relative
+upstream, treat `deepseek_v3_b1` as unsupported from the packaged artifact.
+
+**`tests.`/`tools.` imports outside the test suite.** 38 modules under `models/`
+(mostly vision demos, not the LLM serving paths) import from the repository's top-level
+`tests.` or `tools.` packages, which are not part of this distribution. Those modules
+are unimportable from the wheel.
+
+**pytest is not a serving dependency.** The demo entry points (`models/demos/**/demo/`)
+and the `conftest.py` files use pytest as a CLI parametrization harness and import it at
+module scope. Serving does not go through those, so pytest is an optional extra
+(`pip install tt-metal-models[demos]`) rather than a hard dependency. This only holds as
+long as no *library* module imports pytest at module scope; `import_matrix.py` checks
+that the serving entry points import in an environment without pytest.
+
+**`TT_METAL_HOME` overrides the installed package.** `models/tt_transformers/tt/model_config.py`
+resolves its data root from `TT_METAL_RUNTIME_ROOT`, then `TT_METAL_HOME`, and only then
+from `__file__`. If you have installed this package *and* have `TT_METAL_HOME` pointing
+at an old checkout, per-model parameters load from that checkout — silently, and with no
+version check. Unset those variables when using the packaged tree.
+
+## Building
+
+The build is not run in place. `models/` sits at the repository root next to the `ttnn`
+distribution's own `pyproject.toml`, and a PEP 517 build cannot reach outside its project
+directory — so `build_wheel.py` stages a build root (these packaging files plus a pruned
+copy of `models/`) and builds from there.
+
+```sh
+pip install build setuptools setuptools-scm
+python packaging/tt-metal-models/build_wheel.py --output-dir dist
+```
+
+The version defaults to the same setuptools-scm derivation the `ttnn` wheel uses, so the
+two artifacts built from one commit agree. Pass `--version` to override.
+
+### Verifying a build
+
+`import_matrix.py` is the package's real contract. It imports every vLLM entry point in
+the tree against an installed wheel and reports which ones resolve:
+
+```sh
+python packaging/tt-metal-models/import_matrix.py --wheel dist/tt_metal_models-*.whl
+```
+
+Run it in a virtual environment containing nothing but the wheel and its declared
+dependencies. A matrix run inside an environment that already has extra packages
+under-reports missing dependencies — a stray `pytest` in the environment is exactly how
+this class of bug reaches users.
+
+### Native packages
+
+`build_native_packages.py` converts a built wheel into `python3-tt-metal-models` for apt
+and dnf. It works from the wheel rather than from the source tree so that the file
+selection has one source of truth.
+
+```sh
+# .deb -- correct from any host; Debian's dist-packages path is version-independent
+python packaging/tt-metal-models/build_native_packages.py --wheel dist/tt_metal_models-*.whl --deb
+
+# .rpm -- run this ON the distro it targets, where %{python3_sitelib} resolves correctly
+python packaging/tt-metal-models/build_native_packages.py --wheel dist/tt_metal_models-*.whl --rpm
+```
+
+CI builds only the `.deb`, because it runs on Ubuntu. RPM distros install into a
+*version-qualified* `/usr/lib/python3.N/site-packages`, and an rpm built with the wrong
+`N` installs cleanly and is then silently unimportable — so the script refuses to guess
+rather than emit a broken package. Build the `.rpm` on the target distro, or pass
+`--rpm-python-minor` if you know which Python that distro ships.
+
+These install into the system Python's `dist-packages`/`site-packages`. Note that they
+are therefore invisible to a virtual environment created without
+`--system-site-packages`, which is the common case for the pip flow — venv users should
+install the wheel. The native packages depend on `python3` only: the `ttnn` runtime they
+need is not available as a system package (the apt `tt-nn` package is the C++ library;
+the Python bindings ship only in the `ttnn` wheel), so `ttnn` must come from pip even
+when `models` comes from apt or dnf.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `pyproject.toml` | Static metadata and package discovery. Namespace discovery is required. |
+| `setup.py` | Build-time version and the `ttnn` pin. |
+| `MANIFEST.in` | Source of truth for the non-Python payload. |
+| `build_wheel.py` | Stages the tree and builds the wheel/sdist. |
+| `import_matrix.py` | CI gate: imports every vLLM entry point against a built wheel. |
+| `build_native_packages.py` | Builds the `.deb` and `.rpm` from a built wheel. |

--- a/packaging/tt-metal-models/build_native_packages.py
+++ b/packaging/tt-metal-models/build_native_packages.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build `python3-tt-metal-models` .deb / .rpm from a built tt-metal-models wheel.
+
+Both packages are produced from the *wheel*, not from the source tree, so that which
+files ship is decided in exactly one place (MANIFEST.in + pyproject.toml). Deriving them
+independently -- a CMake `install(DIRECTORY models/ FILES_MATCHING ...)` rule, say --
+would create a second file-selection policy that drifts from the wheel silently, and the
+drift would only show up as a missing data file at model-construction time.
+
+The result is `Architecture: all` / `BuildArch: noarch`: this is a pure-Python package,
+so it deliberately does not go through the repository's CMake/CPack pipeline, which
+would tie a platform-independent artifact to a full C++ build.
+
+Usage:
+    python build_native_packages.py --wheel dist/tt_metal_models-*.whl --deb
+    python build_native_packages.py --wheel dist/tt_metal_models-*.whl --rpm
+
+Requires `dpkg-deb` for --deb and `rpmbuild` for --rpm; each is only needed for the
+format requested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from email.parser import BytesParser
+from pathlib import Path
+from zipfile import ZipFile
+
+PACKAGE_NAME = "python3-tt-metal-models"
+MAINTAINER = "Tenstorrent <support@tenstorrent.com>"
+HOMEPAGE = "https://github.com/tenstorrent/tt-metal"
+
+DESCRIPTION_SHORT = "Tenstorrent tt-metal model implementations"
+# Debian wraps the extended description with a leading space per line; the blank-line
+# marker is " ." Written once here and reflowed per format below.
+DESCRIPTION_LONG = """\
+The tt-metal models/ Python tree, providing the models.* namespace used by the
+Tenstorrent vLLM plugin to load model implementations.
+
+This package installs into the system Python and is therefore not visible to a
+virtual environment created without --system-site-packages. Install the
+tt-metal-models wheel instead when working inside a virtualenv.
+
+The ttnn runtime this package requires is not available as a system package: the
+tt-nn deb ships the C++ library, while the Python bindings ship only in the ttnn
+wheel. Install a matching ttnn with pip.\
+"""
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"+ {' '.join(str(c) for c in cmd)}", flush=True)
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+def _require(tool: str, fmt: str) -> None:
+    if shutil.which(tool) is None:
+        raise SystemExit(f"error: `{tool}` is required to build the {fmt} package but was not found on PATH.")
+
+
+def wheel_version(wheel: Path) -> str:
+    """Read the version from the wheel's own METADATA, rather than parsing its filename."""
+    with ZipFile(wheel) as zf:
+        metadata_name = next(n for n in zf.namelist() if n.endswith(".dist-info/METADATA"))
+        metadata = BytesParser().parsebytes(zf.read(metadata_name))
+    version = metadata.get("Version")
+    if not version:
+        raise SystemExit(f"error: {wheel} has no Version in its METADATA.")
+    return version
+
+
+def distro_suffix() -> str:
+    """`~ubuntuXX.YY`, matching the convention the repository's C++ debs already use.
+
+    cmake/version.cmake appends this so packages built for different Ubuntu releases can
+    coexist in one repository. This package is architecture- and Python-independent, but
+    it follows the same convention so that it sorts and upgrades alongside them.
+    """
+    try:
+        result = subprocess.run(["lsb_release", "-sr"], capture_output=True, text=True, check=True)
+        return f"~ubuntu{result.stdout.strip()}"
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+
+
+def install_wheel_to(wheel: Path, root: Path, target: str) -> None:
+    """Unpack the wheel into `root` under a system Python path, with no dependencies.
+
+    --no-deps is deliberate: dependency resolution belongs to the OS package manager via
+    the Depends/Requires fields, not to pip writing into a staging root.
+    """
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--no-deps",
+            "--no-compile",
+            "--target",
+            str(root / target.lstrip("/")),
+            str(wheel),
+        ]
+    )
+
+
+def build_deb(wheel: Path, version: str, outdir: Path, workdir: Path) -> Path:
+    _require("dpkg-deb", "deb")
+    deb_version = f"{version}{distro_suffix()}"
+    root = workdir / "deb"
+    # Debian's system Python location. dist-packages (not site-packages) is what the
+    # Debian/Ubuntu python3 puts on sys.path for system-installed modules.
+    install_wheel_to(wheel, root, "usr/lib/python3/dist-packages")
+
+    debian = root / "DEBIAN"
+    debian.mkdir(parents=True, exist_ok=True)
+    description = "\n".join(f" {line}" if line.strip() else " ." for line in DESCRIPTION_LONG.splitlines())
+    (debian / "control").write_text(
+        f"Package: {PACKAGE_NAME}\n"
+        f"Version: {deb_version}\n"
+        f"Section: python\n"
+        f"Priority: optional\n"
+        f"Architecture: all\n"
+        f"Depends: python3 (>= 3.10)\n"
+        f"Maintainer: {MAINTAINER}\n"
+        f"Homepage: {HOMEPAGE}\n"
+        f"Description: {DESCRIPTION_SHORT}\n"
+        f"{description}\n"
+    )
+
+    output = outdir / f"{PACKAGE_NAME}_{deb_version}_all.deb"
+    _run(["dpkg-deb", "--build", "--root-owner-group", str(root), str(output)])
+    return output
+
+
+def rpm_macros_available() -> bool:
+    """Whether rpmbuild will resolve %{python3_sitelib} itself (python3-rpm-macros)."""
+    try:
+        result = subprocess.run(["rpm", "--eval", "%{python3_sitelib}"], capture_output=True, text=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    # An undefined macro evaluates to its own literal text.
+    return result.stdout.strip() not in ("", "%{python3_sitelib}")
+
+
+def rpm_sitelib(python_minor: str | None) -> str | None:
+    """The site-packages path to install into, or None to let rpmbuild decide.
+
+    Unlike Debian's version-independent /usr/lib/python3/dist-packages, Fedora and RHEL
+    put system modules in a *version-qualified* /usr/lib/python3.N/site-packages, and
+    /usr/lib/python3/site-packages is not on sys.path there at all. Getting N wrong
+    produces an rpm that installs cleanly and is then silently unimportable.
+
+    So this deliberately does not guess. When %{python3_sitelib} is available the macro
+    is correct by construction, and None means "use it". Otherwise the caller must say
+    which Python the target distro ships -- the build host's own version is not evidence
+    of that, and on a cross-distro build (an Ubuntu runner producing a Fedora rpm) it is
+    reliably wrong.
+    """
+    if rpm_macros_available():
+        return None
+    if python_minor:
+        return f"/usr/lib/python3.{python_minor}/site-packages"
+    raise SystemExit(
+        "error: this host has no %{python3_sitelib} rpm macro (python3-rpm-macros), so the\n"
+        "site-packages path for the target distro cannot be determined.\n"
+        "  Build the rpm on the distro it targets, where the macro resolves correctly,\n"
+        "  or pass --rpm-python-minor with that distro's Python 3 minor version\n"
+        "  (for example: RHEL 9 -> 9, RHEL 10 -> 12, recent Fedora -> 13).\n"
+        "Guessing from this host's Python would produce an rpm that installs but whose\n"
+        "modules are not importable."
+    )
+
+
+def build_rpm(wheel: Path, version: str, outdir: Path, workdir: Path, python_minor: str | None) -> Path:
+    _require("rpmbuild", "rpm")
+    # RPM forbids '-' in Version. Python pre-release and local versions (0.75.0rc1,
+    # 1.0+g1234) keep their other characters, which RPM accepts.
+    rpm_version = version.replace("-", "_")
+
+    # Staged outside the eventual install path: %install copies it into whatever
+    # %{python3_sitelib} resolves to on the build host, which is not known here.
+    staged = workdir / "rpmstage"
+    install_wheel_to(wheel, staged, "payload")
+    staged_payload = staged / "payload"
+
+    topdir = workdir / "rpmbuild"
+    for sub in ("SPECS", "RPMS", "BUILD", "BUILDROOT"):
+        (topdir / sub).mkdir(parents=True, exist_ok=True)
+
+    sitelib = rpm_sitelib(python_minor)
+    # When the macro is available it is authoritative; the %global only fills the gap on
+    # a host without python3-rpm-macros, using the explicitly supplied target version.
+    sitelib_define = f"%{{!?python3_sitelib: %global python3_sitelib {sitelib}}}\n\n" if sitelib else ""
+
+    spec = topdir / "SPECS" / f"{PACKAGE_NAME}.spec"
+    spec.write_text(
+        f"{sitelib_define}"
+        f"Name:           {PACKAGE_NAME}\n"
+        f"Version:        {rpm_version}\n"
+        f"Release:        1\n"
+        f"Summary:        {DESCRIPTION_SHORT}\n"
+        f"License:        Apache-2.0\n"
+        f"URL:            {HOMEPAGE}\n"
+        f"BuildArch:      noarch\n"
+        f"Requires:       python3 >= 3.10\n"
+        # The dependencies are Python distributions from PyPI (ttnn, torch,
+        # transformers), not RPM packages, so automatic requires generation would
+        # produce unsatisfiable names. See the description for how ttnn is supplied.
+        f"AutoReqProv:    no\n"
+        f"\n"
+        f"%description\n"
+        f"{DESCRIPTION_LONG}\n"
+        f"\n"
+        f"%install\n"
+        f"mkdir -p %{{buildroot}}%{{python3_sitelib}}\n"
+        f"cp -a {staged_payload}/. %{{buildroot}}%{{python3_sitelib}}/\n"
+        f"\n"
+        f"%files\n"
+        f"%{{python3_sitelib}}/*\n"
+    )
+
+    _run(["rpmbuild", "-bb", "--define", f"_topdir {topdir}", str(spec)])
+    built = next((topdir / "RPMS").rglob("*.rpm"))
+    output = outdir / built.name
+    shutil.copy2(built, output)
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--wheel", type=Path, required=True, help="The built tt-metal-models wheel.")
+    parser.add_argument("--output-dir", type=Path, default=Path("dist"), help="Where to write the packages.")
+    parser.add_argument("--deb", action="store_true", help="Build the .deb.")
+    parser.add_argument("--rpm", action="store_true", help="Build the .rpm.")
+    parser.add_argument(
+        "--rpm-python-minor",
+        help=(
+            "Python 3 minor version of the target distro, used for the site-packages path when "
+            "the build host has no %%{python3_sitelib} macro. Defaults to the running interpreter's. "
+            "Ignored when the macro is defined, i.e. when building on Fedora/RHEL."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not args.deb and not args.rpm:
+        parser.error("nothing to do: pass --deb, --rpm, or both.")
+    if not args.wheel.is_file():
+        raise SystemExit(f"error: no such wheel: {args.wheel}")
+
+    version = wheel_version(args.wheel)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Building native packages for {PACKAGE_NAME} {version} from {args.wheel.name}")
+
+    built = []
+    with tempfile.TemporaryDirectory(prefix="tt-metal-models-native-") as tmp:
+        workdir = Path(tmp)
+        if args.deb:
+            built.append(build_deb(args.wheel, version, args.output_dir, workdir))
+        if args.rpm:
+            built.append(build_rpm(args.wheel, version, args.output_dir, workdir, args.rpm_python_minor))
+
+    print("\nBuilt:")
+    for path in built:
+        print(f"  {path}  ({path.stat().st_size / 1e6:.1f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/tt-metal-models/build_native_packages.py
+++ b/packaging/tt-metal-models/build_native_packages.py
@@ -56,8 +56,15 @@ wheel. Install a matching ttnn with pip.\
 
 
 def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    # Resolve the executable before invoking it: a missing tool becomes one clear error
+    # rather than a FileNotFoundError from deep inside subprocess, and only a verified
+    # executable path ever reaches the invocation.
+    executable = shutil.which(cmd[0])
+    if executable is None:
+        raise SystemExit(f"error: `{cmd[0]}` was not found on PATH.")
+    cmd = [executable, *cmd[1:]]
     print(f"+ {' '.join(str(c) for c in cmd)}", flush=True)
-    return subprocess.run(cmd, check=True, **kwargs)
+    return subprocess.run(cmd, check=True, shell=False, **kwargs)
 
 
 def _require(tool: str, fmt: str) -> None:
@@ -253,8 +260,9 @@ def main() -> int:
 
     if not args.deb and not args.rpm:
         parser.error("nothing to do: pass --deb, --rpm, or both.")
-    if not args.wheel.is_file():
+    if not args.wheel.is_file() or args.wheel.suffix != ".whl":
         raise SystemExit(f"error: no such wheel: {args.wheel}")
+    args.wheel = args.wheel.resolve()
 
     version = wheel_version(args.wheel)
     args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/packaging/tt-metal-models/build_wheel.py
+++ b/packaging/tt-metal-models/build_wheel.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the `tt-metal-models` wheel (and optionally an sdist) from this repository.
+
+Why a staging step: `models/` lives at the repository root, next to the `ttnn`
+distribution's own pyproject.toml. A PEP 517 build cannot reach outside its project
+directory, and the root pyproject.toml already belongs to `ttnn`. So this script copies
+the packaging files and a pruned `models/` tree into a build root and builds there.
+
+Usage:
+    python packaging/tt-metal-models/build_wheel.py --output-dir dist
+    python packaging/tt-metal-models/build_wheel.py --version 0.77.0 --sdist
+
+The version defaults to the same setuptools-scm derivation the `ttnn` wheel uses, so an
+artifact built from a given commit matches the `ttnn` wheel built from that commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PACKAGING_DIR = Path(__file__).resolve().parent
+REPO_ROOT = PACKAGING_DIR.parent.parent
+
+# Copied verbatim into the staged build root.
+PACKAGING_FILES = ("pyproject.toml", "setup.py", "MANIFEST.in", "README.md")
+
+# Directory names pruned wherever they appear under models/.
+#
+# `tests` is the stable, one-line rule from the packaging plan: it removes the test
+# suites without needing a per-release import-graph computation. `test` and `unit_tests`
+# are the two places test code lives under a differently-spelled directory
+# (models/experimental/petr/test, models/experimental/bert_large_performant/unit_tests).
+PRUNED_DIR_NAMES = frozenset({"tests", "test", "unit_tests", "__pycache__"})
+
+# The one git submodule under models/. It is not initialized in a normal clone, and two
+# vLLM entry points import from it.
+#
+# Populating it before building makes both of those entry points work -- but the
+# submodule is Meta's llama repository, licensed under the Llama 2 Community License,
+# not Apache-2.0. Including it in a wheel that declares Apache-2.0 and is published to a
+# package index is a redistribution decision with licence consequences, so this script
+# never populates it on its own: it builds without it and warns. See README.md.
+SUBMODULE_PATH = "models/demos/t3000/llama2_70b/reference/llama"
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print(f"+ {' '.join(str(c) for c in cmd)}", flush=True)
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+def derive_version(repo_root: Path) -> str:
+    """Derive the version exactly as the `ttnn` wheel does.
+
+    The scm configuration (tag_regex, git_describe_command) is read from the repository's
+    own pyproject.toml rather than restated here, so the two artifacts cannot drift
+    apart when that configuration changes. The version/local schemes mirror
+    `get_metal_main_version_scheme` / `get_metal_local_version_scheme` in the repo root
+    setup.py -- keep them in sync if that file changes.
+    """
+    try:
+        from setuptools_scm import get_version
+        from setuptools_scm.version import guess_next_dev_version
+    except ImportError:
+        raise SystemExit(
+            "setuptools-scm is required to derive the version.\n"
+            "Install it (`pip install setuptools-scm`) or pass --version explicitly."
+        )
+
+    # Kept separate from the setuptools-scm import above so the two failures cannot be
+    # reported as each other. tomllib is stdlib only from Python 3.11; `tomli` is the
+    # same library under its pre-stdlib name.
+    try:
+        import tomllib
+    except ImportError:
+        try:
+            import tomli as tomllib
+        except ImportError:
+            raise SystemExit(
+                f"reading {repo_root / 'pyproject.toml'} needs a TOML parser, which this "
+                f"interpreter (Python {sys.version_info.major}.{sys.version_info.minor}) "
+                "does not provide.\n"
+                "Use Python 3.11 or newer, `pip install tomli`, or pass --version explicitly."
+            )
+
+    # setuptools_scm.get_version() builds its configuration from the keyword arguments
+    # it is given; it does not read pyproject.toml when called this way. So forward the
+    # repository's own [tool.setuptools_scm] table rather than restating it here. That
+    # table matters: `git_describe_command` excludes `*-dev*` tags, without which a
+    # nightly tag like v0.77.0-dev20260804 makes the bump fail outright.
+    with open(repo_root / "pyproject.toml", "rb") as f:
+        scm_config = tomllib.load(f).get("tool", {}).get("setuptools_scm", {})
+
+    def version_scheme(version):
+        if version is None:
+            return "0.0.0.dev0"
+        if getattr(version, "exact", False):
+            return version.format_with("{tag}")
+        return guess_next_dev_version(version)
+
+    def local_scheme(version):
+        return f"+g{version.node}" if version.dirty else ""
+
+    return get_version(
+        root=str(repo_root),
+        version_scheme=version_scheme,
+        local_scheme=local_scheme,
+        **scm_config,
+    )
+
+
+def submodule_is_populated(repo_root: Path) -> bool:
+    path = repo_root / SUBMODULE_PATH
+    return path.is_dir() and any(path.iterdir())
+
+
+def stage(repo_root: Path, build_root: Path, prune: bool) -> None:
+    """Copy the packaging files and the `models/` tree into a clean build root."""
+    if build_root.exists():
+        shutil.rmtree(build_root)
+    build_root.mkdir(parents=True)
+
+    for name in PACKAGING_FILES:
+        shutil.copy2(PACKAGING_DIR / name, build_root / name)
+    shutil.copy2(repo_root / "LICENSE", build_root / "LICENSE")
+
+    def ignore(directory: str, names: list[str]) -> set[str]:
+        if not prune:
+            return {n for n in names if n == "__pycache__"}
+        return {n for n in names if n in PRUNED_DIR_NAMES and (Path(directory) / n).is_dir()}
+
+    shutil.copytree(repo_root / "models", build_root / "models", ignore=ignore, symlinks=False)
+
+
+def build(build_root: Path, output_dir: Path, version: str, sdist: bool) -> None:
+    env = {**os.environ, "TT_METAL_MODELS_VERSION": version}
+    targets = ["--wheel"] + (["--sdist"] if sdist else [])
+    _run(
+        [sys.executable, "-m", "build", "--no-isolation", *targets, "--outdir", str(output_dir), str(build_root)],
+        env=env,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--version",
+        help="Version string for the artifact. Defaults to the same setuptools-scm derivation the ttnn wheel uses.",
+    )
+    parser.add_argument("--output-dir", type=Path, default=REPO_ROOT / "dist", help="Where to write the artifacts.")
+    parser.add_argument(
+        "--build-root",
+        type=Path,
+        default=REPO_ROOT / "build_tt_metal_models",
+        help="Staging directory. Recreated from scratch on every run.",
+    )
+    parser.add_argument("--sdist", action="store_true", help="Also build an sdist.")
+    parser.add_argument(
+        "--no-prune",
+        action="store_true",
+        help="Keep test directories in the staged tree. For debugging the build only.",
+    )
+    parser.add_argument(
+        "--print-requirements",
+        action="store_true",
+        help=(
+            "Print the runtime dependencies, one per line, and exit without building. "
+            "Excludes the exact `ttnn` pin, which is not on any index until the ttnn wheel "
+            "from the same commit is published. Used by CI to provision the import-matrix venv."
+        ),
+    )
+    parser.add_argument(
+        "--require-submodule",
+        action="store_true",
+        help=(
+            "Fail if the llama reference submodule is not populated. Two vLLM entry points "
+            "import from it; without it they are unimportable from the built wheel."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.print_requirements:
+        # setup.py guards its setup() call behind __main__, so importing it here reads
+        # the dependency list without triggering a build.
+        sys.path.insert(0, str(PACKAGING_DIR))
+        import setup as models_setup
+
+        print("\n".join(models_setup.INSTALL_REQUIRES))
+        return 0
+
+    version = args.version or derive_version(REPO_ROOT)
+    print(f"tt-metal-models version: {version}")
+
+    if not submodule_is_populated(REPO_ROOT):
+        message = (
+            f"the git submodule at {SUBMODULE_PATH} is not populated, so\n"
+            "  models.demos.t3000.llama2_70b.tt.generator_vllm and\n"
+            "  models.demos.llama3_70b_galaxy.tt.generator_vllm\n"
+            "will not be importable from the resulting wheel. Populate it with:\n"
+            f"  git submodule update --init {SUBMODULE_PATH}\n"
+            "but note that it is licensed under the Llama 2 Community License, not\n"
+            "Apache-2.0: shipping it changes the licensing of the published artifact."
+        )
+        if args.require_submodule:
+            raise SystemExit(f"error: {message}")
+        print(f"warning: {message}", file=sys.stderr)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    stage(REPO_ROOT, args.build_root, prune=not args.no_prune)
+    build(args.build_root, args.output_dir, version, args.sdist)
+
+    print(f"\nArtifacts in {args.output_dir}:")
+    for path in sorted(args.output_dir.glob("tt_metal_models-*")):
+        print(f"  {path.name}  ({path.stat().st_size / 1e6:.1f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/tt-metal-models/build_wheel.py
+++ b/packaging/tt-metal-models/build_wheel.py
@@ -53,8 +53,15 @@ SUBMODULE_PATH = "models/demos/t3000/llama2_70b/reference/llama"
 
 
 def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    # Resolve the executable before invoking it: a missing tool becomes one clear error
+    # rather than a FileNotFoundError from deep inside subprocess, and only a verified
+    # executable path ever reaches the invocation.
+    executable = shutil.which(cmd[0])
+    if executable is None:
+        raise SystemExit(f"error: `{cmd[0]}` was not found on PATH.")
+    cmd = [executable, *cmd[1:]]
     print(f"+ {' '.join(str(c) for c in cmd)}", flush=True)
-    return subprocess.run(cmd, check=True, **kwargs)
+    return subprocess.run(cmd, check=True, shell=False, **kwargs)
 
 
 def derive_version(repo_root: Path) -> str:

--- a/packaging/tt-metal-models/import_matrix.py
+++ b/packaging/tt-metal-models/import_matrix.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Import every vLLM entry point in an installed `tt-metal-models` against the wheel.
+
+This is the package's real contract. A wheel that is missing a `package_data` file, or
+that has been pruned too far, still builds and still imports at the top level -- it fails
+later, at model construction, which is the worst shape of bug. Importing every entry
+point catches both immediately.
+
+Two properties make the result trustworthy, and both are easy to lose:
+
+* **Each import runs in its own subprocess, from a neutral working directory.** `models`
+  is a PEP 420 namespace package, so a `models/` directory in the current directory --
+  a tt-metal checkout, most obviously -- silently shadows the installed one, and the
+  matrix would then be testing the checkout rather than the wheel.
+* **The environment must contain nothing but the wheel and its declared dependencies.**
+  A run inside an environment that already has extra packages under-reports missing
+  dependencies. A stray `pytest` is exactly how this class of bug reaches users, so it
+  is checked for explicitly.
+
+Usage:
+    # Against the current environment (CI: install the wheel first)
+    python import_matrix.py
+
+    # Build a clean venv, install the wheel into it, and run the matrix there
+    python import_matrix.py --wheel dist/tt_metal_models-*.whl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+# Packages that a consumer of this one supplies, not this one. The `generator_vllm`
+# entry points import `vllm` because they exist to be loaded *by* vLLM; depending on it
+# here would invert the relationship (the Tenstorrent vLLM plugin is what depends on
+# `models`). Their absence is reported as SKIP rather than failure, so the matrix stays
+# runnable in a CI job that has no vLLM fork installed. Use --strict to demand them.
+CONSUMER_SUPPLIED = frozenset({"vllm"})
+
+# Entry points that cannot import unless the `models/demos/t3000/llama2_70b/reference/llama`
+# git submodule was populated when the wheel was built. Reported as expected failures
+# when the submodule is absent from the installed tree, so that the common case (a wheel
+# built from a plain clone) does not drown the real signal -- but still counted as
+# failures for a release build, which must populate the submodule. See README.md.
+SUBMODULE_DEPENDENT = {
+    "models.demos.t3000.llama2_70b.tt.generator_vllm",
+    "models.demos.llama3_70b_galaxy.tt.generator_vllm",
+}
+SUBMODULE_MARKER = "models/demos/t3000/llama2_70b/reference/llama"
+
+# Entry points that are already broken in the source tree, for reasons that have nothing
+# to do with packaging. Keyed by the *specific* module whose absence is expected, so that
+# any other failure in the same entry point is still reported: this allowlist cannot
+# silently absorb a regression, and it stops being satisfied the moment upstream fixes
+# the defect.
+# This entry is arch-dependent, and will not fire in CI -- do not delete it as dead.
+# The branch is chosen by is_blackhole(), i.e. ttnn.get_arch_name(), which returns
+# 'invalid' on a machine with no Tenstorrent device (verified). CI runners therefore
+# take the Wormhole branch and this entry point passes there; it fails only on an actual
+# Blackhole host, which is where the entry earns its keep.
+KNOWN_BROKEN = {
+    "models.demos.wormhole.bge_large_en.demo.generator_vllm": (
+        "models.demos.blackhole.bge_large_en",
+        "models/demos/bge_large_en/runner/performant_runner_infra.py takes a Blackhole "
+        "branch importing models.demos.blackhole.bge_large_en, which does not exist in "
+        "the repository. Unimportable on any Blackhole host, packaged or not.",
+    ),
+}
+
+# Imported in addition to the discovered entry points. `model_config` is the module that
+# reads the per-model parameter JSON and the prefetcher YAML, so it is the one that fails
+# when the non-Python payload is missing from the wheel.
+EXTRA_SENTINELS = (
+    "models.tt_transformers.tt.model_config",
+    "models.demos.utils.model_targets",
+    "models.demos.utils.trace_region_sizes",
+)
+
+
+def find_models_root(python: str, cwd: str) -> Path:
+    """Locate the installed `models` namespace package, without importing it.
+
+    Runs from a neutral directory for the same reason the probes do: from a tt-metal
+    checkout, `models` resolves to the checkout and every result below would describe
+    the source tree rather than the wheel under test.
+    """
+    code = (
+        "import importlib.machinery as m, json;"
+        "s = m.PathFinder.find_spec('models');"
+        "print(json.dumps(list(s.submodule_search_locations) if s else []))"
+    )
+    out = subprocess.run([python, "-c", code], capture_output=True, text=True, check=True, cwd=cwd)
+    locations = json.loads(out.stdout)
+    if not locations:
+        raise SystemExit("error: no `models` package is importable in the target environment.")
+    return Path(locations[0])
+
+
+def discover_entry_points(models_root: Path) -> list[str]:
+    """Every `generator_vllm` module in the installed tree.
+
+    Discovered from the installed files rather than from a hardcoded list, so that a
+    model family added upstream is covered by this gate without anyone remembering to
+    update it.
+    """
+    modules = []
+    for path in sorted(models_root.rglob("generator_vllm.py")):
+        rel = path.relative_to(models_root.parent).with_suffix("")
+        modules.append(str(rel).replace(os.sep, "."))
+    return modules
+
+
+# Reporting the failure cannot rely on reading the last line of stderr: importing ttnn
+# installs a nanobind leak checker that prints at interpreter shutdown, so the last line
+# is reliably teardown noise rather than the exception. Catch the exception in-process
+# and emit it as JSON on a marker line instead.
+_MARKER = "@@PROBE@@"
+_PROBE_SNIPPET = textwrap.dedent(
+    f"""
+    import json, sys, traceback
+    try:
+        import %(module)s
+    except BaseException as exc:
+        frames = traceback.extract_tb(sys.exc_info()[2])
+        sys.stdout.write("{_MARKER}" + json.dumps({{
+            "error": type(exc).__name__,
+            "message": str(exc),
+            "missing": getattr(exc, "name", None),
+            "filename": getattr(exc, "filename", None),
+            "origin": frames[-1].filename if frames else None,
+        }}) + "\\n")
+        sys.stdout.flush()
+        sys.exit(17)
+    """
+)
+
+
+def probe(python: str, module: str, cwd: str) -> dict | None:
+    """Import one module in a subprocess. Returns None on success, else failure detail."""
+    result = subprocess.run(
+        [python, "-c", _PROBE_SNIPPET % {"module": module}],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    if result.returncode == 0:
+        return None
+    for line in result.stdout.splitlines():
+        if line.startswith(_MARKER):
+            return json.loads(line[len(_MARKER) :])
+    return {"error": "ProbeFailed", "message": f"exited {result.returncode}", "missing": None}
+
+
+def classify(failure: dict) -> tuple[str, str]:
+    """Map a failure onto the packaging defect it represents.
+
+    The distinction is the useful part of this gate. A missing `models.*` module means
+    the prune went too far; a missing third-party module means the wheel under-declares
+    its dependencies; a FileNotFoundError means a data file never made it into the
+    wheel at all. Those are three different fixes.
+    """
+    error, missing = failure.get("error"), failure.get("missing")
+    message = failure.get("message") or ""
+
+    if error == "ModuleNotFoundError" and missing:
+        root = missing.split(".", 1)[0]
+        if root in CONSUMER_SUPPLIED:
+            return "SKIP", f"needs `{missing}`, which the consumer supplies (not a dependency of this package)"
+        if root == "models":
+            return "FAIL", f"missing module `{missing}` -- the tree was pruned too far"
+        if root in ("tests", "tools"):
+            return "FAIL", f"imports `{missing}` from the repository, which is not part of this distribution"
+        return "FAIL", f"missing dependency `{missing}` -- the wheel does not declare it"
+
+    if error == "FileNotFoundError":
+        return "FAIL", f"missing data file {failure.get('filename') or message} -- not included in the wheel"
+
+    return "FAIL", f"{error}: {message}"
+
+
+def check_ttnn_present(python: str) -> None:
+    """Fail loudly if `ttnn` is missing, rather than blaming every entry point on it.
+
+    `ttnn` is a declared dependency, but it is routinely installed separately (the
+    matching build is not on any index until it is published), so it is easy to end up
+    with an environment that has everything *except* it. Without this check, every model
+    import fails with `No module named 'ttnn'` and gets classified as an undeclared
+    dependency -- a whole matrix of misleading failures with one real cause.
+    """
+    failure = probe(python, "ttnn", cwd=tempfile.gettempdir())
+    if failure is None:
+        return
+    raise SystemExit(
+        "error: `ttnn` is not importable in the target environment, so no model can be\n"
+        "imported and the matrix would report every entry point as broken.\n"
+        f"  {failure.get('error')}: {failure.get('message')}\n"
+        "Install a ttnn matching this build, or the nearest published release, and re-run."
+    )
+
+
+def check_environment_is_clean(python: str) -> list[str]:
+    """Warn about packages whose presence would make the matrix over-report success."""
+    warnings = []
+    for package in ("pytest",):
+        if probe(python, package, cwd=tempfile.gettempdir()) is None:
+            warnings.append(
+                f"`{package}` is installed in the target environment. It is not a declared "
+                f"dependency of tt-metal-models, so any entry point that needs it will "
+                f"pass here and fail for users. Re-run in a clean environment."
+            )
+    return warnings
+
+
+def make_venv(wheel: Path, workdir: Path) -> str:
+    """Create a venv containing only the wheel and its declared dependencies."""
+    venv = workdir / "venv"
+    print(f"Creating a clean virtual environment at {venv}", flush=True)
+    subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
+    python = str(venv / "bin" / "python")
+    subprocess.run([python, "-m", "pip", "install", "--quiet", "--upgrade", "pip"], check=True)
+    print(f"Installing {wheel.name} and its declared dependencies", flush=True)
+    subprocess.run([python, "-m", "pip", "install", "--quiet", str(wheel)], check=True)
+    return python
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--wheel",
+        type=Path,
+        help=(
+            "Build a clean venv and install this wheel into it. Omit to test the current environment. "
+            "Note that this resolves the wheel's exact `ttnn==<version>` pin, so it only works once the "
+            "ttnn wheel from the same commit has been published; before that, install the wheel yourself "
+            "with --no-deps and point --python at that environment."
+        ),
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Interpreter whose environment to test. Ignored when --wheel is given.",
+    )
+    parser.add_argument(
+        "--strict-submodule",
+        action="store_true",
+        help="Count the submodule-dependent entry points as failures even when the submodule is absent.",
+    )
+    parser.add_argument(
+        "--strict-known-broken",
+        action="store_true",
+        help="Count the KNOWN_BROKEN entry points as failures. Use to check whether upstream has fixed them.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Count consumer-supplied packages as required. Use when the Tenstorrent vLLM fork is "
+            "installed, to cover the entry points that are otherwise skipped."
+        ),
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="tt-metal-models-matrix-") as tmp:
+        workdir = Path(tmp)
+        python = make_venv(args.wheel, workdir) if args.wheel else args.python
+
+        # A neutral cwd: importing from the repository root would resolve `models` to the
+        # checkout instead of the installed package, and the matrix would prove nothing.
+        neutral_cwd = str(workdir)
+
+        models_root = find_models_root(python, cwd=neutral_cwd)
+        print(f"Testing `models` at {models_root}\n")
+
+        check_ttnn_present(python)
+
+        for warning in check_environment_is_clean(python):
+            print(f"warning: {warning}\n", file=sys.stderr)
+
+        have_submodule = (models_root.parent / SUBMODULE_MARKER).is_dir() and any(
+            (models_root.parent / SUBMODULE_MARKER).iterdir()
+        )
+
+        modules = discover_entry_points(models_root) + list(EXTRA_SENTINELS)
+
+        passed, skipped, failures, expected_failures, known_broken = [], [], [], [], []
+        width = max(len(m) for m in modules)
+        for module in modules:
+            failure = probe(python, module, cwd=neutral_cwd)
+            if failure is None:
+                status, detail = "PASS", ""
+                passed.append(module)
+            else:
+                status, detail = classify(failure)
+                known = KNOWN_BROKEN.get(module)
+                if status == "SKIP" and args.strict:
+                    status = "FAIL"
+                if status == "SKIP":
+                    skipped.append(module)
+                elif known and failure.get("missing") == known[0] and not args.strict_known_broken:
+                    status = "KNOWN"
+                    detail = known[1]
+                    known_broken.append(module)
+                elif module in SUBMODULE_DEPENDENT and not have_submodule and not args.strict_submodule:
+                    status = "XFAIL"
+                    expected_failures.append(module)
+                else:
+                    failures.append((module, detail))
+            print(f"  {status:<6} {module:<{width}}  {detail}".rstrip(), flush=True)
+
+        print(
+            f"\n{len(passed)} passed, {len(skipped)} skipped, {len(known_broken)} known broken, "
+            f"{len(expected_failures)} expected failures, {len(failures)} failed "
+            f"(of {len(modules)})."
+        )
+
+        if known_broken:
+            print(
+                f"\n{len(known_broken)} entry point(s) are broken upstream, independently of "
+                f"packaging. These are tracked in KNOWN_BROKEN in this script and should be "
+                f"removed from it as they are fixed."
+            )
+
+        if skipped:
+            print(
+                f"\n{len(skipped)} entry point(s) were skipped because a consumer-supplied package "
+                f"({', '.join(sorted(CONSUMER_SUPPLIED))}) is not installed. To cover them, install the "
+                f"Tenstorrent vLLM fork into the same environment and re-run with --strict."
+            )
+
+        if expected_failures:
+            print(
+                f"\n{len(expected_failures)} expected failure(s): the llama reference submodule was "
+                f"not populated when this wheel was built.\n"
+                f"  Release builds must populate it: git submodule update --init {SUBMODULE_MARKER}"
+            )
+
+        if failures:
+            print(f"\n{len(failures)} entry point(s) failed to import:", file=sys.stderr)
+            for module, detail in failures:
+                print(f"  {module}\n      {detail}", file=sys.stderr)
+            return 1
+
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/tt-metal-models/import_matrix.py
+++ b/packaging/tt-metal-models/import_matrix.py
@@ -113,7 +113,10 @@ def checked_interpreter(python: str) -> str:
     resolved = shutil.which(python)
     if resolved is None:
         raise SystemExit(f"error: {python!r} is not an executable Python interpreter.")
-    return str(Path(resolved).resolve())
+    # Absolutize WITHOUT following symlinks: a venv's bin/python is a symlink to the
+    # base interpreter, and resolving it would silently escape the venv -- the matrix
+    # would then probe an environment that does not contain the wheel under test.
+    return os.path.abspath(resolved)
 
 
 def find_models_root(python: str, cwd: str) -> Path:

--- a/packaging/tt-metal-models/import_matrix.py
+++ b/packaging/tt-metal-models/import_matrix.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -87,6 +89,33 @@ EXTRA_SENTINELS = (
 )
 
 
+# The probe embeds the module name into Python source (see _PROBE_SNIPPET), so this is
+# an injection boundary: anything that is not a plain dotted identifier is refused
+# before it gets near the interpolation. Names arrive from filesystem discovery, and a
+# hostile filename in the tree under test must not become code.
+_MODULE_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*\Z")
+
+
+def checked_module(module: str) -> str:
+    if not _MODULE_NAME.match(module):
+        raise SystemExit(f"error: {module!r} is not a dotted module name; refusing to probe it.")
+    return module
+
+
+def checked_interpreter(python: str) -> str:
+    """Resolve `python` to a concrete executable file, or fail with one clear error.
+
+    Interpreter paths arrive from the command line (--python) or from a venv this script
+    just created. Resolving them here keeps unvetted strings out of every subprocess
+    invocation below, and turns a typo into an immediate error instead of a confusing
+    per-probe failure.
+    """
+    resolved = shutil.which(python)
+    if resolved is None:
+        raise SystemExit(f"error: {python!r} is not an executable Python interpreter.")
+    return str(Path(resolved).resolve())
+
+
 def find_models_root(python: str, cwd: str) -> Path:
     """Locate the installed `models` namespace package, without importing it.
 
@@ -99,7 +128,7 @@ def find_models_root(python: str, cwd: str) -> Path:
         "s = m.PathFinder.find_spec('models');"
         "print(json.dumps(list(s.submodule_search_locations) if s else []))"
     )
-    out = subprocess.run([python, "-c", code], capture_output=True, text=True, check=True, cwd=cwd)
+    out = subprocess.run([python, "-c", code], capture_output=True, text=True, check=True, cwd=cwd, shell=False)
     locations = json.loads(out.stdout)
     if not locations:
         raise SystemExit("error: no `models` package is importable in the target environment.")
@@ -148,10 +177,11 @@ _PROBE_SNIPPET = textwrap.dedent(
 def probe(python: str, module: str, cwd: str) -> dict | None:
     """Import one module in a subprocess. Returns None on success, else failure detail."""
     result = subprocess.run(
-        [python, "-c", _PROBE_SNIPPET % {"module": module}],
+        [python, "-c", _PROBE_SNIPPET % {"module": checked_module(module)}],
         capture_output=True,
         text=True,
         cwd=cwd,
+        shell=False,
     )
     if result.returncode == 0:
         return None
@@ -223,13 +253,16 @@ def check_environment_is_clean(python: str) -> list[str]:
 
 def make_venv(wheel: Path, workdir: Path) -> str:
     """Create a venv containing only the wheel and its declared dependencies."""
+    wheel = wheel.resolve(strict=True)
+    if wheel.suffix != ".whl" or not wheel.is_file():
+        raise SystemExit(f"error: {wheel} is not a wheel file.")
     venv = workdir / "venv"
     print(f"Creating a clean virtual environment at {venv}", flush=True)
-    subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
-    python = str(venv / "bin" / "python")
-    subprocess.run([python, "-m", "pip", "install", "--quiet", "--upgrade", "pip"], check=True)
+    subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True, shell=False)
+    python = checked_interpreter(str(venv / "bin" / "python"))
+    subprocess.run([python, "-m", "pip", "install", "--quiet", "--upgrade", "pip"], check=True, shell=False)
     print(f"Installing {wheel.name} and its declared dependencies", flush=True)
-    subprocess.run([python, "-m", "pip", "install", "--quiet", str(wheel)], check=True)
+    subprocess.run([python, "-m", "pip", "install", "--quiet", str(wheel)], check=True, shell=False)
     return python
 
 
@@ -272,7 +305,7 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="tt-metal-models-matrix-") as tmp:
         workdir = Path(tmp)
-        python = make_venv(args.wheel, workdir) if args.wheel else args.python
+        python = make_venv(args.wheel, workdir) if args.wheel else checked_interpreter(args.python)
 
         # A neutral cwd: importing from the repository root would resolve `models` to the
         # checkout instead of the installed package, and the matrix would prove nothing.

--- a/packaging/tt-metal-models/pyproject.toml
+++ b/packaging/tt-metal-models/pyproject.toml
@@ -15,7 +15,9 @@
 # same version string, as the `ttnn` wheel.
 
 [build-system]
-requires = ["setuptools>=64", "wheel"]
+# >=77 for PEP 639 (SPDX license expression + license-files); the expression below is
+# rejected by older setuptools rather than silently mis-declared.
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -23,13 +25,24 @@ name = "tt-metal-models"
 description = "Tenstorrent tt-metal model implementations (the `models.*` Python tree)"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
+# Tenstorrent's own code is Apache-2.0, but the tree vendors third-party reference
+# implementations under their upstream terms, and the wheel redistributes them:
+#   MIT            -- DeepSeek-V3 reference (models/demos/deepseek_v3/reference/deepseek),
+#                     Z Lab dflash (models/demos/deepseek_v3_d_p/reference/dflash_prefill),
+#                     Motif (models/tt_dit/reference/motif), nanoGPT
+#                     (models/experimental/nanogpt/reference)
+#   LGPL-3.0-only  -- EfficientDet reference (models/experimental/efficientdetd0/reference)
+#   LicenseRef-Kimi-K3 -- MIT plus Model-as-a-Service and attribution conditions
+#                     (models/demos/deepseek_v3_d_p/reference/kimi_k3/attn_res)
+# Each subtree carries its governing text (license-files below); MANIFEST.in also ships
+# them inside the package next to the code they cover.
+license = "Apache-2.0 AND MIT AND LGPL-3.0-only AND LicenseRef-Kimi-K3"
+license-files = ["LICENSE", "models/**/LICENSE*"]
 authors = [{ name = "Tenstorrent" }, { email = "info@tenstorrent.com" }]
 keywords = ["tenstorrent", "tt-metal", "ttnn", "models", "machine learning", "vllm"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/packaging/tt-metal-models/pyproject.toml
+++ b/packaging/tt-metal-models/pyproject.toml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Build configuration for the `tt-metal-models` distribution: the tt-metal `models/`
+# Python tree, packaged so it can be installed rather than cloned.
+#
+# This file is NOT built in place. `build_wheel.py` stages a build root (this file plus
+# a pruned copy of the repo's `models/` tree) and builds from there, because `models/`
+# lives at the repo root and a PEP 517 build cannot reach outside its own project
+# directory. See README.md.
+#
+# The version and the `ttnn` pin are injected at build time by `build_wheel.py` via
+# `setup.py`, so that this artifact is always built from the same commit, and carries the
+# same version string, as the `ttnn` wheel.
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tt-metal-models"
+description = "Tenstorrent tt-metal model implementations (the `models.*` Python tree)"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Tenstorrent" }, { email = "info@tenstorrent.com" }]
+keywords = ["tenstorrent", "tt-metal", "ttnn", "models", "machine learning", "vllm"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+# `version` and `dependencies` are supplied by setup.py at build time:
+#   - version      -> must match the ttnn wheel built from the same commit
+#   - dependencies -> the static list below, plus `ttnn==<that same version>`
+dynamic = ["version", "dependencies"]
+
+[project.optional-dependencies]
+# The demo entry points (`models/demos/**/demo/*.py`) use pytest as a CLI
+# parametrization harness and import it at module scope. Serving does not need this;
+# see README.md "pytest is not a serving dependency".
+demos = ["pytest>=8"]
+
+[project.urls]
+Homepage = "https://github.com/tenstorrent/tt-metal"
+Documentation = "https://docs.tenstorrent.com/tt-metal/latest/ttnn"
+Repository = "https://github.com/tenstorrent/tt-metal"
+Issues = "https://github.com/tenstorrent/tt-metal/issues"
+
+[tool.setuptools]
+# REQUIRED. Much of the runtime payload (per-model params, kernel sources) lives in
+# directories that contain no .py file at all, and some of those directory names are not
+# valid Python identifiers (`Llama-3.1-70B-Instruct`, `Qwen3.6-27B`). Those directories
+# are therefore not packages and cannot be reached by package-data globs. With
+# `include-package-data`, setuptools instead takes the file list from MANIFEST.in and
+# attaches each file to the deepest *discovered* package above it, preserving the
+# relative path. MANIFEST.in is the source of truth for data files -- do not "simplify"
+# it into [tool.setuptools.package-data].
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["models*"]
+# REQUIRED. `models/` is a PEP 420 implicit namespace package: none of its 1174
+# directories at any top level has an `__init__.py` (only ~138 deep leaves do).
+# Plain find_packages() discovers nothing here.
+namespaces = true

--- a/packaging/tt-metal-models/setup.py
+++ b/packaging/tt-metal-models/setup.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build-time metadata for the `tt-metal-models` distribution.
+
+Everything static lives in pyproject.toml. This file exists only to supply the two
+pieces of metadata that are computed at build time:
+
+* ``version`` -- taken from ``TT_METAL_MODELS_VERSION``, which ``build_wheel.py`` sets
+  from the same setuptools-scm derivation the ``ttnn`` wheel uses, so that both
+  artifacts built from one commit carry one version string.
+* the ``ttnn`` pin -- ``ttnn==<that same version>``. The coupling between this tree and
+  the runtime it calls is exact and undeclared in the source (``models/`` contains no
+  version asserts), so a strict pin is the honest expression of it: skew becomes a
+  resolver error instead of an ``AttributeError`` deep in model construction.
+
+This file is copied into the staged build root by ``build_wheel.py``; it is not built
+in place.
+"""
+
+import os
+
+from setuptools import setup
+
+VERSION_ENV_VAR = "TT_METAL_MODELS_VERSION"
+
+# Runtime dependencies of the `models/` tree itself.
+#
+# Deliberately NOT inherited from tt_metal/python_env/requirements-dev.txt: that file is
+# a development environment (pytest, black, jupyterlab, fiftyone, ...) and installing it
+# to serve a model is what this package exists to avoid.
+#
+# Lower bounds, not pins, for the large ML frameworks. This package is installed
+# alongside a vLLM fork that pins its own torch/transformers, and hard pins here would
+# turn a working combination into a resolver conflict. The exact combination tt-metal
+# tests against is in tt_metal/python_env/requirements-dev.txt. `ttnn` is the one
+# genuine pin, added below.
+INSTALL_REQUIRES = [
+    # Core numerics and the tt-metal Python runtime's own stack. `ttnn` already brings
+    # numpy/loguru/pyyaml/networkx/pandas; they are restated here because `models/`
+    # imports them directly and should not depend on a transitive gift.
+    "loguru>=0.6.0",
+    "numpy>=1.24.4,<2",
+    "pyyaml>=5.4",
+    # Reference implementations and weight loading.
+    "torch>=2.6",
+    "transformers>=4.50",
+    "huggingface-hub>=0.30.0",
+    "safetensors>=0.4",
+    # Tokenizers used by the Llama / Gemma / Mistral families.
+    "sentencepiece>=0.2.0",
+    "tiktoken>=0.7.0",
+    "blobfile>=3.0.0",
+    # Multimodal preprocessing: reached through the vision generators and, transitively,
+    # through vLLM's pixtral/mistral3 chain.
+    "torchvision>=0.21",
+    "pillow>=10.0.0",
+    # Small, widely imported utilities across models/.
+    "einops>=0.6.1",
+    "tqdm>=4.66.3",
+    "pytz>=2023.3",
+    "pydantic>=2.0",
+]
+
+
+def _version() -> str:
+    version = os.environ.get(VERSION_ENV_VAR)
+    if not version:
+        raise SystemExit(
+            f"{VERSION_ENV_VAR} is not set.\n"
+            "This package is built through packaging/tt-metal-models/build_wheel.py, "
+            "which derives the version from the repository so that it matches the ttnn "
+            "wheel built from the same commit. Building this directory directly is not "
+            "supported."
+        )
+    return version
+
+
+def _install_requires(version: str) -> list:
+    return [*INSTALL_REQUIRES, f"ttnn=={version}"]
+
+
+if __name__ == "__main__":
+    version = _version()
+    setup(version=version, install_requires=_install_requires(version))


### PR DESCRIPTION
The ttnn wheel ships the runtime but not the model implementations, so serving requires a git clone and PYTHONPATH. The Tenstorrent vLLM plugin maps every registered architecture to a dotted path rooted at `models.`, so without an importable models tree every model fails to load, and vLLM reports it only as "Model architectures [...] failed to be inspected".

Add packaging/tt-metal-models/, which builds that tree as a distribution:

- The wheel takes its version from the same setuptools-scm derivation ttnn uses and declares ttnn==<that version>. The coupling is real but invisible in the source (models/ has no version asserts), so a strict pin makes skew a resolver error instead of an AttributeError deep in model construction.
- MANIFEST.in is the source of truth for the non-Python payload. models/ is a PEP 420 namespace package, so discovery needs namespaces=true; and the data lives in directories that hold no .py and whose names are not valid Python identifiers (Llama-3.1-70B-Instruct), so package-data globs cannot reach it.
- import_matrix.py is the gate: it imports every vLLM entry point against the built wheel, each in its own subprocess from a neutral directory, because a models/ directory in the cwd otherwise shadows the installed one and the matrix would silently test the checkout instead.
- build_native_packages.py produces python3-tt-metal-models from the wheel, so file selection has one source of truth rather than a second policy that drifts.

Fix the defects the matrix found, all of which broke serving from a package:

- models/common/utility_functions.py imported pytest at module scope, making a test framework a hard runtime dependency of essentially every model. Moved into the only function that uses it.
- The bge_large_en runners imported assert_with_pcc from their own test package, which the test-directory prune necessarily removes. Moved it beside the comp_pcc it wraps; the test module re-exports it, so the tests are unchanged.
- model_config.py resolved its data root from TT_METAL_HOME before __file__, so a stale value silently loaded model params from an old checkout. It now prefers the installed package when the env-pointed root has no matching tree, and warns.

Known limitations are documented in packaging/tt-metal-models/README.md. Two need a decision rather than code: the llama reference submodule is Llama 2 Community Licensed, not Apache-2.0, so the build never vendors it implicitly; and deepseek_v3_b1 refers to its kernels by repo-relative string literals that the runtime resolves against its kernel search root, not __file__.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->


---

**Supersedes #54340.** That PR was opened from a fork, and the CI runner hook rejects fork PRs that modify `.github/workflows/*` (the `Build Release` job failed before building anything). Same branch, rebased onto current main, now pushed in-repo. Prior discussion and Cycode history live on #54340.

**Note on Cycode findings:** the SAST rule flags every `subprocess.run` in the packaging scripts as "unsanitized user input in an OS command". All calls are list-form with `shell=False`; inputs (interpreter paths, wheel paths, module names) are validated before use — module names in particular are checked against a dotted-identifier regex because the import matrix interpolates them into probe source. The scanner does not recognize these as sanitizers and re-flags the sinks, so remaining findings on this developer/CI tooling need a platform-side dismissal rather than further code change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=knauth/tt-metal-models-packaging)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:knauth/tt-metal-models-packaging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=knauth/tt-metal-models-packaging)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:knauth/tt-metal-models-packaging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=knauth/tt-metal-models-packaging)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:knauth/tt-metal-models-packaging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=knauth/tt-metal-models-packaging)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:knauth/tt-metal-models-packaging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=knauth/tt-metal-models-packaging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:knauth/tt-metal-models-packaging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=knauth/tt-metal-models-packaging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:knauth/tt-metal-models-packaging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=knauth/tt-metal-models-packaging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:knauth/tt-metal-models-packaging)