### PR TITLE
[Bug fix] llk perf: qualify SfpuType globally in sfpu_binop_scalar_perf (fixes LLK perf nightly)

### DIFF
--- a/tt_metal/tt-llk/tests/sources/sfpu_binop_scalar_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binop_scalar_perf.cpp
@@ -98,7 +98,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
-        ckernel::llk_math_eltwise_unary_sfpu_init<ckernel::SfpuType::unused, is_fp32_dest_acc_en>();
+        ckernel::llk_math_eltwise_unary_sfpu_init<::SfpuType::unused, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }
     {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

`tt_metal/tt-llk/tests/sources/sfpu_binop_scalar_perf.cpp` has failed to **compile** on both Wormhole and Blackhole since #52887 (merged 2026-08-25 17:41 UTC), taking out the `LLK perf` nightly's group 5/5 on both arches for two consecutive nights:

| run | WH group 5/5 | BH group 5/5 |
|---|---|---|
| [32926183466](https://github.com/tenstorrent/tt-metal/actions/runs/32926183466) (26 Aug) | fail | fail |
| [33040431355](https://github.com/tenstorrent/tt-metal/actions/runs/33040431355) (27 Aug) | fail | fail |

Those two jobs' only annotations are this module's 20 variants (2 formats x 2 `dest_acc` x 5 `mathop`); the other four groups pass on both arches. pytest-split lands the module in group 5 on both. The consumer pass runs under `-x`, so the whole group aborts once the first variant fails — hence the short 39m job instead of the usual ~1h11m.

**Root cause.** #52887 removed this file's local `DST_ACCUM_MODE` constant, so it had to replace `SFPU_UNARY_INIT(unused)` with the init call that macro expands to. The transcription qualified the op enum as `ckernel::SfpuType`:

```cpp
ckernel::llk_math_eltwise_unary_sfpu_init<ckernel::SfpuType::unused, is_fp32_dest_acc_en>();
//                                        ^^^^^^^^^
```

On WH/BH, `SfpuType` is declared at **global** scope in `llk_sfpu_types.h:7`; only `llk_math_eltwise_unary_sfpu_init` lives in `ckernel`. The template argument fails name lookup, the `<...>` list then fails to parse, and the call falls through to `no matching function ... there are 2 candidates`:

```
sfpu_binop_scalar_perf.cpp:101:60: error: 'SfpuType' is not a member of 'ckernel'; did you mean 'SfpuType'?
sfpu_binop_scalar_perf.cpp:101:18: error: parse error in template argument list
sfpu_binop_scalar_perf.cpp:101:98: error: no matching function for call to
                                  'llk_math_eltwise_unary_sfpu_init<<expression error> >()'
```

The `ckernel::` prefix looks plausible because on **Quasar** `SfpuType` really is `ckernel::SfpuType` — `tt_llk_quasar/llk_lib/llk_defs.h:216` re-exports it into the global namespace "for compatibility with test infrastructure". And the Quasar perf compile job only builds `quasar/perf_*_quasar.py`, so it never built this file. The sibling functional test `sfpu_binop_scalar_test.cpp` received the same edit in the same commit and got it right.

**Fix.** Use `::SfpuType` — the spelling `SFPU_UNARY_INIT` itself uses (`llk_math_eltwise_unary_sfpu_macros.h:66`), and portable across all three arches thanks to Quasar's global alias. Behaviour is identical to the pre-#52887 macro: the two-arg overload (`llk_math_eltwise_unary_sfpu_init.h:116`) dispatches to `sfpu::unused_init()`, with `is_fp32_dest_acc_en` now passed explicitly rather than via the deleted `DST_ACCUM_MODE`.

Relates to #52763.

### Notes for reviewers

One token. No behavioural change intended, and none is possible — this is the exact expansion of the macro the file used before #52887.

**Verified on a Blackhole p100a**, all 20 variants of the module:

| pass | before | after |
|---|---|---|
| `CHIP_ARCH=blackhole --compile-producer` | 20 failed | **20 passed** |
| `CHIP_ARCH=wormhole --compile-producer` | 20 failed | **20 passed** |
| `CHIP_ARCH=blackhole --compile-consumer` (on hardware) | — | **20 passed** |

```
cd tt_metal/tt-llk/tests/python_tests
CHIP_ARCH=blackhole pytest -q --speed-of-light --compile-producer -n 4 \
  -m "perf and not accuracy" perf_sfpu_binop_scalar.py
CHIP_ARCH=blackhole pytest -q --speed-of-light --compile-consumer -n 4 \
  -m "perf and not accuracy" perf_sfpu_binop_scalar.py
```

**Process gap worth a follow-up (not in this PR).** `tests/sources/*_perf.cpp` is compiled *only* by the scheduled `LLK perf` workflow — `llk-perf.yaml` is `schedule` + `workflow_dispatch` only, and no other LLK pipeline builds these sources. That is why a plain compile error reached main and sat there for two nights. A hardware-free `--compile-producer`-only pass over the perf suite in the LLK PR pipeline would have caught this in the PR: it took **14s** for this one module locally.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrsmanovic/fix-sfpu-binop-perf-sfputype-scope)