### PR TITLE
Fix merge-gate build: keep unit_tests_gha_annotation on metal_common_pch

### DIFF
--- a/tests/tt_metal/test_utils/CMakeLists.txt
+++ b/tests/tt_metal/test_utils/CMakeLists.txt
@@ -14,7 +14,13 @@ target_link_libraries(
         gtest
         gtest_main
 )
-target_precompile_headers(unit_tests_gha_annotation REUSE_FROM metal_test_pch)
+# NOTE: deliberately metal_common_pch, not metal_test_pch. metal_test_pch is compiled with
+# TT::Metalium's usage requirements (TRACY_IMPORTS, the tt-metalium/ include dirs) and its
+# contents #include <tt-metalium/...>. REUSE_FROM does not propagate those to the consumer, so a
+# target that doesn't link Metalium can neither validate the .gch (-Winvalid-pch) nor fall back to
+# parsing the header textually. This test links only TT::STL + gtest and includes no Metalium
+# headers; keep it on the common PCH rather than linking Metalium just to satisfy the PCH.
+target_precompile_headers(unit_tests_gha_annotation REUSE_FROM metal_common_pch)
 set_target_properties(
     unit_tests_gha_annotation
     PROPERTIES


### PR DESCRIPTION
Fixes the merge-gate failure on #53733 — [build-sweeps / build (Ubuntu 24.04, gcc-14, Release)](https://github.com/tenstorrent/tt-metal/actions/runs/32432181133/job/96626266027).

## Failure

```
[1772/2184] Building CXX object tests/tt_metal/test_utils/CMakeFiles/unit_tests_gha_annotation.dir/test_gha_annotation.cpp.o
FAILED: ...
cc1plus: error: /work/build/tests/CMakeFiles/metal_test_pch.dir/cmake_pch.hxx.gch:
         not used because `TRACY_IMPORTS' not defined [-Werror=invalid-pch]
/work/build/tests/CMakeFiles/metal_test_pch.dir/cmake_pch.hxx:23:10:
         fatal error: tt-metalium/host_api.hpp: No such file or directory
```

## Root cause

`metal_test_pch` links `test_common_libs` → `TT::Metalium`, so it is compiled with

- `-DTRACY_IMPORTS` (`TracyClient` is a `PUBLIC` dep of `TT::Metalium`), and
- the `tt-metalium/` include directories,

and its contents `#include <tt-metalium/host_api.hpp>`, `<tt-metalium/distributed.hpp>`, etc.

`target_precompile_headers(... REUSE_FROM ...)` does **not** propagate the provider's compile definitions or include directories to the consumer — the consumer has to already have matching flags for the `.gch` to be usable.

`unit_tests_gha_annotation` links only `tt_metal_test_utils_gha_annotation` (→ `TT::STL`) plus gtest/gmock. It has neither the define nor the include dirs, so gcc rejects the `.gch` under `-Winvalid-pch` (fatal via `-Werror`), then falls back to parsing `cmake_pch.hxx` textually and cannot find the Metalium headers.

## Fix

Revert this one target to `metal_common_pch` (std + fmt + nlohmann only), as it was before this PR, and add a comment so the pairing isn't re-broken.

`test_gha_annotation.cpp` includes no Metalium headers at all — it tests a header-only `tt_stl` utility — so linking `TT::Metalium` into it purely to satisfy the PCH would be a regression for a deliberately standalone test.

## Scope check

I checked every target switched to `metal_test_pch` in #53733 for transitive reachability of `TT::Metalium` (via `test_common_libs` / `test_metal_common_libs` / `Metalium::Metal`). `unit_tests_gha_annotation` is the only one that doesn't reach it, which matches the log — exactly one `FAILED` line. The rest are fine.

## Alternative, if you'd prefer it

This target does use gtest/gmock heavily, so it loses out on the gtest headers now in `metal_test_pch`. A third, Metalium-free "light test PCH" (std + fmt + gtest) would cover it — but that's an extra PCH compilation to speed up a single small TU, which seemed net-negative. Happy to switch if you disagree.

## Verification

- `gersemi==0.16.2 --check` passes on the modified file.
- Not built locally — a full tt-metal build isn't feasible in my sandbox. The mechanism is fully determined by the compile line in the failing log (no `-DTRACY_IMPORTS`, no tt-metalium include dirs), and `metal_common_pch` for this target is the configuration currently green on `main`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=blozano/pch-fix-gha-annotation-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:blozano/pch-fix-gha-annotation-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=blozano/pch-fix-gha-annotation-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:blozano/pch-fix-gha-annotation-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/pch-fix-gha-annotation-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/pch-fix-gha-annotation-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=blozano/pch-fix-gha-annotation-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:blozano/pch-fix-gha-annotation-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/pch-fix-gha-annotation-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/pch-fix-gha-annotation-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=blozano/pch-fix-gha-annotation-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:blozano/pch-fix-gha-annotation-pch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=blozano/pch-fix-gha-annotation-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:blozano/pch-fix-gha-annotation-pch)