### PR TITLE
[ Bug Fix][TT-NOP Injector] Added STALLWAIT on MATH for SFPU path on moe_gate_test to fix race

### DIFF
--- a/tt_metal/tt-llk/tests/sources/generalized_moe_gate_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/generalized_moe_gate_test.cpp
@@ -526,7 +526,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if constexpr (GMG_MODE != MODE_BINARY && !STEP2_RUNS)
         {
-            TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
+// Wait until unpack has posted both dummy valids; clearing before they arrive leaves unpack blocked after math completes.
+TTI_STALLWAIT(
+    p_stall::STALL_MATH,
+    p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
             TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
         }
 

--- a/tt_metal/tt-llk/tests/sources/generalized_moe_gate_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/generalized_moe_gate_test.cpp
@@ -526,6 +526,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if constexpr (GMG_MODE != MODE_BINARY && !STEP2_RUNS)
         {
+            TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU | p_stall::SRCA_VLD | p_stall::SRCB_VLD);
             TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD);
         }
 


### PR DESCRIPTION
### PR Category
Race Bug fix

### Summary
Fixes #53413 

The TT-NOP injector first exposed this race as unpack hangs at delayed SEMGET sites. When 61 TTI_NOPs were added before the semget  in _llk_unpack_A_ after the MOP, it  made this fail deterministic. The  UNPACR_NOPs that set DVALIDs were delayed until after math had already done CLR_AB and entered KERNEL_COMPLETE.

In the test, unpack thread always posts dummy SrcA/SrcB valids (UNPACR_NOP SET_DVALID) after the tile unpacks. Math is supposed to consume them with SETRWC CLR_AB. On SFPU-only paths, nothing waited for those valids, so math could CLR_AB and go idle before unpack posted them. Unpack then hung forever on UNPACR_NOP SET_DVALID (Stall_Clr_Cntrl=0) with srcb_data_ready stuck at 1.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmohammed/generalized-moe-gate-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmohammed/generalized-moe-gate-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmohammed/generalized-moe-gate-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmohammed/generalized-moe-gate-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmohammed/generalized-moe-gate-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmohammed/generalized-moe-gate-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmohammed/generalized-moe-gate-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmohammed/generalized-moe-gate-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmohammed/generalized-moe-gate-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmohammed/generalized-moe-gate-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmohammed/generalized-moe-gate-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmohammed/generalized-moe-gate-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmohammed/generalized-moe-gate-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmohammed/generalized-moe-gate-race)