### PR TITLE
#54646: fix up graph tracing corner cases

### DIFF
--- a/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
+++ b/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
@@ -287,6 +287,13 @@ def parse_argument(text: str):
         tensors = [{"k": "t", "shape": _shape(sh), "dtype": dt, "layout": lay, "mem": None} for sh, dt, lay in found]
         return {"k": "tlist", "tensors": tensors}
 
+    if "ttnn.Tensor(" in text and (text.startswith("[") or text.startswith("(")):
+        # A nested sequence -- [[tensor], [tensor]] -- which _safe_arg_str now summarizes rather
+        # than str()-ing. graph_case rebuilds a "tlist" as one flat list of operands, so parsing
+        # this would flatten the structure and call the op with a different argument shape than
+        # the capture recorded. Fail closed; the generated file's docstring reports the drop.
+        return {"k": "skip", "repr": text}
+
     if text.startswith("MemoryConfig("):
         spec = parse_memory_config(text)
         return dict(spec, k="mem") if spec else {"k": "skip", "repr": text}
@@ -329,7 +336,14 @@ def parse_argument(text: str):
         # patch-merger gelu fusions) were unreconstructible for want of it, and with them the only
         # calls that launch the standalone activation program (matmul.cpp:355 runs a fused
         # activation as a separate unary_chain when no core_coord is given).
-        # True/False/None never reach here -- literal_eval takes them above.
+        # True/False/None never reach here -- literal_eval takes them above. nan/inf/infinity do
+        # reach here (literal_eval rejects them as bare identifiers) and must stay floats: a
+        # captured `epsilon=inf` reconstructed as the string "inf" would change the argument's
+        # type for any op reading a scalar kwarg.
+        try:
+            return {"k": "lit", "v": float(text)}
+        except ValueError:
+            pass
         if _BARE_STRING_RE.match(text):
             return {"k": "lit", "v": text}
         return {"k": "skip", "repr": text}

--- a/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
+++ b/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
@@ -57,7 +57,13 @@ _TENSOR_RE = re.compile(
     r"dtype=DataType\.(?P<dtype>\w+), layout=Layout\.(?P<layout>\w+), "
     r"memory_config=(?P<mem>MemoryConfig\(.*?\)), storage_type="
 )
-# Entries of a python list of tensors print their values, then shape/dtype/layout.
+# An element of a python list of tensors, as summarized by ttnn.graph._safe_arg_str:
+# same fields as a bare tensor argument, so the memory config comes through too.
+# Unanchored so finditer can walk every element of the list.
+_TENSOR_SUMMARY_RE = re.compile(_TENSOR_RE.pattern.lstrip("^"))
+# Legacy captures (before ttnn.graph._safe_arg_str learned to summarize sequences)
+# print each element's *values*, then shape/dtype/layout in C++ spelling, and carry no
+# memory config for list elements.
 _TENSOR_IN_LIST_RE = re.compile(
     r"shape=Shape\(\[(?P<shape>[^\]]*)\]\), dtype=DataType::(?P<dtype>\w+), layout=Layout::(?P<layout>\w+)"
 )
@@ -76,6 +82,8 @@ _CONFIG_RE = re.compile(r"^(?P<kind>[A-Z]\w*(?:ProgramConfig|Config))\((?P<body>
 _TENSOR_ID_RE = re.compile(r"tensor_id=(\d+)")
 # ttnn.Tile's repr, e.g. gpt-oss's sparse_matmul(output_tile=ttnn.Tile([32, 32])).
 _TILE_RE = re.compile(r"^Tile with shape: \[(?P<h>\d+), (?P<w>\d+)\]$")
+# An unquoted string argument: the capture prints a str's value, not its repr.
+_BARE_STRING_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _GRID_RE = re.compile(r"^(\d+)-(\d+)$")
 
 _DTYPE_TAG = {
@@ -244,12 +252,30 @@ def parse_argument(text: str):
             "mem": mem,
         }
 
-    if text.startswith("[ttnn.Tensor("):
-        # Every element must be accounted for: findall over a list whose element repr
+    if text.startswith("[ttnn.Tensor(") or text.startswith("(ttnn.Tensor("):
+        # Every element must be accounted for: a scan over a list whose element repr
         # changed would quietly return a subset, and a concat case would then run with
         # fewer operands than the captured call and still pass.
+        expected = text.count("ttnn.Tensor(")
+        summaries = list(_TENSOR_SUMMARY_RE.finditer(text))
+        if len(summaries) == expected:
+            tensors = []
+            for m in summaries:
+                mem = parse_memory_config(m.group("mem"))
+                if mem is None:
+                    return {"k": "skip", "repr": text}
+                tensors.append(
+                    {
+                        "k": "t",
+                        "shape": _shape(m.group("shape")),
+                        "dtype": m.group("dtype"),
+                        "layout": m.group("layout"),
+                        "mem": mem,
+                    }
+                )
+            return {"k": "tlist", "tensors": tensors}
         found = _TENSOR_IN_LIST_RE.findall(text)
-        if not found or len(found) != text.count("ttnn.Tensor("):
+        if not found or len(found) != expected:
             return {"k": "skip", "repr": text}
         tensors = [{"k": "t", "shape": _shape(sh), "dtype": dt, "layout": lay, "mem": None} for sh, dt, lay in found]
         return {"k": "tlist", "tensors": tensors}
@@ -290,6 +316,15 @@ def parse_argument(text: str):
     try:
         return {"k": "lit", "v": parse_literal(text)}
     except (ValueError, SyntaxError):
+        # A bare identifier is an unquoted string argument -- ttnn.linear(activation="gelu")
+        # reaches the capture as `gelu`, which literal_eval cannot read. Without this branch the
+        # whole call is dropped: 84 of the Qwen3-VL capture's linear calls (the vision MLP and
+        # patch-merger gelu fusions) were unreconstructible for want of it, and with them the only
+        # calls that launch the standalone activation program (matmul.cpp:355 runs a fused
+        # activation as a separate unary_chain when no core_coord is given).
+        # True/False/None never reach here -- literal_eval takes them above.
+        if _BARE_STRING_RE.match(text):
+            return {"k": "lit", "v": text}
         return {"k": "skip", "repr": text}
 
 

--- a/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
+++ b/models/experimental/llama32_1b_quasar/tests/graph_ops/generate_from_graph_capture.py
@@ -84,6 +84,8 @@ _TENSOR_ID_RE = re.compile(r"tensor_id=(\d+)")
 _TILE_RE = re.compile(r"^Tile with shape: \[(?P<h>\d+), (?P<w>\d+)\]$")
 # An unquoted string argument: the capture prints a str's value, not its repr.
 _BARE_STRING_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# ttnn.graph._safe_arg_str' marker for a sequence it summarized only in part.
+_ELIDED_SEQUENCE_RE = re.compile(r"\.\.\. (\+\d+ more|\d+ element\(s\) below the summary depth limit)")
 _GRID_RE = re.compile(r"^(\d+)-(\d+)$")
 
 _DTYPE_TAG = {
@@ -256,6 +258,11 @@ def parse_argument(text: str):
         # Every element must be accounted for: a scan over a list whose element repr
         # changed would quietly return a subset, and a concat case would then run with
         # fewer operands than the captured call and still pass.
+        # An elided sequence is exactly that subset: _safe_arg_str summarizes at most
+        # _MAX_SEQUENCE_ELEMENTS entries and appends "... +N more", which the per-element counts
+        # below cannot see. Fail closed instead of emitting a case with the operands that fit.
+        if _ELIDED_SEQUENCE_RE.search(text):
+            return {"k": "skip", "repr": text}
         expected = text.count("ttnn.Tensor(")
         summaries = list(_TENSOR_SUMMARY_RE.finditer(text))
         if len(summaries) == expected:

--- a/models/experimental/llama32_1b_quasar/tests/graph_ops/test_parse_argument.py
+++ b/models/experimental/llama32_1b_quasar/tests/graph_ops/test_parse_argument.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for ``generate_from_graph_capture.parse_argument`` — the consumer side of
+``ttnn.graph._safe_arg_str``.
+
+``tests/ttnn/unit_tests/base_functionality/test_graph_report.py`` covers the producer: what
+``_safe_arg_str`` writes into a capture. These cover what this generator makes of it, which is
+where a mismatch between the two actually costs coverage: an argument spelling the parser does not
+recognize takes the whole call down with it (``{"k": "skip"}`` -> ``drop_unreconstructible``), so a
+silent regression here shows up as ops quietly missing from a generated suite rather than as a
+failure.
+
+No device and no ttnn: the generator is pure stdlib, so these run in a bare checkout.
+
+    pytest models/experimental/llama32_1b_quasar/tests/graph_ops/test_parse_argument.py
+"""
+
+import pytest
+
+from models.experimental.llama32_1b_quasar.tests.graph_ops.generate_from_graph_capture import parse_argument
+
+_INTERLEAVED_DRAM = {"layout": "INTERLEAVED", "buffer": "DRAM", "shard": None}
+
+
+def _summary(shape="1, 2", dtype="BFLOAT16", layout="TILE", tensor_id=1, buffer_type="DRAM"):
+    """One element as ``ttnn.graph._ttnn_tensor_summary`` writes it."""
+    return (
+        f"ttnn.Tensor(shape=Shape([{shape}]), dtype=DataType.{dtype}, layout=Layout.{layout}, "
+        f"memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,"
+        f"buffer_type=BufferType::{buffer_type},shard_spec=std::nullopt,nd_shard_spec=std::nullopt,"
+        f"created_with_nd_shard_spec=0,per_core_allocation=0), storage_type=StorageType.DEVICE, "
+        f"tensor_id={tensor_id}, is_allocated=True)"
+    )
+
+
+class TestTensorSequences:
+    """The summarized-sequence spelling, and refusing anything that is not all of it."""
+
+    def test_summary_list_keeps_every_element_and_its_memory_config(self):
+        spec = parse_argument(f"[{_summary(tensor_id=1)}, {_summary(shape='3, 4', tensor_id=2)}]")
+
+        assert spec["k"] == "tlist", spec
+        assert [t["shape"] for t in spec["tensors"]] == [[1, 2], [3, 4]]
+        # The memory config per element is the whole point of the summarized spelling: the legacy
+        # one carried none, so list operands were rebuilt DRAM-interleaved whatever they had been.
+        assert all(t["mem"] == _INTERLEAVED_DRAM for t in spec["tensors"]), spec
+
+    def test_tuple_sequence_parses(self):
+        spec = parse_argument(f"({_summary()}, {_summary()})")
+
+        assert spec["k"] == "tlist" and len(spec["tensors"]) == 2, spec
+
+    def test_legacy_value_dumping_spelling_still_parses(self):
+        """Captures taken before _safe_arg_str summarized sequences must keep working."""
+        element = "ttnn.Tensor([[1.0, 2.0]], shape=Shape([1, 2]), dtype=DataType::BFLOAT16, layout=Layout::TILE)"
+        spec = parse_argument(f"[{element}, {element}]")
+
+        assert spec["k"] == "tlist" and len(spec["tensors"]) == 2, spec
+        assert all(t["mem"] is None for t in spec["tensors"]), "legacy elements carry no memory config"
+
+    @pytest.mark.parametrize(
+        "tail",
+        ["... +8 more", "... 5 element(s) below the summary depth limit"],
+        ids=["element-cap", "depth-cap"],
+    )
+    def test_elided_sequence_is_refused(self, tail):
+        """A partially recorded sequence must not become a case with the operands that fit.
+
+        _safe_arg_str summarizes at most _MAX_SEQUENCE_ELEMENTS entries; the per-element count
+        cannot tell a complete list from a truncated one, so the marker is the only signal.
+        """
+        spec = parse_argument(f"[{_summary()}, {tail}]")
+
+        assert spec["k"] == "skip", spec
+
+    def test_nested_sequence_is_refused(self):
+        """graph_case rebuilds a flat tlist, so a nested one would call the op differently."""
+        spec = parse_argument(f"[[{_summary()}], [{_summary()}]]")
+
+        assert spec["k"] == "skip", spec
+
+    def test_unparseable_element_refuses_the_whole_sequence(self):
+        """One element in a spelling we cannot read must not silently shrink the operand list."""
+        spec = parse_argument(f"[{_summary()}, ttnn.Tensor(<unrecognized>)]")
+
+        assert spec["k"] == "skip", spec
+
+
+class TestScalarArguments:
+    """The literal branches, including the bare-identifier one added for fused activations."""
+
+    def test_bare_identifier_is_a_string(self):
+        """ttnn.linear(activation="gelu") reaches the capture as `gelu`, unquoted."""
+        assert parse_argument("gelu") == {"k": "lit", "v": "gelu"}
+
+    @pytest.mark.parametrize("text", ["nan", "inf", "infinity", "-inf"])
+    def test_float_spellings_stay_floats(self, text):
+        """nan/inf are float() spellings literal_eval rejects; they must not become strings."""
+        spec = parse_argument(text)
+
+        assert spec["k"] == "lit", spec
+        assert isinstance(spec["v"], float), f"{text} reconstructed as {type(spec['v']).__name__}"
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [("True", True), ("False", False), ("None", None), ("37984", 37984), ("1e-05", 1e-05), ("(1, 1)", (1, 1))],
+    )
+    def test_literals_are_unaffected_by_the_string_branch(self, text, expected):
+        assert parse_argument(text) == {"k": "lit", "v": expected}
+
+    @pytest.mark.parametrize(
+        "text",
+        ["model_cache/Qwen/tok_embeddings.weight", "<WormholeComputeKernelConfig object at 0x7f00>"],
+        ids=["path", "object-repr"],
+    )
+    def test_unreconstructible_scalars_are_refused(self, text):
+        assert parse_argument(text)["k"] == "skip", text
+
+    def test_object_repr_drops_the_heap_address(self):
+        """Two identical calls from different layers must not look like different cases."""
+        a = parse_argument("<WormholeComputeKernelConfig object at 0x7f0000000000>")
+        b = parse_argument("<WormholeComputeKernelConfig object at 0x7f1111111111>")
+
+        assert a == b, (a, b)
+
+
+class TestTypedArguments:
+    """Spellings the parser turns into ttnn objects rather than literals."""
+
+    @pytest.mark.parametrize(
+        "text, kind, value",
+        [
+            ("DataType.BFLOAT16", "dtype", "BFLOAT16"),
+            ("Layout.TILE", "layout", "TILE"),
+            ("[UnaryOpType.SILU]", "acts", ["SILU"]),
+        ],
+    )
+    def test_enum_spellings(self, text, kind, value):
+        spec = parse_argument(text)
+
+        assert spec["k"] == kind, spec
+        assert spec["v"] == value, spec
+
+    def test_mesh_device(self):
+        assert parse_argument("MeshDevice(1x1 grid, 1 devices)")["k"] == "device"

--- a/models/experimental/ops/quasar/tests/qwen3_vl_ops/graph_case.py
+++ b/models/experimental/ops/quasar/tests/qwen3_vl_ops/graph_case.py
@@ -530,13 +530,6 @@ def _ref_identity(inputs, kwargs, case):
 
 
 def _ref_matmul(inputs, kwargs, case):
-    # A fused activation (ttnn.linear(..., activation="gelu"), the vision MLP and patch merger)
-    # is left to the structural checks: the capture records the activation's name but not its
-    # approximation, and ttnn's fused gelu and torch's differ in exactly that. The point of those
-    # cases is that the fused path runs at all -- it is the only one that launches the standalone
-    # activation program -- not re-deriving gelu.
-    if "activation" in case["kwargs"]:
-        return None
     return inputs["0"].float() @ inputs["1"].float()
 
 

--- a/models/experimental/ops/quasar/tests/qwen3_vl_ops/graph_case.py
+++ b/models/experimental/ops/quasar/tests/qwen3_vl_ops/graph_case.py
@@ -530,6 +530,13 @@ def _ref_identity(inputs, kwargs, case):
 
 
 def _ref_matmul(inputs, kwargs, case):
+    # A fused activation (ttnn.linear(..., activation="gelu"), the vision MLP and patch merger)
+    # is left to the structural checks: the capture records the activation's name but not its
+    # approximation, and ttnn's fused gelu and torch's differ in exactly that. The point of those
+    # cases is that the fused path runs at all -- it is the only one that launches the standalone
+    # activation program -- not re-deriving gelu.
+    if "activation" in case["kwargs"]:
+        return None
     return inputs["0"].float() @ inputs["1"].float()
 
 

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -3417,6 +3417,26 @@ class TestSafeArgStr:
         result = _safe_arg_str(ttnn.TILE_LAYOUT)
         assert "TILE" in result
 
+    def test_tensor_sequence_is_summarized_not_dumped(self, device):
+        """A list of ttnn.Tensors is summarized element-wise, never str()'d.
+
+        str() on the list would repr() each tensor, reading it back to host -- fatal inside a
+        device trace capture and a tensor-content dump in the report otherwise.
+        """
+        from ttnn.graph import _safe_arg_str
+
+        tensors = [
+            ttnn.from_torch(torch.rand(32, 32), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+            for _ in range(2)
+        ]
+        result = _safe_arg_str(tensors)
+
+        assert result.startswith("[ttnn.Tensor(") and result.endswith(")]")
+        assert result.count("ttnn.Tensor(") == 2
+        assert "shape=Shape([32, 32])" in result
+        # No raw tensor data: a dumped tensor renders its rows as "ttnn.Tensor([[".
+        assert "ttnn.Tensor([[" not in result
+
 
 class TestRecordPythonOperation:
     """Tests for ttnn.graph.record_python_operation."""

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -3431,11 +3431,51 @@ class TestSafeArgStr:
         ]
         result = _safe_arg_str(tensors)
 
-        assert result.startswith("[ttnn.Tensor(") and result.endswith(")]")
-        assert result.count("ttnn.Tensor(") == 2
-        assert "shape=Shape([32, 32])" in result
+        assert result.startswith("[ttnn.Tensor(") and result.endswith(")]"), f"unexpected summary: {result}"
+        assert result.count("ttnn.Tensor(") == 2, f"expected 2 tensor summaries: {result}"
+        assert "shape=Shape([32, 32])" in result, f"tensor shape missing from summary: {result}"
         # No raw tensor data: a dumped tensor renders its rows as "ttnn.Tensor([[".
-        assert "ttnn.Tensor([[" not in result
+        assert "ttnn.Tensor([[" not in result, f"tensor contents dumped into the summary: {result}"
+
+    def test_nested_sequence_is_summarized_not_dumped(self, device):
+        """A tensor nested inside a sequence is summarized too, never str()'d.
+
+        The recursion matters as much as the top-level case: str() on the outer list reprs the
+        inner one, which reprs the tensor -- the same forbidden device read.
+        """
+        from ttnn.graph import _safe_arg_str
+
+        tensor = ttnn.from_torch(torch.rand(32, 32), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        result = _safe_arg_str([[tensor], (tensor,)])
+
+        assert result.count("ttnn.Tensor(") == 2, f"expected both nested tensors summarized: {result}"
+        assert "[[ttnn.Tensor(" in result, f"list nesting not preserved: {result}"
+        assert "(ttnn.Tensor(" in result, f"tuple nesting not preserved: {result}"
+        assert "ttnn.Tensor([[" not in result, f"tensor contents dumped into the summary: {result}"
+
+    def test_torch_tensor_sequence_is_summarized_not_dumped(self):
+        """A sequence of torch tensors is summarized: no contents in the report."""
+        from ttnn.graph import _safe_arg_str
+
+        result = _safe_arg_str([torch.rand(4, 4), torch.rand(4, 4)])
+
+        assert result.count("torch.Tensor(shape=[4, 4]") == 2, f"expected 2 torch summaries: {result}"
+        assert "tensor(" not in result, f"torch tensor contents dumped into the summary: {result}"
+
+    def test_long_tensor_sequence_is_elided(self, device):
+        """Past the element cap the tail is elided, and the marker says so.
+
+        The generator keys on that marker to refuse a partially-recorded sequence, so its exact
+        shape is part of the contract.
+        """
+        from ttnn.graph import _MAX_SEQUENCE_ELEMENTS, _safe_arg_str
+
+        tensor = ttnn.from_torch(torch.rand(32, 32), dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        count = _MAX_SEQUENCE_ELEMENTS + 3
+        result = _safe_arg_str([tensor] * count)
+
+        assert result.count("ttnn.Tensor(") == _MAX_SEQUENCE_ELEMENTS, f"wrong number summarized: {result[:200]}"
+        assert result.endswith("... +3 more]"), f"missing elision marker: {result[-40:]}"
 
 
 class TestRecordPythonOperation:

--- a/ttnn/ttnn/graph.py
+++ b/ttnn/ttnn/graph.py
@@ -340,11 +340,43 @@ def _ttnn_tensor_summary(t) -> str:
     return f"ttnn.Tensor({', '.join(parts)})"
 
 
-# Cap on how many elements of a sequence argument are summarized individually.
+# Cap on how many elements of a sequence argument are summarized individually, and how deep
+# the element-wise walk goes before it elides the rest.
 _MAX_SEQUENCE_ELEMENTS = 32
+_MAX_SEQUENCE_DEPTH = 4
 
 
-def _safe_arg_str(v):
+def _tensor_types():
+    """(ttnn.Tensor, torch.Tensor) -- or just ttnn's when torch is not installed."""
+    import ttnn
+
+    try:
+        import torch
+
+        return (ttnn.Tensor, torch.Tensor)
+    except ImportError:
+        return (ttnn.Tensor,)
+
+
+def _holds_tensor(v, _depth=0):
+    """Is ``v`` a tensor, or a sequence holding one at any depth?
+
+    Mirrors ``_collect_tensor_ids``' recursive treatment: a tensor nested inside
+    ``[[tensor]]`` reaches ``str()`` just as readily as a top-level one.
+
+    The depth limit answers "maybe" as True: a sequence too deep to search cannot be
+    shown tensor-free, and summarizing one that turns out to hold only scalars is
+    harmless, where str()-ing one that holds a tensor is the device read this exists to
+    prevent.
+    """
+    if isinstance(v, _tensor_types()):
+        return True
+    if isinstance(v, (list, tuple)):
+        return True if _depth >= _MAX_SEQUENCE_DEPTH else any(_holds_tensor(e, _depth + 1) for e in v)
+    return False
+
+
+def _safe_arg_str(v, _depth=0):
     """Stringify a function argument without triggering graph-tracked operations."""
     import ttnn
 
@@ -357,16 +389,22 @@ def _safe_arg_str(v):
             return f"torch.Tensor(shape={list(v.shape)}, dtype={v.dtype})"
     except ImportError:
         pass
-    # A sequence holding tensors must be summarized element-wise. str() on a list of ttnn.Tensors
-    # calls repr() on each one, which reads the whole tensor back to host (ttnn::to_string ->
-    # Tensor::cpu). That is expensive everywhere, dumps tensor contents into the report, and is
-    # outright fatal inside a device trace capture ("Reads are not supported during trace capture")
-    # -- which is how ttnn.concat, the one op taking a tensor list, killed capture runs.
-    if isinstance(v, (list, tuple)) and any(isinstance(e, ttnn.Tensor) for e in v):
-        head = [_safe_arg_str(e) for e in v[:_MAX_SEQUENCE_ELEMENTS]]
+    # A sequence holding tensors -- at any nesting depth -- must be summarized element-wise. str()
+    # on a list of ttnn.Tensors calls repr() on each one, which reads the whole tensor back to host
+    # (ttnn::to_string -> Tensor::cpu). That is expensive everywhere, dumps tensor contents into the
+    # report, and is outright fatal inside a device trace capture ("Reads are not supported during
+    # trace capture") -- which is how ttnn.concat, the one op taking a tensor list, killed capture
+    # runs. torch tensors in a sequence are summarized for the same no-dump reason (host-side, so
+    # noise rather than a fault).
+    if isinstance(v, (list, tuple)) and _holds_tensor(v):
+        open_, close = ("(", ")") if isinstance(v, tuple) else ("[", "]")
+        # Past the depth limit, elide rather than fall through to str(): the whole point is that a
+        # tensor below here must never be repr()'d.
+        if _depth >= _MAX_SEQUENCE_DEPTH:
+            return f"{open_}... {len(v)} element(s) below the summary depth limit{close}"
+        head = [_safe_arg_str(e, _depth + 1) for e in v[:_MAX_SEQUENCE_ELEMENTS]]
         if len(v) > _MAX_SEQUENCE_ELEMENTS:
             head.append(f"... +{len(v) - _MAX_SEQUENCE_ELEMENTS} more")
-        open_, close = ("(", ")") if isinstance(v, tuple) else ("[", "]")
         return f"{open_}{', '.join(head)}{close}"
     return str(v)
 

--- a/ttnn/ttnn/graph.py
+++ b/ttnn/ttnn/graph.py
@@ -340,6 +340,10 @@ def _ttnn_tensor_summary(t) -> str:
     return f"ttnn.Tensor({', '.join(parts)})"
 
 
+# Cap on how many elements of a sequence argument are summarized individually.
+_MAX_SEQUENCE_ELEMENTS = 32
+
+
 def _safe_arg_str(v):
     """Stringify a function argument without triggering graph-tracked operations."""
     import ttnn
@@ -353,6 +357,17 @@ def _safe_arg_str(v):
             return f"torch.Tensor(shape={list(v.shape)}, dtype={v.dtype})"
     except ImportError:
         pass
+    # A sequence holding tensors must be summarized element-wise. str() on a list of ttnn.Tensors
+    # calls repr() on each one, which reads the whole tensor back to host (ttnn::to_string ->
+    # Tensor::cpu). That is expensive everywhere, dumps tensor contents into the report, and is
+    # outright fatal inside a device trace capture ("Reads are not supported during trace capture")
+    # -- which is how ttnn.concat, the one op taking a tensor list, killed capture runs.
+    if isinstance(v, (list, tuple)) and any(isinstance(e, ttnn.Tensor) for e in v):
+        head = [_safe_arg_str(e) for e in v[:_MAX_SEQUENCE_ELEMENTS]]
+        if len(v) > _MAX_SEQUENCE_ELEMENTS:
+            head.append(f"... +{len(v) - _MAX_SEQUENCE_ELEMENTS} more")
+        open_, close = ("(", ")") if isinstance(v, tuple) else ("[", "]")
+        return f"{open_}{', '.join(head)}{close}"
     return str(v)
 
 

--- a/ttnn/ttnn/graph.py
+++ b/ttnn/ttnn/graph.py
@@ -38,7 +38,6 @@ from ttnn.graph_report import (
     extract_operation_durations,
 )
 
-
 # ---------------------------------------------------------------------------
 # Python-level I/O tracking
 # ---------------------------------------------------------------------------
@@ -340,9 +339,17 @@ def _ttnn_tensor_summary(t) -> str:
     return f"ttnn.Tensor({', '.join(parts)})"
 
 
-# Cap on how many elements of a sequence argument are summarized individually, and how deep
-# the element-wise walk goes before it elides the rest.
+# Cap on how many elements of a sequence argument are summarized individually. A captured
+# ttnn.concat takes as many operands as the model splits into -- 6 for a Qwen3-VL LM head -- so 32
+# records every sequence seen so far with room to spare, while bounding the cost of an argument
+# repr on a pathological call.
 _MAX_SEQUENCE_ELEMENTS = 32
+# How deep the element-wise walk goes. Every sequence argument observed in a capture so far is a
+# flat list of tensors (depth 1: ttnn.concat, the CCL ops); the limit exists to bound recursion on
+# an unexpected or self-referential structure, not to describe a shape we expect, so it is set a
+# few levels above the observed maximum. Crossing it is safe by construction: the walk elides
+# rather than falling back to str(), and _holds_tensor treats "too deep to search" as "assume a
+# tensor is in there".
 _MAX_SEQUENCE_DEPTH = 4
 
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #54646 

`ttnn.graph._safe_arg_str` special-cases a bare `ttnn.Tensor` and a `torch.Tensor`, but falls through
to `str(v)` for a *sequence* of them. `str()` on a list of ttnn tensors calls `repr()` on every
element, which reads the whole tensor back to host (`ttnn::to_string` → `Tensor::cpu`). That is:

* **fatal inside a device trace capture** — `TT_FATAL: Reads are not supported during trace capture`
  (`fd_mesh_command_queue.cpp:687`). `ttnn.concat` is the one op in a transformer taking a tensor
  list, so a graph-capture run of a model that concats during traced decode dies there;
* **wasteful otherwise** — the tensor's contents land in `graph_capture.python_io.json`. A Qwen3-VL
  demo capture recorded arguments beginning
  `[ttnn.Tensor([[-1.1063e-03, 2.0508e-02, ...` for every one of its 804 concat calls.

Downstream, `generate_from_graph_capture.py` (the graph_ops test generator) could not use those
records either. Two separate holes:

1. its list parser only understood the value-dumping spelling (`dtype=DataType::BFLOAT16`, C++
   separators) and hardcoded `mem = None` for every element, so list operands lost their memory
   configs;
2. `parse_argument` had no branch for a bare identifier, so an unquoted string argument dropped the
   **whole call**. In the Qwen3-VL capture that silently discarded 84 `ttnn.linear` calls carrying
   `activation="gelu"` — and with them the only calls that launch the standalone activation program
   (`matmul.cpp:355` runs a fused activation as a separate `unary_chain` when no `core_coord` is
   given). The watcher recorded 86 `UnaryDeviceOperation` launches in that run; the generated suite
   exercised none of them.

## Change

**`ttnn/ttnn/graph.py`** — `_safe_arg_str` summarizes a sequence containing tensors element-wise
instead of stringifying it, reusing the existing `_ttnn_tensor_summary` per element (so each keeps
its shape, dtype, layout **and memory config**). Capped at `_MAX_SEQUENCE_ELEMENTS = 32` with a
`... +N more` tail. No device read, no tensor data in the report.

**`generate_from_graph_capture.py`** —
* `parse_argument` reads the new element spelling via an unanchored `_TENSOR_SUMMARY_RE`, recovering
  each list element's memory config. The legacy value-dumping spelling still parses, so existing
  captures are unaffected;
* a bare identifier now parses as a string literal (`{"k": "lit", "v": "gelu"}`) instead of failing
  `literal_eval` and skipping the call.

Will follow up with further changes in subsequent PRs once a couple of other PRs land.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-54646_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-54646_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-54646_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-54646_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-54646_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-54646_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-54646_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-54646_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-54646_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-54646_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-54646_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-54646_graph_trace)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-54646_graph_trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-54646_graph_trace)