### PR TITLE
[CI] Recompile the silencer and test-command locks to match their workflows

### DIFF
--- a/.github/workflows/silencer.lock.yml
+++ b/.github/workflows/silencer.lock.yml
@@ -1668,7 +1668,6 @@ jobs:
                         "description": "Select model to test",
                         "enum": [
                           "all",
-                          "dits",
                           "tttv2 modules",
                           "qwen3_vl"
                         ],
@@ -1839,6 +1838,7 @@ jobs:
                           "gemma-4-26b-a4b",
                           "gemma-4-31b",
                           "dit-common",
+                          "dit-encoders",
                           "wan-2.2-t2v",
                           "wan-2.2-i2v",
                           "llama3.3-70b-galaxy",

--- a/.github/workflows/test-command.lock.yml
+++ b/.github/workflows/test-command.lock.yml
@@ -953,8 +953,7 @@ jobs:
                           "unit",
                           "fabric",
                           "multiprocess",
-                          "distributed-ops",
-                          "tttv2"
+                          "distributed-ops"
                         ],
                         "type": "string"
                       },
@@ -1400,7 +1399,6 @@ jobs:
                         "description": "Select model to test",
                         "enum": [
                           "all",
-                          "dits",
                           "tttv2 modules",
                           "qwen3_vl"
                         ],
@@ -1698,6 +1696,7 @@ jobs:
                           "gemma-4-26b-a4b",
                           "gemma-4-31b",
                           "dit-common",
+                          "dit-encoders",
                           "wan-2.2-t2v",
                           "wan-2.2-i2v",
                           "llama3.3-70b-galaxy",


### PR DESCRIPTION
### Problem

Both agentic-workflow locks on `main` embed dispatch input schemas that no longer match the workflows they describe:

| Lock | Stale value | Reality |
|---|---|---|
| `silencer.lock.yml` | `"dits"` | renamed to `dit-encoders` in `models-t1-unit-tests.yaml:27` |
| `test-command.lock.yml` | `"dits"` | same |
| `test-command.lock.yml` | `"tttv2"` | removed from `galaxy-unit-tests.yaml` |

`dits` was renamed by #54465 and `tttv2` removed by #54443. Neither recompiled the agentic workflows.

Consequence: `dits` is now offered by **no workflow at all**, and `galaxy-unit-tests` rejects `tttv2`, so a dispatch through either agent validates the value against the stale lock and then fails when GitHub refuses it.

No CI job recompiles these, so nothing goes red. The drift surfaces as an unexplained diff for whoever next edits one of the `.md` files — which is how it was found, while rebasing #54462.

### Change

`gh aw compile silencer` and `gh aw compile test-command` with gh-aw v0.86.2. Two files, 3 insertions, 4 deletions:

```diff
 # silencer.lock.yml
-                          "dits",
+                          "dit-encoders",

 # test-command.lock.yml
-                          "distributed-ops",
-                          "tttv2"
+                          "distributed-ops"
-                          "dits",
+                          "dit-encoders",
```

No `.md` edits — the sources were already correct; only the generated output lagged.

### Verification

- All six agentic workflows compile (`ci-failure-triage`, `mattpocock-skills-reviewer`, `repo-assist`, `silencer`, `tenstorrent-skills-reviewer`, `test-command`)
- A second compile is a no-op, so the committed locks are exactly what the compiler produces
- `grep '^\s*- dits$'` across `.github/workflows/*.yaml` returns nothing, confirming the rename is complete on the source side
- `galaxy-unit-tests.yaml` contains no `tttv2`

### Note

#54462 currently carries this same recompile, because it had to recompile both locks for its own enum change and could not commit a lock that disagreed with the compiler. Whichever lands first makes the other's copy a no-op; the content is identical either way.

### Worth considering separately

This is the third stale-lock instance today (#54569 was the first, caused by deleted workflows still named in a dispatch list). Nothing in CI recompiles the agentic workflows or re-verifies time budgets after a merge, so both classes of drift are only found by the next person to rebase. A post-merge check running `gh aw compile` for each agentic workflow plus `verify_time_budget.py` would catch them at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/recompile-agentic-locks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/recompile-agentic-locks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/recompile-agentic-locks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/recompile-agentic-locks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/recompile-agentic-locks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/recompile-agentic-locks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/recompile-agentic-locks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/recompile-agentic-locks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/recompile-agentic-locks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/recompile-agentic-locks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/recompile-agentic-locks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/recompile-agentic-locks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/recompile-agentic-locks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/recompile-agentic-locks)