### PR TITLE
[Bug fix] embedding_bw: zero the trailing partial tile row when num_embeddings is not tile-aligned

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py
@@ -18,6 +18,11 @@ from loguru import logger
         (2, 64, 160, 96),
         (3, 32, 384, 320),
         (2, 1024, 4096, 3200),
+        # num_embeddings not a multiple of TILE_HEIGHT: the output is tile-padded, so
+        # the trailing partial tile row still has to be zeroed before accumulation.
+        (2, 64, 160, 9),
+        (1, 32, 64, 33),
+        (2, 32, 128, 100),
     ],
 )
 @pytest.mark.parametrize(
@@ -65,6 +70,54 @@ def test_embedding_bw(input_dtype, output_dtype, batch_size, seq_len, embedding_
 
     logger.debug(comp_out)
     assert comp_pass
+
+
+SENTINEL = 999.0
+
+
+@pytest.mark.parametrize("num_embeddings", [9, 32, 33, 64, 96, 100, 320])
+def test_embedding_bw_unindexed_rows_are_zero(num_embeddings, device):
+    """Rows no index points at must come back exactly zero.
+
+    The op zeroes its whole output before accumulating, so PCC over the full tensor
+    hides a partially zeroed one; this asserts the untouched rows directly. When
+    num_embeddings is not a multiple of TILE_HEIGHT its trailing partial tile row was
+    left out of the zero-init pass and came back holding whatever the DRAM pages
+    already contained, so the test first dirties those pages with a sentinel.
+    """
+    torch.manual_seed(1234)
+    embedding_dim, seq_len = 64, 32
+
+    indexed_rows = sorted(range(0, num_embeddings, 3))
+    input_index = torch.tensor(indexed_rows, dtype=torch.int32)
+    input_index = input_index.repeat((seq_len + len(indexed_rows) - 1) // len(indexed_rows))[:seq_len]
+    input_tensor = ttnn.from_torch(input_index.reshape(1, seq_len), dtype=ttnn.uint32, device=device)
+
+    grad_data = torch.randn(1, 1, seq_len, embedding_dim)
+    grad_tensor = ttnn.from_torch(grad_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    weights = torch.zeros(num_embeddings, embedding_dim)
+    weights_ttnn = ttnn.from_torch(weights, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Allocate an identically shaped tensor full of a sentinel and free it, so the
+    # allocator hands the same pages to the output and a missed zero-init is visible.
+    dirty = ttnn.from_torch(
+        torch.full((1, 1, num_embeddings, embedding_dim), SENTINEL),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+    ttnn.deallocate(dirty)
+
+    out = ttnn.to_torch(ttnn.embedding_bw(input_tensor, weights_ttnn, grad_tensor, dtype=ttnn.bfloat16)).reshape(
+        num_embeddings, embedding_dim
+    )
+
+    touched = set(input_index.tolist())
+    untouched = [row for row in range(num_embeddings) if row not in touched]
+    assert untouched, "test needs at least one row no index points at"
+    nonzero = [row for row in untouched if out[row].abs().max() != 0]
+    assert not nonzero, f"rows {nonzero} are not zero (num_embeddings={num_embeddings})"
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_descriptor.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_descriptor.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/math.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
@@ -58,7 +59,11 @@ ProgramDescriptor EmbeddingBackwardDeviceOperation::create_descriptor(
     uint32_t seq_len_tiles = tensor_args.index_tensor.padded_shape()[-1] / TILE_WIDTH;
     uint32_t input_height_tiles = batch_size * seq_len_tiles;
 
-    uint32_t num_embeddings_tiles = operation_attributes.num_embeddings / TILE_HEIGHT;
+    // Round up: the output is tile-padded, so a weight table whose row count is not a
+    // multiple of TILE_HEIGHT still owns a full trailing tile row. Truncating here left
+    // that tile row out of the reader's output zero-init loop, so it kept whatever was
+    // in the freshly allocated DRAM and the accumulation added on top of garbage.
+    uint32_t num_embeddings_tiles = tt::div_up(operation_attributes.num_embeddings, TILE_HEIGHT);
 
     // We split work based on the number of tiles in the embedding dimension
     auto grid_size = device->compute_with_storage_grid_size();


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #54561

`ttnn.embedding_bw` returns garbage when `num_embeddings` is not a multiple of `TILE_HEIGHT`.

The reader kernel zeroes the output before the accumulate-in-place pass (read output tile → reshuffle-add grad → write back). That zero-init loop is bounded by a compile-time arg computed in `embedding_backward_program_descriptor.cpp` as:

```cpp
uint32_t num_embeddings_tiles = operation_attributes.num_embeddings / TILE_HEIGHT;  // truncates
```

The output is tile-padded, so a weight table whose row count is not a multiple of 32 still owns a full trailing tile row — and that row was left out of the loop. It came back holding whatever the freshly allocated DRAM pages contained, and the gradient was then accumulated on top of that.

Affected rows are exactly `num_embeddings % 32`, so anything under 32 rows means the entire output is garbage:

| `num_embeddings` | `floor(n/32)` | stale rows |
|---|---|---|
| 9 | 0 | all 9 |
| 33 | 1 | row 32 |
| 100 | 3 | rows 96-99 |
| 32 / 64 / 96 / 320 | exact | none |

The fix is `tt::div_up` so the partial tile row is zeroed too. Zeroing the padding rows past `num_embeddings` is correct — they must read as zero.

**How this was found.** tt-mlir lowers a torch `scatter_reduce_(0, ..., reduce="sum")` (and `index_add_`) to `ttnn.embedding_bw`, passing the accumulation buffer as the weight table. A DeepSeek-MoE-16B expert-combine buffer is `seq_len` rows tall, so a 9-token prompt hit the `tiles = 0` case on every run — PCC 0.03 against CPU, which read as model flakiness rather than an op bug.

### Notes for reviewers

**Why existing coverage missed it.** Every `num_embeddings` in `test_backward_embedding.py` (96, 320, 3200) and in `tests/sweep_framework/sweeps/embedding_bw` (`gen_shapes` with step 32) is a multiple of 32. Adding non-aligned sizes to the existing PCC test is enough to catch this — on the pre-fix binary, 15 of 29 cases fail, and they are exactly the `num_embeddings` ∈ {9, 33, 100} cases across every dtype combination.

**On the second test.** `test_embedding_bw_unindexed_rows_are_zero` asserts directly that rows no index points at come back zero, because PCC over the full tensor can pass while part of the output is unzeroed. To make a missed zero-init observable it allocates an identically shaped tensor full of a sentinel and frees it, so the allocator hands the same pages to the output. That leans on allocator reuse behaviour, which is an implementation detail — if you would rather not depend on it, the added `test_embedding_bw` parameters carry the regression coverage on their own and this test can be dropped.

**Verification** (Blackhole, `tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py`):

- with the fix: `29 passed, 4 skipped`
- pre-fix, same file: `15 failed, 14 passed, 4 skipped` — every failure a non-aligned `num_embeddings`
- end-to-end through tt-mlir/tt-xla, DeepSeek-MoE-shaped graph (8 experts, top-6, real gate/up/down MLPs, hidden 2048, 9-row buffer): PCC 0.027 → 0.999986 vs CPU
- aligned sizes are bit-identical before and after

I did not run the `embedding_bw` sweep suite or a broader `tests/ttnn` sweep — worth a CI pass over those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
