### PR TITLE
refactor: deduplicate mesh-packing machinery in topology_mapper_utils.cpp

### DIFF
--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -833,6 +833,183 @@ std::map<MeshId, MeshPhysicalLayout> mesh_physical_layouts_from_psd_placements(
     return layouts;
 }
 
+// -----------------------------------------------------------------------------
+// Shared round-robin mesh-packing machinery used by both
+// build_physical_multi_mesh_adjacency_graph overloads (single-MGD and
+// multi-MGD). MeshEnumState, the bitmask helpers, and DisjointPackingSearch
+// below were previously duplicated verbatim inside each overload.
+//
+// MeshEnumState bundles everything needed to drive one shape's solver and
+// remember what it has found so far:
+//   logical_graph   — the pattern we want to place: either the mesh
+//                     instances from the logical descriptor, or the full
+//                     physical coarse topology when only one shape exists
+//                     and all placements need to be assigned.
+//   physical_graph  — the hardware mesh-level connectivity for this shape.
+//   session         — the incremental solver; it keeps prior constraints in
+//                     memory so each call only adds new work.
+//   excluded        — solutions already returned; fed back to the solver so
+//                     it doesn't repeat them.
+//   solutions       — all solutions found so far, in the order returned.
+//   solution_bits   — a chip bitmask for each solution; used for fast
+//                     overlap checks in the packing search below.
+//   embedding_sizes — how many meshes each solution places; used to try
+//                     larger placements first (better pruning).
+//   exhausted       — set to true once the solver finds no more options.
+// -----------------------------------------------------------------------------
+struct MeshEnumState {
+    AdjacencyGraph<MeshId> logical_graph;
+    AdjacencyGraph<MeshId> physical_graph;
+    ::tt::tt_fabric::MappingConstraints<MeshId, MeshId> constraints;
+    ::tt::tt_fabric::TopologyMappingEnumerationSession<MeshId, MeshId> session;
+    std::vector<std::map<MeshId, MeshId>> excluded;
+    std::vector<::tt::tt_fabric::MappingResult<MeshId, MeshId>> solutions;
+    std::vector<std::vector<std::uint64_t>> solution_bits;
+    std::vector<std::size_t> embedding_sizes;
+    bool exhausted = false;
+};
+
+// -----------------------------------------------------------------------------
+// BITMASK HELPERS
+// Each cached solution carries a bitmask with one bit per chip in the
+// cluster. Three helpers operate on these bitmasks word by word
+// (asic_word_count = number of 64-bit words per bitmask, passed explicitly by
+// the callers):
+//
+//   bitset_disjoint(a, b) — true if a and b share no chip (no bit set in
+//                           both), i.e. the two placements don't overlap.
+//   mark_used(dst, src)   — dst |= src  (mark src's chips as taken).
+//   unmark(dst, src)      — dst &= ~src (release src's chips on backtrack).
+//
+// These are tight 64-bit word loops that the compiler can auto-vectorise.
+// The cost per combination is proportional to cluster size in words, not
+// to the number of chips per mesh.
+// -----------------------------------------------------------------------------
+bool bitset_disjoint(
+    const std::vector<std::uint64_t>& cand, const std::vector<std::uint64_t>& occupied, std::size_t asic_word_count) {
+    for (std::size_t i = 0; i < asic_word_count; ++i) {
+        if (cand[i] & occupied[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+void mark_used(std::vector<std::uint64_t>& dst, const std::vector<std::uint64_t>& src, std::size_t asic_word_count) {
+    for (std::size_t i = 0; i < asic_word_count; ++i) {
+        dst[i] |= src[i];
+    }
+}
+void unmark(std::vector<std::uint64_t>& dst, const std::vector<std::uint64_t>& src, std::size_t asic_word_count) {
+    for (std::size_t i = 0; i < asic_word_count; ++i) {
+        dst[i] &= ~src[i];
+    }
+}
+
+// -----------------------------------------------------------------------------
+// DisjointPackingSearch — depth-first search over all combinations of one
+// placement per mesh shape.
+//
+// At each level of the recursion we try every cached placement for one
+// shape (largest first), skip any that overlap chips already claimed by
+// earlier levels, and recurse deeper if it fits.
+//
+// "Test each combination only once" rule: in round k we only check
+// combinations that include at least one placement that is new this round
+// (cache index k-1). Any combination made entirely of older placements was
+// already checked in a previous round. This is enforced by carrying a
+// flag (frontier_satisfied) through the recursion; at the leaf level we
+// only accept a candidate if the flag is already set or the candidate
+// itself is the new one.
+// -----------------------------------------------------------------------------
+struct DisjointPackingSearch {
+    const std::vector<MeshEnumState*>& states;
+    const std::vector<std::vector<std::size_t>>& try_order_per_depth;
+    std::vector<std::size_t>& chosen_index;
+    std::vector<std::uint64_t>& occupied_asics;
+    std::size_t round;       // current round number (1-based)
+    std::size_t target_idx;  // = round - 1; the "new" cache index this round
+    std::size_t n_meshes;
+    std::size_t& combinations_tested;
+    std::size_t& timer_check_mask;
+    std::chrono::steady_clock::time_point& last_progress_log_time;
+    const std::chrono::steady_clock::time_point& search_start_time;
+    std::size_t asic_word_count;
+    // frontier_reachable_from[d] = true if any depth >= d has a solution
+    // with index target_idx (i.e., can still satisfy the new-this-round
+    // rule). Computed once before each search call and used to prune
+    // interior subtrees that can never satisfy the frontier.
+    std::vector<bool> frontier_reachable_from;
+    std::chrono::seconds progress_interval{10};
+
+    // Returns true (and fills chosen_index[depth..n_meshes)) when it finds
+    // a conflict-free assignment that satisfies the new-this-round rule.
+    bool run(std::size_t depth, bool frontier_satisfied) {
+        // Interior pruning: if no depth from here to the leaf can provide
+        // the required new-this-round solution, skip this whole subtree.
+        if (!frontier_satisfied && !frontier_reachable_from[depth]) {
+            return false;
+        }
+
+        const MeshEnumState& s = *states[depth];
+        const std::vector<std::size_t>& order = try_order_per_depth[depth];
+        const bool is_leaf = (depth + 1 == n_meshes);
+
+        if (is_leaf) {
+            for (std::size_t si : order) {
+                if (si >= round) {
+                    continue;
+                }
+                // Only accept this leaf if the "new this round" rule is
+                // already satisfied, or if this candidate is itself new.
+                if (!frontier_satisfied && si != target_idx) {
+                    continue;
+                }
+                ++combinations_tested;
+                // Log progress periodically so a long search isn't silent.
+                if ((combinations_tested & timer_check_mask) == 0) {
+                    const auto now = std::chrono::steady_clock::now();
+                    if (now - last_progress_log_time >= progress_interval) {
+                        const auto elapsed_sec =
+                            std::chrono::duration_cast<std::chrono::seconds>(now - search_start_time).count();
+                        log_info(
+                            tt::LogFabric,
+                            "Topology mapper round-robin: tested {} mesh-level combinations in {}s (round {})",
+                            combinations_tested,
+                            elapsed_sec,
+                            round);
+                        last_progress_log_time = now;
+                    }
+                }
+                if (!bitset_disjoint(s.solution_bits[si], occupied_asics, asic_word_count)) {
+                    continue;
+                }
+                chosen_index[depth] = si;
+                return true;
+            }
+            return false;
+        }
+
+        // Interior level: try each candidate, claim its chips, recurse
+        // into the next level, and release the chips if we backtrack.
+        for (std::size_t si : order) {
+            if (si >= round) {
+                continue;
+            }
+            if (!bitset_disjoint(s.solution_bits[si], occupied_asics, asic_word_count)) {
+                continue;
+            }
+            mark_used(occupied_asics, s.solution_bits[si], asic_word_count);
+            chosen_index[depth] = si;
+            const bool child_frontier = frontier_satisfied || (si == target_idx);
+            if (run(depth + 1, child_frontier)) {
+                return true;
+            }
+            unmark(occupied_asics, s.solution_bits[si], asic_word_count);
+        }
+        return false;
+    }
+};
+
 }  // namespace
 
 PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
@@ -970,37 +1147,9 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
     }
 
     // -------------------------------------------------------------------------
-    // Phase 5: Set up the incremental solver state for each mesh shape.
-    //
-    // MeshEnumState bundles everything needed to drive one shape's solver and
-    // remember what it has found so far:
-    //   logical_graph   — the pattern we want to place: either the mesh
-    //                     instances from the logical descriptor, or the full
-    //                     physical coarse topology when only one shape exists
-    //                     and all placements need to be assigned.
-    //   physical_graph  — the hardware mesh-level connectivity for this shape.
-    //   session         — the incremental solver; it keeps prior constraints in
-    //                     memory so each call only adds new work.
-    //   excluded        — solutions already returned; fed back to the solver so
-    //                     it doesn't repeat them.
-    //   solutions       — all solutions found so far, in the order returned.
-    //   solution_bits   — a chip bitmask for each solution; used for fast
-    //                     overlap checks in the packing search below.
-    //   embedding_sizes — how many meshes each solution places; used to try
-    //                     larger placements first (better pruning).
-    //   exhausted       — set to true once the solver finds no more options.
+    // Phase 5: Set up the incremental solver state for each mesh shape (see
+    // MeshEnumState at the top of this file).
     // -------------------------------------------------------------------------
-    struct MeshEnumState {
-        AdjacencyGraph<MeshId> logical_graph;
-        AdjacencyGraph<MeshId> physical_graph;
-        MappingConstraints<MeshId, MeshId> constraints;
-        TopologyMappingEnumerationSession<MeshId, MeshId> session;
-        std::vector<std::map<MeshId, MeshId>> excluded;
-        std::vector<MappingResult<MeshId, MeshId>> solutions;
-        std::vector<std::vector<std::uint64_t>> solution_bits;
-        std::vector<std::size_t> embedding_sizes;
-        bool exhausted = false;
-    };
 
     // Read the inter-mesh connections from the logical descriptor once here;
     // they are reused when building the pattern graph for each mesh shape.
@@ -1084,44 +1233,10 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
 
     // -------------------------------------------------------------------------
     // Phase 6: Round-by-round search for a conflict-free chip assignment.
-    //
-    // BITMASK HELPERS
-    // Each cached solution carries a bitmask with one bit per chip in the
-    // cluster. Three helpers operate on these bitmasks word by word:
-    //
-    //   bitset_disjoint(a, b) — true if a and b share no chip (no bit set in
-    //                           both), i.e. the two placements don't overlap.
-    //   mark_used(dst, src)   — dst |= src  (mark src's chips as taken).
-    //   unmark(dst, src)      — dst &= ~src (release src's chips on backtrack).
-    //
-    // These are tight 64-bit word loops that the compiler can auto-vectorise.
-    // The cost per combination is proportional to cluster size in words, not
-    // to the number of chips per mesh.
+    // Bitmask helpers bitset_disjoint / mark_used / unmark are defined at the
+    // top of this file.
     // -------------------------------------------------------------------------
     std::vector<std::uint64_t> occupied_asics(asic_word_count, 0);
-
-    auto bitset_disjoint = [asic_word_count](
-                               const std::vector<std::uint64_t>& cand,
-                               const std::vector<std::uint64_t>& occupied) -> bool {
-        for (std::size_t i = 0; i < asic_word_count; ++i) {
-            if (cand[i] & occupied[i]) {
-                return false;
-            }
-        }
-        return true;
-    };
-    auto mark_used = [asic_word_count](
-                         std::vector<std::uint64_t>& dst, const std::vector<std::uint64_t>& src) {
-        for (std::size_t i = 0; i < asic_word_count; ++i) {
-            dst[i] |= src[i];
-        }
-    };
-    auto unmark = [asic_word_count](
-                      std::vector<std::uint64_t>& dst, const std::vector<std::uint64_t>& src) {
-        for (std::size_t i = 0; i < asic_word_count; ++i) {
-            dst[i] &= ~src[i];
-        }
-    };
 
     // Build the chip bitmask for one solver solution by OR-ing together the
     // pre-computed per-group bitsets. No hash lookups in this hot path.
@@ -1191,119 +1306,14 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
         return true;
     };
 
-    // -----------------------------------------------------------------------
-    // DisjointPackingSearch — depth-first search over all combinations of one
-    // placement per mesh shape.
-    //
-    // At each level of the recursion we try every cached placement for one
-    // shape (largest first), skip any that overlap chips already claimed by
-    // earlier levels, and recurse deeper if it fits.
-    //
-    // "Test each combination only once" rule: in round k we only check
-    // combinations that include at least one placement that is new this round
-    // (cache index k-1). Any combination made entirely of older placements was
-    // already checked in a previous round. This is enforced by carrying a
-    // flag (frontier_satisfied) through the recursion; at the leaf level we
-    // only accept a candidate if the flag is already set or the candidate
-    // itself is the new one.
-    // -----------------------------------------------------------------------
+    // Per-depth state for DisjointPackingSearch (defined at the top of this
+    // file).
     std::vector<MeshEnumState*> mesh_state_ptrs(n_meshes, nullptr);
     for (std::size_t d = 0; d < n_meshes; ++d) {
         mesh_state_ptrs[d] = &mesh_enum_states.at(mesh_order[d]);
     }
     std::vector<std::vector<std::size_t>> try_order_per_depth(n_meshes);
     std::vector<std::size_t> chosen_index(n_meshes, 0);
-
-    struct DisjointPackingSearch {
-        const std::vector<MeshEnumState*>& states;
-        const std::vector<std::vector<std::size_t>>& try_order_per_depth;
-        std::vector<std::size_t>& chosen_index;
-        std::vector<std::uint64_t>& occupied_asics;
-        std::size_t round;       // current round number (1-based)
-        std::size_t target_idx;  // = round - 1; the "new" cache index this round
-        std::size_t n_meshes;
-        std::size_t& combinations_tested;
-        std::size_t& timer_check_mask;
-        std::chrono::steady_clock::time_point& last_progress_log_time;
-        const std::chrono::steady_clock::time_point& search_start_time;
-        decltype(bitset_disjoint)& is_disjoint;
-        decltype(mark_used)& mark_used_fn;
-        decltype(unmark)& unmark_fn;
-        // frontier_reachable_from[d] = true if any depth >= d has a solution
-        // with index target_idx (i.e., can still satisfy the new-this-round
-        // rule). Computed once before each search call and used to prune
-        // interior subtrees that can never satisfy the frontier.
-        std::vector<bool> frontier_reachable_from;
-        std::chrono::seconds progress_interval{10};
-
-        // Returns true (and fills chosen_index[depth..n_meshes)) when it finds
-        // a conflict-free assignment that satisfies the new-this-round rule.
-        bool run(std::size_t depth, bool frontier_satisfied) {
-            // Interior pruning: if no depth from here to the leaf can provide
-            // the required new-this-round solution, skip this whole subtree.
-            if (!frontier_satisfied && !frontier_reachable_from[depth]) {
-                return false;
-            }
-
-            const MeshEnumState& s = *states[depth];
-            const std::vector<std::size_t>& order = try_order_per_depth[depth];
-            const bool is_leaf = (depth + 1 == n_meshes);
-
-            if (is_leaf) {
-                for (std::size_t si : order) {
-                    if (si >= round) {
-                        continue;
-                    }
-                    // Only accept this leaf if the "new this round" rule is
-                    // already satisfied, or if this candidate is itself new.
-                    if (!frontier_satisfied && si != target_idx) {
-                        continue;
-                    }
-                    ++combinations_tested;
-                    // Log progress periodically so a long search isn't silent.
-                    if ((combinations_tested & timer_check_mask) == 0) {
-                        const auto now = std::chrono::steady_clock::now();
-                        if (now - last_progress_log_time >= progress_interval) {
-                            const auto elapsed_sec =
-                                std::chrono::duration_cast<std::chrono::seconds>(now - search_start_time).count();
-                            log_info(
-                                tt::LogFabric,
-                                "Topology mapper round-robin: tested {} mesh-level combinations in {}s (round {})",
-                                combinations_tested,
-                                elapsed_sec,
-                                round);
-                            last_progress_log_time = now;
-                        }
-                    }
-                    if (!is_disjoint(s.solution_bits[si], occupied_asics)) {
-                        continue;
-                    }
-                    chosen_index[depth] = si;
-                    return true;
-                }
-                return false;
-            }
-
-            // Interior level: try each candidate, claim its chips, recurse
-            // into the next level, and release the chips if we backtrack.
-            for (std::size_t si : order) {
-                if (si >= round) {
-                    continue;
-                }
-                if (!is_disjoint(s.solution_bits[si], occupied_asics)) {
-                    continue;
-                }
-                mark_used_fn(occupied_asics, s.solution_bits[si]);
-                chosen_index[depth] = si;
-                const bool child_frontier = frontier_satisfied || (si == target_idx);
-                if (run(depth + 1, child_frontier)) {
-                    return true;
-                }
-                unmark_fn(occupied_asics, s.solution_bits[si]);
-            }
-            return false;
-        }
-    };
 
     // -----------------------------------------------------------------------
     // Main loop: keep growing each shape's solution cache by one per round,
@@ -1423,9 +1433,7 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
             timer_check_mask_ref,
             last_progress_log_time,
             search_start_time,
-            bitset_disjoint,
-            mark_used,
-            unmark,
+            asic_word_count,
             std::move(frontier_reachable)};
         found_disjoint_combination = search.run(0, /*frontier_satisfied=*/false);
         log_debug(
@@ -1794,37 +1802,9 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
     }
 
     // -------------------------------------------------------------------------
-    // Phase 5: Set up the incremental solver state for each mesh shape.
-    //
-    // MeshEnumState bundles everything needed to drive one shape's solver and
-    // remember what it has found so far:
-    //   logical_graph   — the pattern we want to place: either the mesh
-    //                     instances from the logical descriptor, or the full
-    //                     physical coarse topology when only one shape exists
-    //                     and all placements need to be assigned.
-    //   physical_graph  — the hardware mesh-level connectivity for this shape.
-    //   session         — the incremental solver; it keeps prior constraints in
-    //                     memory so each call only adds new work.
-    //   excluded        — solutions already returned; fed back to the solver so
-    //                     it doesn't repeat them.
-    //   solutions       — all solutions found so far, in the order returned.
-    //   solution_bits   — a chip bitmask for each solution; used for fast
-    //                     overlap checks in the packing search below.
-    //   embedding_sizes — how many meshes each solution places; used to try
-    //                     larger placements first (better pruning).
-    //   exhausted       — set to true once the solver finds no more options.
+    // Phase 5: Set up the incremental solver state for each mesh shape (see
+    // MeshEnumState at the top of this file).
     // -------------------------------------------------------------------------
-    struct MeshEnumState {
-        AdjacencyGraph<MeshId> logical_graph;
-        AdjacencyGraph<MeshId> physical_graph;
-        MappingConstraints<MeshId, MeshId> constraints;
-        TopologyMappingEnumerationSession<MeshId, MeshId> session;
-        std::vector<std::map<MeshId, MeshId>> excluded;
-        std::vector<MappingResult<MeshId, MeshId>> solutions;
-        std::vector<std::vector<std::uint64_t>> solution_bits;
-        std::vector<std::size_t> embedding_sizes;
-        bool exhausted = false;
-    };
 
     // Count how many mesh shapes actually have a hardware-derived placement
     // graph. Used below to decide whether to expand the pattern to cover the
@@ -1924,44 +1904,10 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
 
     // -------------------------------------------------------------------------
     // Phase 6: Round-by-round search for a conflict-free chip assignment.
-    //
-    // BITMASK HELPERS
-    // Each cached solution carries a bitmask with one bit per chip in the
-    // cluster. Three helpers operate on these bitmasks word by word:
-    //
-    //   bitset_disjoint(a, b) — true if a and b share no chip (no bit set in
-    //                           both), i.e. the two placements don't overlap.
-    //   mark_used(dst, src)   — dst |= src  (mark src's chips as taken).
-    //   unmark(dst, src)      — dst &= ~src (release src's chips on backtrack).
-    //
-    // These are tight 64-bit word loops that the compiler can auto-vectorise.
-    // The cost per combination is proportional to cluster size in words, not
-    // to the number of chips per mesh.
+    // Bitmask helpers bitset_disjoint / mark_used / unmark are defined at the
+    // top of this file.
     // -------------------------------------------------------------------------
     std::vector<std::uint64_t> occupied_asics(asic_word_count, 0);
-
-    auto bitset_disjoint = [asic_word_count](
-                               const std::vector<std::uint64_t>& cand,
-                               const std::vector<std::uint64_t>& occupied) -> bool {
-        for (std::size_t i = 0; i < asic_word_count; ++i) {
-            if (cand[i] & occupied[i]) {
-                return false;
-            }
-        }
-        return true;
-    };
-    auto mark_used = [asic_word_count](
-                         std::vector<std::uint64_t>& dst, const std::vector<std::uint64_t>& src) {
-        for (std::size_t i = 0; i < asic_word_count; ++i) {
-            dst[i] |= src[i];
-        }
-    };
-    auto unmark = [asic_word_count](
-                      std::vector<std::uint64_t>& dst, const std::vector<std::uint64_t>& src) {
-        for (std::size_t i = 0; i < asic_word_count; ++i) {
-            dst[i] &= ~src[i];
-        }
-    };
 
     // Build the chip bitmask for one solver solution by OR-ing together the
     // pre-computed per-group bitsets. No hash lookups in this hot path.
@@ -2031,119 +1977,14 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
         return true;
     };
 
-    // -----------------------------------------------------------------------
-    // DisjointPackingSearch — depth-first search over all combinations of one
-    // placement per mesh shape.
-    //
-    // At each level of the recursion we try every cached placement for one
-    // shape (largest first), skip any that overlap chips already claimed by
-    // earlier levels, and recurse deeper if it fits.
-    //
-    // "Test each combination only once" rule: in round k we only check
-    // combinations that include at least one placement that is new this round
-    // (cache index k-1). Any combination made entirely of older placements was
-    // already checked in a previous round. This is enforced by carrying a
-    // flag (frontier_satisfied) through the recursion; at the leaf level we
-    // only accept a candidate if the flag is already set or the candidate
-    // itself is the new one.
-    // -----------------------------------------------------------------------
+    // Per-depth state for DisjointPackingSearch (defined at the top of this
+    // file).
     std::vector<MeshEnumState*> mesh_state_ptrs(n_meshes, nullptr);
     for (std::size_t d = 0; d < n_meshes; ++d) {
         mesh_state_ptrs[d] = &mesh_enum_states.at(mesh_order[d]);
     }
     std::vector<std::vector<std::size_t>> try_order_per_depth(n_meshes);
     std::vector<std::size_t> chosen_index(n_meshes, 0);
-
-    struct DisjointPackingSearch {
-        const std::vector<MeshEnumState*>& states;
-        const std::vector<std::vector<std::size_t>>& try_order_per_depth;
-        std::vector<std::size_t>& chosen_index;
-        std::vector<std::uint64_t>& occupied_asics;
-        std::size_t round;       // current round number (1-based)
-        std::size_t target_idx;  // = round - 1; the "new" cache index this round
-        std::size_t n_meshes;
-        std::size_t& combinations_tested;
-        std::size_t& timer_check_mask;
-        std::chrono::steady_clock::time_point& last_progress_log_time;
-        const std::chrono::steady_clock::time_point& search_start_time;
-        decltype(bitset_disjoint)& is_disjoint;
-        decltype(mark_used)& mark_used_fn;
-        decltype(unmark)& unmark_fn;
-        // frontier_reachable_from[d] = true if any depth >= d has a solution
-        // with index target_idx (i.e., can still satisfy the new-this-round
-        // rule). Computed once before each search call and used to prune
-        // interior subtrees that can never satisfy the frontier.
-        std::vector<bool> frontier_reachable_from;
-        std::chrono::seconds progress_interval{10};
-
-        // Returns true (and fills chosen_index[depth..n_meshes)) when it finds
-        // a conflict-free assignment that satisfies the new-this-round rule.
-        bool run(std::size_t depth, bool frontier_satisfied) {
-            // Interior pruning: if no depth from here to the leaf can provide
-            // the required new-this-round solution, skip this whole subtree.
-            if (!frontier_satisfied && !frontier_reachable_from[depth]) {
-                return false;
-            }
-
-            const MeshEnumState& s = *states[depth];
-            const std::vector<std::size_t>& order = try_order_per_depth[depth];
-            const bool is_leaf = (depth + 1 == n_meshes);
-
-            if (is_leaf) {
-                for (std::size_t si : order) {
-                    if (si >= round) {
-                        continue;
-                    }
-                    // Only accept this leaf if the "new this round" rule is
-                    // already satisfied, or if this candidate is itself new.
-                    if (!frontier_satisfied && si != target_idx) {
-                        continue;
-                    }
-                    ++combinations_tested;
-                    // Log progress periodically so a long search isn't silent.
-                    if ((combinations_tested & timer_check_mask) == 0) {
-                        const auto now = std::chrono::steady_clock::now();
-                        if (now - last_progress_log_time >= progress_interval) {
-                            const auto elapsed_sec =
-                                std::chrono::duration_cast<std::chrono::seconds>(now - search_start_time).count();
-                            log_info(
-                                tt::LogFabric,
-                                "Topology mapper round-robin: tested {} mesh-level combinations in {}s (round {})",
-                                combinations_tested,
-                                elapsed_sec,
-                                round);
-                            last_progress_log_time = now;
-                        }
-                    }
-                    if (!is_disjoint(s.solution_bits[si], occupied_asics)) {
-                        continue;
-                    }
-                    chosen_index[depth] = si;
-                    return true;
-                }
-                return false;
-            }
-
-            // Interior level: try each candidate, claim its chips, recurse
-            // into the next level, and release the chips if we backtrack.
-            for (std::size_t si : order) {
-                if (si >= round) {
-                    continue;
-                }
-                if (!is_disjoint(s.solution_bits[si], occupied_asics)) {
-                    continue;
-                }
-                mark_used_fn(occupied_asics, s.solution_bits[si]);
-                chosen_index[depth] = si;
-                const bool child_frontier = frontier_satisfied || (si == target_idx);
-                if (run(depth + 1, child_frontier)) {
-                    return true;
-                }
-                unmark_fn(occupied_asics, s.solution_bits[si]);
-            }
-            return false;
-        }
-    };
 
     // -----------------------------------------------------------------------
     // Main loop: keep growing each shape's solution cache by one per round,
@@ -2263,9 +2104,7 @@ PhysicalMultiMeshGraph build_physical_multi_mesh_adjacency_graph(
             timer_check_mask_ref,
             last_progress_log_time,
             search_start_time,
-            bitset_disjoint,
-            mark_used,
-            unmark,
+            asic_word_count,
             std::move(frontier_reachable)};
         found_disjoint_combination = search.run(0, /*frontier_satisfied=*/false);
         log_debug(

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -836,8 +836,7 @@ std::map<MeshId, MeshPhysicalLayout> mesh_physical_layouts_from_psd_placements(
 // -----------------------------------------------------------------------------
 // Shared round-robin mesh-packing machinery used by both
 // build_physical_multi_mesh_adjacency_graph overloads (single-MGD and
-// multi-MGD). MeshEnumState, the bitmask helpers, and DisjointPackingSearch
-// below were previously duplicated verbatim inside each overload.
+// multi-MGD).
 //
 // MeshEnumState bundles everything needed to drive one shape's solver and
 // remember what it has found so far:


### PR DESCRIPTION
### What

`tt_metal/fabric/topology_mapper_utils.cpp` contained **124 lines of byte-identical duplication**: the two `build_physical_multi_mesh_adjacency_graph` overloads (single-MGD and multi-MGD) each carried their own private copy of the same three entities (verified byte-identical by `diff` before the change):

| entity | copy A (old line) | copy B (old line) | size |
|---|---|---|---|
| `struct MeshEnumState` | 993 | 1817 | 11 lines |
| lambdas `bitset_disjoint`, `mark_used`, `unmark` | 1103–1125 | 1943–1965 | 23 lines |
| `struct DisjointPackingSearch` | 1217 | 2057 | 90 lines |

This PR hoists a single copy of all three into the file-level anonymous namespace (next to `mesh_physical_layouts_from_psd_placements`, which both overloads already share) and deletes both function-local copies. Internal linkage is preserved. **Net delta: +191 / −352 = −161 lines** (the extra savings beyond 124x2 come from the duplicated doc comments moving with the code).

### The coupling and how it was resolved

The three entities form a dependency cluster: `DisjointPackingSearch` held members typed via `decltype` of the enclosing function's lambdas (`decltype(bitset_disjoint)& is_disjoint;` etc.), and those lambdas captured `asic_word_count` from function scope, so none of them could be moved to file scope unchanged. Resolution:

- The three lambdas become plain free functions with `std::size_t asic_word_count` as an explicit trailing parameter. Bodies are otherwise verbatim; a by-value capture becomes a by-value parameter, so each call computes exactly what it did before.
- `DisjointPackingSearch` replaces the three `decltype(...)&` members with a single `std::size_t asic_word_count;` member and calls the free functions directly. The value stored is the same `const std::size_t asic_word_count` local the lambdas used to capture, passed at the same aggregate-init position where the three lambda references were passed. Everything else in the struct is verbatim.
- `MeshEnumState` is hoisted verbatim except that `MappingConstraints`, `TopologyMappingEnumerationSession`, and `MappingResult` are now spelled `::tt::tt_fabric::...` — at namespace scope the function-local `using namespace ::tt::tt_fabric;` no longer applies. These are the same types the unqualified names resolved to before (the public header `topology_mapper_utils.hpp` imports only `AdjacencyGraph`/`MeshId` into `tt::tt_metal::experimental::tt_fabric`, and itself spells `::tt::tt_fabric::MappingConstraints` for the same reason).

This was chosen over templating `DisjointPackingSearch` on the callable types (which would only recover ~101 of the 124 lines and leave the lambdas duplicated) and over a factory returning lambdas to keep `decltype` alive (more indirection for no benefit). No renaming beyond the member-name cleanup the hoist forces (`is_disjoint`/`mark_used_fn`/`unmark_fn` reference members are gone; the struct calls the free functions by their real names). Both call sites execute the same logic as before.

### Verification (exactly what was and was not done)

- **Done:** `clang++ -std=c++20 -fsyntax-only` (clang 20.1.8) on the full modified TU with reconstructed include paths (repo `tt_metal/api`, `tt_metal`, `tt_stl`, `tt_metal/hw/inc`, umd submodule at its pinned commit, hal codegen headers generated via `tt_metal/llrt/hal/codegen/codegen.sh`, third-party deps from a CPM cache). **Passes with no errors.** The pristine `origin/main` version of the file passes the identical command, so the check is apples-to-apples.
- **Done:** `git-clang-format --style=file` against `origin/main` — no changes on the modified lines.
- **Done:** pre-change `diff` confirming all three duplicated regions were byte-identical between the two overloads.
- **Not done:** a full `./build_metal.sh --build-tests` build or link (impractical in this environment), and no runtime/hardware testing. CI should be relied on for the full build.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=refactor/dedupe-topology-mapper-packing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:refactor/dedupe-topology-mapper-packing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=refactor/dedupe-topology-mapper-packing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:refactor/dedupe-topology-mapper-packing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=refactor/dedupe-topology-mapper-packing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:refactor/dedupe-topology-mapper-packing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=refactor/dedupe-topology-mapper-packing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:refactor/dedupe-topology-mapper-packing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=refactor/dedupe-topology-mapper-packing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:refactor/dedupe-topology-mapper-packing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=refactor/dedupe-topology-mapper-packing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:refactor/dedupe-topology-mapper-packing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=refactor/dedupe-topology-mapper-packing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:refactor/dedupe-topology-mapper-packing)