### PR TITLE
[CI] Guard the cpupower governor steps so Galaxy device perf jobs can run

### DIFF
--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -142,12 +142,16 @@ jobs:
           mkdir -p /localdev/blackhole_demos/huggingface_data/meta-llama
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       # The retired galaxy-perf impl pinned the host governor around its perf jobs.
-      # Galaxy SKUs only: those runners are bare-metal with cpupower available, unlike
-      # the container SKUs this pipeline otherwise targets.
+      # Galaxy SKUs only. cpupower is absent on some of those runners, so probe for it
+      # first: a missing governor tool must not fail the job before any test runs.
       - name: Enable performance mode
         if: ${{ contains(matrix.test-group.sku, 'galaxy') }}
         run: |
-          sudo cpupower frequency-set -g performance
+          if command -v cpupower >/dev/null 2>&1; then
+            sudo cpupower frequency-set -g performance
+          else
+            echo "::notice::cpupower is not available on this runner; the CPU governor is unchanged"
+          fi
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         uses: ./docker-job/.github/actions/run-with-log
@@ -238,7 +242,9 @@ jobs:
       - name: Disable performance mode
         if: ${{ always() && contains(matrix.test-group.sku, 'galaxy') }}
         run: |
-          sudo cpupower frequency-set -g ondemand
+          if command -v cpupower >/dev/null 2>&1; then
+            sudo cpupower frequency-set -g ondemand
+          fi
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
 


### PR DESCRIPTION
### Problem

Tier 1 Models device perf produces **no Galaxy signal at all**, and has not since #54324 merged.

That PR added `Enable performance mode` and `Disable performance mode` to `models-device-perf-tests-impl.yaml`, carried over from the retired `galaxy-perf` pipeline which pinned the host CPU governor around its perf jobs. The intent was right — a drifting governor adds noise to device-perf numbers. The premise in the comment was not:

```yaml
      # Galaxy SKUs only: those runners are bare-metal with cpupower available, unlike
      # the container SKUs this pipeline otherwise targets.
```

`wh_galaxy_perf` resolves to `runs_on: [arch-wormhole_b0, pipeline-perf, topology-6u, in-service]`. Those runners have no `cpupower`:

```
sudo: cpupower: command not found
##[error]Process completed with exit code 1
```

Neither step had `continue-on-error`, so a missing binary fails the step and then the job — **before pytest starts**. Confirmed in run [33108635474](https://github.com/tenstorrent/tt-metal/actions/runs/33108635474): zero pytest invocations in either job log.

Blast radius is both Galaxy device-perf entries, including `DeepSeek-V3 decode device perf tests (Galaxy)`, which predates #54324 entirely.

### Change

Probe for the binary rather than assume it, on both steps:

```yaml
          if command -v cpupower >/dev/null 2>&1; then
            sudo cpupower frequency-set -g performance
          else
            echo "::notice::cpupower is not available on this runner; the CPU governor is unchanged"
          fi
```

### Why not `continue-on-error: true`

It is one word and it would unblock the job. It would also swallow a genuine failure of the step, and leave no record that the governor was never pinned.

That record matters here. The device-perf thresholds these entries validate were tuned on the retired pipeline **with** the governor pinned. A run that silently skips the pinning measures under different conditions. The `::notice::` makes that visible in the job summary instead of invisible.

### Scope

`wh_galaxy_perf` is the only Galaxy SKU in `models_device_perf_tests.yaml`, so no other SKU changes behaviour. Non-Galaxy SKUs never ran these steps — the `if:` already gated them.

### What this does and does not fix

It restores the signal. It does not make the jobs green.

`DeepSeek-V3 fused-op device perf tests (Galaxy)` still carries a defect: `TT_FATAL @ buffer.cpp:200: allocator.has_bank(bank_type, core) || is_claimed_service_core(core)` in `test_ds_ff1_3`, which failed 7 of 8 runs on the retired pipeline. That is tracked as section 3 of #54710, and this PR is the prerequisite for confirming it reproduces in the tiered pipeline.

### Testing

The change is a shell guard in a workflow step. Dispatching `(Tier 1) Models Device Perf` on `wh_galaxy_perf` shows whether the jobs now reach pytest.

- [ ] (Tier 1) Models Device Perf — `sku: wh_galaxy_perf (WH Galaxy perf)` — jobs reach pytest and the notice appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/guard-cpupower-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/guard-cpupower-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/guard-cpupower-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/guard-cpupower-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/guard-cpupower-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/guard-cpupower-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/guard-cpupower-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/guard-cpupower-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/guard-cpupower-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/guard-cpupower-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/guard-cpupower-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/guard-cpupower-device-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/guard-cpupower-device-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/guard-cpupower-device-perf)