### PR TITLE
[Bug fix] Power gradient: write through preallocated output and honour memory_config

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
@@ -302,9 +302,22 @@ def test_bw_pow_preallocated_output_wins_over_memory_config(input_shapes, expone
 
     This is the invariant whose behaviour changed: the gradient is written into the
     supplied tensor, so it stays in that tensor's memory space even when a different
-    config is requested. `full_like_impl` reaches this via
-    `optional_output_tensor.value().memory_config()` in `full_impl`, so flipping that
-    precedence would break it silently.
+    config is requested.
+
+    The two parametrizations reach it by different routes, and neither goes through
+    `full_impl`:
+
+    - exponent 0: `zeros_like` -> `full_like_impl` takes the fast path for a device
+      tensor in TILE layout whose dtype already matches, short-circuiting to
+      `ttnn::fill(tensor, 0.0f, memory_config, optional_output_tensor)`. `fill` is a
+      DEFINE_UNARY_OP_SCALAR_VARIANT, so precedence is decided by `unary_impl`
+      (eltwise/unary/unary.cpp:38-40), which prefers
+      `optional_output_tensor.value().memory_config()` over the requested config.
+    - exponent 2: `full_like_impl` is not involved. The write-through is the
+      `where(lez(input), inf, final_result, output_mem_config, input_grad)` at the end
+      of `pow_bw`, via `where`'s output-tensor handling.
+
+    Changing either of those would break this silently.
     """
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     in_data, input_tensor = data_gen_with_range(input_shapes, 0.1, 10, device)

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
@@ -293,3 +293,30 @@ def test_bw_pow_honours_requested_memory_config(input_shapes, exponent, device):
     assert (
         result[0].memory_config().buffer_type == ttnn.BufferType.L1
     ), f"requested L1 but gradient landed in {result[0].memory_config().buffer_type}"
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("exponent", [0.0, 2.0])
+def test_bw_pow_preallocated_output_wins_over_memory_config(input_shapes, exponent, device):
+    """A caller-supplied input_grad takes precedence over memory_config.
+
+    This is the invariant whose behaviour changed: the gradient is written into the
+    supplied tensor, so it stays in that tensor's memory space even when a different
+    config is requested. `full_like_impl` reaches this via
+    `optional_output_tensor.value().memory_config()` in `full_impl`, so flipping that
+    precedence would break it silently.
+    """
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0.1, 10, device)
+
+    preallocated = ttnn.full(input_shapes, 7.0, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG)
+
+    result = ttnn.pow_bw(
+        grad_tensor, input_tensor, exponent, memory_config=ttnn.DRAM_MEMORY_CONFIG, input_grad=preallocated
+    )
+
+    assert result[0].memory_config().buffer_type == ttnn.BufferType.L1, (
+        "preallocated output should win over memory_config, but the result moved to "
+        f"{result[0].memory_config().buffer_type}"
+    )
+    assert preallocated.memory_config().buffer_type == ttnn.BufferType.L1

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
@@ -26,7 +26,7 @@ def test_negative_exponent(input_shapes, exponent, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
-    with pytest.raises(RuntimeError) as _e:
+    with pytest.raises(RuntimeError) as _e:  # allow-pytest.raises: pre-existing, predates this hook
         tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
     assert "exponent >= 0.0" in str(_e.value)
 
@@ -248,3 +248,48 @@ def test_bw_unary_pow_edge_case_exponents(device, input_shapes, exponent, high1,
 
     status = compare_pcc(output_tensor, golden_tensor, pcc=0.99)
     assert status
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("exponent", [0.0, 2.0])
+def test_bw_pow_writes_through_preallocated_input_grad(input_shapes, exponent, device):
+    """The caller's preallocated input_grad must be written, not replaced.
+
+    Regression: for exponent 0, `input_grad = ttnn::zeros_like(input)` rebound the local
+    optional instead of filling the supplied tensor, so a caller reading its own tensor
+    got stale data. Comparing only the returned tensor does not catch that.
+    """
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0.1, 10, device)
+
+    sentinel = 7.0
+    preallocated = ttnn.full(input_shapes, sentinel, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG)
+
+    ttnn.pow_bw(grad_tensor, input_tensor, exponent, input_grad=preallocated)
+
+    written = ttnn.to_torch(preallocated)
+    assert not torch.equal(
+        written, torch.full(input_shapes, sentinel, dtype=torch.bfloat16)
+    ), "preallocated input_grad was never written"
+    if exponent == 0.0:
+        assert torch.all(written == 0.0), "exponent 0 gradient must be zero"
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("exponent", [0.0, 2.0])
+def test_bw_pow_honours_requested_memory_config(input_shapes, exponent, device):
+    """With no preallocated output, the gradient must land in the requested memory config.
+
+    Regression: `empty_like`/`zeros_like` were called without `output_mem_config`, so the
+    result inherited the input's config instead. Existing tests use the same config for
+    inputs and output, so the two never diverge there.
+    """
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0.1, 10, device)
+
+    # inputs land in DRAM by default, so request L1 to force a divergence
+    result = ttnn.pow_bw(grad_tensor, input_tensor, exponent, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    assert (
+        result[0].memory_config().buffer_type == ttnn.BufferType.L1
+    ), f"requested L1 but gradient landed in {result[0].memory_config().buffer_type}"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -251,13 +251,13 @@ std::vector<std::optional<Tensor>> pow_bw(
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> grad_tensor;
+    TT_FATAL(exponent >= 0.0, "negative exponents are not supported; use recip(pow(input,abs(exponent)))");
     // Not value_or: its argument is evaluated even when input_grad already holds a
     // tensor, which would allocate and immediately discard a device tensor.
     if (!input_grad.has_value()) {
         input_grad = ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
     const float ZERO_THRESHOLD = std::numeric_limits<float>::epsilon() * 10.0f;
-    TT_FATAL(exponent >= 0.0, "negative exponents are not supported; use recip(pow(input,abs(exponent)))");
     if (std::abs(exponent) < ZERO_THRESHOLD) {
         // Write through input_grad so a caller-supplied tensor is filled, matching the
         // non-zero-exponent path below and fill_bw.

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -251,11 +251,14 @@ std::vector<std::optional<Tensor>> pow_bw(
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> grad_tensor;
-    input_grad = input_grad.value_or(ttnn::empty_like(input));
+    input_grad =
+        input_grad.value_or(ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
     const float ZERO_THRESHOLD = std::numeric_limits<float>::epsilon() * 10.0f;
     TT_FATAL(exponent >= 0.0, "negative exponents are not supported; use recip(pow(input,abs(exponent)))");
     if (std::abs(exponent) < ZERO_THRESHOLD) {
-        input_grad = ttnn::zeros_like(input);
+        // Write through input_grad so a caller-supplied tensor is filled, matching the
+        // non-zero-exponent path below and fill_bw.
+        input_grad = ttnn::zeros_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config, input_grad);
         grad_tensor.emplace_back(input_grad);
         return grad_tensor;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -251,8 +251,11 @@ std::vector<std::optional<Tensor>> pow_bw(
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> grad_tensor;
-    input_grad =
-        input_grad.value_or(ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config));
+    // Not value_or: its argument is evaluated even when input_grad already holds a
+    // tensor, which would allocate and immediately discard a device tensor.
+    if (!input_grad.has_value()) {
+        input_grad = ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
+    }
     const float ZERO_THRESHOLD = std::numeric_limits<float>::epsilon() * 10.0f;
     TT_FATAL(exponent >= 0.0, "negative exponents are not supported; use recip(pow(input,abs(exponent)))");
     if (std::abs(exponent) < ZERO_THRESHOLD) {


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/54549

### What this does

Two changes in `pow_bw`:

- For `|exponent| < eps`, writes the zero gradient **through** the caller's `input_grad` instead of rebinding the local `std::optional`.
- Passes `output_mem_config` to the `empty_like` and `zeros_like` calls.

### Why

`input_grad = ttnn::zeros_like(input);` replaced the optional rather than filling the caller's tensor, so a preallocated `input_grad` came back holding its previous contents — a caller reading its own tensor instead of the returned vector silently got stale data. The non-zero-exponent path already writes through via `where(..., input_grad)`, and `fill_bw` does the same; this line was the outlier.

Separately, neither creation call passed `output_mem_config`, so with nothing preallocated the gradient inherited the input's config instead of the requested one.

Measured on a Wormhole card, bfloat16/TILE, inputs in L1, `memory_config=DRAM`:

| | before | after |
| --- | --- | --- |
| no prealloc, exp 0 | L1 | DRAM |
| no prealloc, exp 2 | L1 | DRAM |
| prealloc, exp 0 | 7.0 (untouched) | 7.0 → 0.0 |
| prealloc, exp 2 | 7.0 → 0.5 | 7.0 → 0.5 |

A caller-supplied tensor still wins over `memory_config`, which is why the preallocated rows stay in L1; only the written value changes.

### Tests

| Test | Result |
| --- | --- |
| `tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py` | 98 passed |
| `tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_rpow.py` | 12 passed |
| `tests/ttnn/docs_examples/test_backward_examples.py -k pow_bw` | 2 passed |
| `tests/ttnn/nightly/unit_tests/operations/eltwise/backward/ -k "pow or fill"` | 119 passed |

No existing test preallocates `input_grad` or requests a differing `memory_config`, so these confirm no regression; the behaviour in the table was verified with a direct probe.

---

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/pow_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/pow_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/pow_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/pow_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/pow_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/pow_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/pow_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/pow_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/pow_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/pow_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/pow_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/pow_bw_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/pow_bw_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/pow_bw_check)
