### PR TITLE
Exp ring joint SDPA for MiniMax-H3: head-segment scheduling + split-head forwarding dedup (21% faster than normal ring joint)

### DIFF
--- a/models/tt_dit/models/transformers/minimax_h3/attention_minimax_h3.py
+++ b/models/tt_dit/models/transformers/minimax_h3/attention_minimax_h3.py
@@ -4,9 +4,12 @@
 
 from __future__ import annotations
 
+import math
+
 import torch
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 
 from ....layers.linear import ColParallelLinear
 from ....layers.module import Module
@@ -123,6 +126,8 @@ class MiniMaxH3Attention(Module):
         self.n_local_heads = num_heads // tp_factor
         self.tp_mesh_axis = parallel_config.tensor_parallel.mesh_axis
         self.sp_mesh_axis = parallel_config.sequence_parallel.mesh_axis
+        # Fractured sequence means attention has to gather K/V around the ring.
+        self.use_ring = is_sequence_parallel and parallel_config.sequence_parallel.factor > 1
 
         fsdp_mesh_axis = self.sp_mesh_axis if is_fsdp else None
 
@@ -175,6 +180,23 @@ class MiniMaxH3Attention(Module):
         self.full_grid = full_grid
         self.sdpa_worker_grid = (full_grid.x - 1, full_grid.y)  # reserve last column for CCL
         self._sdpa_program_configs: dict[tuple[int, bool], ttnn.SDPAProgramConfig] = {}
+
+        # The exp ring op walks head-SEGMENTS (a head's Q chunks split over segs_per_head rows) as
+        # serial passes, ceil(n_local_heads * segs / rows) passes per row. Segmentation is what
+        # balances 14 local heads over 10 rows: segs=1 gives 2 passes of 10-tile chunks with 6 rows
+        # idle on the second pass, while segs=2 gives 3 passes of 5-tile chunks on every core --
+        # 15 Q tile-rows per core instead of 20 on the bottleneck cores.
+        self.exp_ring_max_passes = 3  # kMaxPasses in exp_ring_joint_sdpa_program_factory.cpp
+        self.exp_ring_num_passes = math.ceil(self.n_local_heads / full_grid.y)
+        self.exp_ring_max_k_chunk = 512  # largest k worth trying; `_exp_sdpa_l1_bytes` picks down from here
+        self.use_exp_ring_sdpa = (
+            self.use_ring
+            and is_blackhole()
+            and tp_factor == 4
+            and parallel_config.sequence_parallel.factor == 32
+            and self.exp_ring_num_passes <= self.exp_ring_max_passes
+        )
+        self._exp_sdpa_program_configs: dict[int, ttnn.SDPAProgramConfig | None] = {}
 
         self.sdpa_compute_kernel_config = ttnn.init_device_compute_kernel_config(
             mesh_device.arch(),
@@ -283,6 +305,137 @@ class MiniMaxH3Attention(Module):
             )
         return self._sdpa_program_configs[key]
 
+    # One accumulator entry and one Q chunk per pass, in tiles of `_EXP_L1_TILE_BYTES`. Mirrors the
+    # CB table in exp_ring_joint_sdpa_program_factory.cpp; reproduces its measured 1,302,528 B at
+    # (224, 512) exactly. Nothing in the op validates this, so an oversized shape would only surface
+    # as a CB allocation failure at program build.
+    _EXP_L1_TILE_BYTES = 2048  # bf16 and Float16_b tiles are both 2 KiB
+    # CB space measured IN THE PIPELINE, not bare L1: the op's CBs must end below the lowest live
+    # L1 buffer (global semaphores etc. occupy the top of L1), which a 15s run measured at
+    # 1,504,000 with the CB region starting at 191,360. The factory checks the live value at build;
+    # this constant only has to be a safe lower bound so the k search picks a buildable shape.
+    _EXP_USABLE_L1_BYTES = 1_312_640
+    # DEST tiles from `get_dest_reg_count`: 1024 * 16 / (32 * 32), halved because dst_full_sync_en is
+    # off, not halved again because `sdpa_compute_kernel_config` has fp32_dest_acc_en off.
+    _EXP_DST_TILES = 8
+    # `determine_largest_subblock_size` in sdpa_subblock_utils.hpp, in its search order.
+    _EXP_SUBBLOCKS = (
+        (2, 4), (4, 2), (1, 8), (8, 1), (1, 7), (7, 1), (2, 3), (3, 2), (1, 6), (6, 1),
+        (1, 5), (5, 1), (2, 2), (1, 4), (4, 1), (1, 3), (3, 1), (1, 2), (2, 1), (1, 1),
+    )  # fmt: skip
+
+    def _exp_streaming_compute_enabled(self, sq_t: int, sk_t: int) -> bool:
+        """Whether the op picks its streaming compute path for a chunk shape.
+
+        Mirrors `use_streaming_compute` in exp_ring_joint_sdpa_program_factory.cpp. The exp compute
+        kernel `static_assert`s on it, so a shape the factory judges ineligible does not fall back --
+        it fails to build the kernel. The binding term in practice is `sk_t % (dst / h) == 0`: it
+        rejects k=320 at q=320 (h=1, so sk_t must be a multiple of 8, and 10 is not).
+        """
+        dst = self._EXP_DST_TILES
+        for h, w in self._EXP_SUBBLOCKS:
+            if h * w <= dst and sq_t % h == 0 and sk_t % w == 0:
+                return h <= 2 and sk_t % (dst // h) == 0 and sq_t // h > 1
+        return False
+
+    def _exp_sdpa_l1_bytes(self, sq_t: int, sk_t: int, p: int, resident_q: bool = True) -> int:
+        """L1 the exp op's circular buffers need for a (q, k, passes) shape, in tiles of head_dim.
+
+        `p` is the candidate's pass count (head-segment scheduling makes it per-candidate:
+        ceil(n_local_heads * segs / rows)). `resident_q=False` models the op's streamed-Q fallback:
+        when the resident total does not fit, the factory sizes c_0 to a single chunk and the reader
+        re-reads each pass's Q every ring iteration. The op selects the mode itself from this same
+        arithmetic; the model only needs it to know which (q, k) shapes are buildable.
+        """
+        dh_t = self.head_dim // ttnn.TILE_SIZE
+        tiles = (
+            (p if resident_q else 1) * sq_t * dh_t  # c_0 Q: one chunk per pass, or one when streamed
+            + 4 * sk_t * dh_t  # c_1/c_14 K and c_2/c_15 V, double buffered
+            + 7  # c_3 mask, scalars, reciprocal scratch
+            + 2 * p * sq_t  # c_6 / c_11 state FIFO running max and sum
+            + p * sq_t * dh_t  # c_7 state FIFO partial output
+            + sq_t  # c_17 stats out (c_10 is dead on this path and not allocated)
+            + 16  # c_16 streaming output ping-pong
+            + sq_t * sk_t  # c_24 qk intermediate
+            + 2 * sq_t * dh_t  # c_25/c_26 output scratch halves
+            + 4 * sq_t  # c_27-c_30 max/sum scratch halves
+            + sq_t  # c_31 exp max diff
+        )
+        return tiles * self._EXP_L1_TILE_BYTES
+
+    def _exp_sdpa_program_config(self, seq_local: int) -> ttnn.SDPAProgramConfig | None:
+        """Exp ring SDPA config for a per-device sequence length, or None if it cannot use the op.
+
+        The op gives Q chunk `x` to core column `x`, so a head's chunks must fill its row exactly:
+        `ceil(seq_local / q_chunk)` has to equal the SDPA column count. That pins q_chunk to the
+        window `[seq_local / cols, seq_local / (cols - 1))` for a given width, and only a TILE
+        multiple will do, so a width is usable only if one lands there. `measured_sdpa_chunk_sizes`
+        therefore does not apply on this path -- though at the H3 10s shape the window happens to
+        give q=224, the value WanAttention measured anyway.
+
+        Widest usable grid wins, so try `full_grid.x - 1` columns first and step down. A narrower
+        grid frees no L1 whatsoever -- every CB is sized from (q_chunk, k_chunk, passes), never from
+        the column count -- so it is never worth taking while a wider one fits. It is only worth
+        taking when no wider width admits a q_chunk at all, and there the comparison is not against
+        a full-grid exp config but against no exp config at all: at 5s, 11 columns admit nothing
+        (96 -> 13 chunks, 128 -> 10) while 10 columns take q=128 with L1 to spare.
+
+        k_chunk is the one genuinely free variable, and the only one that buys L1 headroom, so take
+        the largest that both fits L1 and keeps the op on its streaming compute path -- the kernel
+        static_asserts on the latter, so an ineligible k fails the build rather than falling back.
+        A shape fits if either Q mode does: resident Q (all passes' chunks stay in L1, read once) or
+        the op's streamed-Q fallback (one chunk resident, re-read per pass per ring iteration).
+        That gives 512 at q=224 resident, and 384 at q=320 streamed -- where the k=256 that resident
+        Q would force measured far slower (small k doubles the per-chunk flash overhead; see
+        exp_more_heads_per_row.md §9).
+        """
+        if not self.use_exp_ring_sdpa:
+            return None
+        if seq_local not in self._exp_sdpa_program_configs:
+            self._exp_sdpa_program_configs[seq_local] = self._build_exp_sdpa_program_config(seq_local)
+        return self._exp_sdpa_program_configs[seq_local]
+
+    def _build_exp_sdpa_program_config(self, seq_local: int) -> ttnn.SDPAProgramConfig | None:
+        """Search (cols, segs_per_head, q_chunk, k_chunk) and take the lightest bottleneck load.
+
+        The per-core matmul work per ring iteration is passes * q_chunk Q rows against the full
+        K/V stream, so `passes * q_chunk` is the primary score: at 14 heads on 10 rows, segs=1
+        gives 2 passes x 320 = 640 rows while segs=2 gives 3 passes x 160 = 480. Larger k_chunk
+        is the tie-break (fewer per-chunk overheads), then wider grids.
+        """
+        tile = ttnn.TILE_SIZE
+        rows = self.full_grid.y
+        best = None
+        for cols in range(self.full_grid.x - 1, 1, -1):
+            for segs in (1, 2, 3):
+                chunks = cols * segs
+                q_chunk = math.ceil(math.ceil(seq_local / chunks) / tile) * tile
+                if math.ceil(seq_local / q_chunk) != chunks:
+                    continue  # this (cols, segs) admits no tile-multiple q_chunk
+                passes = math.ceil(self.n_local_heads * segs / rows)
+                if passes > self.exp_ring_max_passes:
+                    continue
+                for k_chunk in range(self.exp_ring_max_k_chunk, 0, -tile):
+                    sq_t, sk_t = q_chunk // tile, k_chunk // tile
+                    fits = (
+                        self._exp_sdpa_l1_bytes(sq_t, sk_t, passes) <= self._EXP_USABLE_L1_BYTES
+                        or self._exp_sdpa_l1_bytes(sq_t, sk_t, passes, resident_q=False) <= self._EXP_USABLE_L1_BYTES
+                    )
+                    if fits and self._exp_streaming_compute_enabled(sq_t, sk_t):
+                        score = (passes * q_chunk, -k_chunk, -cols)
+                        if best is None or score < best[0]:
+                            best = (score, cols, q_chunk, k_chunk)
+                        break
+        if best is None:
+            return None
+        _, cols, q_chunk, k_chunk = best
+        return ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(cols + 1, self.full_grid.y),
+            q_chunk_size=q_chunk,
+            k_chunk_size=k_chunk,
+            exp_approx_mode=False,  # NOTE: False is more correct
+        )
+
     # ------------------------------------------------------------------ forward
 
     def forward(
@@ -319,9 +472,7 @@ class MiniMaxH3Attention(Module):
             raise ValueError(msg)
 
         tp_factor = self.parallel_config.tensor_parallel.factor
-        sp_factor = self.parallel_config.sequence_parallel.factor
-        use_ring = self.is_sequence_parallel and sp_factor > 1
-        assert not (use_ring and N is None), "ring attention needs the logical sequence length N"
+        assert not (self.use_ring and N is None), "ring attention needs the logical sequence length N"
 
         # Passing parallel_config puts ColParallelLinear on all_gather_minimal_matmul_async: the TP
         # all-gather of the K-fractured input folds into the matmul that consumes it, instead of
@@ -362,9 +513,38 @@ class MiniMaxH3Attention(Module):
         k_BHNE = self.norm_k(k_1BNF, **norm_kwargs)
         v_BHNE = create_heads(v_1BNF)
 
-        if use_ring:
-            # Sequence is fractured across SP, so attention must gather K/V around the ring.
-            # The packed sequence is one attention document and logical_n masks the pad tail, so no mask.
+        # Sequence is fractured across SP, so attention must gather K/V around the ring.
+        # The packed sequence is one attention document and logical_n masks the pad tail, so no mask.
+        exp_program_config = self._exp_sdpa_program_config(q_BHNE.shape[2])
+        if exp_program_config is not None:
+            spatial_BHNE, _prompt, _lse = ttnn.transformer.exp_ring_joint_scaled_dot_product_attention(
+                q_BHNE,
+                k_BHNE,
+                v_BHNE,
+                self.dummy_joint_input,
+                self.dummy_joint_input,
+                self.dummy_joint_input,
+                persistent_output_buffer_k=self.ccl_manager.get_ag_ping_pong_buffer(
+                    k_BHNE.shape, 2, self.sp_mesh_axis, dtype=k_BHNE.dtype
+                ),
+                persistent_output_buffer_v=self.ccl_manager.get_ag_ping_pong_buffer(
+                    v_BHNE.shape, 2, self.sp_mesh_axis, dtype=v_BHNE.dtype
+                ),
+                joint_strategy="rear",
+                logical_n=N,
+                program_config=exp_program_config,
+                compute_kernel_config=self.sdpa_compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=self.ccl_manager.get_exp_ring_ping_pong_semaphore(self.sp_mesh_axis),
+                num_links=self.ccl_manager.num_links,
+                cluster_axis=self.sp_mesh_axis,
+                mesh_device=self.mesh_device,
+                topology=self.ccl_manager.topology,
+                subdevice_id=self.ccl_manager.ccl_sub_device_id,
+                num_workers_per_link=5,
+                num_buffers_per_channel=32,
+            )
+        elif self.use_ring:
             spatial_BHNE, _prompt, _lse = ttnn.transformer.ring_joint_scaled_dot_product_attention(
                 q_BHNE,
                 k_BHNE,

--- a/models/tt_dit/tests/models/minimax_h3/common.py
+++ b/models/tt_dit/tests/models/minimax_h3/common.py
@@ -113,9 +113,10 @@ def create_fractal_image(width: int, height: int) -> Image.Image:
 # the quad's `trace_denoise`; the region is only reserved, so 4x8 pays nothing but address space.
 _L1_SMALL = 65536
 _ring = {**ring_params_req_exact_devices, "l1_small_size": _L1_SMALL}
+_ring_8k = {**ring_params_8k_req_exact_devices, "l1_small_size": _L1_SMALL}
 _ring_8k_trace = {**ring_params_8k_req_exact_devices, "trace_region_size": 150_000_000, "l1_small_size": _L1_SMALL}
 
-MESH_4X8_RING = pytest.param((4, 8), _ring, id="4x8")
+MESH_4X8_RING = pytest.param((4, 8), _ring_8k, id="4x8")
 MESH_4X32_RING = pytest.param((4, 32), _ring_8k_trace, id="4x32")
 
 GALAXY_MESHES = [MESH_4X8_RING, MESH_4X32_RING]
@@ -142,7 +143,9 @@ def randomize_norm_weights(module: torch.nn.Module, *, scale: float = 0.5) -> to
 GALAXY_RING = pytest.mark.parametrize(
     ("mesh_device", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
     [
-        pytest.param((4, 8), 1, 0, 2, _ring, ttnn.Topology.Ring, False, id="4x8sp1tp0nl2_ring_is_fsdp0"),
+        # 4x8 takes the 8 KB router payload like 4x32: sp_sim runs on it emulate the 4x32 machine,
+        # and the exp ring SDPA's fabric all-gather packs 4 tiles per packet only at 8 KB.
+        pytest.param((4, 8), 1, 0, 2, _ring_8k, ttnn.Topology.Ring, False, id="4x8sp1tp0nl2_ring_is_fsdp0"),
         pytest.param((4, 32), 1, 0, 2, _ring_8k_trace, ttnn.Topology.Ring, False, id="4x32sp1tp0nl2_ring_is_fsdp0"),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/tt_dit/tests/models/minimax_h3/test_performance_minimax_h3.py
+++ b/models/tt_dit/tests/models/minimax_h3/test_performance_minimax_h3.py
@@ -83,25 +83,37 @@ def _packed_sizes(duration_s: float) -> dict:
         pytest.param(15.0, id="15s_768p"),
     ],
 )
+@pytest.mark.parametrize(
+    "sp_simulate",
+    [
+        pytest.param(1, id="sp_sim1"),
+        pytest.param(4, id="sp_sim4"),
+    ],
+)
 def test_minimax_h3_transformer_block_perf(
     mesh_device: ttnn.MeshDevice,
     sp_axis: int,
     tp_axis: int,
     num_links: int,
     duration_s: float,
+    sp_simulate: int,
     is_fsdp: bool,
     topology: ttnn.Topology,
     reset_seeds,
 ) -> None:
     skip_if_unsupported_num_links(mesh_device, num_links)
+    # Simulate a larger SP mesh (e.g. 4x32) on a smaller one (4x8) by shrinking the total sequence
+    # so each device carries a shard the larger mesh would produce. `sp_simulate` is that SP ratio.
+    SIM = sp_simulate
 
     sp_factor = tuple(mesh_device.shape)[sp_axis]
     tp_factor = tuple(mesh_device.shape)[tp_axis]
 
     sizes = _packed_sizes(duration_s)
     seq_len = sizes["seq_len"]
-    alignment = sp_factor * ttnn.TILE_SIZE
+    alignment = sp_factor * ttnn.TILE_SIZE * SIM
     padded_len = ((seq_len + alignment - 1) // alignment) * alignment
+    padded_len = padded_len // SIM
     logger.info(
         f"{duration_s:g}s @ {sizes['height']}x{sizes['width']}: {sizes['num_frames']} frames -> "
         f"{sizes['latent_frames']} latent frames x {sizes['grid_h']}x{sizes['grid_w']} patches = "
@@ -110,8 +122,18 @@ def test_minimax_h3_transformer_block_perf(
     )
 
     num_timesteps = 2
+    # Simulate a 4x32 per-device shard on a 4x8 mesh: shrink the total sequence by SIM (32/8) so each
+    # 4x8 device carries a 4x32-sized shard. num_video must stay a whole number of (grid_h, grid_w)
+    # frames, so floor it to a frame boundary rather than dividing the raw token count.
+    frame = sizes["grid_h"] * sizes["grid_w"]
+    sim_num_video = (sizes["num_video"] // SIM // frame) * frame
+    sim_seq_len = sizes["num_text"] // SIM + sizes["num_audio"] // SIM + sim_num_video
     position_ids, tags, timestep_indices = packed_layout(
-        sizes["num_text"], sizes["num_audio"], sizes["num_video"], (sizes["grid_h"], sizes["grid_w"]), padded_len
+        sizes["num_text"] // SIM,
+        sizes["num_audio"] // SIM,
+        sim_num_video,
+        (sizes["grid_h"], sizes["grid_w"]),
+        padded_len,
     )
     adaln_indices = timestep_indices * MINIMAX_H3_MODALITY_NUM + tags.clamp(min=0)
 
@@ -141,6 +163,19 @@ def test_minimax_h3_transformer_block_perf(
     tt_block.load_torch_state_dict(torch_block.state_dict())
     del torch_block
 
+    if SIM > 1:
+        # The exp-ring gate keys on sequence_parallel.factor == 32, a proxy for "the per-device
+        # shard is the 4x32 shape". SP simulation produces exactly that shard on a smaller mesh,
+        # but the model only sees the real mesh's factor — force the flag so the simulated run
+        # exercises what a real 4x32 would.
+        tt_block.attn.use_exp_ring_sdpa = tt_block.attn.use_ring and sp_factor * SIM == 32
+        if sp_factor * SIM == 32:
+            assert tt_block.attn.use_exp_ring_sdpa, "simulated 4x32 run must exercise the exp ring SDPA path"
+            assert tt_block.attn._exp_sdpa_program_config(padded_len // sp_factor) is not None, (
+                "exp ring SDPA has no valid program config for the simulated shard "
+                f"({padded_len // sp_factor} tokens/device); the run would silently measure the normal ring path"
+            )
+
     tt_spatial = bf16_tensor_2dshard(
         torch.randn(1, 1, padded_len, HIDDEN_SIZE),
         device=mesh_device,
@@ -159,7 +194,7 @@ def test_minimax_h3_transformer_block_perf(
     def run_block() -> ttnn.Tensor:
         out = tt_block(
             tt_spatial,
-            N=seq_len,  # unpadded length: ring attention masks the pad tail via logical_n
+            N=sim_seq_len,  # simulated unpadded length: ring attention masks the pad tail via logical_n
             temb=tt_temb,
             adaln_indices=tt_adaln,
             rope_cos=tt_rope_cos,

--- a/models/tt_dit/tests/unit/test_exp_ring_joint_attention.py
+++ b/models/tt_dit/tests/unit/test_exp_ring_joint_attention.py
@@ -45,7 +45,10 @@ def run_exp_ring_joint_sdpa(
     num_buffers_per_channel=32,
 ):
     full_compute_grid = submesh.compute_with_storage_grid_size()
-    sdpa_compute_grid = (full_compute_grid.x - 1, full_compute_grid.y)
+    # The op reserves the last column for the fabric MUX (sdpa_grid.x = x - 1) and needs one Q
+    # chunk per SDPA column, so size the grid from the chunk count.
+    local_padded_N = padded_seq_len // tuple(submesh.shape)[rp_axis]
+    sdpa_compute_grid = (math.ceil(local_padded_N / q_chunk_size) + 1, full_compute_grid.y)
 
     # Basic CCL setup
     ccl_sub_device_crs = ttnn.CoreRangeSet(
@@ -359,13 +362,24 @@ def run_test_exp_ring_joint_sdpa(
     ids=["ring"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, num_links, nh, base_seq_len, rp_axis, rp_factor, up_axis, up_factor",
+    "mesh_device, num_links, nh, base_seq_len, rp_axis, rp_factor, up_axis, up_factor, q_chunk_size, k_chunk_size",
     [
-        ((4, 32), 2, 40, 75600, 1, 32, 0, 4),
-        ((4, 8), 2, 40, 18944, 1, 8, 0, 4),
-        ((1, 4), 2, 10, 8960, 1, 4, 0, 1),
+        ((4, 32), 2, 40, 75600, 1, 32, 0, 4, 224, 512),
+        # Head-serial passes: nh/up_factor heads land on each device and the op walks
+        # ceil(heads_per_device / grid_rows) of them per core row as serial passes. With 10 grid
+        # rows, 40 heads -> 10 per device -> 1 pass; 80 heads -> 20 per device -> 2 passes.
+        ((4, 32), 2, 80, 75600, 1, 32, 0, 4, 224, 512),
+        # Minimal spillover: 44 heads -> 11 per device -> row 0 runs 2 passes (heads 0 and 10),
+        # rows 1-9 run 1 pass (heads 1-9) on the same P=2 build. Isolates the multi-pass row.
+        ((4, 32), 2, 44, 75600, 1, 32, 0, 4, 224, 512),
+        # H3 15s: 108544 = 106 * 1024 -> 3392 local tiles -> q=320 (11 columns), k=384. Resident Q
+        # does not fit L1 at P=2, so this is the one config that exercises the factory's streamed-Q
+        # fallback (stream_q). 56 heads -> 14/device: rows 0-3 run 2 passes, rows 4-9 run 1.
+        ((4, 32), 2, 56, 108544, 1, 32, 0, 4, 320, 384),
+        ((4, 8), 2, 40, 18944, 1, 8, 0, 4, 224, 512),
+        ((1, 4), 2, 10, 8960, 1, 4, 0, 1, 224, 512),
     ],
-    ids=["4x32", "4x8", "1x4"],
+    ids=["4x32", "4x32_2pass", "4x32_1spill", "4x32_2pass_streamq", "4x8", "1x4"],
     indirect=["mesh_device"],
 )
 @pytest.mark.skipif(
@@ -381,13 +395,13 @@ def test_exp_ring_joint_sdpa_dit_bh_glx_custom(
     rp_factor,
     up_axis,
     up_factor,
+    q_chunk_size,
+    k_chunk_size,
     all_gather_topology,
     reset_seeds,
 ):
     dtype = ttnn.bfloat16
     b, joint_seq_len, d = 1, 0, 128
-    q_chunk_size = 224
-    k_chunk_size = 512
     n_iters = 5
     trace_enabled = False
     skip_check = False

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
@@ -215,9 +215,11 @@ void ExpRingJointSDPADeviceOperation::validate_on_program_cache_miss(
     }
 
     // --- Grid and chunk compatibility ---
-    // The factory always computes sdpa_grid = {device_x - 1, device_y} (last column = CCL MUX).
-    // The op is designed for at most one (batch, head) per grid row and one Q chunk per core,
-    // so total Q chunks must not exceed the SDPA core count.
+    // The factory computes sdpa_grid = {user_grid.x - 1, user_grid.y} (last column = fabric MUX),
+    // where user_grid is the program config's grid. Work is assigned row-aligned: each core row
+    // hosts ceil(B*NQH / rows) heads and walks them as serial passes, one Q chunk per pass, with a
+    // head's Q chunks filling its row. Mirror the factory's grid derivation exactly so validation
+    // and the factory never disagree.
 
     TT_FATAL(
         DH % tt::constants::TILE_WIDTH == 0,
@@ -235,8 +237,38 @@ void ExpRingJointSDPADeviceOperation::validate_on_program_cache_miss(
         "Got {} columns.",
         device_grid.x);
 
-    const uint32_t sdpa_grid_x = device_grid.x - 1;
-    const uint32_t sdpa_grid_y = device_grid.y;
+    const CoreCoord user_grid =
+        args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size : device_grid;
+    TT_FATAL(
+        user_grid.x <= device_grid.x && user_grid.y <= device_grid.y,
+        "Program config grid ({}x{}) exceeds device grid ({}x{}).",
+        user_grid.x,
+        user_grid.y,
+        device_grid.x,
+        device_grid.y);
+    // Mirrors the factory's grid derivation, including the bottom-row MUX experiment.
+    // Lower-bound the grid BEFORE the derivation: last-column mode subtracts the reserved MUX
+    // column from x and bottom-row mode subtracts two rows from y, so an undersized
+    // program-config grid would otherwise underflow unsigned here (and the num_q_chunks modulo
+    // below would divide by zero) instead of failing with a clear error.
+    const bool mux_on_bottom_row = exp_sdpa_mux_on_bottom_row();
+    if (mux_on_bottom_row) {
+        TT_FATAL(
+            user_grid.y >= 3,
+            "Program config grid ({}x{}) too short for bottom-row MUX placement: needs at least 3 "
+            "rows (2 reserved for the MUX row and its spacer).",
+            user_grid.x,
+            user_grid.y);
+    } else {
+        TT_FATAL(
+            user_grid.x >= 2,
+            "Program config grid ({}x{}) too narrow: needs at least 2 columns (the last column is "
+            "reserved for the fabric MUX kernels).",
+            user_grid.x,
+            user_grid.y);
+    }
+    const uint32_t sdpa_grid_x = mux_on_bottom_row ? user_grid.x : user_grid.x - 1;
+    const uint32_t sdpa_grid_y = mux_on_bottom_row ? user_grid.y - 2 : user_grid.y;
     const uint32_t num_sdpa_cores = sdpa_grid_x * sdpa_grid_y;
 
     // Joint sequence must divide evenly (or be zero); last local Q chunk may be padded.
@@ -251,40 +283,71 @@ void ExpRingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const uint32_t num_q_chunks = num_local_q_chunks + num_joint_q_chunks;
     const uint32_t total_q_chunks = B * NQH * num_q_chunks;
 
-    // One head per row: each (batch, head) pair must map to its own grid row.
+    // Every head-segment must fill its row exactly: fewer chunks than columns would idle the
+    // trailing columns, and the last two SDPA columns are the fabric MUX clients that drive the
+    // K/V all-gather — an idle MUX column means that link never forwards its shard.
     TT_FATAL(
-        B * NQH <= sdpa_grid_y,
-        "Number of (batch × heads) combinations (B={} × NQH={} = {}) exceeds SDPA grid rows ({}) on "
-        "device grid {}×{}. Reduce batch size or head count (e.g. via tensor parallelism).",
-        B,
-        NQH,
-        B * NQH,
-        sdpa_grid_y,
-        device_grid.x,
-        device_grid.y);
-
-    // One Q chunk per column: all Q chunks for one head must fit across the grid columns.
-    TT_FATAL(
-        num_q_chunks <= sdpa_grid_x,
-        "Q chunks per head (num_local={} + num_joint={} = {}) exceeds SDPA grid columns ({}) on "
-        "device grid {}×{}. Increase q_chunk_size or reduce sequence length.",
+        num_q_chunks % sdpa_grid_x == 0,
+        "Q chunks per head (num_local={} + num_joint={} = {}) must be a multiple of the SDPA grid "
+        "columns ({}) on device grid {}×{}. Adjust q_chunk_size so ceil(N_local / q_chunk_size) is "
+        "a multiple of {}.",
         num_local_q_chunks,
         num_joint_q_chunks,
         num_q_chunks,
         sdpa_grid_x,
         device_grid.x,
-        device_grid.y);
+        device_grid.y,
+        sdpa_grid_x);
+    const uint32_t segs_per_head = num_q_chunks / sdpa_grid_x;
+    const uint32_t total_segments = B * NQH * segs_per_head;
 
-    // Final sanity: total Q chunks must not exceed total SDPA cores.
+    // Every SDPA row must own at least one head-segment. An empty row builds no K/V chain and no
+    // injector, and the MUX-writer columns of that row would then hit the row-has-injector
+    // TT_FATAL during program construction — reject the shape here with an actionable message
+    // instead.
     TT_FATAL(
-        total_q_chunks <= num_sdpa_cores,
-        "Total Q chunks (B={} × NQH={} × num_q_chunks={} = {}) exceeds SDPA cores ({}). "
-        "The two constraints above should have caught this.",
+        total_segments >= sdpa_grid_y,
+        "Head-segments (B={} x NQH={} x segs_per_head={} = {}) must cover all {} SDPA grid rows; "
+        "rows without a segment are not supported. Use a program_config grid with at most {} rows, "
+        "or a smaller q_chunk_size to raise segs_per_head.",
+        B,
+        NQH,
+        segs_per_head,
+        total_segments,
+        sdpa_grid_y,
+        total_segments);
+
+    // Segments per row: each core row hosts up to kMaxPasses head-segments, walked as serial
+    // passes. Keep in lockstep with kMaxPasses in exp_ring_joint_sdpa_program_factory.cpp
+    // (L1-bound).
+    constexpr uint32_t kMaxPasses = 3;
+    const uint32_t num_passes = (total_segments + sdpa_grid_y - 1) / sdpa_grid_y;
+    TT_FATAL(
+        num_passes <= kMaxPasses,
+        "Number of head-segments (B={} × NQH={} × segs_per_head={} = {}) needs {} serial passes on "
+        "{} SDPA grid rows (device grid {}×{}), but at most {} are supported. Reduce batch size or "
+        "head count (e.g. via tensor parallelism), or use a larger q_chunk_size.",
+        B,
+        NQH,
+        segs_per_head,
+        total_segments,
+        num_passes,
+        sdpa_grid_y,
+        device_grid.x,
+        device_grid.y,
+        kMaxPasses);
+
+    // Final sanity: total Q chunks must fit the cores across all passes.
+    TT_FATAL(
+        total_q_chunks <= num_passes * num_sdpa_cores,
+        "Total Q chunks (B={} × NQH={} × num_q_chunks={} = {}) exceeds SDPA cores ({}) across {} "
+        "passes. The two constraints above should have caught this.",
         B,
         NQH,
         num_q_chunks,
         total_q_chunks,
-        num_sdpa_cores);
+        num_sdpa_cores,
+        num_passes);
 }
 
 ExpRingJointSDPAResultSpec ExpRingJointSDPADeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
@@ -297,7 +297,12 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     const auto device_grid = mesh_device->compute_with_storage_grid_size();
     CoreCoord user_grid =
         args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size : device_grid;
-    CoreCoord sdpa_grid = {user_grid.x - 1, user_grid.y};
+    const bool mux_on_bottom_row = exp_sdpa_mux_on_bottom_row();
+    // Bottom-row experiment: SDPA keeps every column but gives up the two bottom rows (row y-1
+    // hosts the MUX kernels, row y-2 idles so the SDPA row count stays even for the direction
+    // split). Default: SDPA keeps every row but gives up the last column to the MUX kernels.
+    CoreCoord sdpa_grid =
+        mux_on_bottom_row ? CoreCoord{user_grid.x, user_grid.y - 2} : CoreCoord{user_grid.x - 1, user_grid.y};
 
     TT_FATAL(
         user_grid.x <= device_grid.x && user_grid.y <= device_grid.y,
@@ -312,6 +317,18 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         "user_grid has {} cols, sdpa_grid has {} cols.",
         user_grid.x,
         sdpa_grid.x);
+    TT_FATAL(
+        sdpa_grid.y % 2 == 0,
+        "SDPA grid rows ({}) must be even so the backward/forward MUX client halves match.",
+        sdpa_grid.y);
+    // The row-half split determines the per-link worker count; derive it from the grid so the
+    // bottom-row experiment (fewer rows) keeps the direction and termination groups uniform.
+    const uint32_t num_workers_per_link = sdpa_grid.y / 2;
+    TT_FATAL(
+        num_workers_per_link == args.num_workers_per_link || mux_on_bottom_row,
+        "num_workers_per_link ({}) must equal sdpa_grid.y / 2 ({}).",
+        args.num_workers_per_link,
+        num_workers_per_link);
 
     bool exp_approx_mode =
         args.program_config.has_value()
@@ -326,40 +343,70 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     log_debug(tt::LogOp, "num_sdpa_cores: {}", num_sdpa_cores);
 
     /**
-     * This parallelization scheme is efficient because it divides the global work,
-     * the total number of Q chunks across all batches and heads, evenly across the cores.
+     * Head-serial passes over row-sized SEGMENTS. A head's num_q_chunks Q chunks are split into
+     * segs_per_head = num_q_chunks / sdpa_grid.x segments of one row each; segment s (flat over
+     * batch x head x segment) runs as pass p = s / rows on row y = s % rows, and core (x, y) owns
+     * that segment's Q chunk x. segs_per_head == 1 is the original one-row-per-head layout.
      *
+     * Per pass the pipeline is exactly the single-head pipeline: each core holds one Q chunk per
+     * pass (all resident, read once) and one flash-attention accumulator state per pass (kept in
+     * the L1 state FIFO, see cb_prev_out). A split head's K/V shard is streamed — and all-gather
+     * forwarded — once per segment: the duplicate fabric writes carry identical bytes to identical
+     * addresses, and each row's chunk-ready signals come from the same row on the previous device,
+     * so every row's pipeline stays self-contained exactly as in the one-row-per-head layout.
+     *
+     * Splitting heads balances the grid when B*NH does not divide the row count: e.g. 14 heads on
+     * 10 rows is 2 passes of 10-tile chunks (20 Q tile-rows on the bottleneck cores, 6 rows idle
+     * on the second pass), while segs_per_head=2 makes it 3 passes of 5-tile chunks (15 Q
+     * tile-rows on every core) — the per-core matmul work drops by a quarter.
      */
-    const uint32_t all_heads_num_q_chunks = B * NH * num_q_chunks;
-    const uint32_t max_q_per_core = tt::div_up(all_heads_num_q_chunks, num_sdpa_cores);
-
-    // Exp ring joint SDPA constraints: single Q-chunk per core, one head per row.
+    const uint32_t rows = sdpa_grid.y;
+    // Every segment must fill its row exactly: fewer chunks than columns would idle the trailing
+    // columns, and the last two SDPA columns are the fabric MUX clients that perform the K/V
+    // all-gather — an idle MUX column means that link never forwards its shard.
     TT_FATAL(
-        max_q_per_core == 1,
-        "Exp ring joint SDPA requires exactly 1 Q-chunk per core. Got max_q_per_core={} "
-        "(total_q_chunks={}, num_sdpa_cores={}). Increase grid size or reduce sequence length.",
-        max_q_per_core,
-        all_heads_num_q_chunks,
-        num_sdpa_cores);
-    TT_FATAL(
-        num_q_chunks <= sdpa_grid.x,
-        "Exp ring joint SDPA requires one head per row (all Q-chunks of a head on the same row). "
-        "Got num_q_chunks={} but grid has only {} columns.",
+        num_q_chunks % sdpa_grid.x == 0,
+        "Exp ring joint SDPA requires a head's Q chunks to fill a whole number of rows. Got "
+        "num_q_chunks={} with {} columns. Adjust q_chunk_size so ceil(local_padded_N / "
+        "q_chunk_size) is a multiple of {}.",
         num_q_chunks,
+        sdpa_grid.x,
         sdpa_grid.x);
+    const uint32_t segs_per_head = num_q_chunks / sdpa_grid.x;
+    const uint32_t total_segments = B * NH * segs_per_head;
+    const uint32_t num_passes = tt::div_up(total_segments, rows);
+
+    // L1-bound: the CB budget must hold num_passes resident Q chunks + state-FIFO entries. The
+    // caller's program config is responsible for picking (q_chunk, k_chunk, segs) that fit; an
+    // oversized combination fails CB allocation at program build.
+    constexpr uint32_t kMaxPasses = 3;
     TT_FATAL(
-        B * NH <= sdpa_grid.y,
-        "Exp ring joint SDPA requires one head per row. "
-        "Got B*NH={} but grid has only {} rows.",
+        num_passes <= kMaxPasses,
+        "Exp ring joint SDPA supports at most {} head-segments per core row. "
+        "Got B*NH={} x segs_per_head={} with {} rows (P={}).",
+        kMaxPasses,
         B * NH,
-        sdpa_grid.y);
+        segs_per_head,
+        rows,
+        num_passes);
 
-    const uint32_t q_buffer_factor = (max_q_per_core > 1) ? 2 : 1;
+    log_debug(tt::LogOp, "num_passes (heads per row): {}", num_passes);
 
-    log_debug(tt::LogOp, "max_q_per_core: {}", max_q_per_core);
+    // Depth of the L1 state FIFO (c_6 max / c_11 sum / c_7 partial-out), in entries.
+    //
+    // A pass pops its own entry at its FIRST K chunk (the merge consumes `prev`) and pushes the
+    // updated entry at its LAST K chunk, so num_passes entries are enough as long as a pass has at
+    // least two K chunks: the pop has already freed the slot the push needs. A pass with exactly one
+    // K chunk is the only case that reserves `cur` before popping `prev` (sdpa_inner_loop_step
+    // reserves the new entry up front), which would deadlock at full depth — so give that case one
+    // spare entry. The last active ring iteration is the only one that can be partial, and it
+    // normalizes into cb_out instead of pushing to the FIFO, so it never needs the spare.
+    const uint32_t state_fifo_entries = num_passes + (num_local_k_chunks <= 1 ? 1 : 0);
+    log_debug(tt::LogOp, "state_fifo_entries: {}", state_fifo_entries);
 
     // These tile capacity counts for CBs need to match the number of tiles expected by the kernel (softmax.cpp)
-    uint32_t q_tiles = Sq_chunk_t * DHt * q_buffer_factor;
+    // Q holds one chunk per pass; all of them stay resident for the whole op (read once).
+    uint32_t q_tiles = num_passes * Sq_chunk_t * DHt;
     uint32_t k_tiles = Sk_chunk_t * DHt * 2;  // double buffer
     uint32_t v_tiles = Sk_chunk_t * DHt * 2;  // double buffer
     uint32_t qk_tiles = Sq_chunk_t * Sk_chunk_t;
@@ -408,8 +455,9 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     const uint32_t out_num_blocks = Sk_chunk_t / out_in0_block_w;
 
     // Streaming: shrink cb_out to a 2-slot ping-pong (see sdpa_subblock_utils.hpp). Safe here
-    // because max_q_per_core == 1 is TT_FATAL-enforced above, so Phase-2's save_to_staging
-    // branch (pack at offset qktv_h*vDHt into a 2*qktv_h*vDHt buffer) never fires.
+    // because every pass runs with q_per_core == 1 (one Q chunk per pass, head-serial), so
+    // Phase-2's save_to_staging branch (pack at offset qktv_h*vDHt into a 2*qktv_h*vDHt buffer)
+    // never fires — cross-ring-iteration state lives in the L1 state FIFO instead.
     if (use_streaming_compute) {
         out0_t = detail::streaming_cb_out_tiles(out_out_subblock_h, out_out_subblock_w, dst_size, Sq_chunk_t, DHt);
         TT_FATAL(
@@ -517,6 +565,46 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         .core_ranges = CoreRangeSet(sdpa_grid_range),
         .initial_value = VALID,
     });
+    // Second receiver valid flag for the mcast ping-pong: K chunks land on receiver_semaphore_id,
+    // V chunks on receiver_semaphore_b_id. With separate flags a receiver can post the
+    // (reserve + flag-reset + ack) credit for chunk n+1 of a channel right after consuming chunk n,
+    // so two row-broadcasts (V of chunk n, K of chunk n+1) can be in flight at once instead of the
+    // injector paying a full receiver round trip between every mcast.
+    const uint32_t receiver_semaphore_b_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = receiver_semaphore_b_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = CoreRangeSet(sdpa_grid_range),
+        .initial_value = INVALID,
+    });
+    // Separate V-channel ack counter. The K/V ack totals must be counted independently: a
+    // receiver's K credits run one chunk ahead of its V credits, so a single combined counter
+    // would let the fast receivers' K(n+1) credits stand in for a slow receiver's missing V(n)
+    // credit — the injector would multicast V(n) before that receiver reset its V flag, and the
+    // relayed VALID would be erased by the late reset (observed deadlock). Counted per channel,
+    // a receiver can be at most one credit ahead, and that credit is exactly the event the
+    // injector waits on, so total >= 10*event_index implies every receiver posted this event.
+    const uint32_t sender_semaphore_v_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = sender_semaphore_v_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = CoreRangeSet(sdpa_grid_range),
+        .initial_value = INVALID,
+    });
+    // Split-head forwarding dedup buddy gate. With segs_per_head == 2 the two rows of an adjacent
+    // pair (2i, 2i+1) process the SAME head against the SAME deterministic ring sequence in every
+    // pass (when both rows are in the same fabric direction half), so their mux clients forward
+    // byte-identical packets to identical remote addresses. The follower (odd) row's clients skip
+    // forwarding entirely; the leader (even) row's injector — after its own per-link gate passes —
+    // relays one on-chip semaphore inc per chunk to the follower's injector, which gates on this
+    // semaphore instead of the (now silent) per-link semaphores.
+    const uint32_t buddy_gate_semaphore_id = static_cast<uint32_t>(desc.semaphores.size());
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = buddy_gate_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = CoreRangeSet(sdpa_grid_range),
+        .initial_value = 0,
+    });
 
     // Append semaphore ids to reader compile-time args (must match reader kernel expectations)
     const auto sem_args_offset = reader_compile_time_args.size();
@@ -524,6 +612,10 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     reader_compile_time_args.push_back(receiver_semaphore_id);
     reader_compile_time_args.push_back(valid_semaphore_id);
     reader_compile_time_args.push_back(0);  // mcast_enabled placeholder (patched after chain construction)
+    reader_compile_time_args.push_back(0);  // stream_q placeholder (patched after CB sizing)
+    reader_compile_time_args.push_back(receiver_semaphore_b_id);
+    reader_compile_time_args.push_back(sender_semaphore_v_id);
+    reader_compile_time_args.push_back(buddy_gate_semaphore_id);
 
     std::vector<uint32_t> writer_compile_time_args = {
         B,
@@ -555,8 +647,9 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
 
+    // Streaming-only compute kernel: NH and the classic matmul block params (in0_block_w,
+    // num_subblocks, num_blocks) are not consumed — only the subblock shapes are.
     std::vector<uint32_t> compute_compile_time_args = {
-        NH,
         DHt,
         Sq_chunk_t,
         Sk_chunk_t,
@@ -569,22 +662,20 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         num_local_k_chunks,
         num_joint_k_chunks,
         args.ring_size,
-        qk_in0_block_w,
         qk_out_subblock_w,
         qk_out_subblock_h,
-        qk_in0_num_subblocks,
-        qk_in1_num_subblocks,
-        qk_num_blocks,
-        out_in0_block_w,
         out_out_subblock_w,
         out_out_subblock_h,
-        out_in0_num_subblocks,
-        out_in1_num_subblocks,
-        out_num_blocks,
         scale_packed,
         static_cast<std::uint32_t>(use_streaming_compute),
         global_n_partial_col,
         joint_l_partial_col,
+        0,  // stream_q placeholder (patched after CB sizing)
+        // Single-pass programs keep the original persist-in-scratch accumulator path: the L1
+        // state FIFO only earns its per-iteration entry/exit cost (redirected packs + a dual
+        // max write) when several head-passes share a core. The 1-pass shapes are gated by
+        // utilization-band perf tests calibrated on the scratch path.
+        (num_passes > 1) ? 1u : 0u,  // use_l1_state_fifo
     };
 
     std::map<std::string, std::string> defines;
@@ -632,7 +723,8 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
 
     const auto sdpa_grid_set = CoreRangeSet(sdpa_grid_range);
 
-    // Q input
+    // Q input. NOTE: sized for resident Q here; the streamed-Q fallback below (search stream_q)
+    // patches desc.cbs[0].total_size down to one chunk when the resident total does not fit L1.
     desc.cbs.push_back(CBDescriptor{
         .total_size = q_tiles * q_tile_size,
         .core_ranges = sdpa_grid_set,
@@ -710,9 +802,9 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         }}},
     });
 
-    // stats input
+    // Running-max half of the L1 state FIFO (num_passes + 1 entries; see cb_prev_out below).
     desc.cbs.push_back(CBDescriptor{
-        .total_size = statistics_tiles * im_tile_size,
+        .total_size = state_fifo_entries * statistics_tiles * im_tile_size,
         .core_ranges = sdpa_grid_set,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_6),
@@ -721,14 +813,25 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         }}},
     });
 
-    // previous block output as input
+    // Partial-output half of the L1 state FIFO.
+    //
+    // Head-serial passes keep one flash-attention accumulator state (max + sum + partial out) per
+    // pass live across all ring iterations. The three state CBs (c_6 max, c_11 sum, c_7 out) are
+    // used as FIFOs: a pass pops its own state at its first K chunk and pushes the updated state at
+    // its last K chunk, so the fixed cyclic pass order keeps each pass's state at the front when it
+    // runs. See state_fifo_entries above for the depth derivation. Sizing stays an exact multiple of
+    // the per-entry tile count so no entry straddles the ring-buffer wrap — intra-entry reads index
+    // tiles relative to the CB front.
+    //
+    // Format is im_df (not out_df): these tiles are accumulator intermediates shared with the
+    // c_25/c_26 scratch halves, not DRAM-formatted output.
     desc.cbs.push_back(CBDescriptor{
-        .total_size = out_im_tiles * out_tile_size,
+        .total_size = state_fifo_entries * out_im_tiles * im_tile_size,
         .core_ranges = sdpa_grid_set,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_7),
-            .data_format = out_df,
-            .page_size = out_tile_size,
+            .data_format = im_df,
+            .page_size = im_tile_size,
         }}},
     });
 
@@ -867,22 +970,13 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         });
     }
 
-    // Deferred norm: sum save/restore CBs for multi Q-chunk DRAM round-trip.
-    // cb_sum_out (c_10) = compute pushes sum for writer to save to DRAM.
-    // cb_sum_in (c_11) = writer pushes restored sum from DRAM for compute to read.
+    // c_10 (cb_sum_out) belongs to the multi-Q DRAM round-trip, which head-serial passes never
+    // take (every pass runs with q_per_core == 1); it is NOT allocated — the kernel's cb_sum_out
+    // index is only touched in the staging branch, which is dead at q_per_core == 1.
+    // c_11 (cb_sum_in) is the running-sum half of the L1 state FIFO — see cb_prev_out (c_7).
     if (use_streaming_compute) {
         desc.cbs.push_back(CBDescriptor{
-            .total_size = statistics_tiles * stats_tile_size,
-            .core_ranges = sdpa_grid_set,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_10),
-                .data_format = stats_df,
-                .page_size = stats_tile_size,
-            }}},
-        });
-
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = statistics_tiles * stats_tile_size,
+            .total_size = state_fifo_entries * statistics_tiles * stats_tile_size,
             .core_ranges = sdpa_grid_set,
             .format_descriptors = {{CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_11),
@@ -891,6 +985,42 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             }}},
         });
     }
+
+    // Streamed-Q fallback: if the CBs do not fit L1 with all num_passes Q chunks resident, keep
+    // only one chunk resident; the reader then re-reads each pass's Q every ring iteration and
+    // compute pops it at the end of the pass. Buys back (num_passes - 1) * Sq_chunk_t * DHt tiles,
+    // which at H3 15s (q=320, k=384, P=2) is the difference between fitting and not.
+    // See exp_more_heads_per_row.md §9.
+    // CBs must end below the lowest live L1 buffer (validate_circular_buffer_region enforces
+    // exactly this). In the pipeline, global semaphores and persistent buffers occupy the top of
+    // L1, so budgeting against the raw L1 size over-promises and the program clashes at allocate.
+    const auto lowest_l1_buffer = mesh_device->lowest_occupied_compute_l1_address();
+    const uint32_t cb_space_top = lowest_l1_buffer.has_value() ? static_cast<uint32_t>(lowest_l1_buffer.value())
+                                                               : mesh_device->l1_size_per_core();
+    const uint32_t usable_l1 =
+        cb_space_top - mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    uint64_t total_cb_bytes = 0;
+    for (const auto& cb : desc.cbs) {
+        total_cb_bytes += cb.total_size;
+    }
+    const bool stream_q = (num_passes > 1) && (total_cb_bytes > usable_l1);
+    if (stream_q) {
+        total_cb_bytes -= desc.cbs[0].total_size;
+        desc.cbs[0].total_size = Sq_chunk_t * DHt * q_tile_size;  // c_0 is the first CB pushed
+        total_cb_bytes += desc.cbs[0].total_size;
+    }
+    TT_FATAL(
+        total_cb_bytes <= usable_l1,
+        "Exp ring joint SDPA CBs need {} B but only {} B of L1 are usable at this chunk shape "
+        "(q_chunk={}, k_chunk={}, passes={}); reduce k_chunk_size.",
+        total_cb_bytes,
+        usable_l1,
+        q_chunk_size,
+        k_chunk_size,
+        num_passes);
+    log_debug(tt::LogOp, "stream_q: {}", stream_q);
+    reader_compile_time_args[sem_args_offset + 4] = stream_q ? 1 : 0;
+    compute_compile_time_args[20] = stream_q ? 1 : 0;
 
     auto* const q_buf = input_tensor_q.buffer();
     auto* const k_buf = input_tensor_k.buffer();
@@ -905,7 +1035,13 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     auto* const stats_buf = stats_output_tensor.buffer();
 
     /**
-     * Build chain selection for store-and-forward across cores per (batch, head).
+     * Build per-row store-and-forward chains.
+     *
+     * Head-serial passes place num_passes heads on every row, and every pass of a row runs on the
+     * same cores (logical x in [0, num_q_chunks)), so a row has ONE chain shared by all its passes.
+     * One injector per row is required, not merely convenient: each MUX writer pre-configures a
+     * single fabric atomic-inc destination for the whole op (see exp_ring_joint_writer.cpp), so
+     * every pass of a row must signal the same injector core.
      */
     struct CoreHeadWork {
         uint32_t batch = 0;
@@ -917,20 +1053,20 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     struct CoreWork {
         CoreCoord logical_core;
         CoreCoord physical_core;
-        uint32_t global_q_start = 0;
-        uint32_t global_q_count = 0;
-        std::vector<CoreHeadWork> head_work;
-    };
-
-    struct HeadSegmentRef {
-        uint32_t core_idx = 0;
-        uint32_t head_work_index = 0;
+        // Q work descriptor: this core owns flat chunks q_base + p * q_stride for p in [0, q_count).
+        uint32_t q_base = 0;
+        uint32_t q_stride = 0;
+        uint32_t q_count = 0;
+        std::vector<CoreHeadWork> head_work;  // one entry per pass, in pass order
     };
 
     struct CoreChainInfo {
         bool participates = false;
         bool is_injector = false;
         bool is_sink = false;
+        // Pass-0 (batch, head) and chunk range. The kernels no longer compare chunks against these:
+        // row-aligned scheduling makes every chunk a core owns part of its row's chain. Kept so the
+        // reader RT-arg layout is unchanged.
         uint32_t batch = 0;
         uint32_t head = 0;
         uint32_t q_chunk_start = 0;
@@ -944,18 +1080,53 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
 
     std::vector<CoreWork> core_work(num_sdpa_cores);
     std::vector<CoreChainInfo> core_chain_info(num_sdpa_cores);
-    const uint32_t total_heads = B * NH;
-    std::vector<std::vector<HeadSegmentRef>> head_segments(total_heads);
 
-    // Evenly distribute flat global q chunks across cores
-    const uint32_t total_q_chunks = B * NH * num_q_chunks;
-    const uint32_t base_chunks_per_core = (num_sdpa_cores == 0) ? 0 : (total_q_chunks / num_sdpa_cores);
-    const uint32_t extra_chunks = (num_sdpa_cores == 0) ? 0 : (total_q_chunks % num_sdpa_cores);
+    /**
+     * Row-aligned work assignment over head-segments. The flat chunk encoding is unchanged:
+     *     flat = (batch * NH + head) * num_q_chunks + q_chunk
+     * Pass p of core (x, y) owns segment s = p * rows + y, chunk x within it. Since
+     * num_q_chunks = segs_per_head * sdpa_grid.x, the flat id collapses to the same affine form
+     * the kernels already consume:
+     *     flat = (s / segs_per_head) * num_q_chunks + (s % segs_per_head) * sdpa_grid.x + x
+     *          = s * sdpa_grid.x + x = q_base + p * q_stride
+     * with q_base = y * sdpa_grid.x + x and q_stride = rows * sdpa_grid.x.
+     *
+     * Two properties the kernels rely on:
+     *   - every kernel derives (batch, head, q_chunk) from the flat id per pass, so a
+     *     pass-dependent q_chunk (segments) needs no kernel change;
+     *   - when total_segments % rows != 0 an entire row idles the final pass, so all cores of a
+     *     row always run the same number of passes (required for K/V CB pointer lockstep under
+     *     mcast).
+     */
+    const uint32_t q_stride = rows * sdpa_grid.x;
+    for (uint32_t i = 0; i < num_sdpa_cores; ++i) {
+        const CoreCoord core = {i % sdpa_grid.x, i / sdpa_grid.x};
+        auto& work = core_work.at(i);
+        work.logical_core = core;
+        work.physical_core = device->worker_core_from_logical_core(core);
+        work.q_base = core.y * sdpa_grid.x + core.x;
+        work.q_stride = q_stride;
+        work.q_count = 0;
+        for (uint32_t p = 0; p < num_passes; ++p) {
+            const uint32_t seg_id = p * rows + core.y;
+            if (seg_id >= total_segments) {
+                break;
+            }
+            const uint32_t head_id = seg_id / segs_per_head;
+            work.q_count++;
+            work.head_work.push_back(CoreHeadWork{
+                .batch = head_id / NH,
+                .head = head_id % NH,
+                .q_chunk_start = (seg_id % segs_per_head) * sdpa_grid.x + core.x,
+                .q_chunk_count = 1,
+            });
+        }
+    }
 
     log_debug(
         tt::LogOp,
         "[ExpRingJointSDPA] grid={}x{}={} cores, B={}, NH={}, num_q_chunks={}({} local+{} joint), "
-        "base_chunks_per_core={} (+{} extras)",
+        "passes_per_row={}, q_stride={}",
         sdpa_grid.x,
         sdpa_grid.y,
         num_sdpa_cores,
@@ -964,96 +1135,29 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         num_q_chunks,
         num_local_q_chunks,
         num_joint_q_chunks,
-        base_chunks_per_core,
-        extra_chunks);
-    uint32_t next_global_chunk = 0;
+        num_passes,
+        q_stride);
 
-    auto decode_flat_chunk = [&](uint32_t flat_chunk_index) {
-        const uint32_t head_span = num_q_chunks;
-        const uint32_t head_index = head_span == 0 ? 0 : (flat_chunk_index / head_span);
-        const uint32_t q_chunk = head_span == 0 ? 0 : (flat_chunk_index % head_span);
-        const uint32_t batch = (NH == 0) ? 0 : (head_index / NH);
-        const uint32_t head = (NH == 0) ? 0 : (head_index % NH);
-        return std::tuple<uint32_t, uint32_t, uint32_t>{batch, head, q_chunk};
-    };
-
-    for (uint32_t i = 0; i < num_sdpa_cores; ++i) {
-        CoreCoord core = {i % sdpa_grid.x, i / sdpa_grid.x};
-        uint32_t chunk_count = base_chunks_per_core + ((i < extra_chunks) ? 1 : 0);
-        if (next_global_chunk >= total_q_chunks) {
-            chunk_count = 0;
-        } else if (chunk_count > total_q_chunks - next_global_chunk) {
-            chunk_count = total_q_chunks - next_global_chunk;
-        }
-
-        auto& work = core_work.at(i);
-        work.logical_core = core;
-        work.physical_core = device->worker_core_from_logical_core(core);
-        work.global_q_start = next_global_chunk;
-        work.global_q_count = chunk_count;
-
-        uint32_t remaining = chunk_count;
-        uint32_t flat_chunk = next_global_chunk;
-        while (remaining > 0) {
-            auto [batch_idx, head_idx, q_chunk_idx] = decode_flat_chunk(flat_chunk);
-            uint32_t chunk_capacity_in_head = num_q_chunks - q_chunk_idx;
-            uint32_t chunk_take = std::min(remaining, chunk_capacity_in_head);
-
-            work.head_work.push_back(CoreHeadWork{
-                .batch = batch_idx,
-                .head = head_idx,
-                .q_chunk_start = q_chunk_idx,
-                .q_chunk_count = chunk_take,
-            });
-
-            if (!head_segments.empty()) {
-                uint32_t head_id = (batch_idx * NH) + head_idx;
-                if (head_id < head_segments.size()) {
-                    head_segments[head_id].push_back(HeadSegmentRef{
-                        .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
-                }
-            }
-
-            remaining -= chunk_take;
-            flat_chunk += chunk_take;
-        }
-
-        next_global_chunk += chunk_count;
-    }
-
-    // Construct chains: for each head that spans >= 2 cores, pick first core
-    // with single head segment as injector. Linear forward traversal only —
-    // no wrap-around (wrapping back would pull in straddling cores whose
-    // q_iter_local is inflated by prior-head work, causing deadlock).
-    // Injector reselection for DRAM channel spreading is deferred to the
-    // mcast eligibility pass below.
-    for (auto& segments : head_segments) {
-        if (segments.size() < 2) {
-            continue;
-        }
-
-        std::optional<std::size_t> chain_start_idx;
-        for (std::size_t idx = 0; idx + 1 < segments.size(); ++idx) {
-            const auto& seg = segments.at(idx);
-            const auto& work = core_work.at(seg.core_idx);
-            if (work.global_q_count == 0) {
+    // One chain per row, over that row's participating cores in ascending logical x (which is
+    // ascending physical x within a row). Injector is refined below for DRAM channel spreading.
+    std::vector<std::vector<uint32_t>> row_chain_cores(rows);
+    for (uint32_t y = 0; y < rows; ++y) {
+        auto& chain_cores = row_chain_cores[y];
+        for (uint32_t x = 0; x < sdpa_grid.x; ++x) {
+            const uint32_t core_idx = y * sdpa_grid.x + x;
+            if (core_work.at(core_idx).q_count == 0) {
                 continue;
             }
-            if (work.head_work.size() == 1) {
-                chain_start_idx = idx;
-                break;
-            }
+            chain_cores.push_back(core_idx);
         }
 
-        if (!chain_start_idx.has_value()) {
-            continue;
+        if (chain_cores.size() < 2) {
+            continue;  // a single-core row needs no store-and-forward
         }
 
-        const std::size_t start = chain_start_idx.value();
-        for (std::size_t idx = start; idx < segments.size(); ++idx) {
-            const auto& seg = segments.at(idx);
-            const uint32_t core_idx = seg.core_idx;
-            const auto& hw = core_work.at(core_idx).head_work.at(seg.head_work_index);
+        for (std::size_t idx = 0; idx < chain_cores.size(); ++idx) {
+            const uint32_t core_idx = chain_cores[idx];
+            const auto& hw = core_work.at(core_idx).head_work.at(0);
             auto& chain = core_chain_info.at(core_idx);
 
             chain.participates = true;
@@ -1061,56 +1165,38 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             chain.head = hw.head;
             chain.q_chunk_start = hw.q_chunk_start;
             chain.q_chunk_count = hw.q_chunk_count;
+            chain.is_injector = (idx == 0);
+            chain.is_sink = (idx + 1 == chain_cores.size());
 
-            if (idx == start) {
-                chain.is_injector = true;
+            if (idx > 0) {
+                chain.prev_physical = core_work.at(chain_cores[idx - 1]).physical_core;
             }
-            if (idx == segments.size() - 1) {
-                chain.is_sink = true;
-            }
-
-            if (idx > start) {
-                const uint32_t prev_core_idx = segments.at(idx - 1).core_idx;
-                chain.prev_physical = core_work.at(prev_core_idx).physical_core;
-            }
-            if (idx + 1 < segments.size()) {
-                const uint32_t next_core_idx = segments.at(idx + 1).core_idx;
+            if (idx + 1 < chain_cores.size()) {
+                const uint32_t next_core_idx = chain_cores[idx + 1];
                 chain.next_physical = core_work.at(next_core_idx).physical_core;
-                const auto& next_hw = core_work.at(next_core_idx).head_work.at(segments.at(idx + 1).head_work_index);
-                chain.next_core_q_chunks = next_hw.q_chunk_count;
+                chain.next_core_q_chunks = core_work.at(next_core_idx).head_work.at(0).q_chunk_count;
             }
         }
     }
 
-    // Log chain summary
     {
         uint32_t num_chains = 0;
-        std::vector<uint32_t> chain_len_counts(num_sdpa_cores + 1, 0);
-        for (uint32_t hi = 0; hi < total_heads; ++hi) {
-            const auto& segs = head_segments[hi];
-            const uint32_t batch_id = hi / NH, head_id = hi % NH;
-            uint32_t chain_len = 0;
-            for (const auto& seg : segs) {
-                const auto& ci = core_chain_info[seg.core_idx];
-                if (ci.participates && ci.batch == batch_id && ci.head == head_id) {
-                    chain_len++;
-                }
-            }
-            if (chain_len >= 2) {
-                num_chains++;
-                chain_len_counts[chain_len]++;
-            }
-        }
         std::string hist_str;
-        for (uint32_t len = 2; len <= num_sdpa_cores; ++len) {
-            if (chain_len_counts[len] > 0) {
-                hist_str += std::to_string(chain_len_counts[len]) + "x" + std::to_string(len) + "-core ";
+        for (uint32_t y = 0; y < rows; ++y) {
+            if (row_chain_cores[y].size() >= 2) {
+                num_chains++;
+                hist_str += std::to_string(row_chain_cores[y].size()) + " ";
             }
         }
-        log_debug(tt::LogOp, "[ExpRingJointSDPA] {} chains ({})", num_chains, hist_str.empty() ? "none" : hist_str);
+        log_debug(
+            tt::LogOp,
+            "[ExpRingJointSDPA] {} row chains (lengths: {})",
+            num_chains,
+            hist_str.empty() ? "none" : hist_str);
     }
 
-    // Third pass: Check multicast eligibility and configure mcast for eligible chains
+    // Multicast eligibility, evaluated per row. All-or-nothing: mcast is mandatory for this op, so
+    // a single ineligible row is a hard error below rather than a per-row fallback.
     uint32_t mcast_chains = 0;
     {
         struct McastCandidate {
@@ -1118,50 +1204,35 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             uint32_t ref_q_chunks;
         };
         std::vector<McastCandidate> candidates;
-        candidates.reserve(head_segments.size());
+        candidates.reserve(rows);
         bool all_eligible = true;
 
-        for (uint32_t head_id = 0; head_id < head_segments.size(); ++head_id) {
-            const auto& segments = head_segments[head_id];
-            if (segments.size() < 2) {
+        for (uint32_t y = 0; y < rows && all_eligible; ++y) {
+            const auto& chain_cores = row_chain_cores[y];
+            if (chain_cores.size() < 2) {
                 continue;
             }
 
-            std::vector<uint32_t> chain_core_indices;
-            chain_core_indices.reserve(segments.size());
-            for (const auto& seg : segments) {
-                if (seg.core_idx < core_chain_info.size() && core_chain_info[seg.core_idx].participates &&
-                    core_chain_info[seg.core_idx].batch == (head_id / NH) &&
-                    core_chain_info[seg.core_idx].head == (head_id % NH)) {
-                    chain_core_indices.push_back(seg.core_idx);
-                }
-            }
-
-            if (chain_core_indices.size() < 2) {
-                continue;
-            }
-
-            // Eligibility condition 1: All physical cores share the same Y coordinate
-            const uint32_t ref_y = core_work[chain_core_indices[0]].physical_core.y;
+            // Condition 1: all physical cores share the same Y coordinate.
+            const uint32_t ref_y = core_work[chain_cores[0]].physical_core.y;
             bool same_row = true;
-            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
-                if (core_work[chain_core_indices[ci]].physical_core.y != ref_y) {
+            for (std::size_t ci = 1; ci < chain_cores.size(); ++ci) {
+                if (core_work[chain_cores[ci]].physical_core.y != ref_y) {
                     same_row = false;
                     break;
                 }
             }
-
             if (!same_row) {
                 all_eligible = false;
-                log_debug(tt::LogOp, "Head {}: mcast ineligible - cores span multiple rows", head_id);
+                log_debug(tt::LogOp, "Row {}: mcast ineligible - cores span multiple physical rows", y);
                 break;
             }
 
-            // Eligibility condition 2: no non-chain worker cores inside the mcast rectangle.
-            uint32_t min_x = core_work[chain_core_indices[0]].physical_core.x;
+            // Condition 2: no non-chain worker core inside the mcast rectangle.
+            uint32_t min_x = core_work[chain_cores[0]].physical_core.x;
             uint32_t max_x = min_x;
-            for (const auto& ci : chain_core_indices) {
-                uint32_t x = core_work[ci].physical_core.x;
+            for (const auto& ci : chain_cores) {
+                const uint32_t x = core_work[ci].physical_core.x;
                 min_x = std::min(min_x, x);
                 max_x = std::max(max_x, x);
             }
@@ -1169,57 +1240,47 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             bool has_gap = false;
             for (uint32_t ci = 0; ci < num_sdpa_cores; ++ci) {
                 const auto& phys = core_work[ci].physical_core;
-                if (phys.y == ref_y && phys.x >= min_x && phys.x <= max_x) {
-                    bool in_chain = false;
-                    for (const auto& chain_ci : chain_core_indices) {
-                        if (chain_ci == ci) {
-                            in_chain = true;
-                            break;
-                        }
-                    }
-                    if (!in_chain) {
-                        has_gap = true;
-                        break;
-                    }
+                if (phys.y != ref_y || phys.x < min_x || phys.x > max_x) {
+                    continue;
+                }
+                if (std::find(chain_cores.begin(), chain_cores.end(), ci) == chain_cores.end()) {
+                    has_gap = true;
+                    break;
                 }
             }
-
             if (has_gap) {
                 all_eligible = false;
-                log_debug(
-                    tt::LogOp, "Head {}: mcast ineligible - non-chain worker core inside mcast rectangle", head_id);
+                log_debug(tt::LogOp, "Row {}: mcast ineligible - non-chain worker core inside mcast rectangle", y);
                 break;
             }
 
-            // Eligibility condition 3: All chain cores must have the same q_chunk_count.
-            const uint32_t ref_q_chunks = core_chain_info[chain_core_indices[0]].q_chunk_count;
+            // Condition 3: uniform per-core chunk count (one chunk per pass, so always uniform).
+            const uint32_t ref_q_chunks = core_chain_info[chain_cores[0]].q_chunk_count;
             bool uniform_q_mcast = true;
-            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
-                if (core_chain_info[chain_core_indices[ci]].q_chunk_count != ref_q_chunks) {
+            for (std::size_t ci = 1; ci < chain_cores.size(); ++ci) {
+                if (core_chain_info[chain_cores[ci]].q_chunk_count != ref_q_chunks) {
                     uniform_q_mcast = false;
                     break;
                 }
             }
-
             if (!uniform_q_mcast) {
                 all_eligible = false;
-                log_debug(tt::LogOp, "Head {}: mcast ineligible - mixed q_chunk_counts", head_id);
+                log_debug(tt::LogOp, "Row {}: mcast ineligible - mixed q_chunk_counts", y);
                 break;
             }
 
-            candidates.push_back(McastCandidate{std::move(chain_core_indices), ref_q_chunks});
+            candidates.push_back(McastCandidate{chain_cores, ref_q_chunks});
         }
 
         if (all_eligible && !candidates.empty()) {
             mcast_chains = candidates.size();
-            // Track injector physical X columns for DRAM channel spreading
+            // Track injector physical X columns for DRAM channel spreading across rows.
             std::vector<uint32_t> injector_phys_x;
             injector_phys_x.reserve(candidates.size());
             for (const auto& cand : candidates) {
                 const uint32_t chain_size = cand.core_indices.size();
                 const uint32_t num_receivers = chain_size - 1;
 
-                // Find current injector
                 uint32_t injector_idx = cand.core_indices[0];
                 for (const auto& ci : cand.core_indices) {
                     if (core_chain_info[ci].is_injector) {
@@ -1228,8 +1289,8 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
                     }
                 }
 
-                // Reselect injector for DRAM channel spreading: pick the core
-                // whose physical X is furthest from all previously chosen injectors.
+                // Reselect injector for DRAM channel spreading: pick the core whose physical X is
+                // furthest from all previously chosen injectors.
                 {
                     uint32_t best_idx = injector_idx;
                     uint32_t best_dist = 0;
@@ -1237,7 +1298,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
                         const uint32_t phys_x = core_work[ci].physical_core.x;
                         uint32_t min_dist = UINT32_MAX;
                         for (uint32_t ix : injector_phys_x) {
-                            uint32_t d = (phys_x > ix) ? (phys_x - ix) : (ix - phys_x);
+                            const uint32_t d = (phys_x > ix) ? (phys_x - ix) : (ix - phys_x);
                             min_dist = std::min(min_dist, d);
                         }
                         if (min_dist > best_dist) {
@@ -1246,7 +1307,6 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
                         }
                     }
                     if (best_idx != injector_idx) {
-                        // Clear old injector, set new one
                         core_chain_info[injector_idx].is_injector = false;
                         core_chain_info[injector_idx].is_sink = true;
                         core_chain_info[best_idx].is_injector = true;
@@ -1258,8 +1318,8 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
 
                 uint32_t min_x = core_work[cand.core_indices[0]].physical_core.x;
                 uint32_t max_x = min_x;
-                for (size_t ci = 1; ci < cand.core_indices.size(); ++ci) {
-                    uint32_t x = core_work[cand.core_indices[ci]].physical_core.x;
+                for (std::size_t ci = 1; ci < cand.core_indices.size(); ++ci) {
+                    const uint32_t x = core_work[cand.core_indices[ci]].physical_core.x;
                     min_x = std::min(min_x, x);
                     max_x = std::max(max_x, x);
                 }
@@ -1291,7 +1351,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
 
                 log_debug(
                     tt::LogOp,
-                    "Head: mcast enabled - {} receivers, injector core {} (phys_x={}), num_dests={} -> rect "
+                    "Row mcast enabled - {} receivers, injector core {} (phys_x={}), num_dests={} -> rect "
                     "({},{}) to ({},{})",
                     num_receivers,
                     injector_idx,
@@ -1306,7 +1366,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
 
         log_debug(
             tt::LogOp,
-            "Multicast eligibility: {}/{} chains using mcast (all-or-nothing)",
+            "Multicast eligibility: {}/{} row chains using mcast (all-or-nothing)",
             mcast_chains,
             static_cast<uint32_t>(candidates.size()));
     }
@@ -1336,29 +1396,96 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     // Update mcast_enabled compile-time arg now that chain construction is complete
     reader_compile_time_args[sem_args_offset + 3] = (mcast_chains > 0) ? 1 : 0;
 
-    // Map (batch * NH + head) -> injector physical coordinates for MUX writer signaling
-    std::unordered_map<uint32_t, CoreCoord> injector_physical_by_head;
+    // Map core row -> injector physical coordinates for MUX writer signaling. Per row (not per
+    // head) because all passes of a row share one injector — the MUX writer bakes a single
+    // atomic-inc destination for the whole op.
+    std::vector<std::optional<CoreCoord>> injector_physical_by_row(rows);
     for (uint32_t ci = 0; ci < num_sdpa_cores; ++ci) {
         if (core_chain_info[ci].is_injector) {
-            uint32_t head_key = core_chain_info[ci].batch * NH + core_chain_info[ci].head;
-            injector_physical_by_head[head_key] = core_work[ci].physical_core;
+            injector_physical_by_row.at(core_work[ci].logical_core.y) = core_work[ci].physical_core;
         }
     }
 
+    // Split-head forwarding dedup roles (see the buddy_gate semaphore comment). Enabled per row
+    // pair (2i, 2i+1), which shares one head in EVERY pass when segs_per_head == 2 and the row
+    // count is even (head = (p*rows + y) / 2, and p*rows is even). Requirements per pair: same
+    // fabric direction half (identical deterministic ring sequences and identical remote
+    // destination device — the cross-direction middle pair keeps duplicate forwarding), equal
+    // q_count (identical gate schedules), and both injectors known. Roles: 0 = none (forward and
+    // gate as before), 1 = leader (forward; relay gate to buddy), 2 = follower (skip forwarding;
+    // gate on the leader's relay).
+    std::vector<uint32_t> row_dedup_role(sdpa_grid.y, 0);
+    std::vector<CoreCoord> row_buddy_injector(sdpa_grid.y, CoreCoord{0, 0});
+    if (mcast_chains > 0 && segs_per_head == 2 && (sdpa_grid.y % 2 == 0)) {
+        for (uint32_t y = 0; y + 1 < sdpa_grid.y; y += 2) {
+            const uint32_t yf = y + 1;
+            const bool same_direction = (y < num_workers_per_link) == (yf < num_workers_per_link);
+            const uint32_t qc_leader = core_work.at(y * sdpa_grid.x).q_count;
+            const uint32_t qc_follower = core_work.at(yf * sdpa_grid.x).q_count;
+            const auto& inj_leader = injector_physical_by_row.at(y);
+            const auto& inj_follower = injector_physical_by_row.at(yf);
+            if (same_direction && qc_leader == qc_follower && qc_leader > 0 && inj_leader.has_value() &&
+                inj_follower.has_value()) {
+                row_dedup_role[y] = 1;
+                row_dedup_role[yf] = 2;
+                row_buddy_injector[y] = inj_follower.value();
+                row_buddy_injector[yf] = inj_leader.value();
+            }
+        }
+    }
+
+    // Follower rows send nothing over fabric, so they do not connect to the MUX at all: the MUX
+    // config allocates channels only for FORWARDING rows (compact channel ids per direction
+    // half), and the freed L1 goes into deeper per-channel buffering (num_buffers_per_channel is
+    // scaled up by the client reduction). With dedup off every row forwards and this reduces to
+    // the original 1:1 layout.
+    uint32_t fwd_rows_dir0 = 0;
+    uint32_t fwd_rows_dir1 = 0;
+    std::vector<uint32_t> row_mux_channel(sdpa_grid.y, 0);
+    for (uint32_t y = 0; y < sdpa_grid.y; ++y) {
+        if (row_dedup_role[y] == 2) {
+            continue;
+        }
+        if (y < num_workers_per_link) {
+            row_mux_channel[y] = fwd_rows_dir0++;
+        } else {
+            row_mux_channel[y] = fwd_rows_dir1++;
+        }
+    }
+    TT_FATAL(
+        fwd_rows_dir0 == fwd_rows_dir1 && fwd_rows_dir0 > 0,
+        "Split-head dedup produced asymmetric forwarding groups ({} backward vs {} forward): the "
+        "shared MUX config and termination count require equal per-direction client counts.",
+        fwd_rows_dir0,
+        fwd_rows_dir1);
+    const uint32_t num_mux_clients_per_group = fwd_rows_dir0;
+
     // ---- Fabric MUX config (needed for writer kernel CT args below) ----
-    // MUX cores are placed at the last x coordinate of the full device grid.
-    // Backward MUX: first y (0) and last y (device_y - 1).
-    // Forward MUX:  middle y - 1 and middle y.
-    const uint32_t fabric_mux_col = user_grid.x - 1;  // Last column of user_grid
-    const uint32_t mid_y = sdpa_grid.y / 2;
-    const std::vector<CoreCoord> mux_backward_logical_cores = {{fabric_mux_col, 0}, {fabric_mux_col, sdpa_grid.y - 1}};
-    const std::vector<CoreCoord> mux_forward_logical_cores = {{fabric_mux_col, mid_y - 1}, {fabric_mux_col, mid_y}};
+    // Default: MUX cores are placed at the last x coordinate of the user grid.
+    //   Backward MUX: first y (0) and last y (sdpa_grid.y - 1). Forward MUX: middle y - 1 and middle y.
+    // Bottom-row experiment: MUX cores sit on the last ROW of the user grid, transposing the same
+    //   arrangement — backward at the first and last x, forward at the middle pair.
+    const uint32_t mid = mux_on_bottom_row ? sdpa_grid.x / 2 : sdpa_grid.y / 2;
+    const uint32_t fabric_mux_col = user_grid.x - 1;  // Last column of user_grid (default placement)
+    const uint32_t fabric_mux_row = user_grid.y - 1;  // Last row of user_grid (bottom-row placement)
+    const bool mux_top_cluster = exp_sdpa_mux_top_cluster();
+    const std::vector<CoreCoord> mux_backward_logical_cores =
+        mux_on_bottom_row ? std::vector<CoreCoord>{{0, fabric_mux_row}, {sdpa_grid.x - 1, fabric_mux_row}}
+        : mux_top_cluster ? std::vector<CoreCoord>{{fabric_mux_col, 0}, {fabric_mux_col, 1}}
+                          : std::vector<CoreCoord>{{fabric_mux_col, 0}, {fabric_mux_col, sdpa_grid.y - 1}};
+    const std::vector<CoreCoord> mux_forward_logical_cores =
+        mux_on_bottom_row ? std::vector<CoreCoord>{{mid - 1, fabric_mux_row}, {mid, fabric_mux_row}}
+        : mux_top_cluster ? std::vector<CoreCoord>{{fabric_mux_col, 2}, {fabric_mux_col, 3}}
+                          : std::vector<CoreCoord>{{fabric_mux_col, mid - 1}, {fabric_mux_col, mid}};
 
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-    const uint32_t num_mux_full_size_channels = args.num_workers_per_link;
+    const uint32_t num_mux_full_size_channels = num_mux_clients_per_group;
     const uint32_t num_mux_header_only_channels = 0;
-    const uint32_t num_mux_buffers_per_channel = args.num_buffers_per_channel;
+    // The caller's num_buffers_per_channel is calibrated for one channel per row; with follower
+    // rows disconnected, redistribute the same L1 across the remaining channels.
+    const uint32_t num_mux_buffers_per_channel =
+        args.num_buffers_per_channel * num_workers_per_link / num_mux_clients_per_group;
     const size_t mux_buffer_size_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
         num_mux_full_size_channels,
@@ -1399,7 +1526,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     // Fabric writer: columns sdpa_grid.x-2 and sdpa_grid.x-1 (backward and forward MUX clients)
     CoreRange mux_writer_range({sdpa_grid.x - 2, 0}, {sdpa_grid.x - 1, sdpa_grid.y - 1});
     auto writer_fabric_compile_time_args = writer_compile_time_args;
-    fabric_mux_connection_ct_args(args.num_workers_per_link, mux_kernel_config, writer_fabric_compile_time_args);
+    fabric_mux_connection_ct_args(num_mux_clients_per_group, mux_kernel_config, writer_fabric_compile_time_args);
 
     // All-gather CT args for the fabric writer (integrated K/V all-gather on MUX client columns)
     const uint32_t ag_page_size = input_tensor_k.buffer()->page_size();
@@ -1446,7 +1573,7 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     std::set<CoreRange> ag_backward_master_ranges, ag_forward_master_ranges;
     for (uint32_t col_offset = 0; col_offset < 2; ++col_offset) {
         CoreCoord bwd_master = {sdpa_grid.x - 2 + col_offset, 0};
-        CoreCoord fwd_master = {sdpa_grid.x - 2 + col_offset, args.num_workers_per_link};
+        CoreCoord fwd_master = {sdpa_grid.x - 2 + col_offset, num_workers_per_link};
         ag_backward_master_cores.push_back(bwd_master);
         ag_forward_master_cores.push_back(fwd_master);
         ag_backward_master_ranges.insert(CoreRange(bwd_master));
@@ -1458,8 +1585,8 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     // This ensures every core (both term-masters and non-masters) has the same number of
     // semaphores allocated before fabric_mux_connection_rt_args runs, keeping
     // termination_sync IDs consistent.
-    CoreRange all_backward_clients({sdpa_grid.x - 2, 0}, {sdpa_grid.x - 1, args.num_workers_per_link - 1});
-    CoreRange all_forward_clients({sdpa_grid.x - 2, args.num_workers_per_link}, {sdpa_grid.x - 1, sdpa_grid.y - 1});
+    CoreRange all_backward_clients({sdpa_grid.x - 2, 0}, {sdpa_grid.x - 1, num_workers_per_link - 1});
+    CoreRange all_forward_clients({sdpa_grid.x - 2, num_workers_per_link}, {sdpa_grid.x - 1, sdpa_grid.y - 1});
     // K/V tensor shape info for all-gather RT args
     const auto& ag_input_shape = input_tensor_k.padded_shape();
     const auto& ag_output_shape = gathered_input_tensor_k.padded_shape();
@@ -1472,19 +1599,16 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
     for (uint32_t i = 0; i < num_sdpa_cores; ++i) {
         CoreCoord core = {i % sdpa_grid.x, i / sdpa_grid.x};
 
-        // Prefer the computed even distribution above for chain construction
+        // Row-aligned head-serial work descriptor: chunks q_base + p*q_stride, p in [0, q_count).
         const auto& work = core_work.at(i);
-        uint32_t global_q_start = work.global_q_start;
-        uint32_t global_q_end = work.global_q_start + work.global_q_count;
 
         // Direction: top half of rows = backward (0), bottom half = forward (1)
-        const uint32_t direction = (core.y < args.num_workers_per_link) ? 0 : 1;
+        const uint32_t direction = (core.y < num_workers_per_link) ? 0 : 1;
 
         // log the above
         log_debug(tt::LogOp, "core: {}", i);
         log_debug(tt::LogOp, "x={},y={}", core.x, core.y);
-        log_debug(tt::LogOp, "global_q_start: {}", global_q_start);
-        log_debug(tt::LogOp, "global_q_end: {}", global_q_end);
+        log_debug(tt::LogOp, "q_base={}, q_stride={}, q_count={}", work.q_base, work.q_stride, work.q_count);
 
         KernelDescriptor::RTArgList reader_args;
         reader_args.push_back(q_buf);
@@ -1495,21 +1619,23 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         reader_args.push_back(joint_q_buf);
         reader_args.push_back(joint_k_buf);
         reader_args.push_back(joint_v_buf);
-        reader_args.push_back(global_q_start);
-        reader_args.push_back(global_q_end);
+        reader_args.push_back(work.q_base);
+        reader_args.push_back(work.q_stride);
+        reader_args.push_back(work.q_count);
         // Append chain runtime args for store-and-forward
         const auto& chain = core_chain_info.at(i);
 
         log_debug(
             tt::LogOp,
-            "core logical=({},{})->phys=({},{}), q=[{},{}), chain={{part:{}, inj:{}, sink:{}, "
+            "core logical=({},{})->phys=({},{}), q_base={} stride={} count={}, chain={{part:{}, inj:{}, sink:{}, "
             "b:{}, h:{}, q_start:{}, q_cnt:{}, next_cnt:{}}}",
             core.x,
             core.y,
             core_work.at(i).physical_core.x,
             core_work.at(i).physical_core.y,
-            global_q_start,
-            global_q_end,
+            work.q_base,
+            work.q_stride,
+            work.q_count,
             chain.participates,
             chain.is_injector,
             chain.is_sink,
@@ -1534,11 +1660,14 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         reader_args.push_back(chain.mcast_num_dests);
         reader_args.push_back(chain.mcast_sender_wait);
 
-        // Determine if this core's writer has a valid MUX connection (for reader-side forwarding)
+        // Determine if this core's writer has a valid MUX connection (for reader-side forwarding).
+        // Split-head dedup follower rows forward nothing, so their clients do not connect and
+        // their readers do not feed c_14/c_15 at all.
+        const bool row_forwards = row_dedup_role.at(core.y) != 2;
         const bool is_mux_writer = (core.x >= sdpa_grid.x - 2);
         bool is_mux_writer_valid = false;
-        if (is_mux_writer) {
-            const uint32_t half_within_col = core.y / args.num_workers_per_link;
+        if (is_mux_writer && row_forwards) {
+            const uint32_t half_within_col = core.y / num_workers_per_link;
             const bool is_backward = (half_within_col == 0);
             const uint32_t link = (core.x == sdpa_grid.x - 1) ? 1 : 0;
             const bool link_in_range = (link < args.num_links) && (link < mux_backward_logical_cores.size()) &&
@@ -1568,6 +1697,11 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         reader_args.push_back(device_index);
         reader_args.push_back(direction);
 
+        // Split-head forwarding dedup descriptor (meaningful on injector cores only).
+        reader_args.push_back(row_dedup_role.at(core.y));
+        reader_args.push_back(static_cast<uint32_t>(row_buddy_injector.at(core.y).x));
+        reader_args.push_back(static_cast<uint32_t>(row_buddy_injector.at(core.y).y));
+
         reader_kernel.emplace_runtime_args(core, reader_args);
 
         // Writer args
@@ -1576,8 +1710,9 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         // Zero-seq when no joint; address unused at runtime (L=0 => no joint writes).
         writer_args.push_back(joint_out_buf);
         writer_args.push_back(stats_buf);
-        writer_args.push_back(global_q_start);
-        writer_args.push_back(global_q_end);
+        writer_args.push_back(work.q_base);
+        writer_args.push_back(work.q_stride);
+        writer_args.push_back(work.q_count);
         writer_args.push_back(static_cast<uint32_t>(args.ring_size));
         writer_args.push_back(device_index);
         writer_args.push_back(direction);
@@ -1585,12 +1720,21 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         if (is_mux_writer) {
             // Direction is determined by row half: top half = backward, bottom half = forward.
             // Link is determined by column: col sdpa_grid.x-2 = link 0, col sdpa_grid.x-1 = link 1.
-            const uint32_t half_within_col = core.y / args.num_workers_per_link;
+            const uint32_t half_within_col = core.y / num_workers_per_link;
             const bool is_backward = (half_within_col == 0);
             const uint32_t link = (core.x == sdpa_grid.x - 1) ? 1 : 0;
-            const uint32_t worker_idx = core.y % args.num_workers_per_link;
-            const bool is_term_master = (worker_idx == 0);
-            const CoreCoord termination_master_logical = {core.x, half_within_col * args.num_workers_per_link};
+            // Compact channel id among the direction half's FORWARDING rows (followers do not
+            // connect and hold no channel). Term master = channel 0 of the group; with dedup off
+            // this is the original worker_idx layout (row 0 of each half).
+            const uint32_t worker_idx = row_mux_channel.at(core.y);
+            const bool is_term_master = row_forwards && (worker_idx == 0);
+            // First forwarding row of this direction half hosts the termination master.
+            uint32_t term_master_row = half_within_col * num_workers_per_link;
+            while (term_master_row + 1 < (half_within_col + 1) * num_workers_per_link &&
+                   row_dedup_role.at(term_master_row) == 2) {
+                term_master_row++;
+            }
+            const CoreCoord termination_master_logical = {core.x, term_master_row};
 
             const bool link_in_range = (link < args.num_links) && (link < mux_backward_logical_cores.size()) &&
                                        (link < mux_forward_logical_cores.size());
@@ -1601,7 +1745,8 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             if (link_in_range) {
                 const CoreCoord& mux_core =
                     is_backward ? mux_backward_logical_cores[link] : mux_forward_logical_cores[link];
-                const bool valid = is_backward ? backward_coord.has_value() : forward_coord.has_value();
+                const bool valid =
+                    row_forwards && (is_backward ? backward_coord.has_value() : forward_coord.has_value());
                 fabric_mux_connection_rt_args(
                     valid,
                     is_term_master,
@@ -1649,30 +1794,18 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
                                           // dispatch via
                                           // ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments
 
-                // Find the injector core for this MUX writer's (batch, head)
-                const auto& mux_head_work = core_work.at(i).head_work;
-                CoreCoord injector_physical = {0, 0};
-                if (mux_head_work.empty()) {
-                    log_warning(
-                        tt::LogOp,
-                        "MUX writer core ({},{}) has no head_work; cannot determine injector",
-                        core.x,
-                        core.y);
-                } else {
-                    uint32_t head_key = mux_head_work[0].batch * NH + mux_head_work[0].head;
-                    auto it = injector_physical_by_head.find(head_key);
-                    if (it != injector_physical_by_head.end()) {
-                        injector_physical = it->second;
-                    } else {
-                        log_warning(
-                            tt::LogOp,
-                            "MUX writer core ({},{}) batch={} head={}: no injector found in chain info",
-                            core.x,
-                            core.y,
-                            mux_head_work[0].batch,
-                            mux_head_work[0].head);
-                    }
-                }
+                // The injector this MUX writer signals is its own row's injector: all passes of a
+                // row share one injector, and this atomic-inc destination is baked once for the
+                // whole op. A participating row without an injector is a host bug, not a runtime
+                // condition, so fail loudly instead of signaling core (0,0).
+                const auto& row_injector = injector_physical_by_row.at(core.y);
+                TT_FATAL(
+                    row_injector.has_value(),
+                    "MUX writer core ({},{}) has no injector for row {}: chain construction is inconsistent.",
+                    core.x,
+                    core.y,
+                    core.y);
+                const CoreCoord injector_physical = row_injector.value();
                 writer_args.push_back(static_cast<uint32_t>(injector_physical.x));
                 writer_args.push_back(static_cast<uint32_t>(injector_physical.y));
                 writer_args.push_back(args.num_links);  // num_muxes_in_direction
@@ -1681,6 +1814,9 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
                 writer_args.push_back(ag_output_Ht);
                 writer_args.push_back(gathered_k_buf);
                 writer_args.push_back(gathered_v_buf);
+                // Split-head forwarding dedup: follower rows' clients skip fabric data + semincs
+                // (the leader row of the pair sends byte-identical packets).
+                writer_args.push_back(row_dedup_role.at(core.y) == 2 ? 1u : 0u);
             }
             writer_fabric_kernel.emplace_runtime_args(core, writer_args);
         } else {
@@ -1689,8 +1825,9 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
 
         // Compute args
         KernelDescriptor::RTArgList compute_args;
-        compute_args.push_back(global_q_start);
-        compute_args.push_back(global_q_end);
+        compute_args.push_back(work.q_base);
+        compute_args.push_back(work.q_stride);
+        compute_args.push_back(work.q_count);
         compute_args.push_back(static_cast<uint32_t>(args.ring_size));
         compute_args.push_back(device_index);
         compute_args.push_back(direction);
@@ -1801,7 +1938,8 @@ void ExpRingJointSDPAMeshWorkloadFactory::override_runtime_arguments(
     auto* mesh_device = tensor_args.input_q.device();
     const CoreCoord user_grid = args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size
                                                                 : mesh_device->compute_with_storage_grid_size();
-    const CoreCoord sdpa_grid = {user_grid.x - 1, user_grid.y};
+    const CoreCoord sdpa_grid = exp_sdpa_mux_on_bottom_row() ? CoreCoord{user_grid.x, user_grid.y - 2}
+                                                             : CoreCoord{user_grid.x - 1, user_grid.y};
     const uint32_t num_sdpa_cores = sdpa_grid.x * sdpa_grid.y;
     const uint32_t expected_reader_args = dyn::reader_arg_count(args.num_links);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include <optional>
 
 #include <tt-metalium/constants.hpp>
@@ -22,6 +23,29 @@
 #include "ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation_types.hpp"
 
 namespace ttnn::prim {
+
+// EXPERIMENT (TT_EXP_SDPA_MUX_BOTTOM_ROW): place the fabric MUX kernels on the BOTTOM ROW of the
+// user grid instead of the reserved right column. The SDPA grid then becomes user_grid.x wide by
+// user_grid.y - 2 tall (the row count is kept even so the backward/forward direction split and the
+// termination groups stay uniform, requiring no kernel changes; the row between the workers and
+// the MUX row is idle). Probes whether MUX-kernel placement relative to the eth cores affects the
+// fabric all-gather rate. NOTE: the env var is not part of the program-cache key — use one setting
+// per process. Shared by the factory build, the cache-hit patch, and validation so all three
+// derive the same grid.
+inline bool exp_sdpa_mux_on_bottom_row() {
+    static const bool enabled = std::getenv("TT_EXP_SDPA_MUX_BOTTOM_ROW") != nullptr;
+    return enabled;
+}
+
+// EXPERIMENT (TT_EXP_SDPA_MUX_TOP_CLUSTER): keep the reserved-column MUX placement (and therefore
+// the exact same SDPA schedule) but cluster the four MUX kernels at the TOP of the column — rows
+// 0..3, which sit 1..4 NoC hops from the eth row (all Blackhole eth cores are at physical row 1) —
+// instead of the spread rows 0 / mid-1 / mid / last, whose farthest core is ~10 hops away.
+// Isolates the MUX->eth distance effect at a fixed schedule.
+inline bool exp_sdpa_mux_top_cluster() {
+    static const bool enabled = std::getenv("TT_EXP_SDPA_MUX_TOP_CLUSTER") != nullptr;
+    return enabled;
+}
 
 // Single source of truth for the DYNAMIC (hash-excluded) global-semaphore address runtime args.
 //
@@ -43,17 +67,21 @@ inline constexpr uint32_t kReaderKernelIdx = 0;
 inline constexpr uint32_t kWriterFabricKernelIdx = 2;
 // Per-core reader runtime-arg slot of the first per-link semaphore address; slots
 // kReaderSemaphoreArgBase .. +num_links-1 hold args.semaphore[lnk].address().
-inline constexpr uint32_t kReaderSemaphoreArgBase = 26;
-// Reader args after the semaphore addresses: ring_size, ring_index, direction.
-inline constexpr uint32_t kReaderTrailingArgCount = 3;
+// Head-serial passes: the Q work descriptor is (q_base, q_stride, q_count) — three args
+// where it used to be (global_q_start, global_q_end) — so every slot after it shifted by 1.
+inline constexpr uint32_t kReaderSemaphoreArgBase = 27;
+// Reader args after the semaphore addresses: ring_size, ring_index, direction, then the
+// split-head forwarding dedup descriptor (dedup_role, buddy_injector_x, buddy_injector_y).
+inline constexpr uint32_t kReaderTrailingArgCount = 6;
 inline constexpr uint32_t reader_arg_count(uint32_t num_links) {
     return kReaderSemaphoreArgBase + num_links + kReaderTrailingArgCount;
 }
 // Per-core fabric-writer runtime-arg slot of out_ready_sem_addr (= args.semaphore[link].address()).
-inline constexpr uint32_t kWriterFabricOutReadySemArg = 25;
+// Shifted by 1 for the (q_base, q_stride, q_count) Q work descriptor — see kReaderSemaphoreArgBase.
+inline constexpr uint32_t kWriterFabricOutReadySemArg = 26;
 // Fabric-writer args after out_ready_sem_addr: injector x/y, num_muxes, mux index, AG Wt/Ht,
-// gathered k/v addresses.
-inline constexpr uint32_t kWriterFabricArgCount = kWriterFabricOutReadySemArg + 9;
+// gathered k/v addresses, dedup_skip_forward (split-head forwarding dedup).
+inline constexpr uint32_t kWriterFabricArgCount = kWriterFabricOutReadySemArg + 10;
 }  // namespace exp_ring_joint_sdpa_dynamic
 
 namespace detail {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1240,7 +1240,10 @@ template <
     uint32_t sliding_window_size = 0,
     bool use_attention_sink = false,
     uint32_t cb_attention_sink = INVALID_CB,
-    bool use_provided_mask = false>
+    bool use_provided_mask = false,
+    // Compile-time gate for q_base_tiles: only the head-serial ring passes read Q at an offset,
+    // and every other caller keeps the original constant-zero index math (and codegen).
+    bool has_q_base_tiles = false>
 static void sdpa_inner_loop_step(
     AccumulatorHalf& prev,
     AccumulatorHalf& cur,
@@ -1264,7 +1267,10 @@ static void sdpa_inner_loop_step(
     const bool apply_sliding_window = false,
     const uint32_t mask_straddle_col = 0,
     const uint32_t mask_straddle_jump = 0,
-    const KVPadRotationContext& kv_pad_rotation = {}) {
+    const KVPadRotationContext& kv_pad_rotation = {},
+    // Tile offset of this call's Q chunk from the front of cb_q_in. Non-zero only for head-serial
+    // ring passes, where cb_q_in holds one resident Q chunk per pass and is popped once at the end.
+    const uint32_t q_base_tiles = 0) {
     // Callers guarantee active_Sk is evenly divisible by actual_sbw (via largest_factor_le).
     const uint32_t kt_num_full_subblocks = active_Sk / actual_sbw;
     constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
@@ -1275,8 +1281,10 @@ static void sdpa_inner_loop_step(
     static_assert(!(use_padded_mask && ring_mode), "use_padded_mask and ring_mode are mutually exclusive");
 
     uint32_t pushed_rows = 0;
-    uint32_t q_wait_tiles = q_subblock_num_tiles;
-    uint32_t q_index_offset = 0;
+    // Q lives at [q_base_tiles, q_base_tiles + Sq_chunk_t*DHt) from the CB front. wait_front counts
+    // from the front, so the wait target includes the chunks of earlier passes that stay resident.
+    uint32_t q_wait_tiles = (has_q_base_tiles ? q_base_tiles : 0) + q_subblock_num_tiles;
+    uint32_t q_index_offset = has_q_base_tiles ? q_base_tiles : 0;
     uint32_t kt_index_offset = 0;
 
     exp_packthread_tile_init<true, scale_fp32, InputClamping::None>();
@@ -2269,6 +2277,12 @@ template <
     bool local_n_mask_enabled = false,
     bool joint_n_mask_enabled = false,
     bool straddle_mask_enabled = false,
+    // Head-serial passes: keep each pass's flash-attention state in an L1 FIFO
+    // ({cb_sum_in, cb_max_in, cb_prev_out}, num_passes+1 entries deep) instead of the caller's
+    // ping-pong halves. Compile-time so non-FIFO callers (normal ring joint) pay zero MATH-thread
+    // instructions for the FIFO branches — the utilization-band perf gates resolve even
+    // fraction-of-a-percent overhead on this path.
+    bool use_l1_state_fifo = false,
     bool kv_pad_rotation_enabled = false,
     uint32_t v_cb_physical_width_t = vDHt,
     bool v_shares_k_buffer = false,
@@ -2306,7 +2320,9 @@ void sdpa_ring_v2(
     const ChunkedContext& chunked = {},
     const bool is_first_active_iter = true,
     // True (unpadded) joint length in tiles; joint K chunks starting at/after it are pure padding.
-    const uint32_t logical_lt = 0) {
+    const uint32_t logical_lt = 0,
+    // Tile offset of this call's Q chunk within cb_q_in (head-serial passes; 0 otherwise).
+    const uint32_t q_base_tiles = 0) {
     init_sdpa_streaming_semaphores();
 
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
@@ -2505,8 +2521,8 @@ void sdpa_ring_v2(
             }
             per_q_valid_kv++;
         }
-        // Use persistent accumulator state from caller (single Q-chunk)
-        // or restore from DRAM (multi Q-chunk).
+        // Use persistent accumulator state from caller (single Q-chunk),
+        // restore from DRAM staging (multi Q-chunk), or pop from the L1 FIFO (head-serial passes).
         AccumulatorHalf q_prev = acc_state.prev, q_cur = acc_state.cur;
 
         const bool is_first_kv_for_this_q = is_first_active_iter;
@@ -2517,7 +2533,11 @@ void sdpa_ring_v2(
         const AccumulatorHalf original_prev = q_prev;
         const bool restore_from_staging = (q_per_core > 1 && !is_first_active_iter);
         ASSERT(!has_sliding_window || !restore_from_staging);
-        if (restore_from_staging) {
+        // FIFO entry: this pass's own state sits at the front (the fixed cyclic pass order
+        // guarantees it), so the first K chunk merges straight out of the FIFO and pops it.
+        // The staging path builds the identical triple, so both share one redirect.
+        const bool fifo_entry = use_l1_state_fifo && !is_first_active_iter;
+        if (restore_from_staging || fifo_entry) {
             q_prev = {cb_sum_in, cb_max_in, cb_prev_out};
         }
 
@@ -2668,10 +2688,15 @@ void sdpa_ring_v2(
             // Writer drains cb_out row-by-row during SALAD; cb_sum_out and cb_max_out bulk after.
             const bool save_to_staging = is_last_k && !is_last_ring_iter && q_per_core > 1;
             ASSERT(!has_sliding_window || !save_to_staging);
-            const uint32_t step_save_out_cb = save_to_staging ? cb_out : INVALID_CB;
-            const uint32_t step_save_max_cb = save_to_staging ? cb_max_out : INVALID_CB;
+            // FIFO exit: sum/out redirect into the FIFO (pack-only, write-pointer relative). max
+            // cannot — the step reads cur.max front-relative — so mirror it via step_save_max_cb.
+            const bool fifo_exit = use_l1_state_fifo && is_last_k && !is_last_ring_iter;
+            const uint32_t step_save_out_cb = save_to_staging ? cb_out : (fifo_exit ? cb_prev_out : INVALID_CB);
+            const uint32_t step_save_max_cb = save_to_staging ? cb_max_out : (fifo_exit ? cb_max_in : INVALID_CB);
             if (save_to_staging) {
                 q_cur.sum = cb_sum_out;
+            } else if (fifo_exit) {
+                q_cur.sum = cb_sum_in;
             }
 
             // K start tile fed to diag stamp must share Q's coord frame (local for is_causal, global for chunked).
@@ -2760,7 +2785,8 @@ void sdpa_ring_v2(
                 sliding_window_size,
                 use_attention_sink,
                 cb_attention_sink,
-                false>(  // use_provided_mask
+                false,               // use_provided_mask
+                use_l1_state_fifo>(  // has_q_base_tiles: head-serial passes read Q at q_base_tiles
                 q_prev,
                 q_cur,
                 is_last_k_of_last_ring_iter,
@@ -2783,7 +2809,8 @@ void sdpa_ring_v2(
                 has_sliding_window,
                 step_straddle_col,
                 step_straddle_jump,
-                step_kv_pad_rotation);
+                step_kv_pad_rotation,
+                q_base_tiles);
 
             // Post-iteration cleanup: pop previous values and swap aliases
             // prev.out and cb_exp_max_diff are already popped row-by-row inside salad_correct_row.
@@ -2797,8 +2824,9 @@ void sdpa_ring_v2(
                 sdpa_cb_pop_front_out_of_line(q_cur.max, Sq_chunk_t);
             } else {
                 std::swap(q_prev, q_cur);
-                // After K0's swap, q_cur holds staging buffers. Reset to original accumulator CBs.
-                if (restore_from_staging && KV_chunks_processed == 1) {
+                // After K0's swap, q_cur holds the staging/FIFO buffers. Reset to the scratch
+                // accumulator CBs so the rest of the pass ping-pongs between scratch halves.
+                if ((restore_from_staging || fifo_entry) && KV_chunks_processed == 1) {
                     q_cur = {original_prev.sum, original_prev.max, original_prev.out};
                 }
             }
@@ -2808,12 +2836,23 @@ void sdpa_ring_v2(
         // Pop Q — not popped inside step since ring_mode gates the early Q pop.
         // When q_per_core == 1, Q is identical across ring iterations so we keep it
         // fronted in the CB and only pop on the last iteration to avoid redundant DRAM re-reads.
-        if (q_per_core > 1 || is_last_ring_iter) {
-            sdpa_cb_pop_front_out_of_line(cb_q_in, Sq_chunk_t * DHt);
+        // Head-serial passes own the pop themselves: all resident chunks are popped together after
+        // the last pass of the last ring iteration, so nothing is popped here.
+        if constexpr (!use_l1_state_fifo) {
+            if (q_per_core > 1 || is_last_ring_iter) {
+                sdpa_cb_pop_front_out_of_line(cb_q_in, Sq_chunk_t * DHt);
+            }
         }
 
-        // Persist or save accumulators for next ring iteration
-        if (q_per_core == 1) {
+        // Persist or save accumulators for next ring iteration.
+        //
+        // FIFO passes persist nothing. Only the scratch max (mirrored, not redirected) is left;
+        // after the last swap it is q_prev.max — pop it.
+        if constexpr (use_l1_state_fifo) {
+            if (!is_last_ring_iter) {
+                sdpa_cb_pop_front_out_of_line(q_prev.max, Sq_chunk_t);
+            }
+        } else if (q_per_core == 1) {
             // Single Q-chunk: persist in L1 (no DRAM round-trip)
             acc_state.prev = q_prev;
             acc_state.cur = q_cur;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -15,37 +15,34 @@
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_fused_op_indexer.hpp"
 
 void kernel_main() {
-    constexpr uint32_t NH = get_compile_time_arg_val(0);
-    constexpr uint32_t DHt = get_compile_time_arg_val(1);
-    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(2);
-    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(3);
-    constexpr uint32_t local_padded_N = get_compile_time_arg_val(4);
-    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(5);
-    constexpr uint32_t logical_n = get_compile_time_arg_val(6);
-    constexpr uint32_t logical_nt = get_compile_time_arg_val(7);
-    constexpr uint32_t Lt = get_compile_time_arg_val(8);
-    constexpr uint32_t L = get_compile_time_arg_val(9);
-    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(10);
-    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(11);
-    constexpr uint32_t ring_size = get_compile_time_arg_val(12);
+    constexpr uint32_t DHt = get_compile_time_arg_val(0);
+    constexpr uint32_t Sq_chunk_t = get_compile_time_arg_val(1);
+    constexpr uint32_t Sk_chunk_t = get_compile_time_arg_val(2);
+    constexpr uint32_t local_padded_N = get_compile_time_arg_val(3);
+    constexpr uint32_t local_padded_Nt = get_compile_time_arg_val(4);
+    constexpr uint32_t logical_n = get_compile_time_arg_val(5);
+    constexpr uint32_t logical_nt = get_compile_time_arg_val(6);
+    constexpr uint32_t Lt = get_compile_time_arg_val(7);
+    constexpr uint32_t L = get_compile_time_arg_val(8);
+    constexpr uint32_t num_local_k_chunks = get_compile_time_arg_val(9);
+    constexpr uint32_t num_joint_k_chunks = get_compile_time_arg_val(10);
+    constexpr uint32_t ring_size = get_compile_time_arg_val(11);
 
-    constexpr uint32_t qk_in0_block_w = get_compile_time_arg_val(13);
-    constexpr uint32_t qk_subblock_w = get_compile_time_arg_val(14);
-    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(15);
-    constexpr uint32_t qk_in0_num_subblocks = get_compile_time_arg_val(16);
-    constexpr uint32_t qk_in1_num_subblocks = get_compile_time_arg_val(17);
-    constexpr uint32_t qk_num_blocks = get_compile_time_arg_val(18);
-    constexpr uint32_t out_in0_block_w = get_compile_time_arg_val(19);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(20);
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(21);
-    constexpr uint32_t out_in0_num_subblocks = get_compile_time_arg_val(22);
-    constexpr uint32_t out_in1_num_subblocks = get_compile_time_arg_val(23);
-    constexpr uint32_t out_num_blocks = get_compile_time_arg_val(24);
+    constexpr uint32_t qk_subblock_w = get_compile_time_arg_val(12);
+    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(13);
+    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(14);
+    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(15);
 
-    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(25);
-    constexpr bool use_streaming_compute = get_compile_time_arg_val(26) == 1;
-    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(27);
-    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(28);
+    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(16);
+    constexpr bool use_streaming_compute = get_compile_time_arg_val(17) == 1;
+    constexpr uint32_t global_n_partial_col = get_compile_time_arg_val(18);
+    constexpr uint32_t joint_l_partial_col = get_compile_time_arg_val(19);
+    // Streamed Q (host fallback when resident Q does not fit L1): cb_q_in holds one chunk; every
+    // pass reads at offset 0 and pops its chunk at pass end so the reader can load the next one.
+    constexpr bool stream_q = get_compile_time_arg_val(20) == 1;
+    // Multi-pass programs keep per-pass accumulator state in the L1 FIFO; single-pass programs
+    // use the original persist-in-scratch path (no FIFO entry/exit cost per ring iteration).
+    constexpr bool use_state_fifo = get_compile_time_arg_val(21) == 1;
 
     // Lightweight mask: all mask tiles live in cb_mask_in (c_3).
     // Layout: [neginf(0)] [global_n_partial?(1)] [joint_l_partial?(1 or 2)]
@@ -62,16 +59,15 @@ void kernel_main() {
     constexpr uint32_t total_mask_tiles = 1 + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
     uint32_t argidx = 0;
-    const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t q_per_core = global_q_end - global_q_start;
+    // Head-serial passes: this core owns flat Q chunks q_base + p * q_stride for p in [0, q_count),
+    // i.e. one chunk of head (p * grid_rows + my_row) per pass. See the program factory.
+    const uint32_t q_base = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_stride = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_count = get_arg_val<uint32_t>(argidx++);
 
     RingSDPAOpIndexer fused_op_indexer = RingSDPAOpIndexer(argidx);
 
     constexpr uint32_t q_chunk_tiles = Sq_chunk_t * DHt;
-    constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
-    constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
-    constexpr uint32_t out_chunk_tiles = Sq_chunk_t * DHt;
 
     constexpr uint32_t cb_q_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_k_in = tt::CBIndex::c_1;
@@ -81,7 +77,6 @@ void kernel_main() {
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
     constexpr uint32_t cb_max_in = tt::CBIndex::c_6;  // deferred norm: running max
-    constexpr uint32_t cb_lse_in = tt::CBIndex::c_6;  // eager norm: LSE
     constexpr uint32_t cb_prev_out = tt::CBIndex::c_7;
     constexpr uint32_t cb_qk_im = tt::CBIndex::c_24;
     constexpr uint32_t cb_out_im_A = tt::CBIndex::c_25;
@@ -94,7 +89,6 @@ void kernel_main() {
 
     constexpr uint32_t cb_out = tt::CBIndex::c_16;
     constexpr uint32_t cb_max_out = tt::CBIndex::c_17;  // deferred norm: running max
-    constexpr uint32_t cb_lse_out = tt::CBIndex::c_17;  // eager norm: LSE
 
     // Streaming compute uses c_9 as 1-tile recip scratch for normalize_row_streaming.
     // (c_4 is used by cb_scale_in in ring joint SDPA, unlike regular SDPA.)
@@ -105,7 +99,10 @@ void kernel_main() {
     constexpr uint32_t cb_sum_in = tt::CBIndex::c_11;
     constexpr uint32_t cb_signal = tt::CBIndex::c_12;
 
-    constexpr uint32_t num_q_chunks = local_padded_Nt / Sq_chunk_t + Lt / Sq_chunk_t;
+    // div_up: the last local chunk may be partial (padded Q rows). Matches the factory's
+    // num_q_chunks so flat-id decoding stays consistent across host and kernels.
+    constexpr uint32_t num_q_chunks =
+        (local_padded_Nt + Sq_chunk_t - 1) / Sq_chunk_t + (Lt + Sq_chunk_t - 1) / Sq_chunk_t;
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_q_in, cb_k_in, cb_qk_im);
     matmul_init(cb_q_in, cb_k_in);
@@ -127,9 +124,13 @@ void kernel_main() {
         (local_padded_Nt % Sk_chunk_t != 0) ? (Sk_chunk_t - (local_padded_Nt % Sk_chunk_t)) : 0;
     constexpr uint32_t joint_n_padded_tiles = (Lt % Sk_chunk_t != 0) ? (Sk_chunk_t - (Lt % Sk_chunk_t)) : 0;
 
-    RingAccumulatorState acc_state = {
-        {cb_sum_A, cb_max_A, cb_out_im_A},  // prev
-        {cb_sum_B, cb_max_B, cb_out_im_B},  // cur
+    // Fixed scratch halves for the within-pass ping-pong. Unlike the single-head path these are
+    // never rewritten: cross-ring-iteration state lives in the L1 state FIFO
+    // ({cb_sum_in, cb_max_in, cb_prev_out} = {c_11, c_6, c_7}), one entry per pass, so every pass
+    // starts from the same scratch roles. See sdpa_ring_v2's use_l1_state_fifo.
+    RingAccumulatorState scratch_state = {
+        {cb_sum_A, cb_max_A, cb_out_im_A},  // prev-scratch
+        {cb_sum_B, cb_max_B, cb_out_im_B},  // cur-scratch
     };
 
     const uint32_t last_active_ring_iter =
@@ -185,7 +186,13 @@ void kernel_main() {
 
         const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
         static_assert(use_streaming_compute, "Streaming compute must be enabled for ring joint SDPA");
-        if constexpr (use_streaming_compute) {
+
+        // Serial passes over this row's heads, same order as the reader and writer. Each pass is a
+        // single-Q-chunk sdpa_ring_v2 call (q_per_core == 1), so every L1-residency property of the
+        // single-head path holds per pass; the only per-pass state is which Q chunk it reads from
+        // cb_q_in (q_base_tiles) and which L1 FIFO entry it merges (handled inside sdpa_ring_v2).
+        for (uint32_t pass = 0; pass < q_count; ++pass) {
+            const uint32_t global_q_chunk = q_base + pass * q_stride;
             sdpa_ring_v2<
                 Sq_chunk_t,
                 Sk_chunk_t,
@@ -225,9 +232,10 @@ void kernel_main() {
                 global_n_has_padding,
                 local_n_has_padding,
                 joint_has_padding,
-                false>(  // straddle_mask_enabled
-                global_q_start,
-                global_q_end,
+                false,            // straddle_mask_enabled
+                use_state_fifo>(  // use_l1_state_fifo — single-pass programs keep the scratch path
+                global_q_chunk,
+                global_q_chunk + 1,
                 num_kv_chunks,
                 num_q_chunks,
                 ring_iter,
@@ -240,79 +248,32 @@ void kernel_main() {
                 global_n_mask_chunk_id,
                 local_n_mask_chunk_id,
                 joint_n_mask_chunk_id,
-                acc_state,
+                scratch_state,
                 is_last_ring_iter,
-                q_per_core,
+                /*q_per_core=*/1,
                 lw_mask,
                 /*skip_first_half_q=*/false,
                 /*use_zigzag_balancing=*/false,
                 ChunkedContext{},
-                /*is_first_active_iter=*/(ring_iter == 0));
-        } else {
-            sdpa_ring<
-                cb_qk_im,
-                cb_identity_scale_in,
-                cb_scale_in,
-                Sq_chunk_t,
-                Sk_chunk_t,
-                NH,
-                DHt,
-                DHt,
-                scale_fp32,
-                needs_lightweight_mask>(
-                qk_in0_block_w,
-                qk_subblock_w,
-                qk_subblock_h,
-                qk_in0_num_subblocks,
-                qk_in1_num_subblocks,
-                qk_num_blocks,
-                out_in0_block_w,
-                out_subblock_w,
-                out_subblock_h,
-                out_in0_num_subblocks,
-                out_in1_num_subblocks,
-                out_num_blocks,
-                global_q_start,
-                global_q_end,
-                0,              // q_num_chunks
-                0,              // iter_k_chunk_start
-                num_kv_chunks,  // iter_k_chunk_end
-                q_chunk_tiles,
-                k_chunk_tiles,
-                k_chunk_tiles,  // v_chunk_tiles = k_chunk_tiles (vDHt = DHt)
-                qk_chunk_tiles,
-                out_chunk_tiles,
-                ring_iter,
-                ring_id,
-                num_local_k_chunks,
-                local_padded_Nt,
-                logical_nt,
-                ring_iter_needs_global_n_mask,
-                ring_iter_needs_joint_n_mask,
-                local_n_needs_masking,
-                global_n_mask_chunk_id,
-                local_n_mask_chunk_id,
-                joint_n_mask_chunk_id,
-                cb_q_in,
-                cb_k_in,
-                cb_v_in,
-                cb_mask_in,
-                cb_col_identity,
-                cb_out_im_A,
-                cb_out_im_B,
-                cb_max_A,
-                cb_max_B,
-                cb_sum_A,
-                cb_sum_B,
-                cb_exp_max_diff,
-                cb_lse_in,
-                cb_lse_out,
-                cb_prev_out,
-                cb_out,
-                lw_mask,
-                false,  // is_causal
-                false,  // is_balanced
-                is_last_ring_iter);
+                /*is_first_active_iter=*/(ring_iter == 0),
+                /*logical_lt=*/0,
+                /*q_base_tiles=*/stream_q ? 0u : pass * q_chunk_tiles);
+
+            if constexpr (stream_q) {
+                // This pass's chunk is spent; free the slot so the reader can load the next pass's
+                // chunk. Uniform on every core (q_count == 1 rows re-read too).
+                sdpa_cb_pop_front_out_of_line(cb_q_in, q_chunk_tiles);
+            }
+        }
+
+        if constexpr (!stream_q && use_state_fifo) {
+            // All q_count Q chunks stay resident in cb_q_in for the whole op (each read once, on the
+            // first active ring iteration) and are popped together once the last pass has consumed
+            // them. On the scratch path (!use_state_fifo) sdpa_ring_v2 pops the single resident
+            // chunk itself on the last ring iteration — popping here too would double-pop.
+            if (is_last_ring_iter) {
+                sdpa_cb_pop_front_out_of_line(cb_q_in, q_count * q_chunk_tiles);
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -411,6 +411,7 @@ void kernel_main() {
                 local_n_has_padding,
                 joint_has_padding,
                 has_straddle && is_causal && is_balanced,
+                false,  // use_l1_state_fifo — compile-time off: no FIFO branch overhead here
                 kv_pad_rotation_enabled,
                 v_cb_physical_width_t,
                 v_shares_k_buffer,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_reader.cpp
@@ -51,22 +51,21 @@ void kernel_main() {
     const uint32_t joint_q_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t joint_k_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t joint_v_addr = get_arg_val<uint32_t>(argidx++);
-    const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t q_per_core = global_q_end - global_q_start;
+    // Head-serial passes: this core owns flat Q chunks q_base + p * q_stride for p in [0, q_count),
+    // i.e. one chunk of head (p * grid_rows + my_row) per pass. See the program factory.
+    const uint32_t q_base = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_stride = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_count = get_arg_val<uint32_t>(argidx++);
 
     const uint32_t is_chain_participant = get_arg_val<uint32_t>(argidx++);
     const uint32_t is_injector = get_arg_val<uint32_t>(argidx++);
     const uint32_t is_sink = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_batch = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_head = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_q_chunk_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t chain_q_chunk_count = get_arg_val<uint32_t>(argidx++);
+    argidx += 4;  // skip chain batch/head/chunk_start/count (unused)
     const uint32_t prev_physical_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t prev_physical_y = get_arg_val<uint32_t>(argidx++);
     const uint32_t next_physical_x = get_arg_val<uint32_t>(argidx++);
     const uint32_t next_physical_y = get_arg_val<uint32_t>(argidx++);
-    const uint32_t next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
+    argidx++;  // skip next_core_q_chunks (unused)
     const uint32_t mcast_num_dests = get_arg_val<uint32_t>(argidx++);
     const uint32_t mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
 
@@ -83,6 +82,13 @@ void kernel_main() {
 
     RingSDPAOpIndexer fused_op_indexer = RingSDPAOpIndexer(argidx);
 
+    // Split-head forwarding dedup descriptor (meaningful on injector cores only):
+    // 0 = none, 1 = leader (gate on fabric, relay each gate pass to the buddy injector),
+    // 2 = follower (this row's remote twin forwards nothing; gate on the leader's relay).
+    const uint32_t dedup_role = get_arg_val<uint32_t>(argidx++);
+    const uint32_t buddy_injector_x = get_arg_val<uint32_t>(argidx++);
+    const uint32_t buddy_injector_y = get_arg_val<uint32_t>(argidx++);
+
     // After fused-op receiver consumed its runtime args, remaining RT args are S&F chain metadata
 
     // Compile-time semaphore ids and mcast flag are appended after all TensorAccessorArgs().
@@ -91,9 +97,32 @@ void kernel_main() {
     const uint32_t receiver_semaphore_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 1);
     const uint32_t valid_semaphore_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 2);
     constexpr bool mcast_enabled = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 3) == 1;
+    // Streamed Q (host fallback when resident Q does not fit L1): cb_q_in holds one chunk, so each
+    // pass's Q is re-read every ring iteration and compute pops it at the end of the pass.
+    constexpr bool stream_q = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 4) == 1;
+    // Ping-pong valid flag: K broadcasts land on receiver_semaphore_id, V broadcasts on this one.
+    // Separate flags per channel let a receiver post its credit (reserve + flag reset + ack) for
+    // chunk n+1 immediately after consuming chunk n, so the injector never waits a post-receipt
+    // round trip between consecutive mcasts (V of chunk n and K of chunk n+1 overlap in flight).
+    const uint32_t receiver_semaphore_b_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 5);
+    // V-channel ack counter, separate from the K-channel counter (sender_semaphore_id). K and V
+    // ack totals MUST be counted independently: K credits run one chunk ahead of V credits, so a
+    // combined total would let fast receivers' K(n+1) credits mask a slow receiver's missing V(n)
+    // credit, releasing the V(n) mcast before that receiver reset its V flag (lost VALID ->
+    // deadlock). Per channel, a receiver is at most one credit ahead — exactly the awaited event.
+    const uint32_t sender_semaphore_v_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 6);
+    // Split-head forwarding dedup buddy gate (see the AG gate below).
+    const uint32_t buddy_gate_semaphore_id = get_compile_time_arg_val(joint_v_args.next_compile_time_args_offset() + 7);
 
     // Receiver flips this to INVALID before each wait; initialize so the first iteration sees it as VALID.
     Semaphore<>(valid_semaphore_id).set(VALID);
+
+    // Injector-side cumulative ack target for the ping-pong protocol. Receivers only ever
+    // increment sender_semaphore (one ack per K or V chunk credit); the injector waits for the
+    // running total instead of wait(N)+set(0), which would race with credits pre-posted for the
+    // next chunk. Reset to 0 at kernel end for cached-program reruns.
+    [[maybe_unused]] uint32_t mcast_k_acks_expected = 0;
+    [[maybe_unused]] uint32_t mcast_v_acks_expected = 0;
 
     uint32_t sender_wait_count = 1;
     if constexpr (mcast_enabled) {
@@ -142,9 +171,11 @@ void kernel_main() {
     const uint32_t last_active_ring_iter =
         find_last_active_ring_iter(fused_op_indexer.seq, local_padded_Nt, logical_n / tt::constants::TILE_HEIGHT, L);
 
-    // Tracks whether Q has been pushed for q_per_core == 1 optimization.
-    // When q_per_core == 1, Q is identical across ring iterations so we only push it once.
-    bool q_pushed = false;
+    // Number of Q chunks already pushed to cb_q_in. Q is identical across ring iterations; with
+    // resident Q each pass reads its head's chunk exactly once (on the first active ring iteration)
+    // and all q_count chunks stay resident until compute pops them after the last pass of the last
+    // iteration. With streamed Q (stream_q) every pass re-reads its chunk every active iteration.
+    uint32_t q_chunks_pushed = 0;
 
     uint32_t chunks_signaled_by_remote = 0;
 
@@ -167,14 +198,32 @@ void kernel_main() {
         const bool ring_iter_does_work = ring_iter_processes_KV_chunks || (do_joint_kv && L != 0);
 
         const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
-        const bool mux_forward_this_iter = is_mux_writer && !is_last_ring_iter;
 
-        uint32_t KV_chunks_processed_in_iter = 0;
         if (!ring_iter_does_work) {
             continue;
         }
 
-        for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
+        // Non-skipped KV chunk count this ring iteration (identical for every pass — the skip
+        // predicate depends only on ring_id). Caps the ping-pong credit pre-posting so a receiver
+        // never acks a chunk the injector will not send: a stale credit would let a later mcast
+        // bypass its receiver handshake and clobber an unconsumed CB slot.
+        uint32_t chunks_this_iter = 0;
+        for (uint32_t kc = 0; kc < num_kv_chunks; ++kc) {
+            const bool kc_is_joint = kc >= num_local_k_chunks;
+            const uint32_t kc_global_start_tile = local_padded_Nt * ring_id + kc * Sk_chunk_t;
+            if (!kc_is_joint && kc_global_start_tile >= logical_nt) {
+                continue;
+            }
+            chunks_this_iter++;
+        }
+
+        // Passes are serial within a ring iteration: pass p attends head (p * rows + my_row) against
+        // this iteration's K/V shard. Every core of a row runs the same number of passes in the same
+        // order, which is what keeps the row's K/V CB pointers in lockstep for the mcast.
+        for (uint32_t pass = 0; pass < q_count; ++pass) {
+            const uint32_t global_q_chunk = q_base + pass * q_stride;
+            // Counted per pass: compute drains its phase-alignment padding per pass too.
+            uint32_t KV_chunks_processed_in_iter = 0;
             // global_q_chunk is index into `B * NH * num_q_chunks`. Need to get nb, nq, q_chunk from this.
             const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
             const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
@@ -195,15 +244,54 @@ void kernel_main() {
                 q_end_seq_tile = local_padded_Nt;
             }
 
-            // Chain forwarding conditions are k_chunk-invariant — compute once before the KV loop
-            const uint32_t q_iter_local = global_q_chunk - global_q_start;
-            const bool should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
-                                        (q_iter_local < next_core_q_chunks);
-            const bool should_receive = is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
+            // Every chunk this core owns is on its row's chain, so participation alone decides.
+            const bool should_forward = is_chain_participant && !is_sink;
+            const bool should_receive = is_chain_participant && !is_injector;
 
-            // When q_per_core == 1, Q is identical across ring iterations: compute keeps it
-            // fronted in the CB, so we only need to read it once on the first active ring iteration.
-            const bool need_q_read = (q_per_core > 1) || !q_pushed;
+            // Ping-pong receive credits (mcast path only). A credit = reserve the next chunk's CB
+            // slot, reset that channel's valid flag, then ack the injector. Order matters: the
+            // reset must precede the ack, because the injector's mcast for that chunk (data +
+            // valid relay) is released by the ack — resetting after could erase an already-landed
+            // VALID. The reserve must precede the ack so the mcast has a landing slot; it also
+            // provides compute-paced backpressure (reserving chunk n+1 waits for chunk n-1's pop).
+            // Credits are capped at chunks_this_iter so the ack total exactly matches the
+            // injector's cumulative expectation.
+            uint32_t k_credits = 0;
+            uint32_t v_credits = 0;
+            auto post_k_credit = [&]() {
+                if (k_credits < chunks_this_iter) {
+                    CircularBuffer(cb_k_in).reserve_back(k_chunk_tiles);
+                    if (is_mux_writer) {
+                        CircularBuffer(cb_k_writer_in).reserve_back(k_chunk_tiles);
+                    }
+                    Semaphore<>(receiver_semaphore_id).set(INVALID);
+                    Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                    k_credits++;
+                }
+            };
+            auto post_v_credit = [&]() {
+                if (v_credits < chunks_this_iter) {
+                    CircularBuffer(cb_v_in).reserve_back(v_chunk_tiles);
+                    if (is_mux_writer) {
+                        CircularBuffer(cb_v_writer_in).reserve_back(v_chunk_tiles);
+                    }
+                    Semaphore<>(receiver_semaphore_b_id).set(INVALID);
+                    Semaphore<>(sender_semaphore_v_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                    v_credits++;
+                }
+            };
+            if constexpr (mcast_enabled) {
+                if (should_receive) {
+                    // Prime the pipeline: credits for the first K and V chunks of this pass.
+                    post_k_credit();
+                    post_v_credit();
+                }
+            }
+
+            // Resident Q: read this pass's chunk exactly once, on the first active ring iteration.
+            // Streamed Q: read it every pass, every active iteration (the reserve blocks until
+            // compute's pass-end pop frees the single slot — a bounded stall, never a deadlock).
+            const bool need_q_read = stream_q || (q_chunks_pushed <= pass);
 
             for (uint32_t k_chunk = 0; k_chunk < num_kv_chunks; ++k_chunk) {
                 /**
@@ -248,43 +336,75 @@ void kernel_main() {
                 // Per-chunk sync: wait for EACH link's MUX writer to finish writing this chunk
                 if (is_injector && ring_iter > 0 && !kv_chunk_is_joint) {
                     chunks_signaled_by_remote++;
-                    for (uint32_t lnk = 0; lnk < num_links; ++lnk) {
-                        noc_semaphore_wait_min(per_link_sem_ptrs[lnk], chunks_signaled_by_remote);
+                    if (dedup_role == 2) {
+                        // Split-head dedup follower: the remote twin of this row forwards nothing.
+                        // The leader row of the pair (same device, same head, same deterministic
+                        // ring sequence, same gathered region) relays its gate result here.
+                        Semaphore<>(buddy_gate_semaphore_id).wait_min(chunks_signaled_by_remote);
+                    } else {
+                        for (uint32_t lnk = 0; lnk < num_links; ++lnk) {
+                            noc_semaphore_wait_min(per_link_sem_ptrs[lnk], chunks_signaled_by_remote);
+                        }
+                        if (dedup_role == 1) {
+                            // Leader: this chunk of the shared head is proven present in the
+                            // gathered tensor — release the follower row's injector.
+                            Semaphore<>(buddy_gate_semaphore_id).up(noc, buddy_injector_x, buddy_injector_y, 1);
+                        }
                     }
                 }
 
-                // K: get data into CB buffer
+                // K: get data into CB buffer. On the mcast path a receiver's slot was already
+                // reserved when its credit was posted (see post_k_credit), so it only waits for
+                // the valid flag here; the injector reserves/fetches as before.
                 CircularBuffer cb_k(cb_k_in);
                 CircularBuffer cb_k_writer(cb_k_writer_in);
-                cb_k.reserve_back(k_chunk_tiles);
-                if (is_mux_writer) {
-                    cb_k_writer.reserve_back(k_chunk_tiles);
+                uint32_t cb_k_start_address = 0;
+                bool k_mcast_receive = false;
+                if constexpr (mcast_enabled) {
+                    k_mcast_receive = should_receive;
                 }
-                uint32_t cb_k_start_address = cb_k.get_write_ptr();
-                if (should_receive) {
-                    Semaphore<> receiver_sem(receiver_semaphore_id);
-                    receiver_sem.set(INVALID);
-                    Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
-                    receiver_sem.wait(VALID);
+                if (k_mcast_receive) {
+                    Semaphore<>(receiver_semaphore_id).wait(VALID);
                 } else {
-                    fetch_block(
-                        kv_chunk_is_joint ? joint_k_generator
-                                          : (ring_iter == 0 ? local_k_generator : gathered_k_generator),
-                        kv_slice,
-                        end_seq_tile,
-                        cb_k_in,
-                        cb_k_start_address,
-                        k_tile_bytes,
-                        true /*transpose*/
-                    );
+                    cb_k.reserve_back(k_chunk_tiles);
+                    if (is_mux_writer) {
+                        cb_k_writer.reserve_back(k_chunk_tiles);
+                    }
+                    cb_k_start_address = cb_k.get_write_ptr();
+                    if (should_receive) {
+                        // Unicast-chain path (mcast disabled): original 1-deep handshake.
+                        Semaphore<> receiver_sem(receiver_semaphore_id);
+                        receiver_sem.set(INVALID);
+                        Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                        receiver_sem.wait(VALID);
+                    } else {
+                        fetch_block(
+                            kv_chunk_is_joint ? joint_k_generator
+                                              : (ring_iter == 0 ? local_k_generator : gathered_k_generator),
+                            kv_slice,
+                            end_seq_tile,
+                            cb_k_in,
+                            cb_k_start_address,
+                            k_tile_bytes,
+                            true /*transpose*/
+                        );
+                    }
                 }
 
                 // Forward K to next core(s) before push_back — prevents compute from
                 // popping the buffer while the mcast is still reading from it.
                 if (should_forward) {
-                    Semaphore<> sender_sem(sender_semaphore_id);
-                    sender_sem.wait(sender_wait_count);
-                    sender_sem.set(0);
+                    if constexpr (mcast_enabled) {
+                        // Receivers pre-post their credit for this chunk right after consuming the
+                        // previous K chunk, so this wait is normally already satisfied — the
+                        // post-receipt round trip is off the critical path.
+                        mcast_k_acks_expected += sender_wait_count;
+                        Semaphore<>(sender_semaphore_id).wait_min(mcast_k_acks_expected);
+                    } else {
+                        Semaphore<> sender_sem(sender_semaphore_id);
+                        sender_sem.wait(sender_wait_count);
+                        sender_sem.set(0);
+                    }
                     if constexpr (mcast_enabled) {
                         noc.async_write_multicast(
                             CoreLocalMem<uint32_t>(cb_k_start_address),
@@ -331,6 +451,11 @@ void kernel_main() {
                     cb_k_writer.push_back(k_chunk_tiles);
                     ASSERT(cb_k.get_write_ptr() == cb_k_writer.get_write_ptr());
                 }
+                // Credit the NEXT K chunk now (reserve after push keeps the CB cursor correct),
+                // so the injector's next K mcast is released before this core reaches its wait.
+                if (k_mcast_receive) {
+                    post_k_credit();
+                }
 
                 // Download Q on the first K iteration — after K is downloaded and forwarded.
                 // Push Q one subblock at a time so compute can start QK matmul incrementally.
@@ -357,41 +482,57 @@ void kernel_main() {
                             false /*transpose*/
                         );
                     }
-                    q_pushed = true;
+                    q_chunks_pushed++;
                 }
 
-                // V: get data into CB buffer
+                // V: get data into CB buffer — same ping-pong structure as K, on the second
+                // valid flag (receiver_semaphore_b_id).
                 CircularBuffer cb_v(cb_v_in);
                 CircularBuffer cb_v_writer(cb_v_writer_in);
-                cb_v.reserve_back(v_chunk_tiles);
-                if (is_mux_writer) {
-                    cb_v_writer.reserve_back(v_chunk_tiles);
+                uint32_t cb_v_start_address = 0;
+                bool v_mcast_receive = false;
+                if constexpr (mcast_enabled) {
+                    v_mcast_receive = should_receive;
                 }
-                uint32_t cb_v_start_address = cb_v.get_write_ptr();
-                if (should_receive) {
-                    Semaphore<> receiver_sem(receiver_semaphore_id);
-                    receiver_sem.set(INVALID);
-                    Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
-                    receiver_sem.wait(VALID);
+                if (v_mcast_receive) {
+                    Semaphore<>(receiver_semaphore_b_id).wait(VALID);
                 } else {
-                    fetch_block(
-                        kv_chunk_is_joint ? joint_v_generator
-                                          : (ring_iter == 0 ? local_v_generator : gathered_v_generator),
-                        kv_slice,
-                        end_seq_tile,
-                        cb_v_in,
-                        cb_v_start_address,
-                        v_tile_bytes,
-                        false /*transpose*/
-                    );
+                    cb_v.reserve_back(v_chunk_tiles);
+                    if (is_mux_writer) {
+                        cb_v_writer.reserve_back(v_chunk_tiles);
+                    }
+                    cb_v_start_address = cb_v.get_write_ptr();
+                    if (should_receive) {
+                        // Unicast-chain path (mcast disabled): original 1-deep handshake.
+                        Semaphore<> receiver_sem(receiver_semaphore_id);
+                        receiver_sem.set(INVALID);
+                        Semaphore<>(sender_semaphore_id).up(noc, prev_physical_x, prev_physical_y, 1);
+                        receiver_sem.wait(VALID);
+                    } else {
+                        fetch_block(
+                            kv_chunk_is_joint ? joint_v_generator
+                                              : (ring_iter == 0 ? local_v_generator : gathered_v_generator),
+                            kv_slice,
+                            end_seq_tile,
+                            cb_v_in,
+                            cb_v_start_address,
+                            v_tile_bytes,
+                            false /*transpose*/
+                        );
+                    }
                 }
 
                 // Forward V to next core(s) before push_back — prevents compute from
                 // popping the buffer while the mcast is still reading from it.
                 if (should_forward) {
-                    Semaphore<> sender_sem(sender_semaphore_id);
-                    sender_sem.wait(sender_wait_count);
-                    sender_sem.set(0);
+                    if constexpr (mcast_enabled) {
+                        mcast_v_acks_expected += sender_wait_count;
+                        Semaphore<>(sender_semaphore_v_id).wait_min(mcast_v_acks_expected);
+                    } else {
+                        Semaphore<> sender_sem(sender_semaphore_id);
+                        sender_sem.wait(sender_wait_count);
+                        sender_sem.set(0);
+                    }
                     if constexpr (mcast_enabled) {
                         noc.async_write_multicast(
                             CoreLocalMem<uint32_t>(cb_v_start_address),
@@ -406,10 +547,11 @@ void kernel_main() {
                              .addr = cb_v_start_address},
                             true /* linked: semaphore mcast follows */);
                         // Companion semaphore mcast — see K path above for rationale.
+                        // V lands on the second (ping-pong) valid flag.
                         Semaphore<>(valid_semaphore_id)
                             .relay_multicast(
                                 noc,
-                                Semaphore<>(receiver_semaphore_id),
+                                Semaphore<>(receiver_semaphore_b_id),
                                 prev_physical_x,
                                 prev_physical_y,
                                 next_physical_x,
@@ -437,23 +579,31 @@ void kernel_main() {
                     cb_v_writer.push_back(v_chunk_tiles);
                     ASSERT(cb_v.get_write_ptr() == cb_v_writer.get_write_ptr());
                 }
+                // Credit the NEXT V chunk (see the K credit above).
+                if (v_mcast_receive) {
+                    post_v_credit();
+                }
             }
-        }
 
-        if (KV_chunks_processed_in_iter % 2 == 0) {
-            CircularBuffer cb_k(cb_k_in);
-            CircularBuffer cb_v(cb_v_in);
-            cb_k.reserve_back(k_chunk_tiles);
-            cb_v.reserve_back(k_chunk_tiles);
-            cb_k.push_back(k_chunk_tiles);
-            cb_v.push_back(k_chunk_tiles);
-            if (is_mux_writer) {
-                CircularBuffer cb_k_writer(cb_k_writer_in);
-                CircularBuffer cb_v_writer(cb_v_writer_in);
-                cb_k_writer.reserve_back(k_chunk_tiles);
-                cb_v_writer.reserve_back(v_chunk_tiles);
-                cb_k_writer.push_back(k_chunk_tiles);
-                cb_v_writer.push_back(v_chunk_tiles);
+            // Phase-alignment padding, per pass. Compute pads once per pass (one sdpa_ring_v2 call
+            // per pass, each ending in dummy_kv_chunks_for_phase_alignment), so the reader must pad
+            // at the same granularity or the K/V CB phases diverge. The exchange is core-local:
+            // reserve/push on our own CBs, no fetch and no mcast.
+            if (KV_chunks_processed_in_iter % 2 == 0) {
+                CircularBuffer cb_k(cb_k_in);
+                CircularBuffer cb_v(cb_v_in);
+                cb_k.reserve_back(k_chunk_tiles);
+                cb_v.reserve_back(k_chunk_tiles);
+                cb_k.push_back(k_chunk_tiles);
+                cb_v.push_back(k_chunk_tiles);
+                if (is_mux_writer) {
+                    CircularBuffer cb_k_writer(cb_k_writer_in);
+                    CircularBuffer cb_v_writer(cb_v_writer_in);
+                    cb_k_writer.reserve_back(k_chunk_tiles);
+                    cb_v_writer.reserve_back(v_chunk_tiles);
+                    cb_k_writer.push_back(k_chunk_tiles);
+                    cb_v_writer.push_back(v_chunk_tiles);
+                }
             }
         }
     }
@@ -463,6 +613,19 @@ void kernel_main() {
         for (uint32_t lnk = 0; lnk < num_links; ++lnk) {
             // noc_semaphore_wait_min(per_link_sem_ptrs[lnk], chunks_signaled_by_remote+1);
             noc_semaphore_set(per_link_sem_ptrs[lnk], 0);
+        }
+        if constexpr (mcast_enabled) {
+            // The cumulative ping-pong ack counters must restart at 0 on a cached-program rerun.
+            // Safe: the last forward's waits already observed every ack (credit caps guarantee
+            // the receivers' ack totals equal the injector's expected totals), so none are in flight.
+            Semaphore<>(sender_semaphore_id).set(0);
+            Semaphore<>(sender_semaphore_v_id).set(0);
+        }
+        if (dedup_role == 2) {
+            // Follower's buddy gate is cumulative — restart at 0 for cached reruns. Safe: the
+            // final wait_min observed the leader's full count (leader and follower run identical
+            // gate schedules), so no incs are in flight.
+            Semaphore<>(buddy_gate_semaphore_id).set(0);
         }
     }
     noc.async_writes_flushed();

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -106,7 +106,6 @@ void kernel_main() {
     constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(mux_ct_base + 3);
     constexpr uint32_t num_mux_clients = get_compile_time_arg_val(mux_ct_base + 4);
 
-
     // All-gather CT args (following 5 MUX CT args)
     constexpr uint32_t ag_ct_base = mux_ct_base + 5;
     constexpr uint32_t ag_packet_size_in_pages = get_compile_time_arg_val(ag_ct_base + 0);
@@ -119,10 +118,12 @@ void kernel_main() {
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t joint_out_addr = get_arg_val<uint32_t>(argidx++);
     argidx++;  // skip stats_addr (unused — stats only needed for multi-Q accumulator save)
-    const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
-    const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    // Only one Q chunk per core is allowed
-    ASSERT(global_q_end - global_q_start <= 1);
+    // Head-serial passes: this core owns flat Q chunks q_base + p * q_stride for p in [0, q_count).
+    const uint32_t q_base = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_stride = get_arg_val<uint32_t>(argidx++);
+    const uint32_t q_count = get_arg_val<uint32_t>(argidx++);
+    // One Q chunk per pass, and at most kMaxPasses passes (see the program factory).
+    ASSERT(q_count <= 3);
 
     RingSDPAOpIndexer fused_op_indexer = RingSDPAOpIndexer(argidx);
 
@@ -151,7 +152,6 @@ void kernel_main() {
     const uint8_t termination_master_noc_x = static_cast<uint8_t>(get_arg_val<uint32_t>(argidx++));
     const uint8_t termination_master_noc_y = static_cast<uint8_t>(get_arg_val<uint32_t>(argidx++));
 
-
     // Build connection object at outer scope (lifetime spans the ring loop and teardown).
     auto mux_conn = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
         fabric_mux_x,
@@ -175,13 +175,30 @@ void kernel_main() {
     }
 
     // ---- MUX writer setup: parsed by all MUX writers with valid connections ----
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* pkt_scatter_hdr = nullptr;
-    volatile tt_l1_ptr PACKET_HEADER_TYPE* pkt_unicast_hdr = nullptr;
+    // Rotated packet headers: reusing one header forces a NoC flush per packet (the header's L1
+    // must not be rewritten while its send is in flight). Rotating a small pool amortizes that to
+    // one flush per kNumFwdHdrs packets — the flush was the dominant serial cost per forwarded
+    // chunk. Pool budget: NUM_PACKET_HEADERS/2 = 12 headers per RISC; 8 + 2 + 1 = 11 used.
+    constexpr uint32_t kNumScatterHdrs = 8;
+    constexpr uint32_t kNumUnicastHdrs = 2;
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* pkt_scatter_hdrs[kNumScatterHdrs] = {nullptr};
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* pkt_unicast_hdrs[kNumUnicastHdrs] = {nullptr};
     volatile tt_l1_ptr PACKET_HEADER_TYPE* pkt_hdr_sem_inc = nullptr;
+    // Per-type sends since the last flush: a header may be rewritten only once every send of it
+    // has been flushed, so each type flushes when its whole pool has been used since the last
+    // flush. A flush clears everything, so both counters reset together.
+    uint32_t scatter_since_flush = 0;
+    uint32_t unicast_since_flush = 0;
+    uint32_t scatter_hdr_idx = 0;
+    uint32_t unicast_hdr_idx = 0;
     uint32_t ag_output_Wt = 0, ag_output_Ht = 0;
     uint32_t gathered_k_addr_ag_rt = 0, gathered_v_addr_ag_rt = 0;
     uint32_t injector_noc_x = 0, injector_noc_y = 0;
     uint32_t num_muxes_in_direction = 1, my_mux_index = 0;
+    // Split-head forwarding dedup: when set, this row is the follower of a pair sharing one head —
+    // the leader row's clients send byte-identical packets, so this client skips all fabric data
+    // and semincs (it still drains c_14/c_15 to keep the reader's CB pacing unchanged).
+    bool dedup_skip_forward = false;
 
     if (mux_connection_valid) {
         const uint32_t out_ready_sem_addr = get_arg_val<uint32_t>(argidx++);
@@ -193,15 +210,20 @@ void kernel_main() {
         ag_output_Ht = get_arg_val<uint32_t>(argidx++);
         gathered_k_addr_ag_rt = get_arg_val<uint32_t>(argidx++);
         gathered_v_addr_ag_rt = get_arg_val<uint32_t>(argidx++);
+        dedup_skip_forward = get_arg_val<uint32_t>(argidx++) == 1;
 
         // OpSignaler constructor advances argidx past its RT args
         OpSignaler(argidx);
 
-        pkt_scatter_hdr = PacketHeaderPool::allocate_header();
-        pkt_unicast_hdr = PacketHeaderPool::allocate_header();
+        for (uint32_t h = 0; h < kNumScatterHdrs; ++h) {
+            pkt_scatter_hdrs[h] = PacketHeaderPool::allocate_header();
+        }
+        for (uint32_t h = 0; h < kNumUnicastHdrs; ++h) {
+            pkt_unicast_hdrs[h] = PacketHeaderPool::allocate_header();
+        }
         pkt_hdr_sem_inc = PacketHeaderPool::allocate_header();
 
-        // Pre-configure scatter write header with max packet size; per-call with_state
+        // Pre-configure scatter write headers with max packet size; per-call with_state
         // overrides DstAddrs, ChunkSizes, and PayloadSize for the actual tile count.
         constexpr uint32_t scatter_init_count = ag_packet_size_in_pages >= 2 ? ag_packet_size_in_pages : 2;
         uint64_t dummy_addrs[4] = {0, 0, 0, 0};
@@ -209,15 +231,20 @@ void kernel_main() {
             static_cast<uint16_t>(ag_page_size),
             static_cast<uint16_t>(ag_page_size),
             static_cast<uint16_t>(ag_page_size)};
-        fabric_unicast_noc_scatter_write_set_state<
-            UnicastScatterWriteUpdateMask::ChunkSizes | UnicastScatterWriteUpdateMask::PayloadSize>(
-            pkt_scatter_hdr, 1,
-            NocUnicastScatterCommandHeader(dummy_addrs, scatter_chunk_sizes, scatter_init_count),
-            ag_page_size * ag_packet_size_in_pages);
+        for (uint32_t h = 0; h < kNumScatterHdrs; ++h) {
+            fabric_unicast_noc_scatter_write_set_state<
+                UnicastScatterWriteUpdateMask::ChunkSizes | UnicastScatterWriteUpdateMask::PayloadSize>(
+                pkt_scatter_hdrs[h],
+                1,
+                NocUnicastScatterCommandHeader(dummy_addrs, scatter_chunk_sizes, scatter_init_count),
+                ag_page_size * ag_packet_size_in_pages);
+        }
 
-        // Pre-configure unicast write header: payload size is constant
-        fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
-            pkt_unicast_hdr, 1, nullptr, ag_page_size);
+        // Pre-configure unicast write headers: payload size is constant
+        for (uint32_t h = 0; h < kNumUnicastHdrs; ++h) {
+            fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::PayloadSize>(
+                pkt_unicast_hdrs[h], 1, nullptr, ag_page_size);
+        }
 
         // Pre-configure atomic inc header for signaling the injector core on the next device
         // safe_get_noc_addr() cannot be migrated to Device 2.0 because it creates a cross-chip semaphore address,
@@ -225,13 +252,15 @@ void kernel_main() {
         const uint64_t injector_out_ready_sem_noc_addr =
             safe_get_noc_addr(injector_noc_x, injector_noc_y, out_ready_sem_addr, 0);
         fabric_unicast_noc_unicast_atomic_inc_set_state<
-            UnicastAtomicIncUpdateMask::DstAddr | UnicastAtomicIncUpdateMask::Val |
-            UnicastAtomicIncUpdateMask::Flush>(
-            pkt_hdr_sem_inc, 1,
-            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{injector_out_ready_sem_noc_addr, 1});
+            UnicastAtomicIncUpdateMask::DstAddr | UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+            pkt_hdr_sem_inc, 1, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{injector_out_ready_sem_noc_addr, 1});
 
-        fabric_set_unicast_route<false>(pkt_scatter_hdr, 1);
-        fabric_set_unicast_route<false>(pkt_unicast_hdr, 1);
+        for (uint32_t h = 0; h < kNumScatterHdrs; ++h) {
+            fabric_set_unicast_route<false>(pkt_scatter_hdrs[h], 1);
+        }
+        for (uint32_t h = 0; h < kNumUnicastHdrs; ++h) {
+            fabric_set_unicast_route<false>(pkt_unicast_hdrs[h], 1);
+        }
         fabric_set_unicast_route<false>(pkt_hdr_sem_inc, 1);
     }
 
@@ -300,7 +329,11 @@ void kernel_main() {
             // Write final normalized output on last ring iteration.
             const bool is_last_ring_iter = (ring_iter == last_active_ring_iter);
 
-            for (uint32_t global_q_chunk = global_q_start; global_q_chunk < global_q_end; ++global_q_chunk) {
+            // Serial passes, same order as the reader and compute: pass p handles head
+            // (p * rows + my_row). Both the AG forwarding below and the output drain are already
+            // parameterized per chunk, so they are correct per pass with no addressing change.
+            for (uint32_t pass = 0; pass < q_count; ++pass) {
+                const uint32_t global_q_chunk = q_base + pass * q_stride;
                 const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
                 const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
                 const uint32_t q_chunk = global_q_chunk % num_q_chunks;
@@ -328,8 +361,7 @@ void kernel_main() {
                         }
                         KV_chunks_processed_in_iter++;
 
-                        const uint32_t gathered_kv_start_tile =
-                            ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
+                        const uint32_t gathered_kv_start_tile = ring_iter_kv_start_tile + k_chunk * Sk_chunk_t;
                         const Slice kv_slice(
                             nb, nq, gathered_kv_start_tile, gathered_kv_start_tile + Sk_chunk_t, 0, DHt);
                         const uint32_t end_seq_tile = std::min(logical_nt, local_padded_Nt * (ring_id + 1));
@@ -338,117 +370,155 @@ void kernel_main() {
 
                         // Wait for reader to fill K, forward this writer's row slice over fabric
                         cb_k_w.wait_front(k_chunk_tiles);
-                        if (!is_last_ring_iter) {
-                        if (!kv_chunk_is_joint) {
-                            const uint32_t base_k_read_ptr = cb_k_w.get_read_ptr();
-                            for (uint32_t col = 0; col < DHt; ++col) {
-                                for (uint32_t row = my_row_start; row < my_row_end; row += ag_packet_size_in_pages) {
-                                    uint32_t tiles_in_batch = 0;
-                                    uint64_t k_noc_addrs[4] = {0, 0, 0, 0};
-                                    for (uint32_t i = 0; i < ag_packet_size_in_pages && row + i < my_row_end; i++) {
-                                        if (kv_slice.d2_start + row + i >= end_seq_tile) break;
-                                        const uint32_t dest_id = bh_offset
-                                            + (kv_global_start_tile + row + i) * ag_output_Wt + col;
-                                        k_noc_addrs[tiles_in_batch] =
-                                            tt::tt_fabric::linear::addrgen_detail::get_noc_address(
-                                                gathered_k_writer, dest_id, 0);
-                                        tiles_in_batch++;
-                                    }
-                                    if (tiles_in_batch == 0) break;
-                                    const uint32_t src_l1_addr = base_k_read_ptr
-                                        + (row + col * Sk_chunk_t) * ag_page_size;
-                                    if (tiles_in_batch == ag_packet_size_in_pages) {
-                                        uint16_t k_cs[3] = {
-                                            static_cast<uint16_t>(ag_page_size),
-                                            static_cast<uint16_t>(ag_page_size),
-                                            static_cast<uint16_t>(ag_page_size)};
-                                        fabric_unicast_noc_scatter_write_with_state<
-                                            UnicastScatterWriteUpdateMask::DstAddrs |
-                                            UnicastScatterWriteUpdateMask::ChunkSizes |
-                                            UnicastScatterWriteUpdateMask::PayloadSize>(
-                                            &mux_conn, pkt_scatter_hdr, src_l1_addr,
-                                            NocUnicastScatterCommandHeader(k_noc_addrs, k_cs, tiles_in_batch),
-                                            ag_page_size * tiles_in_batch);
-                                        noc.async_writes_flushed();
-                                    } else {
-                                        // Partial batch: fall back to per-tile unicast writes to avoid
-                                        // variable chunk_count scatter writes which cause non-determinism.
-                                        // noc.async_writes_flushed() after each send ensures the previous
-                                        // header NOC write completes before pkt_unicast_hdr is modified
-                                        // for the next tile (they share the same L1 header).
-                                        for (uint32_t i = 0; i < tiles_in_batch; i++) {
-                                            fabric_unicast_noc_unicast_write_with_state<
-                                                UnicastWriteUpdateMask::DstAddr>(
+                        if (!dedup_skip_forward && !is_last_ring_iter) {
+                            if (!kv_chunk_is_joint) {
+                                const uint32_t base_k_read_ptr = cb_k_w.get_read_ptr();
+                                for (uint32_t col = 0; col < DHt; ++col) {
+                                    for (uint32_t row = my_row_start; row < my_row_end;
+                                         row += ag_packet_size_in_pages) {
+                                        uint32_t tiles_in_batch = 0;
+                                        uint64_t k_noc_addrs[4] = {0, 0, 0, 0};
+                                        for (uint32_t i = 0; i < ag_packet_size_in_pages && row + i < my_row_end; i++) {
+                                            if (kv_slice.d2_start + row + i >= end_seq_tile) {
+                                                break;
+                                            }
+                                            const uint32_t dest_id =
+                                                bh_offset + (kv_global_start_tile + row + i) * ag_output_Wt + col;
+                                            k_noc_addrs[tiles_in_batch] =
+                                                tt::tt_fabric::linear::addrgen_detail::get_noc_address(
+                                                    gathered_k_writer, dest_id, 0);
+                                            tiles_in_batch++;
+                                        }
+                                        if (tiles_in_batch == 0) {
+                                            break;
+                                        }
+                                        const uint32_t src_l1_addr =
+                                            base_k_read_ptr + (row + col * Sk_chunk_t) * ag_page_size;
+                                        if (tiles_in_batch == ag_packet_size_in_pages) {
+                                            uint16_t k_cs[3] = {
+                                                static_cast<uint16_t>(ag_page_size),
+                                                static_cast<uint16_t>(ag_page_size),
+                                                static_cast<uint16_t>(ag_page_size)};
+                                            if (scatter_since_flush >= kNumScatterHdrs) {
+                                                noc.async_writes_flushed();
+                                                scatter_since_flush = 0;
+                                                unicast_since_flush = 0;
+                                            }
+                                            fabric_unicast_noc_scatter_write_with_state<
+                                                UnicastScatterWriteUpdateMask::DstAddrs |
+                                                UnicastScatterWriteUpdateMask::ChunkSizes |
+                                                UnicastScatterWriteUpdateMask::PayloadSize>(
                                                 &mux_conn,
-                                                pkt_unicast_hdr,
-                                                src_l1_addr + i * ag_page_size,
-                                                NocUnicastCommandHeader{k_noc_addrs[i]});
-                                            noc.async_writes_flushed();
+                                                pkt_scatter_hdrs[scatter_hdr_idx],
+                                                src_l1_addr,
+                                                NocUnicastScatterCommandHeader(k_noc_addrs, k_cs, tiles_in_batch),
+                                                ag_page_size * tiles_in_batch);
+                                            scatter_hdr_idx = (scatter_hdr_idx + 1) % kNumScatterHdrs;
+                                            scatter_since_flush++;
+                                        } else {
+                                            // Partial batch: fall back to per-tile unicast writes to avoid
+                                            // variable chunk_count scatter writes which cause non-determinism.
+                                            for (uint32_t i = 0; i < tiles_in_batch; i++) {
+                                                if (unicast_since_flush >= kNumUnicastHdrs) {
+                                                    noc.async_writes_flushed();
+                                                    scatter_since_flush = 0;
+                                                    unicast_since_flush = 0;
+                                                }
+                                                fabric_unicast_noc_unicast_write_with_state<
+                                                    UnicastWriteUpdateMask::DstAddr>(
+                                                    &mux_conn,
+                                                    pkt_unicast_hdrs[unicast_hdr_idx],
+                                                    src_l1_addr + i * ag_page_size,
+                                                    NocUnicastCommandHeader{k_noc_addrs[i]});
+                                                unicast_hdr_idx = (unicast_hdr_idx + 1) % kNumUnicastHdrs;
+                                                unicast_since_flush++;
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
-                        }
+                        // Flush before pop: the payload sends read straight out of the CB pages.
+                        noc.async_writes_flushed();
+                        scatter_since_flush = 0;
+                        unicast_since_flush = 0;
                         cb_k_w.pop_front(k_chunk_tiles);
 
                         // Wait for reader to fill V, forward this writer's row slice over fabric
                         cb_v_w.wait_front(v_chunk_tiles);
-                        if (!is_last_ring_iter) {
-                        if (!kv_chunk_is_joint) {
-                            const uint32_t base_v_read_ptr = cb_v_w.get_read_ptr();
-                            for (uint32_t row = my_row_start; row < my_row_end; ++row) {
-                                if (kv_slice.d2_start + row >= end_seq_tile) break;
-                                for (uint32_t col = 0; col < DHt; col += ag_packet_size_in_pages) {
-                                    uint32_t tiles_in_batch = 0;
-                                    uint64_t v_noc_addrs[4] = {0, 0, 0, 0};
-                                    for (uint32_t i = 0; i < ag_packet_size_in_pages && col + i < DHt; i++) {
-                                        const uint32_t dest_id = bh_offset
-                                            + (kv_global_start_tile + row) * ag_output_Wt + col + i;
-                                        v_noc_addrs[tiles_in_batch] =
-                                            tt::tt_fabric::linear::addrgen_detail::get_noc_address(
-                                                gathered_v_writer, dest_id, 0);
-                                        tiles_in_batch++;
+                        if (!dedup_skip_forward && !is_last_ring_iter) {
+                            if (!kv_chunk_is_joint) {
+                                const uint32_t base_v_read_ptr = cb_v_w.get_read_ptr();
+                                for (uint32_t row = my_row_start; row < my_row_end; ++row) {
+                                    if (kv_slice.d2_start + row >= end_seq_tile) {
+                                        break;
                                     }
-                                    if (tiles_in_batch == 0) break;
-                                    const uint32_t src_l1_addr = base_v_read_ptr
-                                        + (row * DHt + col) * ag_page_size;
-                                    if (tiles_in_batch == ag_packet_size_in_pages) {
-                                        uint16_t v_cs[3] = {
-                                            static_cast<uint16_t>(ag_page_size),
-                                            static_cast<uint16_t>(ag_page_size),
-                                            static_cast<uint16_t>(ag_page_size)};
-                                        fabric_unicast_noc_scatter_write_with_state<
-                                            UnicastScatterWriteUpdateMask::DstAddrs |
-                                            UnicastScatterWriteUpdateMask::ChunkSizes |
-                                            UnicastScatterWriteUpdateMask::PayloadSize>(
-                                            &mux_conn, pkt_scatter_hdr, src_l1_addr,
-                                            NocUnicastScatterCommandHeader(v_noc_addrs, v_cs, tiles_in_batch),
-                                            ag_page_size * tiles_in_batch);
-                                        noc.async_writes_flushed();
-                                    } else {
-                                        // Partial batch: fall back to per-tile unicast writes to avoid
-                                        // variable chunk_count scatter writes which cause non-determinism.
-                                        // noc.async_writes_flushed() after each send ensures the previous
-                                        // header NOC write completes before pkt_unicast_hdr is modified
-                                        // for the next tile (they share the same L1 header).
-                                        for (uint32_t i = 0; i < tiles_in_batch; i++) {
-                                            fabric_unicast_noc_unicast_write_with_state<
-                                                UnicastWriteUpdateMask::DstAddr>(
+                                    for (uint32_t col = 0; col < DHt; col += ag_packet_size_in_pages) {
+                                        uint32_t tiles_in_batch = 0;
+                                        uint64_t v_noc_addrs[4] = {0, 0, 0, 0};
+                                        for (uint32_t i = 0; i < ag_packet_size_in_pages && col + i < DHt; i++) {
+                                            const uint32_t dest_id =
+                                                bh_offset + (kv_global_start_tile + row) * ag_output_Wt + col + i;
+                                            v_noc_addrs[tiles_in_batch] =
+                                                tt::tt_fabric::linear::addrgen_detail::get_noc_address(
+                                                    gathered_v_writer, dest_id, 0);
+                                            tiles_in_batch++;
+                                        }
+                                        if (tiles_in_batch == 0) {
+                                            break;
+                                        }
+                                        const uint32_t src_l1_addr = base_v_read_ptr + (row * DHt + col) * ag_page_size;
+                                        if (tiles_in_batch == ag_packet_size_in_pages) {
+                                            uint16_t v_cs[3] = {
+                                                static_cast<uint16_t>(ag_page_size),
+                                                static_cast<uint16_t>(ag_page_size),
+                                                static_cast<uint16_t>(ag_page_size)};
+                                            if (scatter_since_flush >= kNumScatterHdrs) {
+                                                noc.async_writes_flushed();
+                                                scatter_since_flush = 0;
+                                                unicast_since_flush = 0;
+                                            }
+                                            fabric_unicast_noc_scatter_write_with_state<
+                                                UnicastScatterWriteUpdateMask::DstAddrs |
+                                                UnicastScatterWriteUpdateMask::ChunkSizes |
+                                                UnicastScatterWriteUpdateMask::PayloadSize>(
                                                 &mux_conn,
-                                                pkt_unicast_hdr,
-                                                src_l1_addr + i * ag_page_size,
-                                                NocUnicastCommandHeader{v_noc_addrs[i]});
-                                            noc.async_writes_flushed();
+                                                pkt_scatter_hdrs[scatter_hdr_idx],
+                                                src_l1_addr,
+                                                NocUnicastScatterCommandHeader(v_noc_addrs, v_cs, tiles_in_batch),
+                                                ag_page_size * tiles_in_batch);
+                                            scatter_hdr_idx = (scatter_hdr_idx + 1) % kNumScatterHdrs;
+                                            scatter_since_flush++;
+                                        } else {
+                                            // Partial batch: fall back to per-tile unicast writes to avoid
+                                            // variable chunk_count scatter writes which cause non-determinism.
+                                            for (uint32_t i = 0; i < tiles_in_batch; i++) {
+                                                if (unicast_since_flush >= kNumUnicastHdrs) {
+                                                    noc.async_writes_flushed();
+                                                    scatter_since_flush = 0;
+                                                    unicast_since_flush = 0;
+                                                }
+                                                fabric_unicast_noc_unicast_write_with_state<
+                                                    UnicastWriteUpdateMask::DstAddr>(
+                                                    &mux_conn,
+                                                    pkt_unicast_hdrs[unicast_hdr_idx],
+                                                    src_l1_addr + i * ag_page_size,
+                                                    NocUnicastCommandHeader{v_noc_addrs[i]});
+                                                unicast_hdr_idx = (unicast_hdr_idx + 1) % kNumUnicastHdrs;
+                                                unicast_since_flush++;
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
-                        }
+                        // Flush before pop: the payload sends read straight out of the CB pages.
+                        noc.async_writes_flushed();
+                        scatter_since_flush = 0;
+                        unicast_since_flush = 0;
                         cb_v_w.pop_front(v_chunk_tiles);
 
-                        if (!is_last_ring_iter) {
+                        if (!dedup_skip_forward && !is_last_ring_iter) {
                             fabric_unicast_noc_unicast_atomic_inc_with_state(&mux_conn, pkt_hdr_sem_inc);
                             noc.async_writes_flushed();
                         }


### PR DESCRIPTION
Enables the experimental fused ring-attention SDPA (`exp_ring_joint_scaled_dot_product_attention`) for MiniMax-H3 on the Blackhole 4x8 galaxy, namely the original exp ring attention implementation forces 1 head per row, which fits the 10-head per device arch of Wan 2.2, but not the 14-head per device arch of H3.

**Measured at 15s_768p, sp_sim4 (per-device shard [1, 14, 3424, 128], ring 8), warm, per device:**

| Variant | Device time |
|---|---|
| Normal ring joint (baseline) | 4,599 µs |
| Exp first implementation, 2 passes of 10 heads, 6/10 rows idle in pass 2 | 5,188 µs |
| **Exp, this PR, 3 passes of 5 heads, each head spans 2 rows** | **3,625 µs (−21% vs baseline)** |

PCC vs torch reference: 0.99968 (threshold 0.9993).

### How

1. **H>rows enablement + streamed-Q fallback** (`Relax H<=core.y constraint in exp attn`, @sadesoyeTT): lifts the one-row-per-head limit and adds a streamed-Q mode so shapes whose resident Q does not fit L1 remain buildable.
2. **Head-segment scheduling**: a head is split into `segs_per_head` row-segments scheduled as serial passes via an affine (q_base, q_stride, q_count) work descriptor. H3's 14 local heads run as 3 passes of 5-tile Q chunks on every core (15 Q tile-rows/core) instead of 2 passes with 6/10 rows idle (20 tile-rows on the bottleneck cores). The model-side config search scores (passes x q_chunk, -k_chunk, -cols) per shape and falls back to normal ring joint when no valid config exists.
3. **Split-head forwarding dedup**: with segs=2 each head's two segments land on an adjacent row pair in the same pass, and both rows were forwarding byte-identical K/V shards over the eth fabric to identical remote addresses — the duplicate traffic paced the row broadcast through the mux-client CB credits (~590 µs/pass). Follower rows now skip fabric data + semincs and don't connect to the MUX at all (their channels are reclaimed as deeper per-channel buffering); the leader row's injector relays its arrival gate to the follower's injector with one on-chip seminc per chunk. This alone was −15% and takes the fabric fully off the critical path (measured K/V input starvation on compute: ~7 µs total).
4. **Ping-pong mcast valid flags**: separate K/V receiver flags with receive credits posted immediately after consuming the previous chunk, and cumulative per-channel ack counters on the injector (K and V acks must be counted separately — a combined total lets fast receivers' K(n+1) credits mask a slow receiver's missing V(n) credit and the early relay is erased by the late flag reset). Perf-neutral at this shape but strictly deeper pipelining.
5. Smaller items: rotated fabric packet headers in the mux writer (flush per header-pool instead of per packet), 8 KB fabric payload for the 4x8 galaxy row (the AG packs 4 tiles/packet only at 8 KB), a `num_q_chunks` div_up fix in the compute kernel, and env-gated MUX placement experiments (both measured neutral-or-worse; placement is not a lever).

The last commit makes the sp_sim4 perf test exercise the exp path: the production enable gate keys on `sequence_parallel.factor == 32` as a proxy for the 4x32 shard, which SP simulation produces on a 4x8 mesh without the model seeing it, so the test forces the flag when the simulated SP totals 32.

### Testing

- Single-op sweep (32 devices, realtime profiler): 14-head 3,766 µs / 10-head 2,519 µs, stable to ±10 µs across devices.
- `test_performance_minimax_h3.py -k "15s_768p and 4x8sp1tp0nl2_ring_is_fsdp0 and sp_sim4"`: ExpRingJointSDPA mean 3,624.5 µs (n=64).
- PCC vs `torch scaled_dot_product_attention` reference: 0.99968.
- All of the above re-run on this branch as cherry-picked onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jonathansu/exp-sdpa-minimax-h3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jonathansu/exp-sdpa-minimax-h3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jonathansu/exp-sdpa-minimax-h3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jonathansu/exp-sdpa-minimax-h3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jonathansu/exp-sdpa-minimax-h3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jonathansu/exp-sdpa-minimax-h3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jonathansu/exp-sdpa-minimax-h3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jonathansu/exp-sdpa-minimax-h3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jonathansu/exp-sdpa-minimax-h3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jonathansu/exp-sdpa-minimax-h3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jonathansu/exp-sdpa-minimax-h3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jonathansu/exp-sdpa-minimax-h3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jonathansu/exp-sdpa-minimax-h3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jonathansu/exp-sdpa-minimax-h3)