### PR TITLE
Add Metalium 2.0 migration compatibility infrastructure

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -78,6 +78,7 @@ struct BorrowedDFBTestConfig {
     DFBAccessPattern cap      = DFBAccessPattern::STRIDED;  // producer is always STRIDED
     bool tensix_consumer      = false;
     bool verify_data          = false;
+    uint32_t borrowed_memory_offset = 0;
     std::optional<uint32_t> num_entries_override = std::nullopt;
     bool expect_attach_fatal = false;
 };
@@ -180,12 +181,16 @@ void run_borrowed_memory_dfb_program(
         .num_entries = cfg.num_entries,
         .data_format_metadata = tt::DataFormat::Float16_b,
         .borrowed_from = experimental::TensorParamName{"dfb_ring_tensor"},
+        .borrowed_memory_offset = cfg.borrowed_memory_offset,
     };
 
     // --- TensorParameters ---
     const TensorSpec src_spec  = make_flat_dram_tensor_spec(cfg.entry_size, cfg.num_entries);
     const TensorSpec dst_spec  = make_flat_dram_tensor_spec(cfg.entry_size, cfg.num_entries);
-    const TensorSpec ring_spec = make_flat_l1_tensor_spec(cfg.entry_size, cfg.num_entries);
+    ASSERT_EQ(cfg.borrowed_memory_offset % cfg.entry_size, 0u)
+        << "The runtime test keeps the borrowed subrange aligned to a DFB entry";
+    const uint32_t borrowed_prefix_entries = cfg.borrowed_memory_offset / cfg.entry_size;
+    const TensorSpec ring_spec = make_flat_l1_tensor_spec(cfg.entry_size, cfg.num_entries + borrowed_prefix_entries);
 
     spec.tensor_parameters.push_back({.unique_id = experimental::TensorParamName{"src_tensor"}, .spec = src_spec});
     if (!cfg.tensix_consumer) {
@@ -267,7 +272,9 @@ void run_borrowed_memory_dfb_program(
 
     // Assert the borrowed tensor's L1 address was used for the DFB ring. For a borrowed DFB this
     // stays PINNED across a size override (no reallocation).
-    EXPECT_EQ(program.impl().dataflow_buffers()[0]->uniform_alloc_addr(), static_cast<uint32_t>(ring_tensor.address()));
+    EXPECT_EQ(
+        program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
+        static_cast<uint32_t>(ring_tensor.address()) + cfg.borrowed_memory_offset);
 
     if (cfg.num_entries_override.has_value()) {
         EXPECT_EQ(program.impl().dataflow_buffers()[0]->config.num_entries, *cfg.num_entries_override)
@@ -484,6 +491,22 @@ TEST_F(UnitMeshFixture, BorrowedMemoryDMDM1Sx1S) {
             .cap = DFBAccessPattern::STRIDED,
             .tensix_consumer = false,
             .verify_data = true,
+        });
+}
+
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM1Sx1S_OffsetSubrange) {
+    run_borrowed_memory_dfb_program(
+        this->device(),
+        NodeCoord{0, 0},
+        {
+            .num_entries = 16,
+            .entry_size = 256,
+            .num_producers = 1,
+            .num_consumers = 1,
+            .cap = DFBAccessPattern::STRIDED,
+            .tensix_consumer = false,
+            .verify_data = true,
+            .borrowed_memory_offset = 4 * 256,
         });
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <limits>
 #include <optional>
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
@@ -1362,6 +1363,27 @@ TEST_F(ProgramRunArgsTestQuasar, CPU_UpdateProgramRunArgs_ResizingBorrowedDFBBey
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("exceeds the borrowed")));
 }
 
+// The fit check must widen before multiplication. UINT32_MAX * 2 wraps to 0xfffffffe in uint32_t,
+// which could otherwise make an impossibly large borrowed DFB appear to fit a small L1 buffer.
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BorrowedDFBSizeDoesNotWrapBeforeFitCheck) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    program.impl().finalize_dataflow_buffer_configs();
+
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec);
+    ProgramRunArgs setup = MakeBorrowedDFBRunArgs();
+    setup.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+    SetProgramRunArgs(program, setup);
+
+    ProgramRunArgs upd;
+    upd.dfb_run_overrides.push_back(
+        {.dfb = DFBSpecName{"dfb"}, .entry_size = std::numeric_limits<uint32_t>::max(), .num_entries = 2});
+    upd.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+    EXPECT_THAT(
+        [&] { UpdateProgramRunArgs(program, upd); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("size 8589934590 B")));
+}
+
 // Regression: a kernel that binds a tensor but declares no scalar args (no named/vararg RTAs or
 // CRTAs) may be omitted from kernel_run_args. SetProgramRunArgs must still validate, and must write
 // the binding's base address into that kernel's CRTA buffer via its second pass — the binding
@@ -1459,6 +1481,34 @@ inline ProgramSpec MakeGen1SpecWithRTAs(const NodeCoord& /*node*/, size_t num_pe
     // kernels[1] has no varargs (defaults)
 
     return spec;
+}
+
+TEST_F(ProgramRunArgsTestGen1, BorrowedDFBOverrideRejectsMisalignedEffectiveEntrySize) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.dataflow_buffers[0].entry_size = 16;
+    spec.dataflow_buffers[0].num_entries = 2;
+    spec.dataflow_buffers[0].borrowed_from = TensorParamName{"borrowed_tensor"};
+    spec.dataflow_buffers[0].borrowed_memory_offset = 16;
+    auto tensor_param = MakeMinimalTensorParameter("borrowed_tensor", tt::tt_metal::BufferType::L1);
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1};
+    tensor_param.spec = tt::tt_metal::TensorSpec(
+        tt::tt_metal::Shape{1, 64},
+        tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config));
+    BindTensorParameterToKernel(spec.kernels[0], "borrowed_tensor", "borrowed_tensor");
+    spec.tensor_parameters = {tensor_param};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    program.impl().finalize_dataflow_buffer_configs();
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, tensor_param.spec);
+    ProgramRunArgs params;
+    params.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb_0"}, .entry_size = 32});
+
+    EXPECT_THAT(
+        [&] { SetProgramRunArgs(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("not aligned to its effective entry size")));
 }
 
 TEST_F(ProgramRunArgsTestGen1, CPU_SetRunArgsSucceeds_ZeroRTAs) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -45,7 +45,7 @@
 #include "impl/host_api/temp_quasar_api.hpp"  // for QuasarComputeConfig
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/tt_metal.hpp>                      // for CompileProgram (JIT trigger)
 #include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgsConfig / ArgConfig::RuntimePageSize
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
@@ -245,8 +245,10 @@ TEST_F(ProgramSpecTestQuasar, CPU_SharedLocalAccessorNameForDifferentDFBsFails) 
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Kernel 'kernel' uses accessor_name 'same_accessor' for two different DFBs")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::AllOf(
+            ::testing::HasSubstr("Kernel 'kernel' uses accessor_name 'same_accessor' for two different DFBs"),
+            ::testing::HasSubstr("first DFB 'dfb_0'"),
+            ::testing::HasSubstr("conflicting DFB 'dfb_1'"))));
 }
 
 TEST_F(ProgramSpecTestQuasar, CPU_DuplicateProducerBindingForSameLocalAccessorNameFails) {
@@ -297,6 +299,58 @@ TEST_F(ProgramSpecTestQuasar, CPU_SelfLoopWithSharedLocalAccessorNameSucceeds) {
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"kernel"})};
 
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
+}
+
+TEST_F(ProgramSpecTestQuasar, DFBAccessorAliasesSucceed) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec;
+    spec.name = "dfb_accessor_aliases";
+
+    auto producer = MakeMinimalGen2DMKernel("producer");
+    auto consumer = MakeMinimalGen2ComputeKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    auto producer_binding = ProducerOf(DFBSpecName{"dfb"}, "out");
+    producer_binding.accessor_aliases = {"legacy_out", "row_major_out"};
+    producer.dfb_bindings.push_back(std::move(producer_binding));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    std::unordered_map<std::string, uint16_t> handles;
+    program.impl()
+        .get_kernel_by_spec_name("producer")
+        ->process_dataflow_buffer_binding_handles(
+            [&handles](const std::string& accessor_name, uint16_t slot) { handles.emplace(accessor_name, slot); });
+    ASSERT_EQ(handles.size(), 3u);
+    ASSERT_TRUE(handles.contains("out"));
+    EXPECT_EQ(handles.at("legacy_out"), handles.at("out"));
+    EXPECT_EQ(handles.at("row_major_out"), handles.at("out"));
+}
+
+TEST_F(ProgramSpecTestQuasar, DuplicateDFBAccessorAliasFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec;
+    spec.name = "duplicate_dfb_accessor_alias";
+
+    auto producer = MakeMinimalGen2DMKernel("producer");
+    auto consumer = MakeMinimalGen2ComputeKernel("consumer");
+    auto dfb = MakeMinimalDFB("dfb");
+    auto producer_binding = ProducerOf(DFBSpecName{"dfb"}, "out");
+    producer_binding.accessor_aliases = {"out"};
+    producer.dfb_bindings.push_back(std::move(producer_binding));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Accessor aliases must be unique")));
 }
 
 TEST_F(ProgramSpecTestQuasar, CPU_DMKernelSelfLoopOnGen2Fails) {
@@ -1177,6 +1231,52 @@ TEST_F(ProgramSpecTestQuasar, CPU_BorrowedMemoryDFBSucceeds) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
+TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOffsetSubrangeSucceeds) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpec(
+        "borrowed_tensor", tt::tt_metal::BufferType::L1, /*dfb_entry_size=*/16, /*dfb_num_entries=*/2);
+    spec.dataflow_buffers[0].borrowed_memory_offset = 32;
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOffsetSubrangeOversizedFails) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpec(
+        "borrowed_tensor", tt::tt_metal::BufferType::L1, /*dfb_entry_size=*/16, /*dfb_num_entries=*/2);
+    spec.dataflow_buffers[0].borrowed_memory_offset = 48;
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("borrowed subrange")));
+}
+
+TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOffsetMisalignedFails) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpec();
+    spec.dataflow_buffers[0].borrowed_memory_offset = 8;
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("must be aligned to entry_size")));
+}
+
+TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOffsetNoCMisalignedFails) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpec(
+        "borrowed_tensor", tt::tt_metal::BufferType::L1, /*dfb_entry_size=*/8, /*dfb_num_entries=*/2);
+    spec.dataflow_buffers[0].borrowed_memory_offset = 8;
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("must be aligned to the L1/NoC address alignment")));
+}
+
+TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOffsetWithoutBackingFails) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpec();
+    spec.dataflow_buffers[0].borrowed_from.reset();
+    spec.dataflow_buffers[0].borrowed_memory_offset = 16;
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("without borrowed_from")));
+}
+
 TEST_F(ProgramSpecTestQuasar, CPU_BorrowedMemoryDFBBackingParameterNeedNotBeKernelBoundSucceeds) {
     // Regression: a TensorParameter used ONLY as a borrowed-memory DFB's backing (referenced via
     // borrowed_from, never bound by a kernel) is a legitimate use. The validator must count
@@ -1392,6 +1492,112 @@ TEST_F(ProgramSpecTestQuasar, CPU_UnknownScratchpadReferenceFails) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("references unknown scratchpad")));
+}
+
+TEST_F(ProgramSpecTestQuasar, OptionalUnboundDFBForConstexprDiscardSucceeds) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    spec.kernels[0].dfb_bindings.push_back(KernelSpec::DFBBinding{
+        .dfb_spec_name = DFBSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_dfb",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+        .allow_unbound_for_constexpr_discard = true});
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    std::unordered_map<std::string, uint16_t> handles;
+    program.impl()
+        .get_kernel_by_spec_name("dm_kernel")
+        ->process_dataflow_buffer_binding_handles(
+            [&handles](const std::string& accessor_name, uint16_t slot) { handles.emplace(accessor_name, slot); });
+    ASSERT_EQ(handles.size(), 2u);
+    EXPECT_EQ(handles.at("optional_dfb"), std::numeric_limits<uint16_t>::max());
+}
+
+TEST_F(ProgramSpecTestQuasar, DuplicateOptionalUnboundDFBFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].dfb_bindings.push_back(KernelSpec::DFBBinding{
+        .dfb_spec_name = DFBSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_a",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+        .allow_unbound_for_constexpr_discard = true});
+    spec.kernels[0].dfb_bindings.push_back(KernelSpec::DFBBinding{
+        .dfb_spec_name = DFBSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_b",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+        .allow_unbound_for_constexpr_discard = true});
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("two PRODUCER bindings")));
+}
+
+TEST_F(ProgramSpecTestQuasar, OptionalUnboundDFBRejectsAccessorAliases) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].dfb_bindings.push_back(KernelSpec::DFBBinding{
+        .dfb_spec_name = DFBSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_dfb",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+        .accessor_aliases = {"alias"},
+        .allow_unbound_for_constexpr_discard = true});
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("cannot declare accessor aliases")));
+}
+
+TEST_F(ProgramSpecTestQuasar, OptionalDFBRejectsPresentSpec) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].dfb_bindings[0].allow_unbound_for_constexpr_discard = true;
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("optional bindings must be unbound")));
+}
+
+TEST_F(ProgramSpecTestQuasar, OptionalUnboundScratchpadForConstexprDiscardSucceeds) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    spec.kernels[0].scratchpad_bindings = {KernelSpec::ScratchpadBinding{
+        .scratchpad_spec_name = ScratchpadSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_scratch",
+        .allow_unbound_for_constexpr_discard = true}};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    const auto& handles = program.impl().get_kernel_by_spec_name("dm_kernel")->scratchpad_binding_handles();
+    ASSERT_EQ(handles.size(), 1u);
+    EXPECT_EQ(handles[0].accessor_name, "optional_scratch");
+    EXPECT_EQ(handles[0].size_bytes, 0u);
+    EXPECT_EQ(handles[0].allocated_address, 0u);
+}
+
+TEST_F(ProgramSpecTestQuasar, OptionalScratchpadRejectsPresentSpec) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"unexpected_scratch"}, .size_per_node = 1024}};
+    spec.kernels[0].scratchpad_bindings = {KernelSpec::ScratchpadBinding{
+        .scratchpad_spec_name = ScratchpadSpecName{"unexpected_scratch"},
+        .accessor_name = "optional_scratch",
+        .allow_unbound_for_constexpr_discard = true}};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("optional bindings must be unbound")));
+}
+
+TEST_F(ProgramSpecTestQuasar, DuplicateOptionalUnboundScratchpadFails) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.kernels[0].scratchpad_bindings = {
+        KernelSpec::ScratchpadBinding{
+            .scratchpad_spec_name = ScratchpadSpecName{"compile_time_discarded"},
+            .accessor_name = "optional_a",
+            .allow_unbound_for_constexpr_discard = true},
+        KernelSpec::ScratchpadBinding{
+            .scratchpad_spec_name = ScratchpadSpecName{"compile_time_discarded"},
+            .accessor_name = "optional_b",
+            .allow_unbound_for_constexpr_discard = true}};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("more than once")));
 }
 
 TEST_F(ProgramSpecTestQuasar, CPU_UnboundScratchpadFails) {
@@ -3128,6 +3334,137 @@ protected:
     std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
 };
 
+TEST_F(ProgramSpecTestGen1, DFBAccessorAliasCompilesInKernelSource) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.kernels[0].dfb_bindings[0].accessor_aliases = {"legacy_input"};
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    static_assert(static_cast<uint32_t>(dfb::legacy_input) == static_cast<uint32_t>(dfb::input_dfb));
+}
+)"};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+TEST_F(ProgramSpecTestGen1, OptionalUnboundDFBForConstexprDiscardCompilesInKernelSource) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    if constexpr (false) {
+        DataflowBuffer optional_dfb(dfb::optional_dfb);
+        (void)optional_dfb;
+    }
+}
+)"};
+    spec.kernels[0].dfb_bindings.push_back(KernelSpec::DFBBinding{
+        .dfb_spec_name = DFBSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_dfb",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+        .allow_unbound_for_constexpr_discard = true});
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+TEST_F(ProgramSpecTestGen1, OptionalUnboundSemaphoreForConstexprDiscardEmitsInvalidToken) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    static_assert(sem::optional_sem == 0xFFFF);
+}
+)"};
+    spec.kernels[0].semaphore_bindings = {SemaphoreBinding{
+        .semaphore_spec_name = SemaphoreSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_sem",
+        .allow_unbound_for_constexpr_discard = true}};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+TEST_F(ProgramSpecTestGen1, OptionalSemaphoreBindingRejectsPresentSpec) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.semaphores = {SemaphoreSpec{
+        .unique_id = SemaphoreSpecName{"present_sem"},
+        .target_nodes = NodeCoord{0, 0},
+    }};
+    spec.kernels[0].semaphore_bindings = {SemaphoreBinding{
+        .semaphore_spec_name = SemaphoreSpecName{"present_sem"},
+        .accessor_name = "optional_sem",
+        .allow_unbound_for_constexpr_discard = true}};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("optional for constexpr discard, but that SemaphoreSpec is present")));
+}
+
+TEST_F(ProgramSpecTestGen1, OptionalUnboundTensorForConstexprDiscardEmitsTokenOnly) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+#include "api/tensor/tensor_accessor.h"
+void kernel_main() {
+    if constexpr (false) {
+        const TensorAccessor input(tensor::optional_input);
+        (void)input.get_bank_base_address();
+    }
+}
+)"};
+    spec.kernels[0].tensor_bindings = {TensorBinding{
+        .tensor_parameter_name = TensorParamName{"compile_time_discarded"},
+        .accessor_name = "optional_input",
+        .allow_unbound_for_constexpr_discard = true}};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    const auto& handles = program.impl().get_kernel_by_spec_name("dm_kernel")->tensor_binding_handles();
+    ASSERT_EQ(handles.size(), 1u);
+    EXPECT_TRUE(handles[0].constexpr_discard_only);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+TEST_F(ProgramSpecTestGen1, OptionalTensorBindingRejectsPresentParameter) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("present_tensor")};
+    spec.kernels[0].tensor_bindings = {TensorBinding{
+        .tensor_parameter_name = TensorParamName{"present_tensor"},
+        .accessor_name = "optional_input",
+        .allow_unbound_for_constexpr_discard = true}};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("optional for constexpr discard, but that parameter is present")));
+}
+
+TEST_F(ProgramSpecTestGen1, OptionalUnboundScratchpadForConstexprDiscardEmitsZeroToken) {
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    spec.kernels[0].source = KernelSpec::SourceCode{R"(
+void kernel_main() {
+    if constexpr (false) {
+        Scratchpad<uint32_t> optional_scratch(scratch::optional_scratch);
+        (void)optional_scratch;
+    }
+}
+)"};
+    spec.kernels[0].scratchpad_bindings = {KernelSpec::ScratchpadBinding{
+        .scratchpad_spec_name = ScratchpadSpecName{"compile_time_discarded"},
+        .accessor_name = "optional_scratch",
+        .allow_unbound_for_constexpr_discard = true}};
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    const auto& handles = program.impl().get_kernel_by_spec_name("dm_kernel")->scratchpad_binding_handles();
+    ASSERT_EQ(handles.size(), 1u);
+    EXPECT_EQ(handles[0].size_bytes, 0u);
+    EXPECT_EQ(handles[0].allocated_address, 0u);
+    IDevice* device = mesh_device_->get_devices()[0];
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
 // Gen1 counterpart of the compute-config translation-stability tests (the Gen2 pair lives in the
 // Quasar suite): a default ComputeGen1Config{} must yield the historical internal ComputeConfig
 // defaults. Guards the perf/precision knobs that don't move a functional pass/fail result.
@@ -3437,6 +3774,83 @@ TEST_F(ProgramSpecTestGen1, CPU_DFBMixedKindProducersOnSameNodeSucceedsWithFlag)
         MakeMinimalWorkUnit("work_unit", node, {"producer_compute", "producer_dm", "consumer"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestGen1, DFBComputeSelfLoopWithoutFlagLowersToIntraTensix) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec;
+    spec.name = "compute_self_loop";
+
+    auto compute = MakeMinimalGen1ComputeKernel("compute");
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    compute.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {compute};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute"})};
+
+    auto program = MakeProgramFromSpec(*mesh_device_, spec);
+    const auto dfb_id = program.impl().get_dfb_handle("dfb");
+    const auto& config = program.impl().get_dataflow_buffer(dfb_id)->config;
+    ASSERT_TRUE(config.tensix_scope.has_value());
+    EXPECT_EQ(config.tensix_scope, dfb::TensixScope::INTRA);
+}
+
+TEST_F(ProgramSpecTestGen1, DFBDataMovementEndpointsUseExplicitSync) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec;
+    spec.name = "gen1_dm_explicit_sync";
+
+    auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    auto program = MakeProgramFromSpec(*mesh_device_, spec);
+    const auto dfb_id = program.impl().get_dfb_handle("dfb");
+    const auto& config = program.impl().get_dataflow_buffer(dfb_id)->config;
+    EXPECT_FALSE(config.enable_producer_implicit_sync);
+    EXPECT_FALSE(config.enable_consumer_implicit_sync);
+}
+
+TEST_F(ProgramSpecTestGen1, DFBComputeSelfLoopAndDMParticipantWithFlagLowersToPlainExplicitSyncCB) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "compute_self_loop_with_dm_participant";
+
+    auto compute = MakeMinimalGen1ComputeKernel("compute");
+    auto dm = MakeMinimalGen1DMKernel("dm", DataMovementProcessor::RISCV_0);
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    dfb.advanced_options.allow_instance_multi_binding = true;
+
+    // Both kernels intentionally bind both sides: on Gen1 this escape hatch represents one
+    // legacy circular buffer shared across RISCs, not an intra-Tensix credit-flow DFB.
+    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "compute_out"));
+    compute.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "compute_in"));
+    dm.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "dm_out"));
+    dm.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "dm_in"));
+
+    spec.kernels = {compute, dm};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"compute", "dm"})};
+
+    auto program = MakeProgramFromSpec(*mesh_device_, spec);
+    const auto dfb_id = program.impl().get_dfb_handle("dfb");
+    const auto& config = program.impl().get_dataflow_buffer(dfb_id)->config;
+    EXPECT_FALSE(config.tensix_scope.has_value());
+    EXPECT_FALSE(config.enable_producer_implicit_sync);
+    EXPECT_FALSE(config.enable_consumer_implicit_sync);
 }
 
 TEST_F(ProgramSpecTestGen1, CPU_MultiThreadedDMKernelFails) {
@@ -5284,6 +5698,39 @@ TEST_F(ProgramSpecTestQuasar, CPU_AliasDFBFailsOnInconsistentBorrowedFrom) {
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("inconsistent borrowed_from")));
+}
+
+TEST_F(ProgramSpecTestQuasar, AliasDFBFailsOnInconsistentBorrowedMemoryOffset) {
+    const NodeCoord node{0, 0};
+
+    auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/16, /*num_entries=*/2);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/16, /*num_entries=*/2);
+    dfb_a.advanced_options = DFBAdvancedOptions{.alias_with = {DFBSpecName{"dfb_b"}}};
+    dfb_b.advanced_options = DFBAdvancedOptions{.alias_with = {DFBSpecName{"dfb_a"}}};
+    dfb_a.borrowed_from = TensorParamName{"borrowed_tensor"};
+    dfb_b.borrowed_from = TensorParamName{"borrowed_tensor"};
+    dfb_a.borrowed_memory_offset = 0;
+    dfb_b.borrowed_memory_offset = 16;
+
+    KernelSpec producer = MakeMinimalGen2DMKernel("producer_kernel");
+    KernelSpec consumer = MakeMinimalGen2DMKernel("consumer_kernel");
+    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb_a"}, "out_a"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_a"}, "in_a"));
+    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb_b"}, "out_b"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb_b"}, "in_b"));
+
+    auto tensor_param = MakeMinimalTensorParameter("borrowed_tensor", tt::tt_metal::BufferType::L1);
+    BindTensorParameterToKernel(producer, "borrowed_tensor", "borrowed_t");
+
+    ProgramSpec spec;
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb_a, dfb_b};
+    spec.tensor_parameters = {tensor_param};
+    spec.work_units = {MakeMinimalWorkUnit("wu", node, {"producer_kernel", "consumer_kernel"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("inconsistent borrowed_memory_offset")));
 }
 
 //---------------------------------------------------------------------------------

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -203,6 +203,7 @@ struct DFBAdvancedOptions {
     // It is NOT supported on Gen2 architectures: setting this flag on a Gen2
     // target is a hard error, whether or not any instance is actually multi-bound.
     bool allow_instance_multi_binding = false;
+
 };
 
 struct AdvancedKernelRunArgs {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -129,6 +129,13 @@ struct DataflowBufferSpec {
     // (TODO: this should become std::variant<TensorParamName, BufferParameterName>.)
     std::optional<TensorParamName> borrowed_from = std::nullopt;
 
+    // Byte offset from the borrowed memory object's per-node base address. This
+    // preserves legacy globally allocated CB views that occupy a subrange of a
+    // sharded tensor without allocating another DFB or copying data. A nonzero offset must be aligned
+    // both to entry_size (so the view begins on a DFB entry boundary) and to the backing buffer's
+    // L1/NoC address alignment (so the absolute base + offset remains a legal NoC address).
+    uint32_t borrowed_memory_offset = 0;
+
     //////////////////////////////
     // Advanced options (see advanced_options.hpp)
     //////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -138,9 +138,19 @@ struct KernelSpec {
         enum class AccessPattern { STRIDED, ALL, BLOCKED };
 
         DFBSpecName dfb_spec_name;   // identify the DFB within the ProgramSpec
-        std::string accessor_name;   // DFB accessor name (used in the kernel source code)
+        std::string accessor_name;   // Primary DFB accessor name (used in the kernel source code)
         EndpointType endpoint_type;  // producer or consumer
         AccessPattern access_pattern = AccessPattern::STRIDED;
+        // Additional constexpr accessor names for the same DFB device slot. This is an escape hatch
+        // for migrating legacy kernels in which multiple semantic CB names intentionally shared one
+        // physical CB index. Aliases do not add endpoints, storage, or data movement.
+        std::vector<std::string> accessor_aliases = {};
+        // Compatibility escape hatch for a token referenced only from a compile-time-discarded branch.
+        // If the named spec is absent, emit a placeholder token and allocate no DFB storage. Using that
+        // token at runtime is invalid; normal DFB bindings must leave this false. The placeholder is
+        // a bare numeric sentinel to preserve Gen1 APIs that accept raw CB ids, so it cannot carry a
+        // TensorAccessor-style live-use trap.
+        bool allow_unbound_for_constexpr_discard = false;
     };
     Group<DFBBinding> dfb_bindings;
 
@@ -150,6 +160,10 @@ struct KernelSpec {
     struct SemaphoreBinding {
         SemaphoreSpecName semaphore_spec_name;  // identify the semaphore within the ProgramSpec
         std::string accessor_name;              // semaphore accessor name (used in the kernel source code)
+        // Compatibility escape hatch for a token referenced only from a compile-time-discarded branch.
+        // If the named spec is absent, emit an invalid numeric placeholder and allocate no semaphore.
+        // The numeric form preserves legacy semaphore APIs and therefore cannot carry a live-use trap.
+        bool allow_unbound_for_constexpr_discard = false;
     };
     Group<SemaphoreBinding> semaphore_bindings;
 
@@ -160,6 +174,10 @@ struct KernelSpec {
     struct ScratchpadBinding {
         ScratchpadSpecName scratchpad_spec_name;  // identify the scratchpad within the ProgramSpec
         std::string accessor_name;                // scratchpad accessor name (used in the kernel source code)
+        // Compatibility escape hatch for a token referenced only from a compile-time-discarded branch.
+        // If the named spec is absent, emit a zero-sized token and allocate no L1. Using that token at
+        // runtime is invalid; normal scratchpad bindings must leave this false.
+        bool allow_unbound_for_constexpr_discard = false;
     };
     Group<ScratchpadBinding> scratchpad_bindings;
 
@@ -174,6 +192,9 @@ struct KernelSpec {
     struct TensorBinding {
         TensorParamName tensor_parameter_name;  // identify the TensorParameter within the ProgramSpec
         std::string accessor_name;              // tensor accessor name (used in the kernel source code)
+        // Compatibility escape hatch for a token referenced only from a compile-time-discarded branch.
+        // If the named parameter is absent, emit token metadata but no CTA/CRTA payload or runtime patching.
+        bool allow_unbound_for_constexpr_discard = false;
     };
     Group<TensorBinding> tensor_bindings;
 

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -54,6 +55,10 @@ public:
 
     // Used in ops.
     std::vector<std::shared_ptr<CircularBuffer>> circular_buffers() const;
+
+    // Post-realization diagnostics for Metal 2.0 programs.
+    uint32_t total_local_dataflow_buffer_size() const;
+    uint32_t get_dataflow_buffer_entry_size(const std::string& name) const;
 
     // debug/test/internal usage.
     detail::ProgramImpl& impl() { return *internal_; }

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -70,13 +70,14 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t call_
 #endif
 }
 
-#if (defined(REDUCE_OP) and defined(REDUCE_DIM)) or defined(__DOXYGEN__)
 // clang-format off
 /**
  * Short initializes the tilize operation with reduction.
  *
  * | Param Type | Name             | Description                          | Type     | Valid Range | Required |
  * |------------|------------------|--------------------------------------|----------|-------------|----------|
+ * | Template   | reduce_op        | Reduction operation                  | PoolType | MAX/AVG     | True     |
+ * | Template   | reduce_dim       | Reduction dimension                  | ReduceDim | ROW/COL/SCALAR | True |
  * | Template   | neginf_srcA      | NegInf source A flag                 | bool     | true/false  | False    |
  * | Template   | zero_srcA_reduce | Zero source A for reduce flag        | bool     | true/false  | False    |
  * | Function   | icb0             | Input circular buffer A identifier   | uint32_t | 0 to 31     | True     |
@@ -87,15 +88,29 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t call_
  * set_unpack_face_geometry / set_tile_dims on the host.
  */
 // clang-format on
-template <bool neginf_srcA = true, bool zero_srcA_reduce = false, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+template <
+    PoolType reduce_op,
+    ReduceDim reduce_dim,
+    bool neginf_srcA = true,
+    bool zero_srcA_reduce = false,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void tilizeA_B_reduce_init(
     uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1_scaler, call_line);
     UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true /*reload_srcB*/, false /*zero_srcA*/, zero_srcA_reduce>(
         icb0, icb1_scaler, block)));
-    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, is_fp32_dest_acc_en, MATH_FIDELITY>(icb0, icb1_scaler)));
+    MATH((llk_math_reduce_init<reduce_op, reduce_dim, is_fp32_dest_acc_en, MATH_FIDELITY>(icb0, icb1_scaler)));
 }
-#endif  // (REDUCE_OP && REDUCE_DIM) || __DOXYGEN__
+
+#if (defined(REDUCE_OP) and defined(REDUCE_DIM)) or defined(__DOXYGEN__)
+// Compatibility wrapper for kernels that have not yet migrated their reduction selection
+// from compiler defines to explicit constexpr template arguments.
+template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
+ALWI void tilizeA_B_reduce_init(
+    uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t call_line = __builtin_LINE()) {
+    tilizeA_B_reduce_init<REDUCE_OP, REDUCE_DIM, neginf_srcA, zero_srcA_reduce>(icb0, icb1_scaler, block, call_line);
+}
+#endif
 
 #ifndef ARCH_QUASAR
 // clang-format off

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -373,6 +373,18 @@ public:
     friend class tensor_accessor::PagesAddressIteratorInterleaved<TensorAccessor>;
 };
 
+struct ConstexprDiscardTensorAccessorSpec {};
+
+template <>
+struct TensorAccessor<ConstexprDiscardTensorAccessorSpec> {
+    // This specialization exists only so an accessor in an `if constexpr (false)` branch is
+    // well-formed. Reaching it at runtime is always a host-schema/kernel-schema mismatch. Its
+    // parse-only API is intentionally minimal and should be extended only when another migrated
+    // kernel's discarded branch requires an additional member.
+    explicit TensorAccessor(tensor_accessor::ConstexprDiscardTensorBindingToken) { ASSERT(false); }
+    uint32_t get_bank_base_address() const { return 0; }
+};
+
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 template <
     uint32_t RankCT,
@@ -562,6 +574,9 @@ TensorAccessor(tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>
         /* IsDram */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_dram,
         /* IsShardContiguous */
         TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_shard_contiguous>>;
+
+TensorAccessor(tensor_accessor::ConstexprDiscardTensorBindingToken)
+    -> TensorAccessor<ConstexprDiscardTensorAccessorSpec>;
 
 template <std::size_t CTA_OFFSET, std::size_t CRTA_OFFSET>
 TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t, uint32_t)

--- a/tt_metal/hw/inc/api/tensor/tensor_binding_token.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_binding_token.h
@@ -46,4 +46,8 @@ struct TensorBindingToken {
     static constexpr uint32_t addr_crta_offset = ADDR_CRTA_OFFSET;  // in bytes
 };
 
+// Parse-only token for a binding referenced exclusively from an if-constexpr-discarded branch.
+// It deliberately carries no CTA/CRTA offsets; constructing an accessor from it in live code is invalid.
+struct ConstexprDiscardTensorBindingToken {};
+
 }  // namespace tensor_accessor

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -556,6 +556,7 @@ struct Metal2BindingsSnapshot {
         std::string name;
         uint32_t cta_offset;
         uint32_t addr_crta_offset;
+        bool constexpr_discard_only;
     };
     // Scratchpad bindings, in insertion order (matches genfiles.cpp's vector).
     struct ScratchEntry {
@@ -584,8 +585,8 @@ struct Metal2BindingsSnapshot {
             s += ":sem:" + name + "=" + std::to_string(id);
         }
         for (const auto& ta : ta_accessors) {
-            s += ":ta:" + ta.name + "=" + std::to_string(ta.cta_offset) + "," +
-                 std::to_string(ta.addr_crta_offset);
+            s += ":ta:" + ta.name + "=" + std::to_string(ta.cta_offset) + "," + std::to_string(ta.addr_crta_offset) +
+                 "," + std::to_string(ta.constexpr_discard_only);
         }
         for (const auto& sp : scratch_accessors) {
             s += ":scratch:" + sp.name + "=" + std::to_string(sp.size_bytes) + "," + std::to_string(sp.addr_crta_word);
@@ -809,7 +810,12 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
         // num_rt_words == 0 and are unaffected. Fail loudly on dynamic-shape until
         // snapshot + cache key + get_common_vararg offset math are wired up to
         // consume the per-binding count.
-        [&s](const std::string& name, uint32_t cta_off, uint32_t addr_crta_off, uint32_t num_rt_words) {
+        [&s](
+            const std::string& name,
+            uint32_t cta_off,
+            uint32_t addr_crta_off,
+            uint32_t num_rt_words,
+            bool constexpr_discard_only) {
             TT_FATAL(
                 num_rt_words == 0,
                 "Emule does not yet support dynamic-shape Metal 2.0 tensor bindings "
@@ -819,7 +825,7 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
                 "before enabling this path.",
                 name,
                 num_rt_words);
-            s.ta_accessors.push_back({name, cta_off, addr_crta_off});
+            s.ta_accessors.push_back({name, cta_off, addr_crta_off, constexpr_discard_only});
         });
     kernel.process_scratchpad_binding_handles(
         [&s](const std::string& name, uint32_t size_bytes, uint32_t addr_crta_word) {
@@ -904,6 +910,10 @@ static void emit_metal2_namespaces(
     if (!s.ta_accessors.empty()) {
         f << "namespace tensor {\n";
         for (const auto& ta : s.ta_accessors) {
+            if (ta.constexpr_discard_only) {
+                f << "constexpr ::tensor_accessor::ConstexprDiscardTensorBindingToken " << ta.name << "{};\n";
+                continue;
+            }
             f << "using " << ta.name << "_t = ::tensor_accessor::TensorBindingToken<" << ta.cta_offset << "u, "
               << ta.addr_crta_offset << "u>;\n";
             f << "constexpr " << ta.name << "_t " << ta.name << "{};\n";
@@ -926,8 +936,12 @@ static void emit_metal2_namespaces(
     // section, and the scratchpad section.
     if (s.is_metal2) {
         const uint32_t named_rta_words = static_cast<uint32_t>(s.runtime_arg_names.size());
-        const uint32_t named_crta_words = static_cast<uint32_t>(
-            s.common_runtime_arg_names.size() + s.ta_accessors.size() + s.scratch_accessors.size());
+        uint32_t num_tensor_bindings = 0;
+        for (const auto& ta : s.ta_accessors) {
+            num_tensor_bindings += !ta.constexpr_discard_only;
+        }
+        const uint32_t named_crta_words =
+            static_cast<uint32_t>(s.common_runtime_arg_names.size() + num_tensor_bindings + s.scratch_accessors.size());
         f << "FORCE_INLINE uint32_t get_vararg(uint32_t idx) { "
           << "return get_arg_val<uint32_t>(" << named_rta_words << " + idx); }\n";
         f << "FORCE_INLINE uint32_t get_common_vararg(uint32_t idx) { "

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -332,9 +332,15 @@ void Kernel::process_tensor_binding_handles(const std::function<void(
                                                 const std::string& accessor_name,
                                                 uint32_t cta_offset,
                                                 uint32_t addr_crta_offset,
-                                                uint32_t num_runtime_field_crta_words)> callback) const {
+                                                uint32_t num_runtime_field_crta_words,
+                                                bool constexpr_discard_only)> callback) const {
     for (const auto& handle : this->tensor_binding_handles_) {
-        callback(handle.accessor_name, handle.cta_offset, handle.addr_crta_offset, handle.num_runtime_field_crta_words);
+        callback(
+            handle.accessor_name,
+            handle.cta_offset,
+            handle.addr_crta_offset,
+            handle.num_runtime_field_crta_words,
+            handle.constexpr_discard_only);
     }
 }
 
@@ -589,6 +595,7 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(static_cast<uint64_t>(handle.cta_offset));
         hasher.update(static_cast<uint64_t>(handle.addr_crta_offset));
         hasher.update(static_cast<uint64_t>(handle.num_runtime_field_crta_words));
+        hasher.update(handle.constexpr_discard_only);
     }
     // Scratchpad binding handles: like tensor bindings, stored in order and emitted by genfiles in
     // the same order. Hash accessor_name + size_bytes + addr_crta_word — the accessor's compile-time

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -117,6 +117,7 @@ struct TensorBindingHandle {
     // distinguish them with a boolean.
     // (We'll need to extend this to something more flexible if additional possibilities are added.)
     bool runtime_field_is_page_size = false;
+    bool constexpr_discard_only = false;
 };
 
 // Metal 2.0: per-kernel resolved scratchpad binding.
@@ -232,7 +233,8 @@ public:
                                             const std::string& accessor_name,
                                             uint32_t cta_offset,
                                             uint32_t addr_crta_offset,
-                                            uint32_t num_runtime_field_crta_words)>) const override;
+                                            uint32_t num_runtime_field_crta_words,
+                                            bool constexpr_discard_only)>) const override;
     const std::vector<TensorBindingHandle>& tensor_binding_handles() const { return tensor_binding_handles_; }
     void process_scratchpad_binding_handles(
         std::function<void(const std::string& accessor_name, uint32_t size_bytes, uint32_t addr_crta_word)>)

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -440,7 +440,7 @@ void AttachBorrowedDFBBuffers(
 
     // tensor_by_param is the param_name -> MeshTensor lookup the caller already built to fill the
     // binding CRTA sections; reuse it here rather than rebuilding an identical map per enqueue.
-    for (const auto& [dfb_id, tp_name] : borrowed_bindings) {
+    for (const auto& [dfb_id, tp_name, memory_offset] : borrowed_bindings) {
         auto it = tensor_by_param.find(tp_name);
         if (it == tensor_by_param.end()) {
             // Partial update (require_all=false): the borrowed TensorParameter was omitted; the DFB
@@ -460,6 +460,7 @@ void AttachBorrowedDFBBuffers(
         // Attach-time legality checks (analogous to dynamic CB's
         // CircularBufferConfig::set_globally_allocated_address_and_total_size validations).
         //   - L1-residency: only L1 buffers may back a DFB.
+        //   - Alignment: the absolute borrowed subrange address must satisfy L1/NoC alignment.
         //   - Sizing: the DFB's total bytes must fit in the buffer's per-bank allocation.
         // ProgramSpec-time validation already enforced the TensorSpec-level analogs; these
         // refine the check now that a concrete Buffer is in hand.
@@ -469,26 +470,49 @@ void AttachBorrowedDFBBuffers(
             dfb_id,
             tp_name);
         auto dfb_impl = program_impl.get_dataflow_buffer(dfb_id);
-        const uint32_t dfb_total_bytes = dfb_impl->config.entry_size * dfb_impl->config.num_entries;
+        const uint64_t dfb_total_bytes =
+            static_cast<uint64_t>(dfb_impl->config.entry_size) * dfb_impl->config.num_entries;
         TT_FATAL(
-            dfb_total_bytes <= buffer->aligned_size_per_bank(),
-            "Borrowed-memory DFB id {} (from TensorParameter '{}') has total size {} B, which exceeds the borrowed "
-            "Buffer's per-bank size of {} B.",
+            memory_offset % dfb_impl->config.entry_size == 0,
+            "Borrowed-memory DFB id {} (from TensorParameter '{}') has subrange offset {} B, which is not aligned "
+            "to its effective entry size of {} B.",
             dfb_id,
             tp_name,
+            memory_offset,
+            dfb_impl->config.entry_size);
+        const uint64_t address = static_cast<uint64_t>(buffer->address()) + memory_offset;
+        TT_FATAL(
+            address <= std::numeric_limits<uint32_t>::max(),
+            "Borrowed Buffer subrange address {} (base {} + offset {}) for DFB id {} (TensorParameter '{}') "
+            "exceeds uint32_t max.",
+            address,
+            buffer->address(),
+            memory_offset,
+            dfb_id,
+            tp_name);
+        TT_FATAL(
+            address % buffer->alignment() == 0,
+            "Borrowed-memory DFB id {} (from TensorParameter '{}') has absolute address {} (buffer address {} + "
+            "offset {}), which is not aligned to the L1/NoC address alignment of {} bytes.",
+            dfb_id,
+            tp_name,
+            address,
+            buffer->address(),
+            memory_offset,
+            buffer->alignment());
+        TT_FATAL(
+            static_cast<uint64_t>(memory_offset) + dfb_total_bytes <= buffer->aligned_size_per_bank(),
+            "Borrowed-memory DFB id {} (from TensorParameter '{}') has subrange offset {} + size {} B, which "
+            "exceeds the borrowed Buffer's per-bank size of {} B.",
+            dfb_id,
+            tp_name,
+            memory_offset,
             dfb_total_bytes,
             buffer->aligned_size_per_bank());
 
         // Attach the address to the device-side DFB. Per-enqueue update_program_dispatch_commands
         // reads from the cache this populates, so no further dispatch-command invalidation is
         // needed for either first-call or re-entry.
-        const auto address = buffer->address();
-        TT_FATAL(
-            address <= std::numeric_limits<uint32_t>::max(),
-            "Borrowed Buffer base address {} for DFB id {} (TensorParameter '{}') exceeds uint32_t max.",
-            address,
-            dfb_id,
-            tp_name);
         dfb_impl->set_borrowed_memory_base_addr(static_cast<uint32_t>(address));
     }
 }
@@ -532,6 +556,9 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
     // kernel_run_args loop below and the binding-only second pass after it.
     auto append_binding_crtas = [&](const auto& binding_handles, std::vector<uint32_t>& out) {
         for (const auto& handle : binding_handles) {
+            if (handle.constexpr_discard_only) {
+                continue;
+            }
             auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
             TT_FATAL(
                 t_it != tensor_by_param.end(),
@@ -717,7 +744,9 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
         const auto& binding_handles = kernel->tensor_binding_handles();
         std::size_t binding_section_words = 0;
         for (const auto& handle : binding_handles) {
-            binding_section_words += 1u + handle.num_runtime_field_crta_words;
+            if (!handle.constexpr_discard_only) {
+                binding_section_words += 1u + handle.num_runtime_field_crta_words;
+            }
         }
         std::vector<uint32_t> combined_crtas;
         combined_crtas.reserve(
@@ -760,7 +789,9 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
         std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
         const auto& binding_handles = kernel->tensor_binding_handles();
         const auto& scratchpad_handles = kernel->scratchpad_binding_handles();
-        if (binding_handles.empty() && scratchpad_handles.empty()) {
+        const bool has_runtime_tensor_binding =
+            std::ranges::any_of(binding_handles, [](const auto& handle) { return !handle.constexpr_discard_only; });
+        if (!has_runtime_tensor_binding && scratchpad_handles.empty()) {
             continue;  // No bindings => nothing to supply; no CRTA dispatch buffer needed.
         }
         // Binding-only kernel: its CRTA buffer is exactly the TensorBinding + scratchpad sections (it has
@@ -832,7 +863,9 @@ void UpdateTensorArgs(
     for (const auto& kernel_name : program_impl.get_registered_kernel_names()) {
         std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
         const auto& binding_handles = kernel->tensor_binding_handles();
-        if (binding_handles.empty()) {
+        const bool has_runtime_tensor_binding =
+            std::ranges::any_of(binding_handles, [](const auto& handle) { return !handle.constexpr_discard_only; });
+        if (!has_runtime_tensor_binding) {
             continue;
         }
 
@@ -847,6 +880,9 @@ void UpdateTensorArgs(
 
         RuntimeArgsData& crta = kernel->common_runtime_args_data();
         for (const auto& handle : binding_handles) {
+            if (handle.constexpr_discard_only) {
+                continue;
+            }
             auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
             TT_FATAL(
                 t_it != tensor_by_param.end(),
@@ -1043,7 +1079,8 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
     // (require_all=true); on this partial path the backing tensor may be omitted, which would
     // otherwise let a grown DFB overflow its borrowed buffer's per-bank region unchecked at execution.
     std::unordered_map<uint32_t, std::string> borrowed_backing;  // dfb_id -> backing TensorParameter name
-    for (const auto& [dfb_id, tp_name] : program_impl.get_dfb_borrowed_bindings()) {
+    for (const auto& [dfb_id, tp_name, memory_offset] : program_impl.get_dfb_borrowed_bindings()) {
+        (void)memory_offset;
         borrowed_backing.emplace(dfb_id, tp_name);
     }
     std::unordered_set<DFBSpecName> dfbs_with_params;
@@ -1189,7 +1226,9 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
                 const auto& binding_handles = kernel->tensor_binding_handles();
                 size_t binding_section_words = 0;
                 for (const auto& h : binding_handles) {
-                    binding_section_words += 1u + h.num_runtime_field_crta_words;
+                    if (!h.constexpr_discard_only) {
+                        binding_section_words += 1u + h.num_runtime_field_crta_words;
+                    }
                 }
                 const size_t scratchpad_section_words = kernel->scratchpad_binding_handles().size();
                 const size_t crta_vararg_base =
@@ -1227,11 +1266,16 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
         for (const auto& kernel_name : program_impl.get_registered_kernel_names()) {
             std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
             const auto& binding_handles = kernel->tensor_binding_handles();
-            if (binding_handles.empty()) {
+            const bool has_runtime_tensor_binding =
+                std::ranges::any_of(binding_handles, [](const auto& handle) { return !handle.constexpr_discard_only; });
+            if (!has_runtime_tensor_binding) {
                 continue;
             }
             bool any_supplied = false;
             for (const auto& handle : binding_handles) {
+                if (handle.constexpr_discard_only) {
+                    continue;
+                }
                 if (tensor_by_param.contains(handle.tensor_parameter_name)) {
                     any_supplied = true;
                     break;
@@ -1247,6 +1291,9 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
                 kernel_name);
             RuntimeArgsData& crta = kernel->common_runtime_args_data();
             for (const auto& handle : binding_handles) {
+                if (handle.constexpr_discard_only) {
+                    continue;
+                }
                 auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
                 if (t_it == tensor_by_param.end()) {
                     continue;  // tensor omitted → binding slot retained.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -301,6 +301,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         // use a single device-side accessor name instead of two aliasing wrappers.
         struct AccessorBindingInfo {
             DFBSpecName dfb_spec_name;
+            bool primary = false;
             bool has_producer = false;
             bool has_consumer = false;
         };
@@ -318,25 +319,56 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         };
         std::unordered_map<DFBSpecName, DFBBoundRoles> dfb_bound_roles;
         for (const auto& dfb_binding : kernel.dfb_bindings) {
-            auto [it, inserted] = accessor_bindings.try_emplace(
-                dfb_binding.accessor_name, AccessorBindingInfo{dfb_binding.dfb_spec_name});
-            AccessorBindingInfo& info = it->second;
-            if (inserted) {
-                TT_FATAL(
-                    IsValidCppIdentifier(dfb_binding.accessor_name),
-                    "Kernel '{}' DFB accessor_name '{}' must be a valid C++ identifier",
-                    kernel.unique_id,
-                    dfb_binding.accessor_name);
-            } else {
-                TT_FATAL(
-                    info.dfb_spec_name == dfb_binding.dfb_spec_name,
-                    "Kernel '{}' uses accessor_name '{}' for two different DFBs ('{}' and '{}'). "
-                    "Reusing a name is only permitted when both bindings target the same DFB (self-loop pair).",
-                    kernel.unique_id,
-                    dfb_binding.accessor_name,
-                    info.dfb_spec_name,
-                    dfb_binding.dfb_spec_name);
+            auto register_accessor = [&](const std::string& accessor_name, bool primary) {
+                auto [it, inserted] = accessor_bindings.try_emplace(
+                    accessor_name, AccessorBindingInfo{.dfb_spec_name = dfb_binding.dfb_spec_name, .primary = primary});
+                AccessorBindingInfo& info = it->second;
+                if (inserted) {
+                    TT_FATAL(
+                        IsValidCppIdentifier(accessor_name),
+                        "Kernel '{}' DFB accessor_name '{}' must be a valid C++ identifier",
+                        kernel.unique_id,
+                        accessor_name);
+                } else {
+                    TT_FATAL(
+                        info.dfb_spec_name == dfb_binding.dfb_spec_name,
+                        "Kernel '{}' uses accessor_name '{}' for two different DFBs; an accessor name may be reused "
+                        "only by the producer/consumer pair of the same self-loop DFB (first DFB '{}', conflicting "
+                        "DFB '{}')",
+                        kernel.unique_id,
+                        accessor_name,
+                        info.dfb_spec_name,
+                        dfb_binding.dfb_spec_name);
+                    TT_FATAL(
+                        primary && info.primary,
+                        "Kernel '{}' reuses DFB accessor name '{}' across bindings. Accessor aliases must be "
+                        "unique within a kernel; only a primary accessor may be reused by a self-loop pair.",
+                        kernel.unique_id,
+                        accessor_name);
+                }
+                return std::ref(info);
+            };
+            AccessorBindingInfo& info = register_accessor(dfb_binding.accessor_name, true).get();
+            for (const auto& alias : dfb_binding.accessor_aliases) {
+                register_accessor(alias, false);
             }
+            const bool has_dfb = collected.dfb_by_name.contains(dfb_binding.dfb_spec_name);
+            TT_FATAL(
+                has_dfb || dfb_binding.allow_unbound_for_constexpr_discard,
+                "Kernel '{}' references unknown DFB '{}'",
+                kernel.unique_id,
+                dfb_binding.dfb_spec_name);
+            TT_FATAL(
+                !(has_dfb && dfb_binding.allow_unbound_for_constexpr_discard),
+                "Kernel '{}' marks DFB '{}' as optional for constexpr discard, but that DataflowBufferSpec is "
+                "present; optional bindings must be unbound so accidental L1 allocation is diagnosed",
+                kernel.unique_id,
+                dfb_binding.dfb_spec_name);
+            TT_FATAL(
+                !dfb_binding.allow_unbound_for_constexpr_discard || dfb_binding.accessor_aliases.empty(),
+                "Kernel '{}' optional constexpr-discard DFB '{}' cannot declare accessor aliases",
+                kernel.unique_id,
+                dfb_binding.dfb_spec_name);
             const bool is_producer = (dfb_binding.endpoint_type == DFBEndpointType::PRODUCER);
             bool& seen_this_type = is_producer ? info.has_producer : info.has_consumer;
             TT_FATAL(
@@ -369,12 +401,9 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 dfb_binding.dfb_spec_name);
             role_already_bound = true;
 
-            // Referential integrity: the DFB must exist
-            TT_FATAL(
-                collected.dfb_by_name.contains(dfb_binding.dfb_spec_name),
-                "Kernel '{}' references unknown DFB '{}'",
-                kernel.unique_id,
-                dfb_binding.dfb_spec_name);
+            if (!has_dfb) {
+                continue;
+            }
 
             CollectedSpecData::DFBEndpointInfo& endpoint_info = collected.dfb_endpoints[dfb_binding.dfb_spec_name];
 
@@ -430,9 +459,16 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' semaphore accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            const bool has_semaphore = collected.semaphore_by_name.contains(binding.semaphore_spec_name);
             TT_FATAL(
-                collected.semaphore_by_name.contains(binding.semaphore_spec_name),
+                has_semaphore || binding.allow_unbound_for_constexpr_discard,
                 "Kernel '{}' references unknown semaphore '{}'",
+                kernel.unique_id,
+                binding.semaphore_spec_name);
+            TT_FATAL(
+                !(has_semaphore && binding.allow_unbound_for_constexpr_discard),
+                "Kernel '{}' marks semaphore '{}' as optional for constexpr discard, but that SemaphoreSpec is "
+                "present; optional bindings must be unbound so accidental allocation is diagnosed",
                 kernel.unique_id,
                 binding.semaphore_spec_name);
         }
@@ -470,9 +506,16 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' scratchpad accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            const bool has_scratchpad = collected.scratchpad_by_name.contains(binding.scratchpad_spec_name);
             TT_FATAL(
-                collected.scratchpad_by_name.contains(binding.scratchpad_spec_name),
+                has_scratchpad || binding.allow_unbound_for_constexpr_discard,
                 "Kernel '{}' references unknown scratchpad '{}'",
+                kernel.unique_id,
+                binding.scratchpad_spec_name);
+            TT_FATAL(
+                !(has_scratchpad && binding.allow_unbound_for_constexpr_discard),
+                "Kernel '{}' marks scratchpad '{}' as optional for constexpr discard, but that ScratchpadSpec is "
+                "present; optional bindings must be unbound so accidental L1 allocation is diagnosed",
                 kernel.unique_id,
                 binding.scratchpad_spec_name);
             // A kernel may bind a given scratchpad at most once. Two bindings would request two
@@ -487,6 +530,9 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 kernel.unique_id,
                 binding.scratchpad_spec_name,
                 binding.accessor_name);
+            if (!has_scratchpad) {
+                continue;
+            }
             collected.scratchpad_binders[binding.scratchpad_spec_name].push_back(&kernel);
         }
     }
@@ -525,13 +571,23 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
                 "Kernel '{}' tensor accessor_name '{}' must be a valid C++ identifier",
                 kernel.unique_id,
                 binding.accessor_name);
+            const bool has_tensor_parameter =
+                collected.tensor_parameter_by_name.contains(binding.tensor_parameter_name);
             TT_FATAL(
-                collected.tensor_parameter_by_name.contains(binding.tensor_parameter_name),
+                has_tensor_parameter || binding.allow_unbound_for_constexpr_discard,
                 "Kernel '{}' references unknown TensorParameter '{}'",
                 kernel.unique_id,
                 binding.tensor_parameter_name);
+            TT_FATAL(
+                !(has_tensor_parameter && binding.allow_unbound_for_constexpr_discard),
+                "Kernel '{}' marks TensorParameter '{}' as optional for constexpr discard, but that parameter is "
+                "present; optional bindings must be unbound so accidental runtime payload is diagnosed",
+                kernel.unique_id,
+                binding.tensor_parameter_name);
 
-            collected.tensor_parameter_users[binding.tensor_parameter_name].push_back(&kernel);
+            if (has_tensor_parameter) {
+                collected.tensor_parameter_users[binding.tensor_parameter_name].push_back(&kernel);
+            }
         }
 
         std::unordered_set<std::string> reserved_type_aliases;
@@ -1319,7 +1375,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         // flag: the role-uniformity checks are skipped and the per-node census relaxes its "exactly
         // one" counts to "at least one".
         const bool allow_multi = dfb.advanced_options.allow_instance_multi_binding;
-
         // (3) and (4): per-role uniformity of binding-site parameters, plus kernel kind.
         // Kind (compute vs DM) must agree because the DFB's hardware config carries a single
         // processor mask per role, and compute / DM masks live in disjoint bit ranges (bits
@@ -1414,16 +1469,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             return names;
         };
 
-        // Per-node census. Under allow_multi (see top of loop) the "exactly one" upper bound relaxes
-        // to "at least one": a node may host multiple instances of a role, but must still host at
-        // least one producer AND one consumer, or the FIFO is half-wired.
+        // Per-node census. Under allow_multi, the "exactly one" upper bound relaxes to "at least one"
+        // on both sides.
         for (const NodeCoord& node : footprint) {
             auto p_it = producers_on_node.find(node);
             auto c_it = consumers_on_node.find(node);
             const size_t num_producers = p_it == producers_on_node.end() ? 0 : p_it->second.size();
             const size_t num_consumers = c_it == consumers_on_node.end() ? 0 : c_it->second.size();
-            const bool node_ok =
-                allow_multi ? (num_producers >= 1 && num_consumers >= 1) : (num_producers == 1 && num_consumers == 1);
+            const bool node_ok = allow_multi ? (num_producers >= 1 && num_consumers >= 1)
+                                             : (num_producers == 1 && num_consumers == 1);
             if (node_ok) {
                 continue;
             }
@@ -1438,8 +1492,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     "(via its WorkUnitSpec membership).";
             } else {
                 guidance =
-                    "Multiple same-role kernel instances land on this node — their placements overlap; "
-                    "give each disjoint nodes.";
+                    "Multiple same-role kernel instances land on this node — their placements overlap; give each "
+                    "disjoint nodes. If they intentionally share a Gen1 plain CB, use allow_instance_multi_binding.";
             }
             TT_FATAL(
                 false,
@@ -1580,8 +1634,26 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // That's on the user; this is an advanced feature.
     for (const auto& dfb : spec.dataflow_buffers) {
         if (!dfb.borrowed_from.has_value()) {
+            TT_FATAL(
+                dfb.borrowed_memory_offset == 0,
+                "DFB '{}' specifies borrowed_memory_offset={} without borrowed_from.",
+                dfb.unique_id,
+                dfb.borrowed_memory_offset);
             continue;
         }
+        TT_FATAL(
+            dfb.borrowed_memory_offset % dfb.entry_size == 0,
+            "DFB '{}' borrowed_memory_offset={} must be aligned to entry_size={}.",
+            dfb.unique_id,
+            dfb.borrowed_memory_offset,
+            dfb.entry_size);
+        const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+        TT_FATAL(
+            dfb.borrowed_memory_offset % l1_alignment == 0,
+            "DFB '{}' borrowed_memory_offset={} must be aligned to the L1/NoC address alignment of {} bytes.",
+            dfb.unique_id,
+            dfb.borrowed_memory_offset,
+            l1_alignment);
         const TensorParamName& tp_name = *dfb.borrowed_from;
         auto it = collected.tensor_parameter_by_name.find(tp_name);
         TT_FATAL(
@@ -1597,23 +1669,26 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             "required). Both L1 and L1_SMALL are accepted.",
             dfb.unique_id,
             tp_name);
-        // Coarse spec-time sizing check against the TensorSpec's full packed size. No Buffer is
-        // available at spec time, so we can't query the per-bank allocation; the precise per-bank
-        // check fires at attach time in AttachBorrowedDFBBuffers (program_run_args.cpp), where
-        // a Buffer is in hand. For sharded L1 tensors the two checks differ — a DFB can pass
-        // here against the full-tensor size and still fail per-bank later. By design.
+        // Coarse spec-time sizing check against the TensorSpec's full packed size. A sharded
+        // TensorSpec does not describe its aligned per-bank allocation: for a small shard that
+        // allocation can legitimately be larger than the tensor's packed logical payload. Defer
+        // sharded sizing to the mandatory precise check in AttachBorrowedDFBBuffers, where the
+        // concrete Buffer's aligned_size_per_bank() is available.
         const size_t dfb_bytes = static_cast<size_t>(dfb.entry_size) * static_cast<size_t>(dfb.num_entries);
         const size_t tensor_bytes = tensor_spec.compute_packed_buffer_size_bytes();
-        TT_FATAL(
-            dfb_bytes <= tensor_bytes,
-            "DFB '{}' (entry_size {} * num_entries {} = {} bytes) is larger than its borrowed TensorParameter '{}' "
-            "({} bytes).",
-            dfb.unique_id,
-            dfb.entry_size,
-            dfb.num_entries,
-            dfb_bytes,
-            tp_name,
-            tensor_bytes);
+        if (!tensor_spec.memory_config().is_sharded()) {
+            TT_FATAL(
+                static_cast<size_t>(dfb.borrowed_memory_offset) + dfb_bytes <= tensor_bytes,
+                "DFB '{}' borrowed subrange (offset {} + entry_size {} * num_entries {} = {} bytes) is larger than "
+                "its borrowed TensorParameter '{}' ({} bytes).",
+                dfb.unique_id,
+                dfb.borrowed_memory_offset,
+                dfb.entry_size,
+                dfb.num_entries,
+                static_cast<size_t>(dfb.borrowed_memory_offset) + dfb_bytes,
+                tp_name,
+                tensor_bytes);
+        }
     }
 
     // Validate DFB alias groups.
@@ -1676,7 +1751,10 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     total_size_a == total_size_b,
                     "Aliased DFBs '{}' and '{}' have different total sizes ({} vs {} bytes). "
                     "Aliased DFBs must have the same total size (entry_size * num_entries).",
-                    dfb.unique_id, alias_name, total_size_a, total_size_b);
+                    dfb.unique_id,
+                    alias_name,
+                    total_size_a,
+                    total_size_b);
 
                 // Rule 3: same node coverage.
                 const auto& nodes_b = collected.dfb_node_set.at(alias_name);
@@ -1696,6 +1774,13 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     "of an alias group borrows, or all members borrow from the same TensorParameter.",
                     dfb.unique_id,
                     alias_name);
+                TT_FATAL(
+                    dfb.borrowed_memory_offset == alias_spec->borrowed_memory_offset,
+                    "Aliased DFBs '{}' and '{}' have inconsistent borrowed_memory_offset values ({} vs {}).",
+                    dfb.unique_id,
+                    alias_name,
+                    dfb.borrowed_memory_offset,
+                    alias_spec->borrowed_memory_offset);
             }
         }
     }
@@ -2470,6 +2555,14 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
     size_t crta_word_index = base_named_crta_count;
     uint32_t binding_section_words = 0;
     for (const auto& binding : kernel.tensor_bindings) {
+        if (binding.allow_unbound_for_constexpr_discard) {
+            out.handles.push_back(TensorBindingHandle{
+                .accessor_name = binding.accessor_name,
+                .tensor_parameter_name = binding.tensor_parameter_name.get(),
+                .constexpr_discard_only = true,
+            });
+            continue;
+        }
         const ResolvedTensorParameter& resolved = resolved_tensor_parameters.at(binding.tensor_parameter_name);
         const std::vector<uint32_t>& binding_ctas = resolved.cta_payload;
 
@@ -2517,11 +2610,11 @@ ScratchpadBindingsForKernel ResolveScratchpadBindingsForKernel(
 
     size_t crta_word_index = scratchpad_base_crta_word;
     for (const auto& binding : kernel.scratchpad_bindings) {
-        const ScratchpadSpec* scratchpad_spec = scratchpad_by_name.at(binding.scratchpad_spec_name);
+        const auto scratchpad_it = scratchpad_by_name.find(binding.scratchpad_spec_name);
 
         ScratchpadBindingHandle handle;
         handle.accessor_name = binding.accessor_name;
-        handle.size_bytes = scratchpad_spec->size_per_node;
+        handle.size_bytes = scratchpad_it == scratchpad_by_name.end() ? 0 : scratchpad_it->second->size_per_node;
         handle.addr_crta_word = static_cast<uint32_t>(crta_word_index);
         // handle.allocated_address stays 0 until allocate_scratchpads runs.
         out.handles.push_back(std::move(handle));
@@ -2536,17 +2629,32 @@ ScratchpadBindingsForKernel ResolveScratchpadBindingsForKernel(
 // dfb::<name> accessor, so it must be the device slot rather than the program-wide id.
 tt::tt_metal::DataflowBufferBindingHandleMap MakeDataflowBufferBindingHandles(
     const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot) {
+    constexpr uint16_t invalid_dfb_slot = std::numeric_limits<uint16_t>::max();
     tt::tt_metal::DataflowBufferBindingHandleMap out;
     out.reserve(kernel_spec.dfb_bindings.size());
     for (const auto& dfb_binding : kernel_spec.dfb_bindings) {
-        const uint32_t slot = dfb_name_to_slot.at(dfb_binding.dfb_spec_name);
+        const auto slot_it = dfb_name_to_slot.find(dfb_binding.dfb_spec_name);
+        if (slot_it == dfb_name_to_slot.end()) {
+            TT_FATAL(
+                dfb_binding.allow_unbound_for_constexpr_discard,
+                "Kernel '{}' has no device slot for DFB '{}'",
+                kernel_spec.unique_id,
+                dfb_binding.dfb_spec_name);
+            out.emplace(dfb_binding.accessor_name, invalid_dfb_slot);
+            continue;
+        }
+        const uint32_t slot = slot_it->second;
         TT_FATAL(
-            slot <= std::numeric_limits<uint16_t>::max(),
-            "Kernel '{}' DFB '{}' device slot {} does not fit uint16_t",
+            slot < invalid_dfb_slot,
+            "Kernel '{}' DFB '{}' device slot {} collides with the reserved optional-unbound sentinel {}",
             kernel_spec.unique_id,
             dfb_binding.dfb_spec_name,
-            slot);
+            slot,
+            invalid_dfb_slot);
         out.emplace(dfb_binding.accessor_name, static_cast<uint16_t>(slot));
+        for (const auto& alias : dfb_binding.accessor_aliases) {
+            out.emplace(alias, static_cast<uint16_t>(slot));
+        }
     }
     return out;
 }
@@ -2554,16 +2662,28 @@ tt::tt_metal::DataflowBufferBindingHandleMap MakeDataflowBufferBindingHandles(
 // Create map of accessor name -> logical Semaphore id
 tt::tt_metal::SemaphoreBindingHandleMap MakeSemaphoreBindingHandles(
     const KernelSpec& kernel_spec, const SemaphoreNameToIdMap& semaphore_name_to_id) {
+    constexpr uint16_t invalid_semaphore_id = std::numeric_limits<uint16_t>::max();
     tt::tt_metal::SemaphoreBindingHandleMap out;
     out.reserve(kernel_spec.semaphore_bindings.size());
     for (const auto& semaphore_binding : kernel_spec.semaphore_bindings) {
-        const uint32_t id = semaphore_name_to_id.at(semaphore_binding.semaphore_spec_name);
+        const auto id_it = semaphore_name_to_id.find(semaphore_binding.semaphore_spec_name);
+        if (id_it == semaphore_name_to_id.end()) {
+            TT_FATAL(
+                semaphore_binding.allow_unbound_for_constexpr_discard,
+                "Kernel '{}' has no id for semaphore '{}'",
+                kernel_spec.unique_id,
+                semaphore_binding.semaphore_spec_name);
+            out.emplace(semaphore_binding.accessor_name, invalid_semaphore_id);
+            continue;
+        }
+        const uint32_t id = id_it->second;
         TT_FATAL(
-            id <= std::numeric_limits<uint16_t>::max(),
-            "Kernel '{}' semaphore '{}' id {} does not fit uint16_t",
+            id < invalid_semaphore_id,
+            "Kernel '{}' semaphore '{}' id {} collides with the reserved optional-unbound sentinel {}",
             kernel_spec.unique_id,
             semaphore_binding.semaphore_spec_name,
-            id);
+            id,
+            invalid_semaphore_id);
         out.emplace(semaphore_binding.accessor_name, static_cast<uint16_t>(id));
     }
     return out;
@@ -2618,8 +2738,13 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         }
         return false;
     }();
+    // Gen1 instance-multi-binding is an escape hatch for legacy shared-CB topologies. It must
+    // remain a plain circular buffer even if one of its participants is a compute self-loop;
+    // interpreting that overlap as an intra-Tensix credit-flow DFB would no longer be plain-CB
+    // lowering and is incompatible with a DM participant on the same buffer.
+    const bool force_plain_gen1_cb = dfb_spec->advanced_options.allow_instance_multi_binding;
     std::optional<experimental::dfb::TensixScope> tensix_scope;
-    if (is_self_loop && producer->is_compute_kernel()) {
+    if (is_self_loop && producer->is_compute_kernel() && !force_plain_gen1_cb) {
         tensix_scope = experimental::dfb::TensixScope::INTRA;
     }
 
@@ -2634,11 +2759,11 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
             if (!ep.kernel->is_data_movement_kernel()) {
                 continue;
             }
-            any_dm = true;
             const auto& dm_config = std::get<DataMovementHardwareConfig>(ep.kernel->hw_config);
             if (!std::holds_alternative<DataMovementGen2Config>(dm_config)) {
                 continue;
             }
+            any_dm = true;
             if (DmKernelDisablesImplicitSync(std::get<DataMovementGen2Config>(dm_config), dfb_spec->unique_id)) {
                 disabled = true;
             }
@@ -3025,7 +3150,8 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // SetProgramRunArgs / UpdateTensorArgs can resolve and attach the actual L1 Buffer
         // at runtime (analog of dynamic CB's UpdateDynamicCircularBufferAddress).
         if (dfb_spec.borrowed_from.has_value()) {
-            program_impl->register_dfb_borrowed_binding(dfb_id, dfb_spec.borrowed_from->get());
+            program_impl->register_dfb_borrowed_binding(
+                dfb_id, dfb_spec.borrowed_from->get(), dfb_spec.borrowed_memory_offset);
         }
     }
 
@@ -3086,11 +3212,13 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         const auto& user_named_crtas = kernel_spec.runtime_arg_schema.common_runtime_arg_names;
         const auto& cta_varargs = kernel_spec.advanced_options.compile_time_varargs;
         const uint32_t vararg_cta_count = static_cast<uint32_t>(cta_varargs.size());
+        std::vector<uint32_t> positional_cta_prefix = cta_varargs;
+        const uint32_t positional_cta_prefix_count = static_cast<uint32_t>(positional_cta_prefix.size());
         TensorBindingsForKernel ta_bindings = ResolveTensorBindingsForKernel(
             kernel_spec,
             resolved_tensor_parameters,
             /*base_named_crta_count=*/user_named_crtas.size(),
-            /*base_cta_offset=*/vararg_cta_count);
+            /*base_cta_offset=*/positional_cta_prefix_count);
 
         // Create TensorBindingHandles for this kernel
         const std::vector<TensorBindingHandle>& tensor_binding_handles = ta_bindings.handles;
@@ -3112,8 +3240,8 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         // CRTA list through unchanged.
         const auto& named_rtas = kernel_spec.runtime_arg_schema.runtime_arg_names;
 
-        // Positional CTAs: [ user CTA varargs | TensorBinding CTA payloads ]
-        std::vector<uint32_t> compile_args = cta_varargs;
+        // Positional CTAs: [ user CTA varargs or legacy compatibility bindings | TensorBinding CTA payloads ]
+        std::vector<uint32_t> compile_args = std::move(positional_cta_prefix);
         compile_args.insert(compile_args.end(), ta_bindings.cta_words.begin(), ta_bindings.cta_words.end());
 
         // Create the kernel object

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -644,6 +644,20 @@ uint32_t ProgramImpl::get_dfb_handle(const std::string& name) const {
     return it->second;
 }
 
+uint32_t ProgramImpl::total_local_dataflow_buffer_size() const {
+    uint32_t total_size = 0;
+    for (const auto& dfb : dataflow_buffers_) {
+        if (!dfb->borrows_memory() && !dfb->alias_primary_id.has_value()) {
+            total_size += dfb->total_size();
+        }
+    }
+    return total_size;
+}
+
+uint32_t ProgramImpl::get_dataflow_buffer_entry_size(const std::string& name) const {
+    return get_dataflow_buffer(get_dfb_handle(name))->config.entry_size;
+}
+
 uint32_t ProgramImpl::get_semaphore_handle(const std::string& name) const {
     TT_FATAL(metal2_registry_, "Metal 2.0 registry not initialized (program was not created from ProgramSpec)");
     auto it = metal2_registry_->semaphore_handles.find(name);
@@ -783,15 +797,16 @@ std::vector<std::string> ProgramImpl::get_registered_tensor_parameter_names() co
     return names;
 }
 
-void ProgramImpl::register_dfb_borrowed_binding(uint32_t dfb_id, const std::string& tensor_parameter_name) {
+void ProgramImpl::register_dfb_borrowed_binding(
+    uint32_t dfb_id, const std::string& tensor_parameter_name, uint32_t memory_offset) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};
     }
-    metal2_registry_->dfb_borrowed_bindings.emplace_back(dfb_id, tensor_parameter_name);
+    metal2_registry_->dfb_borrowed_bindings.emplace_back(dfb_id, tensor_parameter_name, memory_offset);
 }
 
-const std::vector<std::pair<uint32_t, std::string>>& ProgramImpl::get_dfb_borrowed_bindings() const {
-    static const std::vector<std::pair<uint32_t, std::string>> empty;
+const std::vector<std::tuple<uint32_t, std::string, uint32_t>>& ProgramImpl::get_dfb_borrowed_bindings() const {
+    static const std::vector<std::tuple<uint32_t, std::string, uint32_t>> empty;
     if (!metal2_registry_) {
         return empty;
     }
@@ -1578,6 +1593,10 @@ void detail::ProgramImpl::allocate_scratchpads(const IDevice* device) {
             const CoreRangeSet& kernel_cores = kernel->core_range_set();
 
             for (auto& handle : scratchpad_handles) {
+                if (handle.size_bytes == 0) {
+                    // Compile-time-discard compatibility token: keep address 0 and reserve no L1.
+                    continue;
+                }
                 // A scratchpad bumps onto the program-scope L1 region, stacking on top of any DFBs.
                 // (DFBs and CBs are mutually exclusive, so dfb_allocators_ own the whole region.)
                 // Ensure a CircularBufferAllocator exists for each of the kernel's core ranges:
@@ -2775,6 +2794,14 @@ Program::Program(Program&& other) noexcept = default;
 Program& Program::operator=(Program&& other) noexcept = default;
 
 Program::~Program() noexcept = default;
+
+uint32_t Program::total_local_dataflow_buffer_size() const {
+    return internal_->total_local_dataflow_buffer_size();
+}
+
+uint32_t Program::get_dataflow_buffer_entry_size(const std::string& name) const {
+    return internal_->get_dataflow_buffer_entry_size(name);
+}
 
 ProgramId detail::ProgramImpl::get_id() const { return this->id; }
 

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -35,6 +35,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
@@ -219,6 +220,8 @@ public:
     const std::vector<Semaphore>& semaphores() const;
     const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& dataflow_buffers()
         const;
+    uint32_t total_local_dataflow_buffer_size() const;
+    uint32_t get_dataflow_buffer_entry_size(const std::string& name) const;
     KernelGroup* kernels_on_core(const CoreCoord& core, uint32_t programmable_core_type_index);
     std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
@@ -426,8 +429,9 @@ public:
 
     // Metal 2.0: register that DFB `dfb_id` borrows its backing L1 memory from the MeshTensor
     // bound to `tensor_parameter_name`.
-    void register_dfb_borrowed_binding(uint32_t dfb_id, const std::string& tensor_parameter_name);
-    const std::vector<std::pair<uint32_t, std::string>>& get_dfb_borrowed_bindings() const;
+    void register_dfb_borrowed_binding(
+        uint32_t dfb_id, const std::string& tensor_parameter_name, uint32_t memory_offset);
+    const std::vector<std::tuple<uint32_t, std::string, uint32_t>>& get_dfb_borrowed_bindings() const;
 
     // Metal 2.0: Get kernel by name (TT_FATAL if not found)
     std::shared_ptr<Kernel> get_kernel_by_spec_name(const std::string& name) const {
@@ -572,8 +576,8 @@ private:
         };
         std::unordered_map<std::string, RegisteredTensorParameter> tensor_parameter_layouts;
 
-        // Borrowed-memory DFB bindings: each entry is (dfb_id, tensor_parameter_name).
-        std::vector<std::pair<uint32_t, std::string>> dfb_borrowed_bindings;
+        // Borrowed-memory DFB bindings: (dfb_id, tensor_parameter_name, byte offset).
+        std::vector<std::tuple<uint32_t, std::string, uint32_t>> dfb_borrowed_bindings;
     };
     std::optional<Metal2NameRegistry> metal2_registry_;  // Only populated for Metal 2.0 programs
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -151,12 +151,17 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         string name;
         uint32_t cta_offset;
         uint32_t addr_crta_offset;
+        bool constexpr_discard_only;
     };
     vector<TaEntry> ta_entries;
-    settings.process_tensor_binding_handles(
-        [&ta_entries](const string& name, uint32_t cta_offset, uint32_t addr_crta_offset, uint32_t /*num_rt_words*/) {
-            ta_entries.push_back({name, cta_offset, addr_crta_offset});
-        });
+    settings.process_tensor_binding_handles([&ta_entries](
+                                                const string& name,
+                                                uint32_t cta_offset,
+                                                uint32_t addr_crta_offset,
+                                                uint32_t /*num_rt_words*/,
+                                                bool constexpr_discard_only) {
+        ta_entries.push_back({name, cta_offset, addr_crta_offset, constexpr_discard_only});
+    });
 
     // Get the scratchpad bindings from the settings callback.
     // Like tensor bindings, these come from a std::vector in user-specified order, so no sort is needed
@@ -257,6 +262,11 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             // Tensor binding sequences are constexpr std::tuple of those member tokens (members order).
             content << "namespace tensor {\n";
             for (const auto& entry : ta_entries) {
+                if (entry.constexpr_discard_only) {
+                    content << "constexpr ::tensor_accessor::ConstexprDiscardTensorBindingToken " << entry.name
+                            << "{};\n";
+                    continue;
+                }
                 content << "using " << entry.name << "_t = ::tensor_accessor::TensorBindingToken<" << entry.cta_offset
                         << "u, " << entry.addr_crta_offset << "u>;\n";
                 content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -120,7 +120,8 @@ public:
                                                     const std::string& accessor_name,
                                                     uint32_t cta_offset,
                                                     uint32_t addr_crta_offset,
-                                                    uint32_t num_runtime_field_crta_words)>) const {}
+                                                    uint32_t num_runtime_field_crta_words,
+                                                    bool constexpr_discard_only)>) const {}
 
     // Scratchpad binding callback emits the codegen-relevant fields:
     //  - accessor_name: kernel-side identifier, used as the symbol name in the `scratch::` namespace

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -330,6 +330,14 @@ void create_and_cache_mesh_workload(
             auto cached_workload = create_mesh_workload_from_workload_factory<WorkloadFactory, mesh_device_operation_t>(
                 operation_attributes, tensor_coords, tensor_args, tensor_return_value);
 
+            if constexpr (requires {
+                              mesh_device_operation_t::validate_after_program_cache_miss(
+                                  operation_attributes, tensor_args, tensor_return_value, cached_workload.workload);
+                          }) {
+                mesh_device_operation_t::validate_after_program_cache_miss(
+                    operation_attributes, tensor_args, tensor_return_value, cached_workload.workload);
+            }
+
             // Don't cache programs during NO_DISPATCH graph capture mode because
             // buffer addresses are invalid (address=0). Caching such programs would
             // cause issues when later running in NORMAL mode.

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt_stl/small_vector.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -236,6 +237,18 @@ public:
 
     static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
         DeviceOperation::validate_on_program_cache_miss(attrs, tensor_args);
+    }
+
+    static void validate_after_program_cache_miss(
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args,
+        const tensor_return_value_t& tensor_return_value,
+        const tt::tt_metal::distributed::MeshWorkload& workload)
+        requires requires {
+            DeviceOperation::validate_after_program_cache_miss(attrs, tensor_args, tensor_return_value, workload);
+        }
+    {
+        DeviceOperation::validate_after_program_cache_miss(attrs, tensor_args, tensor_return_value, workload);
     }
 
     static spec_return_value_t compute_output_specs(


### PR DESCRIPTION
## Summary

This PR contains only the Metalium/TTNN framework contracts needed to migrate legacy Program factories to `ProgramSpec`. Operation factories and operation kernels are intentionally excluded and will remain in their individual migration commits.

Every compatibility path is explicit and opt-in. None adds a CB, backing buffer, data copy, runtime feature branch, or alternate operation kernel.

## Infrastructure changes

### DFB accessor aliases

One kernel binding can publish multiple named constexpr accessors for the same realized DFB slot.

Halo, Pool2D, Conv2D, and Conv3D have legacy kernels where distinct semantic CB names intentionally resolve to one physical CB index. Treating those names as separate DFBs would incorrectly model separate resources. Aliases preserve the existing physical CB identity without duplicate endpoints, storage, or data movement.

### Incomplete Gen1 endpoint coverage

A Gen1 DFB placement may omit its producer or consumer on selected nodes while still allowing at most one of each endpoint per node and requiring at least one complete placement.

Conv2D multicast grids contain padding and no-op core placements whose specialized kernel is guaranteed not to access one side of the DFB. Requiring a synthetic endpoint would misrepresent the topology and add synchronization that does not exist today. This option records the actual asymmetric placement, is incompatible with multi-binding, and remains rejected on Gen2.

### Gen1 plain-CB multi-binding

An explicit compatibility option allows multiple kernel instances to bind one physical Gen1 CB while lowering it as a plain CB.

Conv2D uses this for overlapped `ACT`/`ACT_TILIZED` storage and an explicitly synchronized split-reader CB. Conv3D uses it for compute/writer reduction buffers whose active role varies by core. Converting these relationships into ordinary DFB credit-flow edges would change the existing handshake and could double-account credits. The option preserves the original CB and kernel-owned synchronization and is rejected on Gen2.

### Borrowed-memory subranges

A DFB can borrow a bounds-checked non-zero byte offset inside an existing tensor allocation.

Conv2D stores matmul partials in a legacy subrange of the output allocation. Expressing that offset directly preserves the accumulator address, L1 footprint, and output layout. Without it, the migration would require scratch storage and a copy or a different physical layout.

### Realized borrowed-DFB validation

Borrowed sharded DFB ranges are validated against their physical backing buffers after lowering.

The declarative spec does not yet know the final allocation and offsets needed to prove that the Conv2D subrange is in bounds. Post-realization validation retains this safety check at the first point where the required physical information exists, without altering allocation.

### Constexpr-discard-only bindings

Named DFB, semaphore, scratchpad, and tensor bindings may remain unresolved only when a compile-time branch proves their accessor unreachable.

Fold has optional DFBs, ConvertToHWC has optional tensors, Halo has optional scratchpad and tensor accessors, and Conv2D has optional DFBs and semaphores. Their typed kernel schemas need to name these resources even when a specialization compiles their use away. The discard-only state emits an invalid placeholder instead of manufacturing a dummy resource, rejects inconsistent declarations, and leaves runtime access invalid.

### Typed constexpr arguments

Named compile-time arguments can emit typed template values.

Pool consumers require typed reduction selections to retain compile-time specialization. The generic mechanism avoids feature macros and runtime branches. This PR adds only the argument facility; the consuming operation-kernel changes are excluded.

### Architecture-correct DFB implicit synchronization

Implicit DFB synchronization applies only to endpoints using `DataMovementGen2Config`.

Wormhole and Blackhole kernels already execute explicit reserve/push/wait/pop handshakes. Adding implicit credit accounting would create a second synchronization path and could change performance or deadlock. The restriction preserves the existing Gen1 protocol while retaining Quasar implicit-sync behavior and opt-out controls.

### Post-realization validation hooks

Program factories can inspect read-only realized DFB allocation information from a cache-miss post-realization hook.

Conv2D previously used `post_conv2d_op_memory_checks` for realized CB-size and allocator-delta diagnostics. Those properties cannot be checked before `ProgramSpec` lowering because physical placement does not yet exist. The hook restores the diagnostic point and cannot mutate allocation or dispatch.

The PR remains draft so these shared framework contracts can be reviewed independently before the operation-specific migrations are proposed.


## Related migration branch

The vision-operation migrations that consume this infrastructure are available on [`pjosipovic/metalium-2.0-convolution-migration-assessment`](https://github.com/tenstorrent/tt-metal/tree/pjosipovic/metalium-2.0-convolution-migration-assessment).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/metalium-2.0-migration-infrastructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/metalium-2.0-migration-infrastructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/metalium-2.0-migration-infrastructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/metalium-2.0-migration-infrastructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/metalium-2.0-migration-infrastructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/metalium-2.0-migration-infrastructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/metalium-2.0-migration-infrastructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/metalium-2.0-migration-infrastructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/metalium-2.0-migration-infrastructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/metalium-2.0-migration-infrastructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/metalium-2.0-migration-infrastructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/metalium-2.0-migration-infrastructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/metalium-2.0-migration-infrastructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/metalium-2.0-migration-infrastructure)