### PR TITLE
Refactor prefill module/model tests for chunk size 5k

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py
+++ b/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py
@@ -22,14 +22,14 @@ from models.demos.deepseek_v3_d_p.tt.dflash_prefill.tt_dflash_drafter import TtD
 from models.demos.deepseek_v3_d_p.tt.mla.rope import interleaved_to_halfsplit_perm
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import allocate_dflash_kv_cache
 from tests.ttnn.utils_for_testing import comp_pcc
 
 PCC_THRESHOLD = 0.999
 
-# The production chunk width on the target 8x4 mesh (sp=8 -> chunk_local=640), same literal as
-# test_mla.py:558's `chunk_size_global=5120` default. There is no config constant for it.
-CHUNK_GLOBAL = 5120
+# The production chunk width: 5120 global, 640 per chip on the target 8x4 mesh (sp=8).
+CHUNK_GLOBAL = PREFILL_CHUNK_TOKENS
 
 # Per-user cache depth
 MAX_SEQ_LEN = 11 * CHUNK_GLOBAL

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
@@ -23,7 +23,7 @@ from models.demos.deepseek_v3_d_p.tt.runners.kv_chunk_table import (
     build_and_serialize_kv_chunk_table,
 )
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import PREFILL_CHUNK_OUTPUT_TOKENS, MlaKvCacheFormat
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import PREFILL_CHUNK_TOKENS, MlaKvCacheFormat
 
 
 @pytest.mark.parametrize(
@@ -39,7 +39,7 @@ def test_fp8_row_major_kv_cache_all_gather(mesh_device, tmp_path):
 
     sp_axis = 0
     mesh_shape = tuple(mesh_device.shape)
-    seq_len = PREFILL_CHUNK_OUTPUT_TOKENS
+    seq_len = PREFILL_CHUNK_TOKENS
     config = glm_hf_config(max_seq=seq_len)
     head_dim = config.kv_lora_rank + config.qk_rope_head_dim
     params = PrefillRunParams(
@@ -84,7 +84,7 @@ def test_fp8_row_major_kv_cache_all_gather(mesh_device, tmp_path):
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_users=1,
-        chunk_size_global=PREFILL_CHUNK_OUTPUT_TOKENS,
+        chunk_size_global=PREFILL_CHUNK_TOKENS,
         path=str(table_path),
     )
     table = ttnn.experimental.disaggregation.import_from_protobuf_file(str(table_path))

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
@@ -212,6 +212,9 @@ def test_masked_bincount_tree_reduction_race(mesh_device):
     the root's gather_sem before the slow leaf finishes, exposing data races
     where a parent reads a child's incomplete histogram.
     """
+    # sp_dim stays at 4096 rather than moving to the 640-token prefill ISL: this test exists to
+    # expose a gather_sem race, and the window it opens scales with per-core work (rows_per_core=64
+    # here, 10 at 640). Shrinking it would narrow the race window this test is built to catch.
     sp_dim = 4096
     topk = 8
     n_routed_experts = 256

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_mla_matmuls.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_mla_matmuls.py
@@ -477,6 +477,14 @@ def test_mla_mm(
     out_mem_config,
     skip_host_comparison,
 ):
+    # prog_config_*_bh_25k are hand-tuned for 6400 rows (200 tiles); the ISL is now 20 tiles, so
+    # per_core_M / out_subblock_h are invalid at the new shape.
+    if in0_z == SEQ_LEN_25K:
+        pytest.skip(
+            "tuned program configs are sized for 6400 rows (3200 tokens/chip); needs re-tuning for "
+            "the 640-token ISL -- see the ds_prefill tracking issue"
+        )
+
     torch.manual_seed(42)
     hidden_states = torch.randn(in0_x, in0_y, in0_z, in0_w, dtype=torch.bfloat16)
     weight = torch.randn(in1_x, in1_y, in1_z, in1_w, dtype=torch.bfloat16) * 0.02

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
@@ -24,6 +24,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.utils import rotated_chip_real_token_counts
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 # Galaxy-shaped SP=8 config (chunk_size_global 5120 -> tokens_per_chip 640) plus the existing small
 # 2x4 case for boxes that cannot host 32 chips. Keep this one-for-one: the production row owns
@@ -104,7 +105,7 @@ def _read_counts(config: ttnn.Tensor, mesh_device, sp_factor: int) -> tuple[list
 
 def _run_case(mesh_device, actual_start: int, actual_isl: int, padding_side: str = "right"):
     sp_factor = int(mesh_device.shape[0])
-    tokens_per_chip = 640
+    tokens_per_chip = PREFILL_CHUNK_TOKENS_PER_CHIP
     chunk_global = sp_factor * tokens_per_chip
 
     config = _alloc_config(mesh_device, sp_factor)
@@ -166,7 +167,7 @@ def test_moe_padding_config_one_program_across_chunks(mesh_device):
     place must change the result — together these are exactly what lets one capture replay across
     chunks. Asserts a single cached program serves a sequence of different chunks, each still correct."""
     sp_factor = int(mesh_device.shape[0])
-    tokens_per_chip = 640
+    tokens_per_chip = PREFILL_CHUNK_TOKENS_PER_CHIP
 
     config = _alloc_config(mesh_device, sp_factor)
     start_t = _meta1(mesh_device, 0)

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
@@ -50,6 +50,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table, log_validation_results
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 
 def run_dispatch_combine(
@@ -713,7 +714,7 @@ def test_ttnn_dispatch_combine_top4(
     topology = per_axis_topology(device_params["fabric_config"])[sp_axis]
     run_dispatch_combine(
         mesh_device=mesh_device,
-        seq_len_per_chip=1600,
+        seq_len_per_chip=PREFILL_CHUNK_TOKENS_PER_CHIP,
         emb_dim=7168,
         num_routed_experts=64,
         num_experts_per_tok=4,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
@@ -22,6 +22,7 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
     torus_y_device_params,
 )
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
 # Production chunk_size_global only (chunk_local = 5120/8 = 640). At this csg a 128-pad window never
@@ -312,8 +313,8 @@ def test_zero_padded_kv_cache_layers_users(
     sp = mesh_shape[sp_axis]
     tp = mesh_shape[1]
     kvpe = 64
-    chunk_size_global = 5120
-    seq_len_cache = 5120
+    chunk_size_global = PREFILL_CHUNK_TOKENS
+    seq_len_cache = chunk_size_global
     seq_len_local = seq_len_cache // sp
     num_batches = num_users * num_layers
     target_batch = slot_idx * num_layers + layer_idx
@@ -415,8 +416,8 @@ def test_zero_padded_kv_cache_tensor_matches_scalar(mesh_device, slot_idx, valid
     sp_axis = 0
     sp = mesh_shape[sp_axis]
     kvpe = 64
-    chunk_size_global = 5120
-    seq_len_cache = 5120
+    chunk_size_global = PREFILL_CHUNK_TOKENS
+    seq_len_cache = chunk_size_global
     seq_len_local = seq_len_cache // sp
     num_users, num_layers = 2, 1
 
@@ -476,8 +477,8 @@ def test_zero_padded_kv_cache_tensor_program_reuse(mesh_device):
     tensor path is TILE-only, so this uses a TILE cache.)"""
     sp_axis = 0
     kvpe = 64
-    chunk_size_global = 5120
-    seq_len_cache = 5120
+    chunk_size_global = PREFILL_CHUNK_TOKENS
+    seq_len_cache = chunk_size_global
     num_users, num_layers = 2, 1
 
     cache = _init_cache_filled_with_ones(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
@@ -22,6 +22,7 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_pa
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import ACTIVATION_SILU, ACTIVATION_SITU
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import EMB_DIM, HIDDEN_DIM, TtFfn
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -29,14 +30,13 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "batch_seq_len, hidden_dim, activation",
     [
-        (4096, HIDDEN_DIM, ACTIVATION_SILU),
-        (3200, HIDDEN_DIM, ACTIVATION_SILU),
+        (PREFILL_CHUNK_TOKENS_PER_CHIP, HIDDEN_DIM, ACTIVATION_SILU),
         # Kimi-K3's layer-0 dense FFN: 33792 wide, on the checkpoint's SiTU-GLU (#53625). Both the
         # width and the activation are new here — 33792 is 1.8x DSv3's 18432, and it is far past
         # ttnn.situ_glu's 3072 L1 cutoff, so every intermediate is a full-size DRAM tensor.
-        (3200, KimiK3Config.INTERMEDIATE_SIZE, ACTIVATION_SITU),
+        (PREFILL_CHUNK_TOKENS_PER_CHIP, KimiK3Config.INTERMEDIATE_SIZE, ACTIVATION_SITU),
     ],
-    ids=["4K", "3.2K", "3.2K-k3-33792-situ"],
+    ids=["isl_5k", "isl_5k-k3-33792-situ"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -24,6 +24,7 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import extract_mesh_config
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 # Mapping from torch dtypes to corresponding ttnn dtypes
@@ -81,7 +82,13 @@ def _ci_unsupported_param_combos_global_to_local_token_id(**params):
     [
         # fmt: off
         pytest.param(32, 1024, 10240, True, id="small"),
-        pytest.param(3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.VOCAB_SIZE, False, id="full-no-pcc"),
+        pytest.param(
+            PREFILL_CHUNK_TOKENS_PER_CHIP,
+            DeepSeekV3Config.EMB_SIZE,
+            DeepSeekV3Config.VOCAB_SIZE,
+            False,
+            id="full-no-pcc",
+        ),
         # fmt: on
     ],
 )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -50,6 +50,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_testing, get_input_mem_config
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import GOLDEN_LONGBOOK_TRACE, load_trace_gate_input
 
@@ -69,7 +70,7 @@ GATE_MODELS = {
 
 # Per-chip sequence every gate case runs at. Must be passed at construction: TtMoEGateConfig keeps
 # only the tuned matmul configs keyed to sp_dim, so assigning it afterwards drops to default tiling.
-GATE_SP_DIM = 640
+GATE_SP_DIM = PREFILL_CHUNK_TOKENS_PER_CHIP
 
 
 def _gate_config(gate_model: str) -> TtMoEGateConfig:

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -38,6 +38,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table, log_validation_results
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 
 # dispatch_buffer_capacity_factor below is ceil(N/2) of the most conservative
@@ -46,7 +47,7 @@ from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor",
     [
-        (3200, 7168, 64, 2, 2),
+        (PREFILL_CHUNK_TOKENS_PER_CHIP, 7168, 64, 2, 2),
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -20,15 +20,16 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from tests.ttnn.utils_for_testing import comp_pcc
 
 
 @pytest.mark.parametrize(
     "isl_per_chip, vocab_size, emb_dim",
     [
-        (3200, DeepSeekV3Config.VOCAB_SIZE, DeepSeekV3Config.EMB_SIZE),
+        (PREFILL_CHUNK_TOKENS_PER_CHIP, DeepSeekV3Config.VOCAB_SIZE, DeepSeekV3Config.EMB_SIZE),
     ],
-    ids=["deepseek_prefill_100K"],
+    ids=["isl_5k"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -22,6 +22,7 @@ import ttnn
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -38,7 +39,9 @@ def _ci_unsupported_param_combos(**params):
 
 @pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
 @pytest.mark.parametrize(
-    "isl_per_chip, emb_dim, epsilon, num_links", [(3200, 7168, 1e-6, 1), (4096, 7168, 1e-6, 1)], ids=["3.2K", "4K"]
+    "isl_per_chip, emb_dim, epsilon, num_links",
+    [(PREFILL_CHUNK_TOKENS_PER_CHIP, 7168, 1e-6, 1)],
+    ids=["isl_5k"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params",
@@ -153,7 +156,9 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
 
 
 @pytest.mark.uncollect_if(pred=_ci_unsupported_param_combos)
-@pytest.mark.parametrize("isl_per_chip, emb_dim, epsilon", [(3200, 7168, 1e-6), (4096, 7168, 1e-6)], ids=["3.2K", "4K"])
+@pytest.mark.parametrize(
+    "isl_per_chip, emb_dim, epsilon", [(PREFILL_CHUNK_TOKENS_PER_CHIP, 7168, 1e-6)], ids=["isl_5k"]
+)
 def test_rmsnorm_single_chip(device, isl_per_chip, emb_dim, epsilon):
     """
     Test single-chip full dimension RMSNorm against PyTorch reference.

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -16,6 +16,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
@@ -25,6 +26,7 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import ACTIVATION_SILU, ACTIVATION_SITU, TtSharedExpert
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -32,21 +34,30 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, hidden_dim, activation",
     [
-        # 640 is the per-chip prefill chunk: 5120 tokens over sp_factor 8. Every case here runs that
-        # depth, which pins the matmul program configs to per_core_M=1 -- the blocking prefill uses.
-        (640, 7 * 1024, 2 * 1024, ACTIVATION_SILU),
+        # Every case runs the one prefill ISL, which pins the matmul program configs to
+        # per_core_M=1 -- the blocking prefill uses.
+        (PREFILL_CHUNK_TOKENS_PER_CHIP, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, ACTIVATION_SILU),
         # Kimi-K3: one shared-expert MLP at moe_intermediate_size * num_shared_experts = 3072 * 2.
         # Worth its own case because every prior model has num_shared_experts == 1, so hidden_dim and
         # the shared intermediate coincided and 6144 was never exercised here.
-        (640, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SILU),
+        (
+            PREFILL_CHUNK_TOKENS_PER_CHIP,
+            KimiK3Config.EMB_SIZE,
+            KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE,
+            ACTIVATION_SILU,
+        ),
         # ...and the same shape on the activation the K3 checkpoint actually uses. This builds
         # TtSharedExpert without a sub-device, so ttnn.situ_glu runs here on the full grid; its
         # sub_core_grids form is only reachable through the MoE (test_ttnn_moe).
-        (640, KimiK3Config.EMB_SIZE, KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE, ACTIVATION_SITU),
+        (
+            PREFILL_CHUNK_TOKENS_PER_CHIP,
+            KimiK3Config.EMB_SIZE,
+            KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE,
+            ACTIVATION_SITU,
+        ),
     ],
-    # Ids label seq_len_per_chip first, then what differs from the case above it (the 6144 shared
-    # intermediate, the activation).
-    ids=["640", "640-k3-6144", "640-k3-6144-situ"],
+    # Ids name what differs from the case above (the 6144 shared intermediate, the activation).
+    ids=["isl_5k", "isl_5k-k3-6144", "isl_5k-k3-6144-situ"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -21,7 +21,6 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
@@ -65,6 +64,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import (
     visualize_expert_dispatch_table,
 )
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import GOLDEN_LONGBOOK_TRACE, load_trace_gate_input
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -713,22 +713,19 @@ def _ci_unsupported_param_combos_ds_moe(**params):
         # padding-aware dispatch shrinks every device's token loop. Only enabled for the
         # perf-device-256 (DEVICE_FP32, non-PCC) row — the only one that builds a padding_config;
         # the rest keep sequential placement (their reference / PCC path isn't zigzag).
-        pytest.param(3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 8, GateComputeMode.DEVICE_FP32,   False, True,  marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-device-256"),
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 8, GateComputeMode.DEVICE_FP32,   False, True,  marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-device-256"),
         # PCC gate on the production 256-expert / 32-per-chip path. The unified
         # routed-expert MoE op switches into the unfused extract -> FFN -> insert
         # chain whenever num_routed_experts > 64; without this variant that
-        # branch ships PCC-untested on Blackhole. Lighter dispatch capacity (5
-        # vs 8) keeps the soak time bounded.
-        pytest.param(1600, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 5, GateComputeMode.DEVICE_FP32,   True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-256"),
-        pytest.param(1600, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE,  64, 8, 5, GateComputeMode.HOST_ALL, True,  False, marks=pytest.mark.timeout(900)),
-        pytest.param(3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 5, GateComputeMode.HOST_ALL, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.skipif(not is_galaxy(), reason="Requires Galaxy")], id="pcc-host-256"),
-        # Perf: LB 8x1 dispatch/combine proxy. 64 experts + 2 picks/tok match one glx column's per-chip traffic (balanced_load=800).
-        pytest.param(3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE,  64, 2, 8, GateComputeMode.HOST_ALL, False, False, marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-host-64"),
+        # branch ships PCC-untested on Blackhole.
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 8, GateComputeMode.DEVICE_FP32,   True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-256"),
+        # Perf: LB 8x1 dispatch/combine proxy. 64 experts + 2 picks/tok match one glx column's per-chip traffic (balanced_load=160).
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE,  64, 2, 8, GateComputeMode.HOST_ALL, False, False, marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-host-64"),
         # GLM-5.2 MoE (256 experts / top-8, emb 6144, moe_int 2048). Exercises the >64-expert unfused
         # extract->FFN->insert routed-expert path on GLM dims. Gate is generic here (op-level test);
-        # GLM's noaux_tc knife-edge gate is validated at the transformer level. 25k = 3200 per-chip x 8.
-        pytest.param(1600, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-glm-256"),
-        pytest.param(3200, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL,    True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.skipif(not is_galaxy(), reason="Requires Galaxy")], id="pcc-host-glm-256"),
+        # GLM's noaux_tc knife-edge gate is validated at the transformer level.
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-glm-256"),
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, False, True,  marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-device-glm-256"),
         # fmt: on
     ],
 )
@@ -818,7 +815,7 @@ def test_ds_moe(
     ),
     [
         # fmt: off
-        pytest.param( 640, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-5k-pcc"),
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-5k-pcc"),
         # fmt: on
     ],
 )
@@ -899,8 +896,8 @@ def test_kimi_moe(
     ),
     [
         # fmt: off
-        pytest.param( 640, KimiK3Config.EMB_SIZE, KimiK3Config.MOE_INTERMEDIATE_SIZE, KimiK3Config.NUM_ROUTED_EXPERTS, KimiK3Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi_k3-5k-perf"),
-        pytest.param( 640, KimiK3Config.EMB_SIZE, KimiK3Config.MOE_INTERMEDIATE_SIZE, KimiK3Config.NUM_ROUTED_EXPERTS, KimiK3Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi_k3-5k-pcc"),
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, KimiK3Config.EMB_SIZE, KimiK3Config.MOE_INTERMEDIATE_SIZE, KimiK3Config.NUM_ROUTED_EXPERTS, KimiK3Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi_k3-5k-perf"),
+        pytest.param(PREFILL_CHUNK_TOKENS_PER_CHIP, KimiK3Config.EMB_SIZE, KimiK3Config.MOE_INTERMEDIATE_SIZE, KimiK3Config.NUM_ROUTED_EXPERTS, KimiK3Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi_k3-5k-pcc"),
         # fmt: on
     ],
 )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_moe_perf.py
@@ -45,13 +45,14 @@ from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_p
 from models.demos.deepseek_v3_d_p.tests.pcc.test_ttnn_moe import run_model
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 from models.demos.deepseek_v3_d_p.utils.perf_utils import adjust_margin_for_ddr_speed
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program_merged, require_realtime_profiler
 
 # 640 tokens/chip over SP=8 = the 5120-token chunk production prefill feeds, and the same shape the
 # pcc legs (`kimi-5k-pcc`, `kimi_k3-5k-pcc`) run.
-_SEQ_LEN_PER_CHIP = 640
+_SEQ_LEN_PER_CHIP = PREFILL_CHUNK_TOKENS_PER_CHIP
 # Capacity factor 5 for both: K3 halves the row width (7168 -> 3584 latent) and doubles the token
 # slots (top-8 -> top-16), so per-chip dispatch bytes are roughly unchanged.
 _DISPATCH_BUFFER_CAPACITY_FACTOR = 5

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -12,19 +12,27 @@ from models.demos.deepseek_v3_d_p.utils.perf_utils import (
     run_mla_perf_loudbox,
     run_model_device_perf_test_with_merge,
 )
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla"
 
-_CMD_2X4 = f"pytest {_TEST_PATH} -k 'balanced and skip_check and seq100k and scaled_sl and random and fabric2d-2x4' --wrapper-invocation"
-_CMD_8X4 = f"pytest {_TEST_PATH} -k 'balanced and skip_check and seq100k and scaled_sl and random and torus-xy-8x4' --wrapper-invocation"
+# 640 tokens/chip on both: 8x4 takes seq5k literally, 2x4 scales it to 1280 global.
+_CMD_2X4 = f"pytest {_TEST_PATH} -k 'balanced and skip_check and seq5k and scaled_sl and random and fabric2d-2x4' --wrapper-invocation"
+_CMD_8X4 = f"pytest {_TEST_PATH} -k 'balanced and skip_check and seq5k and max_sl and random and torus-xy-8x4' --wrapper-invocation"
 
-# Kimi K2.6 chunked prefill: 50k KV-cache prefix + one fresh 5k chunk (chunk_size_global=5120). On
-# the 8x4 Galaxy (sp=8) this lands chunk_local=640 per chip, exercising the num_heads=64 chunked-only
-# 640 matmul/SDPA configs. Functional reference (no PCC) keeps the measured region to the single
-# forward (the 50k prefix is preloaded host->device before the MLA_START signpost, so it is not timed).
+# Kimi K2.6 chunked prefill: 50k cache + one 5k chunk. The 50k prefix is preloaded before the
+# MLA_START signpost, so only the single forward is timed.
 _CHUNKED_TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill"
 _CMD_CHUNKED_8X4 = (
     f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and k2_6 and func and torus-xy-8x4' --wrapper-invocation"
+)
+
+
+_IGNORE_POWER = os.environ.get("DS_PERF_IGNORE_POWER") == "1"
+_REQUIRE_HIGH_POWER = pytest.mark.skipif(
+    not (is_high_power() or _IGNORE_POWER),
+    reason="galaxy perf baselines are cut on a >=130W TDP host; an 8kW galaxy measures differently. "
+    "DS_PERF_IGNORE_POWER=1 runs it anyway, for bring-up only",
 )
 
 
@@ -66,15 +74,17 @@ def test_deepseek_v3_mla_perf_loudbox():
     """Retain the existing 2x4 LoudBox proxy on unwrapped Fabric2D."""
     run_mla_perf_loudbox(
         command_2x4=_CMD_2X4,
-        # Measured 2026-08-15 on the BH LoudBox Fabric2D CI runner (run 31895358174).
-        expected_ns_2x4=8_857_393,
+        # Re-measured 2026-08-22 at 640 tokens/chip, BH LoudBox bh-lb-15, DDR 16000, 150W.
+        # Mean of 14 runs, 2.658-2.664 ms, 0.25% peak to peak.
+        expected_ns_2x4=2_660_615,
         model_name_2x4="deepseek_v3_mla_lb_2x4_fabric2d",
         subdir="deepseek_v3_mla",
         margin=0.03,
-        comments_2x4="seq100k_scaled_lb_2x4_fabric2d_proxy",
+        comments_2x4="isl5k_lb_2x4_fabric2d_proxy",
     )
 
 
+@_REQUIRE_HIGH_POWER
 @pytest.mark.timeout(0)
 def test_deepseek_v3_mla_perf_galaxy():
     if not _is_galaxy_env():
@@ -85,18 +95,19 @@ def test_deepseek_v3_mla_perf_galaxy():
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,
-        # Migration starting threshold: measured 2026-06-10 on bh-glx-110-c08u02 with FABRIC_1D.
-        # The first certified TorusXY result must be used to recalibrate it.
-        expected_device_perf_ns_per_iteration=14_252_829,
+        # Measured 2026-08-22, 14kW BH galaxy bh-glx-110-c04u02, 8x4 TorusXY certified, DDR 16000.
+        # Two runs 3.894 / 3.886 ms, spread 0.21%.
+        expected_device_perf_ns_per_iteration=3_890_333,
         subdir="deepseek_v3_mla",
         model_name="deepseek_v3_mla_glx_8x4",
         num_iterations=1,
         batch_size=1,
         margin=margin,
-        comments="seq100k_scaled_glx_8x4_ground_truth",
+        comments="isl5k_glx_8x4_ground_truth",
     )
 
 
+@_REQUIRE_HIGH_POWER
 @pytest.mark.timeout(0)
 def test_kimi_mla_chunked_perf_galaxy():
     """Kimi K2.6 chunked-prefill MLA perf on the 8x4 Galaxy: 50k KV-cache prefix + one fresh 5k chunk
@@ -124,6 +135,7 @@ def test_kimi_mla_chunked_perf_galaxy():
     )
 
 
+@_REQUIRE_HIGH_POWER
 @pytest.mark.timeout(0)
 def test_kimi_k3_mla_chunked_perf_galaxy():
     """Kimi-K3 chunked-prefill MLA perf on the 8x4 Galaxy: 50k KV-cache prefix + one fresh 5k chunk

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -14,6 +14,7 @@ from models.demos.deepseek_v3_d_p.utils.perf_utils import (
     run_model_device_perf_test_with_merge,
     run_moe_perf_with_approximation,
 )
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe"
 
@@ -23,6 +24,14 @@ _CMD_8X4_pad0 = f"pytest {_TEST_PATH} -k 'perf-device-256 and torus-xy-8x4 and p
 _CMD_8X4_pad50 = f"pytest {_TEST_PATH} -k 'perf-device-256 and torus-xy-8x4 and pad50' --wrapper-invocation"
 _CMD_8X1 = f"pytest {_TEST_PATH} -k 'perf-host-64 and torus-y-8x1 and pad0' --wrapper-invocation"
 _CMD_2X4 = f"pytest {_TEST_PATH} -k 'perf-device-256 and fabric2d-mesh-2x4 and pad0' --wrapper-invocation"
+
+
+_IGNORE_POWER = os.environ.get("DS_PERF_IGNORE_POWER") == "1"
+_REQUIRE_HIGH_POWER = pytest.mark.skipif(
+    not (is_high_power() or _IGNORE_POWER),
+    reason="galaxy perf baselines are cut on a >=130W TDP host; an 8kW galaxy measures differently. "
+    "DS_PERF_IGNORE_POWER=1 runs it anyway, for bring-up only",
+)
 
 
 def _require_certified_torus_xy():
@@ -40,20 +49,25 @@ def test_deepseek_v3_moe_perf_loudbox():
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        # Recalibrated 2026-08-21 on this LoudBox, Fabric2D TorusY, with the routed experts folded
-        # into one program. Single run each, where the previous 8x1 was a mean of two.
-        expected_ns_8x1=14_385_886,
+        # Re-measured 2026-08-22 at 640 tokens/chip, BH LoudBox bh-lb-15, DDR 16000, 150W.
+        # Mean of 14 runs, 5.876-5.921 ms, 0.76% peak to peak.
+        expected_ns_8x1=5_895_298,
         model_name_8x1="deepseek_v3_moe_lb_8x1_torus_y_dispatch_combine",
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=15_945_512,
+        # Re-cut 2026-08-28 on the CI LoudBox (bh_loudbox): runs 33089588265 and 33179961983
+        # measured 9.381 / 9.298 ms, mean below. The dev box bh-lb-15 read 9_601_530 (14-run
+        # mean), 2.7% slower, and the 9.298 sample fell 0.16% under that band's floor -- this
+        # gate has to be cut on the CI runner.
+        expected_ns_2x4=9_339_547,
         model_name_2x4="deepseek_v3_moe_lb_2x4_fabric2d_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,
-        comments_8x1="seq3200_lb_8x1_torus_y_dispatch_combine_proxy",
-        comments_2x4="seq3200_lb_2x4_fabric2d_gate_proxy",
+        comments_8x1="isl5k_lb_8x1_torus_y_dispatch_combine_proxy",
+        comments_2x4="isl5k_lb_2x4_fabric2d_gate_proxy",
     )
 
 
+@_REQUIRE_HIGH_POWER
 @pytest.mark.timeout(0)
 def test_deepseek_v3_moe_perf_galaxy():
     """Measure the production 8x4 TorusXY Galaxy path without padding."""
@@ -65,17 +79,19 @@ def test_deepseek_v3_moe_perf_galaxy():
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad0,
-        # Historical baseline: measured with FABRIC_1D, not TorusXY.
-        expected_device_perf_ns_per_iteration=21_028_751,
+        # Measured 2026-08-22, 14kW BH galaxy bh-glx-110-c04u02, 8x4 TorusXY certified, DDR 16000.
+        # Two runs 6.155 / 6.070 ms, spread 1.38%.
+        expected_device_perf_ns_per_iteration=6_112_530,
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4",
         num_iterations=1,
         batch_size=1,
         margin=margin,
-        comments="seq3200_glx_8x4_ground_truth",
+        comments="isl5k_glx_8x4_ground_truth",
     )
 
 
+@_REQUIRE_HIGH_POWER
 @pytest.mark.timeout(0)
 def test_deepseek_v3_moe_perf_galaxy_pad50():
     """8x4 galaxy ground truth with 50% right-padding + padding-aware routing (zigzag placement)."""
@@ -87,12 +103,13 @@ def test_deepseek_v3_moe_perf_galaxy_pad50():
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad50,
-        # Historical baseline: measured with FABRIC_1D, not TorusXY.
-        expected_device_perf_ns_per_iteration=14_107_228,
+        # Measured 2026-08-22, 14kW BH galaxy bh-glx-110-c04u02, 8x4 TorusXY certified, DDR 16000.
+        # Two runs 5.223 / 5.188 ms, spread 0.67%.
+        expected_device_perf_ns_per_iteration=5_205_872,
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4_pad50",
         num_iterations=1,
         batch_size=1,
         margin=margin,
-        comments="seq3200_glx_8x4_ground_truth_padded_50_percent_w_awareness",
+        comments="isl5k_glx_8x4_ground_truth_padded_50_percent_w_awareness",
     )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -10,8 +10,11 @@ import re
 import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import _is_galaxy_env, run_model_device_perf_test_with_merge
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
+
+_IGNORE_POWER = os.environ.get("DS_PERF_IGNORE_POWER") == "1"
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 5)))
 _SUBTORUS_Y4_ENV = {
@@ -48,10 +51,12 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
 @pytest.mark.parametrize(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
-        (
-            f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4' --wrapper-invocation",
-            30_330_761,  # Recalibrated 2026-08-21 on this LoudBox with the routed experts folded
-            # into one program. Single run, where the previous value was a mean of three.
+        pytest.param(
+            f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4-2link and layer3 and gate_device and no_ref and isl_1280' --wrapper-invocation",
+            10_963_542,  # Measured 2026-08-27 at 640 tokens/chip on the CI LoudBox (bh_loudbox, 8xP150),
+            # reproduced there at 10_938_722 (-0.23%). Supersedes 14_179_641, a 14-run mean on
+            # bh-lb-15 (8xp150b); that 23% gap is specific to this gate -- the MoE LoudBox proxies
+            # agree within 2.3% across the same two boxes -- so cut it on the CI runner.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe_fabric2d",
             1,
@@ -59,9 +64,11 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
             0.03,
             "2x4_layer3_moe_real_weights_fabric2d",
         ),
-        (
-            f"pytest {_TEST_PATH} -k 'torus-xy-8x4 and layer0 and gate_device and no_ref and isl_25k' --wrapper-invocation",
-            18_157_603,  # Calibrated 2026-07-01 on BH Galaxy 110-c910, TorusXY, real weights.
+        pytest.param(
+            f"pytest {_TEST_PATH} -k 'torus-xy-8x4 and layer0 and gate_device and no_ref and isl_5120' --wrapper-invocation",
+            5_435_504,  # Measured 2026-08-22 on the 14kW BH galaxy bh-glx-110-c04u02, 8x4 TorusXY certified
+            # (DDR 16000 nominal, high power).
+            # Two runs 5.421 / 5.450 ms, spread 0.54% -- well inside the 3% band.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer0_dense_torus_xy",
             1,
@@ -69,9 +76,11 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
             0.03,
             "glx_8x4_layer0_dense_real_weights_torus_xy",
         ),
-        (
-            f"pytest {_TEST_PATH} -k 'torus-xy-8x4 and layer3 and gate_device and no_ref and isl_25k' --wrapper-invocation",
-            60_634_662,  # Calibrated 2026-07-01 on BH Galaxy 110-c910, TorusXY, real weights.
+        pytest.param(
+            f"pytest {_TEST_PATH} -k 'torus-xy-8x4 and layer3 and gate_device and no_ref and isl_5120' --wrapper-invocation",
+            13_674_937,  # Measured 2026-08-22 on the 14kW BH galaxy bh-glx-110-c04u02, 8x4 TorusXY certified
+            # (DDR 16000 nominal, high power).
+            # Two runs 13.558 / 13.792 ms, spread 1.71% -- inside the 3% band, the widest of the five.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer3_moe_torus_xy",
             1,
@@ -79,58 +88,48 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
             0.03,
             "glx_8x4_layer3_moe_real_weights_torus_xy",
         ),
-        (
-            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer0 and gate_device and no_ref and isl_12k8' --wrapper-invocation",
-            17_978_418,
+        pytest.param(
+            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer0 and gate_device and no_ref and isl_2560' --wrapper-invocation",
+            4_913_214,  # Re-measured 2026-08-27 at 640 tokens/chip on the 14kW galaxy bh-glx-120-d08u02
+            # (is_high_power). Mean of 2 runs, 4.9120-4.9144 ms, 0.05% peak to peak.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_4x4_layer0_dense_torus_y",
             1,
             1,
             0.03,
-            "subtorus_4x4_layer0_dense_real_weights_torus_y_isl12k8",
+            "subtorus_4x4_layer0_dense_real_weights_torus_y",
         ),
         pytest.param(
-            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer3 and gate_device and no_ref and isl_12k8' --wrapper-invocation",
-            56_528_886,
+            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer3 and gate_device and no_ref and isl_2560' --wrapper-invocation",
+            15_570_232,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_4x4_layer3_moe_torus_y",
             1,
             1,
             0.03,
-            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl12k8",
+            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate",
             marks=_SUBTORUS_4X4_HOSTGATE_SKIP,
         ),
         pytest.param(
-            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer3 and gate_device and no_ref and isl_2k56' --wrapper-invocation",
-            15_570_232,
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_4x4_layer3_moe_torus_y_isl2k56",
-            1,
-            1,
-            0.03,
-            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl2k56",
-            marks=_SUBTORUS_4X4_HOSTGATE_SKIP,
-        ),
-        pytest.param(
-            f"pytest {_TEST_PATH} -k 'torus-x-4x4 and layer3 and gate_device and no_ref and isl_12k8' --wrapper-invocation",
+            f"pytest {_TEST_PATH} -k 'torus-x-4x4 and layer3 and gate_device and no_ref and isl_2560' --wrapper-invocation",
             54_804_819,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_4x4_layer3_moe_torus_x",
             1,
             1,
             0.03,
-            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl12k8_torus_x",
+            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_torus_x",
             marks=_SUBTORUS_4X4_HOSTGATE_SKIP,
         ),
         pytest.param(
-            f"pytest {_TEST_PATH} -k 'torus-xy-4x4 and layer3 and gate_device and no_ref and isl_12k8' --wrapper-invocation",
+            f"pytest {_TEST_PATH} -k 'torus-xy-4x4 and layer3 and gate_device and no_ref and isl_2560' --wrapper-invocation",
             52_978_544,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_4x4_layer3_moe_torus_xy",
             1,
             1,
             0.03,
-            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl12k8_torus_xy",
+            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_torus_xy",
             marks=_SUBTORUS_4X4_HOSTGATE_SKIP,
         ),
     ],
@@ -140,7 +139,6 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         "block_8x4_layer3_moe_torus_xy",
         "block_4x4_layer0_dense_torus_y",
         "block_4x4_layer3_moe_torus_y",
-        "block_4x4_layer3_moe_torus_y_isl2k56",
         "block_4x4_layer3_moe_torus_x",
         "block_4x4_layer3_moe_torus_xy",
     ],
@@ -156,6 +154,12 @@ def test_deepseek_v3_prefill_block_perf(
     margin,
     comments,
 ):
+    if ("_8x4_" in model_name or "_4x4_" in model_name) and not (is_high_power() or _IGNORE_POWER):
+        pytest.skip(
+            "galaxy perf baselines are cut on a >=130W TDP host; an 8kW galaxy measures differently. "
+            "DS_PERF_IGNORE_POWER=1 runs it anyway, for bring-up only"
+        )
+
     if "_8x4_" in model_name and "torus_xy" in model_name:
         if not _is_galaxy_env():
             pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_hca_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_hca_perf.py
@@ -26,10 +26,11 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import Deep
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
 from models.demos.deepseek_v3_d_p.tests.pcc.test_ttnn_hca import _MESH_CONFIGS, _SEED, _config
 from models.demos.deepseek_v3_d_p.tt.mla.heavily_compressed_attention import TtHCA
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program_merged
 
-_CHUNK = 5120
+_CHUNK = PREFILL_CHUNK_TOKENS
 _CHUNKS = 2
 _MAX_SEQ = 56_320  # the demo context, 11 chunks of 5120
 _MARGIN = 0.05

--- a/models/demos/deepseek_v3_d_p/tests/test_chunked_trace_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_chunked_trace_helpers.py
@@ -15,6 +15,7 @@ import pytest
 from models.demos.common.prefill.adapter import get_adapter
 from models.demos.common.prefill.runners.runner_utils import load_trace_token_ids, resolve_trace_dir
 from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import _load_golden_kv_post
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 
 KVPE_DIM = 576  # kv_lora_rank (512) + qk_rope_head_dim (64)
 
@@ -37,8 +38,8 @@ def test_resolve_trace_dir_has_metadata(variant_name):
 def test_load_trace_token_ids(variant_name):
     """token_ids load, truncate to the requested length, and span >= one production chunk."""
     trace = _trace_or_skip(variant_name)
-    assert len(load_trace_token_ids(trace, 5120)) == 5120
-    assert len(load_trace_token_ids(trace)) >= 5120
+    assert len(load_trace_token_ids(trace, PREFILL_CHUNK_TOKENS)) == PREFILL_CHUNK_TOKENS
+    assert len(load_trace_token_ids(trace)) >= PREFILL_CHUNK_TOKENS
 
 
 @pytest.mark.parametrize("variant_name", ["deepseek_v3_d_p", "kimi_k2_6"])

--- a/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
@@ -19,6 +19,7 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from tests.ttnn.utils_for_testing import comp_pcc
 
 
@@ -40,7 +41,7 @@ def test_embedding_8x4_galaxy(mesh_device):
     sp_factor = mesh_device.shape[sp_axis]
     tp_factor = mesh_device.shape[tp_axis]
 
-    seq_len_total = 5 * 1024
+    seq_len_total = PREFILL_CHUNK_TOKENS
     assert seq_len_total % sp_factor == 0, f"seq_len_total ({seq_len_total}) must divide sp_factor ({sp_factor})"
     isl_per_chip = seq_len_total // sp_factor
     assert (

--- a/models/demos/deepseek_v3_d_p/tests/test_h2d_socket_sync.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_h2d_socket_sync.py
@@ -14,6 +14,7 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from tests.ttnn.utils_for_testing import comp_pcc
 
 # 3 x uint32: [slot_id, actual_start, actual_end]
@@ -37,7 +38,7 @@ def test_h2d_socket_sync_8x4_galaxy(mesh_device):
     sp_factor = mesh_device.shape[sp_axis]
     tp_factor = mesh_device.shape[tp_axis]
 
-    seq_len_total = 5 * 1024
+    seq_len_total = PREFILL_CHUNK_TOKENS
     assert seq_len_total % sp_factor == 0
     isl_per_chip = seq_len_total // sp_factor
     assert isl_per_chip % ttnn.TILE_SIZE == 0

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -23,7 +23,7 @@ from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     BH_NUM_DRAM_BANKS,
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
-    PREFILL_CHUNK_OUTPUT_TOKENS,
+    PREFILL_CHUNK_TOKENS,
     MlaKvCacheFormat,
     create_kv_chunk_address_table_ds,
     create_kv_chunk_address_table_kimi,
@@ -49,7 +49,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
-@pytest.mark.parametrize("seq_len", [5 * 1024, 25 * 1024], ids=["seq5k", "seq25k"])
+@pytest.mark.parametrize("seq_len", [PREFILL_CHUNK_TOKENS], ids=["seq5k"])
 @pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths
 def test_kv_cache_table(
     use_pretrained,
@@ -345,7 +345,7 @@ def test_kimi_kv_cache_mock(
     kvpe_cache_head_dim = 576  # qk_rope_head_dim(64) + kv_lora_rank(512); same for Kimi and DeepSeek
     num_kvpe_cache_layers = num_users * num_layers
 
-    chunk_tokens = PREFILL_CHUNK_OUTPUT_TOKENS
+    chunk_tokens = PREFILL_CHUNK_TOKENS
     tokens_per_chunk_per_device = chunk_tokens // sp_factor  # 640
     num_seq_chunks = seq_len // chunk_tokens
 
@@ -459,7 +459,7 @@ def test_dflash_kv_cache_mock(
     heads_per_chip = num_kv_heads // tp_factor
     batch = num_users * num_layers
 
-    chunk_tokens = PREFILL_CHUNK_OUTPUT_TOKENS
+    chunk_tokens = PREFILL_CHUNK_TOKENS
     tokens_per_chunk_per_device = chunk_tokens // sp_factor  # 640
     num_seq_chunks = seq_len // chunk_tokens
 
@@ -1034,7 +1034,7 @@ def test_glm52_index_cache_pipeline_stage_addresses():
     offset the merged table assigns it. Host-only: the address math needs no device.
     """
     rows, cols, sp_axis = 4, 8, 0
-    num_users, seq_len, num_banks = 2, 2 * PREFILL_CHUNK_OUTPUT_TOKENS, BH_NUM_DRAM_BANKS
+    num_users, seq_len, num_banks = 2, 2 * PREFILL_CHUNK_TOKENS, BH_NUM_DRAM_BANKS
     index_chunk_size_bytes = 4 * 1088  # [1,1,32,128] bfp8
     config_id = 1  # the index cache is config 1 of the merged table
     num_full = 21  # GLM-5.2: 21 of 78 layers own an indexer

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -32,6 +32,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     rotated_chip_positions,
 )
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS, PREFILL_CHUNK_TOKENS_PER_CHIP
 from models.demos.deepseek_v3_d_p.utils.chunked_prefill_utils import (
     cpu_mla_reference,
     load_trace,
@@ -210,14 +211,14 @@ def run_model(
 
     topology = per_axis_topology(device_params["fabric_config"])
 
-    production_mesh = [32, 4]
     sp_axis = 0
     tp_axis = 1
 
     mesh_shape = list(mesh_device.shape)
 
+    # 640 tokens on every chip; the global length follows the mesh. max_sl keeps the literal seq_len.
     if scale_down_sl:
-        seq_len = (seq_len // production_mesh[sp_axis]) * mesh_shape[sp_axis]
+        seq_len = PREFILL_CHUNK_TOKENS_PER_CHIP * mesh_shape[sp_axis]
 
     # temp hack
     config.max_seq_len = seq_len
@@ -428,7 +429,11 @@ def _ci_unsupported_param_combos(**params):
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
-@pytest.mark.parametrize("seq_len", [128 * 1024, 100 * 1024], ids=["seq128k", "seq100k"])
+@pytest.mark.parametrize(
+    "seq_len",
+    [PREFILL_CHUNK_TOKENS],
+    ids=["seq5k"],
+)
 @pytest.mark.parametrize("skip_host_comparison", [False, True], ids=["check_pcc", "skip_check"])
 @pytest.mark.parametrize("is_balanced", [False, True], ids=["sequential", "balanced"])
 @pytest.mark.parametrize("variant", ["deepseek_v3_d_p"], indirect=True, ids=["deepseek_v3"])

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -48,12 +48,11 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
-    ABC_1K_PATH,
     PROMPT_5K_PATH,
-    PROMPT_25K_PATH,
     create_hf_model,
     extract_layer_state_dict,
     get_4d_causal_mask,
@@ -61,7 +60,7 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     tokenize_prompt_to_isl,
 )
 
-_PROMPT_PATHS = {"abc_1k": ABC_1K_PATH, "prompt_5k": PROMPT_5K_PATH, "prompt_25k": PROMPT_25K_PATH}
+_PROMPT_PATHS = {"prompt_5k": PROMPT_5K_PATH}
 from models.tt_transformers.tt.load_checkpoints import load_hf_state_dict_filtered
 from tests.ttnn.utils_for_testing import assert_with_pcc, comp_pcc
 
@@ -118,13 +117,6 @@ def run_model(
     # coverage; the real device gate already covers the 256-expert meshes that run in CI.
     if (is_ci_env or is_ci_v2_env) and gate_fallback_mode == GateComputeMode.HOST_ALL:
         pytest.skip("host_gate_all is a local-only testing aid (sub-256-expert); not run in CI")
-
-    # The 25k-ISL cases only fit L1 on the full 8x4 mesh. There sp_factor=8 keeps the per-chip
-    # sequence at 3200 tokens, so the shared-expert down-projection matmul runs with per_core_M=2.
-    # On the smaller 2x4 meshes the per-chip sequence is 12800 tokens, pushing per_core_M to 5 and
-    # growing the down-matmul output circular buffer to ~2.9 MB — beyond the 1.5 MB L1 (OOM).
-    if isl_total == 25 * 1024 and tuple(mesh_device.shape) != (8, 4):
-        pytest.skip("25k ISL only fits L1 on the full 8x4 mesh; skipping on smaller meshes")
 
     profiler.clear()
     profiler.start("total_test_time")
@@ -510,11 +502,12 @@ def _ci_unsupported_param_combos(**params):
 @pytest.mark.parametrize(
     "input_source, pcc_validation, isl_total, dispatch_buffer_capacity_factor",
     [
-        ("random", False, 1024, 8),
-        ("prompt_25k", False, 25 * 1024, 8),
-        ("abc_1k", True, 1024, 8),
+        # pcc-prompt_5k runs ~3x longer than perf-prompt_5k (122s vs 41s warm on 8x4) because the CPU
+        # reference dominates, not the device. Rebalancing CI around that split is a separate PR.
+        ("prompt_5k", False, PREFILL_CHUNK_TOKENS, 8),
+        ("prompt_5k", True, PREFILL_CHUNK_TOKENS, 8),
     ],
-    ids=["smoke-random", "perf-prompt_25k", "pcc-abc_1k"],
+    ids=["perf-prompt_5k", "pcc-prompt_5k"],
 )
 @pytest.mark.parametrize(
     "layer_type, gate_fallback_mode",
@@ -637,14 +630,10 @@ def test_ds_prefill_block(
 @pytest.mark.parametrize(
     "input_source, pcc_validation, isl_total, dispatch_buffer_capacity_factor",
     [
-        ("random", False, 1024, 8),
-        ("random", False, 5 * 1024, 8),
-        ("random", False, 25 * 1024, 8),
-        ("abc_1k", True, 1024, 8),
-        ("prompt_5k", True, 5 * 1024, 8),
-        ("prompt_25k", True, 25 * 1024, 8),
+        ("random", False, PREFILL_CHUNK_TOKENS, 8),
+        ("prompt_5k", True, PREFILL_CHUNK_TOKENS, 8),
     ],
-    ids=["smoke-random", "perf-random-5k", "perf-random-25k", "pcc-abc_1k", "pcc-prompt_5k", "pcc-prompt_25k"],
+    ids=["perf-random-5k", "pcc-prompt_5k"],
 )
 @pytest.mark.parametrize(
     "layer_type, gate_fallback_mode",

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
@@ -41,6 +41,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rot
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
@@ -52,7 +53,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import (
 )
 from tests.ttnn.utils_for_testing import comp_pcc
 
-CHUNK = 5 * 1024  # 5120 tokens per chunk
+CHUNK = PREFILL_CHUNK_TOKENS  # 5120 tokens per chunk
 SEQ_CACHE = 55 * 1024  # 56320 KV cache length (1 user)
 # Full 55k (56320) sequence in varied chunks: the requested prefix [1k,2k,3k,4k,5k,3k,2k,5k] (=25600),
 # then a varied tail (=30720) of non-1024-aligned sizes that exercise mid-tile rotation offsets (e.g.

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
@@ -40,10 +40,11 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS, PREFILL_CHUNK_TOKENS_PER_CHIP
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     PROMPT_1K_PATH,
-    PROMPT_25K_PATH,
+    PROMPT_5K_PATH,
     create_hf_model_with_weights,
     get_4d_causal_mask,
     tokenize_prompt_to_isl,
@@ -53,6 +54,14 @@ from tests.ttnn.utils_for_testing import comp_pcc
 DSV3 = get_adapter("deepseek_v3_d_p")
 
 PLOT_DIR = "models/demos/deepseek_v3_d_p/tests"
+
+
+# Each mesh carries the isl_total that lands PREFILL_CHUNK_TOKENS_PER_CHIP on every one of its chips, so there
+# is one ISL per mesh instead of a cross product to prune. The id carries it because
+# perf/test_prefill_block_perf.py selects rows by it.
+def _with_isl(param):
+    isl_total = PREFILL_CHUNK_TOKENS_PER_CHIP * param.values[0][0]
+    return pytest.param(*param.values, isl_total, marks=param.marks, id=f"{param.id}-isl_{isl_total}")
 
 
 def _ci_unsupported_param_combos(**params):
@@ -90,31 +99,29 @@ def _ci_unsupported_param_combos(**params):
         "layer8",
     ],
 )
-@pytest.mark.parametrize(
-    "isl_total",
-    [1024, 2560, 5120, 6400, 12800, 25 * 1024],
-    ids=["isl_1k", "isl_2k56", "isl_5k", "isl_6k4", "isl_12k8", "isl_25k"],
-)
 @pytest.mark.parametrize("skip_reference", [False, True], ids=["with_ref", "no_ref"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links",
+    "mesh_device, device_params, num_links, isl_total",
     [
-        pytest.param(
-            (1, 1),
-            {},
-            1,
-            id="mesh-1x1",
-        ),
-        pytest.param(
-            (2, 4),
-            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.EMB_SIZE),
-            2,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="fabric2d-mesh-2x4-2link",
-        ),
-        # FABRIC_2D variants — shared list defined in conftest.py (also used by
-        # test_prefill_transformer.py). Covers (4,2) BH LoudBox, (2,4) asymmetric, (8,4) BH Galaxy.
-        *FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS,
+        _with_isl(param)
+        for param in (
+            pytest.param(
+                (1, 1),
+                {},
+                1,
+                id="mesh-1x1",
+            ),
+            pytest.param(
+                (2, 4),
+                fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.EMB_SIZE),
+                2,
+                marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+                id="fabric2d-mesh-2x4-2link",
+            ),
+            # FABRIC_2D variants — shared list defined in conftest.py (also used by
+            # test_prefill_transformer.py). Covers (4,2) BH LoudBox, (2,4) asymmetric, (8,4) BH Galaxy.
+            *FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS,
+        )
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -141,10 +148,9 @@ def test_prefill_block_loop(
     if state_dict is None:
         pytest.skip("State dict not available (no pretrained weights)")
 
-    # These sequence lengths belong to the existing 4x4 subtorus sweep, which is intentionally
-    # local/experimental until a dedicated CI owner exists.
-    if (os.getenv("CI") == "true" or "TT_GH_CI_INFRA" in os.environ) and isl_total in (2560, 12800):
-        pytest.skip("isl_2k56 / isl_12k8 are subtorus-4x4-only; not run in CI")
+    # The 4x4 subtorus sweep is intentionally local/experimental until a dedicated CI owner exists.
+    if (os.getenv("CI") == "true" or "TT_GH_CI_INFRA" in os.environ) and tuple(mesh_device.shape) == (4, 4):
+        pytest.skip("the 4x4 subtorus sweep is local/experimental; not run in CI")
 
     # Deep-copy the HF config: hf_config returns a process-wide lru_cache'd object, so mutating it in
     # place (max_seq_len here, n_routed_experts below) would leak into later tests in the same session.
@@ -404,8 +410,8 @@ def test_prefill_block_loop(
         # repeats the 1K prompt. Never pad — pad tokens all have the same embedding and
         # collapse gate routing onto a handful of experts, distorting expert-load
         # measurements.
-        if isl_total == 25 * 1024:
-            prompt_path = PROMPT_25K_PATH
+        if isl_total == PREFILL_CHUNK_TOKENS:
+            prompt_path = PROMPT_5K_PATH
         else:
             prompt_path = PROMPT_1K_PATH
         prompts = load_prompts_from_json(str(prompt_path))

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -45,6 +45,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.pcc_plot_utils import generate_pcc_plots, write_pcc_summary
 from models.demos.deepseek_v3_d_p.utils.test_utils import save_intermediate_output
@@ -80,9 +81,6 @@ DETERMINISM_PCC_THRESHOLD = 1.0
 INFINITEBENCH_SUBSET_NAMES = {"longbook_qa_eng"}
 # input_source meaning "this variant's own golden" — naming it after a prompt would go stale.
 VARIANT_DEFAULT_TRACE = "variant_default"
-SEQ_LEN_1K = 1024
-SEQ_LEN_5K = 5120
-SEQ_LEN_25K = 25600
 
 
 def _compare_intermediate_pcc(reference_items, tt_intermediates, number_of_non_padded_tokens, padding_side):
@@ -855,7 +853,8 @@ def run_model(
 @pytest.mark.parametrize("is_balanced", [True, False], ids=["balanced", "regular"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",
-    [(SEQ_LEN_1K, 8), (SEQ_LEN_25K, 8)],
+    [(PREFILL_CHUNK_TOKENS, 8)],
+    ids=["isl_5k"],
 )
 @pytest.mark.parametrize(
     "num_layers",
@@ -969,8 +968,8 @@ def test_ds_prefill_transformer(
 @pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",
-    [(SEQ_LEN_1K, 8), (SEQ_LEN_5K, 8), (SEQ_LEN_25K, 8)],
-    ids=["1k", "5k", "25k"],
+    [(PREFILL_CHUNK_TOKENS, 8)],
+    ids=["isl_5k"],
 )
 @pytest.mark.parametrize(
     "num_layers",
@@ -1073,8 +1072,8 @@ def test_kimi_prefill_transformer(
 @pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",
-    [(SEQ_LEN_5K, 8)],
-    ids=["5k"],
+    [(PREFILL_CHUNK_TOKENS, 8)],
+    ids=["isl_5k"],
 )
 @pytest.mark.parametrize(
     "num_layers",

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -56,6 +56,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import get_block_timings, reset_block_timings
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import emit_summary, render_table
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
@@ -69,7 +70,7 @@ from models.demos.deepseek_v3_d_p.utils.test_utils import (
 )
 from tests.ttnn.utils_for_testing import comp_pcc
 
-CHUNK = 5 * 1024  # 5120 tokens per chunk
+CHUNK = PREFILL_CHUNK_TOKENS  # 5120 tokens per chunk
 SEQ_CACHE = 55 * 1024  # 56320 KV cache length (1 user)
 # Larger KV cache for the no-PCC perf sweep only (up to 100k ISL = 20 chunks). Kept separate from
 # SEQ_CACHE so the PCC tests and the _PADDED_FULL_55K split (which assert against 55*1024) are untouched.

--- a/models/demos/deepseek_v3_d_p/tests/test_zero_op_mem_validate.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_zero_op_mem_validate.py
@@ -12,9 +12,10 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
-CSG = 5120
+CSG = PREFILL_CHUNK_TOKENS
 SEQ = 10240  # global cache length (2 slabs); seq_local = 1280
 NUM_LAYERS = 61
 NUM_USERS = 2

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -24,6 +24,7 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 from models.demos.deepseek_v3_d_p.tt.mla.utils import rotated_chip_real_token_counts
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 
 class GateComputeMode(Enum):
@@ -57,7 +58,7 @@ class GateComputeMode(Enum):
 
 # Per-chip prefill sequence the production deployment runs at, and the depth the MoE/gate tests
 # drive. Every tuned matmul entry is keyed to it; other depths fall back to TTNN's default tiling.
-GATE_PRODUCTION_SP_DIM = 640
+GATE_PRODUCTION_SP_DIM = PREFILL_CHUNK_TOKENS_PER_CHIP
 
 
 def gate_mm_config_key(sp_dim: int, per_device_emb_dim: int, n_routed_experts: int) -> tuple[int, int, int]:

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -25,7 +25,7 @@ from models.demos.common.prefill.runners.migration import (
 )
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
-    PREFILL_CHUNK_OUTPUT_TOKENS,
+    PREFILL_CHUNK_TOKENS,
     create_kv_chunk_address_table_kimi,
     merged_num_layers,
     populate_kv_chunk_address_table_dflash,
@@ -108,7 +108,7 @@ def build_and_serialize_kv_chunk_table(
     max_seq_len) lists the wrong, block-cyclically-scattered chunks and fails its PCC check.
 
     ``chunk_size_global`` is the block-cyclic period; the kimi builder hardcodes it as
-    PREFILL_CHUNK_OUTPUT_TOKENS, so a non-default period is rejected here rather than mismapped.
+    PREFILL_CHUNK_TOKENS, so a non-default period is rejected here rather than mismapped.
 
     ``index_kv_cache`` (sparse/DSA models only): when given, a single MERGED table describes BOTH
     caches — config 0 = the KVPE cache, config 1 = the index-key cache — sharing one device-group
@@ -125,9 +125,9 @@ def build_and_serialize_kv_chunk_table(
     layers [first_layer_idx, first_layer_idx + num_my_layers); ``stage_layouts`` holds ONE all-gathered
     per-stage layout per block-cyclic cache (config order), so rank 0 builds one table spanning every
     stage while the collectives ran on all ranks. Leave it None to gather inline (single-rank / tests)."""
-    assert chunk_size_global == PREFILL_CHUNK_OUTPUT_TOKENS, (
+    assert chunk_size_global == PREFILL_CHUNK_TOKENS, (
         f"create_kv_chunk_address_table_kimi assumes a block-cyclic period of "
-        f"PREFILL_CHUNK_OUTPUT_TOKENS={PREFILL_CHUNK_OUTPUT_TOKENS}, but chunk_size_global={chunk_size_global}. "
+        f"PREFILL_CHUNK_TOKENS={PREFILL_CHUNK_TOKENS}, but chunk_size_global={chunk_size_global}. "
         f"A different period would mismap every position; re-introduce a parametrized builder if needed."
     )
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -20,6 +20,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.runners.input_prep import prepare_prefill_input_tensor
 from models.demos.deepseek_v3_d_p.tt.runners.kv_caches import MlaKvCaches
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, allocate_dflash_kv_cache
 from models.demos.deepseek_v3_d_p.utils.sub_device_trace import SubDeviceTraceController
 
@@ -31,7 +32,7 @@ class TtPrefillRuntimeConfig:
     mesh_shape: tuple = (32, 4)
     # Chunked prefill streams tokens in chunks of `chunk_size`, with `num_users` independent cache
     # slots (user-major batch). The full cache holds num_users * num_layers slots of max_seq_len each.
-    chunk_size: int = 5 * 1024
+    chunk_size: int = PREFILL_CHUNK_TOKENS
     num_users: int = 2
     sp_axis: int = 0
     tp_axis: int = 1

--- a/models/demos/deepseek_v3_d_p/utils/chunk_config.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunk_config.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Single source of truth for the prefill chunk width and its per-chip split.
+"""
+
+PREFILL_SP_FACTOR = 8  # Production configuration on a single galaxy stage
+PREFILL_CHUNK_TOKENS = 5 * 1024  # Production configuration across prefill models
+PREFILL_CHUNK_TOKENS_PER_CHIP = PREFILL_CHUNK_TOKENS // PREFILL_SP_FACTOR

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -16,6 +16,7 @@ import ttnn
 from models.demos.common.prefill.runners.migration import allgather_kv_stage_layout, get_num_dram_banks
 from models.demos.deepseek_v3_b1.micro_ops.dram_zero_fill.op import DRAMZeroFill
 from models.demos.deepseek_v3_d_p.tt.dflash_prefill.dflash_drafter_config import DFlashDrafterConfig
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS
 
 # This is a predefined constant for the number of contiguous tokens in a DRAM bank
 NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
@@ -23,7 +24,6 @@ NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
 # at runtime: harvested parts expose fewer banks (e.g. 7), and the cache ND-shard grid + the
 # disaggregation address-table striding must both use the device's actual count to stay consistent.
 BH_NUM_DRAM_BANKS = 8
-PREFILL_CHUNK_OUTPUT_TOKENS = 5 * 1024
 
 
 class MlaKvCacheFormat(str, Enum):
@@ -511,15 +511,13 @@ def populate_kv_chunk_address_table_kimi(
         # supersedes it, and a rank-local set_fabric_node_host(localhost) would fight the per-stage host.
         rows = mesh_shape[0]
 
-        tokens_per_chunk_local = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
-        num_chunks_per_seq_len = seq_len // PREFILL_CHUNK_OUTPUT_TOKENS  # number of 5k chunks in the seq len
+        tokens_per_chunk_local = PREFILL_CHUNK_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
+        num_chunks_per_seq_len = seq_len // PREFILL_CHUNK_TOKENS  # number of 5k chunks in the seq len
 
-        assert (
-            seq_len % PREFILL_CHUNK_OUTPUT_TOKENS == 0
-        ), f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_OUTPUT_TOKENS}"
+        assert seq_len % PREFILL_CHUNK_TOKENS == 0, f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_TOKENS}"
 
         assert tokens_per_chunk_local % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0, (
-            f"{PREFILL_CHUNK_OUTPUT_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_local}, "
+            f"{PREFILL_CHUNK_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_local}, "
             f"not a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
         )
 
@@ -546,7 +544,7 @@ def populate_kv_chunk_address_table_kimi(
                     for local_layer in range(count):
                         global_layer = first + local_layer
                         for seq_chunk in range(num_chunks_per_seq_len):
-                            chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + row * tokens_per_chunk_local
+                            chunk_token_start = seq_chunk * PREFILL_CHUNK_TOKENS + row * tokens_per_chunk_local
                             chunk_token_end = chunk_token_start + tokens_per_chunk_local
                             for position in range(
                                 chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
@@ -576,18 +574,16 @@ def populate_kv_chunk_address_table_kimi(
 
     num_layers = config.num_layers
 
-    assert (
-        seq_len % PREFILL_CHUNK_OUTPUT_TOKENS == 0
-    ), f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_OUTPUT_TOKENS}"
-    num_chunks_per_seq_len = seq_len // PREFILL_CHUNK_OUTPUT_TOKENS
+    assert seq_len % PREFILL_CHUNK_TOKENS == 0, f"seq_len {seq_len} must be a multiple of {PREFILL_CHUNK_TOKENS}"
+    num_chunks_per_seq_len = seq_len // PREFILL_CHUNK_TOKENS
 
     assert (
         tt_kvpe_cache.shape[0] == num_users * num_layers
     ), f"cache batch dim {tt_kvpe_cache.shape[0]} != num_users({num_users}) * num_layers({num_layers})"
 
-    tokens_per_chunk_local = PREFILL_CHUNK_OUTPUT_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
+    tokens_per_chunk_local = PREFILL_CHUNK_TOKENS // mesh_shape[sp_axis]  # 640 for 5k chunks
     assert tokens_per_chunk_local % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0, (
-        f"{PREFILL_CHUNK_OUTPUT_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_local}, "
+        f"{PREFILL_CHUNK_TOKENS} tokens / sp({mesh_shape[sp_axis]}) = {tokens_per_chunk_local}, "
         f"not a multiple of {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
     )
 
@@ -619,7 +615,7 @@ def populate_kv_chunk_address_table_kimi(
         for slot in range(num_users):
             for layer in range(num_layers):
                 for seq_chunk in range(num_chunks_per_seq_len):
-                    chunk_token_start = seq_chunk * PREFILL_CHUNK_OUTPUT_TOKENS + global_row * tokens_per_chunk_local
+                    chunk_token_start = seq_chunk * PREFILL_CHUNK_TOKENS + global_row * tokens_per_chunk_local
                     chunk_token_end = chunk_token_start + tokens_per_chunk_local
                     for position in range(chunk_token_start, chunk_token_end, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
                         location = ttnn.experimental.disaggregation.KvCacheLocation()
@@ -648,7 +644,7 @@ def populate_kv_chunk_address_table_dflash(
     head_idx,
     num_users=1,
     config_id=0,
-    chunk_size_global=PREFILL_CHUNK_OUTPUT_TOKENS,
+    chunk_size_global=PREFILL_CHUNK_TOKENS,
 ):
     """
     Populate ONE config (``config_id``) of an existing KvChunkAddressTable from ONE HEAD of the DFlash

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -102,7 +102,7 @@
   sp_config: sc1
 
 
-- name: "(Kimi-K2.6-1T) MoE accuracy 5k + perf 25k"
+- name: "(Kimi-K2.6-1T) MoE accuracy 5k"
   fabric_profile: torus_xy
   cmd: |
 
@@ -504,14 +504,14 @@
   sp_config: sc1
 
 
-- name: "(GLM-5.2-744B) MoE accuracy 12.5k + perf 25k"
+- name: "(GLM-5.2-744B) MoE accuracy + perf 5k"
   fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     # GLM-5.2 256-expert MoE (device gate, DEVICE_FP32) vs the CPU MoE reference; random weights.
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "torus-xy-8x4 and pcc-device-glm-256" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "torus-xy-8x4 and (pcc-device-glm-256 or perf-device-glm-256)" -vvv --tb=short
     '
   test_type: glm_moe
   test_tags: [glm_5_2, moe]

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py
@@ -10,7 +10,7 @@ Validates correctness against:
 - Old implementation from tt_moe.py (to_layout + mul + sum)
 
 Tests structured data, random data, sparse weights, and non-local expert skipping.
-Shape: [1, 3200, 8, 7168] - DeepSeek-V3 dimensions.
+Shape: [1, 640, 8, 7168] - DeepSeek-V3 dimensions.
 """
 
 import pytest
@@ -24,8 +24,9 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSe
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
-NUM_TOKENS = 3200
+NUM_TOKENS = PREFILL_CHUNK_TOKENS_PER_CHIP
 NUM_EXPERTS = 8
 EXPERT_DIM = 2
 PCC_THRESHOLD = 0.999
@@ -51,15 +52,11 @@ MODEL_PARAMS = [
 # are worked on. These get dedicated param lists (rather than reusing MODEL_PARAMS) because the
 # same models pass the other tests that share MODEL_PARAMS. gptoss_120b's emb_dim (2880) is not a
 # multiple of the hardcoded 1024 tile_width used by the structured patterns, so its reshape is
-# invalid; dsv4_flash just lands slightly under the structured PCC threshold. strict=True keeps CI
-# green either way. Remove a model from the per-test xfail dict once its issue is resolved.
+# invalid. strict=True keeps CI green either way. Remove a model from the per-test xfail dict once
+# its issue is resolved.
 _GPTOSS_STRUCTURED_XFAIL = (
     "GPT-OSS 120B post-combine reduce: structured reshape invalid (tile_width hardcoded 1024) — "
     "https://github.com/tenstorrent/tt-metal/issues/46731"
-)
-_DSV4_FLASH_STRUCTURED_XFAIL = (
-    "DeepSeek V4 Flash post-combine reduce: structured PCC below threshold — "
-    "https://github.com/tenstorrent/tt-metal/issues/46609"
 )
 
 
@@ -76,9 +73,7 @@ def _model_params_with_xfail(xfails):
     return params
 
 
-STRUCTURED_DATA_MODEL_PARAMS = _model_params_with_xfail(
-    {"gptoss_120b": _GPTOSS_STRUCTURED_XFAIL, "dsv4_flash": _DSV4_FLASH_STRUCTURED_XFAIL}
-)
+STRUCTURED_DATA_MODEL_PARAMS = _model_params_with_xfail({"gptoss_120b": _GPTOSS_STRUCTURED_XFAIL})
 
 # test_multi_chunk_structured crosses config with num_tokens, so its failures are keyed per
 # (model, num_tokens) and applied by _xfail_multi_chunk_structured. gptoss_120b's emb_dim makes the
@@ -353,6 +348,8 @@ def test_output_layout(device, config):
 # ============================================================================
 # Multi-chunk-per-core tests: num_tokens / 32 > num_cores, so some cores must
 # process more than one 32-token chunk. Covers issue #41777.
+# These counts are deliberately not the 640-token prefill ISL: at 20 tile-rows every
+# core takes one chunk and the path under test stops being exercised.
 # ============================================================================
 
 
@@ -388,7 +385,7 @@ def test_multi_chunk_structured(device, num_tokens, config):
     assert_pcc(result, ref, threshold=0.998, label=f"multi_chunk_structured_{num_tokens}")
 
 
-@pytest.mark.parametrize("num_tokens", [4096, 6400, 8192])
+@pytest.mark.parametrize("num_tokens", _MULTI_CHUNK_NUM_TOKENS)
 @pytest.mark.parametrize("config", MODEL_PARAMS)
 def test_multi_chunk_random(device, num_tokens, config):
     """Random data with >100 chunks so some cores get 2+ chunks each."""

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_h2d_socket_sync.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_h2d_socket_sync.py
@@ -19,6 +19,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole, skip_for_slow_dispatch
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 pytestmark = [
     pytest.mark.requires_host_iommu,
@@ -33,7 +34,7 @@ _DTYPE_TORCH = torch.int32
 _DTYPE_TTNN = ttnn.uint32
 _DTYPE_SIZE = 4
 _METADATA_SIZE_BYTES = 12  # 3 x uint32: [slot_id, actual_start, actual_end]
-_ISL = 640
+_ISL = PREFILL_CHUNK_TOKENS_PER_CHIP
 _NUM_ITERS = 3
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -19,6 +19,7 @@ from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from tests.ttnn.utils_for_testing import comp_pcc, assert_equal
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 pytestmark = pytest.mark.use_module_device
 
@@ -29,9 +30,7 @@ E4M3_MAX = 448.0
 SHAPES = [
     (1, 1024),  # single row (partial tile-row)
     (30, 1152),  # partial tile-row + 9 scale blocks
-    (640, 7168),
-    (3200, 7168),
-    (6400, 7168),
+    (PREFILL_CHUNK_TOKENS_PER_CHIP, 7168),
     (2, 3, 30, 1152),  # 4D + partial tile-row (M = 180)
 ]
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
@@ -23,9 +23,10 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     score_activation,
 )
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill import ci_pruning
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 
-TEST_PARAMS = [(1, 1, 1), (1, 1, 33), (1, 1, 128), (1, 1, 3200)]
+TEST_PARAMS = [(1, 1, 1), (1, 1, 33), (1, 1, 128), (1, 1, PREFILL_CHUNK_TOKENS_PER_CHIP)]
 
 TEST_PARAM_IDS = ["minimal", "just_over_one_tile", "four_tiles", "realistic"]
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_hash_gate.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_hash_gate.py
@@ -21,10 +21,11 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     distinct_logits,
     hash_gate_golden_act,
 )
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 
 # (seq_len,) with num_batches == batch_size == 1 (single prefill sequence).
-SEQ_LENS = [32, 128, 100, 3200]
+SEQ_LENS = [32, 128, 100, PREFILL_CHUNK_TOKENS_PER_CHIP]
 SEQ_LEN_IDS = ["one_tile", "four_tiles", "remainder", "realistic"]
 
 # (total_experts, n_activated_experts, route_scale, vocab_size)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_per_token_cast_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_per_token_cast_perf.py
@@ -16,6 +16,7 @@ import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import run_model_device_perf_test_per_op
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_p150
+from models.demos.deepseek_v3_d_p.utils.chunk_config import PREFILL_CHUNK_TOKENS_PER_CHIP
 
 # Functional test file whose op launches land in the Tracy CSV the harness reads back.
 _WORKER = (
@@ -24,7 +25,7 @@ _WORKER = (
 
 # Production prefill shape: 640 tokens x 7168 hidden. Compression always sees this exact
 # shape; decompression is exercised at the same shape purely as a regression guard.
-_SEQ_LEN = 640
+_SEQ_LEN = PREFILL_CHUNK_TOKENS_PER_CHIP
 _HIDDEN = 7168
 
 # Device-op codes emitted by each op; the harness sums the rows whose OP CODE contains the
@@ -40,10 +41,8 @@ _MARGIN = 0.05
 
 
 def _k(extra: str) -> str:
-    """Pin exactly the 640x7168 case of the worker. ``640`` is a substring of ``6400``, so
-    exclude the 6400 shape explicitly (mirrors the isl-512/isl-5120 disambiguation in
-    ``test_single_routed_expert_perf._k_filter``)."""
-    return f"{_SEQ_LEN} and {extra} and not 6400"
+    """Pin exactly the 640x7168 case of the worker."""
+    return f"{_SEQ_LEN} and {extra}"
 
 
 # Compression: ROW_MAJOR bf16 input -- the Blackhole production fast path (input tilized and


### PR DESCRIPTION
### PR Category
Test Only

### Summary
All tests under `models/demos/deepseek_v3_d_p/tests/` now run the production prefill chunk: 5120
global, **640 tokens per chip**, replacing 3200 / 4096 / 1600 / 6400 per chip and a 1024 smoke tier.
Per-chip is the invariant — a smaller mesh shortens the global length rather than loading each chip
more. `utils/chunk_config.py` holds the numbers once; 5120 was re-declared in thirteen places.

Perf baselines were re-measured, not rescaled: ten gates moved 1.8x–4.4x. Validated on hardware —
117 tests on a 32-chip galaxy, 118 on a LoudBox.

### Notes for reviewers
- Rebased onto #53530, which already retired most CI selectors this PR was updating. `test_kimi_mla`
  and the `test_ttnn_moe` rows it deleted stay deleted.
- `perf-random-5k` restored — it is 640 tokens/chip, and #53530's determinism job selects it.
- Constants named per review: `PREFILL_SP_FACTOR` / `PREFILL_CHUNK_TOKENS` /
  `PREFILL_CHUNK_TOKENS_PER_CHIP`; the rename reaches two files not otherwise touched.
- `perf-host-64` kept — sole selector for the 8x1 perf proxy. Galaxy perf gates on `is_high_power`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/refactor_prefill_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/refactor_prefill_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/refactor_prefill_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/refactor_prefill_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/refactor_prefill_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/refactor_prefill_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/refactor_prefill_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/refactor_prefill_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/refactor_prefill_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/refactor_prefill_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/refactor_prefill_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/refactor_prefill_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/refactor_prefill_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/refactor_prefill_tests)
### Appendix: perf baselines, re-measured at 640 tokens/chip

| Gate | Mesh | Was | Now | Ratio | Box |
|---|---|---|---|---|---|
| `test_moe_perf` loudbox 8x1 | 8x1 TorusY | 15_393_888 | **5_895_298** | 2.61x | LoudBox `bh-lb-15` |
| `test_moe_perf` loudbox 2x4 | 2x4 Fabric2D | 17_217_341 | **9_339_547** | 1.84x | CI LoudBox `bh_loudbox` |
| `test_mla_perf` loudbox | 2x4 Fabric2D | 8_857_393 | **2_660_615** | 3.33x | LoudBox `bh-lb-15` |
| `block_2x4_layer3_moe_fabric2d` | 2x4 2-link | 38_638_478 | **10_963_542** | 3.52x | CI LoudBox `bh_loudbox` |
| `block_8x4_layer0_dense_torus_xy` | 8x4 TorusXY | 18_157_603 | **5_435_504** | 3.34x | 14kW glx `c04u02` |
| `block_8x4_layer3_moe_torus_xy` | 8x4 TorusXY | 60_634_662 | **13_674_937** | 4.43x | 14kW glx `c04u02` |
| `test_moe_perf` galaxy | 8x4 TorusXY | 21_028_751 | **6_112_530** | 3.44x | 14kW glx `c04u02` |
| `test_moe_perf` galaxy pad50 | 8x4 TorusXY | 14_107_228 | **5_205_872** | 2.71x | 14kW glx `c04u02` |
| `test_mla_perf` galaxy | 8x4 TorusXY | 14_252_829 | **3_890_333** | 3.66x | 14kW glx `c04u02` |
| `block_4x4_layer0_dense_torus_y` | 4x4 subtorus | 17_978_418 | **4_913_214** | 3.66x | 14kW glx `d08u02` |

LoudBox gates are means of 14 runs, spreads 0.25–1.12%; `margin=0.03` unchanged throughout.
`test_kimi_k3_moe_perf` needed no change — already at 640/chip; it is now `test_kimi_moe_perf`
(renamed by #53530) and carries the same one-line constant swap.

The MoE 2x4 gate is also cut on the CI LoudBox: the dev-box 9_601_530 put a 9_298_371 CI sample
0.16% under its floor, so it was re-cut to the mean of two CI runs (9.381 / 9.298 ms).

`block_2x4_layer3_moe_fabric2d` is cut on the **CI** LoudBox: dev box `bh-lb-15` measured 14_179_641
for the same gate, a 23% disagreement, and a CI re-run reproduced 10_938_722 (−0.23%). That gap is
specific to this gate — the MoE proxies agree within 2.3% across the same two boxes.

