### PR TITLE
[LLK] Gate mul_reduce_scalar's Dest->Src moves on source bank-valid

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
@@ -139,6 +139,19 @@ inline void incr_counters(const std::uint32_t incr_a, const std::uint32_t incr_b
     TT_INCRWC(incr_cr, incr_d, incr_b, incr_a);
 }
 
+// MOVD2A/MOVD2B write SrcA/SrcB from Dest, so they fall outside the Src auto-wait, which covers
+// only instructions that read Src. Gate the row moves on the target bank's DVALID, and drain
+// in-flight math so the Dest values those moves read back have settled.
+inline void srca_bank_wait()
+{
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
+}
+
+inline void srcb_bank_wait()
+{
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+}
+
 inline void move_d2a_fixed_face(const std::uint8_t addrmod)
 {
     // Drain preceding math instructions so their source-bank release is visible before testing

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -89,6 +89,10 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
         }
 
+        // MOVD2A writes SrcA from Dest and so is outside the Src auto-wait. Gate on the unpacker's
+        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
+
         switch (idst)
         {
             case 0:
@@ -121,6 +125,10 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
     }
     else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
     {
+        // MOVD2B writes SrcB from Dest and so is outside the Src auto-wait. Gate on the unpacker's
+        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+
         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
 
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
@@ -247,6 +255,9 @@ inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ck
 template <MathFidelity math_fidelity>
 inline void _llk_math_mul_reduce_scalar_()
 {
+    // Same gate as the DEST_TO_SRCB move: MOVD2B is outside the Src auto-wait.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+
     // Copy row 0 from dest to srcB (rows 16-31 as scratch) and transpose
     TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
     TTI_GATESRCRST(0b1, 0b1);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -89,9 +89,7 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
         }
 
-        // MOVD2A writes SrcA from Dest and so is outside the Src auto-wait. Gate on the unpacker's
-        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
+        math::srca_bank_wait();
 
         switch (idst)
         {
@@ -125,9 +123,7 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
     }
     else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
     {
-        // MOVD2B writes SrcB from Dest and so is outside the Src auto-wait. Gate on the unpacker's
-        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+        math::srcb_bank_wait();
 
         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
 
@@ -255,8 +251,7 @@ inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ck
 template <MathFidelity math_fidelity>
 inline void _llk_math_mul_reduce_scalar_()
 {
-    // Same gate as the DEST_TO_SRCB move: MOVD2B is outside the Src auto-wait.
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+    math::srcb_bank_wait();
 
     // Copy row 0 from dest to srcB (rows 16-31 as scratch) and transpose
     TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
@@ -27,7 +27,9 @@ inline void _llk_unpack_mul_reduce_scalar_switch_to_reduce_()
 {
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
     semaphore_post(semaphore::UNPACK_SYNC);
-    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    // Stall_Clr_Cntrl=1: wait on Unpackers[i].SrcBank -- the bank actually cleared and published --
+    // not MatrixUnit.Src?Bank, which is a different bank once double-buffering reaches steady state.
+    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 1, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
     t6_semaphore_get(semaphore::UNPACK_SYNC);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -138,6 +138,19 @@ inline void incr_counters(const std::uint32_t incr_a, const std::uint32_t incr_b
     TT_INCRWC(incr_cr, incr_d, incr_b, incr_a);
 }
 
+// MOVD2A/MOVD2B write SrcA/SrcB from Dest, so they fall outside the Src auto-wait, which covers
+// only instructions that read Src. Gate the row moves on the target bank's DVALID, and drain
+// in-flight math so the Dest values those moves read back have settled.
+inline void srca_bank_wait()
+{
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
+}
+
+inline void srcb_bank_wait()
+{
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+}
+
 inline void move_d2a_fixed_face(const std::uint8_t addrmod)
 {
     TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD); // MOVD2A for a whole face assumes unpacker will set a dummy data_valid, so we want to wait on that

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -89,6 +89,10 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
         }
 
+        // MOVD2A writes SrcA from Dest and so is outside the Src auto-wait. Gate on the unpacker's
+        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
+
         switch (idst)
         {
             case 0:
@@ -121,6 +125,10 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
     }
     else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
     {
+        // MOVD2B writes SrcB from Dest and so is outside the Src auto-wait. Gate on the unpacker's
+        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
+        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+
         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
 
         TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
@@ -247,6 +255,9 @@ inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ck
 template <MathFidelity math_fidelity>
 inline void _llk_math_mul_reduce_scalar_()
 {
+    // Same gate as the DEST_TO_SRCB move: MOVD2B is outside the Src auto-wait.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+
     // Copy row 0 from dest to srcB (rows 16-31 as scratch) and transpose
     TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
     TTI_GATESRCRST(0b1, 0b1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -89,9 +89,7 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
         }
 
-        // MOVD2A writes SrcA from Dest and so is outside the Src auto-wait. Gate on the unpacker's
-        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
+        math::srca_bank_wait();
 
         switch (idst)
         {
@@ -125,9 +123,7 @@ inline void _llk_math_mul_reduce_scalar_move_dest_to_src_([[maybe_unused]] std::
     }
     else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
     {
-        // MOVD2B writes SrcB from Dest and so is outside the Src auto-wait. Gate on the unpacker's
-        // dummy DVALID -- its UNP_ZEROSRC zeroes the bank these rows fill -- and drain in-flight math.
-        TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+        math::srcb_bank_wait();
 
         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
 
@@ -255,8 +251,7 @@ inline void _llk_math_mul_reduce_column_(const std::uint32_t dst_index, const ck
 template <MathFidelity math_fidelity>
 inline void _llk_math_mul_reduce_scalar_()
 {
-    // Same gate as the DEST_TO_SRCB move: MOVD2B is outside the Src auto-wait.
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
+    math::srcb_bank_wait();
 
     // Copy row 0 from dest to srcB (rows 16-31 as scratch) and transpose
     TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
@@ -28,9 +28,11 @@ inline void _llk_unpack_mul_reduce_scalar_switch_to_reduce_()
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
     semaphore_post(semaphore::UNPACK_SYNC);
     // WH requires ZEROSRC and SET_DVALID to be sequenced as separate UNPACR_NOPs.
-    TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC);
+    // ZEROSRC carries the wait-like-UNPACR bit so it gates on Unpackers[i].SrcBank -- the bank it
+    // actually clears -- rather than MatrixUnit.Src?Bank; SET_DVALID inherits that wait by sequencing.
+    TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC_STALL_RESET_WR_RDY);
     TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_SET_DVALID);
-    TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC_STALL_RESET_WR_RDY);
     TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_SET_DVALID);
     t6_semaphore_get(semaphore::UNPACK_SYNC);
 }


### PR DESCRIPTION
Fixes #53412 (sub-issue of #53394, TT-NOP injector race findings).

## The race

`MOVD2A` / `MOVD2B` write SrcA/SrcB **from Dest**. The Src auto-wait covers instructions that *read* Src, so these moves fall outside it and need an explicit bank-valid gate. The reduce-phase moves had **no gate at all** — not a wrong mask, absent:

- `_llk_math_mul_reduce_scalar_move_dest_to_src_` — 16x `MOVD2A` (`DEST_TO_SRCA`) and 16x `MOVD2B` (`DEST_TO_SRCB`)
- `_llk_math_mul_reduce_scalar_` — the row-0 `MOVD2B` into the SrcB scratch rows

They race `_llk_unpack_mul_reduce_scalar_switch_to_reduce_`'s `UNPACR_NOP(SrcX, SET_DVALID, UNP_ZEROSRC)`. When MATH wins, it fills the bank from Dest and the unpacker's **`UNP_ZEROSRC` then zeroes the rows just written**, so `GAPOOL` reduces zeros and the scalar comes out `0.0`.

## The fix

Adopt the idiom already three functions away in the same tree — `cmath_common.h`'s `move_d2a_fixed_face` / `move_d2b_fixed_face`, whose own comment states it outright ("MOVD2A does not auto-wait for `SrcA[MatrixUnit.SrcABank].AllowedClient == MatrixUnit`, so gate on SRCA_VLD before the row moves"):

```c
TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);   // before the MOVD2A rows
TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);   // before the MOVD2B rows
```

The `MATH` condition additionally drains the multiply-phase Dest writes that the moves read back.

**Cost is bounded to one wait per reduce phase.** The unpacker posts the dummy DVALID once in `switch_to_reduce_`, and nothing clears it until the closing `CLEARDVALID` — so the gate blocks only the first move of a phase; the `move_dest_to_src<DEST_TO_SRCA>(i)` calls in the per-tile loop find the bank already valid and fall straight through. Checked every caller (`mul_reduce_scalar.h`, `sum_reduce_scalar.h`, `rmsnorm.h`, and the four tt-llk test sources) — all pair `switch_to_reduce` with the moves before any `clear_dvalid`, so no call site can deadlock on the new wait.

## Also in this diff: the unpack-side bank wait (throughput, not part of the fix)

`llk_unpack_mul_reduce_scalar.h` (both arches) also switches its two dummy publications to the pipelined bank wait — `Stall_Clr_Cntrl=1` on Blackhole, `UNP_ZEROSRC_STALL_RESET_WR_RDY` on Wormhole. Note the shapes differ: BH carries `Set_Dvalid` and `Unpack_Pop=UNP_ZEROSRC` in one instruction, whereas WH needs two, and it is the `ZEROSRC` of the pair that takes the bit — the following bare `SET_DVALID` performs no wait of its own and inherits one by sequencing. **This is a throughput/parity change and is not what the validation below exercises.** Calling it out because the diff contains it and the rest of this description is about the math-side gate.

The bit selects only *which bank the publication waits on*: set, it gates on `Unpackers[i].SrcBank` — the bank it actually clears — so unpack can prepare the next bank while math consumes the current one; clear (the default), it gates on `MatrixUnit.Src?Bank`, which under the bank-pointer lockstep invariant is back with the unpackers only when *no* bank is outstanding. The default is therefore the **stronger, serializing** wait, and it implies the own-bank condition — so the old form over-waits, it does not under-wait. The bank cleared is `UnpackBank` either way.

This matches #52256, whose commit message calls `Stall_Clr_Cntrl=1` *"the preferred Blackhole operating mode ... complementary to, rather than a replacement for, the explicit math-pipeline drain."* The gate added above is that drain; this bit is the mode.

Both publications clear a single bank (`Bank_Clr_Ctrl=0`). That matters: with a both-banks clear the own-bank wait would cover only the bank being prepared and could overwrite one the Matrix Unit still owns, so the bit is valid only for single-bank publications.

The **36/36** result cited below is a no-regression result for this half, not fail-without/pass-with evidence — a pipelining change is expected to be behaviour-neutral. The Wormhole side of it is unexercised for the same reason the gate is (see the reviewer note at the end).

## Validation (Blackhole p100a, sfpi 7.72.0)

Fail-without / pass-with, using the issue's own recreate command:

```bash
CHIP_ARCH=blackhole ./focus.sh --site sync --sites unpack:3 --nop tti_nop \
  --delays 5-100 --repeats 5 \
  'test_mul_reduce_scalar.py::test_mul_reduce_scalar[formats:Float16_b->Float16_b-math_fidelity:HiFi2-num_tiles:1-tile_dimensions:[16, 16]]'
```

| tree | result |
| --- | --- |
| `origin/main` (pristine) | **96/96 variants mismatch**, 5/5 runs each, `device=0.0 golden=130.703125` |
| this PR | **0 findings**, every variant passes |
| control: this PR **minus only the SrcA gate** | failure returns, same site and signature |

The third row is there because "no findings" on its own does not prove the injector was still
firing. Dropping just the `SRCA_VLD` gate from the patched tree brings the mismatch straight back
at the same `SEMGET` site, so injection is live on the patched tree and the SrcA gate is the one
this failure needs.

`device=0.0` is the mechanism above showing through directly: the reduction ran on a zeroed bank.

Unperturbed suite: `test_mul_reduce_scalar.py` **54/54 pass** on Blackhole with the fix.

The delay band is 5-100 rather than the issue's original counts because NOP counts are harness-build-specific (the report was taken at an older sfpi pin); the site and the mechanism are the same.

## Wormhole

The two `llk_math_mul_reduce_scalar.h` files are byte-identical apart from the `ZEROACC` signature, so Wormhole carries the same missing gate, and WH's own `cmath_common.h` has the same `move_d2*_fixed_face` idiom. Fixed there too, deliberately, to avoid the recurring pattern of a Blackhole dest-reuse fix never reaching Wormhole.

Verified the WH edit is actually emitted rather than compiled away: the WH math kernel builds clean, and its `.text` grows from 3280 to 3332 bytes against pristine (`INSTRUCTION_WORD` embeds the Tensix word as a RISC-V immediate, so the instructions do not appear as standalone `.text` words).

**Reviewer note:** the Wormhole change is reasoned, compile-verified and binary-verified, but **not HW-validated** — there is no WH silicon on this box, and `test_mul_reduce_scalar.py` skips itself on non-Blackhole (`"mul_reduce_scalar is a Blackhole-only experimental LLK"`). Worth a WH run before merge if anyone has a board. Note the compute APIs `mul_reduce_scalar.h` / `sum_reduce_scalar.h` are *not* `ARCH_BLACKHOLE`-gated the way `rmsnorm.h` is, so the WH path is reachable live code, not dead.

## Not in this PR

The audit behind #53412 found two further defects on this path, left out to keep the fix reviewable. Neither is required for the mismatch above:

1. `_llk_math_mul_reduce_scalar_init_` rewrites `ADDR_MOD_0/1/2` with no drain while multiply-phase `ELWMUL`s are still in the FPU (`ApplyAddrMod` runs as the FPU instruction's last step and reads those words).
2. No SFPU->FPU Dest drain between `_calculate_fill_`'s `SFPSTORE`s and the following `MOVD2B`/`GAPOOL`; `DISABLE_IMPLIED_SRCA_FMT_Base` is also never set around the Dest->Src moves, though the ISA calls it strongly recommended on Blackhole.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/bh-mul-reduce-scalar-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/bh-mul-reduce-scalar-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/bh-mul-reduce-scalar-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/bh-mul-reduce-scalar-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/bh-mul-reduce-scalar-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/bh-mul-reduce-scalar-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/bh-mul-reduce-scalar-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/bh-mul-reduce-scalar-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/bh-mul-reduce-scalar-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/bh-mul-reduce-scalar-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/bh-mul-reduce-scalar-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/bh-mul-reduce-scalar-sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/bh-mul-reduce-scalar-sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/bh-mul-reduce-scalar-sync)

