### PR TITLE
rearrange fabric pipeline dispatch controls.

### DIFF
--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -6,8 +6,19 @@ name: "(TM-Fabric) Fabric Tests"
 #                                        + fabric-cpu-only-tests-impl.yaml (CPU-only)
 #   - tm-fabric-tests-perf-impl.yaml  -> tests/pipeline_reorg/fabric_perf_tests.yaml
 #
-# Scheduled run (nightly cron) covers CPU-only tests only. workflow_dispatch
-# exposes `test-names` filters for running subsets of each list.
+# Scheduled run (nightly cron) covers CPU-only tests only.
+#
+# workflow_dispatch UX:
+#   * HW SKU selection: one boolean per SKU (run-wh_n300_civ2, run-wh_llmbox_civ2,
+#     run-wh_galaxy, run-bh_loudbox, run-bh_p300, run-bh_quietbox_2). All default
+#     true, so the form is fully checked out of the box. Uncheck the SKUs you don't want; if every HW
+#     SKU box is unchecked, the HW matrix is skipped entirely (no separate
+#     on/off toggle needed).
+#   * hw-test-names / perf-test-names: comma-separated entry-name filters for
+#     power-user narrowing. Every valid entry name is listed inline in each
+#     input's description so it can be copied straight from the Run workflow UI.
+#     If the entry list changes in fabric_tests.yaml / fabric_perf_tests.yaml,
+#     update the matching description here too.
 
 on:
   schedule:
@@ -16,37 +27,74 @@ on:
   workflow_dispatch:
     inputs:
       run-fabric-cpu-only-unit-tests:
-        description: "Run fabric CPU-only unit tests (no hardware needed)"
+        description: "Run on CPU"
         required: false
         default: true
         type: boolean
-      run-fabric-hw-tests:
-        description: "Run the hardware fabric matrix (fabric_tests.yaml)"
+      # HW SKU selection: each checkbox controls whether the HW matrix runs on that SKU.
+      # All default true. If every HW SKU box is unchecked, the HW matrix is skipped
+      # (CPU-only tests still respect their own toggle above).
+      run-wh_n300_civ2:
+        description: "Run on wh_n300_civ2"
         required: false
         default: true
         type: boolean
+      run-wh_llmbox_civ2:
+        description: "Run on wh_llmbox_civ2"
+        required: false
+        default: true
+        type: boolean
+      run-wh_galaxy:
+        description: "Run on wh_galaxy"
+        required: false
+        default: true
+        type: boolean
+      run-bh_loudbox:
+        description: "Run on bh_loudbox"
+        required: false
+        default: true
+        type: boolean
+      run-bh_p300:
+        description: "Run on bh_p300"
+        required: false
+        default: true
+        type: boolean
+      run-bh_quietbox_2:
+        description: "Run on bh_quietbox_2"
+        required: false
+        default: true
+        type: boolean
+      # Keep the "Available names" list below in sync with tests/pipeline_reorg/fabric_tests.yaml.
+      hw-test-names:
+        description: >
+          Filter by test name. Composes on top of the per-SKU checkboxes above.
+          WH N300 scaleout unit tests , t3k fabric tests , t3k UDM tests ,
+          6U fabric quick , 6U multi-process ,
+          BH fabric 1D unit tests , BH fabric 2D fixture unit tests ,
+          BH fabric mux v2 unit tests , BH fabric UDM mode unit tests ,
+          BH ttnn UDM unit tests , BH fabric system health tests ,
+          BH fabric stability nightly tests , BH ccl nightly tests ,
+          BH fabric infra unit tests
+        required: false
+        default: ""
+        type: string
       run-fabric-perf-tests:
         description: "Run T3K fabric perf ubench (fabric_perf_tests.yaml)"
         required: false
         default: true
         type: boolean
-      hw-enabled-skus:
-        description: "Comma-separated SKUs for the hardware fabric matrix (or ALL_SKUS_IN_TESTS)"
-        required: false
-        default: "ALL_SKUS_IN_TESTS"
-        type: string
-      hw-test-names:
-        description: "Comma-separated entry names from fabric_tests.yaml to run (default: all)"
-        required: false
-        default: ""
-        type: string
       perf-enabled-skus:
         description: "Comma-separated SKUs for the perf matrix (or ALL_SKUS_IN_TESTS)"
         required: false
         default: "ALL_SKUS_IN_TESTS"
         type: string
+      # Keep the "Available names" list below in sync with tests/pipeline_reorg/fabric_perf_tests.yaml.
       perf-test-names:
-        description: "Comma-separated entry names from fabric_perf_tests.yaml to run (default: all)"
+        description: >
+          Filter by test name.
+          T3K ubench - Fabric BW && Latency ,
+          T3K ubench - Fabric Mux BW ,
+          T3K ubench - Fabric Mux V2 Throughput
         required: false
         default: ""
         type: string
@@ -119,12 +167,30 @@ jobs:
         github.event_name == 'schedule'
         || (github.event_name == 'workflow_dispatch' && inputs.run-fabric-cpu-only-unit-tests != false)
         || github.event_name == 'push' }}
+      # HW matrix runs when: (a) non-schedule non-dispatch events, or (b) dispatch
+      # with at least one SKU box checked. Unchecking every SKU box on dispatch
+      # skips the HW load-test-matrix and per-SKU legs (CPU-only still respects
+      # its own toggle above).
       run-fabric-hw-tests: ${{
         github.event_name == 'schedule' && false
-        || (github.event_name == 'workflow_dispatch' && inputs.run-fabric-hw-tests != false)
+        || (github.event_name == 'workflow_dispatch' && (
+              inputs.run-wh_n300_civ2 || inputs.run-wh_llmbox_civ2 || inputs.run-wh_galaxy
+              || inputs.run-bh_loudbox || inputs.run-bh_p300 || inputs.run-bh_quietbox_2))
         || github.event_name == 'push'
         || github.event_name == 'workflow_call' }}
-      enabled-skus: ${{ inputs.hw-enabled-skus || 'ALL_SKUS_IN_TESTS' }}
+      # Assemble enabled-skus from the checked per-SKU booleans on workflow_dispatch;
+      # non-dispatch events (push / workflow_call) preserve ALL_SKUS_IN_TESTS.
+      # Trailing commas are stripped by prepare_test_matrix.py's parse_enabled_skus.
+      enabled-skus: >-
+        ${{ github.event_name == 'workflow_dispatch' && format(
+              '{0}{1}{2}{3}{4}{5}',
+              inputs.run-wh_n300_civ2  && 'wh_n300_civ2,'   || '',
+              inputs.run-wh_llmbox_civ2 && 'wh_llmbox_civ2,' || '',
+              inputs.run-wh_galaxy     && 'wh_galaxy,'      || '',
+              inputs.run-bh_loudbox    && 'bh_loudbox,'     || '',
+              inputs.run-bh_p300       && 'bh_p300,'        || '',
+              inputs.run-bh_quietbox_2 && 'bh_quietbox_2,'  || ''
+            ) || 'ALL_SKUS_IN_TESTS' }}
       test-names: ${{ inputs.hw-test-names || '' }}
 
   fabric-perf-tests:

--- a/tests/pipeline_reorg/fabric_tests.yaml
+++ b/tests/pipeline_reorg/fabric_tests.yaml
@@ -185,8 +185,7 @@
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric stability nightly tests
-  # TT_METAL_OPERATION_TIMEOUT_SECONDS=0 disables hang detection for the long-running
-  # stability suite (matches pre-refactor tm-fabric-tests-impl inline cmd).
+  # TT_METAL_OPERATION_TIMEOUT_SECONDS=0 disables hang detection for the long-running stability suite.
   cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
   skus:
     bh_loudbox:


### PR DESCRIPTION
## Summary
Rework the `(TM-Fabric) Fabric Tests` workflow_dispatch UX so the "Run workflow" form is usable without knowing SKU or entry-name strings.

## Changes
- **Per-SKU checkboxes**: replace the free-text `hw-enabled-skus` input with one boolean per SKU (`run-wh_n300_civ2`, `run-wh_llmbox_civ2`, `run-wh_galaxy`, `run-bh_loudbox`, `run-bh_p300`, `run-bh_quietbox_2`), all default true. `enabled-skus` is assembled from the checked boxes; if every box is unchecked the HW matrix is skipped, so no separate `run-fabric-hw-tests` toggle is needed and it's removed.
- **Inline entry catalog**: `hw-test-names` / `perf-test-names` descriptions now enumerate every valid entry name from `fabric_tests.yaml` / `fabric_perf_tests.yaml` so users can copy names straight from the Run workflow UI. A comment tells maintainers to keep these lists in sync.
- **Descriptions**: shortened to `Run on <sku>` / `Run on CPU` for the checkboxes.
- Minor: collapse a two-line comment in `fabric_tests.yaml` on `BH fabric stability nightly tests`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ucheema/tm-fabric-control-update-staged)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ucheema/tm-fabric-control-update-staged)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ucheema/tm-fabric-control-update-staged)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ucheema/tm-fabric-control-update-staged)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ucheema/tm-fabric-control-update-staged)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ucheema/tm-fabric-control-update-staged)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ucheema/tm-fabric-control-update-staged)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ucheema/tm-fabric-control-update-staged)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ucheema/tm-fabric-control-update-staged)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ucheema/tm-fabric-control-update-staged)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ucheema/tm-fabric-control-update-staged)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ucheema/tm-fabric-control-update-staged)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ucheema/tm-fabric-control-update-staged)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ucheema/tm-fabric-control-update-staged)