### PR TITLE
[EXPERIMENT — DO NOT MERGE] Drop -flto=auto from JIT kernel common_flags to see what CI reports

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -168,8 +168,9 @@ void JitBuildEnv::init(
         "-std=c++17 -ftt-nttp -ftt-constinit -ftt-consteval "
         // Ban dynamic initializations, via a check we've added
         "-ftt-no-dyninit "
-        // Rely on Link Time Optimization (removes globally unreachable code)
-        "-flto=auto "
+        // EXPERIMENT (do not merge): "-flto=auto " removed here to see what CI reports.
+        // See tenstorrent/tt-metal#54692 -- locally this fails with three
+        // -Werror=array-bounds errors on fixed-address mailbox accesses.
         // Fast math allows non-IEEE compliant optimizations ...
         "-ffast-math "
         // ... but we require these IEEE behaviors


### PR DESCRIPTION
> **This PR is expected to fail and must not be merged.** It exists to get CI's verdict on a one-token change, as an independent check against a local reproduction. Draft, and I'll close it once CI has reported.

## What this changes

One token removed from `common_flags` in `tt_metal/jit_build/build.cpp:172`:

```diff
-        // Rely on Link Time Optimization (removes globally unreachable code)
-        "-flto=auto "
```

`common_flags` is assigned to **both** `cflags_` (`:188`) and `lflags_` (`:358`), so this affects JIT kernel compile *and* link.

## What I expect CI to report

Locally, replaying a real logged compile command (captured with `TT_METAL_LOG_KERNELS_COMPILE_COMMANDS=1`) with exactly this token deleted fails with three `-Werror=array-bounds` errors:

| Location | Expression |
|---|---|
| `tt_metal/hw/inc/internal/tt-1xx/blackhole/eth_fw_api.h:257` | `GET_MAILBOX_ADDRESS_DEV(link_status_check_timestamp)` |
| `tt_metal/hw/inc/internal/firmware_common.h:201` | `mailboxes->go_message_index` |
| `tt_metal/hw/inc/internal/firmware_common.h:203` | `mailboxes->go_messages[go_message_index].signal` |

each with `cc1plus: note: source object is likely at address zero`, then `cc1plus: all warnings being treated as errors`.

**Diagnosis:** these are casts of literal device addresses to pointers. With LTO enabled GCC cannot see across translation units to bounds-check them; with it disabled it can, concludes the object is at address zero, and `-Werror` makes it fatal. The diagnostic is correct in the abstract and inapplicable in fact — the "array at address 0" is a memory-mapped mailbox.

**If CI reports something different**, that is the more interesting outcome and worth knowing — my repro was on Blackhole `-DCOMPILE_FOR_BRISC` only, replaying one object's command rather than a full build, so CI covers ground I could not.

## Why it's worth knowing

Measured on a CPU-only MockDevice rig (tt-metal `d103fdd`, sfpi 7.69.0, per-kernel timings from `TT_METAL_LOG_KERNEL_COMPILE`):

| Phase | Time |
|---|---|
| Compile (direct measurement, 3 runs, ±3 ms) | 313 ms |
| Per-binary total (compile + link) | 688 ms |
| Link / LTO (inferred) | **~375 ms (~55%)** |

LTO link is the majority of per-binary JIT compile cost. Whether it can be removed or replaced is therefore worth measuring — but today that experiment cannot be run at all, because the build does not complete without it.

**To be clear: I am not proposing removing LTO.** The ask in #54692 is only that building without it should be *possible*, so the trade can be measured. Any real change would also need to replace what LTO provides (`build.cpp:171`: *"removes globally unreachable code"*) and re-verify L1 text budgets.

## Related

- #54692 — tracking issue, full commands and error output
- #41370 — `-mno-tt-fix-whbhebreak` silently defeated by `-flto=auto` in the same JIT path
- #21844 — LTO for the host CMake build (notes `jit_build/build.cpp` already carried `-flto`)
- tenstorrent/tt-blaze#3680 — downstream report with the generated kernel source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=test/no-lto-jit-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:test/no-lto-jit-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=test/no-lto-jit-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:test/no-lto-jit-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=test/no-lto-jit-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:test/no-lto-jit-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=test/no-lto-jit-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:test/no-lto-jit-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=test/no-lto-jit-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:test/no-lto-jit-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=test/no-lto-jit-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:test/no-lto-jit-kernels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=test/no-lto-jit-kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:test/no-lto-jit-kernels)