### PR TITLE
[FIX] Duplicate measurements for dest_acc 

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/constraints.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/constraints.py
@@ -5,6 +5,7 @@
 from typing import List
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.data_format_inference import is_format_combination_outlier
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import TILE_DIMENSIONS
 from helpers.llk_params import (
@@ -71,6 +72,28 @@ def get_valid_dest_accumulation_modes(formats):
             return [DestAccumulation.Yes]
 
     return [DestAccumulation.No, DestAccumulation.Yes]
+
+
+def distinct_dest_accumulation_modes(formats, modes):
+    """Drop dest_acc modes that TestConfig normalizes onto another requested mode.
+
+    TestConfig promotes dest_acc to Yes for outlier format combinations (expB input
+    to Float16 output), and the perf CSV records the promoted value. A sweep that
+    asks for both No and Yes therefore writes two rows with an identical
+    (sweep-params, marker) key: one kernel, measured twice. Keep only the modes
+    that stay distinct after that promotion.
+    """
+    if get_chip_architecture() == ChipArchitecture.QUASAR:
+        return list(modes)
+    if (
+        DestAccumulation.No in modes
+        and DestAccumulation.Yes in modes
+        and is_format_combination_outlier(
+            formats.input_format, formats.output_format, DestAccumulation.No
+        )
+    ):
+        return [DestAccumulation.Yes]
+    return list(modes)
 
 
 def get_valid_math_fidelities(format, operation, PERF_RUN: bool = False):

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_binary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_binary_sfpu.py
@@ -4,6 +4,7 @@
 
 import pytest
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.constraints import distinct_dest_accumulation_modes
 from helpers.format_config import DataFormat
 from helpers.llk_params import (
     ApproximationMode,
@@ -30,7 +31,11 @@ from helpers.test_variant_parameters import (
 def get_dest_accum_modes(formats):
     if formats.input_format.is_32_bit() and formats.input_format.is_integer():
         return [DestAccumulation.No]
-    return [DestAccumulation.Yes, DestAccumulation.No]
+    # TestConfig promotes dest_acc=No to Yes for outlier format combos, so asking
+    # for both would record two rows with an identical key (the same kernel twice).
+    return distinct_dest_accumulation_modes(
+        formats, [DestAccumulation.Yes, DestAccumulation.No]
+    )
 
 
 @pytest.mark.perf
@@ -55,10 +60,7 @@ def get_dest_accum_modes(formats):
         MathOperation.SfpuElwrsub,
         MathOperation.SfpuElwpow,
     ],
-    dest_acc=[
-        DestAccumulation.Yes,
-        DestAccumulation.No,
-    ],
+    dest_acc=lambda formats: get_dest_accum_modes(formats),
     loop_factor=[
         16,
     ],  # Number of iterations to run the test in order to minimize profiler overhead in measurement

--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu.py
@@ -4,6 +4,7 @@
 
 import pytest
 from conftest import skip_for_blackhole
+from helpers.constraints import distinct_dest_accumulation_modes
 from helpers.format_config import DataFormat
 from helpers.llk_params import (
     ApproximationMode,
@@ -68,10 +69,14 @@ _OPS_WITH_STABLE_SORT = {
 }
 
 
-def _get_dest_acc_modes(mathop):
+def _get_dest_acc_modes(mathop, formats):
     if mathop in _OPS_WITHOUT_DEST_ACC:
         return [DestAccumulation.No]
-    return [DestAccumulation.Yes, DestAccumulation.No]
+    # TestConfig promotes dest_acc=No to Yes for outlier format combos, so asking
+    # for both would record two rows with an identical key (the same kernel twice).
+    return distinct_dest_accumulation_modes(
+        formats, [DestAccumulation.Yes, DestAccumulation.No]
+    )
 
 
 def _get_fast_modes(mathop):
@@ -153,7 +158,7 @@ def _get_formats(mathop):
         ApproximationMode.No,
     ],
     mathop=PERF_SWEEP_OPS,
-    dest_acc=lambda mathop: _get_dest_acc_modes(mathop),
+    dest_acc=lambda mathop, formats: _get_dest_acc_modes(mathop, formats),
     loop_factor=[
         16,
     ],  # Number of iterations to run the test in order to minimize profiler overhead in measurement


### PR DESCRIPTION
### PR Category

Test infrastructure

### Summary

Two LLK perf tests sweep `dest_acc=[No, Yes]` over format combinations where the
harness cannot honour `No`. The harness silently promotes those runs to `Yes`, and
the perf CSV records the promoted value. Each such pair therefore writes two rows
with an identical `(sweep-params, marker)` key. `_collapse_duplicate_keys` averages
them and logs a warning.

Both rows measure the same kernel, built once. So the numbers are not wrong. The
cost is 136 redundant hardware measurements per nightly, and a sweep point that
silently disappears from the matrix.

This PR stops generating the point that cannot exist. No column changes, so no perf
schema catalog version bumps.

### The mechanism

`TestConfig.__init__` promotes `dest_acc` for outlier format combinations — an
exponent-B input packed to `Float16`, which the packer cannot do directly:

```python
# helpers/test_config.py:998
if is_format_combination_outlier(formats.input_format, formats.output_format, dest_acc):
    self.dest_acc = DestAccumulation.Yes
```

`PerfConfig` subclasses `TestConfig`, and `_build_sweep_frame` records
`self.dest_acc`. So the CSV carries the value **after** the promotion:

| pytest case | kernel actually built | row written |
|---|---|---|
| `dest_acc=No`  | `dest_acc=Yes` | `dest_acc=DestAccumulation.Yes` |
| `dest_acc=Yes` | `dest_acc=Yes` | `dest_acc=DestAccumulation.Yes` |

### Before and after

These two cases both ran on silicon last night (run 33040431355):

```
test_perf_eltwise_binary_sfpu_float[formats:Float16_b->Float16-approx_mode:Yes-mathop:SfpuElwadd-dest_acc:No-...]
test_perf_eltwise_binary_sfpu_float[formats:Float16_b->Float16-approx_mode:Yes-mathop:SfpuElwadd-dest_acc:Yes-...]
```

**Before** — `perf_eltwise_binary_sfpu.csv` from that run. The outlier pair has one
row, and its metric is the mean of the two runs above. A normal pair keeps both:

```
-- OUTLIER: Float16_b -> Float16          (1 row: two runs averaged)
formats.input_A formats.output             dest_acc          approx_mode                   mathop    marker  mean(L1_TO_L1)
      Float16_b        Float16 DestAccumulation.Yes ApproximationMode.No MathOperation.SfpuElwadd TILE_LOOP         31553.0

-- NORMAL:  Float16_b -> Float16_b        (2 rows: both distinct)
      Float16_b      Float16_b  DestAccumulation.No ApproximationMode.No MathOperation.SfpuElwadd TILE_LOOP         31408.0
      Float16_b      Float16_b DestAccumulation.Yes ApproximationMode.No MathOperation.SfpuElwadd TILE_LOOP         31325.0
```

**After** — the `dest_acc=No` case is never generated. The outlier pair keeps the
same single row, now a single measurement instead of a mean of two. The normal pair
is untouched.

### The change

New helper in `helpers/constraints.py`:

```python
def distinct_dest_accumulation_modes(formats, modes):
    if get_chip_architecture() == ChipArchitecture.QUASAR:
        return list(modes)
    if (
        DestAccumulation.No in modes
        and DestAccumulation.Yes in modes
        and is_format_combination_outlier(
            formats.input_format, formats.output_format, DestAccumulation.No
        )
    ):
        return [DestAccumulation.Yes]
    return list(modes)
```

It drops `No` **only** when `Yes` is also requested. A test that asks for `No` alone
writes one row and was never a duplicate, so it is left alone.

`perf_eltwise_binary_sfpu.py` — the float sweep used a literal list:

```diff
-    dest_acc=[
-        DestAccumulation.Yes,
-        DestAccumulation.No,
-    ],
+    dest_acc=lambda formats: get_dest_accum_modes(formats),
```

```diff
 def get_dest_accum_modes(formats):
     if formats.input_format.is_32_bit() and formats.input_format.is_integer():
         return [DestAccumulation.No]
-    return [DestAccumulation.Yes, DestAccumulation.No]
+    return distinct_dest_accumulation_modes(
+        formats, [DestAccumulation.Yes, DestAccumulation.No]
+    )
```

`perf_eltwise_unary_sfpu.py` — the mode list now also depends on `formats`:

```diff
-def _get_dest_acc_modes(mathop):
+def _get_dest_acc_modes(mathop, formats):
     if mathop in _OPS_WITHOUT_DEST_ACC:
         return [DestAccumulation.No]
-    return [DestAccumulation.Yes, DestAccumulation.No]
+    return distinct_dest_accumulation_modes(
+        formats, [DestAccumulation.Yes, DestAccumulation.No]
+    )
...
-    dest_acc=lambda mathop: _get_dest_acc_modes(mathop),
+    dest_acc=lambda mathop, formats: _get_dest_acc_modes(mathop, formats),
```

`parametrize` resolves callables in dependency order, so `formats` is available.

### Scope: which tests are affected

Measured on run 33040431355 by comparing each shard's JUnit passed-case count
against its CSV row count (`rows == cases x markers`):

| Test | Duplicate case pairs per arch | Rows lost per arch |
|---|---|---|
| `perf_eltwise_unary_sfpu` | 44 | 132 |
| `perf_eltwise_binary_sfpu` | 24 | 72 |
| **Both arches** | **136** | **408** |

Clean, and untouched by this PR: `perf_eltwise_binary` (already filters via
`get_valid_dest_accumulation_modes`), `perf_matmul`, `perf_math_matmul`, and every
other perf test. 24 test/shard reports checked, 4 with a shortfall.

### Verification

Simulated the new filter against every executed case in that nightly, by parsing
the parameters out of the JUnit reports:

```
REMOVED (a dest_acc=Yes twin exists -> was a duplicate):   136
KEPT    (no twin -> single row, never a duplicate):         40
```

136 removed matches the 136 pairs measured from the row shortfall exactly. No data
is lost, and nothing extra is removed.

`test_perf_header_gate.py` re-derives with 0 drift across all 41 catalog entries.

### Note on the alternative

Replacing the local mode functions with `get_valid_dest_accumulation_modes(formats)`
also removes the duplicates, but it changes more. That function returns `[Yes]` for
Int32 input, while `perf_eltwise_binary_sfpu.get_dest_accum_modes` returns `[No]`.
Swapping it in flips every Int32 measurement from `No` to `Yes` and breaks that
series. This PR changes nothing except the duplicate points.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-dedupe-dest-acc-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-dedupe-dest-acc-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-dedupe-dest-acc-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-dedupe-dest-acc-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-dedupe-dest-acc-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-dedupe-dest-acc-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-dedupe-dest-acc-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-dedupe-dest-acc-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-dedupe-dest-acc-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-dedupe-dest-acc-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-dedupe-dest-acc-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-dedupe-dest-acc-sweep)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-dedupe-dest-acc-sweep)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-dedupe-dest-acc-sweep)