### PR TITLE
[Test Only] Fix mesh tests on larger system topologies

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -62,8 +62,7 @@ TEST_F(MeshDevice2x4Test, SystemMeshTearDownWithoutClose) {
 
     const auto system_shape = sys.shape();
     ASSERT_EQ(system_shape.dims(), 2);
-    EXPECT_EQ(system_shape[0], 2);
-    EXPECT_EQ(system_shape[1], 4);
+    EXPECT_GE(system_shape.mesh_size(), mesh_device_->shape().mesh_size());
 }
 
 TEST_F(MeshDevice2x4Test, MemoryAllocationStatistics) {

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -118,13 +118,16 @@ public:
 
 TEST_F(MeshDevice1x8ReshapeTest, InvalidRequestedShape) {
     auto& system_mesh = tt::tt_metal::MetalContext::instance().get_system_mesh();
+    const auto& system_shape = system_mesh.shape();
+    ASSERT_EQ(system_shape.dims(), 2);
 
     // Shape too big.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(9)));
-    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(2, 5)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(system_shape.mesh_size() + 1)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(system_shape[0] + 1, system_shape[1])));
 
     // Invalid offset.
-    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(2, 3), /*offset=*/MeshCoordinate(1, 1)));
+    EXPECT_ANY_THROW(system_mesh.get_mapped_devices(
+        MeshShape(2, 2), /*offset=*/MeshCoordinate(system_shape[0] - 1, system_shape[1] - 1)));
 
     // Offset dimensionality mismatch.
     EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(2, 3), /*offset=*/MeshCoordinate(1)));


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Fixes #53880, fixes #53881

Fixes checks within MeshDevice2x4Test.SystemMeshTearDownWithoutClose and MeshDevice1x8ReshapeTest.InvalidRequestedShape to support systems with topologies larger than their mesh dimensions.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/fix-sub-mesh-tests-on-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/fix-sub-mesh-tests-on-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/fix-sub-mesh-tests-on-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/fix-sub-mesh-tests-on-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/fix-sub-mesh-tests-on-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/fix-sub-mesh-tests-on-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/fix-sub-mesh-tests-on-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/fix-sub-mesh-tests-on-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/fix-sub-mesh-tests-on-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/fix-sub-mesh-tests-on-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/fix-sub-mesh-tests-on-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/fix-sub-mesh-tests-on-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/fix-sub-mesh-tests-on-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/fix-sub-mesh-tests-on-galaxy)