### PR TITLE
[Quasar Resnet] Pass1 Cleanup: Call compute API, drop packer SFPU_ACTIVATION, unguard fast_tilize

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -46,19 +46,8 @@ constexpr bool is_fp32_output_format() {
 
 template <uint32_t block_width_tiles, uint32_t input_dfb, uint32_t output_dfb>
 constexpr bool can_use_fast_tilize() {
-#ifdef ARCH_QUASAR
-    // Quasar has no fast-tilize LLK (and per the LLK team it never will) — only regular tilize.
-    // Always take the regular tilize_init/tilize_block/tilize_uninit path below.
-    return false;
-#else
-    // Float32 OUTPUT is unsupported: fast-tilize's pack path uses Read_32b=0
-    // (bf16-stride stepping through DEST), which truncates fp32 DEST to bf16.
-    // That truncation is acceptable for bf16/bfp output but destroys precision
-    // for fp32 output, producing garbage results in downstream fp32 consumers
-    // (see attn_matmul_fp32 regression).
     return block_width_tiles < 256 && dfb_has_32x32_tiles<output_dfb>() && !get_dst_full_sync_enabled() &&
            has_supported_fast_tilize_format<input_dfb>() && !is_fp32_output_format<output_dfb>();
-#endif
 }
 
 // =============================================================================
@@ -143,13 +132,7 @@ ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages)
             } else
 #endif
             {
-#ifndef ARCH_QUASAR  // Quasar has no fast tilize (use_fast is always false here); keep the name out of the parse
                 fast_tilize_init(input_dfb, block_width_tiles, output_dfb);
-#else
-                // Unreachable: can_use_fast_tilize() returns false on Quasar so use_fast is always false.
-                // Trap (watcher/runtime assert) in case this path is ever reached.
-                ASSERT(false);
-#endif
             }
         } else {
             tilize_init(input_dfb, block_width_tiles, output_dfb);
@@ -199,13 +182,7 @@ ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages)
         out_dfb.reserve_back(block_width_tiles);
 
         if constexpr (use_fast) {
-#ifndef ARCH_QUASAR  // Quasar has no fast tilize (use_fast is always false here); keep the name out of the parse
             fast_tilize_block(input_dfb, block_width_tiles, output_dfb);
-#else
-            // Unreachable: can_use_fast_tilize() returns false on Quasar so use_fast is always false.
-            // Trap (watcher/runtime assert) in case this path is ever reached.
-            ASSERT(false);
-#endif
         } else {
             tilize_block(input_dfb, block_width_tiles, output_dfb);
         }
@@ -223,13 +200,7 @@ ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages)
         init_uninit_mode == tilize_config::InitUninitMode::InitAndUninit ||
         init_uninit_mode == tilize_config::InitUninitMode::UninitOnly) {
         if constexpr (use_fast) {
-#ifndef ARCH_QUASAR  // Quasar has no fast tilize (use_fast is always false here); keep the name out of the parse
             fast_tilize_uninit(input_dfb, output_dfb, block_width_tiles);
-#else
-            // Unreachable: can_use_fast_tilize() returns false on Quasar so use_fast is always false.
-            // Trap (watcher/runtime assert) in case this path is ever reached.
-            ASSERT(false);
-#endif
         } else {
             tilize_uninit(input_dfb, output_dfb);
         }

--- a/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/tilize_helpers.inl
@@ -106,10 +106,10 @@ ALWI void tilize(uint32_t num_blocks, std::optional<uint32_t> total_input_pages)
         // Reconfigure srcA for unpack
         reconfig_data_format_srca(input_dfb);
 
-#ifndef ARCH_BLACKHOLE
+#ifdef ARCH_WORMHOLE
         if constexpr (use_fast) {
             // WH fast-tilize uses both SrcA and SrcB; reconfigure SrcB to match input.
-            // BH fast-tilize only uses SrcA — SrcB must not be touched so matmul
+            // BH/Quasar fast-tilize only uses SrcA — SrcB must not be touched so matmul
             // weights stay configured correctly.
             reconfig_data_format_srcb(input_dfb);
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_no_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_no_bcast_dfb.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb_post_lhs_id, dfb_post_rhs_id, dfb_out_id);
 #ifdef PACK_RELU
-    PACK((llk_pack_relu_config(ReluConfig::zero())));
+    pack_relu_config(ReluConfig::zero());
 #endif
 
 #if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1269,17 +1269,7 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     // Convenience accessor for CB sizing.
     auto cb = [&](Conv2dCb name) -> const CBInfo& { return get_cb_info_by_name(cb_info, name); };
 
-    // QSR: the packer RELU (llk_pack_relu_config(ReluConfig::zero())) leaves ~one 16x16 face per output tile
-    // UNCLAMPED on Quasar -- proven by bisect (test_conv2d_correctness_bisect): a height-sharded conv is
-    // correct with the activation off (PCC 0.99997) but drops to 0.8547 with RELU on, uniform / tap-count-
-    // independent / fidelity-independent, with stale negatives surviving (output absmax > golden). WH is fine.
-    // Route RELU through the SFPU activation path on Quasar instead (full DEST tile; the same path GELU uses)
-    // by NOT taking the packer-relu fast-path here -- the `!pack_relu` branch below then merges the SFPU relu
-    // defines (SFPU_OP_*_ACTIVATION), applied per output tile in the compute kernel after the bias add.
-    // TODO(LLK): fix the Quasar packer relu face coverage so the faster packer clamp can be used again.
-    // (arch_is_quasar is declared earlier, near the out_subblock 1x1 workaround.)
-    bool pack_relu =
-        fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU && !arch_is_quasar;
+    bool pack_relu = fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU;
 
     const bool check_skip_compute = input_cores != output_cores;
     // populate_skipped_work_cores is only reachable with split reader (deferred), so it is always false.
@@ -1376,10 +1366,11 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     // ---- compute defines ----
     std::map<std::string, std::string> compute_defines;
     if (fused_activation.has_value() && !pack_relu) {
-        // Pass the activation input dtype: several unary ops (RELU, SIGNBIT, ...) branch float-vs-int in
-        // get_op_init_and_func and TT_FATAL if it is absent. On Quasar RELU takes this SFPU path (packer-relu
-        // is disabled above), so the dtype is now required. The activation runs on the accumulated conv
-        // result that becomes the output, so use the output dtype (bf16 => the float relu_tile path).
+        // Non-RELU fused activations (GELU, SILU, ...) take the SFPU path. RELU uses packer relu
+        // (`pack_relu` above) and skips this branch. Pass the activation input dtype: several unary
+        // ops branch float-vs-int in get_op_init_and_func and TT_FATAL if it is absent. The
+        // activation runs on the accumulated conv result that becomes the output, so use the output
+        // dtype.
         compute_defines.merge(ttnn::operations::unary::utils::get_defines(
             fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i", output.dtype()));
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -5309,7 +5309,6 @@ m2::KernelSpec make_compute_kernel(
     bool has_bias,
     uint32_t bias_ntiles,
     bool row_broadcast_bias,
-    const std::optional<UnaryWithParam>& fused_activation,
     const std::map<std::string, std::string>& mm_kernel_defines,
     const m2::ComputeHardwareConfig& compute_hw_config) {
     std::vector<m2::DFBBinding> dfb_bindings = {
@@ -5366,14 +5365,6 @@ m2::KernelSpec make_compute_kernel(
     };
     if (has_bias) {
         cta.insert({"row_broadcast_bias", row_broadcast_bias ? 1u : 0u});
-    }
-    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
-        using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
-        const auto params = get_activation_params(fused_activation.value());
-        cta.insert({"activation_type", static_cast<uint32_t>(params.type)});
-        cta.insert({"activation_param0", params.param0});
-        cta.insert({"activation_param1", params.param1});
-        cta.insert({"activation_param2", params.param2});
     }
 
     return m2::KernelSpec{
@@ -5648,11 +5639,11 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
         mm_kernel_in1_sender_writer_defines["FUSE_BIAS"] = "1";
     }
     if (fused_activation.has_value()) {
-        if (fused_activation.value().op_type == UnaryOpType::RELU) {
-            mm_kernel_defines["PACK_RELU"] = "1";
-        } else {
-            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
-        }
+        TT_FATAL(
+            fused_activation.value().op_type == UnaryOpType::RELU,
+            "Quasar 1D matmul fused activation only supports RELU (packer); packer-thread SFPU "
+            "activations (SFPU_ACTIVATION) are not supported.");
+        mm_kernel_defines["PACK_RELU"] = "1";
     }
     if (packer_l1_acc_en) {
         mm_kernel_defines["PACKER_L1_ACC"] = "1";
@@ -6210,7 +6201,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_artifacts(
         bias_tensor.has_value(),
         in1_per_core_w,
         row_broadcast_bias,
-        fused_activation,
         mm_kernel_defines,
         compute_hw_config));
 
@@ -6672,11 +6662,11 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
         mm_kernel_in1_receiver_writer_defines["FUSE_BIAS"] = "1";
     }
     if (fused_activation.has_value()) {
-        if (fused_activation.value().op_type == UnaryOpType::RELU) {
-            mm_kernel_defines["PACK_RELU"] = "1";
-        } else {
-            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
-        }
+        TT_FATAL(
+            fused_activation.value().op_type == UnaryOpType::RELU,
+            "Quasar 1D matmul fused activation only supports RELU (packer); packer-thread SFPU "
+            "activations (SFPU_ACTIVATION) are not supported.");
+        mm_kernel_defines["PACK_RELU"] = "1";
     }
     if (packer_l1_acc_en) {
         mm_kernel_defines["PACKER_L1_ACC"] = "1";
@@ -7164,7 +7154,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
         bias_tensor.has_value(),
         in1_per_core_w,
         row_broadcast_bias,
-        fused_activation,
         mm_kernel_defines,
         compute_hw_config));
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -3208,7 +3208,6 @@ m2::KernelSpec make_compute_kernel(
     bool has_bias,
     uint32_t bias_ntiles,
     bool row_broadcast_bias,
-    const std::optional<UnaryWithParam>& fused_activation,
     const std::map<std::string, std::string>& mm_kernel_defines,
     const m2::ComputeHardwareConfig& compute_hw_config) {
     std::vector<m2::DFBBinding> dfb_bindings = {
@@ -3264,14 +3263,6 @@ m2::KernelSpec make_compute_kernel(
     };
     if (has_bias) {
         cta.insert({"row_broadcast_bias", row_broadcast_bias ? 1u : 0u});
-    }
-    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
-        using ttnn::operations::experimental::quasar::matmul::utilities::get_activation_params;
-        const auto params = get_activation_params(fused_activation.value());
-        cta.insert({"activation_type", static_cast<uint32_t>(params.type)});
-        cta.insert({"activation_param0", params.param0});
-        cta.insert({"activation_param1", params.param1});
-        cta.insert({"activation_param2", params.param2});
     }
 
     return m2::KernelSpec{
@@ -3615,11 +3606,11 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
         mm_kernel_in1_receiver_writer_other_noc_setup_defines["FUSE_BIAS"] = "1";
     }
     if (fused_activation.has_value()) {
-        if (fused_activation.value().op_type == UnaryOpType::RELU) {
-            mm_kernel_defines["PACK_RELU"] = "1";
-        } else {
-            mm_kernel_defines["SFPU_ACTIVATION"] = "1";
-        }
+        TT_FATAL(
+            fused_activation.value().op_type == UnaryOpType::RELU,
+            "Quasar 2D matmul fused activation only supports RELU (packer); packer-thread SFPU "
+            "activations (SFPU_ACTIVATION) are not supported.");
+        mm_kernel_defines["PACK_RELU"] = "1";
     }
     if (packer_l1_acc_en) {
         mm_kernel_defines["PACKER_L1_ACC"] = "1";
@@ -4265,7 +4256,6 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
         bias_tensor.has_value(),
         in1_per_core_w,
         row_broadcast_bias,
-        fused_activation,
         mm_kernel_defines,
         compute_hw_config));
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
@@ -304,7 +304,7 @@ void kernel_main() {
 #ifdef PACK_RELU
                 // for each batch we start with relu disabled so that intermediate results are not relu'd
                 if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
                 }
 #endif
 
@@ -318,7 +318,7 @@ void kernel_main() {
 #if not defined FUSE_BIAS and defined PACK_RELU
                     if (last_out) {
                         // if last block we pack the final result with relu enabled
-                        PACK((llk_pack_relu_config(ReluConfig::zero())));
+                        pack_relu_config(ReluConfig::zero());
                     }
 #endif
 
@@ -327,7 +327,7 @@ void kernel_main() {
                         transpose_init(in0_transpose_cb_id);
                         PACK((pack_reconfig_data_format(in0_cb_id)));
 #ifdef PACKER_L1_ACC
-                        PACK((llk_pack_reconfig_l1_acc(0)));
+                        pack_reconfig_l1_acc(0);
 #endif
                         transpose_tile_block<in0_block_num_tiles>(in0_transpose_cb_id, in0_cb_id);
                         reconfig_data_format_srca(in0_transpose_cb_id, in1_cb_id);
@@ -418,12 +418,12 @@ void kernel_main() {
 #ifdef PACKER_L1_ACC
 #ifdef FUSE_BIAS
                                 if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                    pack_reconfig_l1_acc(0);
                                 } else {
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 }
 #else
-                                PACK((llk_pack_reconfig_l1_acc(0)));
+                                pack_reconfig_l1_acc(0);
 #endif
 #endif
                                 uint32_t start_dst_index = 0;
@@ -440,13 +440,13 @@ void kernel_main() {
 
 #ifdef PACKER_L1_ACC
                                 if (block == 0) {  // no accumulation for first iteration
-                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                    pack_reconfig_l1_acc(0);
                                 } else if (block == 1) {
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 } else if (in0_transpose_tile) {
                                     // For each block, l1_acc would have been enabled during the
                                     // transpose stage. So let us put it back here.
-                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                    pack_reconfig_l1_acc(1);
                                 }
 #endif
 
@@ -537,19 +537,19 @@ void kernel_main() {
 #ifdef FUSE_BIAS
 #ifdef PACK_RELU
                 // if last block we pack the final result with relu enabled
-                PACK((llk_pack_relu_config(ReluConfig::zero())));
+                pack_relu_config(ReluConfig::zero());
 #endif
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
                 PACK((pack_reconfig_data_format(out_cb_id)));
 #endif
 #ifdef PACKER_L1_ACC
-                PACK((llk_pack_reconfig_l1_acc(0)));
+                pack_reconfig_l1_acc(0);
 #endif
                 reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
                 if constexpr (row_broadcast_bias) {
-                    add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+                    add_bcast_rows_init(mm_partials_cb_id, bias_cb_id);
                 } else {
-                    add_tiles_init(mm_partials_cb_id, bias_cb_id);
+                    add_init(mm_partials_cb_id, bias_cb_id);
                 }
                 // Reader only pushes bias once when num_blocks_w_dim == 1;
                 // the tiles stay in the CB for reuse across bh/batch iterations.
@@ -624,7 +624,7 @@ void kernel_main() {
 #endif  // FUSE_BIAS
                 if constexpr (untilize_out) {
 #ifdef PACK_RELU
-                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                    pack_relu_config(ReluConfig::none());
 #endif  // PACK_RELU
 #ifndef FUSE_BIAS
                     reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
@@ -632,7 +632,7 @@ void kernel_main() {
                     PACK((pack_reconfig_data_format(out_cb_id)));
 #endif
 #ifdef PACKER_L1_ACC
-                    PACK((llk_pack_reconfig_l1_acc(0)));
+                    pack_reconfig_l1_acc(0);
 #endif
 #endif  // FUSE_BIAS
                     pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
@@ -15,7 +15,7 @@
 // is converted:
 //   - positional get_compile_time_arg_val(N) -> named get_arg(args::name)
 //   - named CB-index CTAs (get_named_compile_time_arg_val("cb_*")) -> dfb::* tokens
-//   - named non-CB CTAs (bias_ntiles, last_subblock_w_valid, activation_*) -> get_arg(args::name)
+//   - named non-CB CTAs (bias_ntiles, last_subblock_w_valid) -> get_arg(args::name)
 //   - the MATMUL_DRAM_SHARDED worker-core RTA -> get_arg(args::is_worker_core)
 //   - kernel_main-local CircularBuffer wrappers -> DataflowBuffer wrappers
 // The file-scope helper functions still take raw uint32_t cb ids (dfb::* converts implicitly) and
@@ -42,9 +42,6 @@
 #endif
 
 #include "api/compute/eltwise_binary.h"
-#ifdef SFPU_ACTIVATION
-#include "bmm_fused_activation.hpp"
-#endif
 
 /**
  * @brief Transposes a block of tiles from one circular buffer to another.
@@ -252,15 +249,6 @@ void kernel_main() {
 #endif
     constexpr bool last_subblock_padded = last_subblock_w_valid < out_subblock_w;
 
-#ifdef SFPU_ACTIVATION
-    constexpr KernelActivation activation_type = static_cast<KernelActivation>(get_arg(args::activation_type));
-    constexpr uint32_t activation_param0 = get_arg(args::activation_param0);
-    constexpr uint32_t activation_param1 = get_arg(args::activation_param1);
-    constexpr uint32_t activation_param2 = get_arg(args::activation_param2);
-
-    ActivationInitHelper<activation_type, activation_param0, activation_param1>::init();
-#endif
-
 #ifdef IN1_TRANSPOSE_TILE
     constexpr uint32_t in1_transpose_tile = true;
 #else
@@ -400,16 +388,7 @@ void kernel_main() {
                             if (last_out) {
                                 tile_regs_commit();
                                 mm_out_cb.reserve_back(out_subblock_num_tiles);
-
-#if defined SFPU_ACTIVATION and not defined FUSE_BIAS
-                                apply_activation_from_pack<
-                                    activation_type,
-                                    activation_param0,
-                                    activation_param1,
-                                    activation_param2>(out_subblock_num_tiles);
-#else
                                 tile_regs_wait();
-#endif
 
 #if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
                                 PACK((pack_reconfig_data_format(mm_out_cb_id)));
@@ -590,25 +569,7 @@ void kernel_main() {
 
                         // Pack out to output buffer
                         untilize_mode_out_cb.reserve_back(out_subblock_num_tiles);
-
-#ifdef SFPU_ACTIVATION
-                        PACK(TTI_SEMWAIT(
-                            p_stall::STALL_TDMA | p_stall::STALL_CFG,
-                            semaphore::t6_sem(semaphore::MATH_PACK),
-                            p_stall::STALL_ON_ZERO));
-
-                        // Flip destination register offset for PACKER access
-                        PACK(TT_SETC16(
-                            DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
-
-                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
-                            ActivationApplyHelper<activation_type, activation_param0, activation_param1>::apply(i);
-                        }
-
-                        PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
-#else
                         tile_regs_wait();
-#endif
                         for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
                             pack_tile(i, untilize_mode_out_cb_id);
                         }


### PR DESCRIPTION
### PR Category
Cleanup

### Issue
https://github.com/tenstorrent/tt-metal/issues/54329

### Summary
- Switch live experimental/quasar compute kernels to the compute API (`pack_relu_config`, `pack_reconfig_l1_acc`, `add_bcast_rows_init`, `add_init`) instead of calling LLK API.
- Re-enable packer ReLU on Quasar conv. RELU no longer takes the math-thread SFPU path.
- Remove the packer-thread `SFPU_ACTIVATION` path from the live metal2 BMM kernel and 1D/2D factories. Fused activation on that path is RELU-only (`PACK_RELU`); anything else `TT_FATAL`s.
- Stop forcing `can_use_fast_tilize()` false on Quasar. Quasar `fast_tilize_*` already aliases to regular `tilize_*`. 

### Notes for reviewers
There is similar cleanup that should be done across different Quasar Resnet compute kernels. This pass includes kernels used by:
```
models/demos/vision/classification/resnet50/quasar/tests/test_resnet50_e2e.py::test_resnet50_e2e
TT_METAL_QSR_CONV_SPLIT_PROGRAM=1 models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d_split_program_e2e.py 
```
compute_pool_2d.cpp is not included and will be covered in a follow up PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/resnet_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/resnet_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/resnet_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/resnet_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/resnet_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/resnet_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/resnet_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/resnet_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/resnet_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/resnet_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/resnet_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/resnet_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/resnet_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/resnet_cleanup)