### PR TITLE
#54692: Compile firmware and kernels with or without LTO

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -195,7 +195,21 @@ void JitBuildEnv::init(
         "-Wno-error=multistatement-macros -Wno-error=parentheses "
         "-Wno-error=unused-but-set-variable "
         // And don't detect these issues
-        "-Wno-unused-variable -Wno-unused-function ";
+        "-Wno-unused-variable -Wno-unused-function "
+        // Firmware and kernels access mailboxes and MMIO through pointers
+        // formed from small literal addresses (e.g. MEM_MAILBOX_BASE is 16
+        // on Wormhole). On these bare-metal cores the bottom of the address
+        // space is ordinary L1 memory, but GCC assumes no object can live in
+        // the first page and -Warray-bounds diagnoses such accesses as
+        // "source object is likely at address zero", which -Werror makes
+        // fatal. (With -flto the literal address is not visible during
+        // per-TU compilation, so today this only fires if LTO is disabled;
+        // see issue #54692.) min-pagesize=0 tells GCC that constant
+        // addresses from zero up are valid objects, disabling exactly that
+        // heuristic while keeping -Warray-bounds active for genuine
+        // out-of-bounds accesses. It is a diagnostics-only parameter with no
+        // effect on generated code.
+        "--param=min-pagesize=0 ";
 
     // Defines
     this->defines_ = "";


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #54692.

JIT firmware and kernel compilation currently *requires* `-flto=auto`. Removing it fails `-Werror=array-bounds` at 88 sites across `brisc.cc`, `trisc.cc`, `ncrisc.cc`, `idle_erisc.cc`, `firmware_common.h` and `eth_fw_api.h`.

The failing expressions access mailboxes and MMIO through pointers formed from small literal addresses. GCC's `-Warray-bounds` presumes no object can live below `--param=min-pagesize` (default 4096), so an access through `(mailboxes_t*)16` is diagnosed as *"source object is likely at address zero"*, and `-Werror` makes it fatal. On these bare-metal cores that presumption is simply false: `MEM_MAILBOX_BASE` is 16 on Wormhole and 96 on Blackhole, and the bottom of the address space is ordinary L1 memory. These are real device addresses, not objects at NULL.

It only shows up without LTO because under `-flto` the per-TU compile cannot see the constant address at the point the bounds check runs.

Fix is one flag added to the JIT `cflags_`:

```
--param=min-pagesize=0
```

This is GCC's documented knob for targets where page zero is addressable. It disables exactly the address-zero presumption and nothing else — `-Warray-bounds` stays fully active. `-flto=auto` is unchanged; the goal is that the build works either way, not that LTO is turned off.

### Notes for reviewers

**`-Warray-bounds` is not weakened.** Verified against sfpi 7.72.0 (g++ 15.1.0):

- ordinary out-of-bounds array access — still diagnosed, identical warning count with and without the parameter;
- out-of-bounds access *through a literal-address pointer* (`((S*)16)->x[10]`) — still diagnosed;
- `-Wnull-dereference` — unaffected.

Only the `'T [0]'` / address-zero false positives disappear.

**No codegen change.** Across all 18 firmware/kernel TU configurations (9 TUs × Wormhole/Blackhole):

- without LTO, objects are **byte-identical** to a baseline that merely suppressed the error;
- with LTO, objects differ only in streamed option metadata (`.gnu.lto_.opts`/`.decls`/`.icf`, ≤ 40 bytes). Recompiling that LTO bytecode to native code via `-flinker-output=nolto-rel` yields **byte-identical machine code in 18/18**, with identical `size` output.

Raw LTO objects can't be compared directly: GCC embeds a per-invocation random seed, so they already differ run-to-run in the unmodified baseline. The comparisons above pin `-frandom-seed`.

**Alternatives rejected.** Wrapping the failing code in `#pragma GCC diagnostic ignored "-Warray-bounds"` does not work cleanly — the warning attaches to each of the 88 dereference sites rather than to the pointer-forming macros in `dev_msgs.h`, so pragmas would have to blanket six entire firmware files, losing genuine bounds coverage exactly where it matters and not protecting future TUs. A blanket `-Wno-error=array-bounds` (the precedent in `rvv_compile_flags`, `bh_hal.cpp`) would silence genuine bounds errors too. Pointer laundering via inline asm blocks constant propagation of the address and costs code size on these cores.

**Known gaps, for reviewer judgement:**

- Verification was done by replaying the exact JIT compile command per TU, not via a full host cmake build or on-device run. The replay was validated by reproducing the issue's failing line numbers exactly before the fix.
- The final linked firmware ELF was not diffed; the per-object post-LTO native relink is the equivalence evidence.
- `active_erisc` and tt-2xx/quasar TUs were not exercised. The flag lives in the shared `cflags_` so it applies to them; quasar has `MEM_MAILBOX_BASE 16` as well and should benefit identically.
- `--param=min-pagesize` is GCC-specific. Harmless today since sfpi is GCC-based, but it would need revisiting if firmware is ever built with clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/compile-without-lto)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/compile-without-lto)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/compile-without-lto)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/compile-without-lto)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/compile-without-lto)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/compile-without-lto)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/compile-without-lto)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/compile-without-lto)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/compile-without-lto)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/compile-without-lto)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/compile-without-lto)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/compile-without-lto)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/compile-without-lto)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/compile-without-lto)