### PR TITLE
fix(ttnn): overflow-safe logaddexp and logaddexp2 fused SFPU implementation (#52037)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -433,3 +433,94 @@ def test_binary_div_edge_case_ttnn(fast_and_approximate_mode, rounding_mode, dev
             torch.isnan(golden_tensor), torch.tensor(float("inf"), dtype=golden_tensor.dtype), golden_tensor
         )
     assert_with_ulp(golden_tensor, output_tensor, 0, allow_nonfinite=True)
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        (100.0, 0.0),  # exact answer is 100; exp(100) overflows in naive formula
+        (89.0, 0.0),  # just past log(FLT_MAX) = 88.72
+        (90.0, 89.0),
+        (200.0, 199.0),
+        (1000.0, 999.0),
+        (100.0, 100.0),
+        (-100.0, -100.0),  # both exponentials underflow to zero
+        (-1000.0, -1000.0),
+        (5.0, 3.0),  # inside currently-working band
+        (0.0, 0.0),
+    ],
+)
+def test_logaddexp_beyond_exp_range_fp32(device, a, b):
+    x_torch = torch.tensor([[a]], dtype=torch.float32)
+    y_torch = torch.tensor([[b]], dtype=torch.float32)
+    golden_fn = ttnn.get_golden_function(ttnn.logaddexp)
+    z_torch = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = ttnn.to_torch(ttnn.logaddexp(x_tt, y_tt))
+
+    assert torch.isfinite(tt_out).all(), (
+        f"logaddexp({a}, {b}) returned {tt_out.flatten()[0].item()}; "
+        f"the exact result is {z_torch.flatten()[0].item()}"
+    )
+    assert_allclose(tt_out, z_torch, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        (150.0, 0.0),  # exp2(150) overflows in naive formula (> 128)
+        (129.0, 0.0),  # just past log2(FLT_MAX) = 128.0
+        (130.0, 129.0),
+        (300.0, 299.0),
+        (1000.0, 999.0),
+        (1e5, 1e5),
+        (-130.0, -130.0),
+        (-1000.0, -1000.0),
+        (5.0, 3.0),
+        (0.0, 0.0),
+    ],
+)
+def test_logaddexp2_beyond_exp_range_fp32(device, a, b):
+    x_torch = torch.tensor([[a]], dtype=torch.float32)
+    y_torch = torch.tensor([[b]], dtype=torch.float32)
+    golden_fn = ttnn.get_golden_function(ttnn.logaddexp2)
+    z_torch = golden_fn(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = ttnn.to_torch(ttnn.logaddexp2(x_tt, y_tt))
+
+    assert torch.isfinite(tt_out).all(), (
+        f"logaddexp2({a}, {b}) returned {tt_out.flatten()[0].item()}; "
+        f"the exact result is {z_torch.flatten()[0].item()}"
+    )
+    assert_allclose(tt_out, z_torch, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("op", [ttnn.logaddexp, ttnn.logaddexp2])
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        (float("inf"), float("inf")),
+        (float("-inf"), float("-inf")),
+        (float("inf"), float("-inf")),
+        (float("-inf"), float("inf")),
+        (float("inf"), 0.0),
+        (float("-inf"), 0.0),
+    ],
+)
+def test_logaddexp_equal_infinities_fp32(device, op, a, b):
+    torch_op = torch.logaddexp if op == ttnn.logaddexp else torch.logaddexp2
+    x_torch = torch.tensor([[a]], dtype=torch.float32)
+    y_torch = torch.tensor([[b]], dtype=torch.float32)
+    z_torch = torch_op(x_torch, y_torch)
+
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_out = ttnn.to_torch(op(x_tt, y_tt))
+
+    got = tt_out.flatten()[0].item()
+    want = z_torch.flatten()[0].item()
+    assert got == want, f"{op.__name__}({a}, {b}) returned {got}; exact result is {want}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_binary_infinities.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_binary_infinities.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+# Both operations should properly handle IEEE-754 semantics:
+# max(inf, inf) + ... = inf
+# max(-inf, -inf) + ... = -inf
+# max(inf, -inf) + ... = inf
+# max(NaN, ...) + ... = NaN
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize("op", [ttnn.logaddexp, ttnn.logaddexp2])
+def test_eltwise_binary_infinities_and_edges(device, dtype, op):
+    # Determine the torch equivalent op
+    torch_op = torch.logaddexp if op == ttnn.logaddexp else torch.logaddexp2
+
+    # Map ttnn dtype to torch dtype
+    torch_dtype = torch.float32 if dtype == ttnn.float32 else torch.bfloat16
+
+    a_values = [
+        float("inf"), float("-inf"), float("inf"), float("-inf"),
+        float("inf"), float("-inf"), 10.0, 10.0,
+        float("nan"), 10.0, float("nan"), float("nan"), float("inf"),
+        0.0, -0.0, 0.0, -0.0,
+        100.0, 0.0, 100.0, -100.0, -100.0,
+        1e4, -1e4, 1000.0, 5.0,
+    ]
+    b_values = [
+        float("inf"), float("-inf"), float("-inf"), float("inf"),
+        10.0, 10.0, float("inf"), float("-inf"),
+        10.0, float("nan"), float("nan"), float("inf"), float("nan"),
+        -0.0, 0.0, 0.0, -0.0,
+        0.0, 100.0, 100.0, -100.0, 0.0,
+        1e4, -1e4, 999.0, 3.0,
+    ]
+    a_tensor = torch.tensor([a_values], dtype=torch_dtype)
+    b_tensor = torch.tensor([b_values], dtype=torch_dtype)
+
+    # Calculate golden result with torch
+    expected = torch_op(a_tensor, b_tensor)
+
+    # Calculate ttnn result
+    input_tensor_a = ttnn.from_torch(a_tensor, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT)
+    input_tensor_b = ttnn.from_torch(b_tensor, dtype=dtype, device=device, layout=ttnn.TILE_LAYOUT)
+
+    output_tensor = op(input_tensor_a, input_tensor_b)
+    actual = ttnn.to_torch(output_tensor)
+
+    # Extract raw lists for explicit per-element comparison of NaNs and Infs
+    expected_list = expected.flatten().tolist()
+    actual_list = actual.flatten().tolist()
+
+    for i in range(len(expected_list)):
+        e = expected_list[i]
+        a = actual_list[i]
+
+        if math.isnan(e):
+            assert math.isnan(a), f"Index {i} (a={a_values[i]}, b={b_values[i]}): Expected NaN, got {a}"
+        elif math.isinf(e):
+            assert math.isinf(a) and (e == a), f"Index {i} (a={a_values[i]}, b={b_values[i]}): Expected {e}, got {a}"
+        else:
+            # Check numerical accuracy for finite values
+            assert math.isfinite(a), f"Index {i} (a={a_values[i]}, b={b_values[i]}): Expected finite {e}, got {a}"
+
+    # Overall PCC check on finite values
+    finite_mask = torch.isfinite(expected)
+    if finite_mask.any():
+        assert_with_pcc(expected[finite_mask], actual[finite_mask], pcc=0.999)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_log1p.h"
+#include "ckernel_sfpu_conversions.h"
+
+namespace ckernel::sfpu {
+
+// logaddexp(a, b) = max(a, b) + log1p(exp(-|a - b|))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_sfpu_logaddexp(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = sfpi::max(a, b);
+
+        // Guard against inf - inf = NaN.
+        // In SFPU, inf == inf is True, NaN == NaN is False.
+        // By replacing identical inputs with 0.0f difference, we correctly
+        // output max(inf, inf) + ln(2) = inf, and NaN naturally propagates.
+        v_if(a == b) {
+            a = 0.0f;
+        }
+        v_else {
+            a = sfpi::abs(a - b);
+        }
+        v_endif;
+
+        // b is re-used to avoid spilling registers. Maximum 3 vFloat live at once.
+        b = _sfpu_exp_fp32_accurate_(-a);
+        result = result + calculate_log1p_fp32<is_fp32_dest_acc_en>(b);
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// logaddexp2(a, b) = max(a, b) + log2(1 + 2^(-|a - b|))
+// Formulated as max(a, b) + log1p(exp(-|a - b| * ln(2))) / ln(2)
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_sfpu_logaddexp2(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = sfpi::max(a, b);
+
+        v_if(a == b) {
+            a = 0.0f;
+        }
+        v_else {
+            a = sfpi::abs(a - b);
+        }
+        v_endif;
+
+        constexpr float LN2 = 0.6931471824645996f;
+        constexpr float INV_LN2 = 1.4426950408889634f;
+
+        b = _sfpu_exp_fp32_accurate_(-a * LN2);
+        result = result + calculate_log1p_fp32<is_fp32_dest_acc_en>(b) * INV_LN2;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Initialization parameters for log1p.
+template <bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_logaddexp_init() {
+    const float LOG_TWO = 0.693147182f;
+    const float TWO_TO_M23 = 1.19209290e-7f;
+    sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
+
+    if constexpr (is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm1 = -0x1.00001ap-2f;
+        sfpi::vConstFloatPrgm2 = 0x1.555572p-2f;
+    } else {
+        sfpi::vConstFloatPrgm1 = 0x1.744p-2f;
+        sfpi::vConstFloatPrgm2 = -0x1.008p-1f;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_log1p.h"
+#include "ckernel_sfpu_binary.h"
+
+namespace ckernel::sfpu {
+
+// logaddexp(a, b) = max(a, b) + log1p(exp(-|a - b|))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_sfpu_logaddexp(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = sfpi::max(a, b);
+
+        // Guard against inf - inf = NaN.
+        // In SFPU, inf == inf is True, NaN == NaN is False.
+        // By replacing identical inputs with 0.0f difference, we correctly
+        // output max(inf, inf) + ln(2) = inf, and NaN naturally propagates.
+        v_if(a == b) {
+            a = 0.0f;
+        }
+        v_else {
+            a = sfpi::abs(a - b);
+        }
+        v_endif;
+
+        // b is re-used to avoid spilling registers. Maximum 3 vFloat live at once.
+        b = _sfpu_exp_fp32_accurate_(-a);
+        result = result + calculate_log1p_fp32<is_fp32_dest_acc_en>(b);
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// logaddexp2(a, b) = max(a, b) + log2(1 + 2^(-|a - b|))
+// Formulated as max(a, b) + log1p(exp(-|a - b| * ln(2))) / ln(2)
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_sfpu_logaddexp2(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = sfpi::max(a, b);
+
+        v_if(a == b) {
+            a = 0.0f;
+        }
+        v_else {
+            a = sfpi::abs(a - b);
+        }
+        v_endif;
+
+        constexpr float LN2 = 0.6931471824645996f;
+        constexpr float INV_LN2 = 1.4426950408889634f;
+
+        b = _sfpu_exp_fp32_accurate_(-a * LN2);
+        result = result + calculate_log1p_fp32<is_fp32_dest_acc_en>(b) * INV_LN2;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Initialization parameters for log1p.
+template <bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_logaddexp_init() {
+    const float LOG_TWO = 0.693147182f;
+    const float TWO_TO_M23 = 1.19209290e-7f;
+    sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
+
+    if constexpr (is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm1 = -0x1.00001ap-2f;
+        sfpi::vConstFloatPrgm2 = 0x1.555572p-2f;
+    } else {
+        sfpi::vConstFloatPrgm1 = 0x1.744p-2f;
+        sfpi::vConstFloatPrgm2 = -0x1.008p-1f;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logaddexp.h
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_log1p.h"
+#include "ckernel_sfpu_conversions.h"
+
+namespace ckernel::sfpu {
+
+// logaddexp(a, b) = max(a, b) + log1p(exp(-|a - b|))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_sfpu_logaddexp(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = sfpi::max(a, b);
+
+        // Guard against inf - inf = NaN.
+        // In SFPU, inf == inf is True, NaN == NaN is False.
+        // By replacing identical inputs with 0.0f difference, we correctly
+        // output max(inf, inf) + ln(2) = inf, and NaN naturally propagates.
+        v_if(a == b) {
+            a = 0.0f;
+        }
+        v_else {
+            a = sfpi::abs(a - b);
+        }
+        v_endif;
+
+        // b is re-used to avoid spilling registers. Maximum 3 vFloat live at once.
+        b = _sfpu_exp_fp32_accurate_(-a);
+        result = result + calculate_log1p_fp32<is_fp32_dest_acc_en>(b);
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// logaddexp2(a, b) = max(a, b) + log2(1 + 2^(-|a - b|))
+// Formulated as max(a, b) + log1p(exp(-|a - b| * ln(2))) / ln(2)
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_sfpu_logaddexp2(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    constexpr uint dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat result = sfpi::max(a, b);
+
+        v_if(a == b) {
+            a = 0.0f;
+        }
+        v_else {
+            a = sfpi::abs(a - b);
+        }
+        v_endif;
+
+        constexpr float LN2 = 0.6931471824645996f;
+        constexpr float INV_LN2 = 1.4426950408889634f;
+
+        b = _sfpu_exp_fp32_accurate_(-a * LN2);
+        result = result + calculate_log1p_fp32<is_fp32_dest_acc_en>(b) * INV_LN2;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Initialization parameters for log1p.
+template <bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_logaddexp_init() {
+    const float LOG_TWO = 0.693147182f;
+    const float TWO_TO_M23 = 1.19209290e-7f;
+    sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
+
+    if constexpr (is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm1 = -0x1.00001ap-2f;
+        sfpi::vConstFloatPrgm2 = 0x1.555572p-2f;
+    } else {
+        sfpi::vConstFloatPrgm1 = 0x1.744p-2f;
+        sfpi::vConstFloatPrgm2 = -0x1.008p-1f;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/inc/api/compute/logaddexp.h
+++ b/tt_metal/hw/inc/api/compute/logaddexp.h
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "ckernel_sfpu_logaddexp.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise log-sum-exp on two inputs: y = log(exp(x0) + exp(x1)),
+ * evaluated as max(x0, x1) + log1p(exp(-|x0 - x1|)) so that no intermediate leaves
+ * the representable range. Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+ALWI void logaddexp_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        calculate_sfpu_logaddexp,
+        (APPROX, is_fp32_dest_acc_en, 8 /* ITERATIONS */),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void logaddexp_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(add1, sfpu::calculate_sfpu_logaddexp_init, (DST_ACCUM_MODE))));
+}
+
+// clang-format off
+/**
+ * Performs an elementwise base-2 log-sum-exp on two inputs: y = log2(2^x0 + 2^x1),
+ * evaluated as max(x0, x1) + log1p(exp(-|x0 - x1| * ln2)) / ln2 so that no intermediate leaves
+ * the representable range. Output overwrites odst in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst           | The index of the tile in DST register buffer to use as output         | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
+ALWI void logaddexp2_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst) {
+    MATH((SFPU_BINARY_CALL(
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        calculate_sfpu_logaddexp2,
+        (APPROX, is_fp32_dest_acc_en, 8 /* ITERATIONS */),
+        idst0,
+        idst1,
+        odst,
+        VectorMode::RC)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void logaddexp2_binary_tile_init() {
+    MATH((SFPU_BINARY_INIT_FN(add1, sfpu::calculate_sfpu_logaddexp_init, (DST_ACCUM_MODE))));
+}
+
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -57,6 +57,7 @@
 #include "llk_sfpu/ckernel_sfpu_lcm.h"
 #include "llk_sfpu/ckernel_sfpu_lgamma.h"
 #include "llk_sfpu/ckernel_sfpu_log.h"
+#include "llk_sfpu/ckernel_sfpu_logaddexp.h"
 #include "llk_sfpu/ckernel_sfpu_logical_not.h"
 #include "llk_sfpu/ckernel_sfpu_logsigmoid.h"
 #include "llk_sfpu/ckernel_sfpu_mask.h"
@@ -1624,6 +1625,14 @@ void call_binary_sfpu_operation_init()
         // fmod uses the reciprocal path; init loads the reciprocal polynomial.
         SFPU_BINARY_INIT_FN(add1, fmod_binary_init, (APPROXIMATION_MODE));
     }
+    else if constexpr (BINOP == BinaryOp::LOGADDEXP || BINOP == BinaryOp::LOGADDEXP2)
+    {
+        // logaddexp and logaddexp2 log1p reads its polynomial coefficients from the program
+        // constant registers; the coefficient set differs by destination precision,
+        // so the init is templated on DST_ACCUM_MODE. Baseline (add1) addrmod setup,
+        // like fmod/remainder. Mirrors logaddexp_binary_tile_init() and logaddexp2_binary_tile_init().
+        SFPU_BINARY_INIT_FN(add1, sfpu::calculate_sfpu_logaddexp_init, (DST_ACCUM_MODE));
+    }
     else if constexpr (BINOP == BinaryOp::REMAINDER)
     {
         // remainder_binary_init loads the reciprocal polynomial (Wormhole) or
@@ -1789,6 +1798,34 @@ void call_binary_sfpu_operation(
             DST_ACCUM_MODE,
             calculate_sfpu_binary_div,
             (APPROXIMATION_MODE, BINOP, PER_FACE_ITERATIONS, DST_ACCUM_MODE),
+            dst_index_in0,
+            dst_index_in1,
+            dst_index_out,
+            vector_mode);
+    }
+    else if constexpr (BINOP == BinaryOp::LOGADDEXP)
+    {
+        // The fused overflow-safe kernel from ckernel_sfpu_logaddexp.h; DST_ACCUM_MODE
+        // (is_fp32_dest_acc_en) selects the fp32 vs bf16 log1p coefficient set that the
+        // paired init loaded, and the bf16 round-to-nearest-even on store.
+        SFPU_BINARY_CALL(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            calculate_sfpu_logaddexp,
+            (APPROXIMATION_MODE, DST_ACCUM_MODE, PER_FACE_ITERATIONS),
+            dst_index_in0,
+            dst_index_in1,
+            dst_index_out,
+            vector_mode);
+    }
+    else if constexpr (BINOP == BinaryOp::LOGADDEXP2)
+    {
+        // The fused overflow-safe kernel for base-2 from ckernel_sfpu_logaddexp.h
+        SFPU_BINARY_CALL(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            calculate_sfpu_logaddexp2,
+            (APPROXIMATION_MODE, DST_ACCUM_MODE, PER_FACE_ITERATIONS),
             dst_index_in0,
             dst_index_in1,
             dst_index_out,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -3803,6 +3803,8 @@ class BinarySFPUGolden(EltwiseBinaryGolden):
                 MathOperation.SfpuLeInt: self._le_int,
                 MathOperation.SfpuGeInt: self._ge_int,
                 MathOperation.SfpuXlogy: self._xlogy,
+                MathOperation.SfpuLogaddexp: self._logaddexp,
+                MathOperation.SfpuLogaddexp2: self._logaddexp2,
                 MathOperation.SfpuElwrsub: self._rsub,
                 MathOperation.SfpuElwpow: self._pow,
                 MathOperation.SfpuElwRightShift: self._right_shift,
@@ -4130,6 +4132,19 @@ class BinarySFPUGolden(EltwiseBinaryGolden):
         )
         res = xf * torch.log(yf)
         return res.to(x.dtype) if isinstance(x, torch.Tensor) else res.item()
+
+    def _logaddexp(self, t1, t2):
+        # logaddexp(a, b) = log(exp(a) + exp(b)), finite for any finite pair. Computed
+        # in fp32 to mirror the SFPU kernel's fused max(a,b) + log1p(exp(-|a-b|)) form,
+        # which never overflows an intermediate.
+        wide = self._wide_dtype(t1)
+        return torch.logaddexp(t1.to(wide), t2.to(wide)).to(t1.dtype)
+
+    def _logaddexp2(self, t1, t2):
+        # logaddexp2(a, b) = log2(2^a + 2^b), finite for any finite pair. Computed
+        # in fp32 to mirror the SFPU kernel's fused max(a,b) + log1p(exp(-|a-b|*ln2))/ln2 form.
+        wide = self._wide_dtype(t1)
+        return torch.logaddexp2(t1.to(wide), t2.to(wide)).to(t1.dtype)
 
     def _rsub(self, t1, t2):
         # rsub(a, b) = b - a. The kernel computes in1 - in0, i.e. src2 - src1.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -246,6 +246,8 @@ class MathOperation(Enum):
     SfpuElwdiv = OpSpec("DIV", MathOpType.SFPU_BINARY)
     SfpuElwrsub = OpSpec("RSUB", MathOpType.SFPU_BINARY)
     SfpuElwpow = OpSpec("POW", MathOpType.SFPU_BINARY)
+    SfpuLogaddexp = OpSpec("LOGADDEXP", MathOpType.SFPU_BINARY)
+    SfpuLogaddexp2 = OpSpec("LOGADDEXP2", MathOpType.SFPU_BINARY)
     SfpuElwmulInt = OpSpec("MUL", MathOpType.SFPU_BINARY_INT)
     SfpuGtInt = OpSpec("GT_INT", MathOpType.SFPU_BINARY_INT)
     SfpuLtInt = OpSpec("LT_INT", MathOpType.SFPU_BINARY_INT)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -797,6 +797,22 @@ _OP_DOMAIN_REGISTRY: Dict[
             distribution=DistributionKind.LOG_UNIFORM, low=1e-4, high=10.0
         ),
     ),
+    MathOperation.SfpuLogaddexp: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-200.0, high=200.0
+        ),
+        spec_B=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-200.0, high=200.0
+        ),
+    ),
+    MathOperation.SfpuLogaddexp2: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-200.0, high=200.0
+        ),
+        spec_B=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-200.0, high=200.0
+        ),
+    ),
     MathOperation.SfpuAddTopRow: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-1.0, high=1.0)
     ),
@@ -1113,6 +1129,8 @@ _SFPU_BINARY_OPS: FrozenSet[MathOperation] = frozenset(
         MathOperation.SfpuElwpow,
         MathOperation.SfpuElwrsub,
         MathOperation.SfpuXlogy,
+        MathOperation.SfpuLogaddexp,
+        MathOperation.SfpuLogaddexp2,
         MathOperation.SfpuElwLeftShift,
         MathOperation.SfpuElwRightShift,
         MathOperation.SfpuElwLogicalRightShift,
@@ -2453,6 +2471,10 @@ _BINARY_SPECIALS_NOT_READY: Dict[MathOperation, str] = {
     MathOperation.SfpuBinaryRemainder: "composition: as fmod. Section 5.6 Q1.",
     MathOperation.SfpuAtan2: "composition: ratio plus a format-specific polynomial. Diverges on "
     "2 cells rather than 4, so its non-finite handling is partial. Section 5.6 Q1.",
+    MathOperation.SfpuLogaddexp: "composition: max(a, b) + log1p(exp(-|a - b|)), so a log and an "
+    "exp behind the same question as div and xlogy. Section 5.6 Q1.",
+    MathOperation.SfpuLogaddexp2: "composition: max(a, b) + log1p(exp(-|a - b|*ln2))/ln2, so a log and an "
+    "exp behind the same question as div and xlogy. Section 5.6 Q1.",
     # (2) Compare-against-zero on an operand that may be a NaN. calculate_mask is
     # `v_if(mask == 0)`, which lowers to SFPSETCC -- whose contract is conditioned "provided that
     # VC is neither negative zero nor any kind of NaN". Identical to what holds Sign and Heaviside

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary_sfpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary_sfpu.py
@@ -256,6 +256,8 @@ _REGISTRY_DOMAIN_OPS = frozenset(
         MathOperation.SfpuElwdiv,
         MathOperation.SfpuElwpow,
         MathOperation.SfpuXlogy,
+        MathOperation.SfpuLogaddexp,
+        MathOperation.SfpuLogaddexp2,
     }
 )
 
@@ -744,6 +746,8 @@ def sfpu_binary(
         MathOperation.SfpuElwrsub,
         MathOperation.SfpuElwpow,
         MathOperation.SfpuXlogy,
+        MathOperation.SfpuLogaddexp,
+        MathOperation.SfpuLogaddexp2,
         # Eq/Ne and Lt/Gt/Le/Ge are excluded from this *random* sweep: independent draws
         # are never equal (the Eq/Ne golden collapses to a constant) and near-ties that
         # the kernel and the total-order golden round differently read as failures. They
@@ -767,8 +771,10 @@ def test_eltwise_binary_sfpu_float(
     if formats.input_format == DataFormat.Bfp8_b and mathop in (
         MathOperation.SfpuElwpow,
         MathOperation.SfpuXlogy,
+        MathOperation.SfpuLogaddexp,
+        MathOperation.SfpuLogaddexp2,
     ):
-        pytest.skip("Bfp8_b is not supported for POW/XLOGY coverage")
+        pytest.skip("Bfp8_b is not supported for POW/XLOGY/LOGADDEXP/LOGADDEXP2 coverage")
 
     if bcast_dim == LlkBroadcastType.Row and (
         dest_acc == DestAccumulation.Yes

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -360,6 +360,8 @@ enum class BinaryOp : std::uint8_t
     REMAINDER_INT32  = 40,
     REMAINDER_UINT32 = 41,
     FMOD_INT32       = 42,
+    LOGADDEXP        = 43,
+    LOGADDEXP2       = 44,
 };
 
 enum class PackMode : std::uint8_t

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -77,6 +77,8 @@ enum class BinaryOp : std::uint8_t
     REQUANT,
     DEQUANT,
     ATAN2,
+    LOGADDEXP,
+    LOGADDEXP2,
 };
 
 // For instructions that address lower/upper 16 bits of a register

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -342,6 +342,8 @@ enum class BinaryOp : std::uint8_t
     REMAINDER_INT32  = 40,
     REMAINDER_UINT32 = 41,
     FMOD_INT32       = 42,
+    LOGADDEXP        = 43,
+    LOGADDEXP2       = 44,
 };
 
 enum class PackMode : std::uint8_t

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -62,7 +62,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b, bool fast_and_a
             return !fast_and_approximate_mode || (a == b && (a == FLOAT32 || a == INT32 || a == UINT32 || a == UINT16));
         case DIV: return !fast_and_approximate_mode || (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32);
         case LOGADDEXP:
-        case LOGADDEXP2:
+        case LOGADDEXP2: return a == b && (a == FLOAT32 || a == BFLOAT16);
         case LDEXP:
         case BIAS_GELU:
         case HYPOT: return (a == FLOAT32 && b == FLOAT32);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -249,17 +249,25 @@ OpConfig::OpConfig(
             break;
         // log( exp(a) + exp(b) )
         case BinaryOpType::LOGADDEXP:
-            process_lhs = unary::UnaryOpType::EXP;
-            process_rhs = unary::UnaryOpType::EXP;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP;
+            } else {
+                process_lhs = unary::UnaryOpType::EXP;
+                process_rhs = unary::UnaryOpType::EXP;
+                binary_op = EnumT::ADD;
+                postprocess = unary::UnaryOpType::LOG;
+            }
             break;
         // log2( 2**a + 2**b )
         case BinaryOpType::LOGADDEXP2:
-            process_lhs = unary::UnaryOpType::EXP2;
-            process_rhs = unary::UnaryOpType::EXP2;
-            binary_op = EnumT::ADD;
-            postprocess = unary::UnaryOpType::LOG2;
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LOGADDEXP2;
+            } else {
+                process_lhs = unary::UnaryOpType::EXP2;
+                process_rhs = unary::UnaryOpType::EXP2;
+                binary_op = EnumT::ADD;
+                postprocess = unary::UnaryOpType::LOG2;
+            }
             break;
         case BinaryOpType::BITWISE_AND:
             if (is_sfpu_op()) {
@@ -557,6 +565,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
                                                                      : "Float16_b";
             return {"where_tile_init();", fmt::format("where_tile<DataFormat::{}>", data_format)};
         }
+        case LOGADDEXP: return {"logaddexp_binary_tile_init();", "logaddexp_binary_tile"};
+        case LOGADDEXP2: return {"logaddexp2_binary_tile_init();", "logaddexp2_binary_tile"};
         case ISCLOSE: return {"isclose_binary_tile_init();", "isclose_binary_tile<(bool)ISCLOSE_EQUAL_NAN>"};
         default: TT_THROW("Unsupported sfpu binary op {}", sfpu_binary_op);
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -79,6 +79,8 @@ struct OpConfig {
         MINIMUM,
         XLOGY,
         ATAN2,
+        LOGADDEXP,
+        LOGADDEXP2,
         LT,
         GT,
         GE,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/logaddexp.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -23,6 +23,7 @@
 #include "api/compute/lcm.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/logaddexp.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -20,6 +20,7 @@
 #include "api/compute/quantization.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"
+#include "api/compute/logaddexp.h"
 #include "api/compute/binary_comp.h"
 #include "api/compute/isclose.h"
 #include "eltwise_utils_common.hpp"


### PR DESCRIPTION
Fixes #52037

Replaces the composite `log(add(exp(a), exp(b)))` fallback with a fused, overflow-safe SFPU formulation to prevent intermediate overflow/underflow for large inputs.

### What changed
* **Numerically Stable Math**: Implements $\max(a, b) + \ln(1 + e^{-|a-b|})$ for `logaddexp` and the equivalent base-2 formula for `logaddexp2`. 
* **Single Kernel Dispatch**: Replaces the 3-kernel fallback graph with a single fused SFPU call, removing intermediate L1/DRAM allocations.
* **Architecture Support**: Added `v_if(a == b)` hardware logic for Blackhole, Wormhole B0, and Quasar. (Verified 0 register spills on all three).
* **Dtypes**: Both `BFLOAT16` and `FLOAT32` now route natively to the SFPU in BinaryNG.
* **Non-finite safety**: Explicitly catches equal-infinity edge cases to avoid `inf - inf = NaN` bugs.

### Verification
* Tested far beyond standard `[-88.7, 88.7]` ranges.
* `(+inf, +inf) -> +inf`, `(-inf, -inf) -> -inf`, and `NaN` propagation all match `torch.logaddexp` exactly.
* Fully wired into the TT-LLK sweep framework and TTNN unit tests.
