### PR TITLE
[CI] Upload logs regardless of run success

### DIFF
--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -170,9 +170,11 @@ jobs:
             ${{ env.LLK_PATH }}/perf_data/runs/
             ${{ env.LLK_PATH }}/perf_data/*.parquet
 
-      - name: Upload test logs on failure
+      # Always, not only on failure: loguru writes warnings to test_run*.log and
+      # never to the console, so a green run used to discard them unread.
+      - name: Upload test logs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: failure()
+        if: always()
         with:
           name: test-logs-${{ env.CHIP_ARCH }}-${{ matrix.test-group.split_group }}
           path: |


### PR DESCRIPTION
### PR Category

CI

### Summary

`llk-perf-impl.yaml` uploaded `test_run*.log` only under `if: failure()`. Those logs
are the only place loguru warnings land, so every warning on a green perf run was
written to a file and then thrown away. Upload them unconditionally.

One line of behaviour, and it is the reason a real problem went unnoticed for weeks.

### The issue

`helpers/logger.py` routes loguru to two sinks:

1. `_PropagateHandler` into stdlib logging. pytest shows that only when `log_cli` is
   on. The perf runners (`run_llk_perf_wormhole.sh`, `run_llk_perf_blackhole.sh`)
   run `pytest -q` with `log_cli` off.
2. `test_run{worker}.log` on disk.

So sink 1 shows nothing in CI, and sink 2 was discarded whenever the job passed.

Evidence, on scheduled run 33040431355. All ten perf jobs, grepped:

```
job 98448943205 : collaps hits = 0
job 98448943277 : collaps hits = 0
job 98448943280 : collaps hits = 0
...
$ gh run view --job=98448943205 --log | grep -c 'Raw appending'
0
```

Zero hits for the warning text, and zero for the routine `Raw appending` info line.
No loguru output reaches the perf console at all.

The artifact list for that run confirms the rest. Only the two **failing** group-5
jobs shipped a log:

```
9640291233   3987   test-logs-blackhole-5      <- failed job
9639470424   3978   test-logs-wormhole-5       <- failed job
9635850033   1509902  perf-data-blackhole-3    <- passing job, no logs
9635841164   1508598  perf-data-blackhole-2    <- passing job, no logs
```

Meanwhile the perf report code was emitting a duplicate-key warning on every one of
those passing jobs. Nobody could see it.

### Before and after

**Before**

```yaml
      - name: Upload test logs on failure
        uses: actions/upload-artifact@... # v7.0.0
        if: failure()
        with:
          name: test-logs-${{ env.CHIP_ARCH }}-${{ matrix.test-group.split_group }}
```

**After**

```yaml
      # Always, not only on failure: loguru writes warnings to test_run*.log and
      # never to the console, so a green run used to discard them unread.
      - name: Upload test logs
        uses: actions/upload-artifact@... # v7.0.0
        if: always()
        with:
          name: test-logs-${{ env.CHIP_ARCH }}-${{ matrix.test-group.split_group }}
```

The `path` list is unchanged: `test_run*.log` and `test_errors*.log`.

### Cost

The failing group-5 log artifacts in that run are about **4 KB** each. Ten shards per
run gives roughly 40 KB per perf run. The `perf-data` artifacts in the same run are
1.2 to 1.7 MB each, so this adds under 3 percent to the run's artifact footprint.

### Verification

Full LLK perf run on a branch carrying this change: run 33068927365. Every shard
should now publish a `test-logs-<arch>-<group>` artifact, not only the failing ones.

Companion PRs, which is how the invisible warning was found:

- #<PR-1> `nstojictt/perf-dedupe-dest-acc-sweep` — removes the duplicate sweep points
- #<PR-2> `nstojictt/perf-duplicate-key-error` — makes a duplicate key fail the run

This PR is independent of both and can merge in any order.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-always-upload-test-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-always-upload-test-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-always-upload-test-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-always-upload-test-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-always-upload-test-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-always-upload-test-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-always-upload-test-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-always-upload-test-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-always-upload-test-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-always-upload-test-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-always-upload-test-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-always-upload-test-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-always-upload-test-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-always-upload-test-logs)