### PR TITLE
[Feature] Consume the prebuilt tests image in PR Gate smoke

### DIFF
--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -10,10 +10,19 @@ name: "Cleanup prebuilt tests images"
 # safety mechanism. Note that N counts untagged versions too, so tagged
 # retention is lower than the number says.
 #
-# That 100/run limit is why this is sized for today's volume, where only the
-# producer's own test workflow pushes. Once a gate workflow consumes these
-# images the push rate goes far above 100/day and the schedule, the limit, or
-# the number of images built per run all have to be revisited together.
+# The action deletes at most 100 versions per run, which is why the schedule is
+# hourly rather than daily. PR Gate builds two images per run at roughly 600
+# runs/day, so ~1,200 versions/day, or ~50/hour, against 24 x 100 deletions.
+#
+# min-versions-to-keep is sized from that RATE, not picked round: retention in
+# hours is roughly N / 50. An image must outlive the gap between its build and
+# the last consumer pulling it, and a hardware leg can sit queued for hours, so
+# N = 1200 buys about a day. Too small a value deletes an image out from under a
+# queued leg, which fails at container startup with no fallback, because
+# container.image is resolved before any step runs.
+#
+# Recompute N if the push rate changes: wiring more consumers raises it, and
+# building one image per run instead of two would halve it.
 #
 # This deletes irreversibly. It is scoped to the one package the
 # build-prebuilt-tests-image producer creates, and never touches a base image.
@@ -23,14 +32,14 @@ permissions:
 
 on:
   schedule:
-    - cron: "30 6 * * *"
+    - cron: "30 * * * *"
   workflow_dispatch:
     inputs:
       min-versions-to-keep:
         description: "Newest versions to keep. Set very high for a safe no-op run."
         required: false
         type: string
-        default: "50"
+        default: "1200"
 
 jobs:
   cleanup:
@@ -45,4 +54,21 @@ jobs:
           owner: tenstorrent
           package-name: tt-metal/prebuilt-tests-image
           package-type: container
-          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '50' }}
+          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '1200' }}
+
+      # A GC that silently falls behind looks exactly like one that is working.
+      - name: Report what is left
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: ${{ inputs.min-versions-to-keep || '1200' }}
+        run: |
+          set -euo pipefail
+          COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-image" --jq '.version_count')
+          echo "versions remaining: ${COUNT}" | tee -a "$GITHUB_STEP_SUMMARY"
+          # Steady state sits near the retention value, so warn relative to it
+          # rather than at a fixed number. A deliberate high-retention no-op run
+          # would otherwise report falling behind.
+          THRESHOLD=$(( KEEP * 2 ))
+          if [ "${COUNT}" -gt "${THRESHOLD}" ]; then
+            echo "::warning::${COUNT} versions left, over ${THRESHOLD}; cleanup is not keeping up with the push rate"
+          fi

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -75,6 +75,7 @@ permissions:
   pull-requests: write
   checks: write
   packages: write
+  actions: read
 
 jobs:
   # NOTE: Platform parsing is handled by build-docker-artifact.yaml and build-artifact.yaml internally.
@@ -189,7 +190,7 @@ jobs:
       - id: find-changes
         uses: ./.github/actions/find-changed-files
 
-  runtime-smoke-tests:
+  build-runtime-smoke-image:
     needs: [asan-build, build-docker-images, find-changed-files]
     if: ${{
       github.ref_name == 'main' ||
@@ -197,9 +198,36 @@ jobs:
       needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
       needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
       }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
+      base-image: ${{ needs.build-docker-images.outputs.ci-test-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: PRODUCT=tt-metalium
+
+  runtime-smoke-tests:
+    needs: [asan-build, build-docker-images, find-changed-files, build-runtime-smoke-image]
+    # Gate on asan-build rather than on nothing having failed. A skipped image
+    # build (forks) or a failed one (a registry or buildx blip) must still let
+    # smoke run on the artifact path: it is in optional-jobs, and
+    # workflow-status counts a skipped optional job as success, so skipping here
+    # would take hardware coverage out of the gate without failing it.
+    if: ${{ !cancelled() && needs.asan-build.result == 'success' && (
+      github.ref_name == 'main' ||
+      needs.find-changed-files.outputs.cmake-changed == 'true' ||
+      needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
+      needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true')
+      }}
     uses: ./.github/workflows/smoke.yaml
     secrets: inherit
     with:
+      # Empty on forks, where smoke falls back to downloading the artifact.
+      prebuilt-image: ${{ needs.build-runtime-smoke-image.outputs.image }}
       docker-image: ${{ needs.asan-build.outputs.ci-test-docker-image }}
       # github_hosted_cpu runs on ubuntu-latest (external runner) — no harbor access.
       # Use raw GHCR tag from build-docker-images, not the harbor-prefixed ref from
@@ -211,8 +239,11 @@ jobs:
       per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       upload-coverage: false
       enable-kernel-ccache: true
-  ttnn-smoke-tests:
-    needs: [asan-build, find-changed-files]
+  # A second image because the tag reflects build-args, and smoke installs a
+  # different package set per product. The two builds run in parallel, so this
+  # costs no extra time on the critical path.
+  build-ttnn-smoke-image:
+    needs: [asan-build, build-docker-images, find-changed-files]
     if: ${{
       github.ref_name == 'main' ||
       needs.find-changed-files.outputs.cmake-changed == 'true' ||
@@ -220,9 +251,37 @@ jobs:
       needs.find-changed-files.outputs.tt-nn-changed == 'true' ||
       needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
       }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
+      base-image: ${{ needs.build-docker-images.outputs.ci-test-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: PRODUCT=tt-nn
+
+  ttnn-smoke-tests:
+    needs: [asan-build, build-docker-images, find-changed-files, build-ttnn-smoke-image]
+    # Gate on asan-build rather than on nothing having failed. A skipped image
+    # build (forks) or a failed one (a registry or buildx blip) must still let
+    # smoke run on the artifact path: it is in optional-jobs, and
+    # workflow-status counts a skipped optional job as success, so skipping here
+    # would take hardware coverage out of the gate without failing it.
+    if: ${{ !cancelled() && needs.asan-build.result == 'success' && (
+      github.ref_name == 'main' ||
+      needs.find-changed-files.outputs.cmake-changed == 'true' ||
+      needs.find-changed-files.outputs.tt-metalium-changed == 'true' ||
+      needs.find-changed-files.outputs.tt-nn-changed == 'true' ||
+      needs.find-changed-files.outputs.tt-metalium-or-tt-nn-tests-changed == 'true')
+      }}
     uses: ./.github/workflows/smoke.yaml
     secrets: inherit
     with:
+      # Empty on forks, where smoke falls back to downloading the artifact.
+      prebuilt-image: ${{ needs.build-ttnn-smoke-image.outputs.image }}
       docker-image: ${{ needs.asan-build.outputs.ci-test-docker-image }}
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-nn

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -22,6 +22,14 @@ on:
       package-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Image with the packages already installed. When set it replaces
+          docker-image and the download and install steps are skipped. Empty
+          means the artifact path, which is what forks always get.
       enabled-skus:
         required: false
         type: string
@@ -120,7 +128,9 @@ jobs:
       # github_hosted_cpu runs on GitHub-hosted runners with no Harbor access, so it
       # needs the canonical (publicly pullable) cpu-docker-image ref instead of the
       # Harbor-prefixed one (same reason dedicated-merge-gate uses the raw ref).
-      image: ${{ (matrix.test-group.sku == 'github_hosted_cpu' && (inputs.cpu-docker-image || inputs.docker-image)) || (inputs.docker-image && (contains(join(matrix.test-group.runs_on, ','), 'dedicated-merge-gate') && inputs.docker-image || format('{0}{1}', inputs.harbor-prefix, inputs.docker-image))) || 'docker-image-unresolved!' }}
+      # A prebuilt image already carries the packages, and is a canonical ghcr
+      # ref so it needs no Harbor prefix on any SKU.
+      image: ${{ inputs.prebuilt-image || (matrix.test-group.sku == 'github_hosted_cpu' && (inputs.cpu-docker-image || inputs.docker-image)) || (inputs.docker-image && (contains(join(matrix.test-group.runs_on, ','), 'dedicated-merge-gate') && inputs.docker-image || format('{0}{1}', inputs.harbor-prefix, inputs.docker-image))) || 'docker-image-unresolved!' }}
       env:
         ASAN_OPTIONS: "color=always"
         TSAN_OPTIONS: "color=always"
@@ -148,6 +158,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - uses: ./.github/actions/download-artifact-with-retry
+        if: ${{ inputs.prebuilt-image == '' }}
         timeout-minutes: 15
         with:
           name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
@@ -179,6 +190,7 @@ jobs:
           echo "Memory limit validated: ${memory_bytes} bytes"
 
       - name: Install packages
+        if: ${{ inputs.prebuilt-image == '' }}
         timeout-minutes: 10
         run: |
           # Ideally only ${{ inputs.product }}-validation, but APT doesn't resolve dependencies from files on disk without being told about them.


### PR DESCRIPTION
### PR Category

Feature

### Summary

PR Gate's smoke legs download the build artifact and install it before they can run anything. This wires them to the prebuilt image from #54412 instead, so neither step is needed.

Measured on a hardware leg, with the other product left on the artifact path in the same run as a control: setup goes from 213s to 92s, around 120s per leg. `download-artifact-with-retry` and `Install packages` are skipped and contribute 0s. Test counts are unchanged: the same product and SKU reports the same 35 tests from 9 suites on both paths.

Scope is deliberately narrow. Only `smoke.yaml`'s two PR Gate call sites are wired. `sdk-examples.yaml` and both Merge Gate callers still use the artifact path, so they stay as a control and can migrate separately once this has run on real traffic.

Stacked on #54412 and targeting its branch.

### Notes for reviewers

- Forks cannot push images, so the image job is skipped there and returns an empty ref, and smoke falls back to downloading the artifact. The `!cancelled() && !failure()` guard on the smoke jobs is what makes that work: without it a skipped image job would skip smoke along with it, silently dropping fork coverage.
- Two images are built per run, one per product, because smoke installs a different package set for each. They differ only in `build-args`, and the producer's tag includes a hash of the build recipe, so they cannot collide. The two builds run concurrently, so the second costs about 12s rather than a second serial step.
- `base-image` comes from `build-docker-images` rather than `asan-build`. The latter is Harbor-prefixed, and the producer runs on a GitHub-hosted runner with no Harbor access. This is the same reason `smoke.yaml` already takes a separate `cpu-docker-image` for its `github_hosted_cpu` leg.
- `actions: read` is added at the workflow level. The producer needs it to download the artifact through the REST path, and a called workflow can only downgrade the caller's token, so granting it inside the producer alone has no effect.
- The cleanup schedule moves from daily to hourly in the same change. `actions/delete-package-versions` deletes at most 100 versions per run, and this wiring pushes roughly 1,200 per day, so a daily sweep could not keep up. The job now also reports how many versions remain, since a cleanup falling behind otherwise looks identical to one that is working.
- The `github_hosted_cpu` leg runs from the same image with no special case, since the ref is a canonical ghcr one and needs no Harbor prefix.
- Validated by dispatching PR Gate against this branch rather than by marking it ready, so the run reflects the modified workflows.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdabasinskas/ci-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdabasinskas/ci-gate-prebuilt-tests)

