### PR TITLE
[Bug fix] Remove debug env hooks and investigation labels from the sampling path

### DIFF
--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect
-import os
 import sys
 
 import torch
@@ -542,22 +541,6 @@ class TTSampling(LightweightModule):
             sub_core_grids=self.sub_core_grids,
         )
 
-    def _no_persist_gather(self):
-        """Drop persistent buffers for the sampling gathers (so the CCL barrier engages).
-
-        TT_SAMPLING_NO_PERSIST=1 forces it on; TT_SAMPLING_NO_PERSIST_TOGGLE=<path> reads the
-        arm from a file each call, so ONE server instance can alternate barrier-on/barrier-off.
-        Cross-restart A/Bs are worthless here -- failure rate varies ~10x between instances.
-        """
-        path = os.environ.get("TT_SAMPLING_NO_PERSIST_TOGGLE")
-        if path:
-            try:
-                with open(path) as fh:
-                    return fh.read().strip().startswith("1")
-            except OSError:
-                pass
-        return bool(os.environ.get("TT_SAMPLING_NO_PERSIST"))
-
     def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
         """
         Flexible all-gather that works across different CCL implementations.
@@ -573,19 +556,8 @@ class TTSampling(LightweightModule):
                 "memory_config": memory_config,
                 "num_links": num_links,
             }
-            # TT_SAMPLING_NO_PERSIST=1: drop the persistent buffer for the sampling gathers.
-            # llama_ccl.line_all_gather allocates the barrier semaphore ONLY when
-            # persistent_buffer is None (llama_ccl.py:1297), and both all-gather program
-            # factories gate the barrier on `barrier_semaphore.has_value() && !using_persistent
-            # _buffers`. SAMPLING_VALUES/SAMPLING_INDICES are always preallocated, so these two
-            # gathers always run WITHOUT the barrier -- and the barrier is what stops a remote
-            # device from STARTING to write a buffer a peer is still reading (out_ready_sem only
-            # covers completion). An earlier attempt to force the barrier while KEEPING the
-            # persistent buffer was inert on device for exactly that gating reason; dropping the
-            # buffer is the inverse, and the only way to make the barrier engage from Python.
             if self._line_all_gather_supports_buffer_key and buffer_key is not None:
-                if not self._no_persist_gather():
-                    line_all_gather_kwargs["buffer_key"] = buffer_key
+                line_all_gather_kwargs["buffer_key"] = buffer_key
             return self._line_all_gather(tensor, **line_all_gather_kwargs)
 
         return ttnn.all_gather(
@@ -1088,7 +1060,7 @@ class TTSampling(LightweightModule):
         sampling_values = self._adjust_values_for_tiebreak(
             topk_values_gathered_bf16_interleaved, topk_global_indices_interleaved
         )
-        # E4: seed immediately before the draw. The tie-break's int32 ops run on the
+        # Seed immediately before the draw. The tie-break's int32 ops run on the
         # SFPU (use_sfpu_reduce_path admits INT32 MIN/MAX/SUM) on the same sub-core grid,
         # and rand_tile's PRNG/LREG state is programmed by manual_seed -- so any SFPU work
         # between seeding and drawing can perturb the draw. The original's fp32 tie-break

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from collections import defaultdict
 from dataclasses import fields, replace
 from typing import List
@@ -230,9 +229,7 @@ class Generator(WarmupForwardMixin):
         self.trace_inputs_decode = defaultdict(lambda: None)
         self.trace_output_decode = defaultdict(lambda: None)
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
-        # DIAGNOSTIC: TT_DECODE_NO_TRACE=1 runs decode untraced so Python probes can observe
-        # the serving path (ttnn.execute_trace never re-enters Python). Slow; debug only.
-        self._disable_decode_tracing = bool(os.environ.get("TT_DECODE_NO_TRACE"))
+        self._disable_decode_tracing = False  # Whether to disable decode traces
         self._decode_inputs_need_reset = False
 
     def _set_prefill_column_mask(self, tt_column_mask):
@@ -1402,18 +1399,6 @@ class Generator(WarmupForwardMixin):
             reset_inputs = True
             reset_reasons.append("reset_batch")
 
-        # DIAGNOSTIC (TT_RESET_PROBE=N): reset_inputs copies HOST tokens over the decode
-        # trace's token input -- the same buffer on-device sampling writes the sampled token
-        # into. With device sampling the host copy is intentionally stale, so a reset firing
-        # every step would overwrite each sampled token. reset_reasons is collected but never
-        # logged, so print it for the first N decode steps.
-        _rp = int(os.environ.get("TT_RESET_PROBE", "0"))
-        if _rp and getattr(self, "_reset_probe_left", _rp) > 0:
-            self._reset_probe_left = getattr(self, "_reset_probe_left", _rp) - 1
-            logger.warning(
-                f"[reset-probe] reset_inputs={reset_inputs} reasons={reset_reasons} "
-                f"page_table_changed={page_table_changed} on_device_sampling={on_device_sampling}"
-            )
         kv_cache = kv_cache[0]
         active_seed_slots = None
         if start_pos is not None:
@@ -1591,35 +1576,6 @@ class Generator(WarmupForwardMixin):
         """
         Executes the trace for the decode_forward method but does not read back outputs.
         """
-        # DIAGNOSTIC (TT_TRACE_ALLOC_PROBE=N): the unsafe-allocation tracker is a query API,
-        # not a logger -- nothing reports on its own. Ask it, right before replay, which
-        # buffers were allocated behind THIS live trace.
-        # DIAGNOSTIC (TT_TOKIN_PROBE=N): read the decode trace's TOKEN INPUT right before
-        # replay. On-device sampling writes the sampled token into this exact buffer; the next
-        # replay reads it back. If the sampler wrote a real token but this reads 0, something
-        # between the two clobbered it (reset_inputs copying stale host tokens is the suspect).
-        _tp = int(os.environ.get("TT_TOKIN_PROBE", "0"))
-        if _tp and getattr(self, "_tokin_probe_left", _tp) > 0:
-            self._tokin_probe_left = getattr(self, "_tokin_probe_left", _tp) - 1
-            try:
-                _tin = device_inputs[0] if device_inputs else None
-                if _tin is not None:
-                    _v = ttnn.to_torch(ttnn.get_device_tensors(_tin)[0]).reshape(-1)[:8]
-                    logger.warning(f"[tokin-probe] decode token input before replay: {_v.tolist()}")
-            except Exception as _e:
-                logger.warning(f"[tokin-probe] read failed: {_e}")
-        _probe = int(os.environ.get("TT_TRACE_ALLOC_PROBE", "0"))
-        if _probe and getattr(self, "_alloc_probe_left", _probe) > 0:
-            self._alloc_probe_left = getattr(self, "_alloc_probe_left", _probe) - 1
-            try:
-                unsafe = ttnn._ttnn.operations.trace.get_unsafe_tracked_ids(self.mesh_device, trace_id)
-                logger.warning(f"[alloc-probe] decode trace {trace_id}: {len(unsafe)} unsafe allocation(s)")
-                from collections import Counter as _C
-
-                for ctx, cnt in _C(unsafe.values()).most_common(12):
-                    logger.warning(f"[alloc-probe]   x{cnt:<4} {str(ctx)[:150]}")
-            except Exception as _e:
-                logger.warning(f"[alloc-probe] query failed: {_e}")
         ttnn.execute_trace(self.mesh_device, trace_id, cq_id=0, blocking=False)
 
         return tt_out_trace


### PR DESCRIPTION
Follow-up to #54292, which was squash-merged as 1ec5b723981 and carried five env-gated diagnostic hooks onto main. They are an A/B experiment harness, not part of the fix.

Removed:
  TT_SAMPLING_NO_PERSIST / _TOGGLE  tt_sampling.py  _no_persist_gather
  TT_DECODE_NO_TRACE                generator.py    __init__
  TT_RESET_PROBE                    generator.py    decode_forward_text
  TT_TOKIN_PROBE                    generator.py    _decode_trace_text
  TT_TRACE_ALLOC_PROBE              generator.py    _decode_trace_text

The toggle variant was the worst: _no_persist_gather is called from _perform_all_gather, so with TT_SAMPLING_NO_PERSIST_TOGGLE set it did an open() + read() per sampling all-gather per token, in the decode hot path.

Behaviour with the hooks unset -- the only configuration anything ever shipped with -- is unchanged:
  _no_persist_gather() returned False, so buffer_key was set; it is now set
  unconditionally.
  _disable_decode_tracing was bool(unset) == False; it is now literal False.
  The three probes read int("0") == 0 and never fired.

Both bool(os.environ.get(...)) sites were inside the removed code. The now-unused `import os` goes from both files -- #54292 added both. Also drops the "E4:" label from the manual_seed comment, an investigation note implying E1-E3; the technical rationale for seeding immediately before the draw is kept.

The same removal is on ctr-ifabijanic/qwen32_fixes for the release branch; the two are byte-identical apart from that branch's corruptible_allocation_scope shim and main's newer ttnn.all_gather fallback signature.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/remove_sampling_debug_hooks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-ifabijanic/remove_sampling_debug_hooks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/remove_sampling_debug_hooks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-ifabijanic/remove_sampling_debug_hooks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-ifabijanic/remove_sampling_debug_hooks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-ifabijanic/remove_sampling_debug_hooks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-ifabijanic/remove_sampling_debug_hooks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-ifabijanic/remove_sampling_debug_hooks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-ifabijanic/remove_sampling_debug_hooks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-ifabijanic/remove_sampling_debug_hooks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-ifabijanic/remove_sampling_debug_hooks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-ifabijanic/remove_sampling_debug_hooks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-ifabijanic/remove_sampling_debug_hooks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-ifabijanic/remove_sampling_debug_hooks)