### PR TITLE
[skip ci] [Models CI] Raise the TT-Transformers common unit tests timeout to 23 min on wh_llmbox

### DIFF
--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1541,7 +1541,7 @@
   model_family: TTTv2
   skus:
     wh_llmbox:
-      timeout: 15
+      timeout: 23
       tier: 1
   owner_id: U08JFM3CFA4 # Gongyu Wang
   team: models


### PR DESCRIPTION
**CI run** — [(Tier 1) Models Unit Tests 33080037375](https://github.com/tenstorrent/tt-metal/actions/runs/33080037375), `model: tt-transformers-common`, `sku: wh_llmbox (T3000)`.

### Problem

`TT-Transformers common unit tests [wh_llmbox]` has been red on every scheduled run for days — `33044979364`, `33012586257`, `32929600689`, `32893573236`, `32808313730`, `32772260578`. Each hit the 15-minute step ceiling:

```
##[error]The action has timed out.
```

Not a hang. Tests were completing right up to the kill instant:

```
05:12:23.67  test_metrics.py::...[identical_random-1x1-tile_bf4b] PASSED
05:12:24.09  test_metrics.py::...[known_diff_max_0.5-1x1-row_major_bf16]   <- started
05:12:24.09  ##[error]The action has timed out.
```

It reached roughly 2704 of 2929 collected items before being killed, leaving about 225 unrun. The suite is also growing: collected count went from 1966 to 2929 between Aug 25 and Aug 26.

### Change

`wh_llmbox` timeout 15 → 23 for this one entry. Nothing else.

### Measured result

The suite completed for the first time, in **19m25s**:

```
==== 4 failed, 2678 passed, 249 skipped, 12 warnings in 1165.50s (0:19:25) =====
```

Zero occurrences of `The action has timed out`. That runtime had never been measured before, because the suite had never once run to the end in CI. 23 min is also exactly what the budget allows without a bump: models / `wh_llmbox` goes 92 → **100 of 100**.

### This does not turn the job green, by design

Four host-side contract tests fail before the timeout ever mattered, identically across every run:

```
models/common/tests/models/deepseek_r1_distill_qwen_14b/test_demo_contract.py::test_eval_prefill_signature_multiset_is_rotation_invariant_and_not_static_warmup_shaped
models/common/tests/models/qwen25_7b/test_demo_contract.py::test_eval_prefill_signature_multiset_is_rotation_invariant_and_not_static_warmup_shaped
models/common/tests/models/qwen2_7b/test_demo_contract.py::test_eval_prefill_signature_multiset_is_rotation_invariant_and_not_static_warmup_shaped
models/common/tests/models/llama32_3b/test_hf_adaptor.py::test_generator_downgrades_n150_all_trace_to_decode_only  - AssertionError: assert 'all' == ...
```

These are pre-existing and are being tackled separately. The value of this PR is that the failures become visible and actionable instead of being hidden behind an opaque timeout — the `llama32_3b` assertion text above only surfaced once the suite was allowed to finish.

Three of the four are the same assertion in three model directories, so they are likely one root cause; the fourth is a separate trace-gate assertion.

### Follow-up worth knowing

At 19m25s inside a 23-minute cap, headroom is about 3.5 minutes, and `wh_llmbox` now has **zero** budget left, so the next raise needs a budget bump. The entry is an unbounded directory glob:

```
pytest --tb=short --ignore=models/common/tests/modules models/common/tests
```

so every test added under that tree lands in a fixed box. Splitting the glob is the durable fix; this PR is the measurement plus the immediate unblock.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/tttv2-common-unit-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/tttv2-common-unit-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/tttv2-common-unit-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/tttv2-common-unit-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/tttv2-common-unit-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/tttv2-common-unit-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/tttv2-common-unit-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/tttv2-common-unit-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/tttv2-common-unit-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/tttv2-common-unit-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/tttv2-common-unit-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/tttv2-common-unit-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/tttv2-common-unit-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/tttv2-common-unit-timeout)