### PR TITLE
[tt-train] Fix sibling `utils` package shadowing that aborts the whole python test session

### DIFF
--- a/tt-train/tests/python/test_grpo_trainer.py
+++ b/tt-train/tests/python/test_grpo_trainer.py
@@ -56,10 +56,33 @@ _GRPO_EXAMPLES_DIR = os.path.join(
     "examples",
     "grpo",
 )
-if _GRPO_EXAMPLES_DIR not in sys.path:
-    sys.path.insert(0, _GRPO_EXAMPLES_DIR)
+# Force the grpo example dir to the front of sys.path so ``import utils`` resolves
+# here even if a sibling example dir is already on the path.
+if _GRPO_EXAMPLES_DIR in sys.path:
+    sys.path.remove(_GRPO_EXAMPLES_DIR)
+sys.path.insert(0, _GRPO_EXAMPLES_DIR)
 
-from utils.llama_completer import LlamaCompletionCtx, LlamaGRPOCompleter  # noqa: E402
+# examples/grpo ships a top-level ``utils`` package, and so do sibling example dirs
+# (examples/grpo_remote_rollout, examples/qwen3). In a single pytest session another
+# module may have imported its own ``utils`` first, caching it in sys.modules and
+# shadowing ours -- tests/python/grpo_remote_rollout/conftest.py puts
+# examples/grpo_remote_rollout on sys.path while conftests load, which is before this
+# module is imported. sys.path.insert cannot override an already-imported module, so
+# evict any cached ``utils*`` for the imports below, then restore the sibling's modules
+# so we do not break whichever test imported them. Same dance as
+# test_tp_vocab_padding.py and test_qwen3_fused_kv_roundtrip.py.
+#
+# ``llama_completer`` is bound here rather than re-imported inside the fixture below:
+# after the restore, a runtime ``from utils import ...`` would resolve against the
+# sibling package again.
+_saved_utils = {k: sys.modules.pop(k) for k in list(sys.modules) if k == "utils" or k.startswith("utils.")}
+try:
+    from utils import llama_completer as _llama_completer  # noqa: E402
+    from utils.llama_completer import LlamaCompletionCtx, LlamaGRPOCompleter  # noqa: E402
+finally:
+    for _k in [k for k in list(sys.modules) if k == "utils" or k.startswith("utils.")]:
+        del sys.modules[_k]
+    sys.modules.update(_saved_utils)
 
 
 HF_MODEL_ID = "unsloth/Llama-3.2-1B-Instruct"  # not gated
@@ -178,10 +201,8 @@ class _RecordingCallback(TrainerCallback):
 @pytest.fixture
 def patch_llama_weight_loading(monkeypatch):
     """Skip the HF download / safetensors load so the tiny model keeps random init."""
-    from utils import llama_completer
-
-    monkeypatch.setattr(llama_completer, "snapshot_download", lambda *args, **kwargs: "/tmp/unused")
-    monkeypatch.setattr(llama_completer, "load_from_safetensors", lambda *args, **kwargs: None)
+    monkeypatch.setattr(_llama_completer, "snapshot_download", lambda *args, **kwargs: "/tmp/unused")
+    monkeypatch.setattr(_llama_completer, "load_from_safetensors", lambda *args, **kwargs: None)
 
 
 @pytest.mark.requires_device


### PR DESCRIPTION
### Symptom

`tt-train python unit tests` fails on every board in the nightly L2 run, and it fails at **collection**, so the entire 977-test session is thrown away:

```
tt-train/tests/python/test_grpo_trainer.py:62: in <module>
    from utils.llama_completer import LlamaCompletionCtx, LlamaGRPOCompleter
E   ModuleNotFoundError: No module named 'utils.llama_completer'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=================== 2 skipped, 4 warnings, 1 error in 11.05s ===================
##[error]Process completed with exit code 2.
```

Seen in [run 33056546111](https://github.com/tenstorrent/tt-metal/actions/runs/33056546111) on `bh_p150b_civ2` and `bh_p100`, and in the nightlies before it.

### Root cause

Three example trees each ship a top-level package literally named `utils`:

| path | has `llama_completer.py`? |
|---|---|
| `tt-train/sources/examples/grpo/utils/` | yes |
| `tt-train/sources/examples/grpo_remote_rollout/utils/` | no |
| `tt-train/sources/examples/qwen3/utils/` | no |

`tt-train/tests/python/grpo_remote_rollout/conftest.py` puts `examples/grpo_remote_rollout` on `sys.path`. Conftests are imported while pytest walks the tree, and `grpo_remote_rollout/` sorts before `test_grpo_trainer.py`, so by the time this module is imported `sys.modules['utils']` is already bound to the remote-rollout package. `test_grpo_trainer.py`'s own `sys.path.insert` cannot undo that — `sys.path` is only consulted for names that are not already in `sys.modules`. That is why the error names the *submodule* rather than `utils` itself.

The module imports fine on its own, which is why this passed pre-merge and only shows up in the full-suite nightly.

The collision predates this failure: `test_tp_vocab_padding.py` and `test_qwen3_fused_kv_roundtrip.py` already carry an evict-and-restore guard for exactly this, and their comments name `examples/grpo` as the sibling to defend against. `test_grpo_trainer.py` is the one importer that never got the guard.

### Fix

Apply the same guard already used by the two qwen3 tests:

- force `examples/grpo` to the front of `sys.path` (remove-then-insert) rather than only appending when absent;
- pop any cached `utils*` out of `sys.modules` around the import, then restore the sibling's entries so the remote-rollout tests are unaffected;
- bind the `llama_completer` **module object** at import time and use it in `patch_llama_weight_loading`, replacing the runtime `from utils import llama_completer` inside the fixture. That deferred import would resolve against the sibling package again after the restore — it is the hazard the qwen3 comments call out, and it is live here because the fixture runs long after module import.

One file, no production code touched.

### Deliberately not in scope

The real defect is three sibling example trees squatting on the same top-level name, with three separate hand-rolled workarounds guarding it. The durable fix is to give them distinct package names (`grpo_utils` / `remote_rollout_utils` / `qwen3_utils`) and delete all three guards. That is a ~25-file rename across `examples/` plus docs, so it is left as a follow-up rather than bundled into a nightly-unblock. Happy to do it in a second PR if that is preferred over this one.

Also unchanged: `tt-train/tests/python/grpo_remote_rollout/_completer_utils.py` still does a bare module-level `from utils.llama_ttt_presets import ...`, which works only because its conftest happens to win the race. It is correct today and this PR keeps it correct, but it is one more thing the rename would make robust.

### Test plan

- [ ] `python -m pytest tt-train/tests/python` collects cleanly (this is the actual regression — collection currently aborts).
- [ ] `test_grpo_trainer.py` passes standalone and as part of the full run.
- [ ] `test_tp_vocab_padding.py`, `test_qwen3_fused_kv_roundtrip.py` and `tt-train/tests/python/grpo_remote_rollout/` still pass — they share the `utils` name and are what the restore step protects.

Draft until the full tt-train python suite has run on hardware.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-grpo-utils-import-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswinmcw/fix-grpo-utils-import-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-grpo-utils-import-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aswinmcw/fix-grpo-utils-import-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswinmcw/fix-grpo-utils-import-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswinmcw/fix-grpo-utils-import-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aswinmcw/fix-grpo-utils-import-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aswinmcw/fix-grpo-utils-import-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswinmcw/fix-grpo-utils-import-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswinmcw/fix-grpo-utils-import-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswinmcw/fix-grpo-utils-import-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswinmcw/fix-grpo-utils-import-shadowing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswinmcw/fix-grpo-utils-import-shadowing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswinmcw/fix-grpo-utils-import-shadowing)