### PR TITLE
[Feature] Consume the prebuilt tests image in Merge Gate smoke and basic tests

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -9,6 +9,14 @@ on:
       package-artifact-name:
         required: true
         type: string
+      prebuilt-image:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Image with the packages already installed. When set it replaces
+          docker-image and the download and install steps are skipped. Empty
+          means the artifact path, which is what forks always get.
       enabled-skus:
         required: true
         type: string
@@ -87,7 +95,8 @@ jobs:
     timeout-minutes: 45
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      # A prebuilt image already carries the packages and needs no Harbor prefix.
+      image: ${{ inputs.prebuilt-image || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         ASAN_OPTIONS: "color=always"
         TSAN_OPTIONS: "color=always"
@@ -109,12 +118,14 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - uses: ./.github/actions/download-artifact-with-retry
+        if: ${{ inputs.prebuilt-image == '' }}
         timeout-minutes: 15
         with:
           name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
           path: /work/pkgs/
 
       - name: Install packages
+        if: ${{ inputs.prebuilt-image == '' }}
         timeout-minutes: 10
         run: |
           # Ideally only ${{ inputs.product }}-validation, but APT doesn't resolve dependencies from files on disk without being told about them.

--- a/.github/workflows/cleanup-prebuilt-tests-images.yaml
+++ b/.github/workflows/cleanup-prebuilt-tests-images.yaml
@@ -11,15 +11,17 @@ name: "Cleanup prebuilt tests images"
 # retention is lower than the number says.
 #
 # The action deletes at most 100 versions per run, which is why the schedule is
-# hourly rather than daily. PR Gate builds two images per run at roughly 600
-# runs/day, so ~1,200 versions/day, or ~50/hour, against 24 x 100 deletions.
+# every 30 minutes rather than daily. PR Gate builds two images per run and
+# Merge Gate four, at roughly 600 runs/day each, so ~3,600 versions/day or
+# ~150/hour against 48 x 100 deletions.
 #
 # min-versions-to-keep is sized from that RATE, not picked round: retention in
-# hours is roughly N / 50. An image must outlive the gap between its build and
-# the last consumer pulling it, and a hardware leg can sit queued for hours, so
-# N = 1200 buys about a day. Too small a value deletes an image out from under a
-# queued leg, which fails at container startup with no fallback, because
-# container.image is resolved before any step runs.
+# hours is roughly N divided by the hourly push rate. An image must outlive the
+# gap between its build and the last consumer pulling it, and a hardware leg can
+# sit queued for hours, so N = 3600 buys about a day at ~150/hour. Too small a
+# value deletes an image out from under a queued leg, which fails at container
+# startup with no fallback, because container.image is resolved before any step
+# runs.
 #
 # Recompute N if the push rate changes: wiring more consumers raises it, and
 # building one image per run instead of two would halve it.
@@ -32,14 +34,14 @@ permissions:
 
 on:
   schedule:
-    - cron: "30 * * * *"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       min-versions-to-keep:
         description: "Newest versions to keep. Set very high for a safe no-op run."
         required: false
         type: string
-        default: "1200"
+        default: "3600"
 
 jobs:
   cleanup:
@@ -54,13 +56,13 @@ jobs:
           owner: tenstorrent
           package-name: tt-metal/prebuilt-tests-image
           package-type: container
-          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '1200' }}
+          min-versions-to-keep: ${{ inputs.min-versions-to-keep || '3600' }}
 
       # A GC that silently falls behind looks exactly like one that is working.
       - name: Report what is left
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KEEP: ${{ inputs.min-versions-to-keep || '1200' }}
+          KEEP: ${{ inputs.min-versions-to-keep || '3600' }}
         run: |
           set -euo pipefail
           COUNT=$(gh api "/orgs/tenstorrent/packages/container/tt-metal%2Fprebuilt-tests-image" --jq '.version_count')

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -51,6 +51,8 @@ permissions:
   pull-requests: write
   checks: write
   packages: write
+  # The producer downloads the artifact via REST; a called workflow only downgrades.
+  actions: read
 
 jobs:
   # ===========================================================================
@@ -270,15 +272,37 @@ jobs:
   #            runtime_validation_basic_tests.yaml
   # ===========================================================================
 
-  runtime-smoke-tests:
-    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor]
+  build-runtime-smoke-image:
+    needs: [find-changes, docker-images, build-tsan]
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
         }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+      # Canonical ref: the producer is GitHub-hosted and cannot reach Harbor.
+      base-image: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: PRODUCT=tt-metalium
+
+  runtime-smoke-tests:
+    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor, docker-images, build-runtime-smoke-image]
+    if: ${{ !cancelled() && needs.build-tsan.result == 'success' && (github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        ) }}
     uses: ./.github/workflows/smoke.yaml
     with:
+      # Empty on forks or a failed build, where smoke falls back to the artifact.
+      prebuilt-image: ${{ needs.build-runtime-smoke-image.outputs.image }}
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
       # Canonical (non-Harbor-prefixed) ref for the github_hosted_cpu leg, which runs
       # on GitHub-hosted runners without Harbor access.
@@ -289,16 +313,40 @@ jobs:
       product: tt-metalium
       enable-kernel-ccache: true
 
-  runtime-basic-tests:
+  build-runtime-basic-image:
     if: ${{
         github.ref_name == 'main' ||
         needs.find-changes.outputs.cmake-changed == 'true' ||
         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
         needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
       }}
-    needs: [build-asan, resolve-docker-pull-refs-asan, find-changes, check-harbor]
+    needs: [build-asan, docker-images, find-changes]
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+      # Canonical ref: the producer is GitHub-hosted and cannot reach Harbor.
+      base-image: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: PRODUCT=tt-metalium
+
+  runtime-basic-tests:
+    # Not !failure(): a failed image build must still let basic use the artifact.
+    if: ${{ !cancelled() && needs.build-asan.result == 'success' && (
+        github.ref_name == 'main' ||
+        needs.find-changes.outputs.cmake-changed == 'true' ||
+        needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+        needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true')
+      }}
+    needs: [build-asan, resolve-docker-pull-refs-asan, find-changes, check-harbor, docker-images, build-runtime-basic-image]
     uses: ./.github/workflows/basic.yaml
     with:
+      # Empty on forks or a failed build; basic then uses the artifact.
+      prebuilt-image: ${{ needs.build-runtime-basic-image.outputs.image }}
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
@@ -330,16 +378,39 @@ jobs:
   #            ttnn_merge_gate_tests.yaml
   # ===========================================================================
 
-  ttnn-smoke-tests:
-    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor]
+  build-ttnn-smoke-image:
+    needs: [find-changes, docker-images, build-tsan]
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-changed == 'true' ||
             needs.find-changes.outputs.tt-nn-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
         }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+      # Canonical ref: the producer is GitHub-hosted and cannot reach Harbor.
+      base-image: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: PRODUCT=tt-nn
+
+  ttnn-smoke-tests:
+    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor, docker-images, build-ttnn-smoke-image]
+    if: ${{ !cancelled() && needs.build-tsan.result == 'success' && (github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        ) }}
     uses: ./.github/workflows/smoke.yaml
     with:
+      # Empty on forks or a failed build, where smoke falls back to the artifact.
+      prebuilt-image: ${{ needs.build-ttnn-smoke-image.outputs.image }}
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS
@@ -347,16 +418,40 @@ jobs:
       product: tt-nn
       enable-kernel-ccache: true
 
-  ttnn-basic-tests:
-    needs: [build-asan, resolve-docker-pull-refs-asan, find-changes, check-harbor]
+  build-ttnn-basic-image:
+    needs: [build-asan, docker-images, find-changes]
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-changed == 'true' ||
             needs.find-changes.outputs.tt-nn-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
         }}
+    uses: ./.github/workflows/build-prebuilt-tests-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    secrets: inherit
+    with:
+      artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+      # Canonical ref: the producer is GitHub-hosted and cannot reach Harbor.
+      base-image: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
+      dockerfile: dockerfile/Dockerfile.prebuilt-tests-packages
+      build-args: PRODUCT=tt-nn
+
+  ttnn-basic-tests:
+    needs: [build-asan, resolve-docker-pull-refs-asan, find-changes, check-harbor, docker-images, build-ttnn-basic-image]
+    # Not !failure(): a failed image build must still let basic use the artifact.
+    if: ${{ !cancelled() && needs.build-asan.result == 'success' && (github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true')
+        }}
     uses: ./.github/workflows/basic.yaml
     with:
+      # Empty on forks or a failed build; basic then uses the artifact.
+      prebuilt-image: ${{ needs.build-ttnn-basic-image.outputs.image }}
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
       enabled-skus: ALL_SKUS_IN_TESTS


### PR DESCRIPTION
### PR Category

Feature

### Summary

Merge Gate's smoke and basic legs download the build artifact and install it before they can run anything. This wires them to the prebuilt image from #54412, the same way #54534 does for PR Gate, so neither step is needed.

Smoke was validated by dispatching Merge Gate against this branch: all seven smoke legs ran from prebuilt images with the download and install steps skipped, across `bh_p150b_civ2_viommu`, `wh_n300_civ2`, `wh_llmbox_civ2_viommu` and `github_hosted_cpu`. `Merge Gate Status` green. The basic legs were added after that run and need the same check before this leaves draft.

With this, every Merge Gate consumer of the packages artifact uses the image. On the PR Gate side only `sdk-examples.yaml` remains, and it needs a producer change because its package set differs.

Stacked on #54534 and targeting its branch.

### Notes for reviewers

- `basic.yaml` installs exactly the same package set as `smoke.yaml`, so it needs no new Dockerfile. It does need its own images because it builds from `build-asan` where smoke builds from `build-tsan`, which is why there are four bake jobs rather than two.
- This differs from the PR Gate wiring in three ways worth checking: the base is `dev` rather than `ci-test`, the payloads are TSan and ASan rather than ASan alone, and the canonical ref comes from `docker-images.outputs.ubuntu-2404-dev-tag`. The last matters because `resolve-docker-pull-refs-*` gives a Harbor-prefixed ref and the producer runs on a GitHub-hosted runner with no Harbor access.
- `actions: read` is added at the workflow level. The producer needs it to download the artifact through the REST path, and a called workflow can only downgrade the caller's token.
- All four consumers gate on `!cancelled() && needs.build-*.result == 'success'` rather than on nothing having failed. A skipped image build (forks) or a failed one must still let the tests run on the artifact path, because these jobs sit in `optional-jobs` and `workflow-status` counts a skipped optional job as success, so skipping would remove hardware coverage without failing the gate.
- Cleanup moves to every 30 minutes with retention 3600. Merge Gate now builds four images per run, taking the fleet-wide rate to roughly 3,600/day or 150/hour, against a hard limit of 100 deletions per run in `actions/delete-package-versions`. Retention is sized from the same rate to keep about a day of headroom for queued legs.
- Six image variants now coexist per commit across both gates. The producer's tag includes the build config, the base image and a hash of the build recipe, so they cannot collide.
- Not covered by the validation: `merge_group` queue semantics. A dispatch cannot reproduce the queue's concurrency behaviour or the `destroyed` action, so the first real merge-queue entries are worth watching.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-merge-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdabasinskas/ci-merge-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdabasinskas/ci-merge-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdabasinskas/ci-merge-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdabasinskas/ci-merge-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdabasinskas/ci-merge-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdabasinskas/ci-merge-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdabasinskas/ci-merge-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdabasinskas/ci-merge-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdabasinskas/ci-merge-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdabasinskas/ci-merge-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdabasinskas/ci-merge-gate-prebuilt-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdabasinskas/ci-merge-gate-prebuilt-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdabasinskas/ci-merge-gate-prebuilt-tests)

