### PR TITLE
SDPA windowed mode with no masking and variable window size

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
@@ -42,8 +42,21 @@ def windowed_mask(seq_len, cu_window_seqlens):
         (256, 32, [0, 64, 128, 256]),  # larger sequence
         (96, 64, [0, 33, 64, 96]),  # sequence padded to chunk size; windowed mask owns padding
         (129, 64, [0, 32, 97, 129]),  # partial final tile plus chunk padding
+        # Aggressive K-range narrowing: each Q chunk's windows cover a small fraction of the 8
+        # K chunks, so a wrong [k_lo, k_hi) (missing or extra keys) craters PCC rather than hiding
+        # behind a nearly-dense range.
+        (1024, 128, [0, 128, 256, 384, 512, 640, 768, 896, 1024]),  # 8 chunk-aligned windows
+        (1024, 128, [0, 200, 480, 730, 1024]),  # uneven windows straddling chunk boundaries
     ],
-    ids=["s128_w2", "s128_w3", "s256_w3", "s96_padded_chunk", "s129_partial_tile"],
+    ids=[
+        "s128_w2",
+        "s128_w3",
+        "s256_w3",
+        "s96_padded_chunk",
+        "s129_partial_tile",
+        "s1024_w8_aligned",
+        "s1024_w4_straddle",
+    ],
 )
 @pytest.mark.parametrize("num_heads", [1, 8])
 @pytest.mark.parametrize(
@@ -115,3 +128,202 @@ def test_windowed_sdpa_smoke(
     logger.info(f"windowed SDPA dtype={dtype} s={seq_len} heads={num_heads} windows={cu_window_seqlens} pcc={pcc}")
     assert passing, f"PCC below threshold: {pcc}"
     assert out.shape == gt.shape, f"shape mismatch: {out.shape} vs {gt.shape}"
+
+
+@pytest.mark.parametrize(
+    "seq_len, chunk, cu_window_seqlens, num_shards",
+    [
+        # Windows aligned to shard boundaries: every shard's rows sit inside one window.
+        (256, 32, [0, 64, 128, 192, 256], 4),
+        # Windows that straddle shard boundaries: shard 1 (64..127) spans windows [0,96) and [96,160).
+        # This is the case a per-block SDPA loop cannot express and the offset exists for.
+        (256, 32, [0, 96, 160, 256], 4),
+        # Uneven windows, 2 shards, and a window shorter than the chunk.
+        (128, 32, [0, 32, 96, 128], 2),
+    ],
+    ids=["aligned_4shard", "straddling_4shard", "uneven_2shard"],
+)
+@pytest.mark.parametrize("num_heads", [1, 8])
+@pytest.mark.parametrize("offset_as_tensor", [False, True], ids=["scalar", "tensor"])
+def test_windowed_sdpa_q_token_offset(
+    device, seq_len, chunk, cu_window_seqlens, num_shards, num_heads, offset_as_tensor
+):
+    """Each Q shard attends over the full K/V with GLOBAL window boundaries.
+
+    This is the sequence-parallel shape: Q holds `seq_len // num_shards` contiguous rows and is indexed
+    locally, while K/V and `cu_window_seqlens` stay global. `windowed_q_token_offset` tells the on-device
+    mask generator where the shard starts, so a row's window is decided by its global position.
+
+    Concatenating the shards must reproduce the unsharded result exactly -- attention is row-independent
+    given the mask, so splitting Q changes no arithmetic. Compared against the same torch reference the
+    unsharded test uses.
+    """
+    torch.manual_seed(42)
+    b, dh = 1, 128
+    scale = dh**-0.5
+    shard_rows = seq_len // num_shards
+    assert shard_rows % 32 == 0, "offset must be tile-aligned"
+
+    q = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+    k = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+    v = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        exp_approx_mode=False,
+        q_chunk_size=chunk,
+        k_chunk_size=chunk,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4, math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=True
+    )
+    # K/V are global and shared by every shard; only Q is sliced.
+    k_tt = ttnn.from_torch(k, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    v_tt = ttnn.from_torch(v, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    cu_tt = ttnn.from_torch(
+        torch.tensor(cu_window_seqlens, dtype=torch.int32),
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint32,
+    )
+
+    shards = []
+    for shard in range(num_shards):
+        offset = shard * shard_rows
+        q_shard = q[:, :, offset : offset + shard_rows, :].contiguous()
+        out_tt = ttnn.transformer.scaled_dot_product_attention(
+            ttnn.from_torch(q_shard, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16),
+            k_tt,
+            v_tt,
+            is_causal=False,
+            scale=scale,
+            program_config=program_config,
+            compute_kernel_config=compute_kernel_config,
+            cu_window_seqlens=cu_tt,
+            # Two ways to supply the same value. The scalar is baked into the program; the tensor is read
+            # on device at dispatch, which is what lets one shared program serve differently-offset
+            # devices when it is sharded on the sequence-parallel axis. They must agree exactly.
+            windowed_q_token_offset=0 if offset_as_tensor else offset,
+            windowed_q_token_offset_tensor=(
+                ttnn.from_torch(
+                    torch.tensor([offset], dtype=torch.int32),
+                    device=device,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    dtype=ttnn.uint32,
+                )
+                if offset_as_tensor
+                else None
+            ),
+        )
+        got = ttnn.to_torch(out_tt).to(torch.float32)
+        assert got.shape[-2] == shard_rows, f"shard {shard} returned {got.shape[-2]} rows, expected {shard_rows}"
+        shards.append(got)
+
+    out = torch.cat(shards, dim=-2)
+
+    mask = windowed_mask(seq_len, cu_window_seqlens).unsqueeze(0).unsqueeze(0)
+    gt = torch.nn.functional.scaled_dot_product_attention(
+        q.to(torch.float32), k.to(torch.float32), v.to(torch.float32), attn_mask=mask, scale=scale
+    )
+
+    passing, pcc = comp_pcc(gt, out, 0.99)
+    logger.info(
+        f"windowed SDPA q-offset s={seq_len} shards={num_shards} heads={num_heads} "
+        f"windows={cu_window_seqlens} pcc={pcc}"
+    )
+    assert passing, f"PCC below threshold: {pcc}"
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "seq_len, chunk, cu_window_seqlens",
+    [
+        # Windows straddle the shard cuts (shards are 64 rows), so every device resolves a different
+        # window set from a different offset -- the strongest test of per-coordinate extraction.
+        (256, 32, [0, 96, 160, 256]),
+    ],
+    ids=["straddling"],
+)
+@pytest.mark.parametrize("num_heads", [8])
+def test_windowed_sdpa_q_offset_tensor_on_mesh(mesh_device, seq_len, chunk, cu_window_seqlens, num_heads):
+    """The offset tensor's actual use case: ONE SDPA call over a mesh, Q sharded on the sequence.
+
+    The serial test above proves each offset value is honored; this proves the per-device plumbing.
+    Every device runs the SAME cached program, so the offsets must diverge through data: Q is sharded
+    on dim 2 across the mesh, K/V and cu_window_seqlens are replicated, and the 1-element offset
+    tensor is sharded so device d's local value is d * shard_rows. If per-coordinate extraction or
+    accessor binding broke (e.g. every device reading device 0's offset), devices 1..3 would mask
+    against the wrong windows and the composed PCC craters.
+
+    Skips (via the mesh_device fixture) on machines with fewer than 4 devices.
+    """
+    torch.manual_seed(42)
+    b, dh = 1, 128
+    scale = dh**-0.5
+    num_shards = mesh_device.get_num_devices()
+    shard_rows = seq_len // num_shards
+    assert shard_rows % 32 == 0, "offset must be tile-aligned"
+
+    q = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+    k = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+    v = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=mesh_device.compute_with_storage_grid_size(),
+        exp_approx_mode=False,
+        q_chunk_size=chunk,
+        k_chunk_size=chunk,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4, math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=True
+    )
+
+    replicate = ttnn.ReplicateTensorToMesh(mesh_device)
+    q_tt = ttnn.from_torch(
+        q,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=2),
+    )
+    k_tt = ttnn.from_torch(k, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=replicate)
+    v_tt = ttnn.from_torch(v, device=mesh_device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=replicate)
+    cu_tt = ttnn.from_torch(
+        torch.tensor(cu_window_seqlens, dtype=torch.int32),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint32,
+        mesh_mapper=replicate,
+    )
+    offsets_tt = ttnn.from_torch(
+        torch.arange(num_shards, dtype=torch.int32) * shard_rows,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint32,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=0),
+    )
+
+    out_tt = ttnn.transformer.scaled_dot_product_attention(
+        q_tt,
+        k_tt,
+        v_tt,
+        is_causal=False,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+        cu_window_seqlens=cu_tt,
+        windowed_q_token_offset_tensor=offsets_tt,
+    )
+    out = ttnn.to_torch(out_tt, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2)).to(torch.float32)
+
+    mask = windowed_mask(seq_len, cu_window_seqlens).unsqueeze(0).unsqueeze(0)
+    gt = torch.nn.functional.scaled_dot_product_attention(
+        q.to(torch.float32), k.to(torch.float32), v.to(torch.float32), attn_mask=mask, scale=scale
+    )
+
+    passing, pcc = comp_pcc(gt, out, 0.99)
+    logger.info(
+        f"windowed SDPA mesh q-offset s={seq_len} devices={num_shards} heads={num_heads} "
+        f"windows={cu_window_seqlens} pcc={pcc}"
+    )
+    assert passing, f"PCC below threshold: {pcc}"

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -1539,7 +1539,9 @@ template <
     bool lightweight_mask_enabled = false,
     bool chunked_enabled = false,
     uint32_t chunked_q_local_padded_Nt = 0,
-    uint32_t chunked_chunk_size_t = 0>
+    uint32_t chunked_chunk_size_t = 0,
+    bool use_windowed_narrowing = false,
+    uint32_t cb_windowed_k_range = 0>
 void sdpa_inner_loop(
     const uint32_t Skt,
     const uint32_t qk_in0_block_w,
@@ -1670,9 +1672,22 @@ void sdpa_inner_loop(
             k_chunk_end = iter_k_chunk_end;
         }
 
+        // Windowed K-range narrowing: this Q chunk's [k_lo, k_hi) comes from the reader's ctrl CB —
+        // read via the UNPACK mailbox so all three TRISCs agree — and overrides BOTH bounds. The
+        // reader streams exactly this many K/V chunks and the writer produces exactly this many mask
+        // chunks; any disagreement deadlocks the CBs.
+        uint32_t k_chunk_start = iter_k_chunk_start;
+        if constexpr (use_windowed_narrowing) {
+            CircularBuffer cb_k_range_obj(cb_windowed_k_range);
+            cb_k_range_obj.wait_front(1);
+            k_chunk_start = ckernel::read_tile_value(cb_windowed_k_range, 0, 0);
+            k_chunk_end = ckernel::read_tile_value(cb_windowed_k_range, 0, 1);
+            cb_k_range_obj.pop_front(1);
+        }
+
         uint32_t processed_k_chunks = 0;
 
-        for (uint32_t k_chunk = iter_k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
+        for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; ++k_chunk) {
             uint32_t kv_global_start_tile = 0;  // RING only: abs K-tile index of this k_chunk's start
             if constexpr (sdpa_type == RING) {
                 const bool kv_chunk_is_joint = k_chunk >= num_local_k_chunks;
@@ -2098,7 +2113,9 @@ template <
     bool is_chunked,
     uint32_t scale_fp32,
     uint32_t sliding_window_size,
-    bool lightweight_mask_enabled = false>
+    bool lightweight_mask_enabled = false,
+    bool use_windowed_narrowing = false,
+    uint32_t cb_windowed_k_range = 0>
 void sdpa_standard(
     const uint32_t Skt,
     const uint32_t qk_in0_block_w,
@@ -2157,7 +2174,12 @@ void sdpa_standard(
         is_chunked,
         scale_fp32,
         sliding_window_size,
-        lightweight_mask_enabled>(
+        lightweight_mask_enabled,
+        false,  // chunked_enabled (not used)
+        0,      // chunked_q_local_padded_Nt (not used)
+        0,      // chunked_chunk_size_t (not used)
+        use_windowed_narrowing,
+        cb_windowed_k_range>(
         Skt,
         qk_in0_block_w,
         qk_subblock_w,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1919,7 +1919,9 @@ template <
     bool is_causal_sdpa = false,
     bool use_attention_sink = false,
     uint32_t cb_attention_sink = INVALID_CB,
-    bool use_provided_mask = false>
+    bool use_provided_mask = false,
+    bool use_windowed_narrowing = false,
+    uint32_t cb_windowed_k_range = INVALID_CB>
 void sdpa_standard_v2(
     const uint32_t q_chunks_per_core,
     const uint32_t k_num_chunks,
@@ -2014,6 +2016,16 @@ void sdpa_standard_v2(
                     k_loop_end = limit < k_num_chunks ? limit : k_num_chunks;
                 }
             }
+        }
+        // Windowed K-range narrowing: this Q chunk's [k_lo, k_hi) comes from the reader's ctrl CB —
+        // read via the UNPACK mailbox so all three TRISCs agree. The reader streams exactly this many
+        // K/V chunks and the writer produces exactly this many mask chunks; disagreement deadlocks.
+        if constexpr (use_windowed_narrowing) {
+            CircularBuffer cb_k_range_obj(cb_windowed_k_range);
+            cb_k_range_obj.wait_front(1);
+            k_loop_start = ckernel::read_tile_value(cb_windowed_k_range, 0, 0);
+            k_loop_end = ckernel::read_tile_value(cb_windowed_k_range, 0, 1);
+            cb_k_range_obj.pop_front(1);
         }
 
         auto call_step = [&](auto profiling_tag,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -51,6 +51,8 @@ void kernel_main() {
     constexpr uint32_t k_partial_col = get_compile_time_arg_val(32);
     // Zigzag remap flag drives the external remap_q_index call on the flat B*NQH*q_num_chunks range.
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(33) == 1;
+    // Windowed K-range narrowing: per-Q-chunk [k_lo, k_hi) arrives from the reader over a ctrl CB.
+    constexpr bool use_windowed_narrowing = get_compile_time_arg_val(34) == 1;
 
     const uint32_t core_id = get_arg_val<uint32_t>(0);
     const uint32_t num_phases = get_arg_val<uint32_t>(1);
@@ -71,7 +73,7 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    constexpr uint32_t cb_arg_offset = 34;
+    constexpr uint32_t cb_arg_offset = 35;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -90,6 +92,7 @@ void kernel_main() {
     constexpr uint32_t cb_sum_A = get_compile_time_arg_val(cb_arg_offset + 15);
     constexpr uint32_t cb_sum_B = get_compile_time_arg_val(cb_arg_offset + 16);
     constexpr uint32_t cb_exp_max_diff = get_compile_time_arg_val(cb_arg_offset + 17);
+    constexpr uint32_t cb_windowed_k_range = get_compile_time_arg_val(cb_arg_offset + 18);
     uint32_t chunked_q_chunk_offset = 0;
     CircularBuffer cb_chunk_start_idx_obj(cb_chunk_start_idx);
     CircularBuffer cb_identity_scale_in_obj(cb_identity_scale_in);
@@ -179,7 +182,9 @@ void kernel_main() {
             is_causal,
             use_attention_sink,
             cb_attention_sink,
-            use_provided_mask>(
+            use_provided_mask,
+            use_windowed_narrowing,
+            cb_windowed_k_range>(
             global_q_count,
             k_num_chunks,
             cb_out_im_A,
@@ -231,7 +236,9 @@ void kernel_main() {
                 is_chunked,
                 scale_fp32,
                 sliding_window_size,
-                use_lightweight_causal_mask>(
+                use_lightweight_causal_mask,
+                use_windowed_narrowing,
+                cb_windowed_k_range>(
                 Skt,
                 qk_in0_block_w,
                 qk_subblock_w,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -11,6 +11,7 @@
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "dataflow_common.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/windowed_loop_geometry.hpp"
 
 // Fetch a KV chunk into L1 for forwarding. No CB lifecycle — caller manages
 // cb_reserve_back / cb_push_back. Single read barrier at end for lower latency.
@@ -95,14 +96,19 @@ void kernel_main() {
     constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(31);
     constexpr bool mcast_enabled = get_compile_time_arg_val(32) == 1;
     constexpr bool use_zigzag_balancing = get_compile_time_arg_val(33) == 1;
+    // Windowed K-range narrowing: the reader computes each Q chunk's [k_lo, k_hi) from
+    // cu_window_seqlens, streams only that range, and feeds it to compute over a ctrl CB.
+    constexpr bool use_windowed_narrowing = get_compile_time_arg_val(34) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<34>();
+    constexpr auto q_args = TensorAccessorArgs<35>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
     constexpr auto page_table_args = TensorAccessorArgs<mask_args.next_compile_time_args_offset()>();
     constexpr auto attention_sink_args = TensorAccessorArgs<page_table_args.next_compile_time_args_offset()>();
     constexpr auto chunk_start_idx_args = TensorAccessorArgs<attention_sink_args.next_compile_time_args_offset()>();
+    constexpr auto cu_window_args = TensorAccessorArgs<chunk_start_idx_args.next_compile_time_args_offset()>();
+    constexpr auto q_offset_args = TensorAccessorArgs<cu_window_args.next_compile_time_args_offset()>();
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -177,6 +183,20 @@ void kernel_main() {
     global_q_start = get_arg_val<uint32_t>(argidx++);
     global_q_count = get_arg_val<uint32_t>(argidx++);
 
+    // Windowed K-range narrowing tail: the same four values the writer receives, so both kernels
+    // resolve each Q chunk's global row range and windows identically (the writer self-computes the
+    // range this reader feeds to compute — they must agree or the CB counts desync).
+    uint32_t cu_window_seqlens_addr = 0;
+    uint32_t cu_window_seqlens_eles = 0;
+    uint32_t windowed_q_tok_offset = 0;
+    uint32_t windowed_q_tok_offset_addr = 0;
+    if constexpr (use_windowed_narrowing) {
+        cu_window_seqlens_addr = get_arg_val<uint32_t>(argidx++);
+        cu_window_seqlens_eles = get_arg_val<uint32_t>(argidx++);
+        windowed_q_tok_offset = get_arg_val<uint32_t>(argidx++);
+        windowed_q_tok_offset_addr = get_arg_val<uint32_t>(argidx++);
+    }
+
     // When chunked: only process K/V up to (chunk_start_idx + Q_chunk_length) tokens.
     // valid_Skt_bound = min(offset_tiles + valid_Sqt, valid_Skt); cap at valid_Skt for callers that pass
     // different valid_Sqt (e.g. ring_distributed uses full Q length in tiles).
@@ -185,7 +205,7 @@ void kernel_main() {
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
     constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
 
-    constexpr uint32_t cb_arg_offset = chunk_start_idx_args.next_compile_time_args_offset();
+    constexpr uint32_t cb_arg_offset = q_offset_args.next_compile_time_args_offset();
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -194,6 +214,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_page_table = get_compile_time_arg_val(cb_arg_offset + 5);
     constexpr uint32_t cb_id_chunk_start_idx_compute = get_compile_time_arg_val(cb_arg_offset + 6);
     constexpr uint32_t cb_id_chunk_start_idx_writer = get_compile_time_arg_val(cb_arg_offset + 7);
+    // Windowed narrowing CBs: the reader's own cu_window copy, and the {k_lo, k_hi} ctrl CB consumed
+    // by compute. Valid fallback ids (q_in) when not windowed; only touched behind the constexpr flag.
+    constexpr uint32_t cb_id_windowed_cu_reader = get_compile_time_arg_val(cb_arg_offset + 8);
+    constexpr uint32_t cb_id_windowed_k_range = get_compile_time_arg_val(cb_arg_offset + 9);
 
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);
@@ -263,6 +287,28 @@ void kernel_main() {
             }
         }
     }
+
+    // Windowed narrowing: load cu_window_seqlens once (the reader's own copy — the writer has its own
+    // CB with its own producer contract), resolving the per-device Q-offset override first so the
+    // 4-byte read can stage through the same landing spot before the full array overwrites it.
+    volatile tt_l1_ptr uint32_t* windowed_cu_ptr = nullptr;
+    if constexpr (use_windowed_narrowing) {
+        CircularBuffer cb_cu_reader(cb_id_windowed_cu_reader);
+        cb_cu_reader.reserve_back(1);
+        const uint32_t cu_write_ptr = cb_cu_reader.get_write_ptr();
+        if (windowed_q_tok_offset_addr != 0) {
+            const auto q_offset_reader = TensorAccessor(q_offset_args, windowed_q_tok_offset_addr);
+            noc.async_read(q_offset_reader, CoreLocalMem<uint32_t>(cu_write_ptr), 4, {.page_id = 0}, {});
+            noc.async_read_barrier();
+            windowed_q_tok_offset = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cu_write_ptr);
+        }
+        const auto cu_window_reader = TensorAccessor(cu_window_args, cu_window_seqlens_addr);
+        constexpr uint32_t cu_tile_bytes = get_tile_size(cb_id_windowed_cu_reader);
+        noc.async_read(cu_window_reader, CoreLocalMem<uint32_t>(cu_write_ptr), cu_tile_bytes, {.page_id = 0}, {});
+        noc.async_read_barrier();
+        windowed_cu_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cu_write_ptr);
+    }
+
     uint32_t read_offset = 0;
     for (uint32_t phase = 0; phase < num_phases; ++phase) {
         if (phase == 0) {
@@ -342,6 +388,33 @@ void kernel_main() {
             const uint32_t q_iter = per_head_q_iter;
             ++per_head_q_iter;
 
+            // Windowed narrowing: this Q chunk's K-chunk range. Pushed to compute over the ctrl CB
+            // BEFORE any blocking CB reserve, so compute learns its bounds even while this reader is
+            // parked on cb_k space. The writer self-computes the same range from the same tensor.
+            uint32_t windowed_k_lo = 0;
+            uint32_t windowed_k_hi = k_num_chunks;
+            if constexpr (use_windowed_narrowing) {
+                const auto range = windowed_k_chunk_range(
+                    q_chunk,
+                    Sq_chunk_t,
+                    valid_Sqt,
+                    windowed_q_tok_offset,
+                    windowed_cu_ptr,
+                    cu_window_seqlens_eles,
+                    Sk_chunk_t,
+                    k_num_chunks,
+                    tt::constants::TILE_HEIGHT);
+                windowed_k_lo = range.k_lo;
+                windowed_k_hi = range.k_hi;
+                CircularBuffer cb_k_range(cb_id_windowed_k_range);
+                cb_k_range.reserve_back(1);
+                volatile tt_l1_ptr uint32_t* k_range_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_k_range.get_write_ptr());
+                k_range_ptr[0] = windowed_k_lo;
+                k_range_ptr[1] = windowed_k_hi;
+                cb_k_range.push_back(1);
+            }
+
             /*
             Determine how many rows of Q will be read. Both start and end rows are
             capped by valid_Sqt, since Sq padding is independent of Sk padding.
@@ -384,6 +457,11 @@ void kernel_main() {
                     const uint32_t window_high_unclamped = q_low_idx + Sq_chunk_t + right_window_tiles;
                     q_high_idx = window_high_unclamped < Skt ? window_high_unclamped : Skt;
                 }
+            }
+            if constexpr (use_windowed_narrowing) {
+                // Must match what this reader pushed to compute and what the writer self-computes.
+                k_loop_start = windowed_k_lo;
+                q_high_idx = windowed_k_hi * Sk_chunk_t;
             }
 
             const uint32_t k_head = nq / q_heads_per_k;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/windowed_mask_gen.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/windowed_mask_gen.hpp
@@ -15,6 +15,7 @@
 #include "api/dataflow/noc.h"
 #include <tt-metalium/constants.hpp>
 #include "dataflow_common.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/windowed_loop_geometry.hpp"
 
 // Zero a [row,col) sub-rectangle of a Float16_b tile that is otherwise -inf (the partial-window boundary
 // tile). A Float16_b tile is 4 row-major 16x16 faces of 2-byte elements, so this is a direct per-element
@@ -58,7 +59,8 @@ inline void generate_windowed_mask_for_q_chunk(
     uint32_t valid_Sqt,
     uint32_t valid_Skt,
     uint32_t k_num_chunks,
-    uint32_t cu_window_seqlens_eles) {
+    uint32_t cu_window_seqlens_eles,
+    uint32_t q_tok_offset) {
     // cu_window_seqlens is INT32/UINT32 (validated host-side); both store non-negative cumulative
     // lengths in 32-bit words, so a plain uint32 read is correct for either.
     CircularBuffer cb_cu(cb_cu_window_in);
@@ -76,8 +78,12 @@ inline void generate_windowed_mask_for_q_chunk(
 
     const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
     const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
-    const uint32_t q_low_tok = q_row_start_tile * tt::constants::TILE_HEIGHT;
-    const uint32_t q_high_tok = q_row_end_tile * tt::constants::TILE_HEIGHT;
+    // Q rows are addressed LOCALLY -- the Q tensor may be a sequence-parallel shard, so `q_chunk` and
+    // `valid_Sqt` count this device's rows only. Windows in cu_window_seqlens are GLOBAL, so the search
+    // and every window comparison run at the global position. K/V are never sharded (Sk is the full
+    // sequence), so k indices are already global and are left alone.
+    const uint32_t q_low_tok = q_tok_offset + q_row_start_tile * tt::constants::TILE_HEIGHT;
+    const uint32_t q_high_tok = q_tok_offset + q_row_end_tile * tt::constants::TILE_HEIGHT;
 
     uint32_t start_window_idx = 0;
     bool found_mask_windows = false;
@@ -91,10 +97,24 @@ inline void generate_windowed_mask_for_q_chunk(
         }
     }
 
+    // Narrowed K-chunk range for this Q chunk: the same shared function the reader uses to bound its
+    // K/V streaming and to feed compute — the three kernels' per-Q-chunk counts must agree exactly.
+    // Skipping the out-of-range chunks cannot change the cursor walk below: their tiles all take the
+    // -inf `continue` branches, which never advance `local_window_idx`.
+    const auto k_range = windowed_k_chunk_range(
+        q_chunk,
+        Sq_chunk_t,
+        valid_Sqt,
+        q_tok_offset,
+        cu_ptr,
+        cu_window_seqlens_eles,
+        Sk_chunk_t,
+        k_num_chunks,
+        tt::constants::TILE_HEIGHT);
     const uint32_t mask_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     CircularBuffer cb_mask(cb_mask_in);
     uint32_t local_window_idx = start_window_idx;
-    for (uint32_t k_chunk = 0; k_chunk < k_num_chunks; ++k_chunk) {
+    for (uint32_t k_chunk = k_range.k_lo; k_chunk < k_range.k_hi; ++k_chunk) {
         const uint32_t k_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt);
 
         cb_mask.reserve_back(mask_chunk_tiles);
@@ -103,7 +123,7 @@ inline void generate_windowed_mask_for_q_chunk(
         int zero_tile_idx = -1;
         int inf_tile_idx = -1;
         for (uint32_t row = 0; row < Sq_chunk_t; ++row) {
-            uint32_t q_start_idx = (q_row_start_tile + row) * tt::constants::TILE_HEIGHT;
+            uint32_t q_start_idx = q_tok_offset + (q_row_start_tile + row) * tt::constants::TILE_HEIGHT;
             uint32_t q_end_idx = q_start_idx + tt::constants::TILE_HEIGHT;
 
             auto result = get_window_indices(local_window_idx);
@@ -183,10 +203,19 @@ inline void windowed_generate_if_enabled(
     uint32_t valid_Sqt,
     uint32_t valid_Skt,
     uint32_t k_num_chunks,
-    uint32_t cu_window_seqlens_eles) {
+    uint32_t cu_window_seqlens_eles,
+    uint32_t q_tok_offset) {
     if constexpr (W) {
         constexpr uint32_t mask_tile_bytes = get_tile_size(cb_mask_in);
         generate_windowed_mask_for_q_chunk<mask_tile_bytes, cb_mask_in, cb_cu_window_in>(
-            noc, q_chunk, Sq_chunk_t, Sk_chunk_t, valid_Sqt, valid_Skt, k_num_chunks, cu_window_seqlens_eles);
+            noc,
+            q_chunk,
+            Sq_chunk_t,
+            Sk_chunk_t,
+            valid_Sqt,
+            valid_Skt,
+            k_num_chunks,
+            cu_window_seqlens_eles,
+            q_tok_offset);
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
+#include "api/debug/assert.h"
 #include "api/tensor/tensor_accessor.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
@@ -47,6 +48,8 @@ void kernel_main() {
     // out accessor, then the cu_window accessor chained immediately after it (before the CB-id block).
     constexpr auto out_args = TensorAccessorArgs<26>();
     constexpr auto cu_window_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+    // Per-device Q offset accessor, chained after cu_window so the offset chain stays intact.
+    constexpr auto q_offset_args = TensorAccessorArgs<cu_window_args.next_compile_time_args_offset()>();
 
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
     const uint32_t core_id = get_arg_val<uint32_t>(1);
@@ -66,11 +69,24 @@ void kernel_main() {
     const uint32_t global_q_count = get_arg_val<uint32_t>(9);
     const uint32_t cu_window_seqlens_addr = get_arg_val<uint32_t>(10);
     const uint32_t cu_window_seqlens_eles = get_arg_val<uint32_t>(11);
+    // Global row index of this tensor's first Q row. Non-zero when Q is a sequence-parallel shard:
+    // Q/output are addressed locally, but cu_window_seqlens and K/V are global, so the mask generator
+    // needs the shard's global origin. Windowed builds only: the ring-distributed factory shares this
+    // kernel, never sets use_windowed_mask, and supplies runtime args only through slot 11 — so slots
+    // 12/13 must not be read there (mirrors the reader's guarded windowed tail).
+    uint32_t q_tok_offset = 0;
+    // Per-device form: when a tensor was supplied its value wins, read below once cb_cu_window_in is
+    // available. Zero address means the caller used the scalar above.
+    uint32_t q_tok_offset_addr = 0;
+    if constexpr (use_windowed_mask) {
+        q_tok_offset = get_arg_val<uint32_t>(12);
+        q_tok_offset_addr = get_arg_val<uint32_t>(13);
+    }
 
     constexpr uint32_t mask_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;  // non-streaming drain only
 
-    constexpr uint32_t cb_arg_offset = cu_window_args.next_compile_time_args_offset();
+    constexpr uint32_t cb_arg_offset = q_offset_args.next_compile_time_args_offset();
     constexpr uint32_t cb_mask_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_identity_scale_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_col_identity = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -78,6 +94,9 @@ void kernel_main() {
     constexpr uint32_t cb_out = get_compile_time_arg_val(cb_arg_offset + 4);
     // cu_window CB id lives in the CB-id block (appended by CBIds for windowed mode; inactive otherwise).
     constexpr uint32_t cb_cu_window_in = get_compile_time_arg_val(cb_arg_offset + 5);
+    // Dedicated 1-tile CB for the per-device Q-offset tensor; allocated only when that tensor is passed
+    // (q_in otherwise, same fallback rule as cb_cu_window_in), and only touched behind the runtime guard.
+    constexpr uint32_t cb_windowed_q_offset = get_compile_time_arg_val(cb_arg_offset + 6);
 
     constexpr uint32_t tile_bytes = get_tile_size(cb_out);
 
@@ -118,6 +137,26 @@ void kernel_main() {
         noc.async_read(
             cu_window_reader, CoreLocalMem<uint32_t>(cb_cu.get_write_ptr()), cu_tile_bytes, {.page_id = 0}, {});
         noc.async_read_barrier();
+        // Per-device Q origin, if the caller passed it as a tensor. Lands in its own dedicated CB —
+        // every other CB here has a producer/consumer contract with another kernel that a writer-side
+        // reserve/push would break.
+        if (q_tok_offset_addr != 0) {
+            const auto q_offset_reader = TensorAccessor(q_offset_args, q_tok_offset_addr);
+            CircularBuffer cb_off(cb_windowed_q_offset);
+            cb_off.reserve_back(1);
+            const uint32_t off_ptr = cb_off.get_write_ptr();
+            noc.async_read(q_offset_reader, CoreLocalMem<uint32_t>(off_ptr), 4, {.page_id = 0}, {});
+            noc.async_read_barrier();
+            q_tok_offset = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(off_ptr);
+        }
+        // Watcher-build guard for the offset contract the host cannot check in the tensor form (the
+        // per-device value lives on device, so validate() never sees it): the origin must be
+        // tile-aligned, and the Q shard must fit in the K sequence. Tile-granular -- the host's
+        // scalar-form check rounded up to whole tiles. Compiled out of non-watcher builds.
+        ASSERT(q_tok_offset % tt::constants::TILE_HEIGHT == 0);
+        ASSERT(
+            q_tok_offset / tt::constants::TILE_HEIGHT + valid_Sqt <=
+            (unpadded_Sk + tt::constants::TILE_HEIGHT - 1) / tt::constants::TILE_HEIGHT);
         cb_cu.push_back(1);
     }
 
@@ -184,7 +223,8 @@ void kernel_main() {
                 valid_Sqt,
                 windowed_valid_Skt,
                 k_num_chunks,
-                cu_window_seqlens_eles);
+                cu_window_seqlens_eles,
+                q_tok_offset);
 
             // Determine how many rows of OUT will be written. Both start and end rows are
             // capped by valid_Sqt, since Sq padding is independent of Sk padding.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/windowed_loop_geometry.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/windowed_loop_geometry.hpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * Shared windowed (block-diagonal) K-loop bound geometry.
+ *
+ * Per Q chunk, windowed attention only needs the contiguous K-chunk range covering the windows
+ * that overlap the chunk's rows; everything outside it is -inf masked. The reader (which streams
+ * K/V and feeds the range to the compute kernel over a control CB) and the writer (which
+ * generates the mask) each call this on their own L1 copy of the same cu_window_seqlens tensor.
+ * They MUST compute identical bounds or the per-Q-chunk K counts desync and the CBs deadlock —
+ * this function is the single source for that math, the same contract as
+ * SlidingWindowLoopGeometry.
+ *
+ * The window search must match windowed_mask_gen.hpp's start_window_idx search bit for bit
+ * (including the first-match-wins rule and the exact overlap disjuncts): the mask generator
+ * seeds its window cursor from that search, and the narrowing proof relies on the generator
+ * entering k_lo with the same cursor it would have had running from chunk 0.
+ *
+ * Q positions are GLOBAL (q_tok_offset added — the tensor may be a sequence-parallel shard);
+ * K positions and the returned chunk indices are never offset.
+ *
+ * Returns [k_lo, k_hi) clamped to [0, k_num_chunks], never empty: a Q chunk overlapping no
+ * window (padded tail rows) gets [0, 1) — one all--inf chunk, preserving the dense path's
+ * semantics (every kernel processes >= 1 K chunk per Q chunk; the NaN rows this produces are
+ * never written, as the writer's output drain clamps to valid_Sqt).
+ */
+struct WindowedKChunkRange {
+    uint32_t k_lo;
+    uint32_t k_hi;
+};
+
+inline WindowedKChunkRange windowed_k_chunk_range(
+    uint32_t q_chunk,
+    uint32_t Sq_chunk_t,
+    uint32_t valid_Sqt,
+    uint32_t q_tok_offset,
+    volatile tt_l1_ptr uint32_t* cu_ptr,
+    uint32_t cu_window_seqlens_eles,
+    uint32_t Sk_chunk_t,
+    uint32_t k_num_chunks,
+    uint32_t tile_height) {
+    // Q token range: identical to windowed_mask_gen.hpp (valid_Sqt clamp, then global offset).
+    const uint32_t q_row_start_tile = q_chunk * Sq_chunk_t < valid_Sqt ? q_chunk * Sq_chunk_t : valid_Sqt;
+    const uint32_t q_row_end_tile =
+        q_row_start_tile + Sq_chunk_t < valid_Sqt ? q_row_start_tile + Sq_chunk_t : valid_Sqt;
+    const uint32_t q_low_tok = q_tok_offset + q_row_start_tile * tile_height;
+    const uint32_t q_high_tok = q_tok_offset + q_row_end_tile * tile_height;
+
+    // First overlapping window: the exact search (and overlap disjuncts) of the mask generator.
+    uint32_t start_window_idx = 0;
+    bool found = false;
+    for (uint32_t w = 0; w + 1 < cu_window_seqlens_eles; ++w) {
+        const uint32_t ws = cu_ptr[w];
+        const uint32_t we = cu_ptr[w + 1];
+        if ((q_low_tok >= ws && q_low_tok < we) || (q_high_tok > ws && q_high_tok <= we)) {
+            start_window_idx = w;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        return {0, 1};
+    }
+
+    // Last overlapping window: walk forward while the window ends before the Q range does.
+    // Empty windows (repeated cu values) are skipped by the same comparison.
+    uint32_t last_window_idx = start_window_idx;
+    while (last_window_idx + 2 < cu_window_seqlens_eles && cu_ptr[last_window_idx + 1] < q_high_tok) {
+        ++last_window_idx;
+    }
+
+    const uint32_t chunk_toks = tile_height * Sk_chunk_t;
+    uint32_t k_lo = cu_ptr[start_window_idx] / chunk_toks;
+    uint32_t k_hi = (cu_ptr[last_window_idx + 1] + chunk_toks - 1) / chunk_toks;
+    if (k_hi > k_num_chunks) {
+        k_hi = k_num_chunks;
+    }
+    if (k_lo >= k_hi) {
+        // Degenerate only when the windows lie entirely in K padding; keep the >= 1 chunk contract.
+        k_lo = k_hi > 0 ? k_hi - 1 : 0;
+        k_hi = k_lo + 1;
+    }
+    return {k_lo, k_hi};
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -300,6 +300,7 @@ ProgramDescriptor build_ring_distributed_sdpa_program_descriptor(
     reader_compile_time_args.push_back(0);  // valid_semaphore_id
     reader_compile_time_args.push_back(0);  // mcast_enabled
     reader_compile_time_args.push_back(static_cast<uint32_t>(use_zigzag_balancing));  // arg 33
+    reader_compile_time_args.push_back(0);  // arg 34: use_windowed_narrowing — ring is never windowed
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
@@ -309,6 +310,8 @@ ProgramDescriptor build_ring_distributed_sdpa_program_descriptor(
         .append_to(reader_compile_time_args);                  // page table
     TensorAccessorArgs().append_to(reader_compile_time_args);  // attention sink (not used in ring)
     TensorAccessorArgs().append_to(reader_compile_time_args);  // chunk_start_idx_tensor (ring has no flexible chunked)
+    TensorAccessorArgs().append_to(reader_compile_time_args);  // cu_window_seqlens (ring is never windowed)
+    TensorAccessorArgs().append_to(reader_compile_time_args);  // windowed_q_token_offset_tensor (never windowed)
 
     std::vector<uint32_t> writer_compile_time_args = {
         // interleaved accessor args
@@ -339,9 +342,10 @@ ProgramDescriptor build_ring_distributed_sdpa_program_descriptor(
         static_cast<uint32_t>(use_zigzag_balancing),  // arg 24
         0,  // arg 25: use_windowed_mask — ring never uses windowed (block-diagonal) attention
     };
-    // out accessor, then the cu_window accessor chained right after it (mirrors the regular factory so the
-    // writer's accessor offset chain stays intact). Ring is never windowed → nullptr placeholder accessor.
+    // out accessor, then the cu_window and Q-offset accessors chained right after it (mirrors the regular
+    // factory so the writer's accessor offset chain stays intact). Ring is never windowed → placeholders.
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
+    TensorAccessorArgs().append_to(writer_compile_time_args);
     TensorAccessorArgs().append_to(writer_compile_time_args);
 
     std::vector<uint32_t> compute_compile_time_args = {
@@ -380,6 +384,7 @@ ProgramDescriptor build_ring_distributed_sdpa_program_descriptor(
         valid_Skt,  // arg 31: unpadded K tiles for streaming padded_k_tiles
         0u,         // arg 32: k_partial_col - unused on ring's non-streaming path
         static_cast<uint32_t>(use_zigzag_balancing),  // arg 33: unified zigzag remap
+        0,                                            // arg 34: use_windowed_narrowing — ring is never windowed
     };
     std::map<std::string, std::string> defines_map;
     defines_map["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -438,11 +443,14 @@ ProgramDescriptor build_ring_distributed_sdpa_program_descriptor(
     };
 
     cb_ids.q_in = allocate_tile_cb(q_tiles, q_tile_size, q_df);
-    // Ring is never windowed, but the writer's windowed block (gated by `if constexpr`) is still compiled
-    // in a non-template function, so get_tile_size(cb_cu_window_in) must resolve to a valid CB id rather
-    // than the `inactive` sentinel (which constexpr-faults on unpack_tile_size[-1]). Mirror the regular
-    // factory and point it at q_in.
+    // Ring is never windowed, but the writer's and reader's windowed blocks (gated by `if constexpr`)
+    // are still compiled in non-template functions, so their get_tile_size calls must resolve to valid
+    // CB ids rather than the `inactive` sentinel (which constexpr-faults on unpack_tile_size[-1]).
+    // Mirror the regular factory and point them all at q_in.
     cb_ids.cu_window_seqlens = cb_ids.q_in;
+    cb_ids.windowed_q_offset = cb_ids.q_in;
+    cb_ids.windowed_cu_reader = cb_ids.q_in;
+    cb_ids.windowed_k_range = cb_ids.q_in;
     cb_ids.k_in = allocate_tile_cb(k_tiles, k_tile_size, k_df);
     cb_ids.v_in = allocate_tile_cb(v_tiles, v_tile_size, v_df);
     cb_ids.mask_in = allocate_tile_cb(mask_tiles, mask_tile_size, mask_df);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -464,6 +464,49 @@ void SDPAOperation::validate_on_program_cache_miss(const SDPAParams& attrs, cons
             "cu_window_seqlens must have between 2 and {} elements, got {}.",
             max_cu_window_seqlens,
             cu_eles);
+        // A sharded Q must start on a tile boundary -- the mask generator offsets whole tiles -- and its
+        // rows must lie inside the sequence the windows describe. The row-count bound holds for any
+        // offset >= 0, so it is checked in both offset forms.
+        const auto q_rows = static_cast<uint32_t>(q.logical_shape()[-2]);
+        const auto k_rows = static_cast<uint32_t>(k.logical_shape()[-2]);
+        TT_FATAL(
+            q_rows <= k_rows,
+            "windowed Q shard has {} rows, more than the K sequence length {}.",
+            q_rows,
+            k_rows);
+        if (!tensors.windowed_q_token_offset_tensor.has_value()) {
+            // Scalar form. (When the tensor is supplied it overrides the scalar on device, and its
+            // per-device values cannot be validated here without a readback -- tile alignment and
+            // offset + q_rows <= Sk are the caller's responsibility in that form.)
+            TT_FATAL(
+                attrs.windowed_q_token_offset % tt::constants::TILE_HEIGHT == 0,
+                "windowed_q_token_offset must be a multiple of {}, got {}.",
+                tt::constants::TILE_HEIGHT,
+                attrs.windowed_q_token_offset);
+            // q_rows <= k_rows was checked above, so the subtraction cannot wrap.
+            TT_FATAL(
+                attrs.windowed_q_token_offset <= k_rows - q_rows,
+                "windowed Q shard [{}, {} + {}) does not fit in the K sequence length {}.",
+                attrs.windowed_q_token_offset,
+                attrs.windowed_q_token_offset,
+                q_rows,
+                k_rows);
+        }
+        if (tensors.windowed_q_token_offset_tensor.has_value()) {
+            const auto& off = tensors.windowed_q_token_offset_tensor.value();
+            TT_FATAL(off.storage_type() == StorageType::DEVICE, "windowed_q_token_offset_tensor must be on device.");
+            TT_FATAL(off.buffer() != nullptr, "windowed_q_token_offset_tensor must be allocated on device.");
+            TT_FATAL(q.device() == off.device(), "windowed_q_token_offset_tensor must be on the same device as Q/K/V.");
+            TT_FATAL(
+                off.dtype() == DataType::INT32 || off.dtype() == DataType::UINT32,
+                "windowed_q_token_offset_tensor must be INT32/UINT32, got {}.",
+                off.dtype());
+            TT_FATAL(off.layout() == Layout::ROW_MAJOR, "windowed_q_token_offset_tensor must be ROW_MAJOR.");
+            TT_FATAL(
+                off.logical_shape().volume() == 1,
+                "windowed_q_token_offset_tensor must hold exactly 1 element, got {}.",
+                off.logical_shape().volume());
+        }
     };
 
     check_conditions();
@@ -602,6 +645,8 @@ Tensor sdpa(
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     const std::optional<Tensor>& cu_window_seqlens,
+    uint32_t windowed_q_token_offset,
+    const std::optional<Tensor>& windowed_q_token_offset_tensor,
     std::optional<ttnn::operations::transformer::PagedCacheGeometryOverride> paged_cache_geometry) {
     using OperationType = ttnn::prim::SDPAOperation;
     return ttnn::device_operation::launch<OperationType>(
@@ -617,6 +662,7 @@ Tensor sdpa(
             .head_dim_v = head_dim_v,
             .sliding_window_size = sliding_window_size,
             .is_windowed = cu_window_seqlens.has_value(),
+            .windowed_q_token_offset = windowed_q_token_offset,
             .paged_cache_geometry =
                 paged_cache_geometry.value_or(ttnn::operations::transformer::PagedCacheGeometryOverride{}),
         },
@@ -629,6 +675,7 @@ Tensor sdpa(
             .chunk_start_idx_tensor = chunk_start_idx_tensor,
             .attention_sink = attention_sink,
             .cu_window_seqlens = cu_window_seqlens,
+            .windowed_q_token_offset_tensor = windowed_q_token_offset_tensor,
         });
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
@@ -58,6 +58,8 @@ Tensor sdpa(
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     const std::optional<Tensor>& cu_window_seqlens = std::nullopt,
+    uint32_t windowed_q_token_offset = 0,
+    const std::optional<Tensor>& windowed_q_token_offset_tensor = std::nullopt,
     std::optional<ttnn::operations::transformer::PagedCacheGeometryOverride> paged_cache_geometry = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation_types.hpp
@@ -25,6 +25,10 @@ struct SDPAParams {
     // Windowed (block-diagonal) attention: when true, the mask is synthesized on-device from the
     // cu_window_seqlens tensor instead of being read from attn_mask. Implies non-causal.
     bool is_windowed = false;
+    // Global row index of Q row 0, when Q is a sequence-parallel shard of a longer sequence. Q and the
+    // output are addressed locally; cu_window_seqlens and K/V stay global, so the mask generator offsets
+    // Q by this to find the right windows. 0 means Q spans the whole sequence (the unsharded case).
+    uint32_t windowed_q_token_offset = 0;
     // Chunked/paged geometry overrides (shared with paged decode). See
     // ttnn::operations::transformer::PagedCacheGeometryOverride.
     ttnn::operations::transformer::PagedCacheGeometryOverride paged_cache_geometry;
@@ -42,6 +46,10 @@ struct SDPAInputs {
     // Cumulative window sequence lengths [num_windows + 1], int32/uint32, ROW_MAJOR. Present only in
     // windowed mode; the writer builds the block-diagonal mask from it.
     std::optional<Tensor> cu_window_seqlens;
+    // Windowed mode: 1-element int32/uint32 ROW_MAJOR tensor holding the Q shard's global row origin,
+    // read by the writer at runtime. Present only when the caller wants a per-device offset under one
+    // shared program; otherwise the scalar windowed_q_token_offset is used.
+    std::optional<Tensor> windowed_q_token_offset_tensor;
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_interleaved_cb_ids.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_interleaved_cb_ids.hpp
@@ -33,14 +33,34 @@ struct CBIds {
     uint32_t sum_A = inactive;
     uint32_t sum_B = inactive;
     uint32_t exp_max_diff = inactive;
-    uint32_t cu_window_seqlens = inactive;  // windowed mode only
+    uint32_t cu_window_seqlens = inactive;   // windowed mode only (the writer's copy)
+    uint32_t windowed_q_offset = inactive;   // windowed mode with a per-device Q-offset tensor only
+    uint32_t windowed_cu_reader = inactive;  // windowed narrowing only: the reader's own cu_window copy
+    uint32_t windowed_k_range = inactive;    // windowed narrowing only: per-Q-chunk {k_lo, k_hi}, reader -> compute
 
     std::vector<uint32_t> reader_compile_time_args() const {
-        return {q_in, k_in, v_in, mask_in, attention_sink, page_table, chunk_start_idx_compute, chunk_start_idx_writer};
+        return {
+            q_in,
+            k_in,
+            v_in,
+            mask_in,
+            attention_sink,
+            page_table,
+            chunk_start_idx_compute,
+            chunk_start_idx_writer,
+            windowed_cu_reader,
+            windowed_k_range};
     }
 
     std::vector<uint32_t> writer_compile_time_args() const {
-        return {mask_in, identity_scale_in, col_identity, chunk_start_idx_writer, out, cu_window_seqlens};
+        return {
+            mask_in,
+            identity_scale_in,
+            col_identity,
+            chunk_start_idx_writer,
+            out,
+            cu_window_seqlens,
+            windowed_q_offset};
     }
 
     std::vector<uint32_t> compute_compile_time_args() const {
@@ -62,7 +82,8 @@ struct CBIds {
             max_B,
             sum_A,
             sum_B,
-            exp_max_diff};
+            exp_max_diff,
+            windowed_k_range};
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -181,6 +181,70 @@ uint32_t attention_sink_tile_count(bool use_attention_sink, bool use_streaming_c
     return use_streaming_compute ? 1 : q_chunk_tiles;
 }
 
+// TensorAccessorArgs placeholder rule for optional tensors: nullptr when absent, so the accessor
+// chain stays intact and kernels compile against it but never read it.
+tt::tt_metal::Buffer* buffer_or_null(const std::optional<Tensor>& t) {
+    return t.has_value() ? t.value().buffer() : nullptr;
+}
+
+// Windowed (block-diagonal) CB allocation and runtime values, split out of create_descriptor (which
+// sits at clang-tidy's cognitive-complexity limit). The allocators are create_descriptor's CB lambdas.
+struct WindowedSetup {
+    tt::tt_metal::Buffer* cu_window_buffer = nullptr;
+    tt::tt_metal::Buffer* q_offset_buffer = nullptr;
+    uint32_t cu_window_seqlens_eles = 0;
+    // Global row index of Q row 0. Non-zero only when Q is a sequence-parallel shard of a longer
+    // sequence: Q and the output are addressed locally, while cu_window_seqlens and K/V stay global,
+    // so the writer's mask generator needs the shard's origin to find the right windows.
+    uint32_t q_token_offset = 0;
+};
+
+template <typename AllocateTileCb, typename AllocateCb>
+WindowedSetup setup_windowed_cbs(
+    const SDPAParams& attrs,
+    const SDPAInputs& tensors,
+    sdpa_cb::CBIds& cb_ids,
+    const AllocateTileCb& allocate_tile_cb,
+    const AllocateCb& allocate_cb) {
+    WindowedSetup w;
+    // When NOT windowed, fall back to a valid CB id (q_in): the writer's windowed block is gated by
+    // `if constexpr`, but in a non-template function the discarded branch is still compiled, so
+    // get_tile_size/get_dataformat on this id must be well-formed (an inactive id would
+    // constexpr-fault on unpack_tile_size[-1]).
+    cb_ids.cu_window_seqlens = cb_ids.q_in;
+    cb_ids.windowed_q_offset = cb_ids.q_in;
+    cb_ids.windowed_cu_reader = cb_ids.q_in;
+    cb_ids.windowed_k_range = cb_ids.q_in;
+    if (!attrs.is_windowed) {
+        return w;
+    }
+    // 1-tile CB holding cu_window_seqlens, loaded once by the writer.
+    const auto& cu = tensors.cu_window_seqlens.value();
+    tt::DataFormat cu_df = tt::tt_metal::datatype_to_dataformat_converter(cu.dtype());
+    cb_ids.cu_window_seqlens = allocate_tile_cb(1, tt::tile_size(cu_df), cu_df);
+    // K-range narrowing: the reader gets its OWN cu_window copy (sharing the writer's CB would put
+    // two producers on one CB), and a small reader->compute ctrl CB carrying each Q chunk's
+    // {k_lo, k_hi} (double-buffered so the reader can run a Q chunk ahead; sparse_sdpa precedent).
+    cb_ids.windowed_cu_reader = allocate_tile_cb(1, tt::tile_size(cu_df), cu_df);
+    constexpr uint32_t k_range_page_size = 16;
+    cb_ids.windowed_k_range = allocate_cb(k_range_page_size, 2, tt::DataFormat::Int32);
+    w.cu_window_buffer = cu.buffer();
+    w.cu_window_seqlens_eles = cu.logical_shape()[-1];
+    w.q_token_offset = attrs.windowed_q_token_offset;
+    if (tensors.windowed_q_token_offset_tensor.has_value()) {
+        // Per-device form: the writer reads the value at runtime, so the scalar baked into the
+        // program is unused. Kept identical across devices, which is the point -- one program.
+        // The offset gets its own 1-tile CB: every other CB has a producer/consumer contract with
+        // another kernel that a writer-side reserve/push would break (borrowing the reader-produced
+        // chunk_start_idx_writer CB deadlocked).
+        const auto& off = tensors.windowed_q_token_offset_tensor.value();
+        tt::DataFormat off_df = tt::tt_metal::datatype_to_dataformat_converter(off.dtype());
+        cb_ids.windowed_q_offset = allocate_tile_cb(1, tt::tile_size(off_df), off_df);
+        w.q_offset_buffer = off.buffer();
+    }
+    return w;
+}
+
 }  // namespace
 
 ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
@@ -565,6 +629,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     reader_compile_time_args.push_back(0);  // valid_semaphore_id placeholder
     reader_compile_time_args.push_back(0);  // mcast_enabled placeholder
     reader_compile_time_args.push_back(static_cast<uint32_t>(use_zigzag_balancing));  // arg 33
+    reader_compile_time_args.push_back(static_cast<uint32_t>(is_windowed));           // arg 34: K-range narrowing
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
@@ -574,6 +639,11 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     TensorAccessorArgs(attention_sink.has_value() ? attention_sink->buffer() : nullptr)
         .append_to(reader_compile_time_args);
     TensorAccessorArgs(flexible_chunked ? tensor_args.chunk_start_idx_tensor.value().buffer() : nullptr)
+        .append_to(reader_compile_time_args);
+    // Windowed K-range narrowing: the reader needs its own view of cu_window_seqlens and the per-device
+    // Q-offset tensor to compute each Q chunk's [k_lo, k_hi) — same placeholder rule as the writer's pair.
+    TensorAccessorArgs(buffer_or_null(tensor_args.cu_window_seqlens)).append_to(reader_compile_time_args);
+    TensorAccessorArgs(buffer_or_null(tensor_args.windowed_q_token_offset_tensor))
         .append_to(reader_compile_time_args);
 
     // Set up semaphore IDs for KV chain forwarding (non-causal only).
@@ -634,7 +704,10 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     // out accessor, then the cu_window accessor chained right after it (before the CB-id block) so the
     // accessor offset chain stays intact. nullptr when not windowed (consistent placeholder).
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
-    TensorAccessorArgs(is_windowed ? tensor_args.cu_window_seqlens.value().buffer() : nullptr)
+    TensorAccessorArgs(buffer_or_null(tensor_args.cu_window_seqlens)).append_to(writer_compile_time_args);
+    // Then the per-device Q-offset accessor. Same chain, same placeholder rule: nullptr when the caller
+    // passed the offset as a scalar (or is not windowed), in which case the writer never reads it.
+    TensorAccessorArgs(buffer_or_null(tensor_args.windowed_q_token_offset_tensor))
         .append_to(writer_compile_time_args);
 
     std::vector<uint32_t> compute_compile_time_args = {
@@ -673,6 +746,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         valid_Skt,                                    // arg 31: unpadded K tile count for streaming padded_k_tiles
         k_partial_col,                                // arg 32: K partial-tile col (0 = no partial)
         static_cast<uint32_t>(use_zigzag_balancing),  // arg 33: unified zigzag remap
+        static_cast<uint32_t>(is_windowed),           // arg 34: K-range narrowing (bounds from the ctrl CB)
     };
 
     std::map<std::string, std::string> defines_map;
@@ -769,20 +843,13 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         cb_ids.mask_in = allocate_tile_cb(mask_tiles, actual_mask_tile_size, actual_mask_df);
     }
 
-    // Windowed: 1-tile CB holding cu_window_seqlens, loaded once by the writer. When NOT windowed, fall
-    // back to a valid CB id (q_in): the writer's windowed block is gated by `if constexpr`, but in a
-    // non-template function the discarded branch is still compiled, so get_tile_size/get_dataformat on
-    // this id must be well-formed (an inactive id would constexpr-fault on unpack_tile_size[-1]).
-    tt::tt_metal::Buffer* cu_window_buffer = nullptr;
-    uint32_t cu_window_seqlens_eles = 0;
-    cb_ids.cu_window_seqlens = cb_ids.q_in;
-    if (is_windowed) {
-        const auto& cu = tensor_args.cu_window_seqlens.value();
-        tt::DataFormat cu_df = tt::tt_metal::datatype_to_dataformat_converter(cu.dtype());
-        cb_ids.cu_window_seqlens = allocate_tile_cb(1, tt::tile_size(cu_df), cu_df);
-        cu_window_buffer = cu.buffer();
-        cu_window_seqlens_eles = cu.logical_shape()[-1];
-    }
+    // Windowed (block-diagonal) CBs and runtime values; see setup_windowed_cbs above.
+    const WindowedSetup windowed =
+        setup_windowed_cbs(operation_attributes, tensor_args, cb_ids, allocate_tile_cb, allocate_cb);
+    tt::tt_metal::Buffer* const cu_window_buffer = windowed.cu_window_buffer;
+    tt::tt_metal::Buffer* const windowed_q_offset_buffer = windowed.q_offset_buffer;
+    const uint32_t cu_window_seqlens_eles = windowed.cu_window_seqlens_eles;
+    const uint32_t windowed_q_token_offset = windowed.q_token_offset;
 
     cb_ids.identity_scale_in = allocate_tile_cb(scale_tiles, scalar_tile_size, scalar_df);
     cb_ids.col_identity = allocate_tile_cb(scale_tiles, scalar_tile_size, scalar_df);
@@ -872,7 +939,11 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     std::vector<std::vector<HeadSegmentRef>> head_segments;
     uint32_t mcast_chains = 0;
 
-    if (!is_causal && !is_chunked && !has_sliding_window) {
+    // Windowed is excluded like sliding-window: both narrow the per-Q-chunk K range, and chains
+    // lock-step-forward K between cores whose Q chunks now need DIFFERENT K ranges — the semaphore
+    // handshake counts diverge and the cores deadlock. Narrowing saves far more K reads than
+    // forwarding did.
+    if (!is_causal && !is_chunked && !has_sliding_window && !is_windowed) {
         head_segments.resize(total_heads);
 
         log_debug(tt::LogOp, "=== Building KV chain forwarding topology ===");
@@ -1438,6 +1509,13 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
         reader_args.push_back(global_q_start);
         reader_args.push_back(global_q_count);
 
+        // Windowed K-range narrowing tail: same four values the writer gets at slots 10-13, so the
+        // reader resolves each Q chunk's global row range and windows identically.
+        reader_args.push_back(cu_window_buffer);
+        reader_args.push_back(cu_window_seqlens_eles);
+        reader_args.push_back(windowed_q_token_offset);
+        reader_args.push_back(windowed_q_offset_buffer);
+
         reader_desc.emplace_runtime_args(core, reader_args);
 
         writer_desc.emplace_runtime_args(
@@ -1453,7 +1531,9 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
              global_q_start,                                   // 8
              global_q_count,                                   // 9
              cu_window_buffer,                                 // 10: windowed mask src (nullptr if unused)
-             cu_window_seqlens_eles});                         // 11: window count + 1
+             cu_window_seqlens_eles,                           // 11: window count + 1
+             windowed_q_token_offset,                          // 12: global origin of this Q shard (scalar)
+             windowed_q_offset_buffer});                       // 13: same, per-device (nullptr => use 12)
 
         compute_desc.emplace_runtime_args(
             core,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -44,7 +44,9 @@ ttnn::Tensor scaled_dot_product_attention(
     std::optional<ttnn::operations::transformer::SDPAProgramConfig> program_config,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<ttnn::Tensor>& attention_sink,
-    const std::optional<ttnn::Tensor>& cu_window_seqlens) {
+    const std::optional<ttnn::Tensor>& cu_window_seqlens,
+    uint32_t windowed_q_token_offset,
+    const std::optional<ttnn::Tensor>& windowed_q_token_offset_tensor) {
     [[maybe_unused]] auto arch = input_tensor_q.storage_type() == StorageType::DEVICE
                                      ? input_tensor_q.device()->arch()
                                      : ttnn::GetDefaultDevice()->arch();
@@ -92,7 +94,9 @@ ttnn::Tensor scaled_dot_product_attention(
         memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG),
         std::move(program_config),
         kernel_config_val,
-        cu_window_seqlens);
+        cu_window_seqlens,
+        windowed_q_token_offset,
+        windowed_q_token_offset_tensor);
 }
 
 // Legacy: chunk_start_idx as scalar (part of program cache key).
@@ -131,6 +135,8 @@ ttnn::Tensor chunked_scaled_dot_product_attention(
         std::move(program_config),
         kernel_config_val,
         std::nullopt,  // cu_window_seqlens
+        0,             // windowed_q_token_offset (windowed mode only)
+        std::nullopt,  // windowed_q_token_offset_tensor
         paged_cache_geometry);
 }
 
@@ -170,6 +176,8 @@ ttnn::Tensor chunked_scaled_dot_product_attention(
         std::move(program_config),
         kernel_config_val,
         std::nullopt,  // cu_window_seqlens
+        0,             // windowed_q_token_offset (windowed mode only)
+        std::nullopt,  // windowed_q_token_offset_tensor
         paged_cache_geometry);
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -25,7 +25,15 @@ ttnn::Tensor scaled_dot_product_attention(
     std::optional<operations::transformer::SDPAProgramConfig> program_config = std::nullopt,
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     const std::optional<ttnn::Tensor>& attention_sink = std::nullopt,
-    const std::optional<ttnn::Tensor>& cu_window_seqlens = std::nullopt);
+    const std::optional<ttnn::Tensor>& cu_window_seqlens = std::nullopt,
+    /// Windowed mode only. Global row index of Q row 0, for a Q holding a contiguous slice of a longer
+    /// sequence: Q and the output are indexed locally while cu_window_seqlens and K/V stay global, so this
+    /// locates the slice among the windows. Must be a multiple of TILE_HEIGHT and satisfy offset+Sq <= Sk.
+    uint32_t windowed_q_token_offset = 0,
+    /// Windowed mode only. Per-device form of the offset above: a 1-element int32/uint32 ROW_MAJOR device
+    /// tensor, read at runtime rather than baked into the program. Shard it on the sequence-parallel axis
+    /// so every device runs the SAME program yet sees its own origin. Overrides the scalar when set.
+    const std::optional<ttnn::Tensor>& windowed_q_token_offset_tensor = std::nullopt);
 
 /// Chunked SDPA over paged K/V: one Q chunk per call, K/V in paged layout.
 /// Two overloads: legacy (chunk_start_idx as int) or flexible (chunk_start_idx_tensor on device).

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -325,6 +325,8 @@ void bind_sdpa(nb::module_& mod) {
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): Defaults to `None`.
             attention_sink (ttnn.Tensor, optional): Defaults to `None`. [1 x nqh x 1 x 1]. Single attention sink value per head. The kernel will efficiently replicate this value across all query positions.
             cu_window_seqlens (ttnn.Tensor, optional): Defaults to `None`. 1D int32/uint32 ROW_MAJOR tensor of cumulative window boundaries [0, w1, w1+w2, ..., s]. When provided, computes block-diagonal (windowed) attention where each token attends only within its window; the mask is built on-device. Non-causal; mutually exclusive with attn_mask/is_causal/sliding_window_size.
+            windowed_q_token_offset (int): Defaults to `0`. Windowed mode only. Global row index of Q row 0, for a Q holding a contiguous slice of a longer sequence: Q and the output are indexed locally while `cu_window_seqlens` and K/V stay global, so this locates the slice among the windows. Must be a multiple of TILE_HEIGHT, and `offset + Sq` must not exceed `Sk`. Use it to split the Q dimension across devices under sequence parallelism.
+            windowed_q_token_offset_tensor (ttnn.Tensor, optional): Defaults to `None`. Windowed mode only. The per-device form of `windowed_q_token_offset`: a 1-element int32/uint32 ROW_MAJOR on-device tensor holding the same global row index; when provided it overrides the scalar. Every device runs the same cached program, so a scalar cannot differ across a mesh -- shard this tensor on the sequence-parallel mesh axis (e.g. `arange(sp) * local_seq_len`) so each device reads its own shard's origin. The scalar's constraints apply to each device's value (a multiple of TILE_HEIGHT; `offset + Sq <= Sk`) but cannot be validated host-side -- they are the caller's responsibility.
 
 
         Returns:
@@ -348,7 +350,9 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("program_config") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("attention_sink") = nb::none(),
-        nb::arg("cu_window_seqlens") = nb::none());
+        nb::arg("cu_window_seqlens") = nb::none(),
+        nb::arg("windowed_q_token_offset") = 0,
+        nb::arg("windowed_q_token_offset_tensor") = nb::none());
 
     ttnn::bind_function<"sparse_sdpa", "ttnn.transformer.">(
         mod,


### PR DESCRIPTION
### Summary
Extends windowed (block-diagonal) SDPA — the `cu_window_seqlens` mode from #48200 — with three capabilities needed to run block-diagonal attention over a sequence-parallel-sharded Q, and to stop paying dense compute (which would mult against all K/V, and then mask out the results) for it. The Qwen3-VL vision tower for the MiniMax-H3 conditioner needs this.

1. **Variable size window of Q** (`windowed_q_token_offset`): Q rows may be `[offset, offset + Sq)` of the sequence the windows describe, instead of the whole sequence or a fixed size window. The offset must be tile-aligned (the mask generator shifts whole tiles) and the shard must fit inside K.
2. **Per-device offset tensor** (`windowed_q_token_offset_tensor`): a 1-element uint32/int32 tensor, sharded on the SP mesh axis, so each device reads its own global origin. A scalar cannot express this — every device runs the same cached program, so per-device divergence has to live in data.
3. **Per-Q-chunk K-loop narrowing**: each Q chunk only visits the contiguous K-chunk range `[k_lo, k_hi)` covering the windows it overlaps; everything outside is skipped (no reads, no matmuls, no mask tiles) instead of computed-then-masked to −inf. Compute drops from O(S²) to Σᵢ blockᵢ². The reader forwards the range to compute over a control CB; the writer derives the same range independently for its mask tiles, so the bound math lives in one shared header (`windowed_loop_geometry.hpp`, the same single-source contract as `SlidingWindowLoopGeometry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jonathansu/sdpa-windowed-q-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jonathansu/sdpa-windowed-q-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jonathansu/sdpa-windowed-q-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jonathansu/sdpa-windowed-q-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jonathansu/sdpa-windowed-q-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jonathansu/sdpa-windowed-q-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jonathansu/sdpa-windowed-q-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jonathansu/sdpa-windowed-q-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jonathansu/sdpa-windowed-q-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jonathansu/sdpa-windowed-q-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jonathansu/sdpa-windowed-q-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jonathansu/sdpa-windowed-q-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jonathansu/sdpa-windowed-q-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jonathansu/sdpa-windowed-q-slice)