### PR TITLE
Add the counter metric columns to the published LLK perf schema

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
@@ -21,7 +21,14 @@ Imports no device libraries, so it loads without hardware.
 
 from dataclasses import dataclass
 
-from .schema import MEAN, STD, stat_column
+from .schema import (
+    MEAN,
+    METRIC_BASES,
+    RUN_TYPE_NAMES,
+    STD,
+    metric_column,
+    stat_column,
+)
 
 
 @dataclass(frozen=True)
@@ -51,12 +58,36 @@ _TIMING_COLUMNS = [
 ]
 
 
+# Counter-derived metric columns, same formula-driven treatment as timing. Both
+# names export_metrics can use are enumerated: the raw value when a run type ran
+# once, mean/std when it ran >=2 times. Run types are listed rather than taken
+# from the frozenset because the schema fixes column order; the assert keeps the
+# two in step.
+_METRIC_RUN_TYPES = (
+    "L1_TO_L1",
+    "UNPACK_ISOLATE",
+    "MATH_ISOLATE",
+    "PACK_ISOLATE",
+    "L1_CONGESTION",
+    "SFPU_ISOLATE",
+)
+assert set(_METRIC_RUN_TYPES) == set(RUN_TYPE_NAMES), (
+    "_METRIC_RUN_TYPES is out of sync with schema.RUN_TYPE_NAMES: "
+    f"{sorted(set(_METRIC_RUN_TYPES) ^ set(RUN_TYPE_NAMES))}"
+)
+_METRIC_COLUMNS = [
+    Column(metric_column(run_type, base), "float64", True, "metrics")
+    for run_type in _METRIC_RUN_TYPES
+    for metric in sorted(METRIC_BASES)
+    for base in (metric, stat_column(metric, MEAN), stat_column(metric, STD))
+]
+
+
 # ── The one published table: every column, headers + provenance ─────────────
 # This IS the table handed to the data team; the Parquet is written with it. Each
 # column's `origin` says who fills it — "test" (default) or "ci".
-# TODO(counters, deferred — see #51249): counter/metric columns join here as
-# nullable once a counter run captures their exact names. Quasar has its own
-# published table in wide_schema_quasar.py — do not mix Quasar columns in here.
+# Quasar has its own published table in wide_schema_quasar.py — do not mix Quasar
+# columns in here.
 DB_SCHEMA = [
     Column("marker", "string", False, "identity"),
     # formats
@@ -127,6 +158,8 @@ DB_SCHEMA = [
     Column("value_bits", "int64", True, "configuration"),
     # timing (complete {mean, std} x base grid — see _TIMING_COLUMNS above)
     *_TIMING_COLUMNS,
+    # counter-derived metrics (complete run type x metric grid — see above)
+    *_METRIC_COLUMNS,
     # ── provenance: stamped by the publish layer, never emitted by a test ──
     Column("test_name", "string", False, "identity", origin="ci"),
     Column("commit_sha", "string", False, "provenance", origin="ci"),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
@@ -58,11 +58,8 @@ _TIMING_COLUMNS = [
 ]
 
 
-# Counter-derived metric columns, same formula-driven treatment as timing. Both
-# names export_metrics can use are enumerated: the raw value when a run type ran
-# once, mean/std when it ran >=2 times. Run types are listed rather than taken
-# from the frozenset because the schema fixes column order; the assert keeps the
-# two in step.
+# Both names export_metrics can use: the raw value for a single run, mean/std for
+# two or more. Listed rather than taken from the frozenset because order matters.
 _METRIC_RUN_TYPES = (
     "L1_TO_L1",
     "UNPACK_ISOLATE",

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -12,6 +12,7 @@ shared wide schema (DB_SCHEMA), that columns a test did not emit become NULL
 import pandas as pd
 import pyarrow.parquet as pq
 import pytest
+from helpers.metrics import export_metrics
 from helpers.perf.parquet import (
     align_to_schema,
     arrow_schema,
@@ -23,6 +24,7 @@ from helpers.perf.parquet import (
     write_parquet,
     write_run_batch,
 )
+from helpers.perf.schema import MARKER, METRIC_BASES, RUN_TYPE_NAMES
 from helpers.perf.test_schemas import PERF_TEST_SCHEMAS
 from helpers.perf.wide_schema import DB_SCHEMA, DROPPED_COLUMNS
 
@@ -310,6 +312,30 @@ def test_catalog_columns_are_in_db_schema():
         "helpers.perf.wide_schema.DB_SCHEMA and would be dropped from Parquet: "
         f"{missing}. Add them as nullable columns (or to DROPPED_COLUMNS if they "
         "must not be published)."
+    )
+
+
+def test_counter_metric_columns_are_in_db_schema():
+    # Drive the real emitter rather than the schema's own constants, so this
+    # fails if export_metrics ever names a column differently. One zone entry
+    # exports the raw value, two export mean/std, and both forms must be in the
+    # published table or a --enable-perf-counters run dies in the writer.
+    schema_names = {c.name for c in DB_SCHEMA} | DROPPED_COLUMNS
+    unknown = set()
+    for run_type in sorted(RUN_TYPE_NAMES):
+        for metric in sorted(METRIC_BASES):
+            for computed in (
+                [{"zone": "ZONE_1", metric: 1.0}],
+                [{"zone": "ZONE_1", metric: 1.0}, {"zone": "ZONE_1", metric: 2.0}],
+            ):
+                frame = export_metrics(computed, run_type, ["INIT", "TILE_LOOP"])
+                unknown |= {
+                    c for c in frame.columns if c != MARKER and c not in schema_names
+                }
+    assert not unknown, (
+        "helpers.metrics.export_metrics emits counter metric column(s) missing "
+        "from helpers.perf.wide_schema.DB_SCHEMA, so a run with "
+        f"--enable-perf-counters fails the strict writer: {sorted(unknown)}"
     )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -316,10 +316,7 @@ def test_catalog_columns_are_in_db_schema():
 
 
 def test_counter_metric_columns_are_in_db_schema():
-    # Drive the real emitter rather than the schema's own constants, so this
-    # fails if export_metrics ever names a column differently. One zone entry
-    # exports the raw value, two export mean/std, and both forms must be in the
-    # published table or a --enable-perf-counters run dies in the writer.
+    # Drives the real emitter, not the schema's constants, so a rename fails here.
     schema_names = {c.name for c in DB_SCHEMA} | DROPPED_COLUMNS
     unknown = set()
     for run_type in sorted(RUN_TYPE_NAMES):


### PR DESCRIPTION
Closes #54592

### Problem

A perf run with `--enable-perf-counters` fails at sessionfinish, after all the tests have passed:

```
PerfSchemaError: CSV -> Parquet conversion is not lossless (strict mode):
  perf_eltwise_binary: columns not in schema, would be DROPPED:
  ['L1_CONGESTION_compute_utilization_pct', ...]
```

`metrics.py::export_metrics` names each counter-derived metric column `<RUN_TYPE>_<metric>`, and none of those names were in `DB_SCHEMA`. The strict converter will not silently drop an unknown column, so the run fails. The measurement itself is unaffected: the tests pass and both CSVs are written.

The schema had a TODO deferring this until a counter run could confirm the exact names. This PR does that.

### Change

`wide_schema.py` declares the metric columns the same way the timing ones are declared, as a grid over the run types and the `METRIC_BASES` that `schema.py` already owns. 306 columns, all nullable, so a test that does not capture counters leaves them NULL.

Both names `export_metrics` can produce are covered, which is the part worth reviewing. It branches on iteration count:

- ran once: `L1_TO_L1_fpu_utilization_pct`
- ran twice or more: `L1_TO_L1_mean(fpu_utilization_pct)`, `L1_TO_L1_std(fpu_utilization_pct)`

A single-iteration run only ever shows the first form, so the column list cannot be read off one sample. I got this wrong on the first pass and only the mean/std branch in the source caught it.

Run types are spelled out rather than iterated from the frozenset, because the schema fixes column order and a frozenset has none. An assert against `RUN_TYPE_NAMES` keeps the list in step, so adding a run type there without adding it here fails the import instead of the nightly.

### Test

`test_counter_metric_columns_are_in_db_schema` drives `export_metrics` for every run type and metric in both modes, and asserts every column it produces is in the schema. It goes through the real emitter rather than the schema's own constants, so it is not tautological: a rename in `metrics.py` fails the test. Checked against the unfixed schema, where it fails and lists all 306 missing columns.

### Verification

- 92 hardware-free perf tests pass, up from 91 with the new one.
- Blackhole, `perf_eltwise_binary` with `--enable-perf-counters`, producer and consumer, `--speed-of-light`: the run now finishes and writes `local-<ts>.parquet`.
- The values survive rather than being nulled out: 4 rows x 388 columns, 71 of the 306 metric columns populated with real numbers, the rest NULL for the run types this test does not exercise.

### Note

No workflow passes `--enable-perf-counters` (no hits under `.github/` or `tests/`), which is why this was never caught. Wiring the flag into a nightly is out of scope here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-parquet-counter-columns)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvlahovic/perf-parquet-counter-columns)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvlahovic/perf-parquet-counter-columns)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvlahovic/perf-parquet-counter-columns)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvlahovic/perf-parquet-counter-columns)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvlahovic/perf-parquet-counter-columns)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvlahovic/perf-parquet-counter-columns)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvlahovic/perf-parquet-counter-columns)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvlahovic/perf-parquet-counter-columns)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvlahovic/perf-parquet-counter-columns)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvlahovic/perf-parquet-counter-columns)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvlahovic/perf-parquet-counter-columns)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvlahovic/perf-parquet-counter-columns)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvlahovic/perf-parquet-counter-columns)

### File-size cost

306 extra columns are not free, and on a small frame it looks bad: the same input written against the old 82-column schema is 20.5 KB, against the new 388-column one it is 112.7 KB. It is fixed per-column metadata rather than per-row, so it amortizes:

| rows | file | per row |
|---:|---:|---:|
| 6 | 112.6 KB | 19220 B |
| 100 | 115.0 KB | 1177 B |
| 1000 | 115.1 KB | 118 B |
| 5000 | 115.1 KB | 24 B |

About 92 KB fixed. A real nightly is thousands of rows, so it rounds to nothing there, but flagging it since every perf run pays it whether or not it captures counters.

### Quasar

Not affected, and deliberately not changed. Quasar never compiles the counter path: both `-DPERF_COUNTERS_COMPILED` sites in `test_config.py` exclude it, and `counters.h` backstops that with a hard `#error` because the entry/exit barrier hardcodes 3 threads and Quasar has a 4th. Confirmed by compiling the Quasar suite with the flag on (490 variants pass, 600 ELFs, 0 counter symbols in the ELFs). `wide_schema_quasar.DB_SCHEMA` correctly has no metric columns, and adding them there would be 306 permanently-NULL columns for a path that cannot produce them.

### Not changed

The measured values. `core.py`, which writes the CSV, does not import this schema at all; only `parquet.py` does. Parquet and CSV were compared cell by cell on a real Blackhole counter run: 340 cells, 238 non-null, 0 mismatches.
