### PR TITLE
[skip ci] ci: remove legacy shared ccache drive mount and group 1457

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -127,7 +127,6 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /home/ubuntu/.ccache-ci:/github/home/.ccache # HOME is hardcoded for no clear reason: https://github.com/actions/runner/issues/863
         # BH-Quietbox-2 (qb2) exposes the model store at /mnt/models on the host rather than
         # /mnt/MLPerf, so mount that into the container's /mnt/MLPerf. All other runners use the
         # direct 1:1 /mnt/MLPerf mount. See .github/workflows/models-unit-tests-impl.yaml
@@ -135,7 +134,6 @@ jobs:
         - ${{ inputs.runner-label == 'BH-Quietbox-2' && '/mnt/models:/mnt/MLPerf:ro' || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
       options: >
         --device /dev/tenstorrent
-        --group-add 1457
         --tmpfs /tmp
     defaults:
       run:

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -476,12 +476,8 @@ jobs:
         TRACY_NO_ISA_EXTENSIONS: 1
       volumes:
         - ${{ github.workspace }}:/work
-        # HOME is hardcoded for no clear reason: https://github.com/actions/runner/issues/863
-        - /home/ubuntu/.ccache-ci:/github/home/.ccache
-      # Group 1457 is for the shared ccache drive
       # tmpfs is for efficiency
       options: >
-        --group-add 1457
         --tmpfs /tmp
     defaults:
       run:

--- a/.github/workflows/clang-tidy-reusable.yaml
+++ b/.github/workflows/clang-tidy-reusable.yaml
@@ -61,12 +61,8 @@ jobs:
         CCACHE_BASEDIR: /work
       volumes:
         - ${{ github.workspace }}:/work
-        # HOME is hardcoded for no clear reason: https://github.com/actions/runner/issues/863
-        - /home/ubuntu/.ccache-ci:/github/home/.ccache
-      # Group 1457 is for the shared ccache drive
       # tmpfs is for efficiency
       options: >
-        --group-add 1457
         --tmpfs /tmp
     defaults:
       run:


### PR DESCRIPTION
## What

Removes the `/home/ubuntu/.ccache-ci:/github/home/.ccache` volume mount and the accompanying `--group-add 1457` from the three workflows that still carry them:

- `.github/workflows/build-artifact.yaml`
- `.github/workflows/clang-tidy-reusable.yaml`
- `.github/workflows/bisect-dispatch.yaml`

No other file in the repo references `.ccache-ci` or gid 1457.

## Why

The mount is a leftover from the shared-local-ccache-drive era. It no longer serves any purpose, for two independent reasons:

**1. `CCACHE_REMOTE_ONLY=true` means no cache entries touch it.** All three workflows set it. Per the [ccache manual](https://ccache.dev/manual/latest.html), `remote_only` makes ccache read from and write to remote storage only — on a remote miss it compiles and writes to remote but *not* local; on a hit it reads from remote and does *not* write local.

**2. The build runners are ephemeral.** `build-artifact` and `clang-tidy` run on `tt-ubuntu-2204-large-stable`, so the host directory starts empty on every job and dies with the runner. Even with `remote_only` disabled, the local cache would be cold every time and could only add write cost.

Confirmed empirically against a recent [Build Release ubuntu 22.04 job](https://github.com/tenstorrent/tt-metal/actions/runs/31142460756/job/92755088712):

```
Cache directory:       /github/home/.ccache
Local storage:
  Cache size (GiB):     0.0 /  5.0 ( 0.00%)
  Files:                  0
  Hits:                   0
  Misses:                 0
  Reads:                  0
  Writes:                 0
Remote storage:
  Hits:                2072 / 2073 (99.95%)
  Reads:               4145
  Writes:               272
```

Zero files, zero reads, zero writes locally; all 2072 hits served from Garage S3.

The one thing the mount still did was hold the ccache stats file — a high-performance shared drive mount to store a counter file that's discarded when the runner is torn down.

## What changes at runtime

Without the mount, `$HOME/.ccache` no longer exists, so ccache falls back to `$HOME/.cache/ccache` (`/github/home/.cache/ccache`) inside the container. `/github/home` is itself a runner-provided bind mount and is writable — the container already writes `.gitconfig` there — so stats creation is unaffected. `ccache -z` and `ccache -sv` behave identically and the **CCache Summary** step output is unchanged apart from the `Cache directory:` line.

## Safety check on `--group-add 1457`

`bisect-dispatch.yaml` runs on hardware runners rather than ephemeral ones, so the group was worth checking separately in case it gated device access. It does not: the shared `.github/actions/docker-run/action.yml` composite that every hardware test workflow uses mounts `--device /dev/tenstorrent` and `/dev/hugepages-1G` with no `--group-add`. Group 1457 is only the ccache drive, exactly as the inline comments in the other two workflows state.

`bisect-dispatch` also keeps `CCACHE_REMOTE_ONLY=true`, so no cache entries were being written to that mount there either.

## Follow-up (outside this repo)

Runner image / infra provisioning may still create `/home/ubuntu/.ccache-ci` and gid 1457. Nothing here depends on it any more, so that's cleanup-able separately.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/remove-legacy-ccache-mount)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/remove-legacy-ccache-mount)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/remove-legacy-ccache-mount)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/remove-legacy-ccache-mount)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/remove-legacy-ccache-mount)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/remove-legacy-ccache-mount)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/remove-legacy-ccache-mount)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/remove-legacy-ccache-mount)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/remove-legacy-ccache-mount)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/remove-legacy-ccache-mount)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/remove-legacy-ccache-mount)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/remove-legacy-ccache-mount)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/remove-legacy-ccache-mount)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/remove-legacy-ccache-mount)