### PR TITLE
[Bug fix] Honour the requested memory_config when allocating gradient outputs

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_add.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_add.py
@@ -122,3 +122,107 @@ def test_bw_add_scalar(input_shapes, scalar, device):
 
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status
+
+
+# Tensor-tensor ops whose gradients are allocated by preallocated_tensors_check.
+# concat_bw is covered separately: it needs a differently shaped grad tensor.
+_TT_GRAD_OPS = {
+    "add": lambda g, a, b, req, mc: ttnn.add_bw(g, a, b, are_required_outputs=req, memory_config=mc),
+    "addalpha": lambda g, a, b, req, mc: ttnn.addalpha_bw(g, a, b, 1.0, are_required_outputs=req, memory_config=mc),
+    "subalpha": lambda g, a, b, req, mc: ttnn.subalpha_bw(g, a, b, 1.0, are_required_outputs=req, memory_config=mc),
+    "rsub": lambda g, a, b, req, mc: ttnn.rsub_bw(g, a, b, are_required_outputs=req, memory_config=mc),
+    "div": lambda g, a, b, req, mc: ttnn.div_bw(g, a, b, are_required_outputs=req, memory_config=mc),
+    "mul": lambda g, a, b, req, mc: ttnn.mul_bw(g, a, b, are_required_outputs=req, memory_config=mc),
+    "assign": lambda g, a, b, req, mc: ttnn.assign_bw(g, a, b, are_required_outputs=req, memory_config=mc),
+}
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+@pytest.mark.parametrize("op", sorted(_TT_GRAD_OPS))
+def test_bw_helper_allocated_grads_honour_memory_config(input_shapes, device, are_required_outputs, op):
+    """Gradients the op allocates itself must land in the requested memory config.
+
+    Regression for `preallocated_tensors_check`, which allocated via `empty_like`
+    without a memory config, so the gradients inherited the input's config instead.
+    Existing coverage either omits `memory_config` or supplies preallocated outputs,
+    so the requested and inherited configs never diverge there.
+
+    Inputs are placed in L1 and DRAM is requested: with DRAM inputs the inherited and
+    requested configs coincide and the defect is invisible.
+    """
+    _, input_tensor_a = data_gen_with_range(input_shapes, 1, 100, device, True)
+    _, input_tensor_b = data_gen_with_range(input_shapes, 1, 100, device, True)
+    _, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+
+    input_tensor_a = ttnn.to_memory_config(input_tensor_a, ttnn.L1_MEMORY_CONFIG)
+    input_tensor_b = ttnn.to_memory_config(input_tensor_b, ttnn.L1_MEMORY_CONFIG)
+    grad_tensor = ttnn.to_memory_config(grad_tensor, ttnn.L1_MEMORY_CONFIG)
+
+    # no preallocated outputs, so the op allocates them through the helper
+    result = _TT_GRAD_OPS[op](
+        grad_tensor, input_tensor_a, input_tensor_b, are_required_outputs, ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    for i, required in enumerate(are_required_outputs):
+        if not required:
+            continue
+        assert result[i] is not None
+        # compare the whole config, not just buffer_type: a wrong memory_layout or shard
+        # spec is the same class of bug, and empty_like is handed the full config
+        assert (
+            result[i].memory_config() == ttnn.DRAM_MEMORY_CONFIG
+        ), f"{op}_bw grad {i} was requested in {ttnn.DRAM_MEMORY_CONFIG} but landed in {result[i].memory_config()}"
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
+def test_bw_concat_helper_allocated_grads_honour_memory_config(input_shapes, device, are_required_outputs):
+    """concat_bw reaches its grads through ttnn.slice, a different write path from assign."""
+    _, input_tensor_a = data_gen_with_range(input_shapes, -100, 100, device, True)
+    _, input_tensor_b = data_gen_with_range(input_shapes, -100, 100, device, True)
+    _, grad_tensor = data_gen_with_range(torch.Size([1, 1, 64, 32]), -50, 50, device)
+
+    input_tensor_a = ttnn.to_memory_config(input_tensor_a, ttnn.L1_MEMORY_CONFIG)
+    input_tensor_b = ttnn.to_memory_config(input_tensor_b, ttnn.L1_MEMORY_CONFIG)
+    grad_tensor = ttnn.to_memory_config(grad_tensor, ttnn.L1_MEMORY_CONFIG)
+
+    result = ttnn.concat_bw(
+        grad_tensor,
+        input_tensor_a,
+        input_tensor_b,
+        0,
+        are_required_outputs=are_required_outputs,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    for i, required in enumerate(are_required_outputs):
+        if required:
+            assert result[i].memory_config() == ttnn.DRAM_MEMORY_CONFIG
+
+
+@pytest.mark.parametrize("input_shapes", ((torch.Size([1, 1, 32, 32])),))
+@pytest.mark.parametrize("op", ["add", "sub", "div", "mul"])
+def test_bw_scalar_overload_grads_honour_memory_config(input_shapes, device, op):
+    """The tensor-scalar overloads allocate their own gradient and must honour memory_config.
+
+    add_bw and sub_bw scalar previously ignored output_mem_config outright (it was
+    commented out in the signature); div_bw and mul_bw scalar took it for the compute but
+    allocated with a bare empty_like. Existing scalar coverage passes no memory_config, so
+    inherited and requested never diverged.
+
+    Inputs must be in L1 with DRAM requested: with DRAM inputs the two coincide and the
+    defect is unobservable.
+    """
+    _, input_tensor = data_gen_with_range(input_shapes, 1, 100, device, True)
+    _, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+
+    input_tensor = ttnn.to_memory_config(input_tensor, ttnn.L1_MEMORY_CONFIG)
+    grad_tensor = ttnn.to_memory_config(grad_tensor, ttnn.L1_MEMORY_CONFIG)
+
+    fn = {"add": ttnn.add_bw, "sub": ttnn.sub_bw, "div": ttnn.div_bw, "mul": ttnn.mul_bw}[op]
+    result = fn(grad_tensor, input_tensor, 2.0, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    assert (
+        result[0].memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    ), f"{op}_bw scalar overload was requested in DRAM but landed in {result[0].memory_config()}"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -31,14 +31,15 @@ void preallocated_tensors_check(
     std::optional<Tensor>& other_grad,
     const Tensor& input,
     const Tensor& other,
-    const std::array<bool, 2>& required_outputs) {
+    const std::array<bool, 2>& required_outputs,
+    const std::optional<MemoryConfig>& memory_config) {
     TT_FATAL(required_outputs[0] || required_outputs[1], "At least one gradient is expected to be calculated.");
 
     if (required_outputs[0] && !input_grad.has_value()) {
-        input_grad = ttnn::empty_like(input);
+        input_grad = ttnn::empty_like(input, std::nullopt, std::nullopt, std::nullopt, memory_config);
     }
     if (required_outputs[1] && !other_grad.has_value()) {
-        other_grad = ttnn::empty_like(other);
+        other_grad = ttnn::empty_like(other, std::nullopt, std::nullopt, std::nullopt, memory_config);
     }
 }
 
@@ -131,7 +132,7 @@ std::vector<std::optional<Tensor>> addalpha_bw(
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]}, output_mem_config);
 
     if (are_required_outputs[0]) {
         ttnn::assign(grad_tensor, input_grad.value());
@@ -155,7 +156,7 @@ std::vector<std::optional<Tensor>> subalpha_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]}, output_mem_config);
     if (are_required_outputs.at(0)) {
         ttnn::assign(grad_tensor, input_grad.value());
         result[0] = input_grad;
@@ -173,10 +174,12 @@ std::vector<std::optional<Tensor>> add_bw(
     const Tensor& grad_tensor,
     const Tensor& input_tensor,
     float /*alpha*/,
-    const std::optional<MemoryConfig>& /*output_mem_config*/,
+    const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
-    input_grad = input_grad.value_or(ttnn::empty_like(input_tensor));
+    if (!input_grad.has_value()) {
+        input_grad = ttnn::empty_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
+    }
     ttnn::assign(grad_tensor, input_grad.value());
     result.emplace_back(input_grad);
     return result;
@@ -192,7 +195,7 @@ std::vector<std::optional<Tensor>> add_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]}, output_mem_config);
     if (are_required_outputs.at(0)) {
         ttnn::assign(grad_tensor, input_grad.value());
         result[0] = input_grad;
@@ -226,12 +229,15 @@ std::vector<std::optional<Tensor>> sub_bw(
     const Tensor& grad_tensor,
     const Tensor& input_tensor,
     float /*alpha*/,
-    const std::optional<MemoryConfig>& /*output_mem_config*/,
+    const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     result.emplace_back(
-        input_grad.has_value() ? ttnn::assign(grad_tensor, input_grad.value())
-                               : ttnn::assign(grad_tensor, ttnn::empty_like(input_tensor)));
+        input_grad.has_value()
+            ? ttnn::assign(grad_tensor, input_grad.value())
+            : ttnn::assign(
+                  grad_tensor,
+                  ttnn::empty_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, output_mem_config)));
     return result;
 }
 
@@ -492,13 +498,18 @@ std::vector<std::optional<Tensor>> assign_bw(
     const Tensor& input_tensor,
     const Tensor& other_tensor,
     const std::vector<bool>& are_required_outputs,
-    const std::optional<MemoryConfig>& /*output_mem_config*/,
+    const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<ttnn::Tensor>> grad_tensor_res = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_tensor, other_tensor, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad,
+        other_grad,
+        input_tensor,
+        other_tensor,
+        {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
 
     if (are_required_outputs[0]) {
         ttnn::assign(grad_tensor, input_grad.value());
@@ -517,13 +528,18 @@ std::vector<std::optional<Tensor>> concat_bw(
     const Tensor& other,
     int dim,
     const std::vector<bool>& are_required_outputs,
-    const std::optional<MemoryConfig>& /*memory_config*/,
+    const std::optional<MemoryConfig>& memory_config,
     std::optional<Tensor> input_grad,
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> grad_tensor = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_tensor_a_arg, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad,
+        other_grad,
+        input_tensor_a_arg,
+        other,
+        {are_required_outputs[0], are_required_outputs[1]},
+        memory_config);
 
     if (are_required_outputs[0]) {
         ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
@@ -533,6 +549,9 @@ std::vector<std::optional<Tensor>> concat_bw(
             input_tensor_a_arg.logical_shape()[2],
             input_tensor_a_arg.logical_shape()[3]};
         ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        // The preallocated output governs placement (slice.cpp:123 prefers
+        // optional_output_tensor's config) and input_grad is always set by the helper above,
+        // so passing memory_config here would be inert.
         ttnn::slice(grad_tensor_arg, start_index, end_index, step, std::nullopt, input_grad);
         grad_tensor[0] = input_grad;
     }
@@ -572,7 +591,12 @@ std::vector<std::optional<Tensor>> rsub_bw(
     std::vector<std::optional<ttnn::Tensor>> result = {std::nullopt, std::nullopt};
 
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, grad_tensor, grad_tensor, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad,
+        other_grad,
+        grad_tensor,
+        grad_tensor,
+        {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
     if (are_required_outputs.at(0)) {
         ttnn::neg(grad_tensor, output_mem_config, input_grad);
         result[0] = input_grad;
@@ -649,7 +673,9 @@ std::vector<std::optional<Tensor>> div_bw(
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
 
     std::vector<std::optional<Tensor>> result;
-    input_grad = input_grad.value_or(ttnn::empty_like(input_tensor));
+    if (!input_grad.has_value()) {
+        input_grad = ttnn::empty_like(input_tensor, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
+    }
 
     if (rounding_mode == std::nullopt) {
         float t_inf = std::numeric_limits<float>::infinity();
@@ -686,7 +712,7 @@ std::vector<std::optional<Tensor>> div_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad, other_grad, input_a, other, {are_required_outputs[0], are_required_outputs[1]}, output_mem_config);
     TT_FATAL(
         (rounding_mode == std::nullopt || rounding_mode == "trunc" || rounding_mode == "floor"),
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
@@ -802,7 +828,7 @@ std::vector<std::optional<Tensor>> mul_bw(
     std::optional<Tensor> input_grad) {
     std::vector<std::optional<Tensor>> result;
     if (!input_grad.has_value()) {
-        input_grad = ttnn::empty_like(grad_tensor_arg);
+        input_grad = ttnn::empty_like(grad_tensor_arg, std::nullopt, std::nullopt, std::nullopt, output_mem_config);
     }
     ttnn::multiply(grad_tensor_arg, scalar, std::nullopt, output_mem_config, input_grad);
     result.push_back(input_grad);
@@ -819,7 +845,12 @@ std::vector<std::optional<Tensor>> mul_bw(
     std::optional<Tensor> other_grad) {
     std::vector<std::optional<Tensor>> result = {std::nullopt, std::nullopt};
     operations::binary_backward::detail::preallocated_tensors_check(
-        input_grad, other_grad, input_tensor_arg, other_tensor_arg, {are_required_outputs[0], are_required_outputs[1]});
+        input_grad,
+        other_grad,
+        input_tensor_arg,
+        other_tensor_arg,
+        {are_required_outputs[0], are_required_outputs[1]},
+        output_mem_config);
 
     if (are_required_outputs.at(0)) {
         ttnn::multiply(grad_tensor_arg, other_tensor_arg, std::nullopt, output_mem_config, input_grad);


### PR DESCRIPTION
### Issue

Closes #54715. Sub-issue B of the memory-config series; related to item 17 of #48240 (#54523).

### What this does

Gradient tensors that these ops allocate themselves now land in the caller's requested `memory_config` instead of inheriting the input's.

- `detail::preallocated_tensors_check` gains a `memory_config` parameter, forwarded to both `empty_like` calls and threaded through the 8 tensor-tensor call sites.
- The four tensor-scalar overloads (`add_bw`, `sub_bw`, `div_bw`, `mul_bw`) allocate in the requested config.
- `output_mem_config` is restored in the signatures of `assign_bw`, `concat_bw`, and the `add_bw`/`sub_bw` scalar overloads, where it had been commented out.

### Why

These helpers allocate the gradient when the caller supplies none, but had no memory config to honour, so every tensor they created inherited the input's config. These are the ops' returned outputs, not intermediates.

`assign`, `concat`, and the `add_bw`/`sub_bw` scalar overloads ignored the config entirely rather than only in the helper, so they change from never honouring it to honouring it — the largest behaviour delta here.

Measured on Wormhole, bfloat16/TILE, inputs in **L1**, `memory_config=DRAM`:

| Path | before | after |
| --- | --- | --- |
| tensor-tensor: `add, mul, div, rsub, assign, addalpha, subalpha, concat` | L1 | DRAM |
| tensor-scalar: `add, sub, div, mul` | L1 | DRAM |

The input placement matters: with DRAM inputs the inherited and requested configs coincide and the defect is invisible, so any check has to use differing configs.

### No accuracy impact

Placement only. Gradient values are identical across `memory_config` unset / L1 / DRAM, `max|diff| = 0.0`. With `memory_config` unset — the default — behaviour is unchanged, since `nullopt` still falls through to the input's config.

### One change deliberately left out

`concat_bw`'s two `ttnn::slice` calls keep `std::nullopt` for the memory config. `slice.cpp:123` resolves it as `optional_output_tensor.has_value() ? its config : memory_config_arg`, and `input_grad` is always set by the helper immediately above, so the argument could never take effect. `concat_bw` still returns DRAM for L1 inputs without it. A comment records this so it is not re-added.

### Tests

Regressions in `test_backward_add.py`, all with inputs in **L1**, DRAM requested, no preallocated outputs, comparing the whole `memory_config` rather than `buffer_type` alone. The tensor-tensor case is table driven (`_TT_GRAD_OPS`), so a new op added to the helper needs one line.

| Path | Ops |
| --- | --- |
| tensor-tensor (× 3 `are_required_outputs`) | `add, addalpha, subalpha, rsub, div, mul, assign` |
| tensor-tensor, separate shape (× 3) | `concat` |
| tensor-scalar | `add, sub, div, mul` |

Every call site this diff touches has a test that fails without its fix, and the two halves fail independently:

| Control | Result |
| --- | --- |
| revert the helper's two `empty_like` args | 24 failed |
| revert the four scalar sites | 4 failed |
| with both fixes | 28 passed |

| Suite | Result |
| --- | --- |
| `eltwise/backward`, affected ops | 819 passed, 20 skipped |
| `docs_examples` for those ops | 1 passed |

Note for anyone reproducing: input placement matters. With DRAM inputs the inherited and requested configs coincide and the defect is invisible, so a check must use differing configs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/bb_grad_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/bb_grad_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/bb_grad_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/bb_grad_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/bb_grad_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/bb_grad_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/bb_grad_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/bb_grad_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/bb_grad_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/bb_grad_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/bb_grad_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/bb_grad_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/bb_grad_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/bb_grad_check)



