### PR TITLE
#54587: add --no-web-server switch to disable the Tracy WASM web UI

### DIFF
--- a/docs/source/tt-metalium/tools/tracy_profiler.rst
+++ b/docs/source/tt-metalium/tools/tracy_profiler.rst
@@ -70,6 +70,14 @@ By default the HTTP server listens on **8080**. To use a different HTTP port, pa
 
 In addition to the HTTP port, a **WebSocket** is used for live refresh on port *P*\ +1 (one above the chosen HTTP port *P*).
 
+The web viewer is started as a **daemon**, so it keeps listening after the run that started it exits. For headless CI, or for measurement loops that only want the numbers, turn it off with ``--no-web-server``:
+
+.. code-block:: bash
+
+    python -m tracy --no-web-server -m pytest path/to/test.py
+
+The equivalent env var is ``TRACY_NO_WEB_SERVER=1``, which is convenient for switching the UI off across a whole CI job without editing each command. With either one, no HTTP or WebSocket port is bound and no server process is left behind; the capture and any reports are unaffected.
+
 Remote host (SSH)
 ~~~~~~~~~~~~~~~~~
 

--- a/models/demos/minimax_m3/tests/perf/README_profiling.md
+++ b/models/demos/minimax_m3/tests/perf/README_profiling.md
@@ -236,6 +236,10 @@ rm -f  build/profiler/build_wasm/traces/*.tracy
 pkill -f tools/tracy/serve_wasm.py     # tracy leaves a WASM server on :8080
 ```
 
+The `pkill` line is only needed if the web viewer was started at all. Profiling runs that just want
+the numbers can skip it by capturing with `python -m tracy --no-web-server ...` (or exporting
+`TRACY_NO_WEB_SERVER=1` for the whole session), which never starts the server in the first place.
+
 ## Reference numbers
 
 Sanity references for "does my capture look right", **not** CI targets — they are per-zone kernel

--- a/tests/ttnn/tracy/test_tracy_wasm_http_integration.py
+++ b/tests/ttnn/tracy/test_tracy_wasm_http_integration.py
@@ -500,3 +500,92 @@ def test_kill_previous_server_is_port_scoped(tmp_path):
         assert proc.poll() is not None, "port-scoped cleanup must reap the matching-port server"
     finally:
         _terminate_serve_wasm(proc)
+
+
+# ---------------------------------------------------------------------------
+# Web-UI kill switch (--no-web-server / TRACY_NO_WEB_SERVER=1).
+#
+# The WASM server is a daemon, so it outlives the `python -m tracy` run that
+# started it and can be left listening on :8080 long after pytest exits. Headless
+# CI and measurement loops need a way to never start it -- these lock in that the
+# switch binds no port and spawns nothing, rather than starting-then-stopping.
+# ---------------------------------------------------------------------------
+
+
+def test_web_server_disabled_reads_env():
+    """web_server_disabled() honours the documented truthy spellings, and nothing else."""
+    from tracy.serve_wasm import web_server_disabled
+
+    prev = os.environ.get("TRACY_NO_WEB_SERVER")
+    try:
+        for value in ("1", "true", "TRUE", "Yes", "on", " 1 "):
+            os.environ["TRACY_NO_WEB_SERVER"] = value
+            assert web_server_disabled(), f"{value!r} should disable the web UI"
+        for value in ("", "0", "false", "no", "off"):
+            os.environ["TRACY_NO_WEB_SERVER"] = value
+            assert not web_server_disabled(), f"{value!r} should leave the web UI enabled"
+        os.environ.pop("TRACY_NO_WEB_SERVER", None)
+        assert not web_server_disabled(), "unset must leave the web UI enabled (default is on)"
+    finally:
+        os.environ.pop("TRACY_NO_WEB_SERVER", None)
+        if prev is not None:
+            os.environ["TRACY_NO_WEB_SERVER"] = prev
+
+
+@pytest.mark.timeout(120)
+def test_no_web_server_env_starts_nothing(tmp_path):
+    """TRACY_NO_WEB_SERVER=1 must return without spawning a server or binding the port."""
+    if not SERVE_WASM.is_file():
+        pytest.skip(f"serve_wasm.py not found: {SERVE_WASM}")
+
+    _make_wasm_serve_dir(tmp_path)
+    port = _find_free_port_pair()
+    snippet = (
+        "import os\n"
+        "os.environ['TRACY_NO_WEB_SERVER'] = '1'\n"
+        "from tracy.serve_wasm import launch_server_subprocess\n"
+        f"r = launch_server_subprocess(port={port})\n"
+        "print('DISABLED' if r is None else 'SPAWNED:%s' % r.pid)\n"
+    )
+    res = _run_in_serve_wasm_env(snippet, tmp_path)
+    assert res.returncode == 0, res.stderr
+    assert "DISABLED" in res.stdout, f"expected no spawn, got stdout={res.stdout!r} stderr={res.stderr!r}"
+    # The point of the switch is that nothing is left listening afterwards.
+    assert _port_free(port), f"HTTP port {port} was bound despite TRACY_NO_WEB_SERVER=1"
+    assert _port_free(port + 1), f"WebSocket port {port + 1} was bound despite TRACY_NO_WEB_SERVER=1"
+
+
+@pytest.mark.timeout(120)
+def test_no_web_server_flag_starts_nothing_with_env_unset(tmp_path):
+    """enabled=False (what --no-web-server passes) disables on its own, no env var needed."""
+    if not SERVE_WASM.is_file():
+        pytest.skip(f"serve_wasm.py not found: {SERVE_WASM}")
+
+    _make_wasm_serve_dir(tmp_path)
+    port = _find_free_port_pair()
+    snippet = (
+        "import os\n"
+        "os.environ.pop('TRACY_NO_WEB_SERVER', None)\n"
+        "from tracy.serve_wasm import launch_server_subprocess\n"
+        f"r = launch_server_subprocess(port={port}, enabled=False)\n"
+        "print('DISABLED' if r is None else 'SPAWNED:%s' % r.pid)\n"
+    )
+    res = _run_in_serve_wasm_env(snippet, tmp_path)
+    assert res.returncode == 0, res.stderr
+    assert "DISABLED" in res.stdout, f"expected no spawn, got stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert _port_free(port), f"HTTP port {port} was bound despite enabled=False"
+    assert _port_free(port + 1), f"WebSocket port {port + 1} was bound despite enabled=False"
+
+
+def test_tracy_cli_exposes_no_web_server_flag():
+    """``python -m tracy --help`` must advertise the switch (this is the user-facing contract)."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(TOOLS_DIR) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    env.setdefault("TT_METAL_HOME", str(REPO_ROOT))
+    res = subprocess.run(
+        [sys.executable, "-m", "tracy", "--help"], env=env, capture_output=True, text=True, timeout=120
+    )
+    if res.returncode != 0:
+        pytest.skip(f"`python -m tracy --help` unavailable in this environment: {res.stderr[-400:]}")
+    assert "--no-web-server" in res.stdout, "python -m tracy must expose --no-web-server"
+    assert "TRACY_NO_WEB_SERVER" in res.stdout, "the --no-web-server help must name the env-var equivalent"

--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -47,6 +47,15 @@ def main():
         help="HTTP port for the Tracy WASM web UI after capture (default: 8080, or TRACY_WASM_HTTP_PORT if set). WebSocket uses this port + 1.",
     )
     parser.add_option(
+        "--no-web-server",
+        dest="web_server",
+        action="store_false",
+        default=None,
+        help="Do not start the Tracy WASM web UI after capture. The server is a daemon and outlives the run that "
+        "started it, so headless CI and measurement loops that only want the numbers should turn it off. "
+        "Same effect as setting TRACY_NO_WEB_SERVER=1.",
+    )
+    parser.add_option(
         "--no-op-info-cache",
         dest="opInfoCache",
         action="store_false",
@@ -481,8 +490,10 @@ def main():
                     logger.info(f"embed.tracy -> traces/{tracy_dst.name}")
                 except Exception as e:
                     logger.warning(f"Could not update embed.tracy: {e}")
-                launch_server_subprocess(port=options.web_app_port)
-                # Start the WASM server as a daemon with defaults
+                # Start the WASM server as a daemon with defaults, unless it was switched off
+                # (--no-web-server / TRACY_NO_WEB_SERVER=1) -- it outlives this process, so a
+                # headless run must be able to avoid leaving one listening.
+                launch_server_subprocess(port=options.web_app_port, enabled=options.web_server)
                 if options.report:
                     generate_report(
                         outputFolder,

--- a/tools/tracy/serve_wasm.py
+++ b/tools/tracy/serve_wasm.py
@@ -30,6 +30,12 @@ from tracy.common import (
 # WebSocket port is always HTTP+1 (see run_server).
 DEFAULT_HTTP_PORT = 8080
 
+# Turn the web UI off entirely (no HTTP server, no WebSocket, no lingering daemon):
+#   - CLI:  python -m tracy --no-web-server ...
+#   - env:  TRACY_NO_WEB_SERVER=1
+# For headless CI and measurement loops that only want the numbers.
+_TRUTHY = ("1", "true", "yes", "on")
+
 _SERVER_LOG_BASENAME = "tracy_wasm_gui_server.log"
 
 
@@ -178,6 +184,16 @@ def _resolve_wasm_http_port(explicit_port=None):
     return port
 
 
+def web_server_disabled() -> bool:
+    """True when ``TRACY_NO_WEB_SERVER`` asks for the WASM web UI to stay off.
+
+    Mirrors ``TRACY_WASM_HTTP_PORT``: an explicit CLI flag wins, this is the env
+    fallback. Enforced inside ``launch_server_subprocess`` so *every* caller is
+    covered, not just ``python -m tracy``.
+    """
+    return os.environ.get("TRACY_NO_WEB_SERVER", "").strip().lower() in _TRUTHY
+
+
 def _list_traces_newest_first(traces_dir: Path) -> list[str]:
     """Basenames of regular ``*.tracy`` files under ``traces_dir``, newest first.
 
@@ -280,7 +296,17 @@ def _kill_previous_server_process(target_port: int):
         logger.warning(f"Could not kill previous server process: {e}")
 
 
-def launch_server_subprocess(directory=None, port=None, daemon=True):
+def launch_server_subprocess(directory=None, port=None, daemon=True, enabled=None):
+    """Start the WASM web UI server, unless it has been switched off.
+
+    ``enabled=False`` (``python -m tracy --no-web-server``) or ``TRACY_NO_WEB_SERVER=1``
+    returns ``None`` without binding a port or spawning anything, so nothing is left
+    listening after the run that started it exits. ``enabled=None`` means "no explicit
+    CLI choice" and defers to the env var.
+    """
+    if enabled is False or (enabled is None and web_server_disabled()):
+        logger.info("Tracy WASM web UI disabled (--no-web-server / TRACY_NO_WEB_SERVER); not starting a server.")
+        return None
     logger.info("Launching tracy web app GUI server subprocess...")
     http_port = _resolve_wasm_http_port(port)
     ws_port = http_port + 1


### PR DESCRIPTION
### PR Category

Feature

Add --no-web-server to disable the Tracy WASM web UI`

### Summary

Relates to #54587.

`python -m tracy` unconditionally started `tools/tracy/serve_wasm.py` after a capture. The
server is a **daemon**, so it kept listening on `:8080` (and `:8081` for the live-reload
WebSocket) long after the run that spawned it had exited. There was no way to opt out, so
headless CI and measurement loops that only want the numbers had to clean up by hand
This adds a switch to turn the web UI off entirely:

```bash
python -m tracy --no-web-server -m pytest path/to/test.py
```

With either one, no HTTP or WebSocket port is bound and no process is spawned. Capture and
report generation are unaffected — this turns off the *viewer*, not the profiling.

Default behaviour is unchanged: with no flag and no env var, the server starts exactly as
before.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mo/54587_tracy_no_web_server)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mo/54587_tracy_no_web_server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mo/54587_tracy_no_web_server)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mo/54587_tracy_no_web_server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mo/54587_tracy_no_web_server)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mo/54587_tracy_no_web_server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mo/54587_tracy_no_web_server)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mo/54587_tracy_no_web_server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mo/54587_tracy_no_web_server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mo/54587_tracy_no_web_server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mo/54587_tracy_no_web_server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mo/54587_tracy_no_web_server)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mo/54587_tracy_no_web_server)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mo/54587_tracy_no_web_server)