### PR TITLE
Size the pre-all-gather x^2 buffer at Wt, not Wt*2

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_distributed_layernorm.py
@@ -11,7 +11,7 @@ import ttnn
 from models.common.utility_functions import tt2torch_tensor
 
 from loguru import logger
-from tests.ttnn.utils_for_testing import assert_numeric_metrics
+from tests.ttnn.utils_for_testing import assert_numeric_metrics, check_with_pcc
 from tests.tests_common.skip_reasons import LEGACY_CCL_SKIP
 from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
@@ -209,3 +209,41 @@ def test_distributed_layernorm_with_program_cache_4chip(
         iterations=iterations,
         has_weights=has_weights,
     )
+
+
+# Regression for #54697: the pre-all-gather x^2 buffer is sized per row, so a wide row with
+# fp32 dest accumulation is what pushes the program past L1. The parametrizations above cannot
+# catch it -- they shard 8192 across 4-8 devices, leaving only 1024 per chip. This runs the
+# widest per-chip row the models actually use (Llama-3.3-70B on a 2-device mesh: 8192/2) on a
+# SINGLE device, with fp32_dest_acc_en on, so it fails at allocation time if the buffer sizing
+# regresses again.
+@pytest.mark.parametrize("width", [4096], ids=["w4096"])
+@pytest.mark.parametrize("is_rmsnorm", rms_norm_parametrizations, ids=rms_norm_parametrization_ids)
+def test_pre_all_gather_wide_row_fp32_dest_acc_fits_l1(device, width, is_rmsnorm):
+    torch.manual_seed(1234)
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+    inp = torch.randn((1, 1, 32, width), dtype=torch.bfloat16)
+    tt_inp = ttnn.from_torch(
+        inp, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    if is_rmsnorm:
+        tt_stats = ttnn.rms_norm_pre_all_gather(
+            tt_inp, compute_kernel_config=compute_kernel_config, dtype=ttnn.bfloat16
+        )
+    else:
+        tt_stats = ttnn.layer_norm_pre_all_gather(
+            tt_inp, compute_kernel_config=compute_kernel_config, dtype=ttnn.bfloat16
+        )
+
+    # Column 0 of the stats tile is sum(x^2) for both variants.
+    got = ttnn.to_torch(tt_stats).to(torch.float32)[..., 0:1]
+    expected = (inp.to(torch.float32) ** 2).sum(dim=-1, keepdim=True)
+    passing, pcc = check_with_pcc(expected, got, 0.99)
+    assert passing, f"sum(x^2) mismatch at width {width}: {pcc}"

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -147,13 +147,19 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
     const uint32_t res_tiles = Wt * double_buffer_constant;    // residual b
     const uint32_t fused_tiles = Wt;                           // a + b
 
-    // x^2 is filled to Wt tiles and then drained by a single BulkWaitBulkPop reduce in the SAME
-    // compute kernel, so the second half of a double buffer can never be live: nothing produces
-    // into it while the reduce consumes the first. Sizing it at Wt keeps the access pattern
-    // identical -- tiles are packed at absolute index wt+wtr over one row -- and gives back a full
-    // row's worth of L1, which a wide fp32_dest_acc_en row needs to fit at all (see #54697).
-    // in0 keeps its double buffer: there the reader genuinely prefetches ahead of compute.
-    const uint32_t intermed0_tiles = Wt;  // x^2
+    // The x^2 buffer is sized per ROW, so a wide fp32_dest_acc_en row is what pushes this program
+    // past L1 (#54697). Keep the double buffer wherever it fits -- the packer and the unpacker are
+    // different RISCs, so it buys real overlap (measured ~1-3% on shapes that already fit) -- and
+    // fall back to a single buffer only when the double-buffered program would not fit at all,
+    // which today throws at allocation instead of running.
+    const uint32_t x2_tiles_double_buffered = Wt * double_buffer_constant;
+    const uint32_t out0_tiles_estimate = is_rmsnorm ? 1 : 2;
+    const uint32_t static_bytes_double_buffered =
+        in0_tiles * in_single_tile_size + in1_tiles * scaler_tile_size +
+        (fuse_pre_add ? (res_tiles * inb_single_tile_size + fused_tiles * single_tile_size) : 0) +
+        x2_tiles_double_buffered * single_tile_size + out0_tiles_estimate * out_single_tile_size;
+    const uint32_t intermed0_tiles =
+        (static_bytes_double_buffered <= device->l1_size_per_core()) ? x2_tiles_double_buffered : Wt;  // x^2
     uint32_t out0_tiles = 1;
     if (!is_rmsnorm) {
         out0_tiles = 2;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -150,10 +150,9 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
     // x^2 is filled to Wt tiles and then drained by a single BulkWaitBulkPop reduce in the SAME
     // compute kernel, so the second half of a double buffer can never be live: nothing produces
     // into it while the reduce consumes the first. Sizing it at Wt keeps the access pattern
-    // identical (tiles are packed at absolute index wt+wtr over one row) and saves Wt * fp32 tile
-    // bytes, which is exactly what pushes a wide fp32_dest_acc_en row past L1: at width 4096 the
-    // program asks 1684672 B against 1499136 B (wormhole) / 1572864 B (blackhole). in0 keeps its
-    // double buffer -- there the reader genuinely prefetches ahead of compute.
+    // identical -- tiles are packed at absolute index wt+wtr over one row -- and gives back a full
+    // row's worth of L1, which a wide fp32_dest_acc_en row needs to fit at all (see #54697).
+    // in0 keeps its double buffer: there the reader genuinely prefetches ahead of compute.
     const uint32_t intermed0_tiles = Wt;  // x^2
     uint32_t out0_tiles = 1;
     if (!is_rmsnorm) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -147,7 +147,14 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
     const uint32_t res_tiles = Wt * double_buffer_constant;    // residual b
     const uint32_t fused_tiles = Wt;                           // a + b
 
-    const uint32_t intermed0_tiles = Wt * double_buffer_constant;  // x^2
+    // x^2 is filled to Wt tiles and then drained by a single BulkWaitBulkPop reduce in the SAME
+    // compute kernel, so the second half of a double buffer can never be live: nothing produces
+    // into it while the reduce consumes the first. Sizing it at Wt keeps the access pattern
+    // identical (tiles are packed at absolute index wt+wtr over one row) and saves Wt * fp32 tile
+    // bytes, which is exactly what pushes a wide fp32_dest_acc_en row past L1: at width 4096 the
+    // program asks 1684672 B against 1499136 B (wormhole) / 1572864 B (blackhole). in0 keeps its
+    // double buffer -- there the reader genuinely prefetches ahead of compute.
+    const uint32_t intermed0_tiles = Wt;  // x^2
     uint32_t out0_tiles = 1;
     if (!is_rmsnorm) {
         out0_tiles = 2;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -158,8 +158,16 @@ ttnn::device_operation::ProgramArtifacts LayerNormPreAllGatherProgramFactory::cr
         in0_tiles * in_single_tile_size + in1_tiles * scaler_tile_size +
         (fuse_pre_add ? (res_tiles * inb_single_tile_size + fused_tiles * single_tile_size) : 0) +
         x2_tiles_double_buffered * single_tile_size + out0_tiles_estimate * out_single_tile_size;
+    // Budget is L1 above the reserved base, matching what validate_dataflow_buffer_region compares
+    // against (it checks an absolute region end, so the reserved base must come off the top here).
+    // Deliberately STATIC: shape, dtypes and device config only. Sizing a buffer from dynamic L1
+    // occupancy (lowest_occupied_compute_l1_address) would make the program depend on state the
+    // program-cache key does not cover, so a program built under one occupancy could be replayed
+    // under another -- unsound with the program cache and with tracing.
+    const uint32_t l1_budget = static_cast<uint32_t>(
+        device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1));
     const uint32_t intermed0_tiles =
-        (static_bytes_double_buffered <= device->l1_size_per_core()) ? x2_tiles_double_buffered : Wt;  // x^2
+        (static_bytes_double_buffered <= l1_budget) ? x2_tiles_double_buffered : Wt;  // x^2
     uint32_t out0_tiles = 1;
     if (!is_rmsnorm) {
         out0_tiles = 2;


### PR DESCRIPTION
Fixes #54697

### Problem

Since #52081 the intermediate CB follows `fp32_dest_acc_en` instead of being hard-coded bf16. That is a **correct precision fix**, but it doubles the `x^2` buffer, and a width-4096 row no longer fits L1:

```
W=4096, fp32_dest_acc_en=True -> 1684672 B vs 1499136 B (wormhole)
                                 1690624 B vs 1572864 B (blackhole p300a)
```

`fp32_dest_acc_en=True` is what `models/common/rmsnorm.py` `RMSNorm` passes by default (line 57), so this is a configuration the models use — it is how Llama-3.3-70B lands on a 2-device mesh (hidden 8192 / 2 = 4096 per chip).

Bisected with the single-device repro in #54697: **passes** on `4dfe546c002` (parent of #52081), **fails** on main, **passes** again with this change.

### Fix

Size the `x^2` buffer **adaptively**: keep the double buffer whenever the double-buffered program fits L1, and fall back to a single buffer only when it would not fit at all.

```cpp
const uint32_t intermed0_tiles =
    (static_bytes_double_buffered <= device->l1_size_per_core()) ? x2_tiles_double_buffered : Wt;
```

An earlier revision of this PR dropped the double buffer unconditionally, on the reasoning that the same thread fills and drains `x^2` so the second half could never be live. **That reasoning was wrong** — the compute kernel is three RISCs, and the *packer* produces into `x^2` while the *unpacker* consumes it, so there is real cross-RISC overlap. Measuring it (below) showed a 1-3% cost, hence the adaptive form: only shapes that cannot fit the double buffer give it up.

`in0` keeps its double buffer in all cases — there the reader genuinely prefetches ahead of compute. #52081's precision improvement is preserved rather than reverted. The `intermed0_tiles % block_size == 0` assert still holds: `block_size` is 1 in this factory.

### Performance vs main (wormhole N300, H=1024, 200 iterations, warm cache)

| width | main | this PR | note |
|---|---|---|---|
| 1024 | 82.1 us | 83.0 - 84.6 us | identical program, delta within noise |
| 2048 | 103.5 us | 103.9 - 106.0 us | identical program, delta within noise |
| 3072 | 130.0 us | 130.9 - 132.2 us | identical program, delta within noise |
| 4096 | **fails to allocate** | 149.5 - 155.2 us | previously impossible |

For every shape main can run, the fit check passes and `intermed0_tiles` takes exactly main's `Wt * double_buffer_constant`, so the emitted program is **identical** — perf equality is structural, not statistical. The PR ranges above are three repeats of the same binary; that run-to-run spread (1.3-2.1 us at these widths) is as large as the apparent gap to main, so the gap is not measurable signal.

For reference, the single-vs-double comparison that motivated the adaptive form, measured same-binary via a temporary env toggle:

| shape | single buffer | double buffer | double faster by |
|---|---|---|---|
| H=1024 W=1024 | 90.9 us | 88.3 us | 2.9% |
| H=2048 W=2048 | 114.7 us | 112.6 us | 1.9% |
| H=1024 W=2048 | 104.7 us | 103.8 us | 0.9% |

At width 4096 the double buffer is not an option at all — forcing it still fails to allocate — so no perf is being left on the table there.

### Validation (wormhole N300)

| | result |
|---|---|
| five previously failing heights at width 4096 (32/128/1024/2048/4096) | now run, **PCC 0.998** vs an fp32 golden |
| widths that already worked (640 / 1024 / 2048) | **bit-identical** PCCs before and after |
| layernorm (non-RMS) path | still correct `sum(x)` and `sum(x^2)` |
| `test_pre_all_gather_wide_row_fp32_dest_acc_fits_l1` | added, covers RMSNorm and LayerNorm on a single device |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-layernorm-preallgather-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-layernorm-preallgather-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-layernorm-preallgather-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-layernorm-preallgather-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-layernorm-preallgather-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-layernorm-preallgather-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-layernorm-preallgather-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-layernorm-preallgather-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-layernorm-preallgather-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-layernorm-preallgather-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-layernorm-preallgather-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-layernorm-preallgather-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-layernorm-preallgather-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-layernorm-preallgather-l1)



