### PR TITLE
[Bug fix] Build the reference rope from the config, not the model

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -254,6 +254,15 @@ class PrefillModelAdapter(ABC):
     def reference_moe_cls(self) -> Optional[type]:
         return None
 
+    @property
+    def reference_rotary_cls(self) -> Optional[type]:
+        """Rope module a standalone reference attention needs its ``(cos, sin)`` from.
+
+        Only needed for references from transformers >= 5, which compute rope at the MODEL level and
+        pass ``position_embeddings`` down, so an attention used on its own has to be handed them.
+        The vendored DeepSeek/Kimi references build rope internally and leave this None."""
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Model registry

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -11,6 +11,7 @@ bundled reference return `None` and the comparison is skipped at the call
 site.
 """
 
+import inspect
 from copy import copy, deepcopy
 from typing import Optional
 
@@ -119,14 +120,32 @@ def run_reference_mla(
     attn.load_state_dict(weights, strict=False)
     attn = attn.eval().to(torch.bfloat16)
     causal = torch.triu(torch.full((q_len, q_len), float("-inf"), dtype=hidden_states.dtype), diagonal=1)
-    with torch.no_grad():
-        out = attn(
-            hidden_states=hidden_states,
-            attention_mask=causal[None, None],
-            position_ids=position_ids,
-            past_key_value=None,
-            use_cache=False,
+    # Bind by signature: vendored DeepSeek/Kimi attentions take `past_key_value` and derive rope
+    # internally; transformers >= 5 takes `past_key_values` and requires `position_embeddings`. The
+    # wrong cache name lands silently in **kwargs and captures no KV.
+    fwd_params = inspect.signature(attn.forward).parameters
+    kwargs = {
+        "hidden_states": hidden_states,
+        "attention_mask": causal[None, None],
+        "position_ids": position_ids,
+        "use_cache": False,
+    }
+    kwargs["past_key_values" if "past_key_values" in fwd_params else "past_key_value"] = None
+    if "position_embeddings" in fwd_params:
+        rotary_cls = getattr(variant, "reference_rotary_cls", None)
+        assert rotary_cls is not None, (
+            f"{type(attn).__name__} requires position_embeddings but {variant.name!r} exposes no "
+            "reference_rotary_cls to build (cos, sin) from"
         )
+        # Built from the CONFIG, not from the model: a reference instantiated in bf16 carries a bf16
+        # `inv_freq` buffer, and .float() cannot recover the lost bits. The resulting ~4.4e-4
+        # frequency error is a phase error that grows with position.
+        rotary = rotary_cls(config=config).float()
+        with torch.no_grad():
+            cos, sin = rotary(hidden_states.float(), position_ids)
+            kwargs["position_embeddings"] = (cos.to(hidden_states.dtype), sin.to(hidden_states.dtype))
+    with torch.no_grad():
+        out = attn(**kwargs)
     # DeepseekV3Attention returns (out, attn_weights, past_kv); Kimi-K3's KimiMLAAttention returns a
     # bare tensor (upstream shape). Accept either.
     return out[0] if isinstance(out, tuple) else out

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -142,7 +142,9 @@ def run_reference_mla(
         # frequency error is a phase error that grows with position.
         rotary = rotary_cls(config=config).float()
         with torch.no_grad():
-            cos, sin = rotary(hidden_states.float(), position_ids)
+            # `forward` reads this tensor only for device and dtype, so pass a small view rather
+            # than an fp32 copy of the whole [batch, seq, hidden] activation.
+            cos, sin = rotary(hidden_states[:1, :1].float(), position_ids)
             kwargs["position_embeddings"] = (cos.to(hidden_states.dtype), sin.to(hidden_states.dtype))
     with torch.no_grad():
         out = attn(**kwargs)

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_reference_rope.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_reference_rope.py
@@ -118,3 +118,34 @@ def test_a_layer_that_computes_rope_internally_needs_no_rotary_emb(expect_error)
     model.layers = [new_layer]
     with expect_error(AssertionError, "exposes no rotary_emb"):
         reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1)
+
+
+def test_mscale_toggle_invalidates_the_chunked_reference_cache():
+    """Guards the mscale half of `fix(mla): build the reference rope from the config...`.
+
+    `mla_disable_yarn_mscale` scales softmax by ``mscale**2``, so a cache key that ignored it served
+    a stale reference for the opposite setting -- valid-looking, silently wrong. Holding weights and
+    hidden state constant, flipping only that flag must change the key.
+    """
+    from types import SimpleNamespace
+
+    from models.demos.deepseek_v3_d_p.utils.chunked_prefill_utils import _ref_cache_key
+
+    weights = {"w": torch.zeros(4, 4)}
+    hidden = torch.zeros(4, 4)
+
+    def cfg(disable_mscale):
+        return SimpleNamespace(
+            num_attention_heads=8,
+            rms_norm_eps=1e-6,
+            mla_use_nope=False,
+            mla_use_output_gate=False,
+            mla_disable_yarn_mscale=disable_mscale,
+            rope_scaling=None,
+        )
+
+    off = _ref_cache_key(cfg(False), weights, hidden)
+    on = _ref_cache_key(cfg(True), weights, hidden)
+    assert off != on, f"mscale toggle must change the reference cache key, got {off} for both"
+    # and the key must be stable for an unchanged config, or every run misses
+    assert off == _ref_cache_key(cfg(False), weights, hidden)

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_reference_rope.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_reference_rope.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only regression tests for the fp32 reference rope. No device, no weights, milliseconds.
+
+Fails on the code as it stood before `fix(mla): build the reference rope from the config, not the
+model`. The bug is silent -- it produces a plausible wrong number rather than an error -- so the
+first test also asserts the *pre-fix* behaviour is detectably wrong, otherwise it could pass for the
+wrong reason.
+"""
+
+from copy import deepcopy
+
+import pytest
+import torch
+
+from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
+    layer_wants_position_embeddings,
+    reference_position_embeddings,
+    reference_rope,
+)
+
+
+def test_reference_rope_is_fp32_even_when_the_model_is_bf16():
+    """Guards `fix(mla): build the reference rope from the config, not the model`.
+
+    A reference instantiated in bf16 carries a bf16 ``inv_freq`` BUFFER, and ``.float()`` cannot
+    recover bits already gone (0.75 where the true value is 0.7498942). The residue is a
+    per-dimension frequency error, i.e. a phase error that grows LINEARLY with position -- harmless
+    at short prompts, ruinous at long ones. Rebuilding from the config in fp32 is the only fix.
+    """
+    transformers = pytest.importorskip("transformers")
+    from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
+
+    cfg = transformers.LlamaConfig(
+        hidden_size=256, num_attention_heads=4, num_hidden_layers=1, rope_theta=10000.0, max_position_embeddings=65536
+    )
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = cfg
+            self.rotary_emb = LlamaRotaryEmbedding(config=cfg)
+
+    model = _Model().to(torch.bfloat16)  # what create_hf_model does
+    assert model.rotary_emb.inv_freq.dtype == torch.bfloat16, "precondition: the buffer must be bf16"
+
+    # Far enough out that a ~4.4e-4 relative frequency error is visible. The error is proportional to
+    # position, so a short prompt would hide it -- which is exactly how this survived.
+    pos = torch.tensor([[40000]], dtype=torch.long)
+    hidden = torch.zeros(1, 1, cfg.hidden_size, dtype=torch.bfloat16)
+
+    cos_fix, sin_fix = reference_rope(model, hidden, pos)
+
+    # Ground truth: an independently constructed fp32 table.
+    gt = LlamaRotaryEmbedding(config=cfg).float()
+    with torch.no_grad():
+        cos_gt, sin_gt = gt(torch.zeros(1, 1, cfg.hidden_size), pos)
+
+    err_fix = max((cos_fix - cos_gt).abs().max().item(), (sin_fix - sin_gt).abs().max().item())
+    assert err_fix < 1e-5, f"reference_rope should match an fp32 table; max err {err_fix:.2e}"
+
+    # The pre-fix path, asserted to be detectably wrong so this test cannot pass vacuously.
+    old = deepcopy(model.rotary_emb).float()
+    with torch.no_grad():
+        cos_old, sin_old = old(torch.zeros(1, 1, cfg.hidden_size), pos)
+    err_old = max((cos_old - cos_gt).abs().max().item(), (sin_old - sin_gt).abs().max().item())
+    assert err_old > 1e-3, (
+        f"the deepcopy(bf16).float() path should be visibly wrong at position {pos.item()} "
+        f"(got {err_old:.2e}); if this fires, the test has stopped discriminating"
+    )
+
+
+class _OldStyleLayer(torch.nn.Module):
+    """A vendored DeepSeek/Kimi/GLM-shaped layer: singular cache kwarg, rope computed internally."""
+
+    def forward(self, hidden_states, attention_mask=None, position_ids=None, past_key_value=None, use_cache=True):
+        raise AssertionError("not called")
+
+
+class _NewStyleLayer(torch.nn.Module):
+    """A transformers-5.x layer: plural cache kwarg, and rope must be handed in."""
+
+    def forward(
+        self, hidden_states, attention_mask=None, position_ids=None, past_key_values=None, position_embeddings=None
+    ):
+        raise AssertionError("not called")
+
+
+def test_a_layer_that_computes_rope_internally_needs_no_rotary_emb(expect_error):
+    """Guards the DeepSeek regression: an unconditional rope build breaks references that never
+    wanted one.
+
+    A transformers-5.x layer requires the caller to pass ``(cos, sin)``; a vendored layer such as
+    DeepSeekV3's computes rope from ``position_ids`` itself and its model exposes no top-level
+    ``rotary_emb``. Building the table for everything asserted with
+    "DeepseekV3Model exposes no rotary_emb to build rope from" on precisely the models that did not
+    need it, so the predicate must come from the layer's SIGNATURE, not from the model's attributes.
+    """
+
+    old_layer, new_layer = _OldStyleLayer(), _NewStyleLayer()
+    assert layer_wants_position_embeddings(old_layer) is False
+    assert layer_wants_position_embeddings(new_layer) is True
+
+    # A model with NO rotary_emb, as DeepSeekV3Model has none. Binding kwargs for the old-style
+    # layer must not reach reference_rope at all -- if it does, the assert there fires.
+    class _ModelWithoutRotary(torch.nn.Module):
+        pass
+
+    # The regression itself: the run-level hoist must return None here, not raise. Before the fix it
+    # called reference_rope unconditionally and died on the missing rotary_emb.
+    model = _ModelWithoutRotary()
+    model.layers = [old_layer]
+    assert reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1) is None
+
+    # ...and a layer that DOES want them still gets a table built (here: absent rotary -> loud).
+    model.layers = [new_layer]
+    with expect_error(AssertionError, "exposes no rotary_emb"):
+        reference_position_embeddings(model, torch.zeros(1, 4, 8), torch.arange(4).unsqueeze(0), 1)

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -47,14 +47,24 @@ def _ref_cache_key(config, weights, hidden_2d) -> str:
         multi-user run two users can share the same total_len while having different inputs. Keying on
         length alone would hand user 1 user 0's reference and silently corrupt its PCC.
       * config -- num_attention_heads changes the absorbed-Q head split even at identical weight
-        shapes; the NoPE / output-gate flags and rope_scaling change the math outright.
+        shapes; the NoPE / output-gate flags and rope_scaling change the math outright, and
+        mla_disable_yarn_mscale changes the softmax scale by mscale**2 (2.2058 for Mistral at
+        factor=128). Any field added here that moves the reference MUST be added to the hash below --
+        omitting one serves a stale reference against a changed device and reads as a device bug.
 
     Hashing the full tensors costs ~2 s at the 56320-token production shape, against a ~7 min
     reference. Content-addressing also makes the key collision-free across variants, so one shared
     cache dir is safe.
     """
     h = hashlib.sha1()
-    for field in ("num_attention_heads", "rms_norm_eps", "mla_use_nope", "mla_use_output_gate", "rope_scaling"):
+    for field in (
+        "num_attention_heads",
+        "rms_norm_eps",
+        "mla_use_nope",
+        "mla_use_output_gate",
+        "mla_disable_yarn_mscale",
+        "rope_scaling",
+    ):
         h.update(f"{field}={getattr(config, field, None)!r}".encode())
     _hash_tensor(h, "hidden", hidden_2d)
     for name in sorted(weights):

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -228,7 +228,18 @@ def reference_rope(hf_model, hidden_states, position_ids):
     rotary_cls = type(rotary)
     if "config" in inspect.signature(rotary_cls.__init__).parameters:
         rotary_f32 = rotary_cls(config=hf_model.config).float()
-    else:  # a rotary that predates `config=`; the bf16 buffer is then unavoidable
+    else:
+        # A rotary predating `config=` cannot be rebuilt, so the bf16 buffer is unavoidable and the
+        # table this returns carries the position-dependent error this function exists to remove.
+        # Not fatal: the four DeepseekV3/Kimi rotaries in reference/ are exactly these classes, and
+        # their vendored layers compute rope internally, so they never reach here -- raising would
+        # be a latent break for them if that ever changed. Say so loudly instead of silently
+        # returning a table that looks fixed.
+        logger.warning(
+            f"{rotary_cls.__name__} does not accept `config=`, so the reference rope falls back to "
+            f"the model's bf16 inv_freq buffer. Long-context PCC from this reference stays subject "
+            f"to the ~4.4e-4 frequency error; give this class a config-based constructor to fix it."
+        )
         rotary_f32 = deepcopy(rotary).float()
     # `forward` reads this tensor only for device and dtype (transformers 5.12), so pass a view --
     # a full fp32 copy of the hidden states is ~251 MB at seq 15360.

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -640,12 +640,16 @@ def load_and_compute_layer_by_layer(
             hf_model.load_state_dict(layer_with_prefix, strict=False)
 
             with torch.no_grad():
+                # transformers >= 5 renamed the cache kwarg to `past_key_values`. The wrong name
+                # lands silently in **kwargs, so no KV is ever captured -- bind it by the layer's
+                # own signature, which is also what decides `position_embeddings` below.
+                layer_params = inspect.signature(hf_model.layers[i].forward).parameters
                 layer_kwargs = {
                     "attention_mask": attention_mask,
                     "position_ids": position_ids,
-                    "past_key_value": ref_cache,
                     "use_cache": True,
                 }
+                layer_kwargs["past_key_values" if "past_key_values" in layer_params else "past_key_value"] = ref_cache
                 if ref_position_embeddings is not None:
                     cos, sin = ref_position_embeddings
                     layer_kwargs["position_embeddings"] = (cos.to(h_ref.dtype), sin.to(h_ref.dtype))

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -13,6 +13,7 @@ Provides:
 """
 
 import gc
+import inspect
 import json
 import os
 from copy import deepcopy
@@ -211,6 +212,56 @@ def create_hf_model(variant, config, num_layers, n_routed_experts=None):
 
     model = variant.reference_model_cls(test_config)
     return model.eval().to(torch.bfloat16)
+
+
+def reference_rope(hf_model, hidden_states, position_ids):
+    """The reference ``(cos, sin)``, built in fp32 from the CONFIG rather than copied from the model.
+
+    A reference instantiated in bf16 carries a bf16 ``inv_freq`` buffer and ``.float()`` cannot
+    recover the lost bits; the resulting ~4.4e-4 frequency error is a phase error that grows with
+    position. Depends only on the positions, so build it once per run.
+    """
+    rotary = getattr(hf_model, "rotary_emb", None)
+    assert rotary is not None, f"{type(hf_model).__name__} exposes no rotary_emb to build rope from"
+    # Check the signature rather than catching: a bare `except` would also swallow a genuine
+    # construction failure and silently fall back to the bf16 buffer this function exists to avoid.
+    rotary_cls = type(rotary)
+    if "config" in inspect.signature(rotary_cls.__init__).parameters:
+        rotary_f32 = rotary_cls(config=hf_model.config).float()
+    else:  # a rotary that predates `config=`; the bf16 buffer is then unavoidable
+        rotary_f32 = deepcopy(rotary).float()
+    # `forward` reads this tensor only for device and dtype (transformers 5.12), so pass a view --
+    # a full fp32 copy of the hidden states is ~251 MB at seq 15360.
+    probe = hidden_states[:1, :1].float()
+    with torch.no_grad():
+        return rotary_f32(probe, position_ids)
+
+
+def layer_wants_position_embeddings(hf_layer) -> bool:
+    """Does this reference decoder layer take ``position_embeddings``?
+
+    The predicate that decides whether a rope table has to be built at all. Layers differ across
+    transformers generations: a transformers-5.x layer (e.g. Mistral4) REQUIRES the caller to pass
+    ``(cos, sin)``, while an older or vendored layer (e.g. DeepSeekV3) computes rope internally from
+    ``position_ids`` and exposes no top-level ``rotary_emb`` to build one from. Asking the signature
+    keeps both working; assuming either shape breaks the other.
+    """
+    return "position_embeddings" in inspect.signature(hf_layer.forward).parameters
+
+
+def reference_position_embeddings(hf_model, hidden_states, position_ids, num_layers: int):
+    """The reference rope table for a whole run, or ``None`` when no layer takes one.
+
+    Built once: it depends only on the positions, and building per layer would construct a rotary
+    module and a full fp32 copy of the hidden states each time (~251 MB at seq 15360).
+
+    Returns None rather than raising for a reference whose layers compute rope internally --
+    DeepSeekV3's vendored layer does, and its model exposes no top-level ``rotary_emb``, so asking
+    unconditionally asserted on exactly the models that never needed a table.
+    """
+    if not num_layers or not layer_wants_position_embeddings(hf_model.layers[0]):
+        return None
+    return reference_rope(hf_model, hidden_states, position_ids)
 
 
 def extract_layer_state_dict(variant, full_sd, layer_idx, hf_layer):
@@ -568,6 +619,16 @@ def load_and_compute_layer_by_layer(
     first_k_dense = config.first_k_dense_replace
     n_routed = config.n_routed_experts
 
+    # Once for the whole reference: identical across layers, and each build would otherwise construct
+    # a rotary module and a full fp32 copy of the hidden states.
+    #
+    # Only when a layer actually takes position_embeddings. A vendored reference such as DeepSeekV3
+    # computes rope internally and exposes no top-level rotary_emb, so building this unconditionally
+    # asserts on exactly the models that never needed it.
+    ref_position_embeddings = (
+        reference_position_embeddings(hf_model, h_ref, position_ids, num_layers) if compute_reference else None
+    )
+
     for i in range(num_layers):
         logger.info(f"Processing layer {i}/{num_layers}...")
 
@@ -579,14 +640,18 @@ def load_and_compute_layer_by_layer(
             hf_model.load_state_dict(layer_with_prefix, strict=False)
 
             with torch.no_grad():
-                layer_out = hf_model.layers[i](
-                    h_ref,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
-                    past_key_value=ref_cache,
-                    use_cache=True,
-                )
-                h_ref = layer_out[0]
+                layer_kwargs = {
+                    "attention_mask": attention_mask,
+                    "position_ids": position_ids,
+                    "past_key_value": ref_cache,
+                    "use_cache": True,
+                }
+                if ref_position_embeddings is not None:
+                    cos, sin = ref_position_embeddings
+                    layer_kwargs["position_embeddings"] = (cos.to(h_ref.dtype), sin.to(h_ref.dtype))
+                layer_out = hf_model.layers[i](h_ref, **layer_kwargs)
+                # A transformers-5.x layer returns a bare tensor, not a tuple; [0] would strip a dim.
+                h_ref = layer_out[0] if isinstance(layer_out, (tuple, list)) else layer_out
             ref_snapshots.append(h_ref)
 
             # Clear layer weights from hf_model


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Fixes #54516.

Rebuild the reference rotary table from the **config** in fp32 rather than deep-copying it off an instantiated model, so a bf16 reference no longer yields a bf16 `inv_freq`. Built once per run rather than per layer — it depends only on the positions, and each build would otherwise construct a rotary module and a full fp32 copy of the hidden states (~251 MB at seq 15360).

The table is built only when a layer's **signature** actually takes `position_embeddings`. A vendored reference such as DeepSeekV3 computes rope internally and exposes no top-level `rotary_emb`, so building it unconditionally asserted on precisely the models that never needed one.

Also adds mscale to the chunked reference cache key — it scales softmax by `mscale**2`, so toggling it served a stale reference — and a generic `reference_rotary_cls` adapter property.

Split out of #53747 per review.

### Notes for reviewers

- Block test at mesh-8x4, KVPE PE part: **0.997590 → 0.999900** at 1024 tokens, **0.946176 → 0.999899** at 5120. The result is now *flat in sequence length*, which is the signature that the position-dependent term is gone rather than merely under a threshold.
- Ruled out along the way, in case the same symptom recurs: a YaRN mismatch (the DeepSeek and Mistral tables are bit-identical for this config), the half-split/interleaved permutation (PCC 1.0 on CPU), and bf16 cos/sin (four orders of magnitude too small).
- `tests/torch/test_reference_rope.py` is host-only (no device, no weights). It asserts the rebuilt fp32 table matches an independent one at position 40000 **and** that the old `deepcopy(bf16).float()` path is wrong there by >1e-3 — without that second assertion the test would pass whether or not the fix is present.
- Rebased onto `58342a6f63d`.

### Testing

Local, on a 32-chip Blackhole galaxy, on a branch carrying all five split fixes on this PR's base:

- `tests/torch/test_reference_rope.py` — host-only, 4 passed; asserts the rebuilt fp32 table matches an independent one at position 40000 **and** that the pre-fix `deepcopy(bf16).float()` path is wrong there by >1e-3
- Mistral Small 4 prefill block, 8x4 — 6 passed; KVPE PE part **0.999952** (pre-fix: 0.946 at this length), and flat in sequence length rather than decaying
- Blaze dispatched on this branch, `test-type=prefill_block,glm_prefill_block,kimi_prefill_block,glm_chunked_accuracy,minimax_prefill_kv_pcc`: [run 33043223403](https://github.com/tenstorrent/tt-metal/actions/runs/33043223403) (passing)
- These jobs were green on `3900b5ea463`, one commit below this base. The overall run there is red only from `high_bw_all_gather CCL perf + accuracy`, a pre-existing flake outside this selection.
- All five together on `kmabee/issue_54515-54519_integration` (base `58342a6f63d`): Blaze [`test-type=all`](https://github.com/tenstorrent/tt-metal/actions/runs/33094428995) green 44/44, [(Blackhole) e2e](https://github.com/tenstorrent/tt-metal/actions/runs/33094442486) 39/40.
- The one red is not from these changes: the DeepSeek perf threshold has 0.15% headroom against 0.41% machine variance ([clean-base control on the same machine passed](https://github.com/tenstorrent/tt-metal/actions/runs/33115646268)).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kmabee/issue_54516_fix-mla-reference-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kmabee/issue_54516_fix-mla-reference-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kmabee/issue_54516_fix-mla-reference-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kmabee/issue_54516_fix-mla-reference-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kmabee/issue_54516_fix-mla-reference-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kmabee/issue_54516_fix-mla-reference-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kmabee/issue_54516_fix-mla-reference-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kmabee/issue_54516_fix-mla-reference-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kmabee/issue_54516_fix-mla-reference-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kmabee/issue_54516_fix-mla-reference-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kmabee/issue_54516_fix-mla-reference-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kmabee/issue_54516_fix-mla-reference-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kmabee/issue_54516_fix-mla-reference-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kmabee/issue_54516_fix-mla-reference-rope)



