### PR TITLE
[Bug fix] Take the plain RMSNorm op when the cluster axis is length 1

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -19,7 +19,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params, torus_xy_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params, torus_y_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
@@ -161,10 +161,10 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
     "mesh_device, device_params",
     [
         pytest.param(
-            (8, 4),
-            torus_xy_device_params(),
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            (8, 1),
+            torus_y_device_params(fabric_payload_size=7 * 1024),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="torus-y-8x1",
         ),
     ],
     indirect=True,
@@ -174,15 +174,15 @@ def test_rmsnorm_tp1(mesh_device, device_params, isl_per_chip, emb_dim, epsilon)
     Regression: the module must survive a cluster axis of length 1.
 
     ``ttnn.all_gather`` aborts at ``num_devices == 1`` rather than degenerating to a copy, so before
-    the TP=1 guard this module died on any single-column mesh. Runs on an ``(8,1)`` submesh carved
-    from the ``8x4`` galaxy -- the shape a PP=4 x TP=1 x SP=8 stage actually uses -- because a bare
-    ``(1,1)`` mesh is not feasible on this hardware and would only skip.
+    the TP=1 guard this module died on any single-column mesh. Runs on LoudBox as a native ``(8,1)``
+    mesh -- the same single-column shape a PP=4 x TP=1 x SP=8 galaxy stage uses -- so it needs no
+    galaxy time. A bare ``(1,1)`` mesh is not feasible on this hardware and would only skip.
     """
     torch.manual_seed(42)
 
-    sm = mesh_device.create_submeshes(ttnn.MeshShape(8, 1))[0]
+    sm = mesh_device
     mesh_shape = sm.shape
-    assert mesh_shape[1] == 1, f"expected a single-column stage submesh, got {tuple(mesh_shape)}"
+    assert mesh_shape[1] == 1, f"expected a single-column mesh, got {tuple(mesh_shape)}"
 
     torch_input = torch.randn((1, 1, isl_per_chip, emb_dim), dtype=torch.bfloat16).float()
     rmsnorm = torch.nn.RMSNorm(emb_dim, eps=epsilon)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -162,7 +162,7 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
     [
         pytest.param(
             (8, 4),
-            torus_xy_device_params(l1_small_size=768),
+            torus_xy_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="mesh-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -19,7 +19,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
@@ -153,6 +153,66 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
     assert pcc_passed, f"Distributed RMSNorm PCC test failed: {pcc_message}"
 
     logger.debug("PCC test passed!")
+
+
+@pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
+@pytest.mark.parametrize("isl_per_chip, emb_dim, epsilon", [(640, 4096, 1e-6)], ids=["640"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(l1_small_size=768),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=True,
+)
+def test_rmsnorm_tp1(mesh_device, device_params, isl_per_chip, emb_dim, epsilon):
+    """
+    Regression: the module must survive a cluster axis of length 1.
+
+    ``ttnn.all_gather`` aborts at ``num_devices == 1`` rather than degenerating to a copy, so before
+    the TP=1 guard this module died on any single-column mesh. Runs on an ``(8,1)`` submesh carved
+    from the ``8x4`` galaxy -- the shape a PP=4 x TP=1 x SP=8 stage actually uses -- because a bare
+    ``(1,1)`` mesh is not feasible on this hardware and would only skip.
+    """
+    torch.manual_seed(42)
+
+    sm = mesh_device.create_submeshes(ttnn.MeshShape(8, 1))[0]
+    mesh_shape = sm.shape
+    assert mesh_shape[1] == 1, f"expected a single-column stage submesh, got {tuple(mesh_shape)}"
+
+    torch_input = torch.randn((1, 1, isl_per_chip, emb_dim), dtype=torch.bfloat16).float()
+    rmsnorm = torch.nn.RMSNorm(emb_dim, eps=epsilon)
+    rmsnorm.weight.data.uniform_(-1, 1)
+    torch_reference = rmsnorm(torch_input).expand(mesh_shape[0], -1, -1, -1)
+
+    signpost(f"RMSNorm PCC test - TP=1 {tuple(mesh_shape)=} {isl_per_chip=} {emb_dim=}")
+
+    norm = TtDistributedRmsNorm(
+        mesh_device=sm,
+        emb_dim=emb_dim,
+        epsilon=epsilon,
+        torch_weight=rmsnorm.weight,
+        cluster_axis=1,
+        num_links=1,
+        topology=ttnn.Topology.Linear,
+    )
+    tt_input = ttnn.from_torch(
+        torch_input,
+        mesh_mapper=ttnn.ShardTensor2dMesh(sm, mesh_shape=mesh_shape, dims=(None, 3)),
+        layout=ttnn.TILE_LAYOUT,
+        device=sm,
+        dtype=ttnn.bfloat16,
+    )
+    tt_output = ttnn.to_torch(
+        norm(tt_input), mesh_composer=ttnn.ConcatMesh2dToTensor(sm, mesh_shape=mesh_shape, dims=(0, 3))
+    )
+
+    pcc_passed, pcc_message = assert_with_pcc(torch_reference.to(torch.float32), tt_output.to(torch.float32), pcc=0.99)
+    assert pcc_passed, f"TP=1 RMSNorm PCC test failed: {pcc_message}"
 
 
 @pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -261,6 +261,20 @@ class TtDistributedRmsNorm(LightweightModule):
             x = ttnn.to_memory_config(x, memory_config=self.input_memcfg)
             logger.debug("Moved input to specified memory config")
 
+        # TP=1: the cluster axis has length 1, so every device already holds the full hidden dim and
+        # there is nothing to distribute. Take the plain fused op. This is not just an optimisation --
+        # BOTH gathers below abort on a singleton axis rather than degenerating to a copy
+        # (all_gather: "num_devices > 1, got 1"; high_bw_all_gather: "selects a singleton mesh axis"),
+        # so which one you hit only depends on whether the tensor's topology supports the high-bw
+        # path. Verified bit-identical to the TP>1 path's output on an (8,1) stage submesh.
+        if self.mesh_device.shape[self.cluster_axis] == 1:
+            return ttnn.rms_norm(
+                x,
+                epsilon=self.epsilon,
+                weight=self.weight,
+                program_config=self.sharded_progcfg,
+            )
+
         # Step 1: Pre-all-gather - each device computes local sum(x^2)
         tt_stats = ttnn.rms_norm_pre_all_gather(
             x,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Fixes #54518.

At a length-1 cluster axis every device already holds the full hidden dim, so nothing is distributed: return `ttnn.rms_norm` before choosing a gather at all.

The cached gamma is reused as-is — plain `layer_norm` accepts the same ROW_MAJOR `[1, 1, dim/32, 32]` layout the distributed op takes — so there is no second weight, no second cache entry, and no existing line changes.

Split out of #53747 per review, and reworked there per @mbezuljTT's suggestion: the version in that PR kept the distributed op pair and fed it un-gathered local stats, which forced a restructure of the surrounding code. Taking the plain op instead makes the fix a 12-line insertion and lets steps 2–3 stay exactly as they are.

### Notes for reviewers

- Measured on an `(8,1)` submesh of an `8x4` Blackhole galaxy — the real PP=4 stage shape:
  - output is **bit-identical** to the pre/post pair (0 of 21M elements differ, max abs diff 0), so this cannot change any existing result;
  - **2.7×** faster device-side at the production row count (182.8 → 67.1 µs traced), 11× eager;
  - full PP=4 256k run unchanged (17.9k vs 17.8k tok/s steady), and the TP=2 shape re-checked to confirm the untouched distributed path still works.
- `test_rmsnorm_tp1` runs on an `(8,1)` submesh rather than a bare `(1,1)` mesh, which is not feasible on this hardware and would only ever skip. Verified it discriminates: with the fix reverted it fails with the `high_bw_all_gather` singleton-axis `TT_FATAL`.
- The underlying CCL behaviour — neither gather degenerating to a copy at one device — is worth fixing centrally; every model hand-rolls this guard today. Out of scope here.

### Testing

Local, on a 32-chip Blackhole galaxy, on a branch carrying all five split fixes on this PR's base:

- `pcc/test_rmsnorm.py::test_rmsnorm_tp1` — passes on an `(8,1)` submesh of the `8x4` galaxy, and **fails with the fix reverted** (`high_bw_all_gather ... singleton mesh axis`), so it discriminates
- Output is **bit-identical** to the pre/post pair at TP=1 — 0 of 21M elements differ, max abs diff 0 — so no existing result can change
- **2.7x faster** device-side at the production row count (182.8 → 67.1 us traced), 11x eager
- Mistral Small 4 PP=4 x TP=1 x SP=8, all 36 layers, real weights, 256k chunked prefill (51 x 5120) — passed, 17841 tok/s steady (unchanged vs the pre-rework 17803). Throughput/no-crash only: the run is headless (no LM head or sampling) and asserts no PCC, so correctness rests on the two bullets above
- TP=2 shape re-checked, confirming the untouched distributed path still works
- Blaze dispatched on this branch, `test-type=prefill_block,prefill_transformer_determinism`: [run 33043205907](https://github.com/tenstorrent/tt-metal/actions/runs/33043205907) (passing)
- These jobs pass on recent `main`. The only chronic red there is `high_bw_all_gather CCL perf + accuracy`, a pre-existing perf-threshold failure outside this selection.
- All five together on `kmabee/issue_54515-54519_integration` (base `58342a6f63d`): Blaze [`test-type=all`](https://github.com/tenstorrent/tt-metal/actions/runs/33094428995) green 44/44, [(Blackhole) e2e](https://github.com/tenstorrent/tt-metal/actions/runs/33094442486) 39/40.
- The one red is not from these changes: the DeepSeek perf threshold has 0.15% headroom against 0.41% machine variance ([clean-base control on the same machine passed](https://github.com/tenstorrent/tt-metal/actions/runs/33115646268)).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kmabee/issue_54518_fix-norm-tp1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kmabee/issue_54518_fix-norm-tp1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kmabee/issue_54518_fix-norm-tp1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kmabee/issue_54518_fix-norm-tp1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kmabee/issue_54518_fix-norm-tp1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kmabee/issue_54518_fix-norm-tp1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kmabee/issue_54518_fix-norm-tp1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kmabee/issue_54518_fix-norm-tp1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kmabee/issue_54518_fix-norm-tp1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kmabee/issue_54518_fix-norm-tp1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kmabee/issue_54518_fix-norm-tp1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kmabee/issue_54518_fix-norm-tp1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kmabee/issue_54518_fix-norm-tp1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kmabee/issue_54518_fix-norm-tp1)



