### PR TITLE
[Bug fix] reciprocal: recip(±2^126) is the representable 2^-126, not 0

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -20,8 +20,17 @@ namespace sfpu {
 
 // Computes the reciprocal of a floating point value x.
 template <int max_iter = 2>
-sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat x) {
-    // sfpi::approx_recip(x) will return ±0 for x = ±inf or x ≥ ±2**126, and ±inf for x = ±0.
+sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat x_in) {
+    // sfpi::approx_recip(x) will return ±0 for x = ±inf or x ≥ ±2**126 — which
+    // wrongly flushes the exactly-representable reciprocal of ±2**126 (and,
+    // through this helper, breaks softsign at |x| = 2**126). Fold exponent-126
+    // inputs back into approx_recip's range with an exact power-of-two scale
+    // and undo it afterwards; both multiplies are exact, so accuracy elsewhere
+    // is untouched. Inputs at exponent 127 keep returning 0 (their reciprocal
+    // is subnormal and flushes anyway), as do ±inf and NaN (exponent 128).
+    sfpi::vFloat x = x_in;
+    v_if (exexp(x_in) == 126) { x = x_in * 0.25F; }
+    v_endif;
     sfpi::vFloat y = sfpi::approx_recip(x);
 
     // Optionally improve the approximation using Newton-Raphson.
@@ -48,6 +57,8 @@ sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat x) {
         }
     }
 
+    v_if (exexp(x_in) == 126) { y = y * 0.25F; }
+    v_endif;
     return y;
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -75,7 +75,26 @@ sfpi_inline sfpi::vFloat _reciprocal_compat_(const sfpi::vFloat in)
         result = result * (val * result + two);
     }
 
+    // An exact power of two has an exact power-of-two reciprocal, but the
+    // mantissa Newton converges to 2.0 from below, so for a power-of-two
+    // input `result` lands ~1 ULP under 2.0 and exexp(result) reads 0
+    // instead of 1. For most inputs the final round to bf16 hides the
+    // undershoot; at orig_exp = 126 it costs the whole binade: new_exp
+    // becomes 0, the result denormalizes, and recip(2^126) returns 0
+    // instead of the exactly-representable 2^-126. A power-of-two input is
+    // exactly val == -0.5 after the setsgn/setexp normalization above; snap
+    // its reciprocal mantissa to the exact 2.0. Guarded to finite normal
+    // inputs so the zero/inf/NaN paths keep their existing behavior.
     sfpi::vInt orig_exp = exexp(in);
+    v_if (orig_exp >= -126 && orig_exp <= 127)
+    {
+        v_if (val == -0.5F)
+        {
+            result = 2.0F;
+        }
+        v_endif;
+    }
+    v_endif;
     sfpi::vInt new_exp  = exexp(result);
 
     // "Subtract" exponents, and re-bias.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -75,7 +75,26 @@ sfpi_inline sfpi::vFloat _reciprocal_compat_(const sfpi::vFloat in)
         result = result * (val * result + two);
     }
 
+    // An exact power of two has an exact power-of-two reciprocal, but the
+    // mantissa Newton converges to 2.0 from below, so for a power-of-two
+    // input `result` lands ~1 ULP under 2.0 and exexp(result) reads 0
+    // instead of 1. For most inputs the final round to bf16 hides the
+    // undershoot; at orig_exp = 126 it costs the whole binade: new_exp
+    // becomes 0, the result denormalizes, and recip(2^126) returns 0
+    // instead of the exactly-representable 2^-126. A power-of-two input is
+    // exactly val == -0.5 after the setsgn/setexp normalization above; snap
+    // its reciprocal mantissa to the exact 2.0. Guarded to finite normal
+    // inputs so the zero/inf/NaN paths keep their existing behavior.
     sfpi::vInt orig_exp = exexp(in);
+    v_if (orig_exp >= -126 && orig_exp <= 127)
+    {
+        v_if (val == -0.5F)
+        {
+            result = 2.0F;
+        }
+        v_endif;
+    }
+    v_endif;
     sfpi::vInt new_exp  = exexp(result);
 
     // "Subtract" exponents, and re-bias.


### PR DESCRIPTION
## PR Category

Bug fix.

## Summary

Closes #54513.

Two reciprocal paths lose `recip(±2^126) = ±2^-126`, which is an exactly representable normal float, and they lose it for different reasons.

**`sfpu_reciprocal_iter`**, the sfpi helper behind softsign and the other composites. `SFPARECIP` returns 0 for `|x| >= 2^126`, and a Newton step cannot recover from `y = 0`. Exponent-126 inputs are folded back into range with an exact `2^-2` scale and the scale is undone afterwards; both multiplies are exact, so nothing else moves. **Blackhole only** — Wormhole does not use `SFPARECIP` here. It splits the exponent with `SFPNOT` and `setman` and runs the estimate on the mantissa alone, so it has no saturation point to fall off. Measured: `ttnn.reciprocal(2^p)` is exact on N300 for every `p` from 0 to 126.

**`_reciprocal_compat_`**, the default `recip_tile()` — `legacy_compat` defaults to `true` at `api/compute/eltwise_unary/recip.h:17` and `:37`, so everything routing through `moreh_common.hpp`'s `recip_tile_to_cb` takes it. The mantissa Newton converges to 2.0 from below, so a power-of-two input reads `exexp(result) = 0` instead of 1. For most inputs the final round hides the undershoot; at `orig_exp = 126` it costs the whole binade and the result denormalizes to 0. `val == -0.5` is exactly a power-of-two input after the normalization above it, so its mantissa is snapped to 2.0, guarded to finite normals. **Both architectures** — the two `rsqrt_compat.h` copies are byte-identical, and the defect measures identically on both.

## Accuracy

**The compat path, fed exact powers of two through its own entry point.** N300 at `141fbea49c5`; P300 gives the same figures at `04cf22f7ee`:

| input | before | after |
|---|---|---|
| `2^0` | 0.999963641166687 | **1.0** |
| `2^1` | 0.4999818205833435 | **0.5** |
| `2^60` | 8.6733020172755e-19 | **8.673617379884035e-19** |
| `2^125` | 2.3509032224382512e-38 | **2.350988701644575e-38** |
| **`2^126`** | **0.0** | **1.1754943508222875e-38** |
| `2^-1` | 1.999927282333374 | **2.0** |
| `2^-126` | 8.506749866277006e+37 | **8.507059173023462e+37** |
| | **0 of 11 exact** | **10 of 11 exact** |

`recip(2^0) = 0.999963...` sitting just under 1.0 is the undershoot itself; `2^126` is where that one-ulp deficit costs an exponent. The one survivor is `2^127`, whose reciprocal is subnormal and flushes on both architectures, before and after.

**The sfpi path, through softsign.** P300 at `04cf22f7ee`:

| | base | this branch |
|---|---|---|
| all 65536 bfloat16 patterns | `±2^126 -> 0` | **`±1.0`**; the other 65534 bit-identical |
| float32 chunks 2024 and 4072, 2·2^20 words full-bit | `±2^126 -> 0` | **`±1.0`**; every other word bit-identical |
| `ttnn.reciprocal`, bf16 exhaustive + fp32 boundary + chunks | — | bit-identical |

N300 needs no change here and gets none: `ttnn.reciprocal` is already exact at every power of two from `2^0` to `2^126` there.

## Cost

Dispatches 1 to 1. Wall clock, softsign, 1 tile P300: 11.64 to 11.80 us, which is 6 added SFPU issue slots. The compat snap is two predicated instructions and runs only inside the finite-normal guard.

## Tests

The compat entry point is not reachable from ttnn with a caller-chosen divisor, so the powers-of-two table above was taken through a probe kernel installed under an existing op's entry point rather than through a unit test. The softsign rows are ordinary sweeps.

## Not covered

- **`ttnn.reciprocal` itself.** It maps to `recip_tile<false>` and the `SFPLOADMACRO` fast paths (`_calculate_reciprocal_fast_8b_3c_` / `_24b_5c_`), which share the `SFPARECIP` root cause. Fixing those means extending the load-macro pipeline schedule, and it is a follow-up. This is why the reciprocal rows above are bit-identical: the issue's `reciprocal(2^126) -> 0` observation lives in the fast path, the softsign break in the sfpi path, and the compat undershoot in a third copy of the same root cause.
- **`2^127`**, whose reciprocal is subnormal. Unchanged on both architectures.
- **`ttnn.div` at divisors of 2^126 and above (#52094)**, which is the same saturation seen through the fast path. Not covered here either.
- A unit test for the compat path. It needs an op that lets the caller set the divisor, and the reachable consumers compute theirs.
