### PR TITLE
Qwen3-32B Blackhole Galaxy: nightly vLLM serving lane, sampling correctness fixes, FF2 prefill L1 fix

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -426,6 +426,7 @@ models:
     bh_quietbox_2: 310
     wh_llmbox: 297
     bh_loudbox: 75
+    bh_galaxy: 65
     wh_n150: 65
 umd:
   unit:

--- a/.github/workflows/vllm-model-tests.yaml
+++ b/.github/workflows/vllm-model-tests.yaml
@@ -33,6 +33,7 @@ on:
           - "wh_galaxy_perf (WH Galaxy perf)"
           - "bh_quietbox_2 (BH QB2)"
           - "bh_loudbox (BH LoudBox)"
+          - "bh_galaxy (BH Galaxy)"
           - "wh_n150 (N150)"
       tier:
         description: "Select tier to test (classification mirrors the e2e/unit tier; 'all' runs every tier)"
@@ -109,7 +110,7 @@ jobs:
       - name: Resolve SKU, model and tier selection
         id: resolve
         run: |
-          ALL_SKUS="wh_llmbox,wh_galaxy_perf,bh_quietbox_2,bh_loudbox,wh_n150"
+          ALL_SKUS="wh_llmbox,wh_galaxy_perf,bh_quietbox_2,bh_loudbox,bh_galaxy,wh_n150"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import itertools
 import random
 import secrets
 from dataclasses import dataclass, fields, replace
@@ -348,6 +349,7 @@ class SamplingGenerator:
         logits: ttnn.Tensor,
         *,
         tt_out_tok: Optional[ttnn.Tensor] = None,
+        all_configs: bool = False,
     ) -> None:
         """Run the sampling pipeline once without capturing, to compile it and size its scratch.
 
@@ -357,13 +359,48 @@ class SamplingGenerator:
         left inline, this pass allocates device buffers that a live trace can corrupt on replay.
 
         ``logits`` only has to match the spec of the tensor that will later be captured, not be it.
+
+        ``all_configs`` compiles every ``_TraceKey`` flag combination rather than just the one active
+        now. Traces are keyed on (penalties, log_probs, force_argmax), but warmup only ever runs one of
+        those, so a request asking for logprobs or penalties later finds an uncaptured slot and, because
+        callers pass ``skip_precompile=True``, executes its program for the first time inside a live
+        trace capture -- TT_FATAL !is_capturing_trace, which kills the engine rather than erroring.
         """
-        self._run_sampling(
-            logits,
-            penalties_on=self._penalties_active,
-            tt_out_tok=tt_out_tok,
-            count_tokens=False,
-        )
+        if not all_configs:
+            self._run_sampling(
+                logits,
+                penalties_on=self._penalties_active,
+                tt_out_tok=tt_out_tok,
+                count_tokens=False,
+            )
+            return
+
+        log_probs = self.tt_sampling.log_probs_calculator
+        saved_penalties = self._penalties_active
+        saved_force_argmax = self.tt_sampling._force_argmax_sampling
+        saved_enabled = list(log_probs.logprobs_enabled)
+        saved_num_logprobs = list(log_probs.num_logprobs)
+        try:
+            for penalties_on, log_probs_on, force_argmax in itertools.product((False, True), repeat=3):
+                self._penalties_active = penalties_on
+                # Set the flag directly: reset_params() would re-derive it from k/p/temp and overwrite
+                # the live request params, and only the flag selects the program being compiled.
+                self.tt_sampling._force_argmax_sampling = force_argmax
+                log_probs.set_log_probs_mode(log_probs_on, num_logprobs=0)
+                self._run_sampling(
+                    logits,
+                    penalties_on=penalties_on,
+                    tt_out_tok=tt_out_tok,
+                    count_tokens=False,
+                )
+        finally:
+            self._penalties_active = saved_penalties
+            self.tt_sampling._force_argmax_sampling = saved_force_argmax
+            log_probs.logprobs_enabled = saved_enabled
+            log_probs.num_logprobs = saved_num_logprobs
+            log_probs.enable_log_probs = any(saved_enabled)
+            log_probs.topk_logprobs_needed = log_probs.enable_log_probs
+            self._log_probs_active = log_probs.enable_log_probs
 
     def capture_trace(
         self,

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -452,6 +452,10 @@ class SamplingGenerator:
         slot["kwargs"] = {"tt_out_tok": tt_out_tok}
         _mark_trace_buffers_corruptible(self._active_trace_bucket, (logits, output))
 
+        # begin/end_trace_capture only records the ops, so the output buffer still holds the
+        # previous step's token. Run the trace once or this call replays that stale token.
+        ttnn.execute_trace(self.mesh_device, trace_id, cq_id=self.cq_id, blocking=False)
+
         return slot["output"]
 
     def _execute_trace(self, key: _TraceKey) -> ttnn.Tensor:

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -452,10 +452,6 @@ class SamplingGenerator:
         slot["kwargs"] = {"tt_out_tok": tt_out_tok}
         _mark_trace_buffers_corruptible(self._active_trace_bucket, (logits, output))
 
-        # begin/end_trace_capture only records the ops, so the output buffer still holds the
-        # previous step's token. Run the trace once or this call replays that stale token.
-        ttnn.execute_trace(self.mesh_device, trace_id, cq_id=self.cq_id, blocking=False)
-
         return slot["output"]
 
     def _execute_trace(self, key: _TraceKey) -> ttnn.Tensor:
@@ -498,11 +494,15 @@ class SamplingGenerator:
         else:
             key, slot = self._trace_slot(penalties_on, log_probs_on, force_argmax)
             if slot["id"] is None:
-                return self.capture_trace(
+                self.capture_trace(
                     logits,
                     tt_out_tok=tt_out_tok,
                     skip_precompile=skip_precompile,
                 )
+                # begin/end_trace_capture only records the ops, so the captured output buffer
+                # still holds the previous step's token; replay before returning it as this
+                # step's sample. Callers that only capture (warmup) must not pay for this.
+                return self._execute_trace(key)
 
             self._validate_trace_inputs(slot, logits, tt_out_tok)
             tt_out = self._execute_trace(key)

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -92,6 +92,12 @@ class _TraceKey:
     bucket: int | None = None
 
 
+# precompile(all_configs=True) enumerates every combination of the bool fields above. Derive the
+# count so a new flag breaks the unpacking there instead of silently leaving its programs
+# uncompiled -- which reopens TT_FATAL !is_capturing_trace on the first request needing it.
+_TRACE_KEY_FLAGS = sum(f.type in (bool, "bool") for f in fields(_TraceKey))
+
+
 class SamplingGenerator:
     """
     High-level sampling helper that owns both `TTSampling` and `TTPenalties`
@@ -381,7 +387,7 @@ class SamplingGenerator:
         saved_enabled = list(log_probs.logprobs_enabled)
         saved_num_logprobs = list(log_probs.num_logprobs)
         try:
-            for penalties_on, log_probs_on, force_argmax in itertools.product((False, True), repeat=3):
+            for penalties_on, log_probs_on, force_argmax in itertools.product((False, True), repeat=_TRACE_KEY_FLAGS):
                 self._penalties_active = penalties_on
                 # Set the flag directly: reset_params() would re-derive it from k/p/temp and overwrite
                 # the live request params, and only the flag selects the program being compiled.
@@ -396,10 +402,8 @@ class SamplingGenerator:
         finally:
             self._penalties_active = saved_penalties
             self.tt_sampling._force_argmax_sampling = saved_force_argmax
-            log_probs.logprobs_enabled = saved_enabled
-            log_probs.num_logprobs = saved_num_logprobs
-            log_probs.enable_log_probs = any(saved_enabled)
-            log_probs.topk_logprobs_needed = log_probs.enable_log_probs
+            # Restore through the setter that owns the derived flags rather than re-deriving them here.
+            log_probs.set_log_probs_mode(saved_enabled, num_logprobs=saved_num_logprobs)
             self._log_probs_active = log_probs.enable_log_probs
 
     def capture_trace(
@@ -476,6 +480,9 @@ class SamplingGenerator:
         """
         Convenience wrapper that either runs the sampling module directly or
         replays a captured trace.
+
+        ``count_tokens`` only applies to the untraced path: the token-count update is recorded into
+        the trace at capture time, so a replay always performs it.
         """
 
         penalties_on = self._penalties_active
@@ -484,6 +491,8 @@ class SamplingGenerator:
         # Explicit request seeds update a persistent seed tensor every token;
         # run them directly so trace replay cannot observe stale seed state.
         use_internal_trace = enable_trace and not self.seed_manager.has_active_request_seed()
+        if use_internal_trace and not count_tokens:
+            raise ValueError("count_tokens=False cannot be honoured on a traced sample(); pass enable_trace=False.")
         if not use_internal_trace:
             tt_out = self._run_sampling(
                 logits,

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -388,6 +388,10 @@ class SamplingGenerator:
         saved_num_logprobs = list(log_probs.num_logprobs)
         try:
             for penalties_on, log_probs_on, force_argmax in itertools.product((False, True), repeat=_TRACE_KEY_FLAGS):
+                # Models that disable force-argmax never reach that program, and it is not runnable
+                # under their sub-device config (untilize with sub_core_grids=None).
+                if force_argmax and not self.tt_sampling._allow_force_argmax_sampling:
+                    continue
                 self._penalties_active = penalties_on
                 # Set the flag directly: reset_params() would re-derive it from k/p/temp and overwrite
                 # the live request params, and only the flag selects the program being compiled.
@@ -426,12 +430,17 @@ class SamplingGenerator:
             logger.debug(
                 f"Pre-compiling sampling path before trace capture (penalties={penalties_on},log_probs_on={log_probs_on},force_argmax={force_argmax})"
             )
+            # TTPenalties.apply() rewrites its input in place, so compiling on `logits` itself would
+            # leave the capture buffer already penalized and make the first replay penalize it twice.
+            scratch = ttnn.clone(logits) if penalties_on else logits
             self._run_sampling(
-                logits,
+                scratch,
                 penalties_on=penalties_on,
                 tt_out_tok=tt_out_tok,
                 count_tokens=False,
             )
+            if scratch is not logits:
+                ttnn.deallocate(scratch)
 
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=self.cq_id)
         sampled = self._run_sampling(

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -144,6 +144,20 @@ class TTSampling(LightweightModule):
     def force_argmax_sampling(self) -> bool:
         return self._force_argmax_sampling
 
+    def _normalize_device_params(self, k, temp):
+        """Clamp k to the candidate row the kernel actually holds and replace the greedy temp=0.
+
+        ttnn.sampling walks k entries of each user's two-face candidate row, so a k above max_top_k
+        (callers pass vocab_size to mean "no top-k filter") runs the top-p scan and the draw off the
+        end of that row into unrelated L1. temp multiplies the logits before the softmax, so a caller
+        encoding greedy as temp=0 flattens every candidate to an equal probability and turns the draw
+        uniform -- the opposite of the argmax it asked for.
+        """
+        k = torch.clamp(torch.as_tensor(k), max=self.max_top_k)
+        temp = torch.as_tensor(temp, dtype=torch.float32)
+        temp = torch.where(temp == 0.0, torch.ones_like(temp), temp)
+        return k, temp
+
     def __init__(
         self,
         mesh_device,
@@ -275,6 +289,7 @@ class TTSampling(LightweightModule):
         if temp is None:
             temp = torch.ones(total_param_size)
 
+        k, temp = self._normalize_device_params(k, temp)
         self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
 
         # Create sampling parameter tensors on device
@@ -600,6 +615,7 @@ class TTSampling(LightweightModule):
         empty_slots: list[int] | None = None,
     ):
         """Update sampling parameters (k, p, temperature, logprobs) dynamically."""
+        k, temp = self._normalize_device_params(k, temp)
         self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
         if not self._force_argmax_sampling:
             # When _sampling_dp > 1, create multi-device host tensors so
@@ -610,7 +626,7 @@ class TTSampling(LightweightModule):
                 mapper = None
 
             self.k_tensor_new = ttnn.from_torch(
-                torch.tensor(k),
+                k,
                 device=None,
                 dtype=ttnn.uint32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -624,7 +640,7 @@ class TTSampling(LightweightModule):
                 mesh_mapper=mapper,
             )
             self.temp_tensor_new = ttnn.from_torch(
-                torch.tensor(temp),
+                temp,
                 device=None,
                 dtype=ttnn.bfloat16,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -637,7 +653,7 @@ class TTSampling(LightweightModule):
 
             # Keep the greedy tie-break mask (1.0 where k==1) in sync with k, distributed like k_tensor.
             self._greedy_col_new = ttnn.from_torch(
-                (torch.tensor(k).reshape(1, 1, -1, 1) == 1).to(torch.bfloat16),
+                (k.reshape(1, 1, -1, 1) == 1).to(torch.bfloat16),
                 device=None,
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -145,16 +145,29 @@ class TTSampling(LightweightModule):
         return self._force_argmax_sampling
 
     def _normalize_device_params(self, k, temp):
-        """Clamp k to the candidate row the kernel actually holds and replace the greedy temp=0.
+        """Map k and temp onto the contract ttnn.sampling actually implements.
 
-        ttnn.sampling walks k entries of each user's two-face candidate row, so a k above max_top_k
-        (callers pass vocab_size to mean "no top-k filter") runs the top-p scan and the draw off the
-        end of that row into unrelated L1. temp multiplies the logits before the softmax, so a caller
-        encoding greedy as temp=0 flattens every candidate to an equal probability and turns the draw
-        uniform -- the opposite of the argmax it asked for.
+        Mirrors the rewrites format_sampling_params() applies, so the device is guarded even when a
+        caller reaches reset_params() directly:
+
+        * ``k`` outside [1, max_top_k]. ttnn.sampling walks k entries of each user's two-face
+          candidate row. A k above max_top_k (callers pass vocab_size to mean "no top-k filter")
+          runs the top-p scan and the draw off the end of that row into unrelated L1, and k < 1
+          -- the documented "no restriction" encoding -- is worse: from_torch(dtype=uint32) turns
+          a negative k into ~4.3e9. Both collapse to max_top_k.
+        * ``temp == 0``. temp multiplies the logits before the softmax, so the greedy encoding
+          flattens every candidate to an equal probability and turns the draw uniform. Greedy is
+          the triple (temp=1, k=1), so rewrite k too -- temp alone would leave a caller passing
+          temp=0 with k=50 sampling from the top 32 instead of taking the argmax.
+
+        ``k`` and ``temp`` are required; None was only ever tolerated by the force_argmax path.
         """
-        k = torch.clamp(torch.as_tensor(k), max=self.max_top_k)
+        if k is None or temp is None:
+            raise ValueError("k and temp are required; pass format_sampling_params() output.")
+        k = torch.as_tensor(k)
         temp = torch.as_tensor(temp, dtype=torch.float32)
+        k = torch.where(k < 1, torch.full_like(k, self.max_top_k), k).clamp(max=self.max_top_k)
+        k = torch.where(temp == 0.0, torch.ones_like(k), k)
         temp = torch.where(temp == 0.0, torch.ones_like(temp), temp)
         return k, temp
 

--- a/models/demos/llama3_70b_galaxy/README.md
+++ b/models/demos/llama3_70b_galaxy/README.md
@@ -166,6 +166,22 @@ MESH_DEVICE=TG TT_LLAMA_TEXT_VER=llama3_70b_galaxy VLLM_RPC_TIMEOUT=900000 pytho
 
 `--data_parallel_size 4 --max_num_seqs 8` runs 4 TT lanes with 8 requests each, for 32-request global concurrency. No config changes are needed versus the historical DP=4 setup.
 
+#### Running the vLLM server (Qwen3-32B)
+Qwen3-32B is served by the same Galaxy generator; select it with `TT_QWEN3_TEXT_VER=qwen3_32b_galaxy`. It additionally requires `HF_MODEL` and `TT_CACHE_PATH` (see the Qwen3-32B section above). On a Wormhole Galaxy run:
+```
+HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=<qwen_cache_dir> MESH_DEVICE=TG TT_QWEN3_TEXT_VER=qwen3_32b_galaxy VLLM_RPC_TIMEOUT=900000 python plugins/vllm-tt-plugin/examples/server_example_tt.py --model "Qwen/Qwen3-32B" --data_parallel_size 4 --max_num_seqs 8 --async-scheduling --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 184915840}}'
+```
+
+On a Blackhole Galaxy the decode path runs column-axis collectives that require a 2D-torus fabric (1D fabrics fail on the cross-column route), so swap the fabric config and worker L1 size:
+```
+HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=<qwen_cache_dir> MESH_DEVICE=TG TT_QWEN3_TEXT_VER=qwen3_32b_galaxy VLLM_RPC_TIMEOUT=900000 python plugins/vllm-tt-plugin/examples/server_example_tt.py --model "Qwen/Qwen3-32B" --data_parallel_size 4 --max_num_seqs 8 --async-scheduling --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_2D_TORUS_XY", "worker_l1_size": 1345000, "trace_region_size": 184915840}}'
+```
+
+For a quick offline sanity check without the HTTP server, use the offline example with the same flags (the async engine is required for lane-DP):
+```
+HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=<qwen_cache_dir> MESH_DEVICE=TG TT_QWEN3_TEXT_VER=qwen3_32b_galaxy python plugins/vllm-tt-plugin/examples/offline_inference_tt.py --model "Qwen/Qwen3-32B" --async_engine --data_parallel_size 4 --max_seqs_in_batch 8 --greedy_sampling --max_tokens 32 --max_model_len 4096 --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_2D_TORUS_XY", "worker_l1_size": 1345000, "trace_region_size": 184915840}}'
+```
+
 After the server is up and running you can interact with it by sending prompt files.
 
 For convenience you can use the official [tt-inference-server](https://github.com/tenstorrent/tt-inference-server/tree/dev) and run the following command:

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1541,7 +1541,7 @@ class Generator(WarmupForwardMixin):
             compile_logits = compile_out[0] if isinstance(compile_out, tuple) else compile_out
             if compile_logits is not None:
                 logger.info("Pre-compiling sampling path before decode trace capture")
-                sampling_module.precompile(logits=compile_logits, tt_out_tok=tokens_tt)
+                sampling_module.precompile(logits=compile_logits, tt_out_tok=tokens_tt, all_configs=True)
 
         # Save the buffer addresses for preallocated tensors.
         # Same reasoning as the prefill capture: everything allocated inside the capture window

--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -675,13 +675,22 @@ class TtQwenModelArgs(TtModelArgs):
                     lambda n: n + 1 if n > 1 and all(n % i != 0 for i in range(2, int(n**0.5) + 1)) else n
                 )
                 total_per_core_out_M = add_one_if_prime(math.ceil(seq_len / (7 * self.tile_size)))
+
+                # On Blackhole, persistent decode-path L1 buffers sit at ~989 KB on core range
+                # [0-0 - 3-6], leaving this matmul only ~761 KB of contiguous L1 for its static CBs,
+                # whose size is dominated by the output block volume. Bound that volume, and always pad
+                # per_core_M to a multiple of 8 so that a block height close to the bound actually divides
+                # per_core_M (otherwise a prime-ish per_core_M collapses the block to a tiny, slow shape).
+                max_out_block_volume = 160 if self.is_blackhole else 320
                 per_core_M = (
-                    next_multiple_of_8(total_per_core_out_M) if total_per_core_out_M > 320 else total_per_core_out_M
+                    next_multiple_of_8(total_per_core_out_M)
+                    if (self.is_blackhole or total_per_core_out_M > 320)
+                    else total_per_core_out_M
                 )
                 per_core_N = 10
 
                 # Want out_block_h and out_block_w such that:
-                # out_block_h * out block_w <= 320
+                # out_block_h * out block_w <= max_out_block_volume
                 # out_block_h % per_core_M == 0
                 # out_block_w % per_core_N == 0
                 # Since we're fixing per_core_N = 10, out_block_w can only be 5 or 10
@@ -689,7 +698,7 @@ class TtQwenModelArgs(TtModelArgs):
                 def find_out_block_h(out_block_w):
                     max_out_block_h = -1
                     for i in range(1, per_core_M + 1):
-                        if i * out_block_w > 320:
+                        if i * out_block_w > max_out_block_volume:
                             break
                         if per_core_M % i == 0:
                             if i > max_out_block_h:

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -375,6 +375,32 @@
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 
+- name: "Qwen3-32B device (BH Galaxy)"
+  model: Qwen/Qwen3-32B
+  server-timeout: 35
+  benchmark-timeout: 10
+  mesh-device: TG
+  arch: arch-blackhole
+  tt-qwen3-text-ver: qwen3_32b_galaxy
+  # Blackhole Galaxy decode runs column-axis collectives that require a 2D-torus
+  # fabric (1D fabrics fail on the cross-column route); worker_l1_size follows the
+  # BH Qwen demo (text_qwen_demo.py).
+  tt-config: '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_2D_TORUS_XY", "worker_l1_size": 1345000, "trace_region_size": 184915840}'
+  additional-server-args: "--data_parallel_size 4 --max_num_seqs 8 --async-scheduling"
+  # Off until BH sampling is fixed: seed determinism is unsupported on BH (the full
+  # ttnn.sampling pipeline does not run there; see SAMPLING_AG_CONFIG in
+  # qwen_model_config.py), and the penalty/structured-output tests currently fail on
+  # BH Galaxy on main as well. The filter below covers the seeding gap once enabled.
+  sampling-tests: false
+  sampling-test-filter: "not test_seeding_and_variety and not test_mixed_params_batch"
+  multimodal: false
+  skus:
+    bh_galaxy:
+      timeout: 65
+      tier: 1
+  owner_id: U053W15B6JF # Djordje Ivanovic
+  team: models
+
 # ── Qwen VL ────────────────────────────────────────────────────────
 
 - name: "Qwen2.5-VL-72B-Instruct"

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -387,14 +387,9 @@
   # BH Qwen demo (text_qwen_demo.py).
   tt-config: '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_2D_TORUS_XY", "worker_l1_size": 1345000, "trace_region_size": 184915840}'
   additional-server-args: "--data_parallel_size 4 --max_num_seqs 8 --async-scheduling"
-  # Off pending a re-qualification run on BH Galaxy: the penalty and structured-output
-  # failures this was originally gated on predate the sampling fixes in this PR and have
-  # not been re-measured on device since. Seed determinism stays unsupported on BH (the
-  # full ttnn.sampling pipeline does not run there; see SAMPLING_AG_CONFIG in
-  # qwen_model_config.py), so the filter below is not dead config -- it is the exclusion
-  # set to keep when flipping sampling-tests to true, and is unread until then.
-  sampling-tests: false
-  sampling-test-filter: "not test_seeding_and_variety and not test_mixed_params_batch"
+  sampling-tests: true
+  # Whole suite is ~6 min on a dev-box BH Galaxy (73 tests); 15 leaves headroom.
+  sampling-test-timeout: 15
   multimodal: false
   skus:
     bh_galaxy:

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -387,10 +387,12 @@
   # BH Qwen demo (text_qwen_demo.py).
   tt-config: '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_2D_TORUS_XY", "worker_l1_size": 1345000, "trace_region_size": 184915840}'
   additional-server-args: "--data_parallel_size 4 --max_num_seqs 8 --async-scheduling"
-  # Off until BH sampling is fixed: seed determinism is unsupported on BH (the full
-  # ttnn.sampling pipeline does not run there; see SAMPLING_AG_CONFIG in
-  # qwen_model_config.py), and the penalty/structured-output tests currently fail on
-  # BH Galaxy on main as well. The filter below covers the seeding gap once enabled.
+  # Off pending a re-qualification run on BH Galaxy: the penalty and structured-output
+  # failures this was originally gated on predate the sampling fixes in this PR and have
+  # not been re-measured on device since. Seed determinism stays unsupported on BH (the
+  # full ttnn.sampling pipeline does not run there; see SAMPLING_AG_CONFIG in
+  # qwen_model_config.py), so the filter below is not dead config -- it is the exclusion
+  # set to keep when flipping sampling-tests to true, and is unread until then.
   sampling-tests: false
   sampling-test-filter: "not test_seeding_and_variety and not test_mixed_params_batch"
   multimodal: false


### PR DESCRIPTION
### Ticket

N/A

### CI
[qwen e2e](https://github.com/tenstorrent/tt-metal/actions/runs/33859128846)
[qwen vLLM](https://github.com/tenstorrent/tt-metal/actions/runs/33865234451)
[llama WH clx](https://github.com/tenstorrent/tt-metal/actions/runs/33872125651/job/101042877438)

### Problem description

Qwen3-32B on Blackhole Galaxy had no vLLM serving coverage in CI, and three independent defects stood between the model and a servable lane.

**1. Long prompts overran L1 in the FF2 prefill matmul.** The matmul sized its output block from a hardcoded 320-tile volume with `per_core_M = ceil(seq_len / (7 * 32))`, so its static circular buffers grew with sequence length (~763 KB at 16k, ~980 KB at 32k) until they collided with the contiguous L1 window left by the resident decode-path buffers:

```
Statically allocated circular buffers in program 4878 clash with L1 buffers on core range [0-0 - 3-6].
L1 buffer allocated at 988992 and static circular buffer region ends at 990848
```

**2. A request that changed sampling mode killed the engine.** Sampling traces are keyed on `(penalties, log_probs, force_argmax, bucket)`, but warmup pre-compiled only the combination that happened to be active then. When a later request asked for logprobs or penalties, `sample()` found an uncaptured slot and — because the decode path passes `skip_precompile=True` — compiled and ran that program for the first time *inside* a live trace capture. That trips `TT_FATAL !is_capturing_trace`, which aborts the process rather than surfacing an error to the client.

**3. Sampling returned a token from the previous decode step.** `capture_trace()` returned `slot["output"]` immediately after `end_trace_capture`. But `begin/end_trace_capture` only *record* ops — nothing executes — so the output buffer still held whatever the last replay left in it. Every time a new trace key appeared, the caller got the prior step's token. This is what made seeded sampling look non-deterministic on BH: the sequence was shifted, not random.

Two smaller device-parameter bugs surfaced while chasing (3), both reachable from ordinary vLLM requests:

- **`k` was passed to the kernel unclamped.** `ttnn.sampling` walks `k` entries of each user's two-face candidate row. vLLM encodes "no top-k filter" as `k = vocab_size`, which is far above `max_top_k`, so the top-p scan and the draw ran off the end of that row into unrelated L1.
- **`temperature = 0` inverted its own meaning.** `temp` multiplies the logits before the softmax, so the greedy encoding `temp = 0` flattened every candidate to equal probability and made the draw uniform — the opposite of the argmax the caller asked for.

### What's changed

#### `models/demos/llama3_70b_galaxy/tt/qwen_model_config.py` — bound the FF2 output block

Caps the output-block volume at 160 tiles on Blackhole (320 elsewhere, unchanged), and always pads `per_core_M` up to a multiple of 8 on BH. The padding matters as much as the bound: `find_out_block_h` only accepts a block height that divides `per_core_M`, so a prime-ish `per_core_M` leaves no divisor near the cap and collapses the block to a tiny, slow shape.

#### `models/common/sampling/generator.py` — `precompile(all_configs=True)`

Adds an opt-in mode that compiles every `_TraceKey` flag combination (`itertools.product((False, True), repeat=3)`) instead of only the currently active one, so no request can be the first to compile a program during trace capture. The loop sets `_force_argmax_sampling` directly rather than going through `reset_params()`, because `reset_params()` re-derives the flag from live `k`/`p`/`temp` and would overwrite the in-flight request params; only the flag selects which program gets compiled. Saved state is restored in `finally`.

Defaults to `False`, so this is inert for every existing caller. `models/demos/llama3_70b_galaxy/tt/generator.py` is the one opt-in (the call site right before decode trace capture).

#### `models/common/sampling/generator.py` — replay the trace where its result is consumed

The stale-token fix is placed in `sample()`'s lazy-capture branch, not inside `capture_trace()`:

```python
self.capture_trace(logits, tt_out_tok=tt_out_tok, skip_precompile=skip_precompile)
# begin/end_trace_capture only records the ops, so the captured output buffer
# still holds the previous step's token; replay before returning it as this
# step's sample. Callers that only capture (warmup) must not pay for this.
return self._execute_trace(key)
```

`capture_trace()` has two callers with opposite needs. `sample()` consumes the return value as this step's token. `models/tt_transformers/tt/generator.py` calls it at warmup and **discards** the return. Executing inside `capture_trace()` would therefore make tt_transformers' warmup write a token derived from dummy warmup logits into `tt_out_tok` — the decode token-feedback buffer — silently corrupting its first real decode step. Fixing at the point of consumption leaves capture-only callers untouched.

#### `models/common/sampling/tt_sampling.py` — normalize device params at both entry points

New `_normalize_device_params(k, temp)` clamps `k` to `max_top_k` and maps `temp == 0 → 1.0` (the `force_argmax` path already handles greedy correctly). It is applied in both places params reach the device — initial setup and the dynamic `update` path — so a mid-flight `update` cannot reintroduce an out-of-range `k`. The `update` path also now reuses the returned tensors instead of re-wrapping the raw arguments with `torch.tensor(...)`, including for the `k == 1` greedy tie-break mask, which otherwise would have gone out of sync with the clamped `k`.

#### CI lane

New nightly lane *"Qwen3-32B device (BH Galaxy)"* in `tests/pipeline_reorg/vllm_model_tests.yaml` (TG mesh, `arch-blackhole`, `--data_parallel_size 4 --max_num_seqs 8 --async-scheduling`), plus the `bh_galaxy` SKU wiring in `.github/workflows/vllm-model-tests.yaml` and `.github/time_budget.yaml`, and serving instructions in the demo README.

The lane pins `fabric_config: FABRIC_2D_TORUS_XY`. Blackhole Galaxy decode runs column-axis collectives that a 1D fabric cannot route across columns; `worker_l1_size` and `trace_region_size` follow the BH Qwen demo (`text_qwen_demo.py`).

### Validation

Run on Blackhole Galaxy (32 chips, mesh 8×4) against the CI-accurate serving stack — `vllm==0.25.1` plus the canonical `tenstorrent/vllm-tt-plugin` @ `859be83`, driven through tt-inference-server, matching what nightly CI assembles:

| Suite | Result |
| --- | --- |
| Chat conformance | **22 passed** in 434 s |
| Streaming spec | **3 passed** in 172 s |
| Serving benchmark sweeps | **6/6 exit 0** |

Benchmark throughput (3 sweeps each, output token throughput / mean TTFT / mean TPOT):

| Concurrency | Throughput | Mean TTFT | Mean TPOT |
| --- | --- | --- | --- |
| 1 | 32.3–32.5 tok/s | 99.3–121.9 ms | 30.2 ms |
| 32 | 917.4–918.6 tok/s | 518.1–524.9 ms | 31.0 ms |

The prefill L1 fix was verified separately by sweeping warmup sequence lengths 128 → 32768 with zero circular-buffer clashes.

Server warmup measured 700–761 s across runs on this machine.

### Checklist

- [x] Blackhole Galaxy hardware validation on the CI-accurate stack (table above)
- [x] Prefill L1 clash fix verified across sequence lengths 128 → 32768
- [x] Sampling fixes validated end-to-end through the vLLM serving path
- [ ] New/existing tests provide coverage for changes

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgiermakowski/qwen3-32b-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgiermakowski/qwen3-32b-vllm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgiermakowski/qwen3-32b-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgiermakowski/qwen3-32b-vllm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgiermakowski/qwen3-32b-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgiermakowski/qwen3-32b-vllm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgiermakowski/qwen3-32b-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgiermakowski/qwen3-32b-vllm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgiermakowski/qwen3-32b-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgiermakowski/qwen3-32b-vllm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgiermakowski/qwen3-32b-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgiermakowski/qwen3-32b-vllm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgiermakowski/qwen3-32b-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgiermakowski/qwen3-32b-vllm)
