### PR TITLE
[Cleanup] Remove unused Cluster::verify_sw_fw_versions()

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1088,25 +1088,6 @@ std::unique_ptr<tt::umd::SysmemBuffer> Cluster::map_sysmem_buffer(
     return sysmem_manager->map_sysmem_buffer(buffer, sysmem_buffer_size, map_to_noc);
 }
 
-void Cluster::verify_sw_fw_versions(
-    int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const {
-    umd::semver_t sw(umd::semver_t::from_wormhole_eth_firmware_tag(sw_version)),
-        fw_first_eth_core(umd::semver_t::from_wormhole_eth_firmware_tag(fw_versions.at(0)));
-    log_info(
-        tt::LogDevice,
-        "Software version {}, Ethernet FW version {} (Device {})",
-        sw.to_string(),
-        fw_first_eth_core.to_string(),
-        device_id);
-    for (std::uint32_t& fw_version : fw_versions) {
-        umd::semver_t fw(umd::semver_t::from_wormhole_eth_firmware_tag(fw_version));
-
-        TT_FATAL(fw == fw_first_eth_core, "FW versions are not the same across different ethernet cores");
-        TT_FATAL(sw.major == fw.major, "SW/FW major version number out of sync");
-        TT_FATAL(sw.minor <= fw.minor, "SW version is newer than FW version");
-    }
-}
-
 std::optional<tt::umd::semver_t> Cluster::get_ethernet_firmware_version() const {
     return this->driver_->get_ethernet_firmware_version();
 }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -48,8 +48,6 @@ class Hal;
 }
 }  // namespace tt
 
-static constexpr std::uint32_t SW_VERSION = 0x00020000;
-
 using tt_target_dram = std::tuple<int, int, int>;
 
 namespace tt {
@@ -137,7 +135,6 @@ public:
     std::optional<int> get_physical_slot(ChipId chip) const;
 
     //! device driver and misc apis
-    void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
     std::optional<tt::umd::semver_t> get_ethernet_firmware_version() const;
 
     void deassert_risc_reset_at_core(


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Remove unused Cluster::verify_sw_fw_versions().
This method is unused. UMD verifies ETH FW version as a part of TopologyDiscovery.

### Notes for reviewers
N/A

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aleksamarkovic/llrt_cleanup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aleksamarkovic/llrt_cleanup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aleksamarkovic/llrt_cleanup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aleksamarkovic/llrt_cleanup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aleksamarkovic/llrt_cleanup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aleksamarkovic/llrt_cleanup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aleksamarkovic/llrt_cleanup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aleksamarkovic/llrt_cleanup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aleksamarkovic/llrt_cleanup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aleksamarkovic/llrt_cleanup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aleksamarkovic/llrt_cleanup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aleksamarkovic/llrt_cleanup1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aleksamarkovic/llrt_cleanup1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aleksamarkovic/llrt_cleanup1)