### PR TITLE
[Test Only] Correct a topk ttsim skip comment: SFPCONFIG, not SFPLOADMACRO

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -462,7 +462,10 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 
 skip_routed_topk_on_sim = pytest.mark.skipif(
     is_blackhole() and bool(os.environ.get("TT_METAL_SIMULATOR")),
-    reason="Large indices topk on BH needs SFPCONFIG instr_mod1=8, unmodeled by ttsim (ttsim-private#798)",
+    reason=(
+        "Large indices topk on BH needs SFPCONFIG instr_mod1=8, unmodeled by ttsim "
+        "(https://github.com/tenstorrent/ttsim-private/issues/798)"
+    ),
 )
 
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -460,21 +460,9 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     )
 
 
-# The BH-routed ttnn.topk path (topk_large_indices, engages for bf16 largest at k>64 or wide
-# non-pow2 widths) aborts under ttsim (silent worker death ~9s in under xdist; the serial re-run
-# shows the error; see the sanity break on 1dc0e9673b6). Its topk_xl LLK gives each SFPU column
-# its own SFPSWAP comparator direction during the wide bitonic phases, via SFPCONFIG with
-# instr_mod1=8 -- a per-SFPU-instance LaneConfig write (the 0x4444/0x5050/0x5500 masks in
-# ckernel_sfpu_topk_xl.h). ttsim does not model that mode:
-#   ERROR: UnsupportedFunctionality: tensix_sfpconfig: instr_mod1=8
-# This is NOT the SFPLOADMACRO gap: topk_xl honours TT_METAL_DISABLE_SFPLOADMACRO (which the sim
-# CI job sets) and the LaneConfig writes sit outside that guard. The mode is unimplemented in
-# v1.10.2, v1.10.3 and ttsim main as of 2026-08-27, so bumping tt_metal/ttsim-version does NOT
-# lift this skip -- tenstorrent/ttsim-private#798 tracks the simulator work. The cells pass on
-# BH silicon.
 skip_routed_topk_on_sim = pytest.mark.skipif(
     is_blackhole() and bool(os.environ.get("TT_METAL_SIMULATOR")),
-    reason="BH-routed topk needs SFPCONFIG instr_mod1=8, unmodeled by ttsim (ttsim-private#798)",
+    reason="Large indices topk on BH needs SFPCONFIG instr_mod1=8, unmodeled by ttsim (ttsim-private#798)",
 )
 
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -461,13 +461,20 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 
 
 # The BH-routed ttnn.topk path (topk_large_indices, engages for bf16 largest at k>64 or wide
-# non-pow2 widths) crashes the CI simulator's ttsim build (silent worker death ~9s in; see the
-# sanity break on 1dc0e9673b6). The same tests pass on BH silicon and on a current ttsim
-# (SFPLOADMACRO-capable). Skip the routed cells on simulator runners until the runner image
-# ships an updated ttsim.
+# non-pow2 widths) aborts under ttsim (silent worker death ~9s in under xdist; the serial re-run
+# shows the error; see the sanity break on 1dc0e9673b6). Its topk_xl LLK gives each SFPU column
+# its own SFPSWAP comparator direction during the wide bitonic phases, via SFPCONFIG with
+# instr_mod1=8 -- a per-SFPU-instance LaneConfig write (the 0x4444/0x5050/0x5500 masks in
+# ckernel_sfpu_topk_xl.h). ttsim does not model that mode:
+#   ERROR: UnsupportedFunctionality: tensix_sfpconfig: instr_mod1=8
+# This is NOT the SFPLOADMACRO gap: topk_xl honours TT_METAL_DISABLE_SFPLOADMACRO (which the sim
+# CI job sets) and the LaneConfig writes sit outside that guard. The mode is unimplemented in
+# v1.10.2, v1.10.3 and ttsim main as of 2026-08-27, so bumping tt_metal/ttsim-version does NOT
+# lift this skip -- tenstorrent/ttsim-private#798 tracks the simulator work. The cells pass on
+# BH silicon.
 skip_routed_topk_on_sim = pytest.mark.skipif(
     is_blackhole() and bool(os.environ.get("TT_METAL_SIMULATOR")),
-    reason="BH-routed topk crashes the CI ttsim build; passes on silicon and current ttsim",
+    reason="BH-routed topk needs SFPCONFIG instr_mod1=8, unmodeled by ttsim (ttsim-private#798)",
 )
 
 


### PR DESCRIPTION
### PR Category

Test Only

### Summary

`skip_routed_topk_on_sim` (added in #53732 to fix #53729) explains the abort as an SFPLOADMACRO

The actual blocker is `SFPCONFIG` with `instr_mod1 = 8`, a per-SFPU-instance LaneConfig write.

```
ERROR: UnsupportedFunctionality: tensix_sfpconfig: instr_mod1=8
```

Relates to #53729. Simulator-side work: tenstorrent/ttsim-private#798.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/topk-sim-skip-comment-798)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/topk-sim-skip-comment-798)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/topk-sim-skip-comment-798)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/topk-sim-skip-comment-798)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/topk-sim-skip-comment-798)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/topk-sim-skip-comment-798)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/topk-sim-skip-comment-798)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/topk-sim-skip-comment-798)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/topk-sim-skip-comment-798)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/topk-sim-skip-comment-798)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/topk-sim-skip-comment-798)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/topk-sim-skip-comment-798)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/topk-sim-skip-comment-798)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/topk-sim-skip-comment-798)