### PR TITLE
[Cleanup] Use correct MetalContext in device, dispatch, program, and kernel internals

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
@@ -33,6 +33,7 @@
 // Access to internal API: ProgramImpl::finalize_offsets, get_sem_base_addr
 #include "impl/program/program_impl.hpp"
 #include "impl/program/dispatch.hpp"
+#include "impl/context/context_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tests/tt_metal/tt_metal/api/cross_node_dfb_test_utils.hpp"
 
@@ -207,7 +208,8 @@ TEST_F(CrossNodeDFBFixture, MeshWorkload_CrossNodeOffsetUsesPerProgramParticipan
     program_with_cn.impl().compile_and_allocate(mesh_device.get(), /*force_slow_dispatch=*/false);
     program_without_cn.impl().compile_and_allocate(mesh_device.get(), /*force_slow_dispatch=*/false);
 
-    const auto& hal = MetalContext::instance().hal();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(mesh_device.get()));
+    const auto& hal = metal_ctx.hal();
     const uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     ASSERT_FALSE(program_with_cn.impl().get_kernel_groups(index).empty());
     ASSERT_FALSE(program_without_cn.impl().get_kernel_groups(index).empty());
@@ -216,7 +218,7 @@ TEST_F(CrossNodeDFBFixture, MeshWorkload_CrossNodeOffsetUsesPerProgramParticipan
     // Any L1-aligned offset that is not the NONE sentinel.
     constexpr uint32_t kSharedRegionOffset = 256;
     program_dispatch::finalize_cross_node_dfbs(
-        index, ttsl::Span<detail::ProgramImpl*>(programs.data(), programs.size()), kSharedRegionOffset);
+        metal_ctx, index, ttsl::Span<detail::ProgramImpl*>(programs.data(), programs.size()), kSharedRegionOffset);
 
     for (const auto& kg : program_with_cn.impl().get_kernel_groups(index)) {
         EXPECT_EQ(
@@ -259,7 +261,8 @@ TEST_F(CrossNodeDFBFixture, DispatchPartitionsHeterogeneousKernelGroupByPayload)
 
     program.impl().compile_and_allocate(mesh_device.get(), /*force_slow_dispatch=*/false);
 
-    const auto& hal = MetalContext::instance().hal();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(mesh_device.get()));
+    const auto& hal = metal_ctx.hal();
     const uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     const auto& kernel_groups = program.impl().get_kernel_groups(index);
     ASSERT_EQ(kernel_groups.size(), 1u);
@@ -426,13 +429,14 @@ TEST_F(CrossNodeDFBFixture, ProgramCrossNodeDFBsAPI_IndependentTopologiesUseProg
     // finalize sizes only the shared dense index from the program-wide slot count (2),
     // not from any one core's sparse participant count (1).
     program.impl().compile_and_allocate(mesh_device.get(), /*force_slow_dispatch=*/false);
-    const auto& hal = MetalContext::instance().hal();
+    const MetalContext& metal_ctx = MetalContext::instance(extract_context_id(mesh_device.get()));
+    const auto& hal = metal_ctx.hal();
     const uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     detail::ProgramImpl* programs[] = {&program.impl()};
     constexpr uint32_t kBase = 256;
-    const uint32_t next =
-        program_dispatch::finalize_cross_node_dfbs(index, ttsl::Span<detail::ProgramImpl*>(programs, 1), kBase);
-    const uint32_t l1_align = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const uint32_t next = program_dispatch::finalize_cross_node_dfbs(
+        metal_ctx, index, ttsl::Span<detail::ProgramImpl*>(programs, 1), kBase);
+    const uint32_t l1_align = hal.get_alignment(HalMemType::L1);
     const uint32_t region_bytes = cross_node_dfb_config_region_words(2) * sizeof(uint32_t);
     const uint32_t expected_next = (kBase + region_bytes + l1_align - 1) & ~(l1_align - 1);
     EXPECT_EQ(next, expected_next);

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -94,6 +94,7 @@ void record_program_sub_device_for_range(
         mesh_device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id);
     for_each_local(mesh_device, device_range, [&](const MeshCoordinate& coord) {
         tt::RecordProgramSubDevice(
+            extract_context_id(mesh_device),
             mesh_device->impl().get_device(coord)->id(),
             active_manager_id,
             runtime_id,
@@ -1267,7 +1268,7 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
         sub_device.take_ownership(sub_device_id, this->id_);
     }
 
-    auto cmd_sequence_sizeB = trace_dispatch::compute_trace_cmd_size(num_sub_devices);
+    auto cmd_sequence_sizeB = trace_dispatch::compute_trace_cmd_size(extract_context_id(mesh_device_), num_sub_devices);
 
     trace_dispatch::TraceDispatchMetadata dispatch_md(
         cmd_sequence_sizeB,

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1338,7 +1338,8 @@ static VecIt remove_by_index(VecIt begin, VecIt end, IndexIt index_begin, IndexI
 }
 
 void FDMeshCommandQueue::record_end() {
-    const auto& hal = MetalContext::instance().hal();
+    MetalContext& metal_ctx = MetalContext::instance(mesh_device_->impl().get_context_id());
+    const auto& hal = metal_ctx.hal();
 
     // At the beginning of the trace, expected_num_workers_completed is 0 on all devices on for each sub-device in the
     // trace. launch_msg_rd_ptr will also be 0 for all core-types used on each subdevice in the trace. At the end of the
@@ -1395,7 +1396,6 @@ void FDMeshCommandQueue::record_end() {
     }
     std::vector<uint32_t> exec_buf_end = {};
 
-    MetalContext& metal_ctx = MetalContext::instance(mesh_device_->impl().get_context_id());
     DeviceCommand command_sequence(metal_ctx, metal_ctx.hal().get_alignment(HalMemType::HOST));
     command_sequence.add_prefetch_exec_buf_end();
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -111,7 +111,8 @@ public:
         this->cq_id = cq_id;
         this->expected_num_workers_completed = expected_num_workers_completed;
         if (src_pinned) {
-            const uint64_t relay_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+            const uint64_t relay_alignment =
+                MetalContext::instance(extract_context_id(buffer.device())).hal().get_alignment(HalMemType::HOST);
             const uint64_t alignment_offset = src_addr % relay_alignment;
             if (alignment_offset != 0) {
                 this->alignment_prefix_bytes = relay_alignment - alignment_offset;
@@ -437,8 +438,10 @@ int32_t calculate_num_pages_available_in_cq(
 }
 
 bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer, uint32_t num_subdevices) {
-    const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    const uint32_t max_data_size = calculate_max_prefetch_data_size_bytes(dispatch_core_type, num_subdevices);
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(buffer.device()));
+    const CoreType dispatch_core_type = metal_ctx.get_dispatch_core_manager().get_dispatch_core_type();
+    const uint32_t max_data_size =
+        calculate_max_prefetch_data_size_bytes(metal_ctx.get_context_id(), dispatch_core_type, num_subdevices);
     return buffer.aligned_page_size() > max_data_size;
 }
 
@@ -446,7 +449,9 @@ uint32_t calculate_partial_page_size(const Buffer& buffer) {
     const HalMemType buffer_mem_type = buffer.memory_type();
     const uint32_t partial_page_size = tt::align(
         DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH,
-        MetalContext::instance().hal().get_common_alignment_with_pcie(buffer_mem_type));
+        MetalContext::instance(extract_context_id(buffer.device()))
+            .hal()
+            .get_common_alignment_with_pcie(buffer_mem_type));
     return partial_page_size;
 }
 
@@ -465,15 +470,16 @@ BufferDispatchConstants generate_buffer_dispatch_constants(
 
     buf_dispatch_constants.issue_queue_cmd_limit = sysmem_manager.get_issue_queue_limit(cq_id);
     buf_dispatch_constants.max_prefetch_cmd_size =
-        MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+        MetalContext::instance(sysmem_manager.get_context_id()).dispatch_mem_map().max_prefetch_command_size();
 
     return buf_dispatch_constants;
 }
 
-void update_offset_on_issue_wait_cmd(uint32_t& byte_offset, bool issue_wait, uint32_t num_sub_devices) {
+void update_offset_on_issue_wait_cmd(
+    ContextId context_id, uint32_t& byte_offset, bool issue_wait, uint32_t num_sub_devices) {
     if (issue_wait) {
         // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
-        byte_offset += (MetalContext::instance().hal().get_alignment(HalMemType::HOST) * num_sub_devices);
+        byte_offset += (MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST) * num_sub_devices);
     }
 }
 
@@ -734,7 +740,7 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             command_sequence.add_dispatch_wait(
                 CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
                 0,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+                metal_ctx.dispatch_mem_map().get_dispatch_stream_index(offset_index),
                 dispatch_params.expected_num_workers_completed[offset_index],
                 dispatch_params.cq_id);
         }
@@ -983,7 +989,7 @@ void issue_buffer_dispatch_command_sequence(
             command_sequence.add_dispatch_wait(
                 CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
                 0,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+                metal_ctx.dispatch_mem_map().get_dispatch_stream_index(offset_index),
                 dispatch_params.expected_num_workers_completed[offset_index],
                 dispatch_params.cq_id);
         }
@@ -1013,8 +1019,7 @@ void issue_buffer_dispatch_command_sequence(
         uint64_t relay_data_size = (uint64_t)dispatch_params.total_pages_to_write * dispatch_params.page_size_to_write;
         if constexpr (std::is_same_v<T, InterleavedBufferWriteDispatchParams>) {
             TT_ASSERT(
-                dispatch_params.alignment_prefix_bytes % MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
-                    0,
+                dispatch_params.alignment_prefix_bytes % metal_ctx.hal().get_alignment(HalMemType::L1) == 0,
                 "Alignment prefix is not aligned to L1");
             relay_src_addr += dispatch_params.alignment_prefix_bytes;
             relay_data_size -= dispatch_params.alignment_prefix_bytes;
@@ -1055,10 +1060,15 @@ void write_interleaved_buffer_to_device(
     bool use_pinned_memory = dispatch_params.use_pinned_transfer;
 
     // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
-    uint32_t byte_offset_in_cq = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    uint32_t byte_offset_in_cq =
+        MetalContext::instance(extract_context_id(dispatch_params.device)).hal().get_alignment(HalMemType::HOST);
 
     dispatch_params.calculate_issue_wait();
-    update_offset_on_issue_wait_cmd(byte_offset_in_cq, dispatch_params.issue_wait, sub_device_ids.size());
+    update_offset_on_issue_wait_cmd(
+        extract_context_id(dispatch_params.device),
+        byte_offset_in_cq,
+        dispatch_params.issue_wait,
+        sub_device_ids.size());
 
     if (use_pinned_memory) {
         if (dispatch_params.is_page_offset_out_of_bounds()) {
@@ -1124,7 +1134,8 @@ void write_sharded_buffer_to_core(
         DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_write_linear<true, false>(0);
         uint32_t data_offset_bytes = calculator.write_offset_bytes();
-        update_offset_on_issue_wait_cmd(data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
+        update_offset_on_issue_wait_cmd(
+            extract_context_id(buffer.device()), data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
 
         while (dispatch_params.core_num_pages_remaining_to_write != 0) {
             const int32_t num_pages_available_in_cq =

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -441,7 +441,7 @@ bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer, uint32_t 
     MetalContext& metal_ctx = MetalContext::instance(extract_context_id(buffer.device()));
     const CoreType dispatch_core_type = metal_ctx.get_dispatch_core_manager().get_dispatch_core_type();
     const uint32_t max_data_size =
-        calculate_max_prefetch_data_size_bytes(metal_ctx.get_context_id(), dispatch_core_type, num_subdevices);
+        calculate_max_prefetch_data_size_bytes(metal_ctx, dispatch_core_type, num_subdevices);
     return buffer.aligned_page_size() > max_data_size;
 }
 
@@ -476,10 +476,10 @@ BufferDispatchConstants generate_buffer_dispatch_constants(
 }
 
 void update_offset_on_issue_wait_cmd(
-    ContextId context_id, uint32_t& byte_offset, bool issue_wait, uint32_t num_sub_devices) {
+    const MetalContext& metal_ctx, uint32_t& byte_offset, bool issue_wait, uint32_t num_sub_devices) {
     if (issue_wait) {
         // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
-        byte_offset += (MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST) * num_sub_devices);
+        byte_offset += (metal_ctx.hal().get_alignment(HalMemType::HOST) * num_sub_devices);
     }
 }
 
@@ -1059,16 +1059,12 @@ void write_interleaved_buffer_to_device(
     TTZoneScopedD(DISPATCH);
     bool use_pinned_memory = dispatch_params.use_pinned_transfer;
 
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(dispatch_params.device));
     // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
-    uint32_t byte_offset_in_cq =
-        MetalContext::instance(extract_context_id(dispatch_params.device)).hal().get_alignment(HalMemType::HOST);
+    uint32_t byte_offset_in_cq = metal_ctx.hal().get_alignment(HalMemType::HOST);
 
     dispatch_params.calculate_issue_wait();
-    update_offset_on_issue_wait_cmd(
-        extract_context_id(dispatch_params.device),
-        byte_offset_in_cq,
-        dispatch_params.issue_wait,
-        sub_device_ids.size());
+    update_offset_on_issue_wait_cmd(metal_ctx, byte_offset_in_cq, dispatch_params.issue_wait, sub_device_ids.size());
 
     if (use_pinned_memory) {
         if (dispatch_params.is_page_offset_out_of_bounds()) {
@@ -1135,7 +1131,7 @@ void write_sharded_buffer_to_core(
         calculator.add_dispatch_write_linear<true, false>(0);
         uint32_t data_offset_bytes = calculator.write_offset_bytes();
         update_offset_on_issue_wait_cmd(
-            extract_context_id(buffer.device()), data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
+            metal_ctx, data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
 
         while (dispatch_params.core_num_pages_remaining_to_write != 0) {
             const int32_t num_pages_available_in_cq =

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -63,8 +63,9 @@ void GlobalSemaphoreImpl::reset_semaphore_value(uint32_t reset_value) const {
     // lost due to device skew.
     std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
     auto mesh_buffer = buffer_.get_mesh_buffer();
-    bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
-    bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
+    const auto& rtoptions = MetalContext::instance(extract_context_id(device_)).rtoptions();
+    bool using_fast_dispatch = rtoptions.get_fast_dispatch();
+    bool using_simulator = rtoptions.get_simulator_enabled();
     if (using_fast_dispatch && !using_simulator) {
         distributed::EnqueueWriteMeshBuffer(
             mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -679,7 +679,10 @@ bool Device::close() {
 
     this->invalidate_smc_dispatch_telemetry_control();
 
-    tt::tt_metal::MetalContext::instance().get_service_core_manager().impl().on_device_close(this->id_);
+    tt::tt_metal::MetalContext::instance(this->get_context_id())
+        .get_service_core_manager()
+        .impl()
+        .on_device_close(this->id_);
 
     this->disable_and_clear_program_cache();
     this->set_program_cache_misses_allowed(true);
@@ -739,7 +742,10 @@ CoreCoord Device::compute_with_storage_grid_size() const {
     auto grid = tt::get_compute_grid_size(MetalEnvAccessor(*env_).impl(), id_, num_hw_cqs_, dispatch_core_config);
     // Cap to FD-mode grid when service cores are claimed — prevents SD workloads
     // from targeting dispatch-column cores running persistent service kernels.
-    if (auto safe = MetalContext::instance().get_service_core_manager().impl().get_safe_compute_grid(id_)) {
+    if (auto safe = MetalContext::instance(this->get_context_id())
+                        .get_service_core_manager()
+                        .impl()
+                        .get_safe_compute_grid(id_)) {
         grid.x = std::min(grid.x, safe->x);
         grid.y = std::min(grid.y, safe->y);
     }

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include "allocator/allocator.hpp"
 #include "context/context_types.hpp"
+#include "impl/context/metal_context.hpp"
 #include "device/device_manager.hpp"
 #include "dispatch/device_command.hpp"
 #include "dispatch/device_command_calculator.hpp"
@@ -15,14 +16,16 @@
 
 namespace tt::tt_metal {
 
-uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& /*dispatch_core_type*/, uint32_t num_subdevices) {
+uint32_t calculate_max_prefetch_data_size_bytes(
+    ContextId context_id, const CoreType& /*dispatch_core_type*/, uint32_t num_subdevices) {
     // CQ capacity would be reduced by the commands and alignment padding.
     // prefetch_relay_inline, dispatch_wait (x #workers), and dispatch_write_linear would add alignment padding
-    const auto host_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
+    const auto host_alignment = metal_ctx.hal().get_alignment(HalMemType::HOST);
     auto padded_commands_size = tt::align(sizeof(CQPrefetchCmd), host_alignment) +
                                 (num_subdevices * tt::align(sizeof(CQDispatchCmd), host_alignment)) +
                                 tt::align(sizeof(CQDispatchCmdLarge), host_alignment);
-    return tt::tt_metal::MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() - padded_commands_size;
+    return metal_ctx.dispatch_mem_map().max_prefetch_command_size() - padded_commands_size;
 }
 
 namespace device_dispatch {
@@ -33,9 +36,10 @@ struct CoreWriteDispatchParams : public CoreDispatchParams {
 
 void validate_core_read_write_bounds(
     IDevice* device, const CoreCoord& virtual_core, DeviceAddr address, uint32_t size_bytes) {
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::L1) {
-        const auto& hal = tt::tt_metal::MetalContext::instance(extract_context_id(device)).hal();
+        const auto& hal = metal_ctx.hal();
         HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(virtual_core);
         const DeviceAddr l1_base_address = hal.get_dev_addr(programmable_core_type, HalL1MemAddrType::BASE);
         const DeviceAddr l1_size = hal.get_dev_size(programmable_core_type, HalL1MemAddrType::BASE);
@@ -45,7 +49,7 @@ void validate_core_read_write_bounds(
     } else {
         TT_ASSERT(mem_type == HalMemType::DRAM);
 
-        const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
+        const auto& soc_desc = metal_ctx.get_cluster().get_soc_desc(device->id());
         const uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
         const DeviceAddr dram_base_address = soc_desc.get_address_offset(dram_channel);
 
@@ -59,7 +63,8 @@ void validate_core_read_write_bounds(
 DeviceAddr add_bank_offset_to_address(IDevice* device, const CoreCoord& virtual_core, DeviceAddr address) {
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::DRAM) {
-        const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
+        const auto& soc_desc =
+            MetalContext::instance(extract_context_id(device)).get_cluster().get_soc_desc(device->id());
         const uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
         address += soc_desc.get_address_offset(dram_channel);
     }
@@ -87,7 +92,7 @@ void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_p
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
             0,
-            tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(offset_index),
             dispatch_params.expected_num_workers_completed[offset_index],
             dispatch_params.cq_id);
     }
@@ -119,9 +124,11 @@ void write_to_core_impl(
     ttsl::Span<const SubDeviceId> sub_device_ids) {
     while (size_bytes > 0) {
         const CoreType dispatch_core_type =
-            MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-        const uint32_t size_bytes_to_write =
-            std::min(size_bytes, calculate_max_prefetch_data_size_bytes(dispatch_core_type, sub_device_ids.size()));
+            MetalContext::instance(extract_context_id(device)).get_dispatch_core_manager().get_dispatch_core_type();
+        const uint32_t size_bytes_to_write = std::min(
+            size_bytes,
+            calculate_max_prefetch_data_size_bytes(
+                extract_context_id(device), dispatch_core_type, sub_device_ids.size()));
 
         CoreWriteDispatchParams dispatch_params{
             {virtual_core,
@@ -194,7 +201,7 @@ void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_par
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
             0,
-            tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(offset_index),
             dispatch_params.expected_num_workers_completed[offset_index],
             dispatch_params.cq_id);
     }
@@ -202,7 +209,7 @@ void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_par
     command_sequence.add_dispatch_wait_with_prefetch_stall(
         CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER,
         0,
-        tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+        metal_ctx.dispatch_mem_map().get_dispatch_stream_index(offset_index),
         dispatch_params.expected_num_workers_completed[offset_index],
         dispatch_params.cq_id);
 
@@ -225,16 +232,14 @@ void read_completion_queue(
     uint16_t channel,
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
     if (sysmem_manager.is_dram_backed()) {
-        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance()
-                                          .device_manager()
-                                          ->get_active_device(device_id)
-                                          ->allocator_impl()
-                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            dst, size_bytes, device_id, dram_channel, addr);
+        const uint32_t dram_channel =
+            metal_ctx.device_manager()->get_active_device(device_id)->allocator_impl()->get_dram_channel_from_bank_id(
+                sysmem_manager.get_dram_region_bank_id());
+        metal_ctx.get_cluster().read_dram_vec(dst, size_bytes, device_id, dram_channel, addr);
     } else {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
+        metal_ctx.get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }
 }
 

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -17,10 +17,9 @@
 namespace tt::tt_metal {
 
 uint32_t calculate_max_prefetch_data_size_bytes(
-    ContextId context_id, const CoreType& /*dispatch_core_type*/, uint32_t num_subdevices) {
+    const MetalContext& metal_ctx, const CoreType& /*dispatch_core_type*/, uint32_t num_subdevices) {
     // CQ capacity would be reduced by the commands and alignment padding.
     // prefetch_relay_inline, dispatch_wait (x #workers), and dispatch_write_linear would add alignment padding
-    MetalContext& metal_ctx = MetalContext::instance(context_id);
     const auto host_alignment = metal_ctx.hal().get_alignment(HalMemType::HOST);
     auto padded_commands_size = tt::align(sizeof(CQPrefetchCmd), host_alignment) +
                                 (num_subdevices * tt::align(sizeof(CQDispatchCmd), host_alignment)) +
@@ -122,13 +121,11 @@ void write_to_core_impl(
     uint32_t cq_id,
     ttsl::Span<const uint32_t> expected_num_workers_completed,
     ttsl::Span<const SubDeviceId> sub_device_ids) {
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
+    const CoreType dispatch_core_type = metal_ctx.get_dispatch_core_manager().get_dispatch_core_type();
     while (size_bytes > 0) {
-        const CoreType dispatch_core_type =
-            MetalContext::instance(extract_context_id(device)).get_dispatch_core_manager().get_dispatch_core_type();
         const uint32_t size_bytes_to_write = std::min(
-            size_bytes,
-            calculate_max_prefetch_data_size_bytes(
-                extract_context_id(device), dispatch_core_type, sub_device_ids.size()));
+            size_bytes, calculate_max_prefetch_data_size_bytes(metal_ctx, dispatch_core_type, sub_device_ids.size()));
 
         CoreWriteDispatchParams dispatch_params{
             {virtual_core,

--- a/tt_metal/impl/device/dispatch.hpp
+++ b/tt_metal/impl/device/dispatch.hpp
@@ -7,10 +7,11 @@
 #include "device.hpp"
 #include "dispatch/topology.hpp"
 #include "hal_types.hpp"
-#include "impl/context/context_types.hpp"
 #include "llrt/hal.hpp"
 
 namespace tt::tt_metal {
+
+class MetalContext;
 
 // Used so the host knows how to properly copy data into user space from the completion queue (in hugepages)
 struct ReadCoreDataDescriptor {
@@ -19,7 +20,7 @@ struct ReadCoreDataDescriptor {
 };
 
 uint32_t calculate_max_prefetch_data_size_bytes(
-    ContextId context_id, const CoreType& dispatch_core_type, uint32_t num_subdevices);
+    const MetalContext& metal_ctx, const CoreType& dispatch_core_type, uint32_t num_subdevices);
 
 namespace device_dispatch {
 

--- a/tt_metal/impl/device/dispatch.hpp
+++ b/tt_metal/impl/device/dispatch.hpp
@@ -7,6 +7,7 @@
 #include "device.hpp"
 #include "dispatch/topology.hpp"
 #include "hal_types.hpp"
+#include "impl/context/context_types.hpp"
 #include "llrt/hal.hpp"
 
 namespace tt::tt_metal {
@@ -17,7 +18,8 @@ struct ReadCoreDataDescriptor {
     uint32_t size_bytes = 0;
 };
 
-uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& dispatch_core_type, uint32_t num_subdevices);
+uint32_t calculate_max_prefetch_data_size_bytes(
+    ContextId context_id, const CoreType& dispatch_core_type, uint32_t num_subdevices);
 
 namespace device_dispatch {
 

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -39,37 +39,36 @@ uint32_t read_cq_host_ptr(
     uint32_t cq_size,
     uint32_t host_addr_offset) {
     uint32_t recv;
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
     if (sysmem_manager.is_dram_backed()) {
-        const uint32_t dram_channel = MetalContext::instance()
-                                          .device_manager()
-                                          ->get_active_device(chip_id)
-                                          ->allocator_impl()
-                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
-        MetalContext::instance().get_cluster().read_dram_vec(
+        const uint32_t dram_channel =
+            metal_ctx.device_manager()->get_active_device(chip_id)->allocator_impl()->get_dram_channel_from_bank_id(
+                sysmem_manager.get_dram_region_bank_id());
+        metal_ctx.get_cluster().read_dram_vec(
             &recv,
             sizeof(uint32_t),
             chip_id,
             dram_channel,
             sysmem_manager.get_dram_region_base_addr() + get_relative_cq_offset(cq_id, cq_size) + host_addr_offset);
     } else {
-        ChipId mmio_device_id = MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
-        uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+        ChipId mmio_device_id = metal_ctx.get_cluster().get_associated_mmio_device(chip_id);
+        uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(chip_id);
         uint32_t sysmem_offset = host_addr_offset + get_relative_cq_offset(cq_id, cq_size);
         if constexpr (include_device_channel_offset) {
             sysmem_offset += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
         }
-        MetalContext::instance().get_cluster().read_sysmem(
-            &recv, sizeof(uint32_t), sysmem_offset, mmio_device_id, channel);
+        metal_ctx.get_cluster().read_sysmem(&recv, sizeof(uint32_t), sysmem_offset, mmio_device_id, channel);
     }
     return recv;
 }
 
 template <bool addr_16B>
-uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
+uint32_t get_cq_issue_rd_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
     uint32_t issue_q_rd_ptr =
-        MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
+        metal_ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
     const SystemMemoryManager& sysmem_manager =
-        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+        metal_ctx.device_manager()->get_active_device(chip_id)->sysmem_manager();
     uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_rd_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
@@ -77,15 +76,16 @@ uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
     return recv;
 }
 
-template uint32_t get_cq_issue_rd_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_issue_rd_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_issue_rd_ptr<true>(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_issue_rd_ptr<false>(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
+uint32_t get_cq_issue_wr_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
     uint32_t issue_q_wr_ptr =
-        MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
+        metal_ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
     const SystemMemoryManager& sysmem_manager =
-        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+        metal_ctx.device_manager()->get_active_device(chip_id)->sysmem_manager();
     uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, issue_q_wr_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
@@ -93,15 +93,16 @@ uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
     return recv;
 }
 
-template uint32_t get_cq_issue_wr_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_issue_wr_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_issue_wr_ptr<true>(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_issue_wr_ptr<false>(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t completion_q_wr_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-        CommandQueueHostAddrType::COMPLETION_Q_WR);
+uint32_t get_cq_completion_wr_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
+    uint32_t completion_q_wr_ptr =
+        metal_ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
     const SystemMemoryManager& sysmem_manager =
-        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+        metal_ctx.device_manager()->get_active_device(chip_id)->sysmem_manager();
     uint32_t recv = read_cq_host_ptr<true>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_wr_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
@@ -109,15 +110,17 @@ uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_siz
     return recv;
 }
 
-template uint32_t get_cq_completion_wr_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_completion_wr_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_completion_wr_ptr<true>(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_completion_wr_ptr<false>(
+    ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
-    uint32_t completion_q_rd_ptr = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
-        CommandQueueHostAddrType::COMPLETION_Q_RD);
+uint32_t get_cq_completion_rd_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
+    uint32_t completion_q_rd_ptr =
+        metal_ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
     const SystemMemoryManager& sysmem_manager =
-        MetalContext::instance().device_manager()->get_active_device(chip_id)->sysmem_manager();
+        metal_ctx.device_manager()->get_active_device(chip_id)->sysmem_manager();
     uint32_t recv = read_cq_host_ptr<false>(sysmem_manager, chip_id, cq_id, cq_size, completion_q_rd_ptr);
     if constexpr (!addr_16B) {
         return recv << 4;
@@ -125,17 +128,19 @@ uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_siz
     return recv;
 }
 
-template uint32_t get_cq_completion_rd_ptr<true>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
-template uint32_t get_cq_completion_rd_ptr<false>(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_completion_rd_ptr<true>(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+template uint32_t get_cq_completion_rd_ptr<false>(
+    ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
-uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
+uint32_t get_cq_dispatch_progress(ContextId context_id, ChipId chip_id, uint8_t cq_id) {
     uint32_t progress = 0;
 
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
     // Get the dispatcher core for this command queue
     // For remote chips: read from DISPATCH_D (on the remote chip where work actually happens)
     // For local chips: read from DISPATCH_HD (combined dispatcher on local chip)
-    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
-    auto& dispatch_core_manager = MetalContext::instance().get_dispatch_core_manager();
+    uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(chip_id);
+    auto& dispatch_core_manager = metal_ctx.get_dispatch_core_manager();
 
     const tt_cxy_pair& dispatcher_core_logical =
         dispatch_core_manager.is_dispatcher_d_core_allocated(chip_id, channel, cq_id)
@@ -145,17 +150,15 @@ uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
     CoreType dispatch_core_type = dispatch_core_manager.get_dispatch_core_type();
 
     // Get the L1 address where dispatch progress counter is stored
-    uint32_t dev_dispatch_progress_ptr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+    uint32_t dev_dispatch_progress_ptr = metal_ctx.dispatch_mem_map().get_device_command_queue_addr(
         CommandQueueDeviceAddrType::DISPATCH_PROGRESS, cq_id);
 
     // read_core expects TRANSLATED (virtual) coordinates
     // dispatcher_core_manager stores logical coordinates, so convert LOGICAL -> TRANSLATED (virtual)
-    tt_cxy_pair dispatcher_core_virtual =
-        MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            dispatcher_core_logical, dispatch_core_type);
+    tt_cxy_pair dispatcher_core_virtual = metal_ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
+        dispatcher_core_logical, dispatch_core_type);
 
-    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
-        &progress, sizeof(uint32_t), dispatcher_core_virtual, dev_dispatch_progress_ptr);
+    metal_ctx.get_cluster().read_core(&progress, sizeof(uint32_t), dispatcher_core_virtual, dev_dispatch_progress_ptr);
 
     return progress;
 }

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -8,6 +8,7 @@
 
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "device.hpp"
+#include "impl/context/context_types.hpp"
 #include "sub_device_types.hpp"
 
 namespace tt::tt_metal {
@@ -68,19 +69,19 @@ uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_siz
 
 // mostly used in debug_tools
 template <bool addr_16B>
-uint32_t get_cq_issue_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+uint32_t get_cq_issue_rd_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_issue_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+uint32_t get_cq_issue_wr_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
 // has usage in system_memory_manager.cpp
 template <bool addr_16B>
-uint32_t get_cq_completion_wr_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+uint32_t get_cq_completion_wr_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
 template <bool addr_16B>
-uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
+uint32_t get_cq_completion_rd_ptr(ContextId context_id, ChipId chip_id, uint8_t cq_id, uint32_t cq_size);
 
-uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id);
+uint32_t get_cq_dispatch_progress(ContextId context_id, ChipId chip_id, uint8_t cq_id);
 
 /// @brief Check if the command queue address type is shared across CQs co-located on the same dispatch core
 /// @param addr_type CommandQueueDeviceAddrType address type to check

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -19,55 +19,64 @@ using tt::tt_metal::detail::ProgramImpl;
 namespace tt {
 
 void RecordDispatchData(
+    ContextId context_id,
     uint64_t program_id,
     data_collector_t type,
     uint32_t transaction_size,
     std::optional<HalProcessorIdentifier> processor) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
     // Do nothing if we're not enabling data collection.
-    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
+    if (!metal_ctx.rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
-    tt::tt_metal::MetalContext::instance().data_collector()->RecordData(program_id, type, transaction_size, processor);
+    metal_ctx.data_collector()->RecordData(program_id, type, transaction_size, processor);
 }
 
-void RecordKernelGroup(ProgramImpl& program, HalProgrammableCoreType core_type, const KernelGroup& kernel_group) {
+void RecordKernelGroup(
+    ContextId context_id, ProgramImpl& program, HalProgrammableCoreType core_type, const KernelGroup& kernel_group) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
     // Do nothing if we're not enabling data collection.
-    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
+    if (!metal_ctx.rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
 
-    tt::tt_metal::MetalContext::instance().data_collector()->RecordKernelGroup(program, core_type, kernel_group);
+    metal_ctx.data_collector()->RecordKernelGroup(program, core_type, kernel_group);
 }
 
-void RecordProgramRun(uint64_t program_id) {
+void RecordProgramRun(ContextId context_id, uint64_t program_id) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
     // Do nothing if we're not enabling data collection.
-    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
+    if (!metal_ctx.rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
 
-    tt::tt_metal::MetalContext::instance().data_collector()->RecordProgramRun(program_id);
+    metal_ctx.data_collector()->RecordProgramRun(program_id);
 }
 
 void RecordProgramSubDevice(
+    ContextId context_id,
     tt::ChipId device_id,
     uint64_t sub_device_manager_id,
     uint64_t runtime_id,
     SubDeviceId sub_device_id,
     uint32_t num_available_worker_cores) {
-    tt::tt_metal::MetalContext::instance().data_collector()->RecordProgramSubDevice(
-        device_id, sub_device_manager_id, runtime_id, sub_device_id, num_available_worker_cores);
+    MetalContext::instance(context_id)
+        .data_collector()
+        ->RecordProgramSubDevice(
+            device_id, sub_device_manager_id, runtime_id, sub_device_id, num_available_worker_cores);
 }
 
-std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, uint64_t runtime_id) {
-    return tt::tt_metal::MetalContext::instance().data_collector()->GetProgramSubDevice(device_id, runtime_id);
+std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(
+    ContextId context_id, tt::ChipId device_id, uint64_t runtime_id) {
+    return MetalContext::instance(context_id).data_collector()->GetProgramSubDevice(device_id, runtime_id);
 }
 
-void RecordProgramMetadata(ProgramImpl& program) {
-    tt::tt_metal::MetalContext::instance().data_collector()->RecordProgramMetadata(program);
+void RecordProgramMetadata(ContextId context_id, ProgramImpl& program) {
+    MetalContext::instance(context_id).data_collector()->RecordProgramMetadata(program);
 }
 
-std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id) {
-    return tt::tt_metal::MetalContext::instance().data_collector()->GetKernelSourcesForRuntimeId(runtime_id);
+std::span<const std::string_view> GetKernelSourcesForRuntimeId(ContextId context_id, uint16_t runtime_id) {
+    return MetalContext::instance(context_id).data_collector()->GetKernelSourcesForRuntimeId(runtime_id);
 }
 
 ProgramRealtimeProfilerCallbackHandle RegisterProgramRealtimeProfilerCallback(

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/experimental/realtime_profiler.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include "program/program_impl.hpp"
+#include "impl/context/context_types.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -43,6 +44,7 @@ using ProgramRealtimeProfilerCallbackHandle = tt::tt_metal::experimental::Progra
  *      processor - processor that this transaction is used for, only relevant for DISPATCH_DATA_BINARY transactions.
  */
 void RecordDispatchData(
+    tt::tt_metal::ContextId context_id,
     uint64_t program_id,
     data_collector_t type,
     uint32_t transaction_size,
@@ -51,15 +53,16 @@ void RecordDispatchData(
 // Record the KernelGroups present in this program (per core type). Should only be called per program created, not
 // program enqueued.
 void RecordKernelGroup(
+    tt::tt_metal::ContextId context_id,
     tt_metal::detail::ProgramImpl& program,
     tt_metal::HalProgrammableCoreType core_type,
     const tt_metal::KernelGroup& kernel_group);
 
 // Update stats with an enqueue of given program.
-void RecordProgramRun(uint64_t program_id);
+void RecordProgramRun(tt::tt_metal::ContextId context_id, uint64_t program_id);
 
 // Record metadata used by profiler lookups for this program dispatch.
-void RecordProgramMetadata(tt_metal::detail::ProgramImpl& program);
+void RecordProgramMetadata(tt::tt_metal::ContextId context_id, tt_metal::detail::ProgramImpl& program);
 
 struct ProgramSubDeviceInfo {
     uint8_t sub_device_id = 0;
@@ -70,6 +73,7 @@ struct ProgramSubDeviceInfo {
 
 // Record which sub-device a program executes on. Should be called at dispatch time when runtime_id is set.
 void RecordProgramSubDevice(
+    tt::tt_metal::ContextId context_id,
     tt::ChipId device_id,
     uint64_t sub_device_manager_id,
     uint64_t runtime_id,
@@ -77,11 +81,12 @@ void RecordProgramSubDevice(
     uint32_t num_available_worker_cores = 0);
 
 // Look up the sub-device a program was dispatched on, keyed by physical device and runtime_id.
-std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, uint64_t runtime_id);
+std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(
+    tt::tt_metal::ContextId context_id, tt::ChipId device_id, uint64_t runtime_id);
 
 // Look up kernel source paths by runtime_id; empty span if the runtime_id is unknown.
 // The returned span is valid until MetalContext teardown or reinitialization.
-std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id);
+std::span<const std::string_view> GetKernelSourcesForRuntimeId(tt::tt_metal::ContextId context_id, uint16_t runtime_id);
 
 // Register a callback to be invoked when real-time profiler data arrives.
 // Multiple callbacks can be registered; each callback is called from its own thread.

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -369,12 +369,18 @@ void dump_completion_queue_entries(
     MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
     ChipId mmio_device_id = metal_ctx.get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
     uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(sysmem_manager.get_device_id());
-    uint32_t completion_write_ptr =
-        get_cq_completion_wr_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
-        << 4;
-    uint32_t completion_read_ptr =
-        get_cq_completion_rd_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
-        << 4;
+    uint32_t completion_write_ptr = get_cq_completion_wr_ptr<true>(
+                                        sysmem_manager.get_context_id(),
+                                        sysmem_manager.get_device_id(),
+                                        cq_interface.id,
+                                        sysmem_manager.get_cq_size())
+                                    << 4;
+    uint32_t completion_read_ptr = get_cq_completion_rd_ptr<true>(
+                                       sysmem_manager.get_context_id(),
+                                       sysmem_manager.get_device_id(),
+                                       cq_interface.id,
+                                       sysmem_manager.get_cq_size())
+                                   << 4;
     uint32_t completion_q_bytes = cq_interface.completion_fifo_size << 4;
     TT_ASSERT(completion_q_bytes % DispatchSettings::TRANSFER_PAGE_SIZE == 0);
     uint32_t base_addr = (cq_interface.issue_fifo_limit << 4);
@@ -467,10 +473,18 @@ void dump_issue_queue_entries(
     ChipId mmio_device_id = metal_ctx.get_cluster().get_associated_mmio_device(sysmem_manager.get_device_id());
     uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(sysmem_manager.get_device_id());
     // TODO: Issue Q read ptr is not prefetcly updated 0 try to read it out from chip on dump?
-    uint32_t issue_read_ptr =
-        get_cq_issue_rd_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size()) << 4;
-    uint32_t issue_write_ptr =
-        get_cq_issue_wr_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size()) << 4;
+    uint32_t issue_read_ptr = get_cq_issue_rd_ptr<true>(
+                                  sysmem_manager.get_context_id(),
+                                  sysmem_manager.get_device_id(),
+                                  cq_interface.id,
+                                  sysmem_manager.get_cq_size())
+                              << 4;
+    uint32_t issue_write_ptr = get_cq_issue_wr_ptr<true>(
+                                   sysmem_manager.get_context_id(),
+                                   sysmem_manager.get_device_id(),
+                                   cq_interface.id,
+                                   sysmem_manager.get_cq_size())
+                               << 4;
     uint32_t issue_q_bytes = cq_interface.issue_fifo_size << 4;
     uint32_t issue_q_base_addr = cq_interface.offset + cq_interface.cq_start;
 
@@ -615,22 +629,34 @@ void dump_command_queue_raw_data(
     std::string queue_type_name;
     if (queue_type == CQ_COMPLETION_QUEUE) {
         write_ptr = get_cq_completion_wr_ptr<true>(
-                        sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+                        sysmem_manager.get_context_id(),
+                        sysmem_manager.get_device_id(),
+                        cq_interface.id,
+                        sysmem_manager.get_cq_size())
                     << 4;
         read_ptr = get_cq_completion_rd_ptr<true>(
-                       sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
+                       sysmem_manager.get_context_id(),
+                       sysmem_manager.get_device_id(),
+                       cq_interface.id,
+                       sysmem_manager.get_cq_size())
                    << 4;
         bytes_to_read = cq_interface.completion_fifo_size << 4;  // Page-aligned, Issue Q is not.
         TT_ASSERT(bytes_to_read % DispatchSettings::TRANSFER_PAGE_SIZE == 0);
         base_addr = cq_interface.issue_fifo_limit << 4;
         queue_type_name = "Completion";
     } else if (queue_type == CQ_ISSUE_QUEUE) {
-        write_ptr =
-            get_cq_issue_wr_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
-            << 4;
-        read_ptr =
-            get_cq_issue_rd_ptr<true>(sysmem_manager.get_device_id(), cq_interface.id, sysmem_manager.get_cq_size())
-            << 4;
+        write_ptr = get_cq_issue_wr_ptr<true>(
+                        sysmem_manager.get_context_id(),
+                        sysmem_manager.get_device_id(),
+                        cq_interface.id,
+                        sysmem_manager.get_cq_size())
+                    << 4;
+        read_ptr = get_cq_issue_rd_ptr<true>(
+                       sysmem_manager.get_context_id(),
+                       sysmem_manager.get_device_id(),
+                       cq_interface.id,
+                       sysmem_manager.get_cq_size())
+                   << 4;
         bytes_to_read = cq_interface.issue_fifo_size << 4;
         base_addr = cq_interface.offset + cq_interface.cq_start;
         queue_type_name = "Issue";

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -29,22 +29,22 @@ HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC /*noc_index*/) :
     id_(id), manager_(device->sysmem_manager()), device_(device) {
     TTZoneScopedDN(DISPATCH, "CommandQueue_constructor");
 
-    uint16_t channel =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
+    MetalContext& metal_ctx = MetalContext::instance(device_->get_context_id());
+    uint16_t channel = metal_ctx.get_cluster().get_assigned_channel_for_device(device_->id());
 
     CoreCoord enqueue_program_dispatch_core;
-    CoreType core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+    CoreType core_type = metal_ctx.get_dispatch_core_manager().get_dispatch_core_type();
+    if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
         // dispatch_s exists with this configuration. Workers write to dispatch_s.
         enqueue_program_dispatch_core =
-            MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(device_->id(), channel, id);
+            metal_ctx.get_dispatch_core_manager().dispatcher_s_core(device_->id(), channel, id);
     } else {
         if (device_->is_mmio_capable()) {
             enqueue_program_dispatch_core =
-                MetalContext::instance().get_dispatch_core_manager().dispatcher_core(device_->id(), channel, id);
+                metal_ctx.get_dispatch_core_manager().dispatcher_core(device_->id(), channel, id);
         } else {
             enqueue_program_dispatch_core =
-                MetalContext::instance().get_dispatch_core_manager().dispatcher_d_core(device_->id(), channel, id);
+                metal_ctx.get_dispatch_core_manager().dispatcher_d_core(device_->id(), channel, id);
         }
     }
     this->virtual_enqueue_program_dispatch_core_ =

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -60,6 +60,7 @@ void loop_and_wait_with_timeout(
     const OnTimeout& on_timeout,
     std::chrono::duration<float> timeout_duration,
     const GetProgress& get_progress,
+    ContextId context_id,
     std::atomic<bool>* exit_condition = nullptr) {
     if (timeout_duration.count() > 0.0f) {
         auto last_progress_time = std::chrono::high_resolution_clock::now();
@@ -68,7 +69,7 @@ void loop_and_wait_with_timeout(
         // interval. Only long running operations will read progress value updates.
         auto last_progress_update_time = std::chrono::high_resolution_clock::now();
         auto progress_update_interval = std::chrono::milliseconds(
-            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_progress_update_ms());
+            tt::tt_metal::MetalContext::instance(context_id).rtoptions().get_dispatch_progress_update_ms());
 
         while (true) {
             if (exit_condition != nullptr && exit_condition->load(std::memory_order_acquire)) {
@@ -725,12 +726,19 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         };
 
         // Get dispatch progress for timeout detection
-        auto get_dispatch_progress = [&]() -> uint32_t { return get_cq_dispatch_progress(this->device_id, cq_id); };
+        auto get_dispatch_progress = [&]() -> uint32_t {
+            return get_cq_dispatch_progress(this->context_id, this->device_id, cq_id);
+        };
 
         auto timeout_duration = ctx.rtoptions().get_timeout_duration_for_operations();
 
         loop_and_wait_with_timeout(
-            fetch_operation_body, fetch_wait_condition, fetch_on_timeout, timeout_duration, get_dispatch_progress);
+            fetch_operation_body,
+            fetch_wait_condition,
+            fetch_on_timeout,
+            timeout_duration,
+            get_dispatch_progress,
+            this->context_id);
     };
 
     wait_for_fetch_q_space();
@@ -758,7 +766,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
 
     // Body of the operation to be timed out
     auto wait_operation_body = [this, cq_id, &write_ptr_and_toggle, &write_ptr, &write_toggle]() {
-        write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
+        write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->context_id, this->device_id, cq_id, this->cq_size);
         write_ptr = write_ptr_and_toggle & 0x7fffffff;
         write_toggle = write_ptr_and_toggle >> 31;
         // Yield to clock the simulator when running on TTSim; no-op on real hardware.
@@ -781,15 +789,16 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
 
     // Get dispatch progress for timeout detection
     auto get_dispatch_progress = [this, cq_id]() -> uint32_t {
-        return get_cq_dispatch_progress(this->device_id, cq_id);
+        return get_cq_dispatch_progress(this->context_id, this->device_id, cq_id);
     };
 
     loop_and_wait_with_timeout(
         wait_operation_body,
         wait_condition,
         on_timeout,
-        tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations(),
+        tt::tt_metal::MetalContext::instance(this->context_id).rtoptions().get_timeout_duration_for_operations(),
         get_dispatch_progress,
+        this->context_id,
         &exit_condition);
 
     return write_ptr_and_toggle;

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -58,7 +58,7 @@ void issue_record_event_commands(
     const uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     const uint32_t num_worker_counters = sub_device_ids.size();
     const uint32_t num_cqs_per_dispatch_core =
-        MetalContext::instance().get_dispatch_query_manager().cq_dispatch_layout().num_cqs_per_core;
+        metal_ctx.get_dispatch_query_manager().cq_dispatch_layout().num_cqs_per_core;
     const uint32_t num_dispatch_cores = num_command_queues / num_cqs_per_dispatch_core;
     const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 
@@ -107,14 +107,14 @@ void issue_record_event_commands(
             command_sequence.add_dispatch_wait_with_prefetch_stall(
                 wait_flags,
                 0,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+                metal_ctx.dispatch_mem_map().get_dispatch_stream_index(offset_index),
                 expected_num_workers_completed[offset_index],
                 cq_id);
         } else {
             command_sequence.add_dispatch_wait(
                 wait_flags,
                 0,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
+                metal_ctx.dispatch_mem_map().get_dispatch_stream_index(offset_index),
                 expected_num_workers_completed[offset_index],
                 cq_id);
         }
@@ -123,18 +123,18 @@ void issue_record_event_commands(
     std::vector<CQDispatchWritePackedUnicastSubCmd> unicast_sub_cmds(num_command_queues);
     std::vector<std::pair<const void*, uint32_t>> event_payloads(num_command_queues);
 
-    const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
+    const CoreType dispatch_core_type = metal_ctx.get_dispatch_core_manager().get_dispatch_core_type();
     for (auto cq = 0; cq < num_command_queues; cq++) {
-        tt_cxy_pair dispatch_location = MetalContext::instance().get_dispatch_query_manager().get_dispatch_core(cq);
+        tt_cxy_pair dispatch_location = metal_ctx.get_dispatch_query_manager().get_dispatch_core(cq);
         CoreCoord dispatch_virtual_core = device->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
         unicast_sub_cmds[cq] = CQDispatchWritePackedUnicastSubCmd{
             .noc_xy_addr = device->get_noc_unicast_encoding(k_dispatch_downstream_noc, dispatch_virtual_core)};
         event_payloads[cq] = {event_payload.data(), event_payload.size() * sizeof(uint32_t)};
     }
 
-    uint32_t completion_q0_last_event_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+    uint32_t completion_q0_last_event_addr = metal_ctx.dispatch_mem_map().get_device_command_queue_addr(
         CommandQueueDeviceAddrType::COMPLETION_Q0_LAST_EVENT, cq_id);
-    uint32_t completion_q1_last_event_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+    uint32_t completion_q1_last_event_addr = metal_ctx.dispatch_mem_map().get_device_command_queue_addr(
         CommandQueueDeviceAddrType::COMPLETION_Q1_LAST_EVENT, cq_id);
     uint32_t address = cq_id == 0 ? completion_q0_last_event_addr : completion_q1_last_event_addr;
     command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
@@ -170,9 +170,9 @@ void issue_wait_for_event_commands(
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
 
     HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
-    uint32_t completion_q0_last_event_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+    uint32_t completion_q0_last_event_addr = metal_ctx.dispatch_mem_map().get_device_command_queue_addr(
         CommandQueueDeviceAddrType::COMPLETION_Q0_LAST_EVENT, cq_id);
-    uint32_t completion_q1_last_event_addr = MetalContext::instance().dispatch_mem_map().get_device_command_queue_addr(
+    uint32_t completion_q1_last_event_addr = metal_ctx.dispatch_mem_map().get_device_command_queue_addr(
         CommandQueueDeviceAddrType::COMPLETION_Q1_LAST_EVENT, cq_id);
 
     uint32_t last_completed_event_address =
@@ -195,16 +195,14 @@ void read_completion_queue(
     uint16_t channel,
     uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
+    MetalContext& metal_ctx = MetalContext::instance(sysmem_manager.get_context_id());
     if (sysmem_manager.is_dram_backed()) {
-        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance()
-                                          .device_manager()
-                                          ->get_active_device(device_id)
-                                          ->allocator_impl()
-                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
-        tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            dst, size_bytes, device_id, dram_channel, addr);
+        const uint32_t dram_channel =
+            metal_ctx.device_manager()->get_active_device(device_id)->allocator_impl()->get_dram_channel_from_bank_id(
+                sysmem_manager.get_dram_region_bank_id());
+        metal_ctx.get_cluster().read_dram_vec(dst, size_bytes, device_id, dram_channel, addr);
     } else {
-        tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
+        metal_ctx.get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }
 }
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -207,7 +207,7 @@ void Kernel::register_kernel_with_watcher() {
 
 void Kernel::register_kernel_elf_paths_with_watcher(IDevice& device, const std::string& binary_root) const {
     // Skip if watcher server not available (e.g. mock or emulated targets)
-    auto& watcher = MetalContext::instance().watcher_server();
+    auto& watcher = MetalContext::instance(this->get_context_id()).watcher_server();
     if (!watcher) {
         return;
     }
@@ -388,8 +388,9 @@ void Kernel::set_compiler_include_paths(const std::vector<std::filesystem::path>
 
 bool Kernel::binaries_exist_on_disk(const IDevice* device, const std::string& binary_root) const {
     TT_ASSERT(this->expected_num_binaries() > 0, "Kernel {} expected at least one binary", this->name());
-    const uint32_t core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    const uint32_t core_type = MetalContext::instance(this->get_context_id())
+                                   .hal()
+                                   .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
     for (int i = 0; i < this->expected_num_binaries(); ++i) {
         auto elf_path = BuildEnvManager::get_instance(extract_context_id(device))
@@ -411,7 +412,7 @@ bool Kernel::binaries_exist_on_disk(const IDevice* device, const std::string& bi
 std::vector<std::string> Kernel::file_paths(const IDevice& device, const std::string& binary_root) const {
     std::vector<std::string> file_paths;
     file_paths.reserve(this->expected_num_binaries());
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(this->get_context_id()).hal();
     uint32_t core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
     for (int i = 0; i < this->expected_num_binaries(); i++) {
@@ -448,7 +449,7 @@ std::vector<std::string> Kernel::elf_paths_by_processor_index(
 
 std::vector<uint32_t> Kernel::get_processor_indices_for_binary(int binary_index) const {
     TT_ASSERT(0 <= binary_index && binary_index < expected_num_binaries(), "binary_index out of bounds");
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(this->get_context_id()).hal();
     uint32_t idx = hal.get_processor_index(
         this->get_kernel_programmable_core_type(),
         this->get_kernel_processor_class(),
@@ -733,9 +734,11 @@ void Kernel::validate_runtime_args_size(
         case HalProgrammableCoreType::IDLE_ETH:
         case HalProgrammableCoreType::DRAM:
         case HalProgrammableCoreType::DISPATCH:
-            expected_max_rt_args = MetalContext::instance().hal().get_dev_size(
-                                       this->get_kernel_programmable_core_type(), HalL1MemAddrType::KERNEL_CONFIG) /
-                                   sizeof(uint32_t);
+            expected_max_rt_args =
+                MetalContext::instance(this->get_context_id())
+                    .hal()
+                    .get_dev_size(this->get_kernel_programmable_core_type(), HalL1MemAddrType::KERNEL_CONFIG) /
+                sizeof(uint32_t);
             break;
         default: TT_THROW("Invalid programmable core type: {}", this->get_kernel_programmable_core_type());
     }
@@ -929,8 +932,9 @@ void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions& /*b
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
         *this,
         this->kernel_src_);
-    uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                    .hal()
+                                    .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->config_.processor);
     jit_build(
@@ -944,8 +948,9 @@ void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
         *this,
         this->kernel_src_);
-    uint32_t erisc_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t erisc_core_type = MetalContext::instance(this->get_context_id())
+                                   .hal()
+                                   .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     int erisc_id = enchantum::to_underlying(this->config_.processor);
     jit_build(
@@ -959,8 +964,9 @@ void DramKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_opt
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
         *this,
         this->kernel_src_);
-    uint32_t dram_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t dram_core_type = MetalContext::instance(this->get_context_id())
+                                  .hal()
+                                  .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     jit_build(
         BuildEnvManager::get_instance(extract_context_id(device))
@@ -973,8 +979,9 @@ void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
         *this,
         this->kernel_src_);
-    uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                    .hal()
+                                    .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
     auto build_states = BuildEnvManager::get_instance(extract_context_id(device))
                             .get_kernel_build_states(device->build_id(), tensix_core_type, compute_class_idx);
@@ -998,12 +1005,15 @@ void DataMovementKernel::read_binaries(IDevice* device, const std::string& binar
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indices
     // TODO(pgk): consolidate read_binaries where possible
-    uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                    .hal()
+                                    .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->config_.processor);
-    auto load_type =
-        MetalContext::instance().hal().get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id).memory_load;
+    auto load_type = MetalContext::instance(this->get_context_id())
+                         .hal()
+                         .get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id)
+                         .memory_load;
     const auto binary_path =
         BuildEnvManager::get_instance(extract_context_id(device))
             .get_kernel_binary_path(
@@ -1020,10 +1030,14 @@ void DataMovementKernel::read_binaries(IDevice* device, const std::string& binar
 void DramKernel::read_binaries(IDevice* device, const std::string& binary_root) {
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
     std::vector<const ll_api::memory*> binaries;
-    uint32_t dram_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t dram_core_type = MetalContext::instance(this->get_context_id())
+                                  .hal()
+                                  .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     constexpr auto k_DmClassIndex = enchantum::to_underlying(HalProcessorClassType::DM);
-    auto load_type = MetalContext::instance().hal().get_jit_build_config(dram_core_type, k_DmClassIndex, 0).memory_load;
+    auto load_type = MetalContext::instance(this->get_context_id())
+                         .hal()
+                         .get_jit_build_config(dram_core_type, k_DmClassIndex, 0)
+                         .memory_load;
     const auto binary_path =
         BuildEnvManager::get_instance(extract_context_id(device))
             .get_kernel_binary_path(
@@ -1040,28 +1054,34 @@ void EthernetKernel::read_binaries(IDevice* device, const std::string& binary_ro
     // untested
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
     std::vector<const ll_api::memory*> binaries;
-    uint32_t erisc_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t erisc_core_type = MetalContext::instance(this->get_context_id())
+                                   .hal()
+                                   .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     constexpr auto k_EthDmClassIndex = enchantum::to_underlying(HalProcessorClassType::DM);
     int erisc_id = enchantum::to_underlying(this->config_.processor);
     // TODO: fix when active eth supports relo
-    auto load_type =
-        MetalContext::instance().hal().get_jit_build_config(erisc_core_type, k_EthDmClassIndex, erisc_id).memory_load;
+    auto load_type = MetalContext::instance(this->get_context_id())
+                         .hal()
+                         .get_jit_build_config(erisc_core_type, k_EthDmClassIndex, erisc_id)
+                         .memory_load;
     const auto binary_path =
         BuildEnvManager::get_instance(extract_context_id(device))
             .get_kernel_binary_path(
                 device->build_id(), erisc_core_type, k_EthDmClassIndex, erisc_id, binary_root, this->kernel_full_name_);
     const ll_api::memory& binary_mem =
         llrt::get_risc_binary(binary_path, load_type, [this](ll_api::memory& binary_mem) {
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
+            if (tt::tt_metal::MetalContext::instance(this->get_context_id()).rtoptions().get_erisc_iram_enabled() &&
                 this->config_.eth_mode != Eth::IDLE) {
                 // text_addr and some of span's addr point to IRAM base address.
                 // However it need to be placed L1 kernel base address for FW to copy it to IRAM then kick off
                 // The kernel can run with IRAM base address once it started.
-                binary_mem.set_text_addr(tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(
-                    (uint64_t)binary_mem.get_text_addr()));
-                std::function<void(uint64_t& addr)> update_callback = [](uint64_t& addr) {
-                    addr = tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(addr);
+                binary_mem.set_text_addr(tt::tt_metal::MetalContext::instance(this->get_context_id())
+                                             .hal()
+                                             .erisc_iram_relocate_dev_addr((uint64_t)binary_mem.get_text_addr()));
+                std::function<void(uint64_t& addr)> update_callback = [this](uint64_t& addr) {
+                    addr = tt::tt_metal::MetalContext::instance(this->get_context_id())
+                               .hal()
+                               .erisc_iram_relocate_dev_addr(addr);
                 };
                 binary_mem.update_spans(update_callback);
             }
@@ -1079,11 +1099,12 @@ void ComputeKernel::read_binaries(IDevice* device, const std::string& binary_roo
     constexpr int num_trisc_binaries = 3;
     std::vector<const ll_api::memory*> binaries;
     binaries.reserve(num_trisc_binaries);
-    uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                    .hal()
+                                    .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id < num_trisc_binaries; trisc_id++) {
-        auto load_type = MetalContext::instance()
+        auto load_type = MetalContext::instance(this->get_context_id())
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, trisc_id)
                              .memory_load;
@@ -1121,7 +1142,7 @@ bool DataMovementKernel::configure(
 
 bool EthernetKernel::configure(
     IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const {
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(this->get_context_id()).hal();
     auto device_id = device->id();
     auto ethernet_core = device->ethernet_core_from_logical_core(logical_core);
     const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance(extract_context_id(device))
@@ -1150,7 +1171,7 @@ bool DramKernel::configure(
     const CoreCoord& logical_core,
     [[maybe_unused]] uint32_t base_address,
     [[maybe_unused]] const uint32_t offsets[]) const {
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(this->get_context_id()).hal();
     auto device_id = device->id();
     auto dram_core = device->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
     const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance(extract_context_id(device))
@@ -1175,7 +1196,9 @@ void experimental::quasar::DispatchEngineKernel::generate_binaries(IDevice* devi
         *this,
         this->kernel_src_);
     const uint32_t dispatch_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+        MetalContext::instance(this->get_context_id())
+            .hal()
+            .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     const int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->dm_processors_[0]);
     jit_build(
@@ -1187,10 +1210,12 @@ void experimental::quasar::DispatchEngineKernel::generate_binaries(IDevice* devi
 void experimental::quasar::DispatchEngineKernel::read_binaries(IDevice* device, const std::string& binary_root) {
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
     const uint32_t dispatch_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+        MetalContext::instance(this->get_context_id())
+            .hal()
+            .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     const int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->dm_processors_[0]);
-    auto load_type = MetalContext::instance()
+    auto load_type = MetalContext::instance(this->get_context_id())
                          .hal()
                          .get_jit_build_config(dispatch_core_type, dm_class_idx, riscv_id)
                          .memory_load;
@@ -1216,7 +1241,7 @@ bool experimental::quasar::DispatchEngineKernel::configure(
     [[maybe_unused]] uint32_t base_address,
     [[maybe_unused]] const uint32_t offsets[]) const {
     TT_FATAL(is_on_logical_core(logical_core), "Cannot configure kernel because it is not on core {}", logical_core.str());
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(this->get_context_id()).hal();
     const ChipId device_id = device->id();
     const CoreCoord dispatch_core = device->virtual_core_from_logical_core(logical_core, CoreType::DISPATCH);
     const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance(extract_context_id(device))
@@ -1255,7 +1280,9 @@ bool ComputeKernel::configure(
     auto worker_core = device->worker_core_from_logical_core(logical_core);
     const std::vector<const ll_api::memory*>& binaries = this->binaries(
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key());
-    int32_t dm_count = MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
+    int32_t dm_count = MetalContext::instance(this->get_context_id())
+                           .hal()
+                           .get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         llrt::write_binary_to_address(
             *binaries[trisc_id], device_id, worker_core, base_address + offsets[dm_count + trisc_id]);
@@ -1307,7 +1334,7 @@ std::vector<uint32_t> QuasarDataMovementKernel::get_processor_indices_for_binary
     if (config_.is_legacy_kernel) {
         return Kernel::get_processor_indices_for_binary(binary_index);
     }
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(this->get_context_id()).hal();
     auto core_type = this->get_kernel_programmable_core_type();
     auto proc_class = this->get_kernel_processor_class();
     std::vector<uint32_t> indices;
@@ -1323,8 +1350,9 @@ void QuasarDataMovementKernel::generate_binaries(IDevice* device, JitBuildOption
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
         *this,
         this->kernel_src_);
-    const uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    const uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                          .hal()
+                                          .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
 
     if (config_.is_legacy_kernel) {
@@ -1348,13 +1376,14 @@ void QuasarDataMovementKernel::read_binaries(IDevice* device, const std::string&
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
     std::vector<const ll_api::memory*> binaries;
     binaries.reserve(this->dm_processors_.size());
-    const uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    const uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                          .hal()
+                                          .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     if (config_.is_legacy_kernel) {
         for (const auto processor : this->dm_processors_) {
             const int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(processor);
-            auto load_type = MetalContext::instance()
+            auto load_type = MetalContext::instance(this->get_context_id())
                                  .hal()
                                  .get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id)
                                  .memory_load;
@@ -1365,7 +1394,7 @@ void QuasarDataMovementKernel::read_binaries(IDevice* device, const std::string&
         }
     } else {
         const int canonical_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->dm_processors_[0]);
-        auto load_type = MetalContext::instance()
+        auto load_type = MetalContext::instance(this->get_context_id())
                              .hal()
                              .get_jit_build_config(tensix_core_type, dm_class_idx, canonical_id)
                              .memory_load;
@@ -1441,7 +1470,7 @@ std::vector<uint32_t> QuasarComputeKernel::get_processor_indices_for_binary(int 
     TT_ASSERT(
         0 <= binary_index && binary_index < static_cast<int>(this->trisc_binary_groups_.size()),
         "binary_index out of bounds");
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(this->get_context_id()).hal();
     auto core_type = this->get_kernel_programmable_core_type();
     auto proc_class = this->get_kernel_processor_class();
     const auto& group = this->trisc_binary_groups_[static_cast<size_t>(binary_index)];
@@ -1458,8 +1487,9 @@ void QuasarComputeKernel::generate_binaries(IDevice* device, JitBuildOptions&) c
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
         *this,
         this->kernel_src_);
-    const uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    const uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                          .hal()
+                                          .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
 
     // One compile/link per TRISC slot (UNPACK/MATH/PACK/ISOLATE_SFPU), shared across all NEOs using that slot.
@@ -1475,13 +1505,14 @@ void QuasarComputeKernel::read_binaries(IDevice* device, const std::string& bina
     TT_ASSERT(this->binaries_exist_on_disk(device, binary_root));
     std::vector<const ll_api::memory*> binaries;
     binaries.reserve(this->trisc_binary_groups_.size());
-    const uint32_t tensix_core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    const uint32_t tensix_core_type = MetalContext::instance(this->get_context_id())
+                                          .hal()
+                                          .get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
     // One loaded image per TRISC slot; link used is the canonical (first) processor in the slot's group.
     for (const auto& group : this->trisc_binary_groups_) {
         const int processor_id = static_cast<std::underlying_type_t<QuasarComputeProcessor>>(group[0]);
-        auto load_type = MetalContext::instance()
+        auto load_type = MetalContext::instance(this->get_context_id())
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, processor_id)
                              .memory_load;
@@ -1517,8 +1548,11 @@ bool QuasarComputeKernel::configure(
     const CoreCoord worker_core = device->worker_core_from_logical_core(logical_core);
     const std::vector<const ll_api::memory*>& binaries = this->binaries(
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key());
-    const uint32_t dm_count = MetalContext::instance().hal().get_processor_types_count(
-        HalProgrammableCoreType::TENSIX, enchantum::to_underlying(HalProcessorClassType::DM));
+    const uint32_t dm_count =
+        MetalContext::instance(this->get_context_id())
+            .hal()
+            .get_processor_types_count(
+                HalProgrammableCoreType::TENSIX, enchantum::to_underlying(HalProcessorClassType::DM));
     for (size_t i = 0; i < this->trisc_binary_groups_.size(); ++i) {
         const QuasarComputeProcessor canonical = this->trisc_binary_groups_[i][0];
         llrt::write_binary_to_address(

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -75,7 +75,8 @@ kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
         kernel_profiler::PROFILER_TIMER_PACKET_TYPE_MASK);
 }
 
-void add_program_sub_device_meta_data(nlohmann::json& meta_data, tt::ChipId device_id, uint32_t runtime_id) {
+void add_program_sub_device_meta_data(
+    nlohmann::json& meta_data, ContextId context_id, tt::ChipId device_id, uint32_t runtime_id) {
     using CacheKey = std::pair<tt::ChipId, uint32_t>;
     struct CacheKeyHash {
         std::size_t operator()(const CacheKey& k) const noexcept {
@@ -93,9 +94,11 @@ void add_program_sub_device_meta_data(nlohmann::json& meta_data, tt::ChipId devi
         std::lock_guard<std::mutex> lock(cache_mutex);
         auto cache_it = sub_device_info_cache.find(cache_key);
         if (cache_it == sub_device_info_cache.end()) {
-            cache_it = sub_device_info_cache
-                           .emplace(cache_key, tt::GetProgramSubDevice(device_id, static_cast<uint16_t>(runtime_id)))
-                           .first;
+            cache_it =
+                sub_device_info_cache
+                    .emplace(
+                        cache_key, tt::GetProgramSubDevice(context_id, device_id, static_cast<uint16_t>(runtime_id)))
+                    .first;
         }
         sub_device_info = cache_it->second;
     }
@@ -106,12 +109,12 @@ void add_program_sub_device_meta_data(nlohmann::json& meta_data, tt::ChipId devi
     meta_data["sub_device_manager_id"] = sub_device_info->sub_device_manager_id;
 }
 
-void add_program_sub_device_meta_data(nlohmann::json& meta_data, uint32_t encoded_run_host_id) {
+void add_program_sub_device_meta_data(nlohmann::json& meta_data, ContextId context_id, uint32_t encoded_run_host_id) {
     if (encoded_run_host_id == 0) {
         return;
     }
     const auto decoded = detail::DecodePerDeviceProgramID(encoded_run_host_id);
-    add_program_sub_device_meta_data(meta_data, decoded.device_id, decoded.base_program_id);
+    add_program_sub_device_meta_data(meta_data, context_id, decoded.device_id, decoded.base_program_id);
 }
 
 #if defined(TRACY_ENABLE)
@@ -1997,7 +2000,7 @@ void DeviceProfiler::readDeviceMarkerData(
     ZoneScoped;
 
     nlohmann::json meta_data;
-    add_program_sub_device_meta_data(meta_data, run_host_id);
+    add_program_sub_device_meta_data(meta_data, this->context_id, run_host_id);
     const tracy::MarkerDetails marker_details = getMarkerDetails(timer_id);
     const kernel_profiler::PacketTypes packet_type = get_packet_type(timer_id);
     const auto [trace_id, trace_id_count] = getTraceIdAndCount(run_host_id, device_trace_counter);

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -97,7 +97,7 @@ uint32_t get_available_worker_core_count_for_program(
     const DispatchCoreConfig& dispatch_core_config) {
     const auto decoded = detail::DecodePerDeviceProgramID(encoded_runtime_host_id);
     const std::optional<tt::ProgramSubDeviceInfo> sub_device_info =
-        tt::GetProgramSubDevice(chip_id, decoded.base_program_id);
+        tt::GetProgramSubDevice(MetalContext::instance().get_context_id(), chip_id, decoded.base_program_id);
     if (sub_device_info.has_value() && sub_device_info->num_available_worker_cores > 0) {
         return sub_device_info->num_available_worker_cores;
     }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -478,14 +478,15 @@ uint32_t finalize_kernel_bins(
     uint32_t base_offset,
     uint32_t& kernel_text_offset,
     uint32_t& kernel_text_size) {
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(device));
     // Mock/emulated devices don't have real binaries, skip finalization
-    if (tt::tt_metal::MetalContext::instance(extract_context_id(device)).get_cluster().is_mock_or_emulated()) {
+    if (metal_ctx.get_cluster().is_mock_or_emulated()) {
         kernel_text_offset = base_offset;
         kernel_text_size = 0;
         return base_offset;
     }
 
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
     uint32_t max_offset = 0;
@@ -647,9 +648,13 @@ void generate_runtime_args_cmds(
         std::is_same_v<PackedSubCmd, CQDispatchWritePackedUnicastSubCmd> or
         std::is_same_v<PackedSubCmd, CQDispatchWritePackedMulticastSubCmd>);
 
+    const uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     thread_local static auto get_runtime_payload_sizeB =
-        [](uint32_t num_packed_cmds, uint32_t runtime_args_len, bool is_unicast, bool no_stride) {
-            uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+        [](uint32_t num_packed_cmds,
+           uint32_t runtime_args_len,
+           bool is_unicast,
+           bool no_stride,
+           uint32_t l1_alignment) {
             uint32_t sub_cmd_sizeB =
                 is_unicast ? sizeof(CQDispatchWritePackedUnicastSubCmd) : sizeof(CQDispatchWritePackedMulticastSubCmd);
             uint32_t dispatch_cmd_sizeB =
@@ -660,8 +665,8 @@ void generate_runtime_args_cmds(
         };
     thread_local static auto get_runtime_args_data_offset = [](uint32_t num_packed_cmds,
                                                                uint32_t /*runtime_args_len*/,
-                                                               bool is_unicast) {
-        uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+                                                               bool is_unicast,
+                                                               uint32_t l1_alignment) {
         uint32_t sub_cmd_sizeB =
             is_unicast ? sizeof(CQDispatchWritePackedUnicastSubCmd) : sizeof(CQDispatchWritePackedMulticastSubCmd);
         uint32_t dispatch_cmd_sizeB = sizeof(CQDispatchCmd) + tt::align(num_packed_cmds * sub_cmd_sizeB, l1_alignment);
@@ -685,12 +690,11 @@ void generate_runtime_args_cmds(
             num_packed_cmds_in_seq,
             max_packed_cmds);
     }
-    uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     while (num_packed_cmds_in_seq != 0) {
         // Generate the device command
         uint32_t num_packed_cmds = std::min(num_packed_cmds_in_seq, max_packed_cmds);
         uint32_t rt_payload_sizeB =
-            get_runtime_payload_sizeB(num_packed_cmds, max_runtime_args_len, unicast, no_stride);
+            get_runtime_payload_sizeB(num_packed_cmds, max_runtime_args_len, unicast, no_stride, l1_alignment);
         DeviceCommandCalculator calculator(metal_ctx);
         calculator.add_dispatch_write_packed<PackedSubCmd>(
             num_packed_cmds,
@@ -698,7 +702,8 @@ void generate_runtime_args_cmds(
             constants.packed_write_max_unicast_sub_cmds,
             no_stride);
         auto& command_obj = runtime_args_command_sequences.emplace_back(metal_ctx, calculator.write_offset_bytes());
-        uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
+        uint32_t data_offset =
+            (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast, l1_alignment);
         // With watcher off, the buffer stays zero-initialized by HostMemDeviceCommand.
         if (metal_ctx.rtoptions().get_watcher_enabled()) {
             uint32_t total_words = (calculator.write_offset_bytes() - data_offset) / sizeof(uint32_t);
@@ -1139,7 +1144,7 @@ BatchedTransfers assemble_runtime_args_commands(
         // Common RTAs
         // Set by the user based on the kernel ID. All cores running that kernel ID will get these RTAs
         // Ethernet only: unicast to each core
-        if (!tt::tt_metal::MetalContext::instance().hal().get_supports_receiving_multicasts(index)) {
+        if (!metal_ctx.hal().get_supports_receiving_multicasts(index)) {
             for (auto& kg : program.get_kernel_groups(index)) {
                 for (size_t idx = 0; idx < kg->kernel_ids.size(); idx++) {
                     auto kernel_id = get_device_local_kernel_handle(kg->kernel_ids[idx]);
@@ -1249,6 +1254,7 @@ class SemphoreCommandGenerator {
 public:
     // Generate batched_transfers (for multicast) and unicast_semaphore_cmds for the semaphores in the program.
     void size_commands(
+        const MetalContext& metal_ctx,
         ProgramImpl& program,
         IDevice* device,
         DeviceCommandCalculator& calculator,
@@ -1278,7 +1284,7 @@ public:
         semaphore_data.reserve(program.semaphores().size());
 
         // Unicast/Multicast Semaphores
-        const auto& hal = MetalContext::instance().hal();
+        const auto& hal = metal_ctx.hal();
         for (const Semaphore& semaphore : program.semaphores()) {
             semaphore_data.push_back(semaphore.initial_value());
 
@@ -1338,10 +1344,12 @@ public:
 
     // Write unicast semaphore commands to the device command sequence.
     void assemble_unicast_commands(
-        HostMemDeviceCommand& device_command_sequence, ProgramImpl& program, const CommandConstants& constants) const {
+        const MetalContext& metal_ctx,
+        HostMemDeviceCommand& device_command_sequence,
+        ProgramImpl& program,
+        const CommandConstants& constants) const {
         // Unicast Semaphore Cmd
-        uint32_t index =
-            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+        uint32_t index = metal_ctx.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
         for (const auto& cmds : unicast_semaphore_cmds) {
             uint32_t curr_sub_cmd_idx = 0;
             for (const auto& [num_sub_cmds_in_cmd, unicast_sem_payload_sizeB] : cmds.payload) {
@@ -1387,8 +1395,12 @@ public:
     // Construct the circular buffer commands for the program into batched_transfers. This class must stay alive until
     // batched_transfers is used, because batched_transfers contains pointers to the circular buffer data in this class.
     void construct_commands(
-        IDevice* device, const CommandConstants& constants, ProgramImpl& program, BatchedTransfers& batched_transfers) {
-        const auto& hal = MetalContext::instance().hal();
+        const MetalContext& metal_ctx,
+        IDevice* device,
+        const CommandConstants& constants,
+        ProgramImpl& program,
+        BatchedTransfers& batched_transfers) {
+        const auto& hal = metal_ctx.hal();
         uint32_t max_cbs = hal.get_arch_num_circular_buffers();
         uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
@@ -1493,13 +1505,17 @@ private:
 class DataflowBufferCommandGenerator {
 public:
     void construct_commands(
-        IDevice* device, const CommandConstants& constants, ProgramImpl& program, BatchedTransfers& batched_transfers) {
+        const MetalContext& metal_ctx,
+        IDevice* device,
+        const CommandConstants& constants,
+        ProgramImpl& program,
+        BatchedTransfers& batched_transfers) {
         const auto& dataflow_buffers = program.dataflow_buffers();
         if (dataflow_buffers.empty()) {
             return;
         }
 
-        const auto& hal = MetalContext::instance().hal();
+        const auto& hal = metal_ctx.hal();
         uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
         const auto unique_coreranges = program.dataflow_buffers_unique_coreranges();
@@ -1585,6 +1601,7 @@ private:
 class CrossNodeDFBCommandGenerator {
 public:
     void construct_commands(
+        const MetalContext& metal_ctx,
         IDevice* device,
         const CommandConstants& constants,
         ProgramImpl& program,
@@ -1595,7 +1612,7 @@ public:
             return;
         }
 
-        const auto& hal = MetalContext::instance().hal();
+        const auto& hal = metal_ctx.hal();
         const uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         const auto& kernel_groups = program.get_kernel_groups(index);
         const auto& program_config = program.get_program_config(index);
@@ -1920,8 +1937,11 @@ public:
     }
 
     // Assemble the program binary commands into the device command sequence.
-    void assemble_commands(HostMemDeviceCommand& device_command_sequence, bool using_prefetcher_cache) const {
-        const auto& hal = MetalContext::instance().hal();
+    void assemble_commands(
+        const MetalContext& metal_ctx,
+        HostMemDeviceCommand& device_command_sequence,
+        bool using_prefetcher_cache) const {
+        const auto& hal = metal_ctx.hal();
         for (const auto& kernel_bins_unicast_cmd : kernel_bins_unicast_cmds) {
             device_command_sequence.add_data(
                 kernel_bins_unicast_cmd.data(),
@@ -1974,8 +1994,9 @@ public:
     // Construct and optimal set of CQDispatchWritePackedLargeSubCmds from the
     // batched transfers.  This is done by combining adjacent or nearly adjacent
     // transfers into a single command and linking transfers to the same CoreRanges.
-    void construct_commands(BatchedTransfers& batched_transfers, DeviceCommandCalculator& calculator) {
-        const auto& hal = MetalContext::instance().hal();
+    void construct_commands(
+        const MetalContext& metal_ctx, BatchedTransfers& batched_transfers, DeviceCommandCalculator& calculator) {
+        const auto& hal = metal_ctx.hal();
         uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
         // Optimize transfers by combining adjacent or nearly adjacent transfers.
         for (auto& transfer_set : batched_transfers) {
@@ -2043,10 +2064,11 @@ public:
 
     // Assemble the batched transfer commands into the device command sequence.
     void assemble_commands(
+        const MetalContext& metal_ctx,
         ProgramCommandSequence& program_command_sequence,
         HostMemDeviceCommand& device_command_sequence,
         DispatchWriteOffsets write_offset = DISPATCH_WRITE_OFFSET_TENSIX_L1_CONFIG_BASE) {
-        const auto& hal = MetalContext::instance().hal();
+        const auto& hal = metal_ctx.hal();
         uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
         const std::vector<uint8_t> fill_data(l1_alignment, 0);
 
@@ -2158,8 +2180,8 @@ public:
     // This class assumes that the launch message has the same layout for all core types.
     // This assumption is currently valid, but may be relaxed.
     // For now, query the size from HAL and assert it is the same for all core types.
-    LaunchMessageGenerator() {
-        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    explicit LaunchMessageGenerator(const MetalContext& metal_ctx) {
+        const auto& hal = metal_ctx.hal();
         for (uint32_t programmable_core_type_index = 0;
              programmable_core_type_index < hal.get_programmable_core_type_count();
              ++programmable_core_type_index) {
@@ -2177,12 +2199,13 @@ public:
     // Construct the launch message commands for the program.
     // This includes the launch message for the TENSIX and ETH cores.
     void construct_commands(
+        const MetalContext& metal_ctx,
         IDevice* device,
         ProgramImpl& program,
         DeviceCommandCalculator& calculator,
         const CommandConstants& constants,
         SubDeviceId sub_device_id) {
-        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+        const auto& hal = metal_ctx.hal();
         for (uint32_t programmable_core_type_index = 0;
              programmable_core_type_index < hal.get_programmable_core_type_count();
              ++programmable_core_type_index) {
@@ -2278,10 +2301,11 @@ public:
 
     // Assemble the launch message commands into the device command sequence.
     void assemble_commands(
+        const MetalContext& metal_ctx,
         ProgramCommandSequence& program_command_sequence,
         HostMemDeviceCommand& device_command_sequence,
         const CommandConstants& constants) const {
-        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+        const auto& hal = metal_ctx.hal();
         uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
         uint32_t aligned_launch_msg_sizeB = tt::align(launch_msg_sizeB, l1_alignment);
         uint32_t launch_msg_size_words = aligned_launch_msg_sizeB / sizeof(uint32_t);
@@ -2384,6 +2408,7 @@ class GoSignalGenerator {
 public:
     // Determine the size of the go signal commands.
     void size_commands(
+        MetalContext& metal_ctx,
         DeviceCommandCalculator& calculator,
         SubDeviceId /*sub_device_id*/,
         const ProgramTransferInfo& program_transfer_info) {
@@ -2391,7 +2416,7 @@ public:
         // barrier on dispatch_d if program is active) if not,  check if the program is active on workers. If active,
         // have dispatch_d issue a write barrier either dispatch_s or dispatch_d will send the go signal
         // (go_signal_mcast command)
-        if (tt_metal::MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+        if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
             calculator.add_notify_dispatch_s_go_signal_cmd();
         } else {
             // Wait Noc Write Barrier, wait for binaries/configs and launch_msg to be written to worker cores
@@ -2404,6 +2429,7 @@ public:
 
     // Assemble the go signal commands into the device command sequence.
     void assemble_commands(
+        MetalContext& metal_ctx,
         ProgramCommandSequence& program_command_sequence,
         HostMemDeviceCommand& device_command_sequence,
         distributed::MeshDevice* mesh_device,
@@ -2417,7 +2443,7 @@ public:
             has_unicast_launch_cmds ? mesh_device->impl().num_noc_unicast_txns(sub_device_id) : 0;
         DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
         auto sub_device_index = *sub_device_id;
-        if (tt_metal::MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+        if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
             // dispatch_d signals dispatch_s to send the go signal, use a barrier if there are cores active
             uint16_t index_bitmask = 0;
             index_bitmask |= 1 << sub_device_index;
@@ -2436,13 +2462,13 @@ public:
         // Num Workers Resolved when the program is enqueued
         device_command_sequence.add_dispatch_go_signal_mcast(
             0,
-            MetalContext::instance().hal().make_go_msg_u32(
+            metal_ctx.hal().make_go_msg_u32(
                 dev_msgs::RUN_MSG_GO,
                 // Dispatch X/Y resolved when the program is enqueued
                 0,
                 0,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(sub_device_index)),
-            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(sub_device_index),
+                metal_ctx.dispatch_mem_map().get_dispatch_message_update_offset(sub_device_index)),
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(sub_device_index),
             has_multicast_launch_cmds ? sub_device_index : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
             num_noc_unicast_txns,
             noc_data_start_idx,
@@ -2456,7 +2482,7 @@ public:
             sub_device_index,
             num_noc_unicast_txns,
             noc_data_start_idx,
-            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(sub_device_index));
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(sub_device_index));
 
         program_command_sequence.mcast_go_signal_cmd_ptr =
             &(reinterpret_cast<CQDispatchCmd*>(
@@ -2497,35 +2523,36 @@ void assemble_device_commands(
 
     SemphoreCommandGenerator semaphore_command_generator;
     semaphore_command_generator.size_commands(
-        program, mesh_device, program_config_buffer_calculator, constants, batched_transfers);
+        metal_ctx, program, mesh_device, program_config_buffer_calculator, constants, batched_transfers);
 
     CircularBufferCommandGenerator circular_buffer_command_generator;
-    circular_buffer_command_generator.construct_commands(mesh_device, constants, program, batched_transfers);
+    circular_buffer_command_generator.construct_commands(metal_ctx, mesh_device, constants, program, batched_transfers);
 
     DataflowBufferCommandGenerator dfb_command_generator;
-    dfb_command_generator.construct_commands(mesh_device, constants, program, batched_transfers);
+    dfb_command_generator.construct_commands(metal_ctx, mesh_device, constants, program, batched_transfers);
 
     BatchedTransfers absolute_cross_node_config_transfers;
     CrossNodeDFBCommandGenerator cross_node_dfb_command_generator;
     cross_node_dfb_command_generator.construct_commands(
-        mesh_device, constants, program, batched_transfers, absolute_cross_node_config_transfers);
+        metal_ctx, mesh_device, constants, program, batched_transfers, absolute_cross_node_config_transfers);
 
     BatchedTransferGenerator batched_transfer_generator;
-    batched_transfer_generator.construct_commands(batched_transfers, program_config_buffer_calculator);
+    batched_transfer_generator.construct_commands(metal_ctx, batched_transfers, program_config_buffer_calculator);
     BatchedTransferGenerator absolute_cross_node_config_generator;
     absolute_cross_node_config_generator.construct_commands(
-        absolute_cross_node_config_transfers, program_config_buffer_calculator);
+        metal_ctx, absolute_cross_node_config_transfers, program_config_buffer_calculator);
 
     program_command_sequence.program_config_buffer_command_sequence =
         HostMemDeviceCommand(metal_ctx, program_config_buffer_calculator.write_offset_bytes());
     batched_transfer_generator.assemble_commands(
-        program_command_sequence, program_command_sequence.program_config_buffer_command_sequence);
+        metal_ctx, program_command_sequence, program_command_sequence.program_config_buffer_command_sequence);
     absolute_cross_node_config_generator.assemble_commands(
+        metal_ctx,
         program_command_sequence,
         program_command_sequence.program_config_buffer_command_sequence,
         DISPATCH_WRITE_OFFSET_ZERO);
     semaphore_command_generator.assemble_unicast_commands(
-        program_command_sequence.program_config_buffer_command_sequence, program, constants);
+        metal_ctx, program_command_sequence.program_config_buffer_command_sequence, program, constants);
     // Ensure that we use the correct amount of space for each command sequence
     TT_ASSERT(
         program_command_sequence.program_config_buffer_command_sequence.size_bytes() ==
@@ -2551,7 +2578,7 @@ void assemble_device_commands(
     program_command_sequence.program_binary_command_sequence =
         HostMemDeviceCommand(metal_ctx, program_binary_calculator.write_offset_bytes());
     program_binary_command_generator.assemble_commands(
-        program_command_sequence.program_binary_command_sequence, use_prefetcher_cache);
+        metal_ctx, program_command_sequence.program_binary_command_sequence, use_prefetcher_cache);
     TT_ASSERT(
         program_command_sequence.program_binary_command_sequence.size_bytes() ==
         program_command_sequence.program_binary_command_sequence.write_offset_bytes());
@@ -2575,14 +2602,14 @@ void assemble_device_commands(
     }
 
     // Assemble launch message
-    LaunchMessageGenerator launch_message_generator;
+    LaunchMessageGenerator launch_message_generator(metal_ctx);
     DeviceCommandCalculator launch_message_calculator(metal_ctx);
     launch_message_generator.construct_commands(
-        mesh_device, program, launch_message_calculator, constants, sub_device_id);
+        metal_ctx, mesh_device, program, launch_message_calculator, constants, sub_device_id);
     program_command_sequence.launch_msg_command_sequence =
         HostMemDeviceCommand(metal_ctx, launch_message_calculator.write_offset_bytes());
     launch_message_generator.assemble_commands(
-        program_command_sequence, program_command_sequence.launch_msg_command_sequence, constants);
+        metal_ctx, program_command_sequence, program_command_sequence.launch_msg_command_sequence, constants);
     TT_ASSERT(
         program_command_sequence.launch_msg_command_sequence.size_bytes() ==
         program_command_sequence.launch_msg_command_sequence.write_offset_bytes());
@@ -2590,10 +2617,11 @@ void assemble_device_commands(
     // Assemble go signal
     GoSignalGenerator go_signal_generator;
     DeviceCommandCalculator go_signal_calculator(metal_ctx);
-    go_signal_generator.size_commands(go_signal_calculator, sub_device_id, program_transfer_info);
+    go_signal_generator.size_commands(metal_ctx, go_signal_calculator, sub_device_id, program_transfer_info);
     program_command_sequence.go_msg_command_sequence =
         HostMemDeviceCommand(metal_ctx, go_signal_calculator.write_offset_bytes());
     go_signal_generator.assemble_commands(
+        metal_ctx,
         program_command_sequence,
         program_command_sequence.go_msg_command_sequence,
         mesh_device,
@@ -2768,6 +2796,8 @@ void update_program_dispatch_commands(
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update,
     uint8_t cq_id) {
+    TT_ASSERT(cached_program_command_sequence.ctx != nullptr);
+    MetalContext& metal_ctx = *cached_program_command_sequence.ctx;
     uint32_t i = 0;
 
     static constexpr uint32_t wait_count_offset = (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, wait.count));
@@ -2793,18 +2823,18 @@ void update_program_dispatch_commands(
         wait_count_offset, &(dispatch_md.sync_count), sizeof(uint32_t));
     // insert_stall_cmds baked in a placeholder wait.addr; patch in the real completion address for cq_id here. Unused
     // when this arch waits via a NOC stream register instead of an L1 address.
-    if (!MetalContext::instance().hal().has_stream_registers()) {
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
-        const uint32_t wait_addr = mem_map.get_dispatch_message_addr_start() +
-                                   mem_map.get_completion_counter_offset(cq_id) *
-                                       MetalContext::instance().hal().get_alignment(HalMemType::L1) +
-                                   mem_map.get_sync_offset(*sub_device_id);
+    if (!metal_ctx.hal().has_stream_registers()) {
+        const auto& mem_map = metal_ctx.dispatch_mem_map();
+        const uint32_t wait_addr =
+            mem_map.get_dispatch_message_addr_start() +
+            mem_map.get_completion_counter_offset(cq_id) * metal_ctx.hal().get_alignment(HalMemType::L1) +
+            mem_map.get_sync_offset(*sub_device_id);
         cached_program_command_sequence.stall_command_sequences[curr_stall_seq_idx].update_cmd_sequence(
             wait_addr_offset, &wait_addr, sizeof(uint32_t));
     }
 
     // Update preamble based on kernel config ring buffer slot
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         tensix_l1_write_offset_offset,
         &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
@@ -2900,8 +2930,6 @@ void update_program_dispatch_commands(
     // Update prefetcher cache initialization
     if (cached_program_command_sequence.prefetcher_cache_used) {
         // reserve space for cache command
-        TT_ASSERT(cached_program_command_sequence.ctx != nullptr);
-        MetalContext& metal_ctx = *cached_program_command_sequence.ctx;
         uint32_t pcie_alignment = metal_ctx.hal().get_alignment(tt::tt_metal::HalMemType::HOST);
         cached_program_command_sequence.program_binary_setup_prefetcher_cache_command =
             HostMemDeviceCommand(metal_ctx, tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
@@ -2963,8 +2991,8 @@ void update_program_dispatch_commands(
         dev_msgs::RUN_MSG_GO,
         dispatch_core.x,
         dispatch_core.y,
-        MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(*sub_device_id) +
-            MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id));
+        metal_ctx.dispatch_mem_map().get_dispatch_message_update_offset(*sub_device_id) +
+            metal_ctx.dispatch_mem_map().get_completion_counter_offset(cq_id));
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
     // Update the number of unicast txns based on user provided parameter
     // This is required when a MeshWorkload uses ethernet cores on a set of devices
@@ -2990,9 +3018,11 @@ void update_traced_program_dispatch_commands(
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update,
     uint8_t cq_id) {
+    TT_ASSERT(cached_program_command_sequence.ctx != nullptr);
+    MetalContext& metal_ctx = *cached_program_command_sequence.ctx;
     uint32_t i = 0;
     TTZoneScopedDN(DISPATCH, "program_loaded_on_device");
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     const ProgramImpl& program = *trace_node.program;
     const TraceDispatchMetadata& dispatch_md = trace_node.dispatch_metadata;
 
@@ -3023,7 +3053,7 @@ void update_traced_program_dispatch_commands(
     // insert_stall_cmds baked in a placeholder wait.addr; patch in the real completion address for cq_id here. Unused
     // when this arch waits via a NOC stream register instead of an L1 address.
     if (!hal.has_stream_registers()) {
-        const auto& mem_map = MetalContext::instance().dispatch_mem_map();
+        const auto& mem_map = metal_ctx.dispatch_mem_map();
         const uint32_t wait_addr = mem_map.get_dispatch_message_addr_start() +
                                    mem_map.get_completion_counter_offset(cq_id) * hal.get_alignment(HalMemType::L1) +
                                    mem_map.get_sync_offset(*sub_device_id);
@@ -3112,8 +3142,6 @@ void update_traced_program_dispatch_commands(
     // Update prefetcher cache initialization
     if (dispatch_md.send_binary && cached_program_command_sequence.prefetcher_cache_used) {
         // reserve space for cache command
-        TT_ASSERT(cached_program_command_sequence.ctx != nullptr);
-        MetalContext& metal_ctx = *cached_program_command_sequence.ctx;
         uint32_t pcie_alignment = metal_ctx.hal().get_alignment(tt::tt_metal::HalMemType::HOST);
         cached_program_command_sequence.program_binary_setup_prefetcher_cache_command =
             HostMemDeviceCommand(metal_ctx, tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
@@ -3185,8 +3213,8 @@ void update_traced_program_dispatch_commands(
         dev_msgs::RUN_MSG_GO,
         dispatch_core.x,
         dispatch_core.y,
-        MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(*sub_device_id) +
-            MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id));
+        metal_ctx.dispatch_mem_map().get_dispatch_message_update_offset(*sub_device_id) +
+            metal_ctx.dispatch_mem_map().get_completion_counter_offset(cq_id));
     cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
     // Update the number of unicast txns based on user provided parameter
     // This is required when a MeshWorkload uses ethernet cores on a set of devices
@@ -3208,6 +3236,8 @@ void write_program_command_sequence(
     bool stall_first,
     bool stall_before_program,
     bool send_binary) {
+    TT_ASSERT(program_command_sequence.ctx != nullptr);
+    const MetalContext& metal_ctx = *program_command_sequence.ctx;
     LOG_TRACE_LAZY(tt::LogDispatch, "");
     LOG_TRACE_LAZY(
         tt::LogDispatch, "========== Writing Program Command Sequence to CQ {} ==========", command_queue_id);
@@ -3221,7 +3251,7 @@ void write_program_command_sequence(
     // Check if it's possible to write all commands in a single fetch queue entry
     uint32_t one_shot_fetch_size =
         program_command_sequence.get_one_shot_fetch_size(stall_first, stall_before_program, send_binary);
-    bool one_shot = one_shot_fetch_size <= MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    bool one_shot = one_shot_fetch_size <= metal_ctx.dispatch_mem_map().max_prefetch_command_size();
 
     LOG_TRACE_LAZY(tt::LogDispatch, "One-shot mode: {}, Fetch size: {} bytes", one_shot, one_shot_fetch_size);
     if (one_shot) {
@@ -3324,6 +3354,8 @@ TraceNode create_trace_node(
     // By using the traced command sequence, we know the RTA data source-of-truth isn't this command sequence (it's in a
     // regular cached program command sequence), so rta_updates includes all the RTAs.
     auto& cached_program_command_sequence = program.get_trace_cached_program_command_sequences().at(command_hash);
+    TT_ASSERT(cached_program_command_sequence.ctx != nullptr);
+    const MetalContext& metal_ctx = *cached_program_command_sequence.ctx;
     std::vector<std::vector<uint8_t>> rta_data;
     rta_data.reserve(cached_program_command_sequence.rta_updates.size());
     for (auto& update : cached_program_command_sequence.rta_updates) {
@@ -3333,7 +3365,7 @@ TraceNode create_trace_node(
 
     std::vector<std::vector<uint32_t>> all_cb_configs_payloads;
     all_cb_configs_payloads.reserve(cached_program_command_sequence.circular_buffers_on_core_ranges.size());
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     uint32_t max_cbs = hal.get_arch_num_circular_buffers();
     uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
@@ -3434,7 +3466,9 @@ uint32_t program_base_addr_on_core(
     TT_FATAL(
         sub_device_ids.size() == 1, "get_sem_base_addr currently only supports programs spanning a single sub-device");
     // ProgramImpl always uses the HAL address and does not support CQs
-    return MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
+    return MetalContext::instance(extract_context_id(device))
+        .hal()
+        .get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
 }
 
 // MeshWorkloadImpl version - supports both CQs and not having CQs
@@ -3450,7 +3484,9 @@ uint32_t program_base_addr_on_core(
     auto sub_device_index = **sub_device_ids.begin();
     auto* cq = mesh_workload.get_last_used_command_queue();
     return cq ? (cq->get_config_buffer_mgr(sub_device_index).get_last_slot_addr(programmable_core_type))
-              : MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
+              : MetalContext::instance(extract_context_id(mesh_device))
+                    .hal()
+                    .get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
 }
 
 void reset_config_buf_mgrs_and_expected_workers(
@@ -3481,12 +3517,12 @@ void reset_worker_dispatch_state_on_device(
         for (int i = 0; i < num_sub_devices; ++i) {
             calculator.add_dispatch_go_signal_mcast();
         }
-        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+        if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
             calculator.add_notify_dispatch_s_go_signal_cmd();
         }
     }
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
-        if (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) {
+        if (metal_ctx.get_dispatch_query_manager().distributed_dispatcher()) {
             calculator.add_dispatch_wait();
         }
         calculator.add_dispatch_wait();
@@ -3498,7 +3534,7 @@ void reset_worker_dispatch_state_on_device(
     HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
     if (reset_launch_msg_state) {
-        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+        if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
             uint16_t index_bitmask = 0;
             for (uint32_t i = 0; i < num_sub_devices; ++i) {
                 index_bitmask |= 1 << i;
@@ -3511,13 +3547,13 @@ void reset_worker_dispatch_state_on_device(
             SubDeviceId sub_device_id(static_cast<uint8_t>(i));
             command_sequence.add_dispatch_go_signal_mcast(
                 expected_num_workers_completed[i],
-                MetalContext::instance().hal().make_go_msg_u32(
+                metal_ctx.hal().make_go_msg_u32(
                     dev_msgs::RUN_MSG_RESET_READ_PTR,
                     dispatch_core.x,
                     dispatch_core.y,
-                    MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(i) +
-                        MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id)),
-                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(i),
+                    metal_ctx.dispatch_mem_map().get_dispatch_message_update_offset(i) +
+                        metal_ctx.dispatch_mem_map().get_completion_counter_offset(cq_id)),
+                metal_ctx.dispatch_mem_map().get_dispatch_stream_index(i),
                 mesh_device->impl().has_noc_mcast_txns(sub_device_id) ? i : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
                 mesh_device->impl().num_noc_unicast_txns(sub_device_id),
                 mesh_device->impl().noc_data_start_index(sub_device_id),
@@ -3534,11 +3570,11 @@ void reset_worker_dispatch_state_on_device(
             expected_num_workers += mesh_device->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) +
                                     mesh_device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
         }
-        if (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) {
+        if (metal_ctx.get_dispatch_query_manager().distributed_dispatcher()) {
             command_sequence.add_dispatch_wait(
                 CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
                 0,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(i),
+                metal_ctx.dispatch_mem_map().get_dispatch_stream_index(i),
                 expected_num_workers,
                 cq_id,
                 1);
@@ -3546,7 +3582,7 @@ void reset_worker_dispatch_state_on_device(
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
             0,
-            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(i),
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(i),
             expected_num_workers,
             cq_id);
     }
@@ -3564,14 +3600,14 @@ void set_num_worker_sems_on_dispatch(
     TT_ASSERT(workers_per_sub_device.size() == num_worker_sems);
     MetalContext& metal_ctx = MetalContext::instance(manager.get_context_id());
     tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
-    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+    if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
         calculator.add_dispatch_set_num_worker_sems();
     }
     calculator.add_dispatch_set_sub_device_worker_counts(num_worker_sems);
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
     HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
-    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+    if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
         command_sequence.add_dispatch_set_num_worker_sems(num_worker_sems, DispatcherSelect::DISPATCH_SUBORDINATE);
         command_sequence.add_dispatch_set_sub_device_worker_counts(
             workers_per_sub_device, DispatcherSelect::DISPATCH_SUBORDINATE);
@@ -3592,10 +3628,9 @@ void set_go_signal_noc_data_on_dispatch(
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
     void* cmd_region = manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
     HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, cmd_sequence_sizeB);
-    DispatcherSelect dispatcher_for_go_signal =
-        MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()
-            ? DispatcherSelect::DISPATCH_SUBORDINATE
-            : DispatcherSelect::DISPATCH_MASTER;
+    DispatcherSelect dispatcher_for_go_signal = metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()
+                                                    ? DispatcherSelect::DISPATCH_SUBORDINATE
+                                                    : DispatcherSelect::DISPATCH_MASTER;
     command_sequence.add_dispatch_set_go_signal_noc_data(go_signal_noc_data, dispatcher_for_go_signal);
     manager.issue_queue_push_back(cmd_sequence_sizeB, cq_id);
     manager.fetch_queue_reserve_back(cq_id);
@@ -3607,8 +3642,7 @@ void reset_expected_num_workers_completed_on_device(
     Device* device, SubDeviceId sub_device_id, uint32_t num_expected_workers, uint8_t cq_id) {
     MetalContext& metal_ctx = MetalContext::instance(device->get_context_id());
     tt::tt_metal::DeviceCommandCalculator calculator(metal_ctx);
-    bool distributed_dispatcher =
-        tt::tt_metal::MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
+    bool distributed_dispatcher = metal_ctx.get_dispatch_query_manager().distributed_dispatcher();
     if (distributed_dispatcher) {
         calculator.add_dispatch_wait();
     }
@@ -3622,7 +3656,7 @@ void reset_expected_num_workers_completed_on_device(
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
             0,
-            tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(*sub_device_id),
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(*sub_device_id),
             num_expected_workers,
             cq_id,
             dispatcher_type);
@@ -3720,13 +3754,13 @@ void set_core_go_message_mapping_on_device(
     // garbage in the GO message entries they aren't using.
     std::vector<uint32_t> go_data(dev_msgs::go_message_num_entries, dev_msgs::RUN_MSG_DONE);
     TT_ASSERT(
-        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG) %
-            MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
+        metal_ctx.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG) %
+            metal_ctx.hal().get_alignment(HalMemType::L1) ==
         0);
     command_sequence.add_dispatch_write_linear<true, true>(
         all_core_range_logical.size(),
         device->get_noc_multicast_encoding(noc_index, all_core_range_virtual),
-        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG),
+        metal_ctx.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG),
         go_msg_size,
         go_data.data());
     // Wait for previous writes before updating index.
@@ -3735,14 +3769,13 @@ void set_core_go_message_mapping_on_device(
     // Write go index to all cores.
     if (!sub_cmds.empty()) {
         TT_ASSERT(
-            MetalContext::instance().hal().get_dev_addr(
-                HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX) %
-                MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
+            metal_ctx.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX) %
+                metal_ctx.hal().get_alignment(HalMemType::L1) ==
             0);
-        uint32_t go_msg_index_addr = MetalContext::instance().hal().get_dev_addr(
-            HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX);
-        uint32_t go_msg_index_size = MetalContext::instance().hal().get_dev_size(
-            HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX);
+        uint32_t go_msg_index_addr =
+            metal_ctx.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX);
+        uint32_t go_msg_index_size =
+            metal_ctx.hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG_INDEX);
         uint32_t curr_sub_cmd_idx = 0;
         for (const auto& [num_sub_cmds_in_cmd, payload_sizeB] : payload) {
             command_sequence.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1024,7 +1024,7 @@ BatchedTransfers assemble_runtime_args_commands(
                     transfer_info.num_dests,
                     crta_offset,
                     size);
-                RecordDispatchData(program.get_id(), DISPATCH_DATA_RTARGS, size);
+                RecordDispatchData(program.get_context_id(), program.get_id(), DISPATCH_DATA_RTARGS, size);
                 transfers[std::make_pair(noc_xy_addr, transfer_info.num_dests)][crta_offset] =
                     std::vector<Transfer>{Transfer{
                         .start = crta_offset,
@@ -1123,7 +1123,11 @@ BatchedTransfers assemble_runtime_args_commands(
                 }
                 for (auto& data_per_kernel : unique_rt_data_and_sizes) {
                     for (auto& data_and_sizes : data_per_kernel) {
-                        RecordDispatchData(program.get_id(), DISPATCH_DATA_RTARGS, std::get<1>(data_and_sizes));
+                        RecordDispatchData(
+                            program.get_context_id(),
+                            program.get_id(),
+                            DISPATCH_DATA_RTARGS,
+                            std::get<1>(data_and_sizes));
                     }
                 }
                 unique_sub_cmds.clear();
@@ -1220,7 +1224,11 @@ BatchedTransfers assemble_runtime_args_commands(
 
                 for (auto& data_per_kernel : common_rt_data_and_sizes) {
                     for (auto& data_and_sizes : data_per_kernel) {
-                        RecordDispatchData(program.get_id(), DISPATCH_DATA_RTARGS, std::get<1>(data_and_sizes));
+                        RecordDispatchData(
+                            program.get_context_id(),
+                            program.get_id(),
+                            DISPATCH_DATA_RTARGS,
+                            std::get<1>(data_and_sizes));
                     }
                 }
             }
@@ -1291,7 +1299,8 @@ public:
                         dst_noc_info.num_dests,
                         start_addr,
                         semaphore_data.back());
-                    RecordDispatchData(program.get_id(), DISPATCH_DATA_SEMAPHORE, sizeof(uint32_t));
+                    RecordDispatchData(
+                        program.get_context_id(), program.get_id(), DISPATCH_DATA_SEMAPHORE, sizeof(uint32_t));
                     batched_transfers[std::make_pair(noc_xy_addr, dst_noc_info.num_dests)][start_addr] =
                         std::vector<Transfer>{
                             {{.start = start_addr,
@@ -1351,7 +1360,8 @@ public:
                     DISPATCH_WRITE_OFFSET_ETH_L1_CONFIG_BASE);
                 curr_sub_cmd_idx += num_sub_cmds_in_cmd;
                 for (const auto& data_and_size : cmds.data) {
-                    RecordDispatchData(program.get_id(), DISPATCH_DATA_SEMAPHORE, data_and_size.second);
+                    RecordDispatchData(
+                        program.get_context_id(), program.get_id(), DISPATCH_DATA_SEMAPHORE, data_and_size.second);
                 }
             }
         }
@@ -1463,7 +1473,8 @@ public:
                     core_range.size(),
                     start_addr,
                     max_index * sizeof(uint32_t));
-                RecordDispatchData(program.get_id(), DISPATCH_DATA_CB_CONFIG, max_index * sizeof(uint32_t));
+                RecordDispatchData(
+                    program.get_context_id(), program.get_id(), DISPATCH_DATA_CB_CONFIG, max_index * sizeof(uint32_t));
 
                 batched_transfers[std::make_pair(noc_xy_addr, core_range.size())][start_addr] = std::vector<Transfer>{
                     {.start = start_addr,
@@ -1744,6 +1755,7 @@ public:
                         nullptr,
                         write_offset);
                     RecordDispatchData(
+                        program.get_context_id(),
                         program.get_id(),
                         DISPATCH_DATA_BINARY,
                         kg_transfer_info.lengths[kernel_idx],
@@ -1858,6 +1870,7 @@ public:
                             .num_mcast_dests = (uint8_t)num_mcast_dests,
                             .flags = CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK});
                         RecordDispatchData(
+                            program.get_context_id(),
                             program.get_id(),
                             DISPATCH_DATA_BINARY,
                             write_length,
@@ -2808,7 +2821,7 @@ void update_program_dispatch_commands(
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         program_host_id_offset, &runtime_id, sizeof(runtime_id));
 
-    RecordProgramMetadata(program);
+    RecordProgramMetadata(program.get_context_id(), program);
 
     if (hal.get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
@@ -3392,7 +3405,7 @@ TraceNode create_trace_node(
         cross_node_config_pages.push_back(page);
     }
 
-    RecordProgramMetadata(program);
+    RecordProgramMetadata(program.get_context_id(), program);
 
     return TraceNode{
         program.shared_from_this(),

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -100,9 +100,8 @@ namespace program_dispatch {
 
 namespace {
 
-inline bool is_watcher_assert_enabled() {
-    return tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() &&
-           !tt::tt_metal::MetalContext::instance().rtoptions().watcher_assert_disabled();
+inline bool is_watcher_assert_enabled(const MetalContext& metal_ctx) {
+    return metal_ctx.rtoptions().get_watcher_enabled() && !metal_ctx.rtoptions().watcher_assert_disabled();
 }
 
 struct CommandConstants {
@@ -143,11 +142,12 @@ DispatchWriteOffsets get_dispatch_write_offset(HalProgrammableCoreType core_type
 };  // namespace
 
 uint32_t configure_rta_offsets_for_kernel_groups(
+    const MetalContext& metal_ctx,
     uint32_t /*programmable_core_type_index*/,
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset) {
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     uint32_t max_unique_rta_size = 0;
     uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
@@ -155,7 +155,7 @@ uint32_t configure_rta_offsets_for_kernel_groups(
         // Initialize RTA/CRTA offsets to sentinel when watcher enabled. Launch message memory
         // may contain stale data from previous dispatches. Can't use 0 as "no args" since 0 is
         // a valid L1 offset. Sentinel (0xFFFF) distinguishes "no args" from "args at offset 0"
-        if (is_watcher_assert_enabled()) {
+        if (is_watcher_assert_enabled(metal_ctx)) {
             auto rta_offsets = kg->launch_msg.view().kernel_config().rta_offset();
             for (size_t i = 0; i < rta_offsets.size(); i++) {
                 kg->launch_msg.view().kernel_config().rta_offset()[i].rta_offset() = RTA_CRTA_NO_ARGS_SENTINEL;
@@ -203,11 +203,12 @@ uint32_t configure_rta_offsets_for_kernel_groups(
 }
 
 uint32_t configure_crta_offsets_for_kernel_groups(
+    const MetalContext& metal_ctx,
     uint32_t /*programmable_core_type_index*/,
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t crta_base_offset) {
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = metal_ctx.hal();
     uint32_t max_crta_size = 0;
     uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
@@ -262,16 +263,17 @@ uint32_t configure_crta_offsets_for_kernel_groups(
 }
 
 uint32_t finalize_rt_args(
+    const MetalContext& metal_ctx,
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset,
     uint32_t programmable_core_type_index,
     uint32_t& rta_offset) {
     uint32_t max_unique_rta_size = program_dispatch::configure_rta_offsets_for_kernel_groups(
-        programmable_core_type_index, kernels, kernel_groups, base_offset);
+        metal_ctx, programmable_core_type_index, kernels, kernel_groups, base_offset);
     uint32_t crta_base_offset = base_offset + max_unique_rta_size;
     uint32_t max_crta_size = program_dispatch::configure_crta_offsets_for_kernel_groups(
-        programmable_core_type_index, kernels, kernel_groups, crta_base_offset);
+        metal_ctx, programmable_core_type_index, kernels, kernel_groups, crta_base_offset);
 
     uint32_t offset = max_unique_rta_size + max_crta_size;
 
@@ -280,25 +282,27 @@ uint32_t finalize_rt_args(
 }
 
 uint32_t finalize_sems(
+    const MetalContext& metal_ctx,
     uint32_t programmable_core_type_index,
     uint32_t sem_base_offset,
     const std::vector<Semaphore>& semaphores,
     uint32_t& semaphore_offset,
     uint32_t& semaphore_size) {
     int max_id = -1;
-    CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
+    CoreType core_type = metal_ctx.hal().get_core_type(programmable_core_type_index);
     for (const auto& sem : semaphores) {
         if (sem.core_type() == core_type && (int)sem.id() > max_id) {
             max_id = sem.id();
         }
     }
-    uint32_t sem_size = (max_id + 1) * MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    uint32_t sem_size = (max_id + 1) * metal_ctx.hal().get_alignment(HalMemType::L1);
     semaphore_offset = sem_base_offset;
     semaphore_size = sem_size;
     return sem_base_offset + sem_size;
 }
 
 uint32_t finalize_cbs(
+    const MetalContext& metal_ctx,
     uint32_t /*programmable_core_type_index*/,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset,
@@ -306,7 +310,7 @@ uint32_t finalize_cbs(
     uint32_t& cb_size,
     uint32_t& local_cb_size) {
     uint32_t max_local_end_index = 0;
-    uint32_t max_cbs = MetalContext::instance().hal().get_arch_num_circular_buffers();
+    uint32_t max_cbs = metal_ctx.hal().get_arch_num_circular_buffers();
     uint32_t min_remote_start_index = max_cbs;
 
     for (auto& kg : kernel_groups) {
@@ -331,7 +335,7 @@ uint32_t finalize_cbs(
     cb_offset = base_offset;
     cb_size = total_cb_size;
 
-    return tt::align(base_offset + total_cb_size, MetalContext::instance().hal().get_alignment(HalMemType::L1));
+    return tt::align(base_offset + total_cb_size, metal_ctx.hal().get_alignment(HalMemType::L1));
 }
 
 void finalize_dfb_masks(
@@ -362,7 +366,10 @@ void finalize_dfb_masks(
 // ranges. Merging participants by logical core would incorrectly give a non-NONE offset to a
 // program with no CrossNodeDFBs, causing firmware to parse stale kernel-config words.
 uint32_t finalize_cross_node_dfbs(
-    uint32_t programmable_core_type_index, ttsl::Span<ProgramImpl*> programs, uint32_t base_offset) {
+    const MetalContext& metal_ctx,
+    uint32_t programmable_core_type_index,
+    ttsl::Span<ProgramImpl*> programs,
+    uint32_t base_offset) {
     uint8_t max_num_cross_node_dfbs = 0;
     for (ProgramImpl* program : programs) {
         max_num_cross_node_dfbs = std::max(max_num_cross_node_dfbs, program->num_cross_node_dfb_slots());
@@ -412,8 +419,7 @@ uint32_t finalize_cross_node_dfbs(
         }
     }
 
-    return tt::align(
-        base_offset + cross_node_dfb_region_bytes, MetalContext::instance().hal().get_alignment(HalMemType::L1));
+    return tt::align(base_offset + cross_node_dfb_region_bytes, metal_ctx.hal().get_alignment(HalMemType::L1));
 }
 
 // Build the dense device config region from a core's sparse host participant records.
@@ -731,7 +737,7 @@ void generate_runtime_args_cmds(
         // When watcher assert is enabled, RTAs are stored as [count | args...] in the command buffer
         // RuntimeArgsData.rt_args_data points to args (skips count) for user-facing API
         // data_in_sequence points to args location in command buffer for retargeting
-        uint32_t count_word_offset = is_watcher_assert_enabled() ? 1 : 0;
+        uint32_t count_word_offset = is_watcher_assert_enabled(metal_ctx) ? 1 : 0;
         const uint32_t data_inc = tt::align(max_runtime_args_len * sizeof(uint32_t), l1_alignment);
         uint32_t num_data_copies = no_stride ? 1 : num_packed_cmds;
         for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
@@ -809,7 +815,7 @@ void generate_runtime_args_cmds_large_unicast(
     // Device reads rta_payload_sizeB bytes per sub-command, then pads the read pointer to `alignment`, so
     // consecutive per-core payloads in the command stream are separated by this aligned size.
     const uint32_t aligned_core_payload = tt::align(rta_payload_sizeB, l1_alignment);
-    const uint32_t count_word_offset = is_watcher_assert_enabled() ? 1 : 0;
+    const uint32_t count_word_offset = is_watcher_assert_enabled(metal_ctx) ? 1 : 0;
     // Cap cores/command by the prefetcher command size, not just the sub-cmd count (see helper above).
     const uint32_t max_cores_per_cmd =
         max_cores_per_large_unicast_cmd(metal_ctx, rta_payload_sizeB, max_prefetch_command_size);
@@ -881,8 +887,8 @@ void generate_runtime_args_cmds_large_unicast(
 // A kernel group's unique RTAs must go through CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST when their
 // per-core payload exceeds one dispatch page: the CQ_DISPATCH_CMD_WRITE_PACKED device handler asserts each
 // per-core write fits a single dispatch page (its `size` field is uint16_t and it does not wrap CB pages).
-bool unique_rta_requires_large_unicast(uint32_t total_rta_size) {
-    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+bool unique_rta_requires_large_unicast(const MetalContext& metal_ctx, uint32_t total_rta_size) {
+    const uint32_t l1_alignment = metal_ctx.hal().get_alignment(HalMemType::L1);
     const uint32_t dispatch_page_size = 1u << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
     return tt::align(total_rta_size, l1_alignment) > dispatch_page_size;
 }
@@ -950,7 +956,7 @@ BatchedTransfers assemble_runtime_args_commands(
         for (auto& kg : program.get_kernel_groups(programmable_core_type_index)) {
             if (kg->total_rta_size != 0) {
                 uint32_t num_sub_cmds = kg->core_ranges.num_cores();
-                if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
+                if (unique_rta_requires_large_unicast(metal_ctx, kg->total_rta_size)) {
                     command_count += div_up(
                         num_sub_cmds,
                         max_cores_per_large_unicast_cmd(
@@ -969,7 +975,7 @@ BatchedTransfers assemble_runtime_args_commands(
         }
     }
 
-    uint32_t count_word_offset = is_watcher_assert_enabled() ? 1 : 0;
+    uint32_t count_word_offset = is_watcher_assert_enabled(metal_ctx) ? 1 : 0;
 
     // Ethernet only: unicast to each core
     for (uint32_t p_idx = 0; p_idx < hal.get_programmable_core_type_count(); p_idx++) {
@@ -1098,7 +1104,7 @@ BatchedTransfers assemble_runtime_args_commands(
                     }
                 }
                 uint32_t rta_offset = program.get_program_config(index).rta_offset;
-                if (unique_rta_requires_large_unicast(kg->total_rta_size)) {
+                if (unique_rta_requires_large_unicast(metal_ctx, kg->total_rta_size)) {
                     // Per-core payload exceeds one dispatch page; the packed-write handler cannot span
                     // pages, so send these unique RTAs via CQ_DISPATCH_CMD_WRITE_PACKED_LARGE_UNICAST.
                     generate_runtime_args_cmds_large_unicast(
@@ -2074,7 +2080,7 @@ public:
 
         // Byte offset to skip count word when watcher enabled. Uses sizeof(uint32_t) instead of 1
         // because transfer.data and data_collection_location are byte pointers (uint8_t*)
-        uint32_t count_word_byte_offset = is_watcher_assert_enabled() ? sizeof(uint32_t) : 0;
+        uint32_t count_word_byte_offset = is_watcher_assert_enabled(metal_ctx) ? sizeof(uint32_t) : 0;
         // Write out batched semaphore + CB multicast transfers.
         for (uint32_t i = 0; i < batched_dispatch_subcmds.size(); ++i) {
             auto& cmd_data = batched_cmd_data[i];

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -29,6 +29,7 @@
 namespace tt::tt_metal {
 class Device;
 class IDevice;
+class MetalContext;
 class Program;
 class Semaphore;
 class SystemMemoryManager;
@@ -66,18 +67,21 @@ struct ExpectedNumWorkerUpdates {
 };
 
 uint32_t configure_rta_offsets_for_kernel_groups(
+    const MetalContext& metal_ctx,
     uint32_t programmable_core_type_index,
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset);
 
 uint32_t configure_crta_offsets_for_kernel_groups(
+    const MetalContext& metal_ctx,
     uint32_t programmable_core_type_index,
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t crta_base_offset);
 
 uint32_t finalize_rt_args(
+    const MetalContext& metal_ctx,
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset,
@@ -85,6 +89,7 @@ uint32_t finalize_rt_args(
     uint32_t& rta_offset);
 
 uint32_t finalize_sems(
+    const MetalContext& metal_ctx,
     uint32_t programmable_core_type_index,
     uint32_t sem_base_offset,
     const std::vector<Semaphore>& semaphores,
@@ -92,6 +97,7 @@ uint32_t finalize_sems(
     uint32_t& semaphore_size);
 
 uint32_t finalize_cbs(
+    const MetalContext& metal_ctx,
     uint32_t programmable_core_type_index,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset,
@@ -109,7 +115,10 @@ void finalize_dfb_masks(
 // Size the CrossNodeDFB dense kernel-config index from the workload-wide max slot count.
 // Each fixed entry is [absolute_config_buffer_addr, entry_size, relay_dfb_id].
 uint32_t finalize_cross_node_dfbs(
-    uint32_t programmable_core_type_index, ttsl::Span<detail::ProgramImpl*> programs, uint32_t base_offset);
+    const MetalContext& metal_ctx,
+    uint32_t programmable_core_type_index,
+    ttsl::Span<detail::ProgramImpl*> programs,
+    uint32_t base_offset);
 
 // Cores of a kernel group that share the same CrossNodeDFB kernel-config payload.
 // Each rectangle in `cores` can be covered by a single multicast.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -106,12 +106,12 @@ namespace {
 using namespace tt::tt_metal;
 
 size_t get_ringbuffer_size(IDevice* device, HalProgrammableCoreType programmable_core_type) {
+    const auto& hal = MetalContext::instance(extract_context_id(device)).hal();
     if (programmable_core_type == HalProgrammableCoreType::TENSIX) {
         return device->allocator_impl()->get_config().l1_unreserved_base -
-               MetalContext::instance().hal().get_dev_addr(
-                   HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+               hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
     }
-    return MetalContext::instance().hal().get_dev_size(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
+    return hal.get_dev_size(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
 }
 
 void validate_kernel_placement(bool force_slow_dispatch, std::shared_ptr<Kernel> kernel, tt::ChipId physical_chip_id) {
@@ -120,17 +120,18 @@ void validate_kernel_placement(bool force_slow_dispatch, std::shared_ptr<Kernel>
     //      - tensix kernels cannot be on dispatch cores
     //  Fast dispatch (ethernet):
     //      - eth kernels cannot be on idle eth cores
-    bool slow_dispatch = !(MetalContext::instance().rtoptions().get_fast_dispatch());
+    MetalContext& metal_ctx = MetalContext::instance(kernel->get_context_id());
+    bool slow_dispatch = !(metal_ctx.rtoptions().get_fast_dispatch());
 
-    const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
-    tt::CoreType dispatch_core_type =
-        resolve_dispatch_core_type(MetalEnvAccessor(MetalContext::instance().get_env()).impl(), physical_chip_id, dispatch_core_config);
+    const auto& dispatch_core_config = metal_ctx.get_dispatch_core_manager().get_dispatch_core_config();
+    tt::CoreType dispatch_core_type = resolve_dispatch_core_type(
+        MetalEnvAccessor(metal_ctx.get_env()).impl(), physical_chip_id, dispatch_core_config);
 
     // Kernels used to implement fast dispatch can be placed on dispatch cores
     if (not slow_dispatch and not force_slow_dispatch) {
         const std::vector<CoreCoord>& dispatch_cores =
-            MetalContext::instance().get_dispatch_query_manager().get_logical_dispatch_cores_on_user_chips();
-        const auto& service_claims = MetalContext::instance().get_service_core_manager().impl();
+            metal_ctx.get_dispatch_query_manager().get_logical_dispatch_cores_on_user_chips();
+        const auto& service_claims = metal_ctx.get_service_core_manager().impl();
         bool on_dispatch_core = std::any_of(
             dispatch_cores.begin(),
             dispatch_cores.end(),
@@ -177,8 +178,9 @@ void generate_kernel_source_files(
 // the client can skip the remote round-trip (preprocess + RPC + ELF transfer) entirely and let
 // read_binaries() load the cached ELF.
 bool remote_kernel_cached(IDevice* device, const std::shared_ptr<Kernel>& kernel) {
-    uint32_t core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
+    uint32_t core_type = MetalContext::instance(kernel->get_context_id())
+                             .hal()
+                             .get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
     uint32_t proc_class = enchantum::to_underlying(kernel->get_kernel_processor_class());
     int num_binaries = kernel->expected_num_binaries();
     if (num_binaries <= 0) {
@@ -200,8 +202,9 @@ bool remote_kernel_cached(IDevice* device, const std::shared_ptr<Kernel>& kernel
 // step left on disk plus the link inputs. Called only after the remote compile succeeds and the ELFs
 // are on disk, so a failed compile leaves no validatable cache to reuse a stale ELF.
 void finalize_preprocess_reuse_cache(IDevice* device, const std::shared_ptr<Kernel>& kernel) {
-    uint32_t core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
+    uint32_t core_type = MetalContext::instance(kernel->get_context_id())
+                             .hal()
+                             .get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
     uint32_t proc_class = enchantum::to_underlying(kernel->get_kernel_processor_class());
     int num_binaries = kernel->expected_num_binaries();
     for (int i = 0; i < num_binaries; ++i) {
@@ -222,8 +225,9 @@ KernelCompileDescriptor build_kernel_descriptor(
     const auto& build_env =
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id());
 
-    uint32_t core_type =
-        MetalContext::instance().hal().get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
+    uint32_t core_type = MetalContext::instance(kernel->get_context_id())
+                             .hal()
+                             .get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
     uint32_t proc_class = enchantum::to_underlying(kernel->get_kernel_processor_class());
 
     KernelCompileDescriptor desc;
@@ -1843,7 +1847,7 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
 
     // Flatten MeshDevice into constituent physical devices so ServiceCoreManager (keyed by ChipId) can be queried per
     // core
-    const auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager().impl();
+    const auto& svc = tt::tt_metal::MetalContext::instance(context_id_).get_service_core_manager().impl();
     std::vector<const IDevice*> devices_for_svc_check;
     if (svc.has_any_claims()) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
@@ -1934,7 +1938,7 @@ void detail::ProgramImpl::validate_circular_buffer_core_ranges(const IDevice* de
     auto grid_size = device->compute_with_storage_grid_size();
     // Flatten MeshDevice into constituent physical devices so ServiceCoreManager (keyed by ChipId) can be queried per
     // core. Mirrors validate_circular_buffer_region.
-    const auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager().impl();
+    const auto& svc = tt::tt_metal::MetalContext::instance(context_id_).get_service_core_manager().impl();
     std::unordered_set<CoreCoord> claimed;
     if (svc.has_any_claims()) {
         if (const auto* mesh = dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device)) {
@@ -1976,14 +1980,15 @@ void detail::ProgramImpl::validate_circular_buffer_core_ranges(const IDevice* de
 
 void detail::ProgramImpl::init_semaphores(
     const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const {
-    const auto& hal = MetalContext::instance().hal();
+    MetalContext& metal_ctx = MetalContext::instance(context_id_);
+    const auto& hal = metal_ctx.hal();
     HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(programmable_core_type_index);
     uint64_t kernel_config_base = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
     uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
-    CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
+    CoreType core_type = hal.get_core_type(programmable_core_type_index);
     auto semaphores_on_core = this->semaphores_on_core(logical_core, core_type);
     for (auto semaphore : semaphores_on_core) {
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        metal_ctx.get_cluster().write_core(
             device.id(),
             device.virtual_core_from_logical_core(logical_core, core_type),
             std::vector{semaphore.get().initial_value()},
@@ -2235,7 +2240,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
     }
 
     std::uint32_t num_active_cores = 0;
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id_).hal();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);
         for (const auto& kernel_group : this->get_kernel_groups(index)) {
@@ -2319,7 +2324,7 @@ const ProgramConfig& detail::ProgramImpl::get_program_config(uint32_t programmab
 }
 
 void detail::ProgramImpl::set_launch_msg_sem_offsets() {
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id_).hal();
     for (uint32_t kg_type_index = 0; kg_type_index < hal.get_programmable_core_type_count(); kg_type_index++) {
         for (auto& kg : this->get_kernel_groups(kg_type_index)) {
             auto sem_offset = kg->launch_msg.view().kernel_config().sem_offset();
@@ -2336,13 +2341,15 @@ uint32_t& detail::ProgramImpl::get_program_config_size(uint32_t programmable_cor
 }
 
 const std::vector<SubDeviceId>& detail::ProgramImpl::determine_sub_device_ids(const IDevice* device) {
+    const auto& metal_ctx = MetalContext::instance(context_id_);
+    const auto& hal = metal_ctx.hal();
     // We need to calculate the sub_device_id when we haven't compiled the program yet, or this is the first time we
     // are getting the sub_device_ids after compilation
     auto sub_device_manager_id = device->get_active_sub_device_manager_id();
     auto& sub_device_ids_map = this->sub_device_ids_[device->id()];
     auto sub_device_ids = sub_device_ids_map.find(sub_device_manager_id);
     if (this->compiled_.empty() || sub_device_ids == sub_device_ids_map.end()) {
-        if (!MetalContext::instance().rtoptions().get_fast_dispatch() ||
+        if (!metal_ctx.rtoptions().get_fast_dispatch() ||
             sub_device_manager_id == device->get_default_sub_device_manager_id()) {
             // No sub device manager, nothing to validate
             auto [sub_device_ids, _] =
@@ -2351,12 +2358,11 @@ const std::vector<SubDeviceId>& detail::ProgramImpl::determine_sub_device_ids(co
         }
         std::unordered_set<SubDeviceId> used_sub_device_ids;
         auto find_sub_device_ids = [&](HalProgrammableCoreType core_type) {
-            auto core_type_index = MetalContext::instance().hal().get_programmable_core_type_index(core_type);
+            auto core_type_index = hal.get_programmable_core_type_index(core_type);
             if (core_type_index == -1) {
                 return;
             }
-            const auto& program_kgs =
-                this->get_kernel_groups(MetalContext::instance().hal().get_programmable_core_type_index(core_type));
+            const auto& program_kgs = this->get_kernel_groups(hal.get_programmable_core_type_index(core_type));
             uint32_t num_intersections = 0;
             uint32_t num_cores = 0;
             for (const auto& kg : program_kgs) {
@@ -2404,12 +2410,13 @@ void detail::ProgramImpl::allocate_kernel_bin_buf_on_device(IDevice* device) {
 
 void ProgramImpl::generate_dispatch_commands(distributed::MeshDevice* mesh_device, bool use_prefetcher_cache) {
     uint64_t command_hash = *mesh_device->get_active_sub_device_manager_id();
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(mesh_device));
 
     uint64_t device_hash =
         BuildEnvManager::get_instance(extract_context_id(mesh_device))
             .get_device_build_env(mesh_device->build_id())
             .build_key();
-    if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
+    if (not metal_ctx.hal().is_coordinate_virtualization_enabled()) {
         ttsl::hash::hash_combine(device_hash, mesh_device->id());
     }
     if (!is_cached()) {
@@ -2424,7 +2431,7 @@ void ProgramImpl::generate_dispatch_commands(distributed::MeshDevice* mesh_devic
     if (!cached_program_command_sequences.contains(command_hash)) {
         // Programs currently only support spanning a single sub-device
         auto sub_device_id = this->determine_sub_device_ids(mesh_device).at(0);
-        ProgramCommandSequence program_command_sequence{MetalContext::instance(extract_context_id(mesh_device))};
+        ProgramCommandSequence program_command_sequence{metal_ctx};
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id);
         program_dispatch::assemble_device_commands(
@@ -2445,12 +2452,13 @@ void ProgramImpl::generate_dispatch_commands(distributed::MeshDevice* mesh_devic
 
 void ProgramImpl::generate_trace_dispatch_commands(distributed::MeshDevice* mesh_device, bool use_prefetcher_cache) {
     uint64_t command_hash = *mesh_device->get_active_sub_device_manager_id();
+    MetalContext& metal_ctx = MetalContext::instance(extract_context_id(mesh_device));
 
     uint64_t device_hash =
         BuildEnvManager::get_instance(extract_context_id(mesh_device))
             .get_device_build_env(mesh_device->build_id())
             .build_key();
-    if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
+    if (not metal_ctx.hal().is_coordinate_virtualization_enabled()) {
         device_hash = (device_hash << 32) | (mesh_device->id());
     }
     if (!is_cached()) {
@@ -2465,7 +2473,7 @@ void ProgramImpl::generate_trace_dispatch_commands(distributed::MeshDevice* mesh
     if (!trace_cached_program_command_sequences.contains(command_hash)) {
         // Programs currently only support spanning a single sub-device
         auto sub_device_id = this->determine_sub_device_ids(mesh_device).at(0);
-        ProgramCommandSequence program_command_sequence{MetalContext::instance(extract_context_id(mesh_device))};
+        ProgramCommandSequence program_command_sequence{metal_ctx};
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id);
         program_dispatch::assemble_device_commands(
@@ -2707,17 +2715,19 @@ void Program::set_runtime_id(ProgramId id) { internal_->set_runtime_id(id); }
 uint32_t detail::ProgramImpl::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = tt::tt_metal::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
-    return base_addr + this->get_program_config(
-                               MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
-                           .sem_offset;
+    return base_addr +
+           this->get_program_config(
+                   MetalContext::instance(context_id_).hal().get_programmable_core_type_index(programmable_core_type))
+               .sem_offset;
 }
 
 uint32_t detail::ProgramImpl::get_cb_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = tt::tt_metal::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
-    return base_addr + this->get_program_config(
-                               MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
-                           .cb_offset;
+    return base_addr +
+           this->get_program_config(
+                   MetalContext::instance(context_id_).hal().get_programmable_core_type_index(programmable_core_type))
+               .cb_offset;
 }
 
 void detail::ProgramImpl::set_last_used_command_queue_for_testing(HWCommandQueue* queue) {
@@ -2731,7 +2741,7 @@ HWCommandQueue* detail::ProgramImpl::get_last_used_command_queue() const {
 uint32_t detail::ProgramImpl::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
     HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(virtual_core);
-    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
+    uint32_t index = MetalContext::instance(context_id_).hal().get_programmable_core_type_index(programmable_core_type);
 
     return this->program_configs_[index].sem_size;
 }
@@ -2739,7 +2749,7 @@ uint32_t detail::ProgramImpl::get_sem_size(IDevice* device, CoreCoord logical_co
 uint32_t detail::ProgramImpl::get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
     HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(virtual_core);
-    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
+    uint32_t index = MetalContext::instance(context_id_).hal().get_programmable_core_type_index(programmable_core_type);
 
     return this->program_configs_[index].cb_size;
 }
@@ -2858,7 +2868,7 @@ void detail::ProgramImpl::set_program_attrs_across_core_types(IDevice* device) {
     program_config_sizes_[programmable_core_count_ + 1] = runs_on_noc_unicast_only_cores();
     set_launch_msg_sem_offsets();
     // TODO: This check is wrong - it populates dispatch data for dispatch kernels
-    if (MetalContext::instance().rtoptions().get_fast_dispatch()) {
+    if (MetalContext::instance(context_id_).rtoptions().get_fast_dispatch()) {
         populate_dispatch_data(device);  // TODO: maybe rename
     }
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1186,7 +1186,8 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
             index++;
         }
         for (const auto& kg : kernel_groups_[programmable_core_type_index]) {
-            RecordKernelGroup(*this, hal.get_programmable_core_type(programmable_core_type_index), *kg);
+            RecordKernelGroup(
+                this->get_context_id(), *this, hal.get_programmable_core_type(programmable_core_type_index), *kg);
         }
     }
 }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2912,7 +2912,8 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
     ttsl::Span<ProgramImpl*> programs) {
     ProgramOffsetsState state;
 
-    const auto& hal = MetalContext::instance(context_id).hal();
+    const MetalContext& metal_ctx = MetalContext::instance(context_id);
+    const auto& hal = metal_ctx.hal();
 
     // Collect dataflow buffers from all programs
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers;
@@ -2931,17 +2932,28 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(index);
         state.offset = program_dispatch::finalize_rt_args(
-            kernels_getter(index), kernel_groups_getter(index), state.config_base_offset, index, state.rta_offset);
+            metal_ctx,
+            kernels_getter(index),
+            kernel_groups_getter(index),
+            state.config_base_offset,
+            index,
+            state.rta_offset);
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 
-        state.offset =
-            program_dispatch::finalize_sems(index, state.offset, semaphores_getter(), state.sem_offset, state.sem_size);
+        state.offset = program_dispatch::finalize_sems(
+            metal_ctx, index, state.offset, semaphores_getter(), state.sem_offset, state.sem_size);
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 
         state.offset = program_dispatch::finalize_cbs(
-            index, kernel_groups_getter(index), state.offset, state.cb_offset, state.cb_size, state.local_cb_size);
+            metal_ctx,
+            index,
+            kernel_groups_getter(index),
+            state.offset,
+            state.cb_offset,
+            state.cb_size,
+            state.local_cb_size);
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 
@@ -2959,7 +2971,7 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
         // CrossNodeDFB dense index; full pages live in program-owned config Buffers.
         // cross_node_dfb_offset is CROSS_NODE_DFB_OFFSET_NONE if there are no participants.
         uint32_t prev_offset_before_cross_node_dfb = state.offset;
-        state.offset = program_dispatch::finalize_cross_node_dfbs(index, programs, state.offset);
+        state.offset = program_dispatch::finalize_cross_node_dfbs(metal_ctx, index, programs, state.offset);
         state.cross_node_dfb_offset = (state.offset > prev_offset_before_cross_node_dfb)
                                           ? (prev_offset_before_cross_node_dfb - state.config_base_offset)
                                           : CROSS_NODE_DFB_OFFSET_NONE;

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -98,7 +98,7 @@ void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDe
 
 void SubDeviceManagerTracker::load_sub_device_manager(SubDeviceManagerId sub_device_manager_id) {
     TT_FATAL(
-        tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch(),
+        tt::tt_metal::MetalContext::instance(extract_context_id(device_)).rtoptions().get_fast_dispatch(),
         "Using sub device managers is unsupported with slow dispatch");
     if (active_sub_device_manager_->id() == sub_device_manager_id) {
         return;

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -91,7 +91,7 @@ void issue_trace_commands(
     HugepageDeviceCommand command_sequence(metal_ctx, cmd_region, dispatch_md.cmd_sequence_sizeB);
 
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
-    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+    if (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled()) {
         uint16_t index_bitmask = 0;
         for (const auto& id : dispatch_md.sub_device_ids) {
             index_bitmask |= 1 << *id;
@@ -111,13 +111,13 @@ void issue_trace_commands(
         // Wait to ensure that all kernels have completed. Then send the reset_rd_ptr go_signal.
         command_sequence.add_dispatch_go_signal_mcast(
             expected_num_workers_completed[index],
-            MetalContext::instance().hal().make_go_msg_u32(
+            metal_ctx.hal().make_go_msg_u32(
                 dev_msgs::RUN_MSG_REPLAY_TRACE,
                 dispatch_core.x,
                 dispatch_core.y,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_message_update_offset(index) +
-                    MetalContext::instance().dispatch_mem_map().get_completion_counter_offset(cq_id)),
-            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(index),
+                metal_ctx.dispatch_mem_map().get_dispatch_message_update_offset(index) +
+                    metal_ctx.dispatch_mem_map().get_completion_counter_offset(cq_id)),
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(index),
             desc.num_traced_programs_needing_go_signal_multicast && mesh_device->impl().has_noc_mcast_txns(id)
                 ? index
                 : CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET,
@@ -139,11 +139,11 @@ void issue_trace_commands(
             expected_num_workers += mesh_device->impl().num_virtual_eth_cores(id);
         }
 
-        if (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) {
+        if (metal_ctx.get_dispatch_query_manager().distributed_dispatcher()) {
             command_sequence.add_dispatch_wait(
                 CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
                 0,
-                MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(index),
+                metal_ctx.dispatch_mem_map().get_dispatch_stream_index(index),
                 expected_num_workers,
                 cq_id,
                 1);
@@ -151,7 +151,7 @@ void issue_trace_commands(
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
             0,
-            MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(index),
+            metal_ctx.dispatch_mem_map().get_dispatch_stream_index(index),
             expected_num_workers,
             cq_id);
     }
@@ -172,14 +172,15 @@ void issue_trace_commands(
     sysmem_manager.fetch_queue_write(dispatch_md.cmd_sequence_sizeB, cq_id, stall_prefetcher);
 }
 
-uint32_t compute_trace_cmd_size(uint32_t num_sub_devices) {
-    const auto& hal = MetalContext::instance().hal();
+uint32_t compute_trace_cmd_size(ContextId context_id, uint32_t num_sub_devices) {
+    MetalContext& metal_ctx = MetalContext::instance(context_id);
+    const auto& hal = metal_ctx.hal();
     uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
     uint32_t go_signals_cmd_size =
         align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) * num_sub_devices;
 
     uint32_t cmd_sequence_sizeB =
-        (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() *
+        (metal_ctx.get_dispatch_query_manager().dispatch_s_enabled() *
          hal.get_alignment(
              HalMemType::HOST)) +  // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
         go_signals_cmd_size +      // go signal cmd
@@ -189,8 +190,7 @@ uint32_t compute_trace_cmd_size(uint32_t num_sub_devices) {
                                    // dispatch_s is responsible for resetting worker count and giving dispatch_d the
                                    // latest worker state. This is encapsulated in the dispatch_s wait command (only to
                                    // be sent when dispatch is distributed on 2 cores)
-          (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) *
-              hal.get_alignment(HalMemType::HOST)) *
+          (metal_ctx.get_dispatch_query_manager().distributed_dispatcher()) * hal.get_alignment(HalMemType::HOST)) *
          num_sub_devices) +
         hal.get_alignment(HalMemType::HOST);  // CQ_PREFETCH_CMD_EXEC_BUF
 

--- a/tt_metal/impl/trace/dispatch.hpp
+++ b/tt_metal/impl/trace/dispatch.hpp
@@ -13,6 +13,7 @@
 #include "core_coord.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "dispatch/worker_config_buffer.hpp"
+#include "impl/context/context_types.hpp"
 #include "sub_device_types.hpp"
 #include "trace_buffer.hpp"
 
@@ -76,7 +77,7 @@ void issue_trace_commands(
     const DispatchArray<uint32_t>& expected_num_workers_completed,
     CoreCoord dispatch_core);
 
-uint32_t compute_trace_cmd_size(uint32_t num_sub_devices);
+uint32_t compute_trace_cmd_size(ContextId context_id, uint32_t num_sub_devices);
 
 void update_worker_state_post_trace_execution(
     const std::unordered_map<SubDeviceId, TraceWorkerDescriptor>& trace_worker_descriptors,


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Related to https://github.com/tenstorrent/tt-metal/issues/52020.

Removes ~220 calls to the zero-argument `MetalContext::instance()` from the device/dispatch runtime and the program/kernel internals. Each call site now gets its context from something it already holds: a `ContextId` stored on the object, one derived from the device or sysmem manager, or a `MetalContext&` already in scope.
The zero-argument `instance()` resolves a single default context, so any code that calls it cannot work with more than one context. This PR moves the affected call sites off it.

What changed:
- Device, command queue, system memory manager, and event/trace/buffer dispatch resolve context from `device` / `sysmem` / an existing local.
- Kernel and program objects use their stored context id.

### Notes for reviewers
Five public realtime-profiler registration wrappers in `data_collection.cpp` are process-global entry points with no caller-side handle, so they are unchanged for now.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/metal-context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/metal-context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/metal-context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/metal-context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/metal-context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/metal-context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/metal-context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/metal-context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/metal-context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/metal-context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/metal-context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/metal-context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/metal-context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/metal-context-2)