### PR TITLE
ds_prefill(atomic_barriers) - drain NOC atomic/posted queues before reader kernel exit

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -374,4 +374,11 @@ void kernel_main() {
     route_info[2] = 0;
     route_info[3] = 0;
     cb_push_back(cb_route_info_id, 1);
+
+    // The per-untilizer credit returns in the loop above are posted atomics
+    // (noc_semaphore_inc<true>), which never ack -- so neither the write barrier nor the
+    // atomic barrier covers them, and today no barrier of any kind follows the last one.
+    // Confirm they have at least departed L1 before returning, so a credit cannot still be
+    // sitting in this core's NIU when the program tears down.
+    noc_async_posted_writes_flushed();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -486,4 +486,15 @@ void kernel_main() {
     sentinel_plan->entry_count = 0;
     sentinel_entries[0].flags = PLAN_FLAG_END;
     cb_push_back(cb_plan_id, 1);
+
+    // Drain the atomic queue before returning.  The baton hand-off at the bottom of the
+    // batch loop (next_turn_sem.up(...)) is a non-posted atomic, and its guard is on
+    // *global* batch order, not this core's loop -- so every core except the one holding
+    // the globally-last batch issues its final increment and then falls straight through
+    // to this teardown.  The only other barrier on that path is a write barrier, which
+    // drains NIU_MST_WR_ACK_RECEIVED and not the NIU_MST_ATOMIC_RESP_RECEIVED counter the
+    // increment acks on.  Without this, the increment can land after the host re-zeros the
+    // turn semaphore for the next launch, handing a core an extra baton credit so it takes
+    // the baton out of turn and reads the shared offsets[] mid-write.
+    noc.async_atomic_barrier();
 }


### PR DESCRIPTION
## Summary

Barrier-only fix for two ds_prefill reader kernels that return with NOC traffic still in flight — same bug class as #41074 (whose reported site was fixed in #43507).

- **`dispatch/.../reader_worker_dispatch.cpp`** — baton hand-off `next_turn_sem.up()` (`:446`) is a non-posted atomic, but the file had no atomic or full barrier. Its guard tests *global* batch order, so every core but one increments and falls straight through to `return`. A late-landing increment, after the next launch re-zeros the turn semaphore, grants an extra baton credit → out-of-turn read of the shared `offsets[]`. Adds `noc.async_atomic_barrier()`.
- **`combine/.../reader_combine.cpp`** — per-untilizer credit incs (`:363`) are posted, never acked, and no barrier followed the last one. Adds `noc_async_posted_writes_flushed()`.

18 insertions, 2 files, no logic change. Draft: not built or tested, CI not triggered.

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2608_dispatch_combine_fix) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2608_dispatch_combine_fix) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2608_dispatch_combine_fix) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2608_dispatch_combine_fix) Blackhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2608_dispatch_combine_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2608_dispatch_combine_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2608_dispatch_combine_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2608_dispatch_combine_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2608_dispatch_combine_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2608_dispatch_combine_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2608_dispatch_combine_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2608_dispatch_combine_fix)