### PR TITLE
[Cleanup] Remove implicit `MetalContext::instance()` / default-HAL lookups in watcher and debug-print helpers.

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -37,8 +37,7 @@ constexpr uint32_t NUM_PUSHES_MULTI = 5;
 
 // Newest-first, limited to buffer capacity.
 std::vector<std::string> get_expected_single_processor(
-    HalProgrammableCoreType core_type, uint32_t thread_idx, uint32_t num_pushes) {
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const Hal& hal, HalProgrammableCoreType core_type, uint32_t thread_idx, uint32_t num_pushes) {
     bool is_mpsc = hal.has_mpsc_ring_buffer();
     uint32_t capacity = hal.get_ring_buffer_capacity();
     uint32_t first_visible = (num_pushes > capacity) ? num_pushes - capacity : 0;
@@ -53,7 +52,7 @@ std::vector<std::string> get_expected_single_processor(
         thread_indices.assign(data.size(), thread_idx);
     }
     std::vector<std::string> result = {"debug_ring_buffer="};
-    auto lines = FormatRingBuffer(data, thread_indices, core_type);
+    auto lines = FormatRingBuffer(hal, data, thread_indices, core_type);
     result.insert(result.end(), lines.begin(), lines.end());
     return result;
 }
@@ -203,7 +202,7 @@ void RunTest(
     uint32_t thread_idx =
         hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
     EXPECT_TRUE(FileContainsAllStringsInOrder(
-        fixture->log_file_name, get_expected_single_processor(processor.core_type, thread_idx, num_pushes)));
+        fixture->log_file_name, get_expected_single_processor(hal, processor.core_type, thread_idx, num_pushes)));
 }
 
 void RunMultiWriterTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -18,10 +18,7 @@
 #include <fmt/format.h>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
-#include "context/metal_env_accessor.hpp"
 #include "llrt/core_descriptor.hpp"
-#include "hostdevcommon/dprint_common.h"
-#include "impl/context/metal_context.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include "llrt.hpp"
 #include <impl/dispatch/dispatch_core_manager.hpp>

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -47,7 +47,7 @@ using CoreDescriptorSet = std::set<umd::CoreDescriptor, CoreDescriptorComparator
 
 // Helper function to get CoreDescriptors for all debug-relevant cores on device.
 inline static CoreDescriptorSet GetAllCores(
-    tt::Cluster& cluster, tt::tt_fabric::ControlPlane& control_plane, ChipId device_id) {
+    const Hal& hal, tt::Cluster& cluster, tt::tt_fabric::ControlPlane& control_plane, ChipId device_id) {
     CoreDescriptorSet all_cores;
     // The set of all printable cores is Tensix + Eth + DRAM (when supported)
     CoreCoord logical_grid_size = cluster.get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
@@ -62,7 +62,6 @@ inline static CoreDescriptorSet GetAllCores(
     for (const auto& logical_core : control_plane.get_inactive_ethernet_cores(device_id)) {
         all_cores.insert({logical_core, CoreType::ETH});
     }
-    const auto& hal = MetalContext::instance().hal();
     if (hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
         const auto& soc_desc = cluster.get_soc_desc(device_id);
         for (const auto& dram_core : soc_desc.get_cores(CoreType::DRAM, CoordSystem::LOGICAL)) {
@@ -94,8 +93,8 @@ inline static CoreDescriptorSet GetAllCores(
     return dispatch_cores;
 }
 
-inline uint64_t GetDevicePrintBufAddr(ChipId device_id, const CoreCoord& virtual_core) {
-    return tt::tt_metal::MetalContext::instance().hal().get_dev_noc_addr(
+inline uint64_t GetDevicePrintBufAddr(const Hal& hal, ChipId device_id, const CoreCoord& virtual_core) {
+    return hal.get_dev_noc_addr(
         llrt::get_core_type(device_id, virtual_core), tt::tt_metal::HalL1MemAddrType::DPRINT_BUFFERS);
 }
 
@@ -309,8 +308,7 @@ struct EnableSymbolsInfo {
 };
 
 // This function gets enable/disable flags for watcher header/legend in the log file
-inline EnableSymbolsInfo get_enable_symbols_info(HalProgrammableCoreType core_type) {
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+inline EnableSymbolsInfo get_enable_symbols_info(const Hal& hal, HalProgrammableCoreType core_type) {
     const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     EnableSymbolsInfo info;
     info.main_processor = hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, 0, false);
@@ -436,13 +434,13 @@ inline int debug_server_finish_timeout_sec(const llrt::RunTimeOptions& rtoptions
 // Returns vector of lines like ["[0x00270028,...,", " 0x001f0020,...,", "]"]
 // or for MPSC: ["[[DM0]0x00270028,...,", " [DM0]0x001f0020,...,", "]"]
 inline std::vector<std::string> FormatRingBuffer(
+    const Hal& hal,
     std::span<const uint32_t> data,
     std::span<const uint32_t> thread_indices = {},
     HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
     if (data.empty()) {
         return {};
     }
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     const bool is_mpsc = hal.has_mpsc_ring_buffer();
     TT_ASSERT(
         !is_mpsc || thread_indices.size() == data.size(),
@@ -472,7 +470,9 @@ inline std::vector<std::string> FormatRingBuffer(
 
 // SPSC overload - extracts data in newest-first order and formats
 inline std::vector<std::string> FormatRingBuffer(
-    const debug_spsc_ring_buf_msg_t& buf, HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
+    const Hal& hal,
+    const debug_spsc_ring_buf_msg_t& buf,
+    HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
     if (buf.current_ptr == DEBUG_RING_BUFFER_STARTING_INDEX) {
         return {};
     }
@@ -487,7 +487,7 @@ inline std::vector<std::string> FormatRingBuffer(
             idx = DEBUG_RING_BUFFER_SPSC_ELEMENTS - 1;
         }
     }
-    return FormatRingBuffer(data, {}, core_type);
+    return FormatRingBuffer(hal, data, {}, core_type);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -1022,7 +1022,7 @@ void DPrintServer::Impl::await() {
 void DPrintServer::Impl::init_device(ChipId device_id) {
     auto& cluster = env_.get_cluster();
     auto& control_plane = env_.get_control_plane();
-    CoreDescriptorSet all_cores = GetAllCores(cluster, control_plane, device_id);
+    CoreDescriptorSet all_cores = GetAllCores(env_.get_hal(), cluster, control_plane, device_id);
     // Initialize all print buffers on all cores on the device to have print disabled magic. We
     // will then write print enabled magic for only the cores the user has specified to monitor.
     // This way in the kernel code (dprint.h) we can detect whether the magic value is present and
@@ -1058,7 +1058,8 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
     // here are virtual.
     auto& cluster = env_.get_cluster();
     auto& control_plane = env_.get_control_plane();
-    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(cluster, control_plane, device_id);
+    tt::tt_metal::CoreDescriptorSet all_cores =
+        tt::tt_metal::GetAllCores(env_.get_hal(), cluster, control_plane, device_id);
     tt::tt_metal::CoreDescriptorSet dispatch_cores =
         tt::tt_metal::GetDispatchCores(env_, device_id, num_hw_cqs_, dispatch_core_config_);
 
@@ -1275,7 +1276,8 @@ void DPrintServer::Impl::detach_device(ChipId device_id) {
     log_info(LogMetal, "DPRINT Server detached device {}", device_id);
 
     // When detaching a device, disable prints on it.
-    tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(cluster, control_plane, device_id);
+    tt::tt_metal::CoreDescriptorSet all_cores =
+        tt::tt_metal::GetAllCores(env_.get_hal(), cluster, control_plane, device_id);
     for (const auto& logical_core : all_cores) {
         init_print_buffers_for_core(device_id, logical_core);
     }

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -55,7 +55,7 @@ void DumpCoreNocData(
     // The kernel-side log_noc_xfer (noc_logging.h) lays out NOC_DATA_SIZE uint32_t buckets per
     // RISC at the base of the device-print buffer. NOC logging is mutually exclusive with DPRINT,
     // so the buffer is fully available for histograms.
-    const uint64_t base_addr = GetDevicePrintBufAddr(device_id, virtual_core);
+    const uint64_t base_addr = GetDevicePrintBufAddr(env.get_hal(), device_id, virtual_core);
     const uint32_t bytes_per_risc = NOC_DATA_SIZE * sizeof(uint32_t);
     for (uint32_t risc_id = 0; risc_id < num_processors; risc_id++) {
         auto from_dev =
@@ -80,7 +80,7 @@ void DumpDeviceNocData(
     CoreDescriptorSet dispatch_cores = GetDispatchCores(env, device_id, num_hw_cqs, dispatch_core_config);
 
     // Now go through all cores on the device, and dump noc data for them.
-    CoreDescriptorSet all_cores = GetAllCores(cluster, control_plane, device_id);
+    CoreDescriptorSet all_cores = GetAllCores(env.get_hal(), cluster, control_plane, device_id);
     for (const umd::CoreDescriptor& logical_core : all_cores) {
         if (dispatch_cores.contains(logical_core)) {
             DumpCoreNocData(env, device_id, logical_core, dispatch_noc_data);
@@ -123,14 +123,15 @@ void ClearNocData(MetalEnvImpl& env, ChipId device_id) {
 
     auto& cluster = env.get_cluster();
     auto& control_plane = env.get_control_plane();
-    CoreDescriptorSet all_cores = GetAllCores(cluster, control_plane, device_id);
+    CoreDescriptorSet all_cores = GetAllCores(env.get_hal(), cluster, control_plane, device_id);
     for (const umd::CoreDescriptor& logical_core : all_cores) {
         CoreCoord virtual_core =
             cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
         uint32_t num_processors = env.get_hal().get_num_risc_processors(llrt::get_core_type(device_id, virtual_core));
         // Zero out the entire NOC histogram region across all RISCs in one write.
         std::vector<uint32_t> initbuf(num_processors * NOC_DATA_SIZE, 0);
-        cluster.write_core(device_id, virtual_core, initbuf, GetDevicePrintBufAddr(device_id, virtual_core));
+        cluster.write_core(
+            device_id, virtual_core, initbuf, GetDevicePrintBufAddr(env.get_hal(), device_id, virtual_core));
     }
 }
 

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -12,7 +12,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
-#include "context/context_types.hpp"
 #include "core_coord.hpp"
 #include "debug_helpers.hpp"
 #include "llrt.hpp"

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -35,7 +35,6 @@
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "hal_types.hpp"
 #include "hostdev/debug_ring_buffer_common.h"
-#include "impl/context/metal_context.hpp"
 #include "watcher_device_reader.hpp"
 #include <impl/debug/watcher_server.hpp>
 #include <llrt/tt_cluster.hpp>
@@ -44,20 +43,6 @@
 
 using namespace tt::tt_metal;
 using std::string;
-
-#define NOC_MCAST_ADDR_START_X(addr) (MetalContext::instance().hal().get_noc_mcast_addr_start_x(addr))
-#define NOC_MCAST_ADDR_START_Y(addr) (MetalContext::instance().hal().get_noc_mcast_addr_start_y(addr))
-#define NOC_MCAST_ADDR_END_X(addr) (MetalContext::instance().hal().get_noc_mcast_addr_end_x(addr))
-#define NOC_MCAST_ADDR_END_Y(addr) (MetalContext::instance().hal().get_noc_mcast_addr_end_y(addr))
-#define NOC_UNICAST_ADDR_X(addr) (MetalContext::instance().hal().get_noc_ucast_addr_x(addr))
-#define NOC_UNICAST_ADDR_Y(addr) (MetalContext::instance().hal().get_noc_ucast_addr_y(addr))
-#define NOC_LOCAL_ADDR(addr) (MetalContext::instance().hal().get_noc_local_addr(addr))
-#define NOC_OVERLAY_START_ADDR (MetalContext::instance().hal().get_noc_overlay_start_addr())
-#define NOC_STREAM_REG_SPACE_SIZE (MetalContext::instance().hal().get_noc_stream_reg_space_size())
-#define STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX \
-    (MetalContext::instance().hal().get_noc_stream_remote_dest_buf_size_reg_index())
-#define STREAM_REMOTE_DEST_BUF_START_REG_INDEX \
-    (MetalContext::instance().hal().get_noc_stream_remote_dest_buf_start_reg_index())
 
 namespace {  // Helper functions
 
@@ -119,15 +104,15 @@ const char* get_riscv_name(const Hal& hal, HalProgrammableCoreType core_type, ui
 }
 
 // Helper function to determine core type from virtual coord. TODO: Remove this once we fix code types.
-tt::CoreType core_type_from_virtual_core(tt::ChipId device_id, const CoreCoord& virtual_coord) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(virtual_coord, device_id)) {
+tt::CoreType core_type_from_virtual_core(tt::Cluster& cluster, tt::ChipId device_id, const CoreCoord& virtual_coord) {
+    if (cluster.is_worker_core(virtual_coord, device_id)) {
         return tt::CoreType::WORKER;
     }
-    if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_coord, device_id)) {
+    if (cluster.is_ethernet_core(virtual_coord, device_id)) {
         return tt::CoreType::ETH;
     }
 
-    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_desc = cluster.get_soc_desc(device_id);
 
     const std::vector<tt::umd::CoreCoord>& translated_dram_cores =
         soc_desc.get_cores(tt::CoreType::DRAM, tt::CoordSystem::TRANSLATED);
@@ -152,11 +137,12 @@ tt::CoreType core_type_from_virtual_core(tt::ChipId device_id, const CoreCoord& 
 }
 
 // Helper function to convert noc coord -> virtual coord. TODO: Remove this once we fix code types.
-CoreCoord virtual_noc_coordinate(tt::ChipId device_id, uint8_t noc_index, CoreCoord coord) {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) {
+CoreCoord virtual_noc_coordinate(
+    const Hal& hal, tt::Cluster& cluster, tt::ChipId device_id, uint8_t noc_index, CoreCoord coord) {
+    if (cluster.arch() == tt::ARCH::BLACKHOLE) {
         return coord;
     }
-    auto grid_size = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).grid_size;
+    auto grid_size = cluster.get_soc_desc(device_id).grid_size;
     if (coord.x >= grid_size.x || coord.y >= grid_size.y) {
         // Coordinate already in virtual space: NOC0 and NOC1 are the same
         return coord;
@@ -164,25 +150,26 @@ CoreCoord virtual_noc_coordinate(tt::ChipId device_id, uint8_t noc_index, CoreCo
     // the system this coordinate belongs to.
     // Use this to convert to NOC0 coordinates and then derive Virtual Coords from it.
     CoreCoord physical_coord = {
-        MetalContext::instance().hal().noc_coordinate(noc_index, grid_size.x, coord.x),
-        MetalContext::instance().hal().noc_coordinate(noc_index, grid_size.y, coord.y)};
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_physical_coordinates(
-        device_id, physical_coord);
+        hal.noc_coordinate(noc_index, grid_size.x, coord.x), hal.noc_coordinate(noc_index, grid_size.y, coord.y)};
+    return cluster.get_virtual_coordinate_from_physical_coordinates(device_id, physical_coord);
 }
 
 // Helper function to get string rep of noc target.
 string get_noc_target_str(
-    const Hal& hal,
+    MetalEnvImpl& env,
     tt::ChipId device_id,
     HalProgrammableCoreType programmable_core_type,
     int noc,
     dev_msgs::debug_sanitize_addr_msg_t::ConstView san) {
-    auto get_core_and_mem_type = [](tt::ChipId device_id, CoreCoord& noc_coord, int noc) -> std::pair<string, string> {
+    const auto& hal = env.get_hal();
+    auto& cluster = env.get_cluster();
+    auto get_core_and_mem_type = [&hal, &cluster](
+                                     tt::ChipId device_id, CoreCoord& noc_coord, int noc) -> std::pair<string, string> {
         // Get the virtual coord from the noc coord
-        CoreCoord virtual_core = virtual_noc_coordinate(device_id, noc, noc_coord);
+        CoreCoord virtual_core = virtual_noc_coordinate(hal, cluster, device_id, noc, noc_coord);
         tt::CoreType core_type;
         try {
-            core_type = core_type_from_virtual_core(device_id, virtual_core);
+            core_type = core_type_from_virtual_core(cluster, device_id, virtual_core);
         } catch (std::runtime_error& e) {
             // We may not be able to get a core type if the virtual coords are bad.
             return {"Unknown", ""};
@@ -209,9 +196,9 @@ string get_noc_target_str(
 
     if (san.is_multicast()) {
         CoreCoord target_virtual_noc_core_start = {
-            NOC_MCAST_ADDR_START_X(san.noc_addr()), NOC_MCAST_ADDR_START_Y(san.noc_addr())};
+            hal.get_noc_mcast_addr_start_x(san.noc_addr()), hal.get_noc_mcast_addr_start_y(san.noc_addr())};
         CoreCoord target_virtual_noc_core_end = {
-            NOC_MCAST_ADDR_END_X(san.noc_addr()), NOC_MCAST_ADDR_END_Y(san.noc_addr())};
+            hal.get_noc_mcast_addr_end_x(san.noc_addr()), hal.get_noc_mcast_addr_end_y(san.noc_addr())};
         auto type_and_mem = get_core_and_mem_type(device_id, target_virtual_noc_core_start, noc);
         out += fmt::format(
             "{} core range w/ virtual coords {}-{} {}",
@@ -220,13 +207,14 @@ string get_noc_target_str(
             target_virtual_noc_core_end.str(),
             type_and_mem.second);
     } else {
-        CoreCoord target_virtual_noc_core = {NOC_UNICAST_ADDR_X(san.noc_addr()), NOC_UNICAST_ADDR_Y(san.noc_addr())};
+        CoreCoord target_virtual_noc_core = {
+            hal.get_noc_ucast_addr_x(san.noc_addr()), hal.get_noc_ucast_addr_y(san.noc_addr())};
         auto type_and_mem = get_core_and_mem_type(device_id, target_virtual_noc_core, noc);
         out += fmt::format(
             "{} core w/ virtual coords {} {}", type_and_mem.first, target_virtual_noc_core.str(), type_and_mem.second);
     }
 
-    out += fmt::format("[addr=0x{:08x}]", NOC_LOCAL_ADDR(san.noc_addr()));
+    out += fmt::format("[addr=0x{:08x}]", hal.get_noc_local_addr(san.noc_addr()));
     return out;
 }
 
@@ -753,47 +741,47 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             }
             break;
         case dev_msgs::DebugSanitizeNocAddrUnderflow:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " address underflow).";
             break;
         case dev_msgs::DebugSanitizeNocAddrOverflow:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " address overflow).";
             break;
         case dev_msgs::DebugSanitizeNocAddrZeroLength:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (zero length transaction).";
             break;
         case dev_msgs::DebugSanitizeNocTargetInvalidXY:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (NOC target address did not map to any known Tensix/Ethernet/DRAM/PCIE core).";
             break;
         case dev_msgs::DebugSanitizeNocMulticastNonWorker:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (multicast to non-worker core).";
             break;
         case dev_msgs::DebugSanitizeNocMulticastInvalidRange:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (multicast invalid range).";
             break;
         case dev_msgs::DebugSanitizeNocAlignment:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (invalid address alignment in NOC transaction).";
             break;
         case dev_msgs::DebugSanitizeNocMixedVirtualandPhysical:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (mixing virtual and virtual coordinates in Mcast).";
             break;
         case dev_msgs::DebugSanitizeInlineWriteDramUnsupported:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (inline dw writes do not support DRAM destination addresses).";
             break;
         case dev_msgs::DebugSanitizeNocAddrMailbox:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += string(san.is_target() ? " (NOC target" : " (Local L1") + " overwrites mailboxes).";
             break;
         case dev_msgs::DebugSanitizeNocLinkedTransactionViolation:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += fmt::format(" (submitting a non-mcast transaction when there's a linked transaction).");
             break;
         case dev_msgs::DebugSanitizeL1AddrOverflow:
@@ -809,7 +797,7 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg += " (ethernet send with L1 source overflow).";
             break;
         case dev_msgs::DebugSanitizeCBOutOfBounds:
-            error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
+            error_msg = get_noc_target_str(reader_.env, reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (NOC transaction overflows a circular buffer).";
             break;
         case dev_msgs::DebugSanitizeNocInvalidTxnId:
@@ -873,7 +861,7 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     DumpWaypoints(true);
     DumpRingBuffer(true);
     LogRunningKernels();
-    MetalContext::instance().watcher_server()->set_exception_message(error_msg);
+    reader_.watcher_server.set_exception_message(error_msg);
     TT_THROW("Watcher detected tripped assert and stopped device.");
 }
 
@@ -1179,13 +1167,14 @@ void WatcherDeviceReader::Core::DumpSyncRegs() const {
         // Read back all of the stream state, most of it is unused
         std::vector<uint32_t> data;
         for (uint32_t operand = 0; operand < max_cbs; operand++) {
-            uint32_t base = NOC_OVERLAY_START_ADDR + ((operand_start_stream + operand) * NOC_STREAM_REG_SPACE_SIZE);
+            uint32_t base = hal.get_noc_overlay_start_addr() +
+                            ((operand_start_stream + operand) * hal.get_noc_stream_reg_space_size());
 
-            uint32_t rcvd_addr = base + (STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX * sizeof(uint32_t));
+            uint32_t rcvd_addr = base + (hal.get_noc_stream_remote_dest_buf_size_reg_index() * sizeof(uint32_t));
             data = reader_.env.get_cluster().read_core(reader_.device_id, virtual_coord_, rcvd_addr, sizeof(uint32_t));
             uint32_t rcvd = data[0];
 
-            uint32_t ackd_addr = base + (STREAM_REMOTE_DEST_BUF_START_REG_INDEX * sizeof(uint32_t));
+            uint32_t ackd_addr = base + (hal.get_noc_stream_remote_dest_buf_start_reg_index() * sizeof(uint32_t));
             data = reader_.env.get_cluster().read_core(reader_.device_id, virtual_coord_, ackd_addr, sizeof(uint32_t));
             uint32_t ackd = data[0];
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -372,7 +372,7 @@ WatcherDeviceReader::WatcherDeviceReader(
     uint32_t core_count = hal.get_programmable_core_type_count();
     for (uint32_t i = 0; i < core_count; i++) {
         auto core_type = hal.get_programmable_core_type(i);
-        symbols_info_cache_.emplace(core_type, get_enable_symbols_info(core_type));
+        symbols_info_cache_.emplace(core_type, get_enable_symbols_info(env.get_hal(), core_type));
     }
 }
 
@@ -933,7 +933,7 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     const auto* ring_buf_data =
         reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
-    EmitRingBuffer(FormatRingBuffer(*ring_buf_data, programmable_core_type_), to_stdout);
+    EmitRingBuffer(FormatRingBuffer(reader_.env.get_hal(), *ring_buf_data, programmable_core_type_), to_stdout);
 }
 
 // Either dumps to stdout or to the log file.
@@ -974,7 +974,7 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
         thread_indices.push_back(slot.write_id - 1);
     }
 
-    EmitRingBuffer(FormatRingBuffer(data, thread_indices, programmable_core_type_), to_stdout);
+    EmitRingBuffer(FormatRingBuffer(reader_.env.get_hal(), data, thread_indices, programmable_core_type_), to_stdout);
 }
 
 void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -710,11 +710,12 @@ void WatcherDeviceReader::Core::Dump() const {
 void WatcherDeviceReader::Core::DumpL1Status() const {
     // Read L1 address 0, looking for memory corruption
     std::vector<uint32_t> data;
-    const auto l1_base = reader_.env.get_hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
+    const auto& hal = reader_.env.get_hal();
+    const auto l1_base = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
     data = reader_.env.get_cluster().read_core(reader_.device_id, virtual_coord_, l1_base, sizeof(uint32_t));
     TT_ASSERT(programmable_core_type_ == HalProgrammableCoreType::TENSIX);
-    uint32_t core_type_idx = reader_.env.get_hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-    auto fw_launch_value = reader_.env.get_hal().get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr_value;
+    uint32_t core_type_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    auto fw_launch_value = hal.get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr_value;
     if (data[0] != fw_launch_value) {
         LogRunningKernels();
         TT_THROW("Watcher found corruption at L1[0] on core {}: read {}", virtual_coord_.str(), data[0]);

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -18,6 +18,8 @@
 
 namespace tt::tt_metal {
 
+class WatcherServer;
+
 constexpr uint64_t DEBUG_SANITIZE_SENTINEL_OK_64 = 0xbadabadabadabada;
 constexpr uint32_t DEBUG_SANITIZE_SENTINEL_OK_32 = 0xbadabada;
 constexpr uint16_t DEBUG_SANITIZE_SENTINEL_OK_16 = 0xbada;

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -299,7 +299,7 @@ void WatcherServer::Impl::create_log_file() {
     fprintf(f, "Legend:\n");
 
     // Get processor info from shared helper
-    auto tensix_info = get_enable_symbols_info(HalProgrammableCoreType::TENSIX);
+    auto tensix_info = get_enable_symbols_info(env_.get_hal(), HalProgrammableCoreType::TENSIX);
 
     fprintf(
         f,


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Related to https://github.com/tenstorrent/tt-metal/issues/52020.

- Shared debug helpers (`GetAllCores`, `GetDevicePrintBufAddr`, `get_enable_symbols_info`, `FormatRingBuffer`) now take `const Hal&` instead of grabbing HAL from the global context.
- Watcher NOC sanitize formatting and exception reporting go through the reader's `MetalEnvImpl` and a stored `WatcherServer&`.
- Hard-coded L1 / NOC overlay constants (`HAL_MEM_L1_BASE`, `NOC_OVERLAY_START_ADDR`, stream register macros) are replaced with HAL queries so the watcher uses the same per-context HAL as the rest of the runtime.

### Notes for reviewers
- `class WatcherServer;` in `watcher_device_reader.hpp` is not a new dependency; `debug_helpers.hpp` no longer includes `metal_context.hpp
- `test_ringbuf.cpp` is changed only for `FormatRingBuffer`, the rest of it will be fixed in future PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/metal-context-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/metal-context-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/metal-context-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/metal-context-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/metal-context-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/metal-context-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/metal-context-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/metal-context-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/metal-context-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/metal-context-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/metal-context-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/metal-context-3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/metal-context-3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/metal-context-3)