### PR TITLE
[Bug fix] Fix Ethernet firmware teardown in multichip simulation

### DIFF
--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -247,8 +247,10 @@ void RiscFirmwareInitializer::teardown_simulator_ethernet_cores() {
     // If simulator is enabled, force a teardown of active ethernet cores for WH
     if (rtoptions_.get_simulator_enabled()) {
         if (hal_.get_eth_fw_is_cooperative()) {
-            auto all_devices = cluster_.all_chip_ids();
-            for (tt::ChipId device_id : all_devices) {
+            // A remote simulator chip is reached through its active Ethernet firmware. Asking that
+            // core to stop over its own remote-I/O path prevents the request from being flushed.
+            // Keep remote routing firmware alive until the shared simulator backend shuts down.
+            for (tt::ChipId device_id : cluster_.mmio_chip_ids()) {
                 for (const auto& logical_core : this->get_control_plane_().get_active_ethernet_cores(device_id)) {
                     CoreCoord virtual_core = cluster_.get_virtual_coordinate_from_logical_coordinates(
                         device_id, logical_core, CoreType::ETH);
@@ -264,8 +266,6 @@ void RiscFirmwareInitializer::teardown_simulator_ethernet_cores() {
 void RiscFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& /*init_done*/) {
     auto all_devices = cluster_.all_chip_ids();
 
-    teardown_simulator_ethernet_cores();
-
     if (!cluster_.is_mock_or_emulated()) {
         for (tt::ChipId device_id : all_devices) {
             assert_cores(device_id);
@@ -277,6 +277,9 @@ void RiscFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& /*ini
             cluster_.set_internal_routing_info_for_ethernet_cores(this->get_control_plane_(), false);
         }
     }
+
+    // Keep simulator routing firmware alive until all cleanup that may access remote chips is done.
+    teardown_simulator_ethernet_cores();
 
     initialized_ = false;
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Remote simulator chips are accessed through their active Ethernet firmware.
Stopping that firmware through its own remote-I/O path prevents Metal from
polling for completion and causes teardown to hang.

Keep Ethernet firmware running until all remote-chip cleanup has completed,
then explicitly stop only the Ethernet cores on MMIO chips. Remote Ethernet
firmware remains active until the shared simulator backend shuts down.

This preserves the transport required during teardown while leaving hardware
and single-chip simulator behavior unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/teardown)