### PR TITLE
[Bug fix]: slow dispatch was not correctly laying out sparse dfb config

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -2263,6 +2264,69 @@ TEST_F(UnitMeshFixture, DFBDeviceSlotsReusedAcrossDisjointCores) {
     }
     // Conflicts only with the wide DFB, so it reuses slot 1 rather than taking slot 4.
     EXPECT_EQ(impl.get_dataflow_buffer(coordinator_id)->device_slot, 1u);
+}
+
+// WH/BH firmware addresses this config as a CB-format table indexed by device_slot. Verify that
+// serialization preserves empty entries when a core's assigned slots are not consecutive.
+TEST_F(UnitMeshFixture, DFBConfigSerializationPreservesGappedDeviceSlots) {
+    if (this->device().arch() == ARCH::QUASAR) {
+        GTEST_SKIP() << "WH/BH use the slot-indexed CB-format DFB config";
+    }
+
+    const CoreCoord grid = this->device().compute_with_storage_grid_size();
+    if (grid.x < 2) {
+        GTEST_SKIP() << "Needs at least two worker cores in a row";
+    }
+
+    const CoreCoord coordinator(0, 0);
+    const CoreCoord worker(1, 0);
+    const CoreRange all_cores(coordinator, worker);
+    Program program = CreateProgram();
+    const auto config = make_minimal_dfb_config();
+
+    for (int i = 0; i < 3; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, CoreRangeSet(CoreRange(worker)), config);
+    }
+    const uint32_t coordinator_id =
+        experimental::dfb::CreateDataflowBuffer(program, CoreRangeSet(CoreRange(coordinator)), config);
+    const uint32_t wide_id = experimental::dfb::CreateDataflowBuffer(program, CoreRangeSet(all_cores), config);
+
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
+
+    const auto& impl = program.impl();
+    EXPECT_EQ(impl.get_dataflow_buffer(coordinator_id)->device_slot, 0u);
+    EXPECT_EQ(impl.get_dataflow_buffer(wide_id)->device_slot, 3u);
+
+    constexpr size_t words_per_slot = 4;
+    constexpr size_t num_slots = 4;
+    std::vector<uint8_t> serialized(num_slots * words_per_slot * sizeof(uint32_t), 0xFF);
+    const auto dfbs = impl.dataflow_buffers_on_core(coordinator);
+    const size_t bytes_written =
+        experimental::dfb::detail::serialize_dfb_config_for_core(coordinator, dfbs, serialized);
+    EXPECT_EQ(bytes_written, serialized.size());
+
+    auto read_word = [&](size_t slot, size_t word) {
+        uint32_t value = 0;
+        std::memcpy(&value, serialized.data() + (slot * words_per_slot + word) * sizeof(uint32_t), sizeof(uint32_t));
+        return value;
+    };
+
+    const auto coordinator_dfb = impl.get_dataflow_buffer(coordinator_id);
+    EXPECT_EQ(read_word(0, 0), coordinator_dfb->uniform_alloc_addr());
+    EXPECT_EQ(read_word(0, 1), coordinator_dfb->total_size());
+    EXPECT_EQ(read_word(0, 2), coordinator_dfb->config.num_entries);
+    EXPECT_EQ(read_word(0, 3), coordinator_dfb->config.entry_size);
+    for (size_t slot : {1u, 2u}) {
+        for (size_t word = 0; word < words_per_slot; word++) {
+            EXPECT_EQ(read_word(slot, word), 0u) << "slot " << slot << ", word " << word;
+        }
+    }
+    const auto wide_dfb = impl.get_dataflow_buffer(wide_id);
+    EXPECT_EQ(read_word(3, 0), wide_dfb->uniform_alloc_addr());
+    EXPECT_EQ(read_word(3, 1), wide_dfb->total_size());
+    EXPECT_EQ(read_word(3, 2), wide_dfb->config.num_entries);
+    EXPECT_EQ(read_word(3, 3), wide_dfb->config.entry_size);
 }
 
 // The per-core slot limit is on how many DFBs share a core, not on how many exist in the program:

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -183,7 +183,7 @@ m2::ProgramSpec make_split_touch_spec(distributed::MeshDevice& mesh_device, uint
     return spec;
 }
 
-TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
+TEST_F(UnitMeshAnyDispatchFixture, HalfGrid3Plus3DFBsOnDevice) {
     require_at_least_two_nodes(this->device());
     const bool is_quasar = this->device().arch() == ARCH::QUASAR;
 
@@ -314,7 +314,7 @@ TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
 
 // Stress: 16+16 DFBs. Credit-handshake over every buffer; host checks entry_size + device slot
 // written back from each consumer.
-TEST_F(UnitMeshFixture, HalfGrid16Plus16DFBsOnDevice) {
+TEST_F(UnitMeshAnyDispatchFixture, HalfGrid16Plus16DFBsOnDevice) {
     require_at_least_two_nodes(this->device());
     const bool is_quasar = this->device().arch() == ARCH::QUASAR;
 
@@ -359,7 +359,7 @@ TEST_F(UnitMeshFixture, HalfGrid16Plus16DFBsOnDevice) {
 }
 
 // End-to-end identity across two disjoint halves: one DFB + producer/consumer pair per half.
-TEST_F(UnitMeshFixture, HalfGridOnDeviceDataflow1DFBEach) {
+TEST_F(UnitMeshAnyDispatchFixture, HalfGridOnDeviceDataflow1DFBEach) {
     require_at_least_two_nodes(this->device());
     const bool is_quasar = this->device().arch() == ARCH::QUASAR;
 
@@ -461,7 +461,7 @@ TEST_F(UnitMeshFixture, HalfGridOnDeviceDataflow1DFBEach) {
     EXPECT_EQ(result_b, input_b) << "right-half DFB round-trip mismatch";
 }
 
-TEST_F(UnitMeshFixture, CoordinatorWorkerSlotReuseOnDevice) {
+TEST_F(UnitMeshAnyDispatchFixture, CoordinatorWorkerSlotReuseOnDevice) {
     const CoreCoord grid = this->device().compute_with_storage_grid_size();
     if (grid.x < 3) {
         GTEST_SKIP() << "Needs at least coordinator + 2 workers (got " << grid.x << "x" << grid.y << ")";
@@ -535,6 +535,103 @@ TEST_F(UnitMeshFixture, CoordinatorWorkerSlotReuseOnDevice) {
     coord_worker_workload.add_program(distributed::MeshCoordinateRange(this->device().shape()), std::move(program));
     distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), coord_worker_workload, /*blocking=*/true);
 
+    expect_touch_results(
+        this->device(),
+        CoreCoord{0, 0},
+        coord_result_addr,
+        2,
+        /*expected_entry_size=*/32,
+        touched_magic,
+        {impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_coord"))->device_slot});
+    expect_touch_results(
+        this->device(),
+        CoreCoord{1, 0},
+        worker_result_addr,
+        4,
+        /*expected_entry_size=*/32,
+        touched_magic,
+        {impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_0"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_1"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_2"))->device_slot});
+}
+
+// Same topology as CoordinatorWorkerSlotReuseOnDevice, but sparse DFBs are created first so the
+// all-cores DFB lands at a high slot.
+TEST_F(UnitMeshAnyDispatchFixture, CoordinatorWorkerGappedSlotsOnDevice) {
+    const CoreCoord grid = this->device().compute_with_storage_grid_size();
+    if (grid.x < 3) {
+        GTEST_SKIP() << "Needs at least coordinator + 2 workers (got " << grid.x << "x" << grid.y << ")";
+    }
+
+    const m2::NodeCoord coordinator{0, 0};
+    const m2::NodeCoord worker_start{1, 0};
+    const m2::NodeCoord worker_end{static_cast<size_t>(grid.x - 1), 0};
+
+    constexpr uint32_t touched_magic = 0xA11CED00u;
+    auto coord_prod = make_touch_producer("coord_prod", 2, this->device());
+    auto coord_cons = make_touch_consumer("coord_cons", 2, touched_magic, this->device());
+    auto worker_prod = make_touch_producer("worker_prod", 4, this->device());
+    auto worker_cons = make_touch_consumer("worker_cons", 4, touched_magic, this->device());
+
+    m2::ProgramSpec spec;
+    spec.name = "dfb_gapped_slot_touch";
+
+    auto add_dfb = [&](const std::string& name) {
+        auto dfb = MakeMinimalDFB(name, 32, 2);
+        dfb.data_format_metadata = tt::DataFormat::Float16_b;
+        spec.dataflow_buffers.push_back(dfb);
+    };
+    add_dfb("dfb_worker_0");
+    add_dfb("dfb_worker_1");
+    add_dfb("dfb_worker_2");
+    add_dfb("dfb_coord");
+    add_dfb("dfb_wide");
+
+    bind_touch_dfbs(coord_prod, coord_cons, "dfb_wide", 0);
+    bind_touch_dfbs(coord_prod, coord_cons, "dfb_coord", 1);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_wide", 0);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_worker_0", 1);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_worker_1", 2);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_worker_2", 3);
+
+    spec.kernels = {coord_prod, coord_cons, worker_prod, worker_cons};
+    spec.work_units = {
+        MakeMinimalWorkUnit("wu_coord", coordinator, {"coord_prod", "coord_cons"}),
+        MakeMinimalWorkUnit("wu_workers", m2::NodeRange{worker_start, worker_end}, {"worker_prod", "worker_cons"}),
+    };
+
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
+    const auto& impl = program.impl();
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_0"))->device_slot, 0u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_1"))->device_slot, 1u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_2"))->device_slot, 2u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_coord"))->device_slot, 0u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot, 3u);
+    expect_no_slot_collision_on_core(program, CoreCoord{0, 0});
+    expect_no_slot_collision_on_core(program, CoreCoord{1, 0});
+
+    m2::ProgramRunArgs params;
+    const uint32_t coord_result_addr = touch_result_l1_addr(this->device(), 2);
+    const uint32_t worker_result_addr = touch_result_l1_addr(this->device(), 4);
+    m2::KernelRunArgs::RuntimeArgValues worker_cons_rtas;
+    for (size_t x = worker_start.x; x <= worker_end.x; ++x) {
+        m2::AddRuntimeArgsForNode(worker_cons_rtas, m2::NodeCoord{x, 0}, {{"result_l1_addr", worker_result_addr}});
+    }
+    params.kernel_run_args = {
+        {.kernel = m2::KernelSpecName{"coord_prod"}},
+        {.kernel = m2::KernelSpecName{"coord_cons"},
+         .runtime_arg_values = m2::MakeRuntimeArgsForSingleNode(coordinator, {{"result_l1_addr", coord_result_addr}})},
+        {.kernel = m2::KernelSpecName{"worker_prod"}},
+        {.kernel = m2::KernelSpecName{"worker_cons"}, .runtime_arg_values = std::move(worker_cons_rtas)},
+    };
+    m2::SetProgramRunArgs(program, params);
+    distributed::MeshWorkload coord_worker_workload;
+    coord_worker_workload.add_program(distributed::MeshCoordinateRange(this->device().shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), coord_worker_workload, /*blocking=*/true);
+
+    // Coordinator: slots 0 (coord-only) and 3 (wide); 1 and 2 unused.
     expect_touch_results(
         this->device(),
         CoreCoord{0, 0},

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -433,7 +433,47 @@ size_t serialize_dfb_config_for_core(
     if (dfbs_on_core.empty()) { return 0; }
     const ContextId context_id = dfbs_on_core.front()->get_context_id();
     const auto& hal = MetalContext::instance(context_id).hal();
-    TT_FATAL(hal.has_tile_counter_registers(), "serialize_dfb_config_for_core requires Quasar");
+    if (!hal.has_tile_counter_registers()) {
+        constexpr size_t config_bytes_per_slot = UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+        size_t bytes_written = 0;
+        for (const auto& dfb : dfbs_on_core) {
+            TT_FATAL(dfb->configs_finalized, "DFB {} configs not finalized before serialization", dfb->id);
+            auto it = dfb->core_lookup_.find(core);
+            TT_FATAL(it != dfb->core_lookup_.end(), "DFB {} has no config for core ({}, {})", dfb->id, core.x, core.y);
+            const uint32_t alloc_addr = it->second.second;
+            TT_FATAL(
+                !dfb->borrows_memory() || alloc_addr != 0,
+                "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
+                dfb->id);
+
+            const size_t byte_offset = static_cast<size_t>(dfb->device_slot) * config_bytes_per_slot;
+            TT_FATAL(
+                byte_offset + config_bytes_per_slot <= out.size(),
+                "DFB {} (device slot {}) config at byte offset {} does not fit in the {}-byte config payload "
+                "sized by finalize_dfbs",
+                dfb->id,
+                dfb->device_slot,
+                byte_offset,
+                out.size());
+            bytes_written = std::max(bytes_written, byte_offset + config_bytes_per_slot);
+        }
+
+        // A core can have gaps in its device slots. Keep those entries zero while placing each
+        // config at the slot firmware and kernel accessors use.
+        std::fill(out.begin(), out.begin() + bytes_written, uint8_t{0});
+        for (const auto& dfb : dfbs_on_core) {
+            const size_t byte_offset = static_cast<size_t>(dfb->device_slot) * config_bytes_per_slot;
+            const uint32_t alloc_addr = dfb->core_lookup_.at(core).second;
+            const uint32_t words[UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG] = {
+                alloc_addr,
+                dfb->config.entry_size * dfb->config.num_entries,
+                dfb->config.num_entries,
+                dfb->config.entry_size,
+            };
+            std::memcpy(out.data() + byte_offset, words, sizeof(words));
+        }
+        return bytes_written;
+    }
 
     // ---------------------------------------------------------------------------
     // 1. Collect per-core risc configs for every DFB (base/limit resolved per core).
@@ -1367,34 +1407,6 @@ void DataflowBufferImpl::append_dm1_remapper_slots_for_core(const CoreCoord& cor
     }
 }
 
-// WH/BH only: emit the 4-word CB-format config for the legacy firmware path.
-std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& core) const {
-    TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
-    TT_FATAL(
-        !MetalContext::instance(context_id_).hal().has_tile_counter_registers(),
-        "serialize_for_core is only used on WH/BH; Quasar uses serialize_dfb_config_for_core");
-
-    auto it = this->core_lookup_.find(core);
-    TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
-    const uint32_t alloc_addr = it->second.second;
-    TT_FATAL(
-        !this->borrows_memory() || alloc_addr != 0,
-        "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
-        this->id);
-
-    std::vector<uint8_t> data;
-    data.reserve(dfb_wh_bh_serialized_size());
-    const uint32_t words[4] = {
-        alloc_addr,
-        this->config.entry_size * this->config.num_entries,
-        this->config.num_entries,
-        this->config.entry_size,
-    };
-    const auto* bytes = reinterpret_cast<const uint8_t*>(words);
-    data.insert(data.end(), bytes, bytes + sizeof(words));
-    return data;
-}
-
 uint32_t DataflowBufferImpl::serialized_size() const {
     if (!MetalContext::instance(context_id_).hal().has_tile_counter_registers()) {
         return dfb_wh_bh_serialized_size();
@@ -1545,7 +1557,7 @@ std::vector<DFBRiscConfig> DataflowBufferImpl::compute_per_core_risc_configs(con
         }
     }
 
-    // Address arithmetic: see inline comments in old serialize_for_core for rationale.
+    // Resolve the per-core address arithmetic used by Quasar serialization.
     const uint32_t entry_size      = this->config.entry_size;
     const uint32_t effective_stride = this->stride_in_entries;
     const uint32_t base_step = (effective_stride > 1) ? entry_size : (this->capacity * entry_size);
@@ -1962,8 +1974,8 @@ void ProgramImpl::finalize_single_dfb_config(
 
     // Finds the DfbGroup whose hw_risc_configs match new_hw_risc_configs (creating one
     // if none exists), extends its core_ranges to include `core`, and appends an
-    // l1_by_core entry.  base_addr/limit are not part of the equality check because
-    // they are derived per-core in serialize_for_core() from each core's alloc_addr.
+    // l1_by_core entry. base_addr/limit are not part of the equality check because
+    // they are derived per-core during serialization from each core's alloc_addr.
     auto bin_into_group = [&]() {
         auto hw_risc_configs_equal = [](const std::vector<DFBRiscConfig>& a, const std::vector<DFBRiscConfig>& b) {
             if (a.size() != b.size()) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -128,8 +128,6 @@ struct DataflowBufferImpl {
     uint16_t dm1_remapper_slot_count() const;  // slots this DFB contributes to the core-wide DM1 blob
     void append_dm1_remapper_slots_for_core(const CoreCoord& core, std::vector<uint8_t>& data) const;
 
-    std::vector<uint8_t> serialize_for_core(const CoreCoord& core) const;  // WH/BH only (4-word CB format)
-
     // Returns per-core DFBRiscConfig with base_addr/limit resolved for core's alloc_addr.
     // Used by serialize_dfb_config_for_core to build per-hart init blobs.
     std::vector<DFBRiscConfig> compute_per_core_risc_configs(const CoreCoord& core) const;
@@ -172,7 +170,10 @@ uint32_t dm1_remapper_blob_core_size(const std::vector<std::shared_ptr<DataflowB
 std::vector<uint8_t> serialize_dm1_remapper_core_blob(
     const CoreCoord& core, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
 
-// Packs Quasar DFB config: [header | offset table | DM1 blobs | DM0 blobs | per-DFB layouts]. Returns bytes written.
+// Packs the architecture-specific per-core DFB config into caller-owned storage.
+// WH/BH uses a sparse, device-slot-indexed format table; Quasar uses
+// [header | offset table | DM1 blobs | DM0 blobs | per-DFB layouts].
+// Returns the number of bytes to transfer.
 size_t serialize_dfb_config_for_core(
     const CoreCoord& core,
     const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core,

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1140,19 +1140,8 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                     std::vector<uint8_t> dfb_config_vec(
                         program.impl().get_program_config(index).dfb_size / sizeof(uint8_t));
 
-                    size_t bytes_written = 0;
-                    if (MetalContext::instance().hal().has_tile_counter_registers()) {
-                        bytes_written = tt::tt_metal::experimental::dfb::detail::serialize_dfb_config_for_core(
-                            logical_core, dfbs_on_core, dfb_config_vec);
-                    } else {
-                        uint32_t offset = 0;
-                        for (const auto& dfb : dfbs_on_core) {
-                            auto serialized = dfb->serialize_for_core(logical_core);
-                            std::memcpy(dfb_config_vec.data() + offset, serialized.data(), serialized.size());
-                            offset += serialized.size();
-                        }
-                        bytes_written = offset;
-                    }
+                    const size_t bytes_written = tt::tt_metal::experimental::dfb::detail::serialize_dfb_config_for_core(
+                        logical_core, dfbs_on_core, dfb_config_vec);
 
                     uint64_t addr = kernel_config_base + program.impl().get_program_config(index).dfb_offset;
                     log_info(

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1515,29 +1515,9 @@ public:
             // All cores in a DFB's range have the same alloc_addr, so any core works.
             const CoreCoord logical_representative = core_range.start_coord;
 
-            size_t max_byte_end = 0;
-            if (!hal.has_tile_counter_registers()) {
-                // WH/BH: DFBs reuse the CB slot format; device slot N starts at N * 4 words.
-                for (const auto& dfb : dfbs_on_corerange) {
-                    size_t dfb_byte_offset = static_cast<size_t>(dfb->device_slot) *
-                                            UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
-                    auto serialized = dfb->serialize_for_core(logical_representative);
-                    TT_FATAL(
-                        dfb_byte_offset + serialized.size() <= payload.size(),
-                        "DFB {} (device slot {}) config at byte offset {} does not fit in the {}-byte config payload "
-                        "sized by finalize_dfbs",
-                        dfb->id,
-                        dfb->device_slot,
-                        dfb_byte_offset,
-                        payload.size());
-                    std::copy(serialized.begin(), serialized.end(), payload.begin() + dfb_byte_offset);
-                    max_byte_end = std::max(max_byte_end, dfb_byte_offset + serialized.size());
-                }
-            } else {
-                max_byte_end = tt::tt_metal::experimental::dfb::detail::serialize_dfb_config_for_core(
-                    logical_representative, dfbs_on_corerange, payload);
-                TT_ASSERT(max_byte_end <= payload.size());
-            }
+            const size_t max_byte_end = tt::tt_metal::experimental::dfb::detail::serialize_dfb_config_for_core(
+                logical_representative, dfbs_on_corerange, payload);
+            TT_ASSERT(max_byte_end <= payload.size());
 
             CoreRange virtual_range(virtual_start, virtual_end);
             auto noc_xy_addr = device->get_noc_multicast_encoding(constants.noc_index, virtual_range);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
https://github.com/tenstorrent/tt-metal/issues/54605

Sparse DFBs were not properly represented in the config that Slow Dispatch writes to device. Update this by making FD and SD share the same payload generator. 

Added missing test case for this and updated the tests to be able to run in FD or SD

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-slot-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-slot-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-slot-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-slot-sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=abhullar/dfb-slot-sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:abhullar/dfb-slot-sd)