### PR TITLE
[emule] Stub the v2 fabric mux kernel too

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -540,6 +540,10 @@ struct KernelInfo {
     // Kernel source path; owns the string __emule_kernel_name points at during
     // this kernel's launch (used by the ASAN trace to name the offending kernel).
     std::string kernel_name;
+    // Count of unique (per-core) runtime-arg words = size of the rta_offset region.
+    // rt_arg_values is [unique..(this many).., common..]; used to bounds-check
+    // out-of-range per-core arg reads to 0 (silicon zero-pad).
+    uint32_t num_unique_rt_args = 0;
 };
 
 // Captures a Metal 2.0 kernel's named bindings. Drives both the JIT wrapper's
@@ -626,6 +630,7 @@ struct PendingKernelInfo {
     // Object-Intent uses them to find this kernel's I/O tensors (§12).
     std::vector<uint32_t> rt_arg_values;
     std::string kernel_name;  // kernel source path, for the ASAN trace
+    uint32_t num_unique_rt_args = 0;  // size of the per-core (rta) region; see KernelInfo
 };
 
 // DFB allocation info for a single DFB on a core. Only device_slot and base_addr
@@ -1933,8 +1938,10 @@ static void collect_kernels(
                         // core; the Object-Intent check uses them to find its I/O tensors
                         // (see ObjectIntentTracker::pre_launch_snapshot). Build once, copy.
                         std::vector<uint32_t> rt_arg_values;
+                        uint32_t num_unique_rt = 0;
                         if (kernel->cores_with_runtime_args().count(logical_core) != 0) {
                             const auto& ra = kernel->runtime_args(logical_core);
+                            num_unique_rt = static_cast<uint32_t>(ra.size());
                             rt_arg_values.insert(rt_arg_values.end(), ra.begin(), ra.end());
                         }
                         const auto& cra = kernel->common_runtime_args();
@@ -1953,7 +1960,8 @@ static void collect_kernels(
                                 rta_off,
                                 crta_off,
                                 rt_arg_values,
-                                src_path});
+                                src_path,
+                                num_unique_rt});
                         }
                     }
                 }
@@ -3605,6 +3613,10 @@ static void launch_cores(
             ctx->common_rt_args = (ki.crta_offset_in_kc != kRtaCrtaNoArgsSentinel)
                 ? reinterpret_cast<uint32_t*>(core->l1_ptr(ki.kernel_config_base + ki.crta_offset_in_kc))
                 : nullptr;
+            // Bounds so out-of-range per-core/common arg reads return 0 (silicon zero-pads
+            // the RTA region; emule's mock L1 keeps stale bytes).
+            ctx->rt_args_count = ki.num_unique_rt_args;
+            ctx->common_rt_args_count = static_cast<uint32_t>(ki.rt_arg_values.size()) - ki.num_unique_rt_args;
             ctx->bridge_l1 = l1_data;
             ctx->l1_size = static_cast<uint32_t>(core->l1_size());
             ctx->bridge_dram = dram_data;
@@ -3796,6 +3808,7 @@ static std::shared_ptr<ResolvedProgram> prepare_program(IDevice* device, Program
                 ki.variants.push_back(resolved_fns.at(key));
             }
             ki.rt_arg_values = std::move(pk.rt_arg_values);
+            ki.num_unique_rt_args = pk.num_unique_rt_args;
             ki.kernel_name = std::move(pk.kernel_name);
             resolved.core_kernels[logical_core].push_back(std::move(ki));
         }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -976,7 +976,7 @@ static std::function<void()> jit_compile_kernel(
     // keeps relative includes in the patched file resolvable.
     std::string patched_kernel_path = dir + "/patched_kernel.cpp";
     // WORKAROUND: see tt-emule/.claude/skills/workarounds (WA-2).
-    // The fabric mux (tt_fabric_mux.cpp) is a transport-layer aggregation kernel: workers write packets
+    // The fabric mux (tt_fabric_mux.cpp, and the v2 rename) is a transport-layer aggregation kernel: workers write packets
     // into its L1 channels and it forwards them over ethernet. emule has no ethernet — WorkerToFabricMux
     // Sender teleports each packet straight to its final destination (same as the no-mux direct path),
     // so the mux has nothing to do. The real kernel is also persistent (loops until an external
@@ -984,12 +984,13 @@ static std::function<void()> jit_compile_kernel(
     // compile and hang emule's run-to-completion join. Substitute a no-op kernel: it compiles, exits
     // immediately, and the teleporting mux sender carries the data. (Mirrors how emule collapses the eth
     // router/switch into the teleport — the mux is the worker-side half of that same transport.)
-    if (std::filesystem::path(abs_kernel).filename() == "tt_fabric_mux.cpp") {
+    const std::string kernel_basename = std::filesystem::path(abs_kernel).filename().string();
+    if (kernel_basename == "tt_fabric_mux.cpp" || kernel_basename == "tt_fabric_mux_v2.cpp") {
         std::ofstream f(patched_kernel_path);
         if (!f) {
             throw std::runtime_error("jit_compile_kernel: cannot write mux stub " + patched_kernel_path);
         }
-        f << "// emule no-op stub for tt_fabric_mux.cpp (the teleporting mux sender carries the data).\n"
+        f << "// emule no-op stub for the fabric mux (the teleporting mux sender carries the data).\n"
           << "#include \"api/dataflow/dataflow_api.h\"\n"
           << "void kernel_main() {}\n";
     } else {


### PR DESCRIPTION
emule substitutes a no-op `kernel_main` for the fabric mux kernel (WA-2 in the
tt-emule-blaze workaround registry): the transport layer the mux aggregates onto is
collapsed into the synchronous teleport, so the mux has nothing to do, and the real
kernel is persistent — `run_forwarder` loops on `while (drain_initiated == 0)` /
`while (true)` until an external drain — which would never terminate under emule's
run-to-completion join.

The substitution matches the kernel **by basename**, so the versioned rewrite
`tt_fabric_mux_v2.cpp` stopped matching and emule compiled the real source, failing the
JIT:

```
error: use of undeclared identifier 'NOC_MAX_TRANSACTION_ID'
  tt_fabric_mux_v2_kernel_ct_args.hpp:51
```

Supplying that constant to emule's `noc_parameters` stub would only trade the compile
error for a hang, so the stub is the correct treatment.

Emule-only: this file lives under `tt_metal/impl/emulation/`, so it stays on the fork
lineage rather than going to tt-metal main.

Reached by the gpt-oss prefill nightly entry through FABRIC_1D_RING. With this plus the
tt-emule-blaze side (tenstorrent/tt-emule-blaze#375), both gpt-oss nightly entries pass
locally under emule:

```
PASSED test_modules.py::test_decoder[blackhole-unpaged-layer_0-decode_low_latency-1x8]
PASSED test_modules.py::test_model[blackhole-1_layer-prefill_b1_s128-1x8]
```

Branch is rooted at `tt-metal-pin.txt` (5cbefb0b) so tt-emule-blaze can pin it exactly.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brapanan/emule-mux-v2-stub)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brapanan/emule-mux-v2-stub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brapanan/emule-mux-v2-stub)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brapanan/emule-mux-v2-stub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brapanan/emule-mux-v2-stub)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brapanan/emule-mux-v2-stub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brapanan/emule-mux-v2-stub)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brapanan/emule-mux-v2-stub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brapanan/emule-mux-v2-stub)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brapanan/emule-mux-v2-stub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brapanan/emule-mux-v2-stub)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brapanan/emule-mux-v2-stub)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brapanan/emule-mux-v2-stub)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brapanan/emule-mux-v2-stub)

## Verification

Both gpt-oss nightly entries pass with this change plus the tt-emule-blaze side
(tenstorrent/tt-emule-blaze#375), locally on **both** arches:

| Entry | BH 8xP150 | WH T3000 |
|---|---|---|
| `test_decoder[...decode_low_latency-1x8]` | ✅ | ✅ |
| `test_model[...prefill_b1_s128-1x8]` | ✅ | ✅ |

And in CI, with `tt-metal-pin.txt` temporarily pointed at this branch so the workflow
builds it: https://github.com/tenstorrent/tt-emule-blaze/actions/runs/33102560729
(`gpt-oss (BH 8xP150)` ✅, `gpt-oss (WH T3000)` ✅).

Only the prefill entry reaches this kernel — it is the FABRIC_1D_RING path — so decode is
unaffected either way and passes with or without this commit.

### Regression

tt-emule-blaze's full-tier ttnn sweep is running against the combined stack
(`run_ttnn_pytests_blackhole.sh`, 101/181 entries at the time of writing, 98 pass). The
two failures are both unrelated to this change: `dm_test_gather_long_vocab` is a
pre-existing timeout the runner documents as unable to pass outside PR_TIER, and
`fused_test_group_norm` failed on a missing `pytest-forked` on the local box, not in the
code. tt-emule-blaze#375's own gates — p150, LoudBox, and the TTNN Pytests shards — are
green, as is the project's Blaze Models sweep
(https://github.com/tenstorrent/tt-emule-blaze/actions/runs/33094763289).
