### PR TITLE
[Bug fix] Fix dispatch and fabric teardown for multichip watcher

### DIFF
--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -270,8 +270,8 @@ void kernel_main() {
     }
 
     fabric_connection.close();
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_async_full_barrier();
+    noc_clear_packet_tags(noc_index);
 
     status_ptr[0] = tt::tt_fabric::FabricMuxStatus::TERMINATED;
     set_l1_data_cache<false>();

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v1.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v1.h
@@ -213,6 +213,8 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
 
 inline __attribute__((always_inline)) void noc_clear_packet_tag(uint32_t /* noc */, uint32_t /* cmd_buf */) {}
 
+inline __attribute__((always_inline)) void noc_clear_packet_tags(uint32_t /* noc */) {}
+
 inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     uint32_t noc, uint32_t cmd_buf, const NocCmdBufState* state) {
     while (!noc_cmd_buf_ready(noc, cmd_buf));

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -252,6 +252,8 @@ inline __attribute__((always_inline)) void noc_cmd_buf_save_state(
 
 inline __attribute__((always_inline)) void noc_clear_packet_tag(uint32_t /* noc */, uint32_t /* cmd_buf */) {}
 
+inline __attribute__((always_inline)) void noc_clear_packet_tags(uint32_t /* noc */) {}
+
 inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     uint32_t noc, uint32_t cmd_buf, const NocCmdBufState* state) {
     while (!noc_cmd_buf_ready(noc, cmd_buf));

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1674,12 +1674,8 @@ void kernel_main() {
 #if defined(COMPILE_FOR_IDLE_ERISC)
         RISC_POST_HEARTBEAT(heartbeat);
         if (early_exit()) {
-            noc_async_full_barrier(my_noc_index);
+            noc_async_full_barrier();
             noc_clear_packet_tags(my_noc_index);
-            if constexpr (my_noc_index != upstream_noc_index) {
-                noc_async_atomic_barrier(upstream_noc_index);
-                noc_clear_packet_tags(upstream_noc_index);
-            }
             set_l1_data_cache<false>();
             return;
         }
@@ -1711,12 +1707,8 @@ void kernel_main() {
     if (is_h_variant && !is_d_variant) {
         relay_client.template teardown<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>();
     }
-    noc_async_full_barrier(my_noc_index);
+    noc_async_full_barrier();
     noc_clear_packet_tags(my_noc_index);
-    if constexpr (my_noc_index != upstream_noc_index) {
-        noc_async_atomic_barrier(upstream_noc_index);
-        noc_clear_packet_tags(upstream_noc_index);
-    }
     // DPRINT("dispatch_{}{}: out\n", is_h_variant, is_d_variant);
     set_l1_data_cache<false>();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1674,8 +1674,12 @@ void kernel_main() {
 #if defined(COMPILE_FOR_IDLE_ERISC)
         RISC_POST_HEARTBEAT(heartbeat);
         if (early_exit()) {
-            noc_async_full_barrier();
+            noc_async_full_barrier(my_noc_index);
             noc_clear_packet_tags(my_noc_index);
+            if constexpr (my_noc_index != upstream_noc_index) {
+                noc_async_full_barrier(upstream_noc_index);
+                noc_clear_packet_tags(upstream_noc_index);
+            }
             set_l1_data_cache<false>();
             return;
         }
@@ -1707,8 +1711,12 @@ void kernel_main() {
     if (is_h_variant && !is_d_variant) {
         relay_client.template teardown<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>();
     }
-    noc_async_full_barrier();
+    noc_async_full_barrier(my_noc_index);
     noc_clear_packet_tags(my_noc_index);
+    if constexpr (my_noc_index != upstream_noc_index) {
+        noc_async_full_barrier(upstream_noc_index);
+        noc_clear_packet_tags(upstream_noc_index);
+    }
     // DPRINT("dispatch_{}{}: out\n", is_h_variant, is_d_variant);
     set_l1_data_cache<false>();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1671,7 +1671,15 @@ void kernel_main() {
         dispatch_cb_reader.wait_for_available_data_and_release_old_pages<DispatchTelemetryBlockGuard>(cmd_ptr);
 
         DeviceZoneScopedN("CQ-DISPATCH");
-        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+#if defined(COMPILE_FOR_IDLE_ERISC)
+        RISC_POST_HEARTBEAT(heartbeat);
+        if (early_exit()) {
+            noc_async_full_barrier();
+            noc_clear_packet_tags(my_noc_index);
+            set_l1_data_cache<false>();
+            return;
+        }
+#endif
 
         done = is_d_variant ? process_cmd_d(cmd_ptr, l1_cache) : process_cmd_h(cmd_ptr);
 
@@ -1699,6 +1707,8 @@ void kernel_main() {
     if (is_h_variant && !is_d_variant) {
         relay_client.template teardown<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>();
     }
+    noc_async_full_barrier();
+    noc_clear_packet_tags(my_noc_index);
     // DPRINT("dispatch_{}{}: out\n", is_h_variant, is_d_variant);
     set_l1_data_cache<false>();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1677,7 +1677,7 @@ void kernel_main() {
             noc_async_full_barrier(my_noc_index);
             noc_clear_packet_tags(my_noc_index);
             if constexpr (my_noc_index != upstream_noc_index) {
-                noc_async_full_barrier(upstream_noc_index);
+                noc_async_atomic_barrier(upstream_noc_index);
                 noc_clear_packet_tags(upstream_noc_index);
             }
             set_l1_data_cache<false>();
@@ -1714,7 +1714,7 @@ void kernel_main() {
     noc_async_full_barrier(my_noc_index);
     noc_clear_packet_tags(my_noc_index);
     if constexpr (my_noc_index != upstream_noc_index) {
-        noc_async_full_barrier(upstream_noc_index);
+        noc_async_atomic_barrier(upstream_noc_index);
         noc_clear_packet_tags(upstream_noc_index);
     }
     // DPRINT("dispatch_{}{}: out\n", is_h_variant, is_d_variant);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -3148,12 +3148,20 @@ void kernel_main() {
     } else {
         ASSERT(0);
     }
-    IDLE_ERISC_RETURN();
+#if defined(COMPILE_FOR_IDLE_ERISC)
+    if (early_exit()) {
+        noc_async_full_barrier();
+        noc_clear_packet_tags(my_noc_index);
+        set_l1_data_cache<false>();
+        return;
+    }
+#endif
 
     // Confirm expected number of pages, spinning here is a leak
     DispatchRelayInlineState::cb_writer.wait_all_pages(downstream_cb_pages);
 
     noc_async_full_barrier();
+    noc_clear_packet_tags(my_noc_index);
 
     DPRINT("prefetcher_{}{}: out\n", is_h_variant, is_d_variant);
     set_l1_data_cache<false>();


### PR DESCRIPTION
## Summary

These fixes are essential for a useful multichip watcher. During mesh shutdown and kernel handoff, idle ERISC dispatch/prefetch and the fabric mux can finish with pending NoC work or sticky transaction packet tags. Watcher then aborts on teardown state, masking the earlier multichip failure it is supposed to diagnose.

- Drain outstanding NoC work and clear packet tags before idle dispatch/prefetch early exits and final returns.
- Drain all outstanding NoC work and clear packet tags before the fabric mux publishes `TERMINATED`.
- Add `noc_clear_packet_tags()` to both Quasar NoC API implementations. It is a no-op there, matching Quasar's existing per-buffer helper, and keeps the teardown calls portable.

## Previous PRs and review follow-up

- Supersedes the stale-closed dispatch fix [#46602](https://github.com/tenstorrent/tt-metal/pull/46602).
- Carries the remaining fabric-mux fix from stale-closed [#46605](https://github.com/tenstorrent/tt-metal/pull/46605). Its all-gather atomic-barrier fix independently landed through [#53951](https://github.com/tenstorrent/tt-metal/pull/53951), so it is not duplicated here.
- Addresses [the review request on #46602](https://github.com/tenstorrent/tt-metal/pull/46602#discussion_r3390894857) by adding the shared packet-tag cleanup helper to Quasar instead of open-coding architecture-specific loops at the call sites.
- Split out from [#54570](https://github.com/tenstorrent/tt-metal/pull/54570) to keep that model-bringup framework PR focused.

## Testing

- `pre-commit run --files` on all five touched source files
- `git diff --check origin/main...HEAD`
- `git submodule update --init --recursive`
- PR Gate: [run 33122355110](https://github.com/tenstorrent/tt-metal/actions/runs/33122355110) — passed on the current head, including runtime/TTNN N150 teardown smokes, SDK examples, ASan build, and full clang-tidy.
- Cross-architecture RTL simulation: [check 98694354764](https://github.com/tenstorrent/tt-metal/pull/54571/checks?check_run_id=98694354764) — all four WH/BH/QSR/Aether simulator tests passed on the current head.
- Runtime Unit Tests, multichip SKUs: [run 33122378078](https://github.com/tenstorrent/tt-metal/actions/runs/33122378078) — the dispatch, fabric, watcher, and multidevice teardown jobs passed across N300, T3K, Galaxy, and Blackhole. The first N300 distributed job hit a transient socket-stress data mismatch and timeout; an independent exact-head N300 rerun completed the full distributed suite successfully, including [`H2DSocketLoopbackMultiThreadedStress`](https://github.com/tenstorrent/tt-metal/actions/runs/33124240179/job/98700111444).
- Focused TM-Fabric `t3k fabric tests` on `wh_llmbox_civ2`: [run 33122383083](https://github.com/tenstorrent/tt-metal/actions/runs/33122383083) — passed on the current head.

The Runtime workflows' only repeatable failure is [`runtime_sd_llk`](https://github.com/tenstorrent/tt-metal/actions/runs/33124240179/job/98700111449), in untouched slow-dispatch LLK test `TensixBinaryComputeColBroadcastThenDestReuseSrcB`. The same numerical tolerance miss is present on scheduled `main` ([baseline job](https://github.com/tenstorrent/tt-metal/actions/runs/33045018297/job/98442881877)); it is unrelated to this teardown patch.

Historical T3K `(1, 8)` `FABRIC_1D_RING` open/close, traced all-gather, and full traced-decode watcher evidence is documented in #46602 and #46605. The targeted hardware CI above runs against `314e95032ae64aa38a20acac9bdbc7c5c11d895d`.

## CI Badges

[![PR Gate](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml/badge.svg?branch=yieldthought%2Fmultichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/runs/33122355110)

[![Runtime Unit — multichip](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=yieldthought%2Fmultichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/runs/33122378078)

[![TM-Fabric — T3K fabric tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=yieldthought%2Fmultichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/runs/33122383083)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yieldthought/multichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yieldthought/multichip-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yieldthought/multichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yieldthought/multichip-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yieldthought/multichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yieldthought/multichip-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yieldthought/multichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yieldthought/multichip-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yieldthought/multichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yieldthought/multichip-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yieldthought/multichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yieldthought/multichip-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yieldthought/multichip-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yieldthought/multichip-watcher-cleanup)
