### PR TITLE
[Bug fix][Test Only] Fix DM interleaved tests on N300

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved/test_interleaved.cpp
@@ -175,7 +175,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Interl
     Finish(cq);
 
     if (test_config.write_kernel) {
-        distributed::EnqueueReadMeshBuffer(cq, packed_output, output_buffer, /*blocking=*/true);
+        distributed::ReadShard(
+            cq, packed_output, output_buffer, distributed::MeshCoordinate(coord_data), /*blocking=*/true);
     } else {
         detail::ReadFromDeviceL1(
             device, corerange_to_cores(test_config.cores)[0], l1_addr, total_size_bytes, packed_output);

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -238,7 +238,8 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
     bool is_equal = false;
 
     if (test_config.write_kernel) {
-        distributed::EnqueueReadMeshBuffer(cq, packed_output, output_buffer, /*blocking=*/true);
+        distributed::ReadShard(
+            cq, packed_output, output_buffer, distributed::MeshCoordinate(coord_data), /*blocking=*/true);
         is_equal = (packed_output == packed_golden);
         if (!is_equal) {
             log_error(tt::LogTest, "Equality Check failed");


### PR DESCRIPTION
### PR Category
Bug fix, Test Only

### Summary

Fixes #54603

According to the fix suggested in the issue, `EnqueueReadMeshBuffer` is replaced with `ReadShard` to avoid assertion failure when the tests work on a non-unit mesh.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
(TM-DM) Data Movement Test Suite: https://github.com/tenstorrent/tt-metal/actions/runs/33126679317

_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov/54603)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov/54603)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov/54603)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov/54603)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov/54603)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov/54603)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov/54603)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov/54603)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov/54603)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov/54603)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov/54603)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov/54603)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov/54603)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov/54603)