### PR TITLE
[CI] Rename Blackhole e2e job display names

### DIFF
--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -140,8 +140,8 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work
         - ${{ (!contains(join(matrix.test-group.runs_on, ' '), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}
         - "${{ (matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && '/mnt/MLPerf/huggingface:/localdev/blackhole_demos/huggingface_data:ro') || (matrix.test-group['weights-cache-mode'] == 'local-disk' && '/localdev/blackhole_demos/huggingface_data:/localdev/blackhole_demos/huggingface_data:ro') || '/no_hf_cache' }}"
-        - "${{ (matrix.test-group['model-name'] == 'deepseek_prefill' && '/mnt/MLPerf/deepseek-prefill-cache:/mnt/MLPerf/deepseek-prefill-cache:ro') || '/no_deepseek_traces' }}"
-        - "${{ (matrix.test-group['model-name'] == 'deepseek_prefill' && '/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface:ro') || '/no_deepseek_weights' }}"
+        - "${{ (matrix.test-group['model-name'] == 'disaggregated_prefill' && '/mnt/MLPerf/deepseek-prefill-cache:/mnt/MLPerf/deepseek-prefill-cache:ro') || '/no_deepseek_traces' }}"
+        - "${{ (matrix.test-group['model-name'] == 'disaggregated_prefill' && '/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface:ro') || '/no_deepseek_weights' }}"
       options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
     defaults:
       run:

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -29,7 +29,7 @@ on:
         type: choice
         options:
           - all
-          - deepseek_prefill
+          - disaggregated_prefill
       test-selection:
         description: 'Select e2e tests to run: all tests, or one test id'
         required: false
@@ -37,8 +37,8 @@ on:
         type: choice
         options:
           - all
-          - bh-lb-deepseek-prefill-perf
-          - bh-qb2-deepseek-d2d-socket-sync
+          - bh-lb-disaggregated-prefill-perf
+          - bh-qb2-disaggregated-prefill-d2d-socket-sync
       build-type:
         required: false
         type: choice

--- a/.github/workflows/silencer.lock.yml
+++ b/.github/workflows/silencer.lock.yml
@@ -780,7 +780,7 @@ jobs:
                         "description": "Select model to test (filters rows strictly by model-name in tests/pipeline_reorg/blackhole_e2e_tests.yaml; use \"all\" to run every row including untagged)",
                         "enum": [
                           "all",
-                          "deepseek_prefill"
+                          "disaggregated_prefill"
                         ],
                         "type": "string"
                       },
@@ -814,8 +814,8 @@ jobs:
                         "description": "Select e2e tests to run: all tests, or one test id",
                         "enum": [
                           "all",
-                          "bh-lb-deepseek-prefill-perf",
-                          "bh-qb2-deepseek-d2d-socket-sync"
+                          "bh-lb-disaggregated-prefill-perf",
+                          "bh-qb2-disaggregated-prefill-d2d-socket-sync"
                         ],
                         "type": "string"
                       }

--- a/.github/workflows/test-command.lock.yml
+++ b/.github/workflows/test-command.lock.yml
@@ -713,7 +713,7 @@ jobs:
                         "description": "Select model to test (filters rows strictly by model-name in tests/pipeline_reorg/blackhole_e2e_tests.yaml; use \"all\" to run every row including untagged)",
                         "enum": [
                           "all",
-                          "deepseek_prefill"
+                          "disaggregated_prefill"
                         ],
                         "type": "string"
                       },
@@ -747,8 +747,8 @@ jobs:
                         "description": "Select e2e tests to run: all tests, or one test id",
                         "enum": [
                           "all",
-                          "bh-lb-deepseek-prefill-perf",
-                          "bh-qb2-deepseek-d2d-socket-sync"
+                          "bh-lb-disaggregated-prefill-perf",
+                          "bh-qb2-disaggregated-prefill-d2d-socket-sync"
                         ],
                         "type": "string"
                       }

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
@@ -12,11 +12,12 @@ first/last COLUMN (varies in y).  This test confines combine to each of the four
 lines (plus the None default) and checks the output still matches the torch reference,
 exercising both the row-oriented and the new column-oriented core layouts.
 
-This file MUST NOT run in CI.  It is collected by every *DeepSeek_PREFILL_OP_TESTS job
-(some of which run the op_unit_tests/ folder unfiltered, e.g. bh_p150 / bh_p300), so a
-``-k`` filter cannot exclude it.  Instead it skips itself in CI via the is_ci_env /
-is_ci_v2_env fixtures (same mechanism as test_sub_device_load_clear_timing.py): all CI
-jobs collect it but report it as skipped, while it still runs locally with no env var.
+This file MUST NOT run in CI.  It is collected by every "Disaggregated prefill op tests"
+job (some of which run the op_unit_tests/ folder unfiltered, e.g. [bh_p150b_civ2] /
+[bh_p300]), so a ``-k`` filter cannot exclude it.  Instead it skips itself in CI via
+the is_ci_env / is_ci_v2_env fixtures (same mechanism as
+test_sub_device_load_clear_timing.py): all CI jobs collect it but report it as skipped,
+while it still runs locally with no env var.
 
 Run locally (needs an 8-chip box for the mesh-4x2 config):
 
@@ -153,9 +154,10 @@ def test_combine_subdevice_placement(
     sub-device manager; each placement gets its own manager, created and torn down here.
     """
     topology = per_axis_topology(device_params["fabric_config"])[0]
-    # Local-only: this file is collected by every DeepSeek_PREFILL_OP_TESTS job (some
-    # unfiltered, e.g. bh_p150/bh_p300), so a -k filter cannot exclude it. Skip in CI the
-    # same way test_sub_device_load_clear_timing.py does; runs locally with no env var.
+    # Local-only: this file is collected by every "Disaggregated prefill op tests" job
+    # (some unfiltered, e.g. [bh_p150b_civ2]/[bh_p300]), so a -k filter cannot exclude
+    # it. Skip in CI the same way test_sub_device_load_clear_timing.py does; runs
+    # locally with no env var.
     if is_ci_env or is_ci_v2_env:
         pytest.skip("Local-only combine subdevice test; skipped in CI")
 

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -1,5 +1,5 @@
 # This file defines the test matrix for the Blackhole e2e pipeline (e2e, integration, perf, unit,
-# DeepSeek prefill).
+# disaggregated prefill).
 
 # Each entry represents a parallel job with the following keys:
 #   id: Stable slug for workflow_dispatch / jq filtering.
@@ -65,7 +65,7 @@
   team: scaleout
 
 - id: bh-grid-20-cores-ttnn-sharding
-  name: ttnn sharding on 20 cores
+  name: ttnn 20-core sharding unit tests
   cmd: pytest tests/ttnn/unit_tests/base_functionality/test_bh_20_cores_sharding.py::test_sharding_on_bh_20_cores
   skus:
     bh_p150b_civ2:
@@ -111,7 +111,7 @@
   team: ttnn
 
 - id: bh-host-io-fast-unit-viommu
-  name: Host IO fast unit test (viommu only)
+  name: Host IO socket loopback unit tests (slow dispatch)
   cmd: TT_METAL_SLOW_DISPATCH_MODE=1 pytest -svv models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
   skus:
     bh_p300:
@@ -142,9 +142,9 @@
   owner_id: U084DDYSWCW # Adrian Morrison
   team: ttnn
 
-# --- deepseek_prefill ---
+# --- disaggregated prefill ---
 - id: bh-lb-deepseek-prefill
-  name: bh_lb_DeepSeek_PREFILL
+  name: Disaggregated prefill accuracy tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -161,7 +161,7 @@
   team: models
 
 - id: bh-lb-deepseek-dsa
-  name: bh_lb_DeepSeek_DSA
+  name: Disaggregated prefill sparse MLA accuracy tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -179,7 +179,7 @@
   team: models
 
 - id: bh-lb-deepseek-prefill-op-tests
-  name: bh_lb_DeepSeek_PREFILL_OP_TESTS
+  name: Disaggregated prefill op tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -194,7 +194,7 @@
   team: models
 
 - id: bh-lb-deepseek-prefill-perf
-  name: bh_lb_DeepSeek_PREFILL_PERF
+  name: Disaggregated prefill perf tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -213,7 +213,7 @@
   team: models
 
 - id: bh-qb-deepseek-prefill
-  name: bh_qb_DeepSeek_PREFILL
+  name: Disaggregated prefill accuracy & weight cache tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -227,7 +227,7 @@
   team: models
 
 - id: bh-p150-deepseek-prefill-op-tests
-  name: bh_p150_DeepSeek_PREFILL_OP_TESTS
+  name: Disaggregated prefill op tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -240,7 +240,7 @@
   team: models
 
 - id: bh-p300-deepseek-prefill-op-tests
-  name: bh_p300_DeepSeek_PREFILL_OP_TESTS
+  name: Disaggregated prefill op tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -253,7 +253,7 @@
   team: models
 
 - id: bh-qb2-deepseek-prefill-op-tests
-  name: bh_qb2_DeepSeek_PREFILL_OP_TESTS
+  name: Disaggregated prefill op tests
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
@@ -266,7 +266,7 @@
   team: models
 
 - id: bh-qb2-deepseek-d2d-socket-sync
-  name: bh_qb2_DeepSeek_D2D_SOCKET_SYNC
+  name: Disaggregated prefill D2D socket sync op tests
   model-name: deepseek_prefill
   # Program-cache validation for outbound_socket_service_sync (D2D sender op) on a 4-chip
   # QuietBox Fabric2D 2x2 variant: 2 sender + 2 receiver chips over tt-fabric. Confirms the

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -111,7 +111,7 @@
   team: ttnn
 
 - id: bh-host-io-fast-unit-viommu
-  name: Host IO socket loopback unit tests (slow dispatch)
+  name: Host IO socket loopback unit tests (slow dispatch, viommu)
   cmd: TT_METAL_SLOW_DISPATCH_MODE=1 pytest -svv models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
   skus:
     bh_p300:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -143,9 +143,9 @@
   team: ttnn
 
 # --- disaggregated prefill ---
-- id: bh-lb-deepseek-prefill
+- id: bh-lb-disaggregated-prefill-accuracy
   name: Disaggregated prefill accuracy tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
@@ -160,9 +160,9 @@
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
 
-- id: bh-lb-deepseek-dsa
+- id: bh-lb-disaggregated-prefill-sparse-mla
   name: Disaggregated prefill sparse MLA accuracy tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     export GLM52_MLA_REF_CACHE=/tmp/glm_5_2_mla_ref_cache
@@ -178,9 +178,9 @@
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
 
-- id: bh-lb-deepseek-prefill-op-tests
+- id: bh-lb-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     # Cheap host-side coverage for the mixed-format cache contract and producer decoding.
@@ -193,9 +193,9 @@
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
-- id: bh-lb-deepseek-prefill-perf
+- id: bh-lb-disaggregated-prefill-perf
   name: Disaggregated prefill perf tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
@@ -212,9 +212,9 @@
   owner_id: U09LK84G4TF # Nikola Milicevic
   team: models
 
-- id: bh-qb-deepseek-prefill
+- id: bh-qb2-disaggregated-prefill-accuracy
   name: Disaggregated prefill accuracy & weight cache tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and ((fabric2d-mesh-2x2 or fabric2d-2x2 or torus-x-1x4) or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe)) and (not hca or (flash and chunk5120-varying))" --timeout 1800 || exit_code=$?
@@ -226,9 +226,9 @@
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
 
-- id: bh-p150-deepseek-prefill-op-tests
+- id: bh-p150-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or fabric2d) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
@@ -239,9 +239,9 @@
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
-- id: bh-p300-deepseek-prefill-op-tests
+- id: bh-p300-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or fabric2d) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
@@ -252,9 +252,9 @@
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
-- id: bh-qb2-deepseek-prefill-op-tests
+- id: bh-qb2-disaggregated-prefill-op-tests
   name: Disaggregated prefill op tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   cmd: |
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (2x2 and pcc_check and fabric2d)) and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out and fp8_disp_compression)))" || exit_code=$?
@@ -265,9 +265,9 @@
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
 
-- id: bh-qb2-deepseek-d2d-socket-sync
+- id: bh-qb2-disaggregated-prefill-d2d-socket-sync
   name: Disaggregated prefill D2D socket sync op tests
-  model-name: deepseek_prefill
+  model-name: disaggregated_prefill
   # Program-cache validation for outbound_socket_service_sync (D2D sender op) on a 4-chip
   # QuietBox Fabric2D 2x2 variant: 2 sender + 2 receiver chips over tt-fabric. Confirms the
   # op is built once and cache-hits on the 2nd dispatch (input addr is a BufferBinding).


### PR DESCRIPTION
Closes #54552

Renames the display names of the Blackhole e2e jobs we own. `prepare_test_matrix.py` already appends ` [<sku>]` to every name, so the old `bh_lb_` / `bh_p150_` prefixes were duplicating information the suffix carries.

Rule applied: `<subject> <scope> <category> tests`
- `DeepSeek` -> `Disaggregated`, `PREFILL` -> `prefill` (sentence case)
- no SKU token in the name; `(viommu only)` dropped too, `bh_p300`'s runner labels are already `P300-viommu`
- category stated explicitly (`accuracy` / `op` / `perf` / `unit` tests), using the vocabulary the other `tests/pipeline_reorg/` matrices already use

| Displayed now | Displayed after |
| --- | --- |
| `bh_lb_DeepSeek_PREFILL [bh_loudbox]` | `Disaggregated prefill accuracy tests [bh_loudbox]` |
| `bh_qb_DeepSeek_PREFILL [bh_quietbox_2]` | `Disaggregated prefill accuracy & weight cache tests [bh_quietbox_2]` |
| `bh_lb_DeepSeek_DSA [bh_loudbox]` | `Disaggregated prefill sparse MLA accuracy tests [bh_loudbox]` |
| `bh_lb_DeepSeek_PREFILL_OP_TESTS [bh_loudbox]` | `Disaggregated prefill op tests [bh_loudbox]` |
| `bh_p150_DeepSeek_PREFILL_OP_TESTS [bh_p150b_civ2]` | `Disaggregated prefill op tests [bh_p150b_civ2]` |
| `bh_p300_DeepSeek_PREFILL_OP_TESTS [bh_p300]` | `Disaggregated prefill op tests [bh_p300]` |
| `bh_qb2_DeepSeek_PREFILL_OP_TESTS [bh_quietbox_2]` | `Disaggregated prefill op tests [bh_quietbox_2]` |
| `bh_qb2_DeepSeek_D2D_SOCKET_SYNC [bh_quietbox_2]` | `Disaggregated prefill D2D socket sync op tests [bh_quietbox_2]` |
| `bh_lb_DeepSeek_PREFILL_PERF [bh_loudbox]` | `Disaggregated prefill perf tests [bh_loudbox]` |
| `Host IO fast unit test (viommu only) [bh_p300]` | `Host IO socket loopback unit tests (slow dispatch, viommu) [bh_p300]` |
| `ttnn sharding on 20 cores [bh_p150b_civ2]` | `ttnn 20-core sharding unit tests [bh_p150b_civ2]` |

The four op-test rows collapse to one name on purpose; the SKU suffix is what separates them. Verified per SKU with `prepare_test_matrix.py` that no two names collide within a SKU, and `verify_time_budget.py` still passes.

### Selectors and ids

The `workflow_dispatch` dropdowns still offered the old slugs, so they move too.

`model`: `deepseek_prefill` -> `disaggregated_prefill` (and the matching `model-name:` on all 9 rows, plus the two volume-mount conditionals in `blackhole-e2e-tests-impl.yaml` that key off it).

`test-selection` / `id:`:

| Old id | New id |
| --- | --- |
| `bh-lb-deepseek-prefill` | `bh-lb-disaggregated-prefill-accuracy` |
| `bh-lb-deepseek-dsa` | `bh-lb-disaggregated-prefill-sparse-mla` |
| `bh-lb-deepseek-prefill-op-tests` | `bh-lb-disaggregated-prefill-op-tests` |
| `bh-lb-deepseek-prefill-perf` | `bh-lb-disaggregated-prefill-perf` |
| `bh-qb-deepseek-prefill` | `bh-qb2-disaggregated-prefill-accuracy` |
| `bh-p150-deepseek-prefill-op-tests` | `bh-p150-disaggregated-prefill-op-tests` |
| `bh-p300-deepseek-prefill-op-tests` | `bh-p300-disaggregated-prefill-op-tests` |
| `bh-qb2-deepseek-prefill-op-tests` | `bh-qb2-disaggregated-prefill-op-tests` |
| `bh-qb2-deepseek-d2d-socket-sync` | `bh-qb2-disaggregated-prefill-d2d-socket-sync` |

`bh-qb-*` is normalized to `bh-qb2-*` to match its `bh_quietbox_2` SKU. The SKU token stays in the ids: the four op-test rows differ only by SKU, so their ids have to stay distinct.

`silencer.lock.yml` and `test-command.lock.yml` embed the dispatch input schema for `blackhole-e2e-tests`, so their enums move with it. They are gh-aw generated; the edit is confined to those two enums and no CI job recompiles them.


CI:
- all SKUs, display names: https://github.com/tenstorrent/tt-metal/actions/runs/33061060176
- P300 only, after the viommu rename: https://github.com/tenstorrent/tt-metal/actions/runs/33065290143
- QuietBox 2, dispatched with `model=disaggregated_prefill` and `test-selection=bh-qb2-disaggregated-prefill-d2d-socket-sync` to exercise the renamed selectors: https://github.com/tenstorrent/tt-metal/actions/runs/33065876822
- all SKUs on the final SHA: https://github.com/tenstorrent/tt-metal/actions/runs/33065889850

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/54552-rename-blackhole-e2e-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/54552-rename-blackhole-e2e-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/54552-rename-blackhole-e2e-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/54552-rename-blackhole-e2e-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/54552-rename-blackhole-e2e-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/54552-rename-blackhole-e2e-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/54552-rename-blackhole-e2e-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/54552-rename-blackhole-e2e-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/54552-rename-blackhole-e2e-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/54552-rename-blackhole-e2e-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/54552-rename-blackhole-e2e-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/54552-rename-blackhole-e2e-jobs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/54552-rename-blackhole-e2e-jobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/54552-rename-blackhole-e2e-jobs)

