### PR TITLE
argmax: Fix uint32 underflow in sub_core_grids work split

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -268,3 +268,92 @@ def test_argmax_reduce_all_multicore_no_deadlock(device):
     ref = int(torch.argmax(t.reshape(-1)))
     got = int(ttnn.to_torch(ttnn.from_device(result["out"])).item())
     assert got == ref, f"argmax reduce_all mismatch: got {got}, expected {ref}"
+
+
+def _run_argmax_in_worker(fn, timeout_s=60.0):
+    """Run `fn` on a worker thread so a device hang surfaces as an assertion, not a hung session."""
+    result = {}
+
+    def _run():
+        try:
+            result["out"] = fn()
+        except Exception as exc:  # surface device/compile errors to the main thread
+            result["error"] = exc
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(timeout=timeout_s)
+    return worker, result
+
+
+@pytest.mark.timeout(120, method="thread")
+@pytest.mark.parametrize(
+    "tensor_shape, core_ranges",
+    [
+        # More sub-grid cores than blocks of work
+        ([8, 32], [((0, 0), (1, 1))]),  # 4 cores, 2 blocks
+        ([1, 64], [((0, 0), (7, 0))]),  # 8 cores, 4 blocks
+        # Fewer cores than blocks
+        ([1, 80], [((0, 0), (3, 0))]),  # 4 cores, 5 blocks -> 2 blocks each = 128 units for 80
+        ([1, 144], [((0, 0), (7, 0))]),  # 8 cores, 9 blocks -> 2 blocks each = 256 units for 144
+        # Two ranges exercise the second core group (cores1 / red_dim_units1).
+        ([4, 80], [((0, 0), (1, 0)), ((0, 1), (1, 1))]),
+        # Widths that already split cleanly
+        ([1, 128], [((0, 0), (7, 0))]),
+        ([8, 1024], [((0, 0), (7, 0))]),
+    ],
+)
+def test_argmax_sub_core_grids_work_split(device, tensor_shape, core_ranges):
+    """
+    Guard the sub_core_grids work-split: rounded-up per-core shares can overshoot the
+    reduction dim by more than one core's share, and trimming only the last core then underflowed
+    uint32 into a large read size and a hang.  Slices are now clamped per core instead.
+    """
+    torch.manual_seed(0)
+    grids = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(*start), ttnn.CoreCoord(*end)) for start, end in core_ranges}
+    )
+
+    torch_tensor = torch.randn(*tensor_shape, dtype=torch.bfloat16)
+    ttnn_tensor = ttnn.from_torch(torch_tensor, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    def _run():
+        out = ttnn.argmax(ttnn_tensor, dim=-1, keepdim=False, sub_core_grids=grids)
+        ttnn.synchronize_device(device)
+        return out
+
+    worker, result = _run_argmax_in_worker(_run)
+
+    assert not worker.is_alive(), f"ttnn.argmax timed out for shape={tensor_shape}, " f"sub_core_grids={core_ranges}"
+    if "error" in result:
+        raise result["error"]
+
+    ttnn_result = ttnn.to_torch(ttnn.from_device(result["out"])).to(torch.int32)
+    assert_equal(torch.argmax(torch_tensor, dim=-1, keepdim=False), ttnn_result)
+
+
+@pytest.mark.timeout(120, method="thread")
+def test_argmax_reduce_all_sub_core_grids_idle_cores(device):
+    """
+    dim=None uses the kernel's separate reduce_all block (its own partial-write and semaphore
+    sequence); drive it with a sub_core_grids wide enough to leave cores with no work.
+    """
+    torch.manual_seed(0)
+    # 4 cores for a 32-wide reduction dim = 2 blocks of work, so two cores are left idle.
+    grids = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))})
+    t = torch.randn(8, 32, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(t, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    def _run():
+        out = ttnn.argmax(ttnn_in, sub_core_grids=grids)  # dim=None -> reduce_all
+        ttnn.synchronize_device(device)
+        return out
+
+    worker, result = _run_argmax_in_worker(_run)
+
+    assert not worker.is_alive(), "ttnn.argmax(dim=None) timed out with sub_core_grids leaving idle cores"
+    if "error" in result:
+        raise result["error"]
+
+    got = int(ttnn.to_torch(ttnn.from_device(result["out"])).item())
+    assert got == int(torch.argmax(t.reshape(-1))), f"reduce_all mismatch: got {got}"

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_multi_core_program_factory.cpp
@@ -4,6 +4,7 @@
 #include "argmax_device_operation.hpp"
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
 
+#include <algorithm>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
@@ -25,7 +26,7 @@ using namespace tt::tt_metal::experimental;
  *
  * If a sub_core_grids is provided, it will be used to distribute the work evenly across the cores.
  * Otherwise, we distribute to maximum of two core groups, with each core group getting a minimum of
- * `min_red_dim_units_per_core` elements to process, except the last core.
+ * `min_red_dim_units_per_core` elements to process, except where the reduction dim runs out.
  * @param device Pointer to the device
  * @param red_dim_units Total units in the reduction dimension
  * @param min_red_dim_units_per_core Minimum units per core (for alignment)
@@ -34,8 +35,9 @@ using namespace tt::tt_metal::experimental;
  *         - all_cores: CoreRangeSet of all cores
  *         - cores0: First group of cores
  *         - cores1: Second group of cores (if any)
- *         - red_dim_units0: Units assigned to first group per core
- *         - red_dim_units1: Units assigned to second group per core
+ *         - red_dim_units0: Nominal per-core units for the first group: the offset stride and CB page size.
+ *           The units a core actually processes are clamped against what is left (see units_for_core).
+ *         - red_dim_units1: Same, for the second group
  */
 static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> distribute_work_to_cores(
     const tt::tt_metal::IDevice* device,
@@ -138,7 +140,7 @@ static inline std::tuple<CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uin
  *    - Each group handles a different portion of the reduction dimension
  *    - cores0 handles red_dim_units0 elements
  *    - cores1 handles red_dim_units1 elements
- *    - Each core gets a minimum of `min_red_dim_units_per_core` elements to process, except the last core
+ *    - Each core gets a minimum of `min_red_dim_units_per_core` elements, except where the reduction dim runs out
  *
  * 2. Core Layout:
  *    - Cores are arranged in a grid pattern
@@ -304,29 +306,10 @@ ttnn::device_operation::ProgramArtifacts ArgMaxMultiCoreProgramFactory::create_p
     SemaphoreSpec start_sem{.unique_id = START, .target_nodes = all_cores};
     SemaphoreSpec done_sem{.unique_id = DONE, .target_nodes = all_cores};
 
-    // Byte size of the data to read from the input DFB for each core
-    const auto src_read_size0 = red_dim_units0 * input_unit_size;
-    const auto src_read_size1 = red_dim_units1 * input_unit_size;
-
-    // If red_dim_units is not a multiple of min_red_dim_units_per_core, then the last core will read a smaller amount
-    // of data We calculate that number here
-    const int ideal_red_dim_units = (num_cores0 * red_dim_units0) + (num_cores1 * red_dim_units1);
-
-    uint32_t red_dim_units_last0 = 0, red_dim_units_last1 = 0;
-    if (num_cores1 > 0) {
-        red_dim_units_last0 = red_dim_units0;
-        red_dim_units_last1 = ideal_red_dim_units == red_dim_units
-                                  ? red_dim_units1
-                                  : red_dim_units1 - (ideal_red_dim_units - red_dim_units);
-    } else {
-        red_dim_units_last0 = ideal_red_dim_units == red_dim_units
-                                  ? red_dim_units0
-                                  : red_dim_units0 - (ideal_red_dim_units - red_dim_units);
-        red_dim_units_last1 = 0;
-    }
-
-    const auto src_read_size_last0 = red_dim_units_last0 * input_unit_size;
-    const auto src_read_size_last1 = red_dim_units_last1 * input_unit_size;
+    // Clamp each slice to the units left
+    const auto units_for_core = [red_dim_units](const uint32_t red_dim_offset, const uint32_t units_per_core) {
+        return red_dim_offset >= red_dim_units ? 0u : std::min(units_per_core, red_dim_units - red_dim_offset);
+    };
 
     // Common compile time args for all cores.
     // Names are the reader kernel's own variable names; refer to the kernel code for what each means.
@@ -442,16 +425,20 @@ ttnn::device_operation::ProgramArtifacts ArgMaxMultiCoreProgramFactory::create_p
     // Set runtime args for cores0 and cores1, only offsets (src and red_dim_units) are different
     // Refer to the kernel code for explanation of the args
     KernelRunArgs reader_run_args0{.kernel = READER0};
+    uint32_t assigned_red_dim_units = 0;
     for (uint32_t i = 0; i < num_cores0; ++i) {
         const CoreCoord& core = cores_coords0.at(i);
+        const uint32_t red_dim_offset = i * red_dim_units0;
+        const uint32_t red_dim_units_this_core = units_for_core(red_dim_offset, red_dim_units0);
         AddRuntimeArgsForNode(
             reader_run_args0.runtime_arg_values,
             core,
             {{"core_id", i},
-             {"src_offset", static_cast<uint32_t>(i * src_read_size0)},
-             {"red_dim_offset", i * red_dim_units0},
-             {"src_read_size", static_cast<uint32_t>((i == num_cores0 - 1) ? src_read_size_last0 : src_read_size0)},
-             {"red_dim_units_this_core", (i == num_cores0 - 1) ? red_dim_units_last0 : red_dim_units0}});
+             {"src_offset", static_cast<uint32_t>(std::min(red_dim_offset, red_dim_units) * input_unit_size)},
+             {"red_dim_offset", red_dim_offset},
+             {"src_read_size", static_cast<uint32_t>(red_dim_units_this_core * input_unit_size)},
+             {"red_dim_units_this_core", red_dim_units_this_core}});
+        assigned_red_dim_units += red_dim_units_this_core;
     }
     kernel_run_args.push_back(std::move(reader_run_args0));
 
@@ -459,23 +446,33 @@ ttnn::device_operation::ProgramArtifacts ArgMaxMultiCoreProgramFactory::create_p
         kernels.push_back(make_reader(READER1, SRC1));
         work_units.push_back(WorkUnitSpec{.name = "group1", .kernels = {READER1}, .target_nodes = cores1});
 
-        const uint32_t src_offset1 = static_cast<uint32_t>(src_read_size0 * num_cores0);
         const uint32_t red_dim_offset1 = static_cast<uint32_t>(red_dim_units0 * num_cores0);
 
         KernelRunArgs reader_run_args1{.kernel = READER1};
         for (uint32_t i = 0; i < num_cores1; ++i) {
             const CoreCoord& core = cores_coords1.at(i);
+            const uint32_t red_dim_offset = red_dim_offset1 + (i * red_dim_units1);
+            const uint32_t red_dim_units_this_core = units_for_core(red_dim_offset, red_dim_units1);
             AddRuntimeArgsForNode(
                 reader_run_args1.runtime_arg_values,
                 core,
                 {{"core_id", static_cast<uint32_t>(num_cores0 + i)},
-                 {"src_offset", static_cast<uint32_t>(src_offset1 + (i * src_read_size1))},
-                 {"red_dim_offset", red_dim_offset1 + (i * red_dim_units1)},
-                 {"src_read_size", static_cast<uint32_t>((i == num_cores1 - 1) ? src_read_size_last1 : src_read_size1)},
-                 {"red_dim_units_this_core", (i == num_cores1 - 1) ? red_dim_units_last1 : red_dim_units1}});
+                 {"src_offset", static_cast<uint32_t>(std::min(red_dim_offset, red_dim_units) * input_unit_size)},
+                 {"red_dim_offset", red_dim_offset},
+                 {"src_read_size", static_cast<uint32_t>(red_dim_units_this_core * input_unit_size)},
+                 {"red_dim_units_this_core", red_dim_units_this_core}});
+            assigned_red_dim_units += red_dim_units_this_core;
         }
         kernel_run_args.push_back(std::move(reader_run_args1));
     }
+
+    // The per-core slices must tile the reduction dim exactly: no gaps (dropped elements) and no
+    // overlap (double-counted elements).
+    TT_FATAL(
+        assigned_red_dim_units == red_dim_units,
+        "Argmax work split covers {} of {} reduction units",
+        assigned_red_dim_units,
+        red_dim_units);
 
     ProgramSpec spec{
         .name = "argmax_multi_core",

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -56,13 +56,16 @@ inline void find_argmax_for_core(
     volatile tt_l1_ptr uint32_t* red_idxs,
     volatile tt_l1_ptr decltype(get_default_value<data_format>())* red_vals) {
     for (uint32_t j = 0; j < inner_dim_units; ++j) {
-        noc.async_read(
-            s_src,
-            src_dfb,
-            src_read_size,
-            {.page_id = outer_idx * inner_dim_units + j, .offset_bytes = src_offset},
-            {.offset_bytes = 0});
-        noc.async_read_barrier();
+        // Cores that sub_core_grids leaves without work skip the empty NoC read but still publish a default partial.
+        if (red_dim_units_this_core > 0) {
+            noc.async_read(
+                s_src,
+                src_dfb,
+                src_read_size,
+                {.page_id = outer_idx * inner_dim_units + j, .offset_bytes = src_offset},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+        }
 
         // Reset max_val for each new output
         if constexpr (not reduce_all) {


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`ttnn.argmax(..., sub_core_grids=...)` could hang the device or corrupt L1.

The multi-core split gave every core in the user grid the same rounded-up share, then subtracted the whole overshoot from the last core. When that overshoot was larger than one core's share, the `uint32_t` subtraction wrapped and the last core was handed a large NoC read and large iteration scan.

Both items in #51228 are this one invariant: the last-core trim assumed overshoot < one core's share. That holds on the default path (`split_work_to_cores` sizes the core count from the work) and fails on the `sub_core_grids` path (the core count is the user's grid).

Each core is now given `min(its share, units left at its offset)`, floored at 0. There is no last-core subtraction, so the wrap cannot happen. Cores with 0 units skip the NoC read (a zero-length read wedges the core) and still write a default partial for the reducer.

Closes #51228


### Notes for reviewers

- **Why this approach:** The issue suggests either capping the number of cores or clamping each core's work. This change uses the per-core clamp because it fixes both reported cases, while keeping the existing core set, semaphore configuration, and multicast setup unchanged.

- **Idle cores:** Cores with no remaining work still write their default partial result and signal `done_sem`. The reducer expects a result from every participating core, so this behavior is required.

- **Validation:** Since the last-core subtraction has been removed, the requested underflow `TT_FATAL` is no longer applicable. Instead, a coverage check verifies that the per-core slices exactly cover `red_dim_units`.

- **No change to existing splits:** For work distributions that were valid before, the new calculation produces the same per-core work.

- **Test coverage:** Added tests for both issue repros, a two-range core grid, clean work splits, and `dim=None` with idle cores. The operations run on a worker thread with a timeout so a device hang is reported as a test failure instead of blocking the test session.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/armax_sub_core_grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/armax_sub_core_grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/armax_sub_core_grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/armax_sub_core_grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/armax_sub_core_grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/armax_sub_core_grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/armax_sub_core_grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/armax_sub_core_grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/armax_sub_core_grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/armax_sub_core_grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/armax_sub_core_grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/armax_sub_core_grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/armax_sub_core_grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/armax_sub_core_grids)