### PR TITLE
[skip ci] [Bug fix] Fix docs sidebar expansion and hidden "View page source" breadcrumb

### DIFF
--- a/docs/source/common/_static/tt_theme.css
+++ b/docs/source/common/_static/tt_theme.css
@@ -511,6 +511,24 @@ body:has(.tt-top-nav) .wy-side-nav-search img {
   padding-left: 15px;
 }
 
+/* Sidebar subtree folding. Expansion is driven by a .tt-open class that
+   tt-search.js toggles on caret click, so mirror the production rules here —
+   without them the caret rotates but the subtree never appears.
+
+   Both declarations need !important. RTD's own
+   `.wy-menu-vertical .toctree-l1.current .toctree-l2 > ul { display: none }`
+   has specificity (0,4,1), which outranks `li.tt-open > ul` (0,2,2). On a page
+   that is itself a toctree-l1 (e.g. ttnn/api.html, where every section below it
+   is an in-page anchor and so never gets .current), that rule pins every
+   toctree-l2 subtree closed and no amount of clicking can open it. */
+.wy-menu-vertical li:not(.tt-open) > ul {
+  display: none !important;
+}
+
+.wy-menu-vertical li.tt-open > ul {
+  display: flex !important;
+}
+
 /* Section group headers (captions) — Figma: Berkeley Mono 12px, #3A5452, py-12px */
 .wy-menu-vertical header,
 .wy-menu-vertical p.caption {
@@ -1092,8 +1110,13 @@ div[role="navigation"][aria-label="Page navigation"] {
   font-weight: 500 !important;
 }
 
-/* Hide "View page source" */
-.wy-breadcrumbs-aside {
+/* Hide "View page source".
+   Must be qualified as `.wy-breadcrumbs > li.wy-breadcrumbs-aside` (0,2,1) to
+   outrank `.wy-breadcrumbs > li { display: inline-flex !important }` (0,1,1)
+   above. A bare `.wy-breadcrumbs-aside` (0,1,0) loses that comparison — both
+   rules are !important, so specificity decides — and the link renders flush
+   against the active breadcrumb with no separator. */
+.wy-breadcrumbs > li.wy-breadcrumbs-aside {
   display: none !important;
 }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Closes #54703

Two CSS specificity bugs in `docs/source/common/_static/tt_theme.css`, both live on the published docs.

**1. Sidebar API subtrees could not be expanded.** Clicking *Operations* on `ttnn/api.html` rotated the caret but never revealed its children.

Expansion is driven by a `.tt-open` class that `tt-search.js` toggles, but `sphinx_rtd_theme`'s own rule outranks the reveal:

| Selector | Specificity | Declaration |
|---|---|---|
| `.wy-menu-vertical .toctree-l1.current .toctree-l2 > ul` (RTD) | **(0,4,1)** | `display: none` |
| `.wy-menu-vertical li.tt-open > ul` | (0,2,2) | `display: flex` |

Neither was `!important`, so specificity decided. This bites hardest on API pages: only **1 of 531** sidebar `<li>` on `api.html` gets `.current` — the `toctree-l1` for APIs — because every group below it is an in-page anchor (`href="#operations"`) that Sphinx never marks current. RTD's rule therefore pinned every subtree closed.

This repo's copy of `tt_theme.css` also carried **no `.tt-open` rules at all**, so the sidebar only worked when a page could fetch the production stylesheet at runtime. Both fold rules are now present locally, with `!important` so they outrank RTD.

**2. "View page source" rendered flush against the active breadcrumb** — `🏠 / APIs / ttnn.asinhView page source`.

| Selector | Specificity | Declaration |
|---|---|---|
| `.wy-breadcrumbs > li` | **(0,1,1)** | `display: inline-flex !important` |
| `.wy-breadcrumbs-aside` | (0,1,0) | `display: none !important` |

Both `!important`, so the generic rule beat the specific hide rule. Qualifying it as `.wy-breadcrumbs > li.wy-breadcrumbs-aside` (0,2,1) restores the intent. The zero spacing followed from `gap: 0` / `font-size: 0` on the container plus the `/` separator excluding the aside, so hiding it correctly resolves both symptoms.

### Test plan

- [x] `cd docs && make html` succeeds with zero warnings (note `SPHINXOPTS ?= -W` makes warnings fatal)
- [x] `ttnn/api.html` — *Operations*, *Core*, *Pointwise Unary* etc. now expand and collapse per-item
- [x] `ttnn/api/ttnn.asinh.html` — breadcrumb reads `🏠 / APIs / ttnn.asinh`, no trailing link
- [x] Verified in a browser against a local `make server` build
- [x] Confirmed no other open PR touches `tt_theme.css`, and PR #49958's branch contains neither fix, so this does not conflict with in-flight docs work

### Notes for reviewers

CSS-only; no template, `conf.py` or content changes.

The `.tt-open` reveal rule missing `!important` is **also a bug in the production stylesheet** at `docs.tenstorrent.com/_static/tt_theme.css`, which appears to be maintained outside this repo. Fixing it here makes tt-metal's docs correct standalone, but the same one-line fix is worth applying upstream so other doc sites benefit.

Separately, and **not addressed here**: `tt_theme.css` on main also hides the dtype/layout table and the entire Parameters/Returns field list on every API page, gated on `body:has(.tt-top-nav)`, expecting a renderer to replace them:

```css
body:has(.tt-top-nav) .rst-content dl.py.function table.docutils { display: none !important; }
body:has(.tt-top-nav) .rst-content dl.py > dd > dl.field-list   { display: none !important; }
```

That renderer (`_ext/tt_api_build.py`, and previously `api_style.js`) is still in open PR #49958 and is absent from main, so the content is currently invisible in production. I left it alone since it resolves when #49958 lands — but if that PR will sit for a while, reverting those two blocks would restore the content in the meantime. Happy to follow up either way.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-docs-sidebar-and-breadcrumb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswinmcw/fix-docs-sidebar-and-breadcrumb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-docs-sidebar-and-breadcrumb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aswinmcw/fix-docs-sidebar-and-breadcrumb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswinmcw/fix-docs-sidebar-and-breadcrumb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswinmcw/fix-docs-sidebar-and-breadcrumb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aswinmcw/fix-docs-sidebar-and-breadcrumb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aswinmcw/fix-docs-sidebar-and-breadcrumb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswinmcw/fix-docs-sidebar-and-breadcrumb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswinmcw/fix-docs-sidebar-and-breadcrumb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswinmcw/fix-docs-sidebar-and-breadcrumb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswinmcw/fix-docs-sidebar-and-breadcrumb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswinmcw/fix-docs-sidebar-and-breadcrumb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswinmcw/fix-docs-sidebar-and-breadcrumb)