### PR TITLE
[Bug fix] ccache: force depend mode for GCC PCH providers to stop stale .gch reuse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,8 +301,8 @@ target_link_libraries(
         nlohmann_json::nlohmann_json
         fmt::fmt-header-only
 )
-if(COMMAND tt_disable_ccache_for_pch)
-    tt_disable_ccache_for_pch(metal_common_pch)
+if(COMMAND tt_configure_ccache_for_pch)
+    tt_configure_ccache_for_pch(metal_common_pch)
 endif()
 
 ############################################################################################################################

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -40,42 +40,100 @@ function(useCcache)
 endfunction()
 useCcache()
 
-# Clang's PCH binary embeds metadata (file sizes) of every header that was
-# included when the PCH was built.  When a translation unit loads the PCH,
-# Clang verifies the on-disk headers still match that metadata.
+# A compiler's PCH binary embeds byte-exact metadata about every header that
+# was included when the PCH was built, and that metadata is consulted when a
+# translation unit later loads the PCH:
+#
+#  * Clang embeds per-header file sizes and hard-errors when an on-disk
+#    header no longer matches:
+#      fatal error: file 'X.hpp' has been modified since the precompiled
+#      header was built: size changed
+#  * GCC embeds a {file size, MD5-of-contents, once_only} record for every
+#    header stacked into the .gch (the "pchf" table in libcpp/files.cc,
+#    _cpp_save_file_entries).  It does not hard-error; instead, when a TU
+#    includes a header whose on-disk bytes no longer match the recorded
+#    (size, MD5), the '#pragma once' / include dedup silently fails, the
+#    header is textually re-included on top of the PCH snapshot, and the TU
+#    dies with hundreds of "error: redefinition of ..." diagnostics.
 #
 # ccache's preprocessor-mode cache key is the hash of the *preprocessed*
-# output, which strips comments.  A comment-only edit to a header therefore
-# produces the same hash, so ccache returns the old .pch — whose embedded
-# sizes no longer match the on-disk files — and every consumer fails with:
+# output (-E), which is blind to comment text and to macro definitions that
+# are never expanded inside the PCH's include closure.  A comment-only or
+# dead-macro-only edit to any header in the closure therefore produces the
+# same key, and ccache serves a stale PCH built from the pre-edit bytes.
+# The embedded metadata then mismatches the on-disk headers, producing the
+# failures above.  (Observed in CI: merge-queue run 33091300710 for PR
+# #54500, which deleted unused trailing #define lines from hal.hpp — a
+# preprocessor-invisible change — and got a stale metal_test_pch .gch from
+# the shared remote cache, failing all cache-miss test TUs with
+# "redefinition of ... dev_msgs ..." errors.)
 #
-#   fatal error: file 'X.hpp' has been modified since the precompiled
-#   header was built: size changed
+# Per-compiler remedy, applied via tt_configure_ccache_for_pch below:
 #
-# Skipping ccache for the (tiny, dedicated) PCH provider targets is the
-# simplest reliable fix: the .pch is always built fresh, so its metadata
-# always matches.  All other translation units still benefit from ccache.
-#
-# This problem is Clang-specific.  GCC uses a different PCH validation
-# mechanism (-fpch-preprocess) that does not embed per-header file sizes,
-# so the stale-metadata issue does not arise.  Disabling ccache for GCC PCH
-# providers is therefore counterproductive: GCC's .gch binary embeds a
-# compilation timestamp, making each fresh build produce a different binary.
-# That causes every consumer translation unit to get a different input hash
-# and miss the cache.  With ccache enabled on the provider, the first worker
-# stores the .gch and all subsequent workers (same run or future runs with
-# identical inputs) retrieve the same binary, giving consumers consistent
-# input hashes and high hit rates.
-function(tt_disable_ccache_for_pch target)
-    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+#  * Clang: skip ccache for the (tiny, dedicated) PCH provider targets.
+#    The .pch is always built fresh, so its metadata always matches.  All
+#    other translation units still benefit from ccache.
+#  * GCC: keep ccache but force *depend mode* (CCACHE_DEPEND=1) for the PCH
+#    provider targets.  Depend mode never uses the preprocessor-mode key;
+#    a cache hit requires the byte-exact content hash of every file listed
+#    in the compiler-generated depfile to match the on-disk files — which
+#    is exactly the data GCC's pchf table validates at PCH-use time, so a
+#    served .gch can never be stale.  Disabling ccache outright for GCC
+#    would be counterproductive: GCC's .gch binary is not reproducible
+#    (it embeds a timestamp), so a freshly built .gch differs every run,
+#    every consumer translation unit gets a different input hash, and the
+#    whole build misses the cache.  With depend mode, identical inputs
+#    across runs retrieve the identical cached .gch, keeping consumer hit
+#    rates high.  (Depend mode requires the compile to emit a depfile via
+#    -MD/-MMD; the Ninja generator — the only generator for which
+#    useCcache() installs the launcher — always does.)
+function(tt_configure_ccache_for_pch target)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set_target_properties(
+            ${target}
+            PROPERTIES
+                C_COMPILER_LAUNCHER
+                    ""
+                CXX_COMPILER_LAUNCHER
+                    ""
+        )
         return()
     endif()
-    set_target_properties(
-        ${target}
-        PROPERTIES
-            C_COMPILER_LAUNCHER
-                ""
-            CXX_COMPILER_LAUNCHER
-                ""
-    )
+    # GCC (and others): force ccache depend mode on the provider target by
+    # injecting CCACHE_DEPEND=1 into the ccache launcher installed by
+    # useCcache().  If ccache is not in use, leave the target alone.
+    foreach(lang IN ITEMS C CXX)
+        set(launcher "${CMAKE_${lang}_COMPILER_LAUNCHER}")
+        if(NOT launcher MATCHES "ccache")
+            continue()
+        endif()
+        list(FIND launcher "env" env_index)
+        if(env_index GREATER -1)
+            math(EXPR value_index "${env_index} + 1")
+            list(INSERT launcher ${value_index} "CCACHE_DEPEND=1")
+        else()
+            list(
+                PREPEND
+                launcher
+                ${CMAKE_COMMAND}
+                -E
+                env
+                CCACHE_DEPEND=1
+            )
+        endif()
+        set_target_properties(
+            ${target}
+            PROPERTIES
+                ${lang}_COMPILER_LAUNCHER
+                    "${launcher}"
+        )
+    endforeach()
+endfunction()
+
+# Deprecated name kept for backward compatibility (callers use
+# `if(COMMAND tt_disable_ccache_for_pch)` guards, which would silently
+# no-op if this alias were removed).  On GCC this never actually disabled
+# ccache; see tt_configure_ccache_for_pch for the real behavior.
+function(tt_disable_ccache_for_pch target)
+    tt_configure_ccache_for_pch(${target})
 endfunction()

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -62,11 +62,7 @@ useCcache()
 # dead-macro-only edit to any header in the closure therefore produces the
 # same key, and ccache serves a stale PCH built from the pre-edit bytes.
 # The embedded metadata then mismatches the on-disk headers, producing the
-# failures above.  (Observed in CI: merge-queue run 33091300710 for PR
-# #54500, which deleted unused trailing #define lines from hal.hpp — a
-# preprocessor-invisible change — and got a stale metal_test_pch .gch from
-# the shared remote cache, failing all cache-miss test TUs with
-# "redefinition of ... dev_msgs ..." errors.)
+# failures above.
 #
 # Per-compiler remedy, applied via tt_configure_ccache_for_pch below:
 #
@@ -102,9 +98,19 @@ function(tt_configure_ccache_for_pch target)
     # GCC (and others): force ccache depend mode on the provider target by
     # injecting CCACHE_DEPEND=1 into the ccache launcher installed by
     # useCcache().  If ccache is not in use, leave the target alone.
+    #
+    # The STATUS messages below are deliberate: this protection fails
+    # *silently* if the launcher shape ever stops matching (e.g. useCcache()
+    # is restructured), and the resulting stale-PCH breakage only shows up
+    # later as baffling redefinition errors in CI.  Keep the injected/skipped
+    # outcome visible in the configure log.
     foreach(lang IN ITEMS C CXX)
         set(launcher "${CMAKE_${lang}_COMPILER_LAUNCHER}")
         if(NOT launcher MATCHES "ccache")
+            message(
+                STATUS
+                "tt_configure_ccache_for_pch: ${target} (${lang}) has no ccache launcher; skipping depend-mode injection"
+            )
             continue()
         endif()
         list(FIND launcher "env" env_index)
@@ -127,6 +133,7 @@ function(tt_configure_ccache_for_pch target)
                 ${lang}_COMPILER_LAUNCHER
                     "${launcher}"
         )
+        message(STATUS "tt_configure_ccache_for_pch: forced CCACHE_DEPEND=1 for ${target} (${lang})")
     endforeach()
 endfunction()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,8 +57,8 @@ target_precompile_headers(
         ${PROJECT_SOURCE_DIR}/tt_metal/llrt/tt_cluster.hpp
 )
 target_link_libraries(metal_test_pch PRIVATE test_common_libs)
-if(COMMAND tt_disable_ccache_for_pch)
-    tt_disable_ccache_for_pch(metal_test_pch)
+if(COMMAND tt_configure_ccache_for_pch)
+    tt_configure_ccache_for_pch(metal_test_pch)
 endif()
 
 if(TT_METAL_BUILD_TESTS)

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -38,8 +38,8 @@ target_link_libraries(
         test_common_libs
         TTNN::CPP
 )
-if(COMMAND tt_disable_ccache_for_pch)
-    tt_disable_ccache_for_pch(ttnn_test_pch)
+if(COMMAND tt_configure_ccache_for_pch)
+    tt_configure_ccache_for_pch(ttnn_test_pch)
 endif()
 
 add_library(test_common_utils STATIC)

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -418,8 +418,8 @@ target_link_libraries(
 
 target_include_directories(ttml_pch PRIVATE ${PROJECT_SOURCE_DIR})
 
-if(COMMAND tt_disable_ccache_for_pch)
-    tt_disable_ccache_for_pch(ttml_pch)
+if(COMMAND tt_configure_ccache_for_pch)
+    tt_configure_ccache_for_pch(ttml_pch)
 endif()
 
 target_precompile_headers(ttml REUSE_FROM ttml_pch)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(
         fmt::fmt-header-only
 )
 target_include_directories(ttnn_pch_lean PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/api)
-# tt_disable_ccache_for_pch already applied to TT::CommonPCH in root CMakeLists.txt.
+# tt_configure_ccache_for_pch already applied to TT::CommonPCH in root CMakeLists.txt.
 
 # ── Full PCH: lean + volatile TT headers — for targets with device operations ──
 # Invalidated on any TT::Metalium change; only use for targets that actually
@@ -74,8 +74,8 @@ target_link_libraries(
         fmt::fmt-header-only
 )
 target_include_directories(ttnn_pch_full PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/api)
-if(COMMAND tt_disable_ccache_for_pch)
-    tt_disable_ccache_for_pch(ttnn_pch_full)
+if(COMMAND tt_configure_ccache_for_pch)
+    tt_configure_ccache_for_pch(ttnn_pch_full)
 endif()
 
 # NOTE: Legacy TTNN::PCH alias removed — all consumers migrated to PCHLean or PCHFull.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

PR #54500 was evicted from the merge queue because `build-sweeps / build (Ubuntu 22.04, gcc-12, Release)` failed ([run 33091300710](https://github.com/tenstorrent/tt-metal/actions/runs/33091300710/job/98585732926)) with hundreds of `error: redefinition of 'constexpr const uint32_t tt::tt_metal::dev_msgs::RUN_MSG_INIT'`-style errors in every cache-miss test TU. That PR's code is not at fault — the same content built the identical job cleanly on its branch an hour later ([run 33098161700](https://github.com/tenstorrent/tt-metal/actions/runs/33098161700)). The root cause is an unsound interaction between ccache and GCC precompiled headers in our build setup, which this PR fixes.

**Root cause mechanism**

1. GCC's `.gch` embeds a byte-exact `{file size, MD5-of-contents, once_only}` record of every header stacked into it (the `pchf` table — `libcpp/files.cc`, `_cpp_save_file_entries` / `check_file_against_entries` in GCC 12). At PCH-use time, a TU's `#include` of a `#pragma once` header is skipped **iff** the on-disk file's `(size, MD5)` matches a `once_only` entry. On mismatch there is no diagnostic — the header is silently textually re-included on top of the PCH snapshot, and the TU dies with redefinition errors.
2. ccache's preprocessor-mode fallback keys on the hash of the `-E` output, which is **blind to comment text and to macro definitions that are never expanded inside the PCH include closure** (macro definitions emit no tokens; comments are stripped).
3. PR #54500 deleted 21 trailing lines of `hal.hpp` — `#define HAL_MEM_*` macros (+ a comment) that are expanded nowhere inside `metal_test_pch`'s include closure. That is precisely the preprocessor-invisible change class: the merge-queue tree's `cmake_pch.hxx` preprocesses identically to trees with the old `hal.hpp` bytes, so ccache (direct mode correctly misses, preprocessor-mode fallback hits) served a stale `metal_test_pch` `.gch` from the shared remote (S3) cache, built against different `hal.hpp` / generated-header bytes. GCC then re-included `hal.hpp` (55 redefinitions) and, through `hal.hpp:31-33`, the generated `dev_msgs.hpp` (200) and `realtime_profiler_msgs.hpp` (23) — exactly the observed failure, including the telltale double include chain (relative TU path vs absolute `/work/...` PCH path).

**Reproduction** (gcc-12 + ccache 4.7.5, same `CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_mtime,include_file_ctime` as CI): prime the cache with a `.gch` whose closure is `pch.h -> context.h -> hal.h -> gen.h`; then delete a trailing `#define` block from `hal.h` (EOF, unused in closure) and change comment text in-place in `gen.h`; rebuild. ccache reports a **hit** and serves the stale `.gch`; the TU then fails with `redeclaration of 'enum GenEnum' ... originally defined here` for both `gen.h` and `hal.h` entities — a structural match for the CI log down to the relative/absolute path asymmetry. With `CCACHE_DEPEND=1` the same edit is a cache **miss** (fresh, correct `.gch`; TU compiles), and re-running on an unchanged tree is still a cache **hit**.

**Why the existing code got this wrong**

`cmake/ccache.cmake` already guards Clang PCH providers against exactly this class of bug (comment-only edits serving a stale `.pch`), but deliberately left ccache enabled for GCC providers on the stated premise that GCC "does not embed per-header file sizes" so "the stale-metadata issue does not arise". That premise is factually incorrect — GCC embeds per-header size + MD5 and, worse than Clang's hard `-Winvalid-pch`-style error, fails *silently* into redefinition storms.

**The fix**

On GCC, run the PCH provider targets' compiles under `CCACHE_DEPEND=1` (ccache depend mode). Depend mode never uses the preprocessor-mode key: a hit requires the byte-exact content hash of every depfile-listed header to match the on-disk files — exactly the data GCC's `pchf` table validates — so a served `.gch` can never be stale. Simply disabling ccache for GCC providers (as we do for Clang) would be much more expensive: GCC `.gch` binaries are not reproducible (verified: two builds of an identical trivial header differ), so every run would produce a new `.gch`, changing every consumer TU's input hash and missing the whole cache. Depend mode keeps identical trees sharing one cached `.gch`, preserving consumer hit rates.

Also renamed `tt_disable_ccache_for_pch` -> `tt_configure_ccache_for_pch` (on GCC it never disabled anything, and now it configures depend mode); a deprecated forwarding alias keeps `if(COMMAND tt_disable_ccache_for_pch)` call sites in in-flight branches working.

### Notes for reviewers

- **Validation done:** the mechanism and the fix were validated with a standalone gcc-12 + ccache 4.7.5 reproduction (stale-serve without depend mode; miss-then-correct plus identical-tree hit with it), and the modified `ccache.cmake` was configure-tested under `-G Ninja` (launcher becomes `cmake;-E;env;CCACHE_DEPEND=1;CCACHE_SLOPPINESS=...;ccache`, alias forwards). `gersemi 0.16.2 --check` passes on all touched files. **Not done:** a full tt-metal CI build with this change — please let CI on this PR be the integration test.
- Depend mode requires the compile to emit a depfile (`-MD`); CMake's Ninja generator always adds it (including for PCH rules), and `useCcache()` only installs the launcher under Ninja. If a future non-Ninja flow used ccache without `-MD`, ccache silently falls back to regular modes — the comment in `ccache.cmake` documents this.
- Residual risk: previously stored preprocessor-mode `.gch` results remain in the remote cache but become unreachable for provider targets (depend mode consults only content-verified manifests). Consumer TU caching is unchanged and was already sound (TU keys include the `.gch` bytes).
- One loose end, stated honestly: the specific donor run that stored the stale `.gch` served to run 33091300710 also had byte-different *generated* headers (`dev_msgs.hpp`, `realtime_profiler_msgs.hpp`) — e.g. a comment-only drift (codegen copies constant lines verbatim from `dev_msgs.h`, and `codegen.sh` silently skips `clang-format` when unavailable) or a store poisoned by a generate-vs-hash race that `CCACHE_SLOPPINESS=include_file_mtime,include_file_ctime` makes cacheable. The remote cache contents aren't inspectable from outside, so the donor's identity is inferred, not proven. The fix is donor-independent: depend mode keys on byte-exact header contents, which forecloses every variant of this failure.

- **Review follow-up (64e33bf27b):** dropped the run/PR-specific parenthetical from the source comment (incident history lives here and in git history), and added `message(STATUS ...)` diagnostics to `tt_configure_ccache_for_pch` — one line when `CCACHE_DEPEND=1` is injected, one when injection is skipped because the launcher carries no ccache — so a future silent mismatch of the launcher-matching logic is visible in every configure log. Both paths verified live in a scratch configure (Ninja+ccache prints the inject line and the property contains `CCACHE_DEPEND=1`; a launcher-less generator prints the skip line).

Relates to the merge-queue eviction of #54500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/gcc-pch-ccache-depend-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/gcc-pch-ccache-depend-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/gcc-pch-ccache-depend-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/gcc-pch-ccache-depend-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/gcc-pch-ccache-depend-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/gcc-pch-ccache-depend-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/gcc-pch-ccache-depend-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/gcc-pch-ccache-depend-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/gcc-pch-ccache-depend-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/gcc-pch-ccache-depend-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/gcc-pch-ccache-depend-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/gcc-pch-ccache-depend-mode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/gcc-pch-ccache-depend-mode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/gcc-pch-ccache-depend-mode)
