### PR TITLE
[Feature] Report AI job and run summaries for the L2 nightly pipeline

### DIFF
--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -285,6 +285,11 @@ def build_test_matrix(tests, enabled_skus, sku_config, event=None, allow_missing
             for key, value in sku_test_config.items():
                 if key != "timeout" and value is not None:
                     entry[key] = value
+            # ai_summary is the authoring surface in the tests yaml; flatten it to the
+            # keys the impls read so every leg carries them and no workflow has to guard
+            # on the section being absent.
+            ai_summary = entry.pop("ai_summary", None) or {}
+            entry["authoritative_job_status"] = bool(ai_summary.get("authoritative_job_status", False))
             sku_entry = sku_config[concrete_sku]
             if "weights-cache-mode" in sku_entry:
                 entry["weights-cache-mode"] = sku_entry["weights-cache-mode"]

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -285,9 +285,10 @@ def build_test_matrix(tests, enabled_skus, sku_config, event=None, allow_missing
             for key, value in sku_test_config.items():
                 if key != "timeout" and value is not None:
                     entry[key] = value
-            # ai_summary is the authoring surface in the tests yaml; flatten it to the
-            # keys the impls read so every leg carries them and no workflow has to guard
-            # on the section being absent.
+            # ai_summary is the authoring surface in the tests yaml; flatten it so an impl
+            # reads a plain key instead of guarding on the section. Only the impls that
+            # forward authoritative_job_status act on it -- setting it on a test under any
+            # other impl is computed here and then dropped.
             ai_summary = entry.pop("ai_summary", None) or {}
             entry["authoritative_job_status"] = bool(ai_summary.get("authoritative_job_status", False))
             sku_entry = sku_config[concrete_sku]

--- a/.github/workflows/llk-unit-tests-impl.yaml
+++ b/.github/workflows/llk-unit-tests-impl.yaml
@@ -39,6 +39,15 @@ on:
           Optional logical SKU allowlist (comma-separated) for change gating.
           Default "*" means no extra filter. Empty string skips all tests.
           Any other value is forwarded as --sku-allowlist.
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -137,16 +146,19 @@ jobs:
           auto-triage: true
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports
-          if [[ '${{ matrix.test-group.dispatch_mode }}' == 'sd' ]]; then
-            TT_METAL_SLOW_DISPATCH_MODE=1 ${{ matrix.test-group.cmd }}
-          elif [[ '${{ matrix.test-group.dispatch_mode }}' == 'fd' ]]; then
-            ${{ matrix.test-group.cmd }}
-          else
-            echo "Unsupported dispatch_mode: '${{ matrix.test-group.dispatch_mode }}'. Expected one of: fd, sd." >&2
-            exit 1
-          fi
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
+            if [[ '${{ matrix.test-group.dispatch_mode }}' == 'sd' ]]; then
+              TT_METAL_SLOW_DISPATCH_MODE=1 ${{ matrix.test-group.cmd }}
+            elif [[ '${{ matrix.test-group.dispatch_mode }}' == 'fd' ]]; then
+              ${{ matrix.test-group.cmd }}
+            else
+              echo "Unsupported dispatch_mode: '${{ matrix.test-group.dispatch_mode }}'. Expected one of: fd, sd." >&2
+              exit 1
+            fi
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -155,3 +167,19 @@ jobs:
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}

--- a/.github/workflows/ops-integration-tests-impl.yaml
+++ b/.github/workflows/ops-integration-tests-impl.yaml
@@ -23,6 +23,15 @@ on:
         required: false
         type: boolean
         default: false
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -108,12 +117,31 @@ jobs:
           enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -143,7 +143,8 @@ jobs:
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
-              "scope": "${{ inputs.summary-scope }}"
+              "scope": "${{ inputs.summary-scope }}",
+              "authoritative_job_status": ${{ (matrix.test-group.ai_summary && matrix.test-group.ai_summary.authoritative_job_status) || false }}
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -25,6 +25,15 @@ on:
         required: false
         type: boolean
         default: false
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -113,12 +122,31 @@ jobs:
           enable-llk-asserts: ${{ inputs.enable-llk-asserts }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/ops-unit-tests-impl.yaml
+++ b/.github/workflows/ops-unit-tests-impl.yaml
@@ -144,7 +144,7 @@ jobs:
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}",
-              "authoritative_job_status": ${{ (matrix.test-group.ai_summary && matrix.test-group.ai_summary.authoritative_job_status) || false }}
+              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status }}
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/syseng-didt-tests-impl.yaml
+++ b/.github/workflows/syseng-didt-tests-impl.yaml
@@ -15,6 +15,15 @@ on:
       enabled-skus:
         required: true
         type: string
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -92,12 +101,31 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/triage-tests-impl.yaml
+++ b/.github/workflows/triage-tests-impl.yaml
@@ -40,6 +40,15 @@ on:
           Max allowed timeout (minutes) for any individual test SKU entry in the
           tests yaml. Verified during load-test-matrix via verify_time_budget.py.
           Empty skips the per-test ceiling check.
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -128,11 +137,14 @@ jobs:
           auto-triage: false # Disable auto-triage because we need to run triage tests explicitly
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports
-          uv pip install -r tools/triage/requirements.txt
-          echo "${{ matrix.test-group.cmd }}"
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
+            uv pip install -r tools/triage/requirements.txt
+            echo "${{ matrix.test-group.cmd }}"
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
@@ -141,3 +153,20 @@ jobs:
       - name: Generate test annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}",
+              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status || false }}
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}

--- a/.github/workflows/triage-tests-impl.yaml
+++ b/.github/workflows/triage-tests-impl.yaml
@@ -165,7 +165,7 @@ jobs:
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}",
-              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status || false }}
+              "authoritative_job_status": ${{ (matrix.test-group.ai_summary && matrix.test-group.ai_summary.authoritative_job_status) || false }}
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/triage-tests-impl.yaml
+++ b/.github/workflows/triage-tests-impl.yaml
@@ -165,7 +165,7 @@ jobs:
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}",
-              "authoritative_job_status": ${{ (matrix.test-group.ai_summary && matrix.test-group.ai_summary.authoritative_job_status) || false }}
+              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status }}
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/tt-cnn-unit-tests-impl.yaml
+++ b/.github/workflows/tt-cnn-unit-tests-impl.yaml
@@ -24,6 +24,15 @@ on:
         required: false
         type: boolean
         default: false
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -109,12 +118,31 @@ jobs:
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -316,6 +316,7 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
+      summary-scope: unit
   tt-train-perf-pretraining-tests:
     needs: [build-artifact, generate-arch-matrix]
     if: |
@@ -331,6 +332,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       subcategories: pretraining
+      summary-scope: pretraining
   tt-train-perf-finetuning-tests:
     needs: [build-artifact, generate-arch-matrix]
     if: |
@@ -346,6 +348,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       subcategories: finetuning
+      summary-scope: finetuning
 
   # =============================================================================
   # Triage team

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -384,3 +384,121 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enabled-skus: ${{ needs.generate-arch-matrix.outputs.l2-nightly-skus }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
+
+  # =============================================================================
+  # AI run summary
+  # =============================================================================
+  # Aggregates the per-leg ai-job-summary artifacts into one run-level report.
+  # expected-jobs is the union of each impl's matrix, so a leg whose runner died is
+  # reported as an infra failure rather than silently dropped. A new test job must be
+  # added to `needs:` below or its legs are absent from that union with no error.
+  #
+  # No scope: this workflow has no workflow_call trigger and no call site carries a
+  # strategy matrix, so exactly one instance of this job exists per run. A scoped run
+  # stage over unscoped job summaries matches nothing and stubs every leg
+  # INFRA_FAILURE, which is strictly worse than the collision scope guards against.
+  #
+  # check-harbor, build-artifact, generate-arch-matrix and resolve-docker-pull-refs
+  # are in `needs:` because every test job is gated on them: when the build fails the
+  # impls are *skipped*, not failed, and without them the combined result would be
+  # `skipped` — which suppresses infra synthesis entirely and reports a broken run as
+  # if nothing was due.
+  ai-run-summary:
+    name: "AI Run Summary"
+    needs:
+      - check-harbor
+      - build-artifact
+      - generate-arch-matrix
+      - resolve-docker-pull-refs
+      - ttsim-unit-tests
+      - syseng-didt-tests
+      - ops-unit-tests
+      - ops-integration-tests
+      - ttnn-integration-tests
+      - cnn-unit-tests
+      - ttnn-p100-tests
+      - umd-p100-tests
+      - tt-train-unit-tests
+      - tt-train-perf-pretraining-tests
+      - tt-train-perf-finetuning-tests
+      - triage-tests
+      - llk-unit-tests
+    # Reports on a run that failed — the case the summary exists for — but not
+    # on one that was cancelled: an aborted run has no outcome to summarize, and
+    # asking for one spends an LLM call to say it stopped early.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # download the per-leg ai_job_summary artifacts
+      contents: read # a job-level block zeroes every scope it omits, incl. checkout's
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          filter: blob:none
+          sparse-checkout: .github
+      - name: Aggregate child matrices and results
+        id: aggregate
+        # Reporting must never fail the run: a jq error here would turn a green
+        # nightly red.
+        continue-on-error: true
+        env:
+          # toJSON(needs) is one object keyed by child job name, each with `result`
+          # and `outputs.matrix`; aggregating from it keeps this data-driven as jobs
+          # are added to or removed from the `needs` list.
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          # Expected legs come from the children that ran. A cancelled child keeps a
+          # successful load-test-matrix, so including it would stub its legs as
+          # INFRA_FAILURE when another child failed; skipped children expose a
+          # null/empty matrix, which fromjson would throw on. On workflow_dispatch
+          # most test jobs are legitimately skipped, so this is the common path here.
+          RAN=$(jq -cn --argjson n "$NEEDS" '
+            [$n[] | select(.result != "cancelled" and .result != "skipped")]')
+
+          EXPECTED=$(jq -cn --argjson r "$RAN" '
+            [$r[] | .outputs.matrix | select(. != null and . != "") | fromjson] | add // []')
+          echo "expected-jobs=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "Merged $(echo "$EXPECTED" | jq 'length') expected legs"
+
+          # Most-severe-wins over every child, so a cancelled run says so in the
+          # report instead of reading as a clean pass. Upstream also treats
+          # cancelled/skipped as "expect nothing", which is what we want: legs that
+          # never finished were aborted, not infra failures.
+          RESULT=$(jq -rn --argjson n "$NEEDS" '
+            [$n[].result] as $s |
+            if   any($s[]; . == "failure")   then "failure"
+            elif any($s[]; . == "cancelled") then "cancelled"
+            elif any($s[]; . == "success")   then "success"
+            else                                  "skipped"
+            end')
+          echo "run-result=$RESULT" >> "$GITHUB_OUTPUT"
+          echo "Combined run-result: $RESULT"
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ steps.aggregate.outputs.expected-jobs }}
+          run-result: ${{ steps.aggregate.outputs.run-result }}
+      - name: Show report
+        if: ${{ always() && steps.ai-run-summary.outputs.report-file != '' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/tt-train-tests.yaml
+++ b/.github/workflows/tt-train-tests.yaml
@@ -280,7 +280,7 @@ jobs:
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}",
-              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status || false }}
+              "authoritative_job_status": ${{ (matrix.test-group.ai_summary && matrix.test-group.ai_summary.authoritative_job_status) || false }}
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/tt-train-tests.yaml
+++ b/.github/workflows/tt-train-tests.yaml
@@ -63,6 +63,15 @@ on:
           Max allowed timeout (minutes) for any individual test SKU entry in the
           tests yaml. Verified during load-test-matrix via verify_time_budget.py.
           Empty skips the per-test ceiling check.
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 permissions:
   contents: read
@@ -190,11 +199,14 @@ jobs:
 
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
-        run: |
-          python3 tools/tt-power-sidecar/tt_power_sidecar.py \
-            --backend sysfs \
-            --out /work/power_report.json \
-            -- bash -c '${{ matrix.test-group.cmd }}'
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            python3 tools/tt-power-sidecar/tt_power_sidecar.py \
+              --backend sysfs \
+              --out /work/power_report.json \
+              -- bash -c '${{ matrix.test-group.cmd }}'
 
       - name: Upload loss plot
         id: upload-loss-plot
@@ -255,6 +267,24 @@ jobs:
         with:
           path: /work/generated/test_reports
           prefix: "test_reports_"
+
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}",
+              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status || false }}
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/tt-train-tests.yaml
+++ b/.github/workflows/tt-train-tests.yaml
@@ -280,7 +280,7 @@ jobs:
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
               "scope": "${{ inputs.summary-scope }}",
-              "authoritative_job_status": ${{ (matrix.test-group.ai_summary && matrix.test-group.ai_summary.authoritative_job_status) || false }}
+              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status }}
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/ttnn-integration-tests-impl.yaml
+++ b/.github/workflows/ttnn-integration-tests-impl.yaml
@@ -23,6 +23,15 @@ on:
         required: false
         type: boolean
         default: false
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -106,12 +115,31 @@ jobs:
           auto-triage: true
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -583,7 +583,8 @@ jobs:
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
               "output_dir": "generated/ai_summaries",
-              "scope": "${{ inputs.summary-scope }}"
+              "scope": "${{ inputs.summary-scope }}",
+              "authoritative_job_status": ${{ matrix.test-group.authoritative_job_status }}
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -25,6 +25,15 @@ on:
         required: false
         type: boolean
         default: false
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -150,12 +159,31 @@ jobs:
           sku: ${{ matrix.test-group.sku }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -34,6 +34,8 @@
 
 - name: ttnn nightly matmul tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n150_civ2:
       timeout: 50

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -282,6 +282,8 @@
 
 - name: ttnn nightly data_movement tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/data_movement -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n150_civ2:
       timeout: 50
@@ -309,6 +311,8 @@
 - name: ttnn nightly data_movement tests (post-commit suite)
   # Measured: bh_p100 ~28 min, bh_p150b ~57 min, wh_n300 ~66 min, wh_n150 ~89 min.
   cmd: 'pytest tests/ttnn/unit_tests/operations/data_movement -xv -m "not disable_fast_runtime_mode" --timeout=300'
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n150_civ2:
       timeout: 120

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -66,6 +66,8 @@
 
 - name: ttnn nightly reduction tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/reduction -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n150_civ2:
       timeout: 45

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -19,6 +19,8 @@
 
 - name: ttnn nightly conv tests
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode" --timeout=600'
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n150_civ2:
       timeout: 150

--- a/tests/pipeline_reorg/train_unit_tests.yaml
+++ b/tests/pipeline_reorg/train_unit_tests.yaml
@@ -29,11 +29,8 @@
   cmd: |
     mkdir -p generated/test_reports
     build/tt-train/tests/ttml_tests --gtest_output=xml:generated/test_reports/ctest_report.xml --gtest_filter="-*NIGHTLY*"
-  # Negative tests here provoke and catch fatal asserts; assert.hpp logs the TT_FATAL
-  # before throwing, so the crash patterns see a real crash on a passing run. There is
-  # no C++ equivalent of the expect_error fixture, so a green job status settles it.
-  # Failed tests, a non-zero exit code and a missing finish marker still decide.
-  authoritative_job_status: true
+  ai_summary:
+    authoritative_job_status: true
   skus:
     bh_p100:
       timeout: 30

--- a/tests/pipeline_reorg/train_unit_tests.yaml
+++ b/tests/pipeline_reorg/train_unit_tests.yaml
@@ -29,6 +29,11 @@
   cmd: |
     mkdir -p generated/test_reports
     build/tt-train/tests/ttml_tests --gtest_output=xml:generated/test_reports/ctest_report.xml --gtest_filter="-*NIGHTLY*"
+  # Negative tests here provoke and catch fatal asserts; assert.hpp logs the TT_FATAL
+  # before throwing, so the crash patterns see a real crash on a passing run. There is
+  # no C++ equivalent of the expect_error fixture, so a green job status settles it.
+  # Failed tests, a non-zero exit code and a missing finish marker still decide.
+  authoritative_job_status: true
   skus:
     bh_p100:
       timeout: 30

--- a/tests/pipeline_reorg/triage_tests.yaml
+++ b/tests/pipeline_reorg/triage_tests.yaml
@@ -9,6 +9,10 @@
 
 - name: triage_hang_report
   cmd: pytest -v -s ./tools/tests/triage/test_hang_report.py
+  # Provoking a device hang is the point of this test, so a passing run always logs
+  # TT_THROW: TIMEOUT from the device layer. That throw is raised below the test, out
+  # of reach of the expect_error fixture, so a green job status settles it.
+  authoritative_job_status: true
   skus:
     wh_n150_civ2:
       timeout: 5

--- a/tests/pipeline_reorg/triage_tests.yaml
+++ b/tests/pipeline_reorg/triage_tests.yaml
@@ -9,10 +9,8 @@
 
 - name: triage_hang_report
   cmd: pytest -v -s ./tools/tests/triage/test_hang_report.py
-  # Provoking a device hang is the point of this test, so a passing run always logs
-  # TT_THROW: TIMEOUT from the device layer. That throw is raised below the test, out
-  # of reach of the expect_error fixture, so a green job status settles it.
-  authoritative_job_status: true
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n150_civ2:
       timeout: 5

--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -37,6 +37,8 @@
     tests/ttnn/unit_tests/operations/data_movement/test_full.py::test_full_int
     tests/ttnn/unit_tests/operations/data_movement/test_dropout.py::test_dopout
     tests/ttnn/unit_tests/operations/data_movement/test_non_zero_indices.py::test_non_zero_indices_ttnn
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n300_civ2:
       timeout: 5
@@ -268,6 +270,8 @@
   # device. Exporting it here rather than relying on the directory conftest's fixture also makes
   # the requirement visible, and satisfies the requires_hybrid_allocator marker on those tests.
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode" && TT_METAL_ALLOCATOR_MODE_HYBRID=1 pytest --timeout 300 tests/ttnn/unit_tests/per_core_allocation -xv'
+  ai_summary:
+    authoritative_job_status: true
   skus:
     wh_n300_civ2:
       timeout: 40

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_concat_memory_configs_and_layouts.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_concat_memory_configs_and_layouts.py
@@ -1451,7 +1451,7 @@ class TestUnsupportedCases:
             dtype=ttnn.bfloat16,
         )
 
-        with expect_error(RuntimeError, "output_tensor"):
+        with expect_error(RuntimeError, "optional output tensor"):
             ttnn.concat([ttnn_t, ttnn_t], dim=2, output_tensor=out_t)
 
     def test_sharded_height_concat_on_height_sharded_not_supported(self, device, expect_error):

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_concat_memory_configs_and_layouts.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_concat_memory_configs_and_layouts.py
@@ -1337,7 +1337,7 @@ class TestUnsupportedCases:
 
     def test_empty_tensor_list(self, device, expect_error):
         """Empty input list should raise."""
-        with expect_error(RuntimeError, "expected a non-empty list of Tensors"):
+        with expect_error(RuntimeError, r"ttnn.concat: expected a non-empty list of Tensors"):
             ttnn.concat([], dim=0)
 
     def test_block_sharded_non_tile_aligned_shard(self, device, expect_error):
@@ -1355,7 +1355,7 @@ class TestUnsupportedCases:
 
         torch_a = random_torch_tensor(ttnn.bfloat16, shape)
 
-        with expect_error(RuntimeError, "shard"):
+        with expect_error(RuntimeError, r"Physical shard shape"):
             ttnn.from_torch(
                 torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=block_mem
             )
@@ -1377,7 +1377,7 @@ class TestUnsupportedCases:
         ttnn_a = ttnn.from_torch(torch_a, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16)
         ttnn_a = ttnn.to_memory_config(ttnn_a, block_mem)
 
-        with expect_error(RuntimeError, "Number of shards along height"):
+        with expect_error(RuntimeError, r"Number of shards along height"):
             ttnn.concat([ttnn_a, ttnn_a], dim=0, memory_config=block_mem)
 
     def test_block_sharded_non_rectangular_grid(self, device, expect_error):
@@ -1400,7 +1400,7 @@ class TestUnsupportedCases:
 
         torch_a = random_torch_tensor(ttnn.bfloat16, shape)
 
-        with expect_error(RuntimeError, "shard"):
+        with expect_error(RuntimeError, r"Shard grid must be one full rectangular grid"):
             ttnn.from_torch(
                 torch_a, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16, memory_config=block_mem
             )
@@ -1413,7 +1413,7 @@ class TestUnsupportedCases:
         ttnn_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
         ttnn_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
 
-        with expect_error(RuntimeError, "index out of range"):
+        with expect_error(RuntimeError, r"ShapeBase\[\] index out of range"):
             ttnn.concat([ttnn_a, ttnn_b], dim=0)
 
     def test_mismatched_non_concat_dims(self, device, expect_error):
@@ -1426,7 +1426,7 @@ class TestUnsupportedCases:
 
         with expect_error(
             RuntimeError,
-            "All dimensions must be the same size except for the dimension along which the contenation is taking place.",
+            r"All dimensions must be the same size except for the dimension along which the contenation is taking place.",
         ):
             ttnn.concat([ttnn_a, ttnn_b], dim=3)
 
@@ -1436,7 +1436,7 @@ class TestUnsupportedCases:
         torch_t = random_torch_tensor(ttnn.bfloat16, shape)
         ttnn_t = ttnn.from_torch(torch_t, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
 
-        with expect_error(RuntimeError, "Index is out of bounds for the rank"):
+        with expect_error(RuntimeError, r"Index is out of bounds for the rank"):
             ttnn.concat([ttnn_t, ttnn_t], dim=4)
 
     def test_optional_output_tensor_unsupported(self, device, expect_error):
@@ -1451,7 +1451,7 @@ class TestUnsupportedCases:
             dtype=ttnn.bfloat16,
         )
 
-        with expect_error(RuntimeError, "optional output tensor"):
+        with expect_error(RuntimeError, r"optional output tensor"):
             ttnn.concat([ttnn_t, ttnn_t], dim=2, output_tensor=out_t)
 
     def test_sharded_height_concat_on_height_sharded_not_supported(self, device, expect_error):
@@ -1479,7 +1479,7 @@ class TestUnsupportedCases:
         ttnn_a = ttnn.from_torch(torch_a, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16)
         ttnn_a = ttnn.to_memory_config(ttnn_a, input_mem)
 
-        with expect_error(RuntimeError, "Only support height concat on width-sharded or block-sharded tensors"):
+        with expect_error(RuntimeError, r"Only support height concat on width-sharded or block-sharded tensors"):
             ttnn.concat([ttnn_a, ttnn_a], dim=2, memory_config=output_mem)
 
     def test_width_concat_on_width_sharded_not_supported(self, device, expect_error):
@@ -1507,5 +1507,5 @@ class TestUnsupportedCases:
         ttnn_a = ttnn.from_torch(torch_a, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=ttnn.bfloat16)
         ttnn_a = ttnn.to_memory_config(ttnn_a, input_mem)
 
-        with expect_error(RuntimeError, "Only support width concat on height-sharded or block-sharded tensors"):
+        with expect_error(RuntimeError, r"Only support width concat on height-sharded or block-sharded tensors"):
             ttnn.concat([ttnn_a, ttnn_a], dim=3, memory_config=output_mem)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_scatter.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_scatter.py
@@ -387,7 +387,7 @@ def test_scatter_reduction(
 
 
 @pytest.mark.parametrize(
-    "dim, input_shape, index_shape, source_shape, torch_dtype, input_dtype, index_dtype, source_dtype",
+    "dim, input_shape, index_shape, source_shape, torch_dtype, input_dtype, index_dtype, source_dtype, expected_message",
     [
         (
             10,
@@ -398,6 +398,7 @@ def test_scatter_reduction(
             ttnn.bfloat16,
             ttnn.uint16,
             ttnn.bfloat16,
+            "is out of range for tensor rank",
         ),  # input_rank vs dim
         (
             -10,
@@ -408,6 +409,7 @@ def test_scatter_reduction(
             ttnn.bfloat16,
             ttnn.uint16,
             ttnn.bfloat16,
+            "is out of range for tensor rank",
         ),  # input_rank vs dim
         (
             0,
@@ -418,6 +420,7 @@ def test_scatter_reduction(
             ttnn.bfloat16,
             ttnn.uint16,
             ttnn.bfloat16,
+            "input_rank must be equal to index_rank",
         ),  # index_shape vs source_shape
         (
             0,
@@ -428,6 +431,7 @@ def test_scatter_reduction(
             ttnn.bfloat16,
             ttnn.bfloat16,
             ttnn.bfloat16,
+            "index_dtype is not integer",
         ),  # index_dtype is integer
     ],
 )
@@ -440,7 +444,9 @@ def test_scatter_failing_cases(
     input_dtype,
     index_dtype,
     source_dtype,
+    expected_message,
     device,
+    expect_error,
 ):
     torch.manual_seed(0)
     torch_index_dtype = select_torch_dtype(index_dtype)
@@ -456,7 +462,7 @@ def test_scatter_failing_cases(
     torch_src = torch.randn(source_shape, dtype=torch_source_dtype)
     ttnn_src = ttnn.from_torch(torch_src, dtype=source_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, expected_message):
         ttnn.scatter(ttnn_input, dim, ttnn_index, ttnn_src)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
@@ -22,13 +22,12 @@ from tests.ttnn.nightly.unit_tests.operations.eltwise.backward.utility_funcs imp
         -1.0,
     ],
 )
-def test_negative_exponent(input_shapes, exponent, device):
+def test_negative_exponent(input_shapes, exponent, device, expect_error):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
-    with pytest.raises(RuntimeError) as _e:  # allow-pytest.raises: pre-existing, predates this hook
-        tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
-    assert "exponent >= 0.0" in str(_e.value)
+    with expect_error(RuntimeError, "negative exponents are not supported"):
+        ttnn.pow_bw(grad_tensor, input_tensor, exponent)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_pow.py
@@ -26,7 +26,7 @@ def test_negative_exponent(input_shapes, exponent, device, expect_error):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
-    with expect_error(RuntimeError, "negative exponents are not supported"):
+    with expect_error(RuntimeError, r"negative exponents are not supported"):
         ttnn.pow_bw(grad_tensor, input_tensor, exponent)
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
@@ -78,7 +78,7 @@ class TestMatmulBlockSharded1DGrid:
         )
 
         # Should raise RuntimeError with message about BLOCK_SHARDED on 1D grid
-        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
+        with expect_error(RuntimeError, r"BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
 
         assert "BLOCK_SHARDED" in str(excinfo.value)
@@ -128,7 +128,7 @@ class TestMatmulBlockSharded1DGrid:
         )
 
         # Should raise RuntimeError with message about BLOCK_SHARDED on 1D grid
-        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
+        with expect_error(RuntimeError, r"BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
 
         assert "BLOCK_SHARDED" in str(excinfo.value)
@@ -336,7 +336,7 @@ class TestMatmulBlockSharded1DGridOriginalIssue:
         )
 
         # With the fix, this should raise RuntimeError instead of hanging
-        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
+        with expect_error(RuntimeError, r"BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(v2, v3, memory_config=memory_config)
 
         error_msg = str(excinfo.value)
@@ -375,7 +375,7 @@ class TestMatmulBlockSharded1DGridOriginalIssue:
         )
 
         # With the fix, this should raise RuntimeError instead of hanging
-        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
+        with expect_error(RuntimeError, r"BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
 
         error_msg = str(excinfo.value)

--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
@@ -43,7 +43,7 @@ class TestMatmulBlockSharded1DGrid:
         ],
     )
     def test_matmul_block_sharded_1d_column_grid_batched_b(
-        self, device, batch_a, batch_b, M, K, N, grid_start, grid_end
+        self, device, batch_a, batch_b, M, K, N, grid_start, grid_end, expect_error
     ):
         """
         Test that BLOCK_SHARDED on 1D column grid with batched B tensor raises an error.
@@ -78,7 +78,7 @@ class TestMatmulBlockSharded1DGrid:
         )
 
         # Should raise RuntimeError with message about BLOCK_SHARDED on 1D grid
-        with pytest.raises(RuntimeError) as excinfo:
+        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
 
         assert "BLOCK_SHARDED" in str(excinfo.value)
@@ -93,7 +93,9 @@ class TestMatmulBlockSharded1DGrid:
             (2, 2, 64, 64, 64, (0, 0), (1, 0)),
         ],
     )
-    def test_matmul_block_sharded_1d_row_grid_batched_b(self, device, batch_a, batch_b, M, K, N, grid_start, grid_end):
+    def test_matmul_block_sharded_1d_row_grid_batched_b(
+        self, device, batch_a, batch_b, M, K, N, grid_start, grid_end, expect_error
+    ):
         """
         Test that BLOCK_SHARDED on 1D row grid with batched B tensor raises an error.
 
@@ -126,7 +128,7 @@ class TestMatmulBlockSharded1DGrid:
         )
 
         # Should raise RuntimeError with message about BLOCK_SHARDED on 1D grid
-        with pytest.raises(RuntimeError) as excinfo:
+        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
 
         assert "BLOCK_SHARDED" in str(excinfo.value)
@@ -299,7 +301,7 @@ class TestMatmulBlockSharded1DGrid:
 class TestMatmulBlockSharded1DGridOriginalIssue:
     """Tests that specifically reproduce the original issue #32306 scenario."""
 
-    def test_original_issue_exact_shapes(self, device):
+    def test_original_issue_exact_shapes(self, device, expect_error):
         """
         Reproduce the EXACT scenario from GitHub issue #32306.
 
@@ -334,7 +336,7 @@ class TestMatmulBlockSharded1DGridOriginalIssue:
         )
 
         # With the fix, this should raise RuntimeError instead of hanging
-        with pytest.raises(RuntimeError) as excinfo:
+        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(v2, v3, memory_config=memory_config)
 
         error_msg = str(excinfo.value)
@@ -343,7 +345,7 @@ class TestMatmulBlockSharded1DGridOriginalIssue:
         # Should suggest workarounds
         assert "HEIGHT_SHARDED" in error_msg or "WIDTH_SHARDED" in error_msg or "2D" in error_msg
 
-    def test_original_issue_shapes_batched_error(self, device):
+    def test_original_issue_shapes_batched_error(self, device, expect_error):
         """
         Reproduce the exact scenario from GitHub issue #32306 using torch tensors.
 
@@ -373,7 +375,7 @@ class TestMatmulBlockSharded1DGridOriginalIssue:
         )
 
         # With the fix, this should raise RuntimeError instead of hanging
-        with pytest.raises(RuntimeError) as excinfo:
+        with expect_error(RuntimeError, "BLOCK_SHARDED") as excinfo:
             _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
 
         error_msg = str(excinfo.value)

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
@@ -135,7 +135,7 @@ def test_moreh_clip_grad_norm_with_error_if_nonfinite(error_if_nonfinite, device
         )
 
     if error_if_nonfinite:
-        with expect_error(RuntimeError, "is non-finite, so it cannot be clipped"):
+        with expect_error(RuntimeError, r"The total norm of order"):
             run_clip_grad_norm()
     else:
         run_clip_grad_norm()

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_clip_grad_norm.py
@@ -99,7 +99,7 @@ def test_moreh_clip_grad_norm(
 
 
 @pytest.mark.parametrize("error_if_nonfinite", [True, False])
-def test_moreh_clip_grad_norm_with_error_if_nonfinite(error_if_nonfinite, device):
+def test_moreh_clip_grad_norm_with_error_if_nonfinite(error_if_nonfinite, device, expect_error):
     torch.manual_seed(2023)
 
     cpu_dtype = torch.bfloat16
@@ -126,14 +126,16 @@ def test_moreh_clip_grad_norm_with_error_if_nonfinite(error_if_nonfinite, device
         assert error_if_nonfinite
 
     # Check tt behavior
-    try:
+    def run_clip_grad_norm():
         ttnn.operations.moreh.clip_grad_norm(
             [ttnn.from_torch(param.grad.bfloat16(), dtype=npu_dtype, layout=ttnn.TILE_LAYOUT, device=device)],
             max_norm,
             norm_type,
             error_if_nonfinite,
         )
-        assert not error_if_nonfinite
-    except RuntimeError as actual_error_msg:
-        assert expected_error_msg in str(actual_error_msg)
-        assert error_if_nonfinite
+
+    if error_if_nonfinite:
+        with expect_error(RuntimeError, "is non-finite, so it cannot be clipped"):
+            run_clip_grad_norm()
+    else:
+        run_clip_grad_norm()

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops.py
@@ -5,6 +5,8 @@
 # Corner cases of the generic reductions (sum/mean/max/min/prod/std/var).
 # Split from test_reduction_ops.py: corner-case tests, not exhaustive sweeps.
 
+import contextlib
+
 import pytest
 import torch
 import ttnn
@@ -61,13 +63,13 @@ OP_CORRECTION = [
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("op, correction", OP_CORRECTION)
-def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correction, op):
+def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correction, op, expect_error):
     """
     Test the compatibility of the torch and ttnn output for the given operation and different
     tensor shapes, keepdim, and dim values.
     Checks that resulting tensors are within a certain tolerance of PyTorch outputs.
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
-    Note: We do not enforce the same exception type or message.
+    Note: We do not enforce the same exception type or message between PyTorch and ttnn.
     """
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=dtype)
@@ -107,23 +109,25 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
         logger.info(f"torch {op} raised: {e}")
         torch_errored = True
 
-    ttnn_errored = False
-    try:
+    # torch has already run, so its outcome is the expectation for ttnn: the two must
+    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
+    # expected so CI log triage does not read it as a crash.
+    ctx = (
+        expect_error(
+            (IndexError, TypeError, RuntimeError),
+            # prod takes a scalar dim, so a tuple is rejected by the binding rather
+            # than by the device-side zero-size check the other ops hit.
+            "Expected reduction dim|incompatible function arguments",
+        )
+        if torch_errored
+        else contextlib.nullcontext()
+    )
+    with ctx:
         # ttnn.prod doesn't support the correction argument.
-        if op in ("var", "std"):
-            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim, correction=correction)
-        elif op != "prod":
-            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim, correction=correction)
-        else:
+        if op == "prod":
             ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
-    except (IndexError, TypeError, RuntimeError) as e:
-        ttnn_errored = True
-        if not torch_errored:
-            logger.error(f"torch passed and produced result: {torch_result}, but ttnn raised exception: {e}")
-
-    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
-
-    # Skip the rest of the test if an exception was raised in both
+        else:
+            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim, correction=correction)
     if torch_errored:
         return
 

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_generic_ops.py
@@ -5,8 +5,6 @@
 # Corner cases of the generic reductions (sum/mean/max/min/prod/std/var).
 # Split from test_reduction_ops.py: corner-case tests, not exhaustive sweeps.
 
-import contextlib
-
 import pytest
 import torch
 import ttnn
@@ -63,13 +61,13 @@ OP_CORRECTION = [
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("op, correction", OP_CORRECTION)
-def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correction, op, expect_error):
+def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correction, op):
     """
     Test the compatibility of the torch and ttnn output for the given operation and different
     tensor shapes, keepdim, and dim values.
     Checks that resulting tensors are within a certain tolerance of PyTorch outputs.
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
-    Note: We do not enforce the same exception type or message between PyTorch and ttnn.
+    Note: We do not enforce the same exception type or message.
     """
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=dtype)
@@ -109,25 +107,23 @@ def test_generic_ops(device, tensor_shape, dim, keepdim, dtype, layout, correcti
         logger.info(f"torch {op} raised: {e}")
         torch_errored = True
 
-    # torch has already run, so its outcome is the expectation for ttnn: the two must
-    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
-    # expected so CI log triage does not read it as a crash.
-    ctx = (
-        expect_error(
-            (IndexError, TypeError, RuntimeError),
-            # prod takes a scalar dim, so a tuple is rejected by the binding rather
-            # than by the device-side zero-size check the other ops hit.
-            "Expected reduction dim|incompatible function arguments",
-        )
-        if torch_errored
-        else contextlib.nullcontext()
-    )
-    with ctx:
+    ttnn_errored = False
+    try:
         # ttnn.prod doesn't support the correction argument.
-        if op == "prod":
-            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
-        else:
+        if op in ("var", "std"):
             ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim, correction=correction)
+        elif op != "prod":
+            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim, correction=correction)
+        else:
+            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
+    except (IndexError, TypeError, RuntimeError) as e:
+        ttnn_errored = True
+        if not torch_errored:
+            logger.error(f"torch passed and produced result: {torch_result}, but ttnn raised exception: {e}")
+
+    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
+
+    # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         return
 

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_op_corners.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_op_corners.py
@@ -4,8 +4,6 @@
 
 # Corner cases of topk/argmax/cumsum/cumprod/moe/sampling and multi-dim RM sum.
 
-import contextlib
-
 import pytest
 import torch
 import ttnn
@@ -199,7 +197,7 @@ def _torch_sampling_reference(values, indices, k, p, temp, seed):
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("k", [50, 1, 0])
-def test_topk(device, tensor_shape, dim, dtype, layout, k, expect_error):
+def test_topk(device, tensor_shape, dim, dtype, layout, k):
     """
     Test the compatibility of the torch and ttnn topk output for different tensor shapes.
     topk returns a tuple of (values, indices). We compare values via PCC and validate
@@ -219,20 +217,19 @@ def test_topk(device, tensor_shape, dim, dtype, layout, k, expect_error):
         logger.info(f"torch topk raised: {e}")
         torch_errored = True
 
-    # torch has already run, so its outcome is the expectation for ttnn: the two must
-    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
-    # expected so CI log triage does not read it as a crash.
-    ctx = (
-        expect_error(
-            (IndexError, TypeError, RuntimeError),
-            # dim=None is rejected by the binding, not by a device assert.
-            "K cannot be larger|index out of range|incompatible function arguments",
-        )
-        if torch_errored
-        else contextlib.nullcontext()
-    )
-    with ctx:
+    ttnn_errored = False
+    try:
         ttnn_result = ttnn_topk(ttnn_tensor, k, dim=dim)
+    except (IndexError, TypeError, RuntimeError) as e:
+        ttnn_errored = True
+        if not torch_errored:
+            logger.error(f"torch passed, but ttnn raised exception: {e}")
+
+    if torch_errored and ttnn_errored:
+        logger.info(f"Both PyTorch and TTNN errored")
+    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
+
+    # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         return
 
@@ -309,7 +306,7 @@ def test_topk(device, tensor_shape, dim, dtype, layout, k, expect_error):
 @pytest.mark.parametrize("keepdim", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-def test_argmax(device, tensor_shape, dim, keepdim, dtype, layout, expect_error):
+def test_argmax(device, tensor_shape, dim, keepdim, dtype, layout):
     """
     Test the compatibility of the torch and ttnn argmax output for different tensor shapes.
     argmax returns indices (UINT32). We validate semantically by checking that the values at
@@ -342,16 +339,17 @@ def test_argmax(device, tensor_shape, dim, keepdim, dtype, layout, expect_error)
         logger.info(f"torch argmax raised: {e}")
         torch_errored = True
 
-    # torch has already run, so its outcome is the expectation for ttnn: the two must
-    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
-    # expected so CI log triage does not read it as a crash.
-    ctx = (
-        expect_error((IndexError, TypeError, RuntimeError), "Expected reduction dim")
-        if torch_errored
-        else contextlib.nullcontext()
-    )
-    with ctx:
+    ttnn_errored = False
+    try:
         ttnn_result = ttnn_argmax(ttnn_tensor, dim=dim, keepdim=keepdim)
+    except (IndexError, TypeError, RuntimeError) as e:
+        ttnn_errored = True
+        if not torch_errored:
+            logger.error(f"torch passed, but ttnn raised exception: {e}")
+
+    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
+
+    # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         return
 
@@ -435,7 +433,7 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
     Unlike standard reductions, cumsum/cumprod produce same-shape outputs (accumulations).
     Checks that resulting tensors are within a certain tolerance of PyTorch outputs.
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
-    Note: We do not enforce the same exception type or message between PyTorch and ttnn.
+    Note: We do not enforce the same exception type or message.
     """
     torch.manual_seed(0)
 
@@ -506,12 +504,12 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
 @pytest.mark.parametrize("tensor_shape", [(), (1, 1, 32, 64), (1, 1, 0, 64), (1, 1, 15, 23), (2, 2, 32, 64)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-def test_moe(device, tensor_shape, dtype, layout, expect_error):
+def test_moe(device, tensor_shape, dtype, layout):
     """
     Test ttnn.moe against the torch reference (topk + softmax + sum) for scalar and
     4D tensor shapes.
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
-    Note: We do not enforce the same exception type or message between PyTorch and ttnn.
+    Note: We do not enforce the same exception type or message.
     """
     torch.manual_seed(0)
     rank = len(tensor_shape)
@@ -563,15 +561,8 @@ def test_moe(device, tensor_shape, dtype, layout, expect_error):
         logger.info(f"torch MOE reference raised: {e}")
         torch_errored = True
 
-    # torch has already run, so its outcome is the expectation for ttnn: the two must
-    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
-    # expected so CI log triage does not read it as a crash.
-    ctx = (
-        expect_error((IndexError, TypeError, RuntimeError), "Input shape must be|Input shape inner dim")
-        if torch_errored
-        else contextlib.nullcontext()
-    )
-    with ctx:
+    ttnn_errored = False
+    try:
         ttnn_input = ttnn.from_torch(torch_input, layout=layout, device=device)
         ttnn_input = ttnn.fill_implicit_tile_padding(ttnn_input, TEST_PADDING_VALUE)
         ttnn_expert_mask = ttnn.from_torch(expert_mask, layout=layout, device=device)
@@ -579,6 +570,14 @@ def test_moe(device, tensor_shape, dtype, layout, expect_error):
         ttnn_topE_mask = ttnn.from_torch(topE_mask, layout=layout, device=device)
         ttnn_topE_mask = ttnn.fill_implicit_tile_padding(ttnn_topE_mask, TEST_PADDING_VALUE)
         ttnn_result = ttnn_moe(ttnn_input, ttnn_expert_mask, ttnn_topE_mask, k)
+    except (IndexError, TypeError, RuntimeError) as e:
+        ttnn_errored = True
+        if not torch_errored:
+            logger.error(f"torch passed, but ttnn raised exception: {e}")
+
+    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
+
+    # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         return
 
@@ -621,7 +620,7 @@ def test_moe(device, tensor_shape, dtype, layout, expect_error):
 @pytest.mark.parametrize("tensor_shape", [(), (1, 1, 32, 64), (1, 1, 32, 0), (1, 1, 18, 22)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-def test_sampling(device, tensor_shape, dtype, layout, expect_error):
+def test_sampling(device, tensor_shape, dtype, layout):
     """
     Test ttnn.sampling against a torch reference (softmax -> top-k -> top-p -> multinomial).
     Structure mirrors test_moe: error parity (including scalar and non-4D), shape/validity checks, and prealloc path.
@@ -660,19 +659,8 @@ def test_sampling(device, tensor_shape, dtype, layout, expect_error):
         logger.info(f"torch sampling reference raised: {e}")
         torch_errored = True
 
-    # torch has already run, so its outcome is the expectation for ttnn: the two must
-    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
-    # expected so CI log triage does not read it as a crash.
-    ctx = (
-        expect_error(
-            (ValueError, IndexError, TypeError, RuntimeError),
-            # A rank-0 input trips ShapeBase indexing before the rank check runs.
-            "Input inner dim|index out of range",
-        )
-        if torch_errored
-        else contextlib.nullcontext()
-    )
-    with ctx:
+    ttnn_errored = False
+    try:
         input_values = ttnn.from_torch(torch_values, layout=layout, device=device)
         input_values = ttnn.fill_implicit_tile_padding(input_values, TEST_PADDING_VALUE)
         input_indices = ttnn.from_torch(
@@ -692,6 +680,13 @@ def test_sampling(device, tensor_shape, dtype, layout, expect_error):
             temp=temp_tensor,
             seed=SAMPLING_SEED,
         )
+    except (ValueError, IndexError, TypeError, RuntimeError) as e:
+        ttnn_errored = True
+        if not torch_errored:
+            logger.error(f"torch passed, but ttnn sampling raised: {e}")
+
+    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
+
     if torch_errored:
         return
 
@@ -785,7 +780,7 @@ INVALID_SHAPE_DIMS = [(s, d) for s in _PARITY_SHAPES for d in _PARITY_DIMS if _d
 
 @pytest.mark.parametrize("tensor_shape, dim", INVALID_SHAPE_DIMS)
 @pytest.mark.parametrize("op", ["sum", "var"])
-def test_generic_ops_dim_parity(device, tensor_shape, dim, op, expect_error):
+def test_generic_ops_dim_parity(device, tensor_shape, dim, op):
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
@@ -797,8 +792,11 @@ def test_generic_ops_dim_parity(device, tensor_shape, dim, op, expect_error):
         logger.info(f"torch {op} raised: {e}")
         torch_errored = True
 
-    # Every parametrization here is an invalid dim, so ttnn must raise; torch is
-    # still probed above to keep the two implementations' behaviour tied together.
-    assert torch_errored, f"torch {op} unexpectedly accepted dim={dim}"
-    with expect_error((IndexError, TypeError, RuntimeError), "Unsupported dim"):
+    ttnn_errored = False
+    try:
         TTNN_REDUCTION_WRAPPERS[op](ttnn_tensor, dim=dim, keepdim=True)
+    except (IndexError, TypeError, RuntimeError) as e:
+        logger.info(f"ttnn {op} raised: {e}")
+        ttnn_errored = True
+
+    assert torch_errored and ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_op_corners.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_op_corners.py
@@ -4,6 +4,8 @@
 
 # Corner cases of topk/argmax/cumsum/cumprod/moe/sampling and multi-dim RM sum.
 
+import contextlib
+
 import pytest
 import torch
 import ttnn
@@ -197,7 +199,7 @@ def _torch_sampling_reference(values, indices, k, p, temp, seed):
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("k", [50, 1, 0])
-def test_topk(device, tensor_shape, dim, dtype, layout, k):
+def test_topk(device, tensor_shape, dim, dtype, layout, k, expect_error):
     """
     Test the compatibility of the torch and ttnn topk output for different tensor shapes.
     topk returns a tuple of (values, indices). We compare values via PCC and validate
@@ -217,19 +219,20 @@ def test_topk(device, tensor_shape, dim, dtype, layout, k):
         logger.info(f"torch topk raised: {e}")
         torch_errored = True
 
-    ttnn_errored = False
-    try:
+    # torch has already run, so its outcome is the expectation for ttnn: the two must
+    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
+    # expected so CI log triage does not read it as a crash.
+    ctx = (
+        expect_error(
+            (IndexError, TypeError, RuntimeError),
+            # dim=None is rejected by the binding, not by a device assert.
+            "K cannot be larger|index out of range|incompatible function arguments",
+        )
+        if torch_errored
+        else contextlib.nullcontext()
+    )
+    with ctx:
         ttnn_result = ttnn_topk(ttnn_tensor, k, dim=dim)
-    except (IndexError, TypeError, RuntimeError) as e:
-        ttnn_errored = True
-        if not torch_errored:
-            logger.error(f"torch passed, but ttnn raised exception: {e}")
-
-    if torch_errored and ttnn_errored:
-        logger.info(f"Both PyTorch and TTNN errored")
-    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
-
-    # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         return
 
@@ -306,7 +309,7 @@ def test_topk(device, tensor_shape, dim, dtype, layout, k):
 @pytest.mark.parametrize("keepdim", [True, False])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-def test_argmax(device, tensor_shape, dim, keepdim, dtype, layout):
+def test_argmax(device, tensor_shape, dim, keepdim, dtype, layout, expect_error):
     """
     Test the compatibility of the torch and ttnn argmax output for different tensor shapes.
     argmax returns indices (UINT32). We validate semantically by checking that the values at
@@ -339,17 +342,16 @@ def test_argmax(device, tensor_shape, dim, keepdim, dtype, layout):
         logger.info(f"torch argmax raised: {e}")
         torch_errored = True
 
-    ttnn_errored = False
-    try:
+    # torch has already run, so its outcome is the expectation for ttnn: the two must
+    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
+    # expected so CI log triage does not read it as a crash.
+    ctx = (
+        expect_error((IndexError, TypeError, RuntimeError), "Expected reduction dim")
+        if torch_errored
+        else contextlib.nullcontext()
+    )
+    with ctx:
         ttnn_result = ttnn_argmax(ttnn_tensor, dim=dim, keepdim=keepdim)
-    except (IndexError, TypeError, RuntimeError) as e:
-        ttnn_errored = True
-        if not torch_errored:
-            logger.error(f"torch passed, but ttnn raised exception: {e}")
-
-    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
-
-    # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         return
 
@@ -433,7 +435,7 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
     Unlike standard reductions, cumsum/cumprod produce same-shape outputs (accumulations).
     Checks that resulting tensors are within a certain tolerance of PyTorch outputs.
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
-    Note: We do not enforce the same exception type or message.
+    Note: We do not enforce the same exception type or message between PyTorch and ttnn.
     """
     torch.manual_seed(0)
 
@@ -504,12 +506,12 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
 @pytest.mark.parametrize("tensor_shape", [(), (1, 1, 32, 64), (1, 1, 0, 64), (1, 1, 15, 23), (2, 2, 32, 64)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-def test_moe(device, tensor_shape, dtype, layout):
+def test_moe(device, tensor_shape, dtype, layout, expect_error):
     """
     Test ttnn.moe against the torch reference (topk + softmax + sum) for scalar and
     4D tensor shapes.
     Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
-    Note: We do not enforce the same exception type or message.
+    Note: We do not enforce the same exception type or message between PyTorch and ttnn.
     """
     torch.manual_seed(0)
     rank = len(tensor_shape)
@@ -561,8 +563,15 @@ def test_moe(device, tensor_shape, dtype, layout):
         logger.info(f"torch MOE reference raised: {e}")
         torch_errored = True
 
-    ttnn_errored = False
-    try:
+    # torch has already run, so its outcome is the expectation for ttnn: the two must
+    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
+    # expected so CI log triage does not read it as a crash.
+    ctx = (
+        expect_error((IndexError, TypeError, RuntimeError), "Input shape must be|Input shape inner dim")
+        if torch_errored
+        else contextlib.nullcontext()
+    )
+    with ctx:
         ttnn_input = ttnn.from_torch(torch_input, layout=layout, device=device)
         ttnn_input = ttnn.fill_implicit_tile_padding(ttnn_input, TEST_PADDING_VALUE)
         ttnn_expert_mask = ttnn.from_torch(expert_mask, layout=layout, device=device)
@@ -570,14 +579,6 @@ def test_moe(device, tensor_shape, dtype, layout):
         ttnn_topE_mask = ttnn.from_torch(topE_mask, layout=layout, device=device)
         ttnn_topE_mask = ttnn.fill_implicit_tile_padding(ttnn_topE_mask, TEST_PADDING_VALUE)
         ttnn_result = ttnn_moe(ttnn_input, ttnn_expert_mask, ttnn_topE_mask, k)
-    except (IndexError, TypeError, RuntimeError) as e:
-        ttnn_errored = True
-        if not torch_errored:
-            logger.error(f"torch passed, but ttnn raised exception: {e}")
-
-    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
-
-    # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         return
 
@@ -620,7 +621,7 @@ def test_moe(device, tensor_shape, dtype, layout):
 @pytest.mark.parametrize("tensor_shape", [(), (1, 1, 32, 64), (1, 1, 32, 0), (1, 1, 18, 22)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
-def test_sampling(device, tensor_shape, dtype, layout):
+def test_sampling(device, tensor_shape, dtype, layout, expect_error):
     """
     Test ttnn.sampling against a torch reference (softmax -> top-k -> top-p -> multinomial).
     Structure mirrors test_moe: error parity (including scalar and non-4D), shape/validity checks, and prealloc path.
@@ -659,8 +660,19 @@ def test_sampling(device, tensor_shape, dtype, layout):
         logger.info(f"torch sampling reference raised: {e}")
         torch_errored = True
 
-    ttnn_errored = False
-    try:
+    # torch has already run, so its outcome is the expectation for ttnn: the two must
+    # fail on exactly the same inputs. Bracketing the provoked failure marks it as
+    # expected so CI log triage does not read it as a crash.
+    ctx = (
+        expect_error(
+            (ValueError, IndexError, TypeError, RuntimeError),
+            # A rank-0 input trips ShapeBase indexing before the rank check runs.
+            "Input inner dim|index out of range",
+        )
+        if torch_errored
+        else contextlib.nullcontext()
+    )
+    with ctx:
         input_values = ttnn.from_torch(torch_values, layout=layout, device=device)
         input_values = ttnn.fill_implicit_tile_padding(input_values, TEST_PADDING_VALUE)
         input_indices = ttnn.from_torch(
@@ -680,13 +692,6 @@ def test_sampling(device, tensor_shape, dtype, layout):
             temp=temp_tensor,
             seed=SAMPLING_SEED,
         )
-    except (ValueError, IndexError, TypeError, RuntimeError) as e:
-        ttnn_errored = True
-        if not torch_errored:
-            logger.error(f"torch passed, but ttnn sampling raised: {e}")
-
-    assert torch_errored == ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"
-
     if torch_errored:
         return
 
@@ -780,7 +785,7 @@ INVALID_SHAPE_DIMS = [(s, d) for s in _PARITY_SHAPES for d in _PARITY_DIMS if _d
 
 @pytest.mark.parametrize("tensor_shape, dim", INVALID_SHAPE_DIMS)
 @pytest.mark.parametrize("op", ["sum", "var"])
-def test_generic_ops_dim_parity(device, tensor_shape, dim, op):
+def test_generic_ops_dim_parity(device, tensor_shape, dim, op, expect_error):
     torch.manual_seed(0)
     torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
     ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
@@ -792,11 +797,8 @@ def test_generic_ops_dim_parity(device, tensor_shape, dim, op):
         logger.info(f"torch {op} raised: {e}")
         torch_errored = True
 
-    ttnn_errored = False
-    try:
+    # Every parametrization here is an invalid dim, so ttnn must raise; torch is
+    # still probed above to keep the two implementations' behaviour tied together.
+    assert torch_errored, f"torch {op} unexpectedly accepted dim={dim}"
+    with expect_error((IndexError, TypeError, RuntimeError), "Unsupported dim"):
         TTNN_REDUCTION_WRAPPERS[op](ttnn_tensor, dim=dim, keepdim=True)
-    except (IndexError, TypeError, RuntimeError) as e:
-        logger.info(f"ttnn {op} raised: {e}")
-        ttnn_errored = True
-
-    assert torch_errored and ttnn_errored, f"torch_errored: {torch_errored}, ttnn_errored: {ttnn_errored}"

--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
@@ -1244,7 +1244,7 @@ def test_paged_fill_cache_batched_program_cache(device):
 
 
 @pytest.mark.parametrize("bad_tensor_size", [1, 3, 5, 7])
-def test_paged_fill_cache_batched_rejects_mismatched_batch_idx_tensor(device, bad_tensor_size):
+def test_paged_fill_cache_batched_rejects_mismatched_batch_idx_tensor(device, bad_tensor_size, expect_error):
     """batch_idx_tensor must have exactly input_batch elements; anything else FATALs.
 
     Covers the silent-wrong-result hole where input_batch > 1 paired with a
@@ -1272,11 +1272,11 @@ def test_paged_fill_cache_batched_rejects_mismatched_batch_idx_tensor(device, ba
         layout=ttnn.ROW_MAJOR_LAYOUT,
         dtype=ttnn.uint32,
     )
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "Batch idx tensor must have input_tensor batch dim"):
         ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx_tensor=bad, batch_idx=0)
 
 
-def test_paged_fill_cache_rejects_multi_batch_input_without_tensor(device):
+def test_paged_fill_cache_rejects_multi_batch_input_without_tensor(device, expect_error):
     """input_batch > 1 with no batch_idx_tensor was previously a silent wrong-result; now FATAL."""
     initial_cache_torch, input_torch, page_table_torch = _build_batched_inputs(
         num_input_batch=4,
@@ -1293,7 +1293,7 @@ def test_paged_fill_cache_rejects_multi_batch_input_without_tensor(device):
     input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
     page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "input_batch must be 1"):
         ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx=0)
 
 
@@ -1346,7 +1346,7 @@ def test_paged_fill_cache_batched_mesh_coords(device):
     assert passing, message
 
 
-def test_paged_fill_cache_batched_rejects_non_row_major_batch_idx_tensor(device):
+def test_paged_fill_cache_batched_rejects_non_row_major_batch_idx_tensor(device, expect_error):
     """The writer kernel reads batch_idx_tensor as a single contiguous noc page;
     require ROW_MAJOR layout so that read covers the whole 1D buffer."""
     initial_cache_torch, input_torch, page_table_torch = _build_batched_inputs(
@@ -1378,5 +1378,5 @@ def test_paged_fill_cache_batched_rejects_non_row_major_batch_idx_tensor(device)
     except (RuntimeError, ValueError):
         pytest.skip("Cannot construct a TILE_LAYOUT uint32 tensor on this build; layout assertion still in place.")
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "Batch idx tensor must have input_tensor batch dim"):
         ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx_tensor=bad, batch_idx=0)

--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_paged_update_cache.py
@@ -1272,7 +1272,7 @@ def test_paged_fill_cache_batched_rejects_mismatched_batch_idx_tensor(device, ba
         layout=ttnn.ROW_MAJOR_LAYOUT,
         dtype=ttnn.uint32,
     )
-    with expect_error(RuntimeError, "Batch idx tensor must have input_tensor batch dim"):
+    with expect_error(RuntimeError, r"Batch idx tensor must have input_tensor batch dim"):
         ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx_tensor=bad, batch_idx=0)
 
 
@@ -1293,7 +1293,7 @@ def test_paged_fill_cache_rejects_multi_batch_input_without_tensor(device, expec
     input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
     page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
 
-    with expect_error(RuntimeError, "input_batch must be 1"):
+    with expect_error(RuntimeError, r"When no batch_idx_tensor is provided, input_batch must be 1"):
         ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx=0)
 
 
@@ -1378,5 +1378,5 @@ def test_paged_fill_cache_batched_rejects_non_row_major_batch_idx_tensor(device,
     except (RuntimeError, ValueError):
         pytest.skip("Cannot construct a TILE_LAYOUT uint32 tensor on this build; layout assertion still in place.")
 
-    with expect_error(RuntimeError, "Batch idx tensor must have input_tensor batch dim"):
+    with expect_error(RuntimeError, r"Batch idx tensor must have input_tensor batch dim"):
         ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx_tensor=bad, batch_idx=0)

--- a/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
@@ -24,5 +24,5 @@ def test_deallocate(device, h, w, expect_error):
     output_tensor_reference = ttnn.reshape(output_tensor, (h, w))
 
     ttnn.deallocate(output_tensor)
-    with expect_error(RuntimeError, "Input Tensor A is not allocated"):
+    with expect_error(RuntimeError, r"Input Tensor A is not allocated"):
         output_tensor_reference + output_tensor_reference

--- a/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_deallocate.py
@@ -11,7 +11,7 @@ import ttnn
 
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [2 * 32])
-def test_deallocate(device, h, w):
+def test_deallocate(device, h, w, expect_error):
     torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT)
@@ -24,5 +24,5 @@ def test_deallocate(device, h, w):
     output_tensor_reference = ttnn.reshape(output_tensor, (h, w))
 
     ttnn.deallocate(output_tensor)
-    with pytest.raises(RuntimeError) as exception:
+    with expect_error(RuntimeError, "Input Tensor A is not allocated"):
         output_tensor_reference + output_tensor_reference

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -774,7 +774,7 @@ def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape, expec
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=mesh_mapper, device=mesh_device
     )
-    with expect_error(RuntimeError, "Attempting to reshape between two shapes with different volumes"):
+    with expect_error(RuntimeError, r"Attempting to reshape between two shapes with different volumes"):
         ttnn.reshape(tt_input_tensor, ttnn.Shape(output_shape))
 
 

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -760,26 +760,22 @@ def test_reshape_zero_element(input_shape, output_shape, layout, ttnn_reshape, u
     assert tt_output_tensor.shape == torch.Size(output_shape)
 
 
-@pytest.mark.xfail(
-    reason="Test that the previously supported reshape accounting for the physical shape is no longer possible"
-)
 @pytest.mark.parametrize(
     "input_shape, output_shape",
     [
         ([32, 256], [1, 256]),
     ],
 )
-def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape):
+def test_reshape_replicated_tensor(mesh_device, input_shape, output_shape, expect_error):
+    """Reshape against a replicated tensor's physical shape is rejected: the logical
+    volumes differ, and only the logical shape is considered."""
     torch_input_tensor = torch.randn(input_shape)
     mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
     tt_input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, mesh_mapper=mesh_mapper, device=mesh_device
     )
-    tt_output_tensor = ttnn.reshape(tt_input_tensor, ttnn.Shape(output_shape))
-
-    for tensor_shard in ttnn.get_device_tensors(tt_output_tensor):
-        tt_output_tensor = ttnn.to_torch(tensor_shard)
-        assert tt_output_tensor.shape == torch.Size(output_shape)
+    with expect_error(RuntimeError, "Attempting to reshape between two shapes with different volumes"):
+        ttnn.reshape(tt_input_tensor, ttnn.Shape(output_shape))
 
 
 @pytest.mark.timeout(320)

--- a/tests/ttnn/unit_tests/base_functionality/test_squeeze.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_squeeze.py
@@ -116,18 +116,23 @@ def test_squeeze_multiple_dims(device, input_shape, dims, layout):
     ],
 )
 @pytest.mark.parametrize(
-    "input_shape, dims, expected_exception",
+    "input_shape, dims, expected_exception, expected_message",
     [
-        ((1, 1, 1, 256), [4], RuntimeError),  # Out of range positive index
-        ((1, 1, 1, 256), [-5], RuntimeError),  # Out of range negative index
-        ((1, 1, 1, 256), [0, 0], RuntimeError),  # Duplicate indices
-        ((1, 1, 1, 256), [0, -4], RuntimeError),  # Duplicate indices (positive and negative)
+        ((1, 1, 1, 256), [4], RuntimeError, "Dimension out of range"),  # Out of range positive index
+        ((1, 1, 1, 256), [-5], RuntimeError, "Dimension out of range"),  # Out of range negative index
+        ((1, 1, 1, 256), [0, 0], RuntimeError, "appears multiple times"),  # Duplicate indices
+        (
+            (1, 1, 1, 256),
+            [0, -4],
+            RuntimeError,
+            "appears multiple times",
+        ),  # Duplicate indices (positive and negative)
     ],
 )
-def test_squeeze_error_cases(device, input_shape, dims, expected_exception, layout):
+def test_squeeze_error_cases(device, input_shape, dims, expected_exception, expected_message, layout, expect_error):
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
-    with pytest.raises(expected_exception):
+    with expect_error(expected_exception, expected_message):
         ttnn.squeeze(input_tensor, dims)
 
 

--- a/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
@@ -1138,12 +1138,10 @@ def test_from_torch_large_tensor_type_conversion_row_major_l1(device, torch_dtyp
 
 
 @skip_for_slow_dispatch()
-@pytest.mark.xfail(
-    reason="sharded buffer write dispatch crashes on dispatch-core-row shards (write path fix not implemented)",
-    strict=True,
-)
-def test_from_torch_sharded_tilize_dispatch_core_overlap(device):
+def test_from_torch_sharded_tilize_dispatch_core_overlap(device, expect_error):
     """
+    ** FAILING TEST **
+
     Regression test for tilize with a shard grid that extends beyond the compute
     grid (e.g. includes dispatch cores).
 
@@ -1187,18 +1185,22 @@ def test_from_torch_sharded_tilize_dispatch_core_overlap(device):
     )
     torch_tensor = torch.zeros(shape, dtype=torch.bfloat16)
 
-    result = ttnn.from_torch(
-        torch_tensor,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=sharded_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
-    )
+    # expect_error rather than xfail: it brackets the rejection so CI log triage does not
+    # read the fatal as a crash, and it fails once the write path accepts the shard grid.
+    # Restore the assertions below at that point.
+    with expect_error(RuntimeError, "Invalid shard grid"):
+        result = ttnn.from_torch(
+            torch_tensor,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=sharded_mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+        )
 
-    assert result.layout == ttnn.TILE_LAYOUT
-    assert result.dtype == ttnn.bfloat16
-    assert list(result.shape) == list(shape)
+    # assert result.layout == ttnn.TILE_LAYOUT
+    # assert result.dtype == ttnn.bfloat16
+    # assert list(result.shape) == list(shape)
 
 
 @skip_for_slow_dispatch()

--- a/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
@@ -1188,7 +1188,7 @@ def test_from_torch_sharded_tilize_dispatch_core_overlap(device, expect_error):
     # expect_error rather than xfail: it brackets the rejection so CI log triage does not
     # read the fatal as a crash, and it fails once the write path accepts the shard grid.
     # Restore the assertions below at that point.
-    with expect_error(RuntimeError, "Invalid shard grid"):
+    with expect_error(RuntimeError, r"Invalid shard grid"):
         result = ttnn.from_torch(
             torch_tensor,
             dtype=ttnn.bfloat16,

--- a/tests/ttnn/unit_tests/base_functionality/test_unsqueeze.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_unsqueeze.py
@@ -42,8 +42,8 @@ def test_unsqueeze(device, input_shape, dim, layout):
         ((1, 1, 253), -5, ttnn.ROW_MAJOR_LAYOUT),
     ],
 )
-def test_invalid_cases(device, input_shape, dim, layout):
+def test_invalid_cases(device, input_shape, dim, layout, expect_error):
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "Dimension out of range"):
         ttnn.unsqueeze(input_tensor, dim)

--- a/tests/ttnn/unit_tests/base_functionality/test_unsqueeze.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_unsqueeze.py
@@ -45,5 +45,5 @@ def test_unsqueeze(device, input_shape, dim, layout):
 def test_invalid_cases(device, input_shape, dim, layout, expect_error):
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
-    with expect_error(RuntimeError, "Dimension out of range"):
+    with expect_error(RuntimeError, r"Dimension out of range"):
         ttnn.unsqueeze(input_tensor, dim)

--- a/tests/ttnn/unit_tests/base_functionality/test_view.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_view.py
@@ -37,34 +37,43 @@ def test_view(input_shape, output_shape, layout, device):
 
 
 @pytest.mark.parametrize(
-    "input_shape, output_shape, layout",
+    "input_shape, output_shape, layout, expected_message",
     [
-        ((2, 1, 1, 1, 15), (1, 30), ttnn.ROW_MAJOR_LAYOUT),  # RM last dimension doesn't match
+        (
+            (2, 1, 1, 1, 15),
+            (1, 30),
+            ttnn.ROW_MAJOR_LAYOUT,
+            "The last dimension can not change in view",
+        ),  # RM last dimension doesn't match
         (
             (16, 1, 256, 1, 16),
             (8, 16, 32, 16),
             ttnn.TILE_LAYOUT,
+            "Invalid second last dims",
         ),  # TILE last dimension match but second last does not match, shape mult of 32 only
         (
             (16, 1, 1, 256, 16),
             (8, 16, 32, 1, 16),
             ttnn.TILE_LAYOUT,
+            "Invalid second last dims",
         ),  # TILE last dimension match but second last does not match, tensor mult of 32 only
         (
             (256, 1, 1, 16, 16),
             (8, 16, 32, 1, 16),
             ttnn.TILE_LAYOUT,
+            "Invalid second last dims",
         ),  # TILE last dimension match but second last does not match, none mult of 32
         (
             (16, 8, 1, 32, 16),
             (8, 16, 31, 16),
             ttnn.TILE_LAYOUT,
+            "Invalid arguments to reshape",
         ),  # Volume doesn't match but padded volume does
     ],
 )
-def test_invalid_cases(input_shape, output_shape, layout, device):
+def test_invalid_cases(input_shape, output_shape, layout, expected_message, device, expect_error):
     # Verifies invalid cases do cause an assertion
     torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=layout, device=device)
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, expected_message):
         ttnn.view(input_tensor, output_shape)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py
@@ -396,7 +396,7 @@ def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device, exp
         input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
     )
 
-    with expect_error(RuntimeError, "When input tensor is in DRAM, output memory_config must be explicitly specified"):
+    with expect_error(RuntimeError, r"When input tensor is in DRAM, output memory_config must be explicitly specified"):
         ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
 
     # Create an output shard that is not padded up to nearest aligned width
@@ -404,5 +404,5 @@ def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device, exp
     output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
 
-    with expect_error(RuntimeError, "Output shard width must be rounded up to next multiple of 8"):
+    with expect_error(RuntimeError, r"Output shard width must be rounded up to next multiple of 8"):
         ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16, memory_config=output_mem_config)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_convert_to_hwc.py
@@ -381,7 +381,7 @@ def test_convert_to_hwc_dram_uneven_sharding(
     assert passed, message
 
 
-def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
+def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device, expect_error):
     C = 4
     HW = 32
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
@@ -396,9 +396,7 @@ def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
         input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
     )
 
-    with pytest.raises(
-        RuntimeError, match="When input tensor is in DRAM, output memory_config must be explicitly specified"
-    ):
+    with expect_error(RuntimeError, "When input tensor is in DRAM, output memory_config must be explicitly specified"):
         ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16)
 
     # Create an output shard that is not padded up to nearest aligned width
@@ -406,5 +404,5 @@ def test_convert_to_hwc_dram_input_without_memory_config_should_fail(device):
     output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "Output shard width must be rounded up to next multiple of 8"):
         ttnn.experimental.convert_to_hwc(input_tensor, dtype=ttnn.bfloat16, memory_config=output_mem_config)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
@@ -288,7 +288,7 @@ def test_interleaved_to_sharded_nd_with_equivalent_2d(
         ],
     ],
 )
-def test_interleaved_to_sharded_rejects_pure_nd(device, tensor_shape, nd_shard_shape, shard_grid):
+def test_interleaved_to_sharded_rejects_pure_nd(device, tensor_shape, nd_shard_shape, shard_grid, expect_error):
     nd_shard_spec = ttnn.NdShardSpec(nd_shard_shape, shard_grid, orientation=ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
 
@@ -296,5 +296,5 @@ def test_interleaved_to_sharded_rejects_pure_nd(device, tensor_shape, nd_shard_s
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "interleaved_to_sharded does not support ND sharding"):
         ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_interleaved_to_sharded.py
@@ -296,5 +296,5 @@ def test_interleaved_to_sharded_rejects_pure_nd(device, tensor_shape, nd_shard_s
     ttnn_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
     ttnn_input_tensor = ttnn.to_device(ttnn_input_tensor, device)
 
-    with expect_error(RuntimeError, "interleaved_to_sharded does not support ND sharding"):
+    with expect_error(RuntimeError, r"interleaved_to_sharded does not support ND sharding"):
         ttnn.interleaved_to_sharded(ttnn_input_tensor, output_mem_config)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad_subcoregrids.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad_subcoregrids.py
@@ -300,7 +300,7 @@ def test_pad_subcoregrids_rejects_sharded(device, expect_error):
     input_tensor = ttnn.to_memory_config(input_tensor, sharded_mem)
 
     sub_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))])
-    with expect_error(RuntimeError, "must not exceed number of cores"):
+    with expect_error(RuntimeError, r"must not exceed number of cores"):
         ttnn.pad(
             input_tensor,
             padding=((0, 0), (0, 0), (0, 32), (0, 0)),
@@ -324,7 +324,7 @@ def test_pad_subcoregrids_rejects_singlecore(device, expect_error):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     sub_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))])
-    with expect_error(RuntimeError, "sub_core_grids is only supported when use_multicore"):
+    with expect_error(RuntimeError, r"sub_core_grids is only supported when use_multicore"):
         ttnn.pad(
             input_tensor,
             padding=((0, 0), (0, 0), (0, 32), (0, 32)),

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad_subcoregrids.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad_subcoregrids.py
@@ -279,7 +279,7 @@ def test_pad_subcoregrids_program_cache(device):
 # ────────────────────────────────────────────────────────────────────────────────
 # Test: Validation — sub_core_grids with sharded input should fail
 # ────────────────────────────────────────────────────────────────────────────────
-def test_pad_subcoregrids_rejects_sharded(device):
+def test_pad_subcoregrids_rejects_sharded(device, expect_error):
     """Verify that sub_core_grids with sharded input raises an error."""
     torch_input = torch.rand(1, 1, 64, 64).bfloat16()
     input_tensor = ttnn.from_torch(
@@ -300,7 +300,7 @@ def test_pad_subcoregrids_rejects_sharded(device):
     input_tensor = ttnn.to_memory_config(input_tensor, sharded_mem)
 
     sub_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))])
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "must not exceed number of cores"):
         ttnn.pad(
             input_tensor,
             padding=((0, 0), (0, 0), (0, 32), (0, 0)),
@@ -313,7 +313,7 @@ def test_pad_subcoregrids_rejects_sharded(device):
 # ────────────────────────────────────────────────────────────────────────────────
 # Test: Validation — sub_core_grids with use_multicore=False should fail
 # ────────────────────────────────────────────────────────────────────────────────
-def test_pad_subcoregrids_rejects_singlecore(device):
+def test_pad_subcoregrids_rejects_singlecore(device, expect_error):
     """Verify that sub_core_grids with use_multicore=False raises an error."""
     torch_input = torch.rand(1, 1, 32, 32).bfloat16()
     input_tensor = ttnn.from_torch(
@@ -324,7 +324,7 @@ def test_pad_subcoregrids_rejects_singlecore(device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     sub_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))])
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "sub_core_grids is only supported when use_multicore"):
         ttnn.pad(
             input_tensor,
             padding=((0, 0), (0, 0), (0, 32), (0, 32)),

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -176,13 +176,13 @@ def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, dtype, error_
     ttnn_errored = False
     ttnn_error_msg = ""
     if error_msg:
-        with expect_error(RuntimeError, error_msg) as exc_info:
+        with expect_error(RuntimeError, error_msg):
             if dim is not None:
                 ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
             else:
                 ttnn_result = ttnn_op(ttnn_tensor)
         ttnn_errored = True
-        ttnn_error_msg = str(exc_info.value)
+        ttnn_error_msg = error_msg
     else:
         try:
             if dim is not None:

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -21,15 +21,16 @@ RM = ttnn.ROW_MAJOR_LAYOUT
 TL = ttnn.TILE_LAYOUT
 
 
-def _case(shape, layout, dim, keepdim, dtype):
+def _case(shape, layout, dim, keepdim, dtype, error_msg=None):
     """Single argmax test case tuple (readable shorthand for parametrization)."""
-    return (shape, layout, dim, keepdim, dtype)
+    return (shape, layout, dim, keepdim, dtype, error_msg)
 
 
 def _argmax_misc_and_rank_special():
     return [
         _case([], RM, None, True, torch.bfloat16),
         _case([32], RM, -1, False, torch.float32),
+        _case([32, 0], RM, 1, True, torch.bfloat16, "Expected reduction dim 1 to have non-zero size"),
         _case([64], RM, -1, True, torch.bfloat16),
         _case([1, 512], RM, -1, True, torch.float32),
         _case([1, 1024], RM, -1, True, torch.int32),
@@ -125,10 +126,10 @@ def argmax_torch_ttnn_cases():
 
 
 @pytest.mark.parametrize(
-    argnames="tensor_shape, tensor_layout, dim, keepdim, dtype",
+    argnames="tensor_shape, tensor_layout, dim, keepdim, dtype, error_msg",
     argvalues=list(argmax_torch_ttnn_cases()),
 )
-def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, dtype):
+def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, dtype, error_msg, expect_error):
     """
     Test the compatibility of the torch and ttnn output for argmax of different
     tensor shapes, dim values, and data types.
@@ -174,14 +175,23 @@ def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, dtype):
 
     ttnn_errored = False
     ttnn_error_msg = ""
-    try:
-        if dim is not None:
-            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
-        else:
-            ttnn_result = ttnn_op(ttnn_tensor)
-    except RuntimeError as e:
+    if error_msg:
+        with expect_error(RuntimeError, error_msg) as exc_info:
+            if dim is not None:
+                ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
+            else:
+                ttnn_result = ttnn_op(ttnn_tensor)
         ttnn_errored = True
-        ttnn_error_msg = str(e)
+        ttnn_error_msg = str(exc_info.value)
+    else:
+        try:
+            if dim is not None:
+                ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
+            else:
+                ttnn_result = ttnn_op(ttnn_tensor)
+        except RuntimeError as e:
+            ttnn_errored = True
+            ttnn_error_msg = str(e)
 
     assert (
         torch_errored == ttnn_errored
@@ -196,31 +206,6 @@ def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, dtype):
 
     # test for equivalance
     assert_equal(torch_result, ttnn_result)
-
-
-def test_argmax_rejects_zero_size_reduction_dim(device, expect_error):
-    """Reducing over a zero-size dim is rejected by both frameworks.
-
-    Kept out of the parity table: expect_error brackets the provoked failure so CI log
-    triage reads the TT_FATAL as expected rather than as a crash, and that bracket has to
-    wrap the ttnn call alone.
-    """
-    torch_tensor = torch.randn([32, 0], dtype=torch.bfloat16)
-
-    torch_errored = False
-    try:
-        torch.argmax(torch_tensor, dim=1, keepdim=True)
-    except (IndexError, RuntimeError) as e:
-        logger.info(f"torch argmax raised: {e}")
-        torch_errored = True
-
-    ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, layout=RM)
-    with expect_error(RuntimeError, "Expected reduction dim 1 to have non-zero size"):
-        ttnn.argmax(ttnn_tensor, dim=1, keepdim=True)
-
-    # ttnn's rejection is enforced by expect_error above, which fails the test if the call
-    # returns instead of raising; this covers the other half of the pair.
-    assert torch_errored, "torch accepted a zero-size reduction dim that ttnn rejects"
 
 
 def test_argmax_nc_ties_first_index_wins(device):

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -30,7 +30,6 @@ def _argmax_misc_and_rank_special():
     return [
         _case([], RM, None, True, torch.bfloat16),
         _case([32], RM, -1, False, torch.float32),
-        _case([32, 0], RM, 1, True, torch.bfloat16),
         _case([64], RM, -1, True, torch.bfloat16),
         _case([1, 512], RM, -1, True, torch.float32),
         _case([1, 1024], RM, -1, True, torch.int32),
@@ -197,6 +196,31 @@ def test_argmax(device, tensor_shape, tensor_layout, dim, keepdim, dtype):
 
     # test for equivalance
     assert_equal(torch_result, ttnn_result)
+
+
+def test_argmax_rejects_zero_size_reduction_dim(device, expect_error):
+    """Reducing over a zero-size dim is rejected by both frameworks.
+
+    Kept out of the parity table: expect_error brackets the provoked failure so CI log
+    triage reads the TT_FATAL as expected rather than as a crash, and that bracket has to
+    wrap the ttnn call alone.
+    """
+    torch_tensor = torch.randn([32, 0], dtype=torch.bfloat16)
+
+    torch_errored = False
+    try:
+        torch.argmax(torch_tensor, dim=1, keepdim=True)
+    except (IndexError, RuntimeError) as e:
+        logger.info(f"torch argmax raised: {e}")
+        torch_errored = True
+
+    ttnn_tensor = ttnn.from_torch(torch_tensor, device=device, layout=RM)
+    with expect_error(RuntimeError, "Expected reduction dim 1 to have non-zero size"):
+        ttnn.argmax(ttnn_tensor, dim=1, keepdim=True)
+
+    # ttnn's rejection is enforced by expect_error above, which fails the test if the call
+    # returns instead of raising; this covers the other half of the pair.
+    assert torch_errored, "torch accepted a zero-size reduction dim that ttnn rejects"
 
 
 def test_argmax_nc_ties_first_index_wins(device):

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -987,18 +987,18 @@ def test_run_reduce_sum_h_after_max_pool(device, input_shape, kernel_size):
 
 
 @pytest.mark.parametrize(
-    argnames="tensor_shape, keepdim, dim, op",
+    argnames="tensor_shape, keepdim, dim, op, error_msg",
     argvalues=[
-        ([], True, None, "mean"),
-        ([], True, None, "std"),
-        ([32], False, -1, "sum"),
-        ([32, 0], True, 0, "max"),
-        ([0, 0, 0], True, 2, "min"),
-        ([0, 32, 0], False, -2, "std"),
-        ([32, 32, 32, 0], False, 3, "var"),
+        ([], True, None, "mean", None),
+        ([], True, None, "std", None),
+        ([32], False, -1, "sum", None),
+        ([32, 0], True, 0, "max", None),
+        ([0, 0, 0], True, 2, "min", "Expected reduction dim 2 to have non-zero size"),
+        ([0, 32, 0], False, -2, "std", None),
+        ([32, 32, 32, 0], False, 3, "var", None),
     ],
 )
-def test_torch_compatibility(device, tensor_shape, keepdim, dim, op):
+def test_torch_compatibility(device, tensor_shape, keepdim, dim, op, error_msg, expect_error):
     """
     Test the compatibility of the torch and ttnn output for the given operation and different
     tensor shapes, keepdim, and dim values.
@@ -1024,10 +1024,15 @@ def test_torch_compatibility(device, tensor_shape, keepdim, dim, op):
         torch_errored = True
 
     ttnn_errored = False
-    try:
-        ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
-    except RuntimeError:
+    if error_msg:
+        with expect_error(RuntimeError, error_msg):
+            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
         ttnn_errored = True
+    else:
+        try:
+            ttnn_result = ttnn_op(ttnn_tensor, dim=dim, keepdim=keepdim)
+        except RuntimeError:
+            ttnn_errored = True
 
     assert torch_errored == ttnn_errored, f"torch: {torch_errored}, ttnn: {ttnn_errored}"
 

--- a/tests/ttnn/unit_tests/tensor/test_copy_host_to_device_tensor_partial.py
+++ b/tests/ttnn/unit_tests/tensor/test_copy_host_to_device_tensor_partial.py
@@ -141,5 +141,5 @@ def test_copy_host_to_device_tensor_partial_interleaved_raises(device, expect_er
     dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, device, mem_config)
     ttnn.copy_host_to_device_tensor(tt_a, dev)
     flt = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
-    with expect_error(RuntimeError, "logical_core_filter is only supported for sharded buffer layouts"):
+    with expect_error(RuntimeError, r"logical_core_filter is only supported for sharded buffer layouts"):
         ttnn.copy_host_to_device_tensor_partial(tt_b, dev, flt)

--- a/tests/ttnn/unit_tests/tensor/test_copy_host_to_device_tensor_partial.py
+++ b/tests/ttnn/unit_tests/tensor/test_copy_host_to_device_tensor_partial.py
@@ -123,7 +123,7 @@ def test_copy_host_to_device_tensor_partial_complementary_filters_dram_sharded(d
     assert torch.equal(got, exp)
 
 
-def test_copy_host_to_device_tensor_partial_interleaved_raises(device):
+def test_copy_host_to_device_tensor_partial_interleaved_raises(device, expect_error):
     shape = (1, 1, 32, 32)
     mem_config = ttnn.DRAM_MEMORY_CONFIG
     tt_a = ttnn.from_torch(
@@ -141,5 +141,5 @@ def test_copy_host_to_device_tensor_partial_interleaved_raises(device):
     dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, device, mem_config)
     ttnn.copy_host_to_device_tensor(tt_a, dev)
     flt = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "logical_core_filter is only supported for sharded buffer layouts"):
         ttnn.copy_host_to_device_tensor_partial(tt_b, dev, flt)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -445,7 +445,7 @@ def test_tensor_creation_from_buffer(dtype, shape, buffer, device):
     ],
 )
 def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device, expect_error):
-    with expect_error(Exception, "Unreachable"):
+    with expect_error(Exception, r"Unreachable"):
         ttnn.from_buffer(buffer, [2, 3], dtype, device, ttnn.TILE_LAYOUT)
 
 

--- a/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_creation.py
@@ -444,13 +444,9 @@ def test_tensor_creation_from_buffer(dtype, shape, buffer, device):
         (ttnn.DataType.INVALID, [[1, 2, 3], [4, 5, 6]]),
     ],
 )
-def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device):
-    try:
-        tt_tensor = ttnn.from_buffer(buffer, [2, 3], dtype, device, ttnn.TILE_LAYOUT)
-    except Exception as e:
-        assert "Unreachable" in str(e)
-    else:
-        pytest.fail("Expected an exception, but got none")
+def test_tensor_creation_from_buffer_with_unsupported_dtype(dtype, buffer, device, expect_error):
+    with expect_error(Exception, "Unreachable"):
+        ttnn.from_buffer(buffer, [2, 3], dtype, device, ttnn.TILE_LAYOUT)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### PR Category
Feature

### Summary

Turns on AI job + run summaries for the L2 nightly pipeline, and stops the reports
calling passing jobs crashed.

- Every job now runs under `run-with-log`, so a `timeout-minutes` kill is
  distinguishable from a real failure instead of reporting as success.
- Per-job summaries on all 9 impls; one `AI Run Summary` job aggregates them.
  Jobs that produced nothing are reported as infra failures rather than dropped.
- Tests that deliberately provoke a device error now declare it, so log triage
  stops reading them as crashes. **33 of 160 green legs were affected per run; now 0.**
- Several jobs that can't declare it (C++ negative tests, a provoked device hang, some ops tests) opt
  out via an `ai_summary` section in their test yaml.

Full run showing the output: https://github.com/tenstorrent/tt-metal/actions/runs/33167878929

### Notes for reviewers

- `prepare_test_matrix.py` flattens the new `ai_summary` yaml section into a flat
  matrix key, so workflows read one plain value.
- Expected-error patterns must come from the message the logger emits, not the
  assert condition and not across a `{}` — those match the exception but never the
  log line, so the suppression silently does nothing.
- `matmul` uses the opt-out rather than a test fix: it logs a fatal from a program
  config it then successfully retries. That's a question for the matmul owners.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/l2-nightly-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/l2-nightly-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/l2-nightly-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/l2-nightly-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/l2-nightly-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/l2-nightly-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/l2-nightly-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/l2-nightly-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/l2-nightly-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/l2-nightly-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/l2-nightly-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/l2-nightly-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/l2-nightly-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/l2-nightly-summary)