### PR TITLE
[Feature] Metal 2.0: Implement variadic tensor parameters

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3979,14 +3979,14 @@ void kernel_main() {
 }
 
 // ============================================================================
-// TensorGroup: validation + JIT smoke (compile-only, no hardware loop)
+// TensorBindingSequence: validation + JIT smoke (compile-only, no hardware loop)
 // ============================================================================
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupSeveralMembersJITSmoke) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceSeveralMembersJITSmoke) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.name = "tensor_group_several";
+    spec.name = "tensor_binding_sequence_several";
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
@@ -3999,8 +3999,8 @@ void kernel_main() {
     static_assert(std::is_same_v<std::tuple_element_t<2, inputs_t>, tensor::in2_t>);
 }
 )"};
-    dm_kernel.advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "in1", "in2"}},
+    dm_kernel.advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "inputs", .members = {"in0", "in1", "in2"}},
     };
 
     spec.kernels = {dm_kernel};
@@ -4018,11 +4018,11 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupEmptyMembersJITSmoke) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceEmptyMembersJITSmoke) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.name = "tensor_group_empty";
+    spec.name = "tensor_binding_sequence_empty";
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
@@ -4032,8 +4032,8 @@ void kernel_main() {
     static_assert(std::is_same_v<std::remove_cv_t<decltype(tensor::empty)>, std::tuple<>>);
 }
 )"};
-    dm_kernel.advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "empty", .members = {}},
+    dm_kernel.advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "empty", .members = {}},
     };
 
     spec.kernels = {dm_kernel};
@@ -4043,11 +4043,11 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupSingletonMembersJITSmoke) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceSingletonMembersJITSmoke) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.name = "tensor_group_singleton";
+    spec.name = "tensor_binding_sequence_singleton";
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
@@ -4058,8 +4058,8 @@ void kernel_main() {
     static_assert(std::is_same_v<std::tuple_element_t<0, solo_t>, tensor::in0_t>);
 }
 )"};
-    dm_kernel.advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "solo", .members = {"in0"}},
+    dm_kernel.advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "solo", .members = {"in0"}},
     };
 
     spec.kernels = {dm_kernel};
@@ -4071,11 +4071,11 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupSameBindingInTwoGroupsJITSmoke) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceSameBindingInTwoSequencesJITSmoke) {
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
-    spec.name = "tensor_group_shared_member";
+    spec.name = "tensor_binding_sequence_shared_member";
 
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
@@ -4089,9 +4089,9 @@ void kernel_main() {
     static_assert(std::is_same_v<std::tuple_element_t<0, g1_t>, tensor::in0_t>);
 }
 )"};
-    dm_kernel.advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "g0", .members = {"in0"}},
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "g1", .members = {"in0"}},
+    dm_kernel.advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "g0", .members = {"in0"}},
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "g1", .members = {"in0"}},
     };
 
     spec.kernels = {dm_kernel};
@@ -4103,15 +4103,15 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupOnComputeKernelJITSmoke) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceOnComputeKernelJITSmoke) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
 
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0"), MakeMinimalTensorParameter("t1")};
     BindTensorParameterToKernel(spec.kernels[1], "t0", "in0");
     BindTensorParameterToKernel(spec.kernels[1], "t1", "in1");
-    spec.kernels[1].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "in1"}},
+    spec.kernels[1].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "inputs", .members = {"in0", "in1"}},
     };
     spec.kernels[1].source = KernelSpec::SourceCode{R"(
 #include <type_traits>
@@ -4127,14 +4127,14 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameEqualsDfbAccessorJITSmoke) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceNameEqualsDfbAccessorJITSmoke) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
     BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
     // Minimal program already binds dfb accessor "input_dfb" on kernels[0].
-    spec.kernels[0].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "input_dfb", .members = {"in0"}},
+    spec.kernels[0].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "input_dfb", .members = {"in0"}},
     };
     spec.kernels[0].source = KernelSpec::SourceCode{R"(
 #include <type_traits>
@@ -4150,12 +4150,12 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupUnknownMemberFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceUnknownMemberFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
     BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
-    spec.kernels[0].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "missing"}},
+    spec.kernels[0].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "inputs", .members = {"in0", "missing"}},
     };
 
     EXPECT_THAT(
@@ -4164,12 +4164,12 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupUnknownMemberFails) {
             ::testing::HasSubstr("references unknown tensor accessor_name 'missing'")));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupDuplicateMembersFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceDuplicateMembersFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
     BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
-    spec.kernels[0].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "in0"}},
+    spec.kernels[0].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "inputs", .members = {"in0", "in0"}},
     };
 
     EXPECT_THAT(
@@ -4177,12 +4177,12 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupDuplicateMembersFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("has duplicate member 'in0'")));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameCollidesWithBindingFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceNameCollidesWithBindingFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
     BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
-    spec.kernels[0].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "in0", .members = {"in0"}},
+    spec.kernels[0].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "in0", .members = {"in0"}},
     };
 
     EXPECT_THAT(
@@ -4191,14 +4191,14 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameCollidesWithBindingFails) {
             ::testing::HasSubstr("collides with a TensorBinding accessor_name")));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameCollidesWithGeneratedTypeAliasFails) {
-    // Codegen emits `using in0_t = TensorBindingToken<...>` for binding "in0". A group named
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceNameCollidesWithGeneratedTypeAliasFails) {
+    // Codegen emits `using in0_t = TensorBindingToken<...>` for binding "in0". A sequence named
     // "in0_t" would emit `constexpr auto in0_t = ...` and fail to compile.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
     BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
-    spec.kernels[0].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "in0_t", .members = {"in0"}},
+    spec.kernels[0].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "in0_t", .members = {"in0"}},
     };
 
     EXPECT_THAT(
@@ -4207,37 +4207,37 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameCollidesWithGeneratedTypeAliasFai
             ::testing::HasSubstr("collides with generated type alias 'in0_t'")));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupDuplicateGroupNamesFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceDuplicateSequenceNamesFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
     BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
-    spec.kernels[0].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0"}},
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0"}},
+    spec.kernels[0].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "inputs", .members = {"in0"}},
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "inputs", .members = {"in0"}},
     };
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("has duplicate tensor group accessor_name 'inputs'")));
+            ::testing::HasSubstr("has duplicate tensor binding sequence_name 'inputs'")));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupInvalidIdentifierFails) {
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceInvalidIdentifierFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
     BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
-    spec.kernels[0].advanced_options.tensor_groups = {
-        KernelAdvancedOptions::TensorGroup{.accessor_name = "has-dash", .members = {"in0"}},
+    spec.kernels[0].advanced_options.tensor_binding_sequences = {
+        KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "has-dash", .members = {"in0"}},
     };
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("tensor group accessor_name 'has-dash' must be a valid C++ identifier")));
+            ::testing::HasSubstr("tensor binding sequence_name 'has-dash' must be a valid C++ identifier")));
 }
 
-TEST_F(ProgramSpecTestGen1, CPU_TensorGroupMemberPartitionAffectsKernelHash) {
-    // Same bindings {a, ab, bc, c}; groups differ only by member partition {"a","bc"} vs {"ab","c"}.
+TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceMemberPartitionAffectsKernelHash) {
+    // Same bindings {a, ab, bc, c}; sequences differ only by member partition {"a","bc"} vs {"ab","c"}.
     // Without per-member length delimiting those would hash identically.
     auto make_spec = [](std::vector<std::string> members) {
         ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
@@ -4251,8 +4251,8 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupMemberPartitionAffectsKernelHash) {
         BindTensorParameterToKernel(spec.kernels[0], "t_ab", "ab");
         BindTensorParameterToKernel(spec.kernels[0], "t_bc", "bc");
         BindTensorParameterToKernel(spec.kernels[0], "t_c", "c");
-        spec.kernels[0].advanced_options.tensor_groups = {
-            KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = std::move(members)},
+        spec.kernels[0].advanced_options.tensor_binding_sequences = {
+            KernelAdvancedOptions::TensorBindingSequence{.sequence_name = "inputs", .members = std::move(members)},
         };
         return spec;
     };
@@ -4263,7 +4263,7 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupMemberPartitionAffectsKernelHash) {
     auto hash_left = prog_left.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
     auto hash_right = prog_right.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
     EXPECT_NE(hash_left, hash_right)
-        << "Tensor groups with different member partitions must not share a JIT cache slot.";
+        << "Tensor binding sequences with different member partitions must not share a JIT cache slot.";
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3992,6 +3992,7 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceSeveralMembersJITSmoke) {
     dm_kernel.source = KernelSpec::SourceCode{R"(
 #include <type_traits>
 void kernel_main() {
+    // Test-only: do not use std::tuple_element_t / remove_cv_t in real kernels unless necessary.
     using inputs_t = std::remove_cv_t<decltype(tensor::inputs)>;
     static_assert(std::tuple_size_v<inputs_t> == 3);
     static_assert(std::is_same_v<std::tuple_element_t<0, inputs_t>, tensor::in0_t>);
@@ -4028,6 +4029,7 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceEmptyMembersJITSmoke) {
     dm_kernel.source = KernelSpec::SourceCode{R"(
 #include <type_traits>
 void kernel_main() {
+    // Test-only: do not use std::tuple_element_t / remove_cv_t in real kernels unless necessary.
     static_assert(std::tuple_size_v<decltype(tensor::empty)> == 0);
     static_assert(std::is_same_v<std::remove_cv_t<decltype(tensor::empty)>, std::tuple<>>);
 }
@@ -4053,6 +4055,7 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceSingletonMembersJITSmoke) {
     dm_kernel.source = KernelSpec::SourceCode{R"(
 #include <type_traits>
 void kernel_main() {
+    // Test-only: do not use std::tuple_element_t / remove_cv_t in real kernels unless necessary.
     using solo_t = std::remove_cv_t<decltype(tensor::solo)>;
     static_assert(std::tuple_size_v<solo_t> == 1);
     static_assert(std::is_same_v<std::tuple_element_t<0, solo_t>, tensor::in0_t>);
@@ -4081,6 +4084,7 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceSameBindingInTwoSequencesJI
     dm_kernel.source = KernelSpec::SourceCode{R"(
 #include <type_traits>
 void kernel_main() {
+    // Test-only: do not use std::tuple_element_t / remove_cv_t in real kernels unless necessary.
     using g0_t = std::remove_cv_t<decltype(tensor::g0)>;
     using g1_t = std::remove_cv_t<decltype(tensor::g1)>;
     static_assert(std::tuple_size_v<g0_t> == 1);
@@ -4116,6 +4120,7 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceOnComputeKernelJITSmoke) {
     spec.kernels[1].source = KernelSpec::SourceCode{R"(
 #include <type_traits>
 void kernel_main() {
+    // Test-only: do not use std::tuple_element_t / remove_cv_t in real kernels unless necessary.
     using inputs_t = std::remove_cv_t<decltype(tensor::inputs)>;
     static_assert(std::tuple_size_v<inputs_t> == 2);
     static_assert(std::is_same_v<std::tuple_element_t<0, inputs_t>, tensor::in0_t>);
@@ -4139,6 +4144,7 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorBindingSequenceNameEqualsDfbAccessorJITSmo
     spec.kernels[0].source = KernelSpec::SourceCode{R"(
 #include <type_traits>
 void kernel_main() {
+    // Test-only: do not use std::tuple_element_t / remove_cv_t in real kernels unless necessary.
     using input_dfb_t = std::remove_cv_t<decltype(tensor::input_dfb)>;
     static_assert(std::tuple_size_v<input_dfb_t> == 1);
     static_assert(std::is_same_v<std::tuple_element_t<0, input_dfb_t>, tensor::in0_t>);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3978,6 +3978,248 @@ void kernel_main() {
     EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
 }
 
+// ============================================================================
+// TensorGroup: validation + JIT smoke (compile-only, no hardware loop)
+// ============================================================================
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupSeveralMembersJITSmoke) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "tensor_group_several";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+#include <type_traits>
+void kernel_main() {
+    using inputs_t = std::remove_cv_t<decltype(tensor::inputs)>;
+    static_assert(std::tuple_size_v<inputs_t> == 3);
+    static_assert(std::is_same_v<std::tuple_element_t<0, inputs_t>, tensor::in0_t>);
+    static_assert(std::is_same_v<std::tuple_element_t<1, inputs_t>, tensor::in1_t>);
+    static_assert(std::is_same_v<std::tuple_element_t<2, inputs_t>, tensor::in2_t>);
+}
+)"};
+    dm_kernel.advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "in1", "in2"}},
+    };
+
+    spec.kernels = {dm_kernel};
+    spec.tensor_parameters = {
+        MakeMinimalTensorParameter("t0"),
+        MakeMinimalTensorParameter("t1"),
+        MakeMinimalTensorParameter("t2"),
+    };
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    BindTensorParameterToKernel(spec.kernels[0], "t1", "in1");
+    BindTensorParameterToKernel(spec.kernels[0], "t2", "in2");
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupEmptyMembersJITSmoke) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "tensor_group_empty";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+#include <type_traits>
+void kernel_main() {
+    static_assert(std::tuple_size_v<decltype(tensor::empty)> == 0);
+    static_assert(std::is_same_v<std::remove_cv_t<decltype(tensor::empty)>, std::tuple<>>);
+}
+)"};
+    dm_kernel.advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "empty", .members = {}},
+    };
+
+    spec.kernels = {dm_kernel};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupSingletonMembersJITSmoke) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "tensor_group_singleton";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+#include <type_traits>
+void kernel_main() {
+    using solo_t = std::remove_cv_t<decltype(tensor::solo)>;
+    static_assert(std::tuple_size_v<solo_t> == 1);
+    static_assert(std::is_same_v<std::tuple_element_t<0, solo_t>, tensor::in0_t>);
+}
+)"};
+    dm_kernel.advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "solo", .members = {"in0"}},
+    };
+
+    spec.kernels = {dm_kernel};
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupSameBindingInTwoGroupsJITSmoke) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "tensor_group_shared_member";
+
+    auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
+    dm_kernel.source = KernelSpec::SourceCode{R"(
+#include <type_traits>
+void kernel_main() {
+    using g0_t = std::remove_cv_t<decltype(tensor::g0)>;
+    using g1_t = std::remove_cv_t<decltype(tensor::g1)>;
+    static_assert(std::tuple_size_v<g0_t> == 1);
+    static_assert(std::tuple_size_v<g1_t> == 1);
+    static_assert(std::is_same_v<std::tuple_element_t<0, g0_t>, tensor::in0_t>);
+    static_assert(std::is_same_v<std::tuple_element_t<0, g1_t>, tensor::in0_t>);
+}
+)"};
+    dm_kernel.advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "g0", .members = {"in0"}},
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "g1", .members = {"in0"}},
+    };
+
+    spec.kernels = {dm_kernel};
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"dm_kernel"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupOnComputeKernelJITSmoke) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    ASSERT_TRUE(spec.kernels[1].is_compute_kernel());
+
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0"), MakeMinimalTensorParameter("t1")};
+    BindTensorParameterToKernel(spec.kernels[1], "t0", "in0");
+    BindTensorParameterToKernel(spec.kernels[1], "t1", "in1");
+    spec.kernels[1].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "in1"}},
+    };
+    spec.kernels[1].source = KernelSpec::SourceCode{R"(
+#include <type_traits>
+void kernel_main() {
+    using inputs_t = std::remove_cv_t<decltype(tensor::inputs)>;
+    static_assert(std::tuple_size_v<inputs_t> == 2);
+    static_assert(std::is_same_v<std::tuple_element_t<0, inputs_t>, tensor::in0_t>);
+    static_assert(std::is_same_v<std::tuple_element_t<1, inputs_t>, tensor::in1_t>);
+}
+)"};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameEqualsDfbAccessorJITSmoke) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    // Minimal program already binds dfb accessor "input_dfb" on kernels[0].
+    spec.kernels[0].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "input_dfb", .members = {"in0"}},
+    };
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+#include <type_traits>
+void kernel_main() {
+    using input_dfb_t = std::remove_cv_t<decltype(tensor::input_dfb)>;
+    static_assert(std::tuple_size_v<input_dfb_t> == 1);
+    static_assert(std::is_same_v<std::tuple_element_t<0, input_dfb_t>, tensor::in0_t>);
+    (void)dfb::input_dfb;
+}
+)"};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    EXPECT_NO_THROW(program.impl().compile(mesh_device_.get()));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupUnknownMemberFails) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.kernels[0].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "missing"}},
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("references unknown tensor accessor_name 'missing'")));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupDuplicateMembersFails) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.kernels[0].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0", "in0"}},
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("has duplicate member 'in0'")));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameCollidesWithBindingFails) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.kernels[0].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "in0", .members = {"in0"}},
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("collides with a TensorBinding accessor_name")));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupDuplicateGroupNamesFails) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.kernels[0].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0"}},
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = {"in0"}},
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("has duplicate tensor group accessor_name 'inputs'")));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupInvalidIdentifierFails) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.kernels[0].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "has-dash", .members = {"in0"}},
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("tensor group accessor_name 'has-dash' must be a valid C++ identifier")));
+}
+
 // ----------------------------------------------------------------------------
 // Scratchpad JIT-compile smoke tests (device-side accessor composes & compiles)
 // ----------------------------------------------------------------------------

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -4191,6 +4191,22 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameCollidesWithBindingFails) {
             ::testing::HasSubstr("collides with a TensorBinding accessor_name")));
 }
 
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupNameCollidesWithGeneratedTypeAliasFails) {
+    // Codegen emits `using in0_t = TensorBindingToken<...>` for binding "in0". A group named
+    // "in0_t" would emit `constexpr auto in0_t = ...` and fail to compile.
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
+    BindTensorParameterToKernel(spec.kernels[0], "t0", "in0");
+    spec.kernels[0].advanced_options.tensor_groups = {
+        KernelAdvancedOptions::TensorGroup{.accessor_name = "in0_t", .members = {"in0"}},
+    };
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("collides with generated type alias 'in0_t'")));
+}
+
 TEST_F(ProgramSpecTestGen1, CPU_TensorGroupDuplicateGroupNamesFails) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     spec.tensor_parameters = {MakeMinimalTensorParameter("t0")};
@@ -4218,6 +4234,36 @@ TEST_F(ProgramSpecTestGen1, CPU_TensorGroupInvalidIdentifierFails) {
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(
             ::testing::HasSubstr("tensor group accessor_name 'has-dash' must be a valid C++ identifier")));
+}
+
+TEST_F(ProgramSpecTestGen1, CPU_TensorGroupMemberPartitionAffectsKernelHash) {
+    // Same bindings {a, ab, bc, c}; groups differ only by member partition {"a","bc"} vs {"ab","c"}.
+    // Without per-member length delimiting those would hash identically.
+    auto make_spec = [](std::vector<std::string> members) {
+        ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+        spec.tensor_parameters = {
+            MakeMinimalTensorParameter("t_a"),
+            MakeMinimalTensorParameter("t_ab"),
+            MakeMinimalTensorParameter("t_bc"),
+            MakeMinimalTensorParameter("t_c"),
+        };
+        BindTensorParameterToKernel(spec.kernels[0], "t_a", "a");
+        BindTensorParameterToKernel(spec.kernels[0], "t_ab", "ab");
+        BindTensorParameterToKernel(spec.kernels[0], "t_bc", "bc");
+        BindTensorParameterToKernel(spec.kernels[0], "t_c", "c");
+        spec.kernels[0].advanced_options.tensor_groups = {
+            KernelAdvancedOptions::TensorGroup{.accessor_name = "inputs", .members = std::move(members)},
+        };
+        return spec;
+    };
+
+    Program prog_left = MakeProgramFromSpec(*mesh_device_, make_spec({"a", "bc"}));
+    Program prog_right = MakeProgramFromSpec(*mesh_device_, make_spec({"ab", "c"}));
+
+    auto hash_left = prog_left.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
+    auto hash_right = prog_right.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash();
+    EXPECT_NE(hash_left, hash_right)
+        << "Tensor groups with different member partitions must not share a JIT cache slot.";
 }
 
 // ----------------------------------------------------------------------------

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -124,8 +124,8 @@ struct KernelAdvancedOptions {
     //
     // To make use of this, the kernel then calls:
     //   /* create a tuple of TensorAccessor from the binding token tuple */
-    //   auto accessor_tuple =  make_tensor_accessors(my_binding_sequence);
-    //   /* create an array non-owning, type-erased TensorAccessor handles */
+    //   auto accessor_tuple =  make_tensor_accessors(tensor::my_binding_sequence);
+    //   /* create an array of non-owning, type-erased TensorAccessor handles */
     //   auto accessor_array = make_abstract_tensor_accessor_wrappers(accessor_tuple);
     //
     // Usage: A niche mechanism for a kernel that wishes to express a compile-time-variadic number of
@@ -141,7 +141,7 @@ struct KernelAdvancedOptions {
     // Constraints:
     //   - Every `members` entry is a TensorBinding::accessor_name on this kernel
     //   - No duplicate members within a sequence (one binding may appear in several sequences)
-    //   - `accessor_name` is a valid C++ identifier, unique in this kernel's `tensor::` namespace
+    //   - `sequence_name` is a valid C++ identifier, unique in this kernel's `tensor::` namespace
     //   - An empty members list is legal; this produces an empty std::tuple<>.
 
     struct TensorBindingSequence {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -110,32 +110,45 @@ struct KernelAdvancedOptions {
     std::vector<uint32_t> compile_time_varargs;
 
     ////////////////////////////////////////////////////////////////////////////////
-    // Tensor groups
+    // Tensor binding sequences
     ////////////////////////////////////////////////////////////////////////////////
 
-    // A tensor group bunches existing TensorBindings on this kernel into a
-    // compile-time-sized pack.
+    // A tensor binding sequence gives a kernel an additional way to retrieve its tensor
+    // bindings: positionally, by index, rather than by name.
     //
-    // Each group is emitted into the same `tensor::` namespace as the member
-    // tokens, as a constexpr std::tuple of those tokens in `members` order:
-    //   constexpr auto inputs = std::make_tuple(in0, in1, /* ... */ inN);
-    // An empty members list is std::tuple<>.
+    // In kernel code, a tensor binding is normally retrieved by name (e.g. `tensor::in0`).
+    // Declaring a TensorBindingSequence with a list of tensor binding names also emits the
+    // following into the generated header's `tensor` namespace, in the order specified:
+    //
+    //    constexpr auto my_binding_sequence = std::make_tuple(in0, in1, /* ... */ inN);
+    //
+    // To make use of this, the kernel then calls:
+    //   /* create a tuple of TensorAccessor from the binding token tuple */
+    //   auto accessor_tuple =  make_tensor_accessors(my_binding_sequence);
+    //   /* create an array non-owning, type-erased TensorAccessor handles */
+    //   auto accessor_array = make_abstract_tensor_accessor_wrappers(accessor_tuple);
+    //
+    // Usage: A niche mechanism for a kernel that wishes to express a compile-time-variadic number of
+    //        tensor bindings, and therefore needs to access them positionally. Prefer the default
+    //        named TensorBindingToken access whenever possible.
+    //
+    // Notes:
+    //   - The named tokens are still emitted, so a sequence adds positional access rather than
+    //      replacing named access.
+    //   - A separate count argument is not required, as the sequence is available kernel-side via
+    //      `std::tuple_size_v<decltype(tensor::my_binding_sequence)>`
     //
     // Constraints:
-    //   - Every members entry is a TensorBinding::accessor_name on this kernel
-    //   - No duplicate members within a group
-    //   - Group accessor_name is a valid C++ identifier, unique in this kernel's
-    //     tensor:: namespace.
-    //
-    // CAUTION: This feature exists to address niche use cases only.
-    //          Named TensorBindings remain how a kernel binds tensors; a group
-    //          only packs some of those bindings when the kernel must consume them as a pack.
+    //   - Every `members` entry is a TensorBinding::accessor_name on this kernel
+    //   - No duplicate members within a sequence (one binding may appear in several sequences)
+    //   - `accessor_name` is a valid C++ identifier, unique in this kernel's `tensor::` namespace
+    //   - An empty members list is legal; this produces an empty std::tuple<>.
 
-    struct TensorGroup {
-        std::string accessor_name;         // device: tensor::<accessor_name>
+    struct TensorBindingSequence {
+        std::string sequence_name;         // device: tensor::<sequence_name>
         std::vector<std::string> members;  // TensorBinding::accessor_name; order is the device tuple order
     };
-    Group<TensorGroup> tensor_groups;
+    Group<TensorBindingSequence> tensor_binding_sequences;
 };
 
 struct DFBAdvancedOptions {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -108,6 +108,34 @@ struct KernelAdvancedOptions {
     //          Always prefer regular, named compile-time arguments.
     [[deprecated("Compile-time varargs is a temporary feature that will be removed in the future.")]]
     std::vector<uint32_t> compile_time_varargs;
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Tensor groups
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // A tensor group bunches existing TensorBindings on this kernel into a
+    // compile-time-sized pack.
+    //
+    // Each group is emitted into the same `tensor::` namespace as the member
+    // tokens, as a constexpr std::tuple of those tokens in `members` order:
+    //   constexpr auto inputs = std::make_tuple(in0, in1, /* ... */ inN);
+    // An empty members list is std::tuple<>.
+    //
+    // Constraints:
+    //   - Every members entry is a TensorBinding::accessor_name on this kernel
+    //   - No duplicate members within a group
+    //   - Group accessor_name is a valid C++ identifier, unique in this kernel's
+    //     tensor:: namespace.
+    //
+    // CAUTION: This feature exists to address niche use cases only.
+    //          Named TensorBindings remain how a kernel binds tensors; a group
+    //          only packs some of those bindings when the kernel must consume them as a pack.
+
+    struct TensorGroup {
+        std::string accessor_name;         // device: tensor::<accessor_name>
+        std::vector<std::string> members;  // TensorBinding::accessor_name; order is the device tuple order
+    };
+    Group<TensorGroup> tensor_groups;
 };
 
 struct DFBAdvancedOptions {

--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
+#include <tuple>
 
 #include "api/core_local_mem.h"
 #include "api/debug/assert.h"
@@ -147,3 +149,33 @@ struct noc_traits_t<LocalTensorAccessor<T>> {
 template <typename T>
 inline constexpr bool noc_zero_l1_endpoint_v<LocalTensorAccessor<T>> = true;
 #endif  // !defined(COMPILE_FOR_TRISC)
+
+/**
+ * @brief Map a tensor sequence (tuple of TensorBindingToken) to an array of LocalTensorAccessor.
+ *
+ * A tuple of TensorBindingTokens is obtained from a TensorBindingSequence: host codegen emits
+ * `tensor::<sequence_name>` as `std::tuple` of the named binding tokens. This helper
+ * maps that sequence into a std::array of LocalTensorAccessors, one per token, in the same order.
+ * LocalTensorAccessor is only templated on the element type T, so all entries share one type.
+ *
+ * All tokens must refer to L1-resident tensors; a DRAM token fails at compile time. For DRAM or
+ * NOC address generation, use make_tensor_accessors instead (DM kernels only).
+ *
+ * Usage:
+ *   auto local_accessors = make_local_tensor_accessors<uint32_t>(tensor::inputs);
+ *   auto& acc = local_accessors[i];  // i-th LocalTensorAccessor in the sequence
+ *   auto& elem = acc[0];            // element in that accessor's local L1 region
+ *
+ * @tparam T Element type stored in each local region.
+ * @param tokens constexpr tuple of TensorBindingTokens from a TensorBindingSequence
+ *               (tensor::<sequence_name>).
+ * @return std::array<LocalTensorAccessor<T>, N>, one per token, in sequence order.
+ */
+template <typename T, typename... Tokens>
+std::array<LocalTensorAccessor<T>, sizeof...(Tokens)> make_local_tensor_accessors(const std::tuple<Tokens...>& tokens) {
+    return std::apply(
+        [](const auto&... toks) {
+            return std::array<LocalTensorAccessor<T>, sizeof...(Tokens)>{LocalTensorAccessor<T>(toks)...};
+        },
+        tokens);
+}

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -634,6 +634,31 @@ auto make_tensor_accessor_tuple(const std::tuple<Args...>& args, uint32_t addres
 }
 
 /**
+ * @brief Map a tensor sequence (tuple of TensorBindingToken) to a tuple of TensorAccessor.
+ *
+ * A tuple of TensorBindingTokens is obtained from a TensorBindingSequence: host codegen emits
+ * `tensor::<sequence_name>` as `std::tuple` of the named binding tokens. This helper
+ * maps that sequence into a std::tuple of TensorAccessors, one per token, in the same order.
+ *
+ * Usage (typed tuple — compile-time index):
+ *   auto accessor_tuple = make_tensor_accessors(tensor::inputs);
+ *   noc.async_read(std::get<0>(accessor_tuple), ...);
+ *
+ * Usage (type-erased array — runtime index):
+ *   auto accessor_tuple = make_tensor_accessors(tensor::inputs);
+ *   auto accessor_array = make_abstract_tensor_accessor_wrappers(accessor_tuple);
+ *   noc.async_read(accessor_array[i], ...);
+ *
+ * @param tokens constexpr tuple of TensorBindingTokens from a TensorBindingSequence
+ *               (tensor::<sequence_name>).
+ * @return std::tuple<TensorAccessor<...>, ...>, one per token, in sequence order.
+ */
+template <typename... Tokens>
+auto make_tensor_accessors(const std::tuple<Tokens...>& tokens) {
+    return std::apply([](const auto&... toks) { return std::make_tuple(TensorAccessor(toks)...); }, tokens);
+}
+
+/**
  * @brief AbstractTensorAccessorWrapper provides a unified interface over templated tensor accessors.
  *
  * The wrapper allows to use and iterate over different kinds of tensor accessors in a unified way.
@@ -671,6 +696,9 @@ auto make_abstract_tensor_accessor_wrappers(
 
 // Wraps a tuple of templated tensor accessors into an array of AbstractTensorAccessorWrapper,
 // allowing for easy iteration and runtime dispatch.
+//
+// CAUTION: each wrapper stores a pointer into `accessors`. The tuple must outlive the returned
+// array; do not pass a temporary from make_tensor_accessors(...) straight through.
 template <typename... Accessors>
 auto make_abstract_tensor_accessor_wrappers(const std::tuple<Accessors...>& accessors) {
     return tensor_accessor::detail::make_abstract_tensor_accessor_wrappers(

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -346,6 +346,14 @@ void Kernel::process_scratchpad_binding_handles(
     }
 }
 
+void Kernel::process_tensor_groups(
+    const std::function<void(const std::string& accessor_name, const std::vector<std::string>& members)> callback)
+    const {
+    for (const auto& group : this->tensor_groups_) {
+        callback(group.accessor_name, group.members);
+    }
+}
+
 ////////////////////////////////////////////////////////////
 // Blaze-only experimental named args
 // Removal is tracked by issue #50953
@@ -590,6 +598,15 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(handle.accessor_name);
         hasher.update(static_cast<uint64_t>(handle.size_bytes));
         hasher.update(static_cast<uint64_t>(handle.addr_crta_word));
+    }
+    // Tensor groups: user order matches genfiles emission; hash size, name, and ordered members.
+    hasher.update(static_cast<uint64_t>(this->tensor_groups_.size()));
+    for (const auto& group : this->tensor_groups_) {
+        hasher.update(group.accessor_name);
+        hasher.update(static_cast<uint64_t>(group.members.size()));
+        for (const auto& member : group.members) {
+            hasher.update(member);
+        }
     }
     // Named RTA/CRTA schema: order matters (determines byte offsets), so hash the sequence.
     // Named RTA and CRTA counts also need to be hashed!

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -599,7 +599,9 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(static_cast<uint64_t>(handle.size_bytes));
         hasher.update(static_cast<uint64_t>(handle.addr_crta_word));
     }
-    // Tensor binding sequences: user order matches genfiles emission; hash size, name, and ordered members.
+    // Tensor Binding Sequence: the ordering of the tensor binding matters here, 2 tensor bindings of
+    // the same set of members but with different orderings are different tensor binding sequences.
+    // Do not sort this sequence.
     // Per-member size is hashed before the bytes so {"a","bc"} and {"ab","c"} do not collide.
     hasher.update(static_cast<uint64_t>(this->tensor_binding_sequences_.size()));
     for (const auto& sequence : this->tensor_binding_sequences_) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -600,11 +600,13 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(static_cast<uint64_t>(handle.addr_crta_word));
     }
     // Tensor groups: user order matches genfiles emission; hash size, name, and ordered members.
+    // Per-member size is hashed before the bytes so {"a","bc"} and {"ab","c"} do not collide.
     hasher.update(static_cast<uint64_t>(this->tensor_groups_.size()));
     for (const auto& group : this->tensor_groups_) {
         hasher.update(group.accessor_name);
         hasher.update(static_cast<uint64_t>(group.members.size()));
         for (const auto& member : group.members) {
+            hasher.update(static_cast<uint64_t>(member.size()));
             hasher.update(member);
         }
     }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -346,11 +346,11 @@ void Kernel::process_scratchpad_binding_handles(
     }
 }
 
-void Kernel::process_tensor_groups(
-    const std::function<void(const std::string& accessor_name, const std::vector<std::string>& members)> callback)
+void Kernel::process_tensor_binding_sequences(
+    const std::function<void(const std::string& sequence_name, const std::vector<std::string>& members)> callback)
     const {
-    for (const auto& group : this->tensor_groups_) {
-        callback(group.accessor_name, group.members);
+    for (const auto& sequence : this->tensor_binding_sequences_) {
+        callback(sequence.sequence_name, sequence.members);
     }
 }
 
@@ -599,13 +599,13 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(static_cast<uint64_t>(handle.size_bytes));
         hasher.update(static_cast<uint64_t>(handle.addr_crta_word));
     }
-    // Tensor groups: user order matches genfiles emission; hash size, name, and ordered members.
+    // Tensor binding sequences: user order matches genfiles emission; hash size, name, and ordered members.
     // Per-member size is hashed before the bytes so {"a","bc"} and {"ab","c"} do not collide.
-    hasher.update(static_cast<uint64_t>(this->tensor_groups_.size()));
-    for (const auto& group : this->tensor_groups_) {
-        hasher.update(group.accessor_name);
-        hasher.update(static_cast<uint64_t>(group.members.size()));
-        for (const auto& member : group.members) {
+    hasher.update(static_cast<uint64_t>(this->tensor_binding_sequences_.size()));
+    for (const auto& sequence : this->tensor_binding_sequences_) {
+        hasher.update(sequence.sequence_name);
+        hasher.update(static_cast<uint64_t>(sequence.members.size()));
+        for (const auto& member : sequence.members) {
             hasher.update(static_cast<uint64_t>(member.size()));
             hasher.update(member);
         }

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -138,6 +138,12 @@ struct ScratchpadBindingHandle {
     uint32_t allocated_address = 0;  // L1 base address; filled by allocate_scratchpads (0 until allocated)
 };
 
+// Metal 2.0: compile-time pack of TensorBinding tokens (KernelAdvancedOptions::tensor_groups).
+struct TensorGroupHandle {
+    std::string accessor_name;
+    std::vector<std::string> members;
+};
+
 class Kernel : public JitBuildSettings {
 public:
     using Config = std::variant<
@@ -240,6 +246,9 @@ public:
     void set_scratchpad_binding_handles(std::vector<ScratchpadBindingHandle> handles) {
         scratchpad_binding_handles_ = std::move(handles);
     }
+    void process_tensor_groups(
+        std::function<void(const std::string& accessor_name, const std::vector<std::string>& members)>) const override;
+    void set_tensor_groups(std::vector<TensorGroupHandle> groups) { tensor_groups_ = std::move(groups); }
     // Metal 2.0: length of the CTA-vararg prefix in compile_time_args_.
     // Values live in compile_time_args_.
     uint32_t get_compile_time_vararg_count() const override { return compile_time_vararg_count_; }
@@ -344,6 +353,8 @@ protected:
     // and allocate_scratchpads fills each handle's allocated_address after L1 allocation.
     // NOTE: Scratchpad allocated addresses can change between enqueues if DFB size overrides are used.
     std::vector<ScratchpadBindingHandle> scratchpad_binding_handles_;
+    // Metal 2.0: tensor groups (set post-construction, like scratchpads).
+    std::vector<TensorGroupHandle> tensor_groups_;
     // Metal 2.0: number of user CTA-vararg words at the start of compile_time_args_.
     uint32_t compile_time_vararg_count_{0};
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -138,9 +138,9 @@ struct ScratchpadBindingHandle {
     uint32_t allocated_address = 0;  // L1 base address; filled by allocate_scratchpads (0 until allocated)
 };
 
-// Metal 2.0: compile-time pack of TensorBinding tokens (KernelAdvancedOptions::tensor_groups).
-struct TensorGroupHandle {
-    std::string accessor_name;
+// Metal 2.0: ordered TensorBinding tokens (KernelAdvancedOptions::tensor_binding_sequences).
+struct TensorBindingSequenceHandle {
+    std::string sequence_name;
     std::vector<std::string> members;
 };
 
@@ -246,9 +246,11 @@ public:
     void set_scratchpad_binding_handles(std::vector<ScratchpadBindingHandle> handles) {
         scratchpad_binding_handles_ = std::move(handles);
     }
-    void process_tensor_groups(
-        std::function<void(const std::string& accessor_name, const std::vector<std::string>& members)>) const override;
-    void set_tensor_groups(std::vector<TensorGroupHandle> groups) { tensor_groups_ = std::move(groups); }
+    void process_tensor_binding_sequences(
+        std::function<void(const std::string& sequence_name, const std::vector<std::string>& members)>) const override;
+    void set_tensor_binding_sequences(std::vector<TensorBindingSequenceHandle> sequences) {
+        tensor_binding_sequences_ = std::move(sequences);
+    }
     // Metal 2.0: length of the CTA-vararg prefix in compile_time_args_.
     // Values live in compile_time_args_.
     uint32_t get_compile_time_vararg_count() const override { return compile_time_vararg_count_; }
@@ -353,8 +355,8 @@ protected:
     // and allocate_scratchpads fills each handle's allocated_address after L1 allocation.
     // NOTE: Scratchpad allocated addresses can change between enqueues if DFB size overrides are used.
     std::vector<ScratchpadBindingHandle> scratchpad_binding_handles_;
-    // Metal 2.0: tensor groups (set post-construction, like scratchpads).
-    std::vector<TensorGroupHandle> tensor_groups_;
+    // Metal 2.0: tensor binding sequences (set post-construction, like scratchpads).
+    std::vector<TensorBindingSequenceHandle> tensor_binding_sequences_;
     // Metal 2.0: number of user CTA-vararg words at the start of compile_time_args_.
     uint32_t compile_time_vararg_count_{0};
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -540,45 +540,45 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
             reserved_type_aliases.insert(binding_name + "_t");
         }
 
-        std::unordered_set<std::string> group_names;
-        for (const auto& group : kernel.advanced_options.tensor_groups) {
+        std::unordered_set<std::string> sequence_names;
+        for (const auto& sequence : kernel.advanced_options.tensor_binding_sequences) {
             TT_FATAL(
-                IsValidCppIdentifier(group.accessor_name),
-                "Kernel '{}' tensor group accessor_name '{}' must be a valid C++ identifier",
+                IsValidCppIdentifier(sequence.sequence_name),
+                "Kernel '{}' tensor binding sequence_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
-                group.accessor_name);
+                sequence.sequence_name);
             TT_FATAL(
-                !accessor_names.contains(group.accessor_name),
-                "Kernel '{}' tensor group accessor_name '{}' collides with a TensorBinding accessor_name",
+                !accessor_names.contains(sequence.sequence_name),
+                "Kernel '{}' tensor binding sequence_name '{}' collides with a TensorBinding accessor_name",
                 kernel.unique_id,
-                group.accessor_name);
+                sequence.sequence_name);
             TT_FATAL(
-                !reserved_type_aliases.contains(group.accessor_name),
-                "Kernel '{}' tensor group accessor_name '{}' collides with generated type alias '{}'",
+                !reserved_type_aliases.contains(sequence.sequence_name),
+                "Kernel '{}' tensor binding sequence_name '{}' collides with generated type alias '{}'",
                 kernel.unique_id,
-                group.accessor_name,
-                group.accessor_name);
-            auto [git, ginserted] = group_names.insert(group.accessor_name);
+                sequence.sequence_name,
+                sequence.sequence_name);
+            auto [sit, sinserted] = sequence_names.insert(sequence.sequence_name);
             TT_FATAL(
-                ginserted,
-                "Kernel '{}' has duplicate tensor group accessor_name '{}'",
+                sinserted,
+                "Kernel '{}' has duplicate tensor binding sequence_name '{}'",
                 kernel.unique_id,
-                group.accessor_name);
+                sequence.sequence_name);
 
             std::unordered_set<std::string> member_names;
-            for (const auto& member : group.members) {
+            for (const auto& member : sequence.members) {
                 TT_FATAL(
                     accessor_names.contains(member),
-                    "Kernel '{}' tensor group '{}' references unknown tensor accessor_name '{}'",
+                    "Kernel '{}' tensor binding sequence '{}' references unknown tensor accessor_name '{}'",
                     kernel.unique_id,
-                    group.accessor_name,
+                    sequence.sequence_name,
                     member);
                 auto [mit, minserted] = member_names.insert(member);
                 TT_FATAL(
                     minserted,
-                    "Kernel '{}' tensor group '{}' has duplicate member '{}'",
+                    "Kernel '{}' tensor binding sequence '{}' has duplicate member '{}'",
                     kernel.unique_id,
-                    group.accessor_name,
+                    sequence.sequence_name,
                     member);
             }
         }
@@ -3198,12 +3198,13 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // will later fill each handle's allocated_address.
         kernel->set_scratchpad_binding_handles(std::move(sp_bindings.handles));
 
-        std::vector<TensorGroupHandle> tensor_groups;
-        tensor_groups.reserve(kernel_spec.advanced_options.tensor_groups.size());
-        for (const auto& group : kernel_spec.advanced_options.tensor_groups) {
-            tensor_groups.push_back(TensorGroupHandle{.accessor_name = group.accessor_name, .members = group.members});
+        std::vector<TensorBindingSequenceHandle> tensor_binding_sequences;
+        tensor_binding_sequences.reserve(kernel_spec.advanced_options.tensor_binding_sequences.size());
+        for (const auto& sequence : kernel_spec.advanced_options.tensor_binding_sequences) {
+            tensor_binding_sequences.push_back(
+                TensorBindingSequenceHandle{.sequence_name = sequence.sequence_name, .members = sequence.members});
         }
-        kernel->set_tensor_groups(std::move(tensor_groups));
+        kernel->set_tensor_binding_sequences(std::move(tensor_binding_sequences));
 
         // Prefix length for device get_compile_time_vararg* bounds (values are in compile_time_args_).
         kernel->set_compile_time_vararg_count(vararg_cta_count);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -533,6 +533,43 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 
             collected.tensor_parameter_users[binding.tensor_parameter_name].push_back(&kernel);
         }
+
+        std::unordered_set<std::string> group_names;
+        for (const auto& group : kernel.advanced_options.tensor_groups) {
+            TT_FATAL(
+                IsValidCppIdentifier(group.accessor_name),
+                "Kernel '{}' tensor group accessor_name '{}' must be a valid C++ identifier",
+                kernel.unique_id,
+                group.accessor_name);
+            TT_FATAL(
+                !accessor_names.contains(group.accessor_name),
+                "Kernel '{}' tensor group accessor_name '{}' collides with a TensorBinding accessor_name",
+                kernel.unique_id,
+                group.accessor_name);
+            auto [git, ginserted] = group_names.insert(group.accessor_name);
+            TT_FATAL(
+                ginserted,
+                "Kernel '{}' has duplicate tensor group accessor_name '{}'",
+                kernel.unique_id,
+                group.accessor_name);
+
+            std::unordered_set<std::string> member_names;
+            for (const auto& member : group.members) {
+                TT_FATAL(
+                    accessor_names.contains(member),
+                    "Kernel '{}' tensor group '{}' references unknown tensor accessor_name '{}'",
+                    kernel.unique_id,
+                    group.accessor_name,
+                    member);
+                auto [mit, minserted] = member_names.insert(member);
+                TT_FATAL(
+                    minserted,
+                    "Kernel '{}' tensor group '{}' has duplicate member '{}'",
+                    kernel.unique_id,
+                    group.accessor_name,
+                    member);
+            }
+        }
     }
 
     // A borrowed-memory DFB uses its backing TensorParameter via DataflowBufferSpec::borrowed_from
@@ -3148,6 +3185,13 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // part of the kernel cache key, so this must run before the kernel is compiled). allocate_scratchpads
         // will later fill each handle's allocated_address.
         kernel->set_scratchpad_binding_handles(std::move(sp_bindings.handles));
+
+        std::vector<TensorGroupHandle> tensor_groups;
+        tensor_groups.reserve(kernel_spec.advanced_options.tensor_groups.size());
+        for (const auto& group : kernel_spec.advanced_options.tensor_groups) {
+            tensor_groups.push_back(TensorGroupHandle{.accessor_name = group.accessor_name, .members = group.members});
+        }
+        kernel->set_tensor_groups(std::move(tensor_groups));
 
         // Prefix length for device get_compile_time_vararg* bounds (values are in compile_time_args_).
         kernel->set_compile_time_vararg_count(vararg_cta_count);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -534,6 +534,12 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
             collected.tensor_parameter_users[binding.tensor_parameter_name].push_back(&kernel);
         }
 
+        std::unordered_set<std::string> reserved_type_aliases;
+        reserved_type_aliases.reserve(accessor_names.size());
+        for (const auto& binding_name : accessor_names) {
+            reserved_type_aliases.insert(binding_name + "_t");
+        }
+
         std::unordered_set<std::string> group_names;
         for (const auto& group : kernel.advanced_options.tensor_groups) {
             TT_FATAL(
@@ -545,6 +551,12 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 !accessor_names.contains(group.accessor_name),
                 "Kernel '{}' tensor group accessor_name '{}' collides with a TensorBinding accessor_name",
                 kernel.unique_id,
+                group.accessor_name);
+            TT_FATAL(
+                !reserved_type_aliases.contains(group.accessor_name),
+                "Kernel '{}' tensor group accessor_name '{}' collides with generated type alias '{}'",
+                kernel.unique_id,
+                group.accessor_name,
                 group.accessor_name);
             auto [git, ginserted] = group_names.insert(group.accessor_name);
             TT_FATAL(

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -172,6 +172,15 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             scratch_entries.push_back({name, size_bytes, addr_crta_word});
         });
 
+    // Tensor groups: user order (matches Kernel::compute_hash); no sort.
+    struct TgEntry {
+        string name;
+        vector<string> members;
+    };
+    vector<TgEntry> tg_entries;
+    settings.process_tensor_groups(
+        [&tg_entries](const string& name, const vector<string>& members) { tg_entries.push_back({name, members}); });
+
     // Emit the header content:
     //  - DFB binding tokens are emitted into the dfb namespace
     //  - Semaphore ids are emitted into the sem namespace (semaphores have no binding-token type;
@@ -193,7 +202,8 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     ostringstream content;
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n";
-    if (dfb_entries.empty() && sem_entries.empty() && ta_entries.empty() && scratch_entries.empty()) {
+    if (dfb_entries.empty() && sem_entries.empty() && ta_entries.empty() && scratch_entries.empty() &&
+        tg_entries.empty()) {
         content << "// No bindings for this kernel.\n";
     } else {
         if (!dfb_entries.empty()) {
@@ -206,6 +216,9 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             // This header defines TensorBindingToken, a type which can be used
             // to construct a TensorAccessor or LocalTensorAccessor.
             content << "#include \"api/tensor/tensor_binding_token.h\"\n";
+        }
+        if (!tg_entries.empty()) {
+            content << "#include <tuple>\n";
         }
         if (!scratch_entries.empty()) {
             // The full Scratchpad type (NOC-free, so it compiles on both data-movement and
@@ -230,7 +243,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             content << "}  // namespace sem\n";
         }
 
-        if (!ta_entries.empty()) {
+        if (!ta_entries.empty() || !tg_entries.empty()) {
             // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
             // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
             // its implicit base-address CRTA.
@@ -238,11 +251,23 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             //
             // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
             // template with extra metadata in the future without touching kernel source.
+            //
+            // Tensor groups are constexpr std::tuple packs of those member tokens (members order).
             content << "namespace tensor {\n";
             for (const auto& entry : ta_entries) {
                 content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset
                         << "u, " << entry.addr_crta_offset << "u>;\n";
                 content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
+            }
+            for (const auto& group : tg_entries) {
+                content << "constexpr auto " << group.name << " = std::make_tuple(";
+                for (size_t i = 0; i < group.members.size(); ++i) {
+                    if (i > 0) {
+                        content << ", ";
+                    }
+                    content << group.members[i];
+                }
+                content << ");\n";
             }
             content << "}  // namespace tensor\n";
         }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -262,14 +262,8 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
                 content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
             }
             for (const auto& sequence : tensor_binding_sequence_entries) {
-                content << "constexpr auto " << sequence.name << " = std::make_tuple(";
-                for (size_t i = 0; i < sequence.members.size(); ++i) {
-                    if (i > 0) {
-                        content << ", ";
-                    }
-                    content << sequence.members[i];
-                }
-                content << ");\n";
+                content << fmt::format(
+                    "constexpr auto {} = std::make_tuple({});\n", sequence.name, fmt::join(sequence.members, ", "));
             }
             content << "}  // namespace tensor\n";
         }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -172,14 +172,16 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             scratch_entries.push_back({name, size_bytes, addr_crta_word});
         });
 
-    // Tensor groups: user order (matches Kernel::compute_hash); no sort.
-    struct TgEntry {
+    // Tensor binding sequences: user order (matches Kernel::compute_hash); no sort.
+    struct TensorBindingSequenceEntry {
         string name;
         vector<string> members;
     };
-    vector<TgEntry> tg_entries;
-    settings.process_tensor_groups(
-        [&tg_entries](const string& name, const vector<string>& members) { tg_entries.push_back({name, members}); });
+    vector<TensorBindingSequenceEntry> tensor_binding_sequence_entries;
+    settings.process_tensor_binding_sequences(
+        [&tensor_binding_sequence_entries](const string& name, const vector<string>& members) {
+            tensor_binding_sequence_entries.push_back({name, members});
+        });
 
     // Emit the header content:
     //  - DFB binding tokens are emitted into the dfb namespace
@@ -203,7 +205,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     content << "// AUTO-GENERATED — do not edit.\n\n"
                "#pragma once\n\n";
     if (dfb_entries.empty() && sem_entries.empty() && ta_entries.empty() && scratch_entries.empty() &&
-        tg_entries.empty()) {
+        tensor_binding_sequence_entries.empty()) {
         content << "// No bindings for this kernel.\n";
     } else {
         if (!dfb_entries.empty()) {
@@ -217,7 +219,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             // to construct a TensorAccessor or LocalTensorAccessor.
             content << "#include \"api/tensor/tensor_binding_token.h\"\n";
         }
-        if (!tg_entries.empty()) {
+        if (!tensor_binding_sequence_entries.empty()) {
             content << "#include <tuple>\n";
         }
         if (!scratch_entries.empty()) {
@@ -243,7 +245,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             content << "}  // namespace sem\n";
         }
 
-        if (!ta_entries.empty() || !tg_entries.empty()) {
+        if (!ta_entries.empty() || !tensor_binding_sequence_entries.empty()) {
             // TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>: pairs the binding's
             // static layout metadata (TensorAccessorArgs<CTA_OFFSET>) with the byte offset of
             // its implicit base-address CRTA.
@@ -252,20 +254,20 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
             // template with extra metadata in the future without touching kernel source.
             //
-            // Tensor groups are constexpr std::tuple packs of those member tokens (members order).
+            // Tensor binding sequences are constexpr std::tuple of those member tokens (members order).
             content << "namespace tensor {\n";
             for (const auto& entry : ta_entries) {
                 content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset
                         << "u, " << entry.addr_crta_offset << "u>;\n";
                 content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
             }
-            for (const auto& group : tg_entries) {
-                content << "constexpr auto " << group.name << " = std::make_tuple(";
-                for (size_t i = 0; i < group.members.size(); ++i) {
+            for (const auto& sequence : tensor_binding_sequence_entries) {
+                content << "constexpr auto " << sequence.name << " = std::make_tuple(";
+                for (size_t i = 0; i < sequence.members.size(); ++i) {
                     if (i > 0) {
                         content << ", ";
                     }
-                    content << group.members[i];
+                    content << sequence.members[i];
                 }
                 content << ");\n";
             }

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -130,10 +130,10 @@ public:
     virtual void process_scratchpad_binding_handles(
         std::function<void(const std::string& accessor_name, uint32_t size_bytes, uint32_t addr_crta_word)>) const {}
 
-    // Tensor group callback: accessor_name + ordered member TensorBinding accessor names.
+    // Tensor binding sequence callback: sequence_name + ordered member TensorBinding accessor names.
     // Emitted as constexpr std::tuple tokens in the `tensor::` namespace (user order; no sort).
-    virtual void process_tensor_groups(
-        std::function<void(const std::string& accessor_name, const std::vector<std::string>& members)>) const {}
+    virtual void process_tensor_binding_sequences(
+        std::function<void(const std::string& sequence_name, const std::vector<std::string>& members)>) const {}
 
     // Named RTA/CRTA schema (Metal 2.0 APIs).
     // The order of names determines the byte offset of each arg within the named-args

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -130,6 +130,11 @@ public:
     virtual void process_scratchpad_binding_handles(
         std::function<void(const std::string& accessor_name, uint32_t size_bytes, uint32_t addr_crta_word)>) const {}
 
+    // Tensor group callback: accessor_name + ordered member TensorBinding accessor names.
+    // Emitted as constexpr std::tuple tokens in the `tensor::` namespace (user order; no sort).
+    virtual void process_tensor_groups(
+        std::function<void(const std::string& accessor_name, const std::vector<std::string>& members)>) const {}
+
     // Named RTA/CRTA schema (Metal 2.0 APIs).
     // The order of names determines the byte offset of each arg within the named-args
     // section of the dispatch buffer.


### PR DESCRIPTION
### PR Category
Feature

### Summary
Add Metal 2.0 variadic tensor parameters: a compile-time pack of existing `TensorBinding`s.

Named single-tensor bindings stay the default. A group is not a new binding kind and not a run-arg; `ProgramRunArgs.tensor_args` is unchanged. Codegen emits each group into the same `tensor::` namespace as a `constexpr std::tuple` of member tokens in `members` order (empty members → `std::tuple<>`).

Constraints (checked at `MakeProgramFromSpec`):
- Every `members` entry is a `TensorBinding::accessor_name` on this kernel
- No duplicate members within a group (empty and size 1 are allowed)
- One binding may appear in more than one group
- Group `accessor_name` is a valid C++ identifier
- Group `accessor_name` is unique in this kernel's `tensor::` namespace (must not collide with a binding name or another group)

**Host**

```cpp
KernelSpec reader{
    .tensor_bindings = {
        TensorBinding{.tensor_parameter_name = IN0, .accessor_name = "in0"},
        TensorBinding{.tensor_parameter_name = IN1, .accessor_name = "in1"},
        TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "output"},
    },
    .advanced_options = {
         // NEW: declares a variadic tensor group.
        .tensor_groups = {
            {
                .accessor_name = "inputs",
                .members = {"in0", "in1"},
            },
        },
    },
};
```

**Device**

```cpp
namespace tensor {
constexpr TensorBindingToken<...> in0{};
constexpr TensorBindingToken<...> in1{};
constexpr TensorBindingToken<...> output{};
// NEW: tensor group — tuple order matches host `members` order
constexpr auto inputs = std::make_tuple(in0, in1);
}
```

### Notes for reviewers
- Public API lives only on `KernelAdvancedOptions::tensor_groups` in `advanced_options.hpp`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/m2-var-dfb-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/m2-var-dfb-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/m2-var-dfb-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/m2-var-dfb-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/m2-var-dfb-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/m2-var-dfb-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/m2-var-dfb-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/m2-var-dfb-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/m2-var-dfb-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/m2-var-dfb-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/m2-var-dfb-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/m2-var-dfb-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/m2-var-dfb-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/m2-var-dfb-tensor)