### PR TITLE
[Cleanup] Port Paged Cache to Device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_fill_cache_interleaved.cpp
@@ -26,11 +26,11 @@ void kernel_main() {
 
     constexpr auto src_args = TensorAccessorArgs<2>();
 
-    const uint32_t tile_bytes = get_tile_size(cb_id_in);
-
     const auto s = TensorAccessor(src_args, src_addr);
 
     CircularBuffer cb_in(cb_id_in);
+
+    const uint32_t tile_bytes = cb_in.get_tile_size();
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t tile_id = start_tile_id;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
@@ -73,8 +73,7 @@ void kernel_main() {
     cb_input.reserve_back(Wt);
     cb_input.push_back(Wt);
 
-    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
-    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
+    const uint32_t cache_tile_bytes = cb_cache.get_tile_size();
 
     constexpr uint32_t TILE_HEIGHT = 32;
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -73,8 +73,7 @@ void kernel_main() {
     cb_input.reserve_back(1);
     cb_input.push_back(1);
 
-    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
-    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
+    const uint32_t cache_tile_bytes = cb_cache.get_tile_size();
 
     constexpr uint32_t TILE_HEIGHT = 32;
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_update_cache_interleaved_start_id.cpp
@@ -60,8 +60,7 @@ void kernel_main() {
     cb_input.reserve_back(Wt);
     cb_input.push_back(Wt);
 
-    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
-    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
+    const uint32_t cache_tile_bytes = cb_cache.get_tile_size();
 
     constexpr uint32_t TILE_HEIGHT = 32;
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_fill_cache_interleaved.cpp
@@ -140,8 +140,7 @@ void kernel_main() {
         }
     }
 
-    const uint32_t tile_bytes = get_tile_size(cb_id_in);
-    const DataFormat data_format = get_dataformat(cb_id_in);
+    const uint32_t tile_bytes = cb_in.get_tile_size();
 
     const auto out_gen = TensorAccessor(s0_args, dst_addr);
     const auto page_table_gen = TensorAccessor(page_table_args, page_table_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -55,8 +55,6 @@ void kernel_main() {
 
     constexpr auto s0_args = TensorAccessorArgs<20>();
 
-    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
-
     constexpr uint32_t TILE_HEIGHT = 32;
 
     const auto s0 = TensorAccessor(s0_args, cache_addr);
@@ -67,6 +65,8 @@ void kernel_main() {
     CircularBuffer cb_untilized_input(untilized_input_cb_id);
     CircularBuffer cb_index(cb_index_id);
     CircularBuffer cb_page_table(page_table_cb_id);
+
+    const uint32_t cache_tile_bytes = cb_cache.get_tile_size();
 
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -62,9 +62,6 @@ void kernel_main() {
     }
     constexpr uint32_t head_offset_t = Wt * St;
 
-    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
-    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
-
     constexpr uint32_t TILE_HEIGHT = 32;
 
     const auto s0 = TensorAccessor(s0_args, cache_addr);
@@ -75,6 +72,8 @@ void kernel_main() {
     CircularBuffer cb_untilized_input(untilized_input_cb_id);
     CircularBuffer cb_index(cb_index_id);
     CircularBuffer cb_page_table(page_table_cb_id);
+
+    const uint32_t cache_tile_bytes = cb_cache.get_tile_size();
 
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -50,9 +50,6 @@ void kernel_main() {
 
     constexpr uint32_t head_offset_t = Wt * St;
 
-    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
-    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
-
     constexpr uint32_t TILE_HEIGHT = 32;
 
     const auto s0 = TensorAccessor(s0_args, cache_addr);
@@ -63,6 +60,8 @@ void kernel_main() {
     CircularBuffer cb_untilized_input(untilized_input_cb_id);
     CircularBuffer cb_index(cb_index_id);
     CircularBuffer cb_page_table(page_table_cb_id);
+
+    const uint32_t cache_tile_bytes = cb_cache.get_tile_size();
 
     uint32_t cache_id = cache_start_id;
     uint32_t update_idx = 0;


### PR DESCRIPTION
### Summary
Paged cache needs to use the Device 2.0 APIs in order to unblock its upcoming Metal 2.0 port.

This is mainly just changing the API used for `get_tile_size()` and removing the unused format variable.

No functional changes are expected

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/Paged_Cache_Device_Port)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/Paged_Cache_Device_Port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/Paged_Cache_Device_Port)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/Paged_Cache_Device_Port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/Paged_Cache_Device_Port)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/Paged_Cache_Device_Port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/Paged_Cache_Device_Port)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/Paged_Cache_Device_Port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/Paged_Cache_Device_Port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/Paged_Cache_Device_Port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/Paged_Cache_Device_Port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/Paged_Cache_Device_Port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/Paged_Cache_Device_Port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/Paged_Cache_Device_Port)