### PR TITLE
[Bug fix] Add channel slicing to conv2d DRAM auto-slice for wide depthwise convolutions

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -1065,3 +1065,61 @@ def test_conv1d_depthwise_default_route_long_seq(device):
         packer_l1_acc=True,
         pcc=0.999,
     )
+
+
+# Qwen3.5 / Qwen3.6 35B-A3B Gated DeltaNet short convolution: depthwise over the fused QKV
+# stream, conv_dim = linear_key_head_dim * linear_num_key_heads * 2 + linear_value_head_dim *
+# linear_num_value_heads = 8192, kernel 4, causal padding 3 over a 20-token prompt.
+_GATED_DELTA_SHORT_CONV_SHAPE = dict(
+    batch_size=1,
+    in_channels=8192,
+    out_channels=8192,
+    input_length=20,
+    kernel_size=4,
+    stride=1,
+    padding=3,
+    groups=8192,
+)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_conv1d_depthwise_channel_slicing_wide(device):
+    """A very deep, spatially tiny depthwise conv must auto-route through DRAM channel
+    slicing. Output is 1 x 23 x 8192: height is 1 and width 23 rounds into a single tile, so
+    neither spatial axis can be split, while the 4-tap halo over 8192 channels needs ~1.5 MB
+    against ~1.4 MB of L1. Before DRAM_CHANNEL existed this aborted the run with "DRAM Auto
+    slice could not find valid slice configuration. Tried up to 1 slices for width-slicing on
+    output dimension 23"."""
+    run_conv1d_route(device, **_GATED_DELTA_SHORT_CONV_SHAPE, shard_layout=None)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_conv1d_channel_slicing_respects_num_slices(device):
+    """An explicitly requested channel slice count must be honoured and stay correct. Two
+    slices of 4096 already fit; 32 slices of 256 exercises many small slices, including the
+    per-slice weight slicing and the concatenation of the results."""
+    for num_slices in (2, 32):
+        run_conv1d_route(
+            device,
+            **_GATED_DELTA_SHORT_CONV_SHAPE,
+            shard_layout=None,
+            slice_config=ttnn.Conv2dSliceConfig(
+                slice_type=ttnn.Conv2dDRAMSliceChannel,
+                num_slices=num_slices,
+            ),
+        )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_conv1d_grouped_not_channel_sliced(device):
+    """Channel slicing must stay gated to fully depthwise convs. At groups=64 each output
+    channel reduces over 128 input channels, so splitting channels at arbitrary boundaries
+    would compute the wrong result. This shape does not need slicing at all (a grouped conv
+    spreads channels over more cores, so it fits), which is exactly why it is worth pinning:
+    a gate regression that offered the channel axis here would corrupt the output silently
+    rather than raise, and only a numerical check would catch it."""
+    run_conv1d_route(
+        device,
+        **{**_GATED_DELTA_SHORT_CONV_SHAPE, "groups": 64},
+        shard_layout=None,
+    )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -20,10 +20,12 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/data_movement/move/move.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/operations/sliding_window/halo/halo.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
@@ -413,6 +415,10 @@ class Conv2dSliceAttr : public ttnn::operations::op_slicing::OpSliceAttr {
     Conv2dConfig conv_config;
     DeviceComputeKernelConfig compute_config;
     MeshDevice* device;
+    // Channel slicing only: ttnn::slice is a device op, so a host-resident weight/bias is uploaded
+    // once and reused for every slice instead of once per slice.
+    std::optional<ttnn::Tensor> channel_slice_weight_on_device;
+    std::optional<ttnn::Tensor> channel_slice_bias_on_device;
 
 public:
     Conv2dSliceAttr(
@@ -659,6 +665,199 @@ public:
     }
 
     std::string name() const override { return "Conv2D"; }
+
+    // ---- Channel slicing -------------------------------------------------------------------------
+    // Legal only for a fully depthwise convolution, where output channel c reduces over input
+    // channel c alone. A dense conv reduces every output channel over all input channels, and a
+    // partially grouped conv would need slices aligned to group boundaries plus per-group weight
+    // bookkeeping, so both stay on the spatial path.
+    uint32_t channel_slice_granularity() const override {
+        const bool depthwise = groups > 1 && groups == input_channels && input_channels == output_channels;
+        if (!depthwise) {
+            return 0;
+        }
+        // Channels are the innermost activation dimension and the tile-width axis of a tiled
+        // output, so slice boundaries must stay tile-aligned.
+        return tt::constants::TILE_WIDTH;
+    }
+
+    // Memory config conv2d_L1 will pick for a channel slice: full spatial extent, narrower channels.
+    tt::tt_metal::MemoryConfig get_channel_slice_input_memory_config(uint32_t channels) const {
+        auto conv_config = this->conv_config;
+        auto [input_height, input_width] = input_shape;
+        auto [output_height, output_width] = calculate_output_image_size(
+            std::array<uint32_t, 2>{input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+        if (!conv_config.shard_layout.has_value()) {
+            if (!conv_config.weights_dtype.has_value()) {
+                conv_config.weights_dtype = weight_tensor.dtype();
+            }
+            conv_config = determine_conv_config_for_auto_shard(
+                conv_config,
+                false,
+                batch_size,
+                channels,
+                channels,
+                output_height,
+                output_width,
+                weight_tensor.logical_shape()[3],
+                input_height,
+                input_width,
+                device->compute_with_storage_grid_size(),
+                input_layout,
+                input_dtype,
+                output_dtype,
+                std::nullopt,
+                kernel_size,
+                stride,
+                dilation,
+                padding_n4,
+                channels,
+                bias_tensor.has_value(),
+                compute_config);
+        }
+        TT_FATAL(conv_config.shard_layout.has_value(), "Conv2D DRAM channel slicing must have a shard layout set.");
+
+        ShardOrientation shard_orientation =
+            conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+        return std::get<1>(determine_input_memory_config(
+            conv_config.shard_layout.value(),
+            shard_orientation,
+            batch_size,
+            ttnn::Shape({batch_size, input_height, input_width, channels}),
+            ttnn::Shape({batch_size, output_height, output_width, channels}),
+            false,
+            device->compute_with_storage_grid_size(),
+            input_layout,
+            BufferType::DRAM));
+    }
+
+    uint32_t get_L1_usage_for_channel_slice(
+        uint32_t channel_start, uint32_t channel_end, const op_slicing::Op2DSliceConfig& slice_config) const override {
+        auto conv_config = this->conv_config;
+        const uint32_t channels = channel_end - channel_start;
+        auto [input_height, input_width] = input_shape;
+        auto [output_height, output_width] = calculate_output_image_size(
+            std::array<uint32_t, 2>{input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+
+        auto slice_input_memory_config = get_channel_slice_input_memory_config(channels);
+        if (!conv_config.shard_layout.has_value()) {
+            conv_config.shard_layout = slice_input_memory_config.memory_layout();
+        }
+        auto conv_L1_usage = calculate_L1_usage_for_conv_op(
+            batch_size,
+            channels,
+            channels,
+            input_height,
+            input_width,
+            output_height,
+            output_width,
+            kernel_size,
+            stride,
+            padding_n4,
+            dilation,
+            channels,  // depthwise: one group per channel in this slice
+            bias_tensor.has_value(),
+            input_dtype,
+            output_dtype,
+            input_layout,
+            device->compute_with_storage_grid_size(),
+            false,
+            conv_config.shard_layout.value(),
+            compute_config,
+            conv_config,
+            slice_input_memory_config);
+
+        log_trace(
+            tt::LogOp,
+            "Conv2D DRAM channel slicing: channels [{}, {}), num_slices = {}, L1 usage = {}",
+            channel_start,
+            channel_end,
+            slice_config.num_slices,
+            conv_L1_usage.total_size);
+        return std::max(conv_L1_usage.halo_input_size + conv_L1_usage.halo_output_size, conv_L1_usage.total_size);
+    }
+
+    std::vector<ttnn::Tensor> run_L1_op_channel_slice(
+        const ttnn::Tensor& sliced_input_tensor, uint32_t channel_start, uint32_t channel_end) override {
+        const uint32_t channels = channel_end - channel_start;
+        auto [input_height, input_width] = input_shape;
+
+        // Depthwise weights are [out_channels, 1, kH, kW], so the channel range selects whole
+        // filters and slicing dim 0 yields this slice's weights. Bias is [1, 1, 1, out_channels].
+        // These stay raw (unprepared), so conv2d_L1 prepares each slice's copy itself -- unlike the
+        // spatial path, one cached prepared weight cannot be shared across slices.
+        //
+        // ttnn::slice is a device op and conv weights usually arrive on host, so upload once here
+        // rather than per slice.
+        const MemoryConfig dram_interleaved{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+        if (!channel_slice_weight_on_device.has_value()) {
+            channel_slice_weight_on_device =
+                ttnn::is_device_tensor(weight_tensor)
+                    ? weight_tensor
+                    : ttnn::operations::core::to_device(weight_tensor, device, dram_interleaved);
+        }
+        const auto& device_weight = channel_slice_weight_on_device.value();
+        ttnn::Tensor weight_slice = ttnn::slice(
+            device_weight,
+            ttsl::SmallVector<uint32_t>{channel_start, 0, 0, 0},
+            ttsl::SmallVector<uint32_t>{
+                channel_end,
+                device_weight.logical_shape()[1],
+                device_weight.logical_shape()[2],
+                device_weight.logical_shape()[3]},
+            ttsl::SmallVector<uint32_t>{1, 1, 1, 1});
+
+        std::optional<ttnn::Tensor> bias_slice = std::nullopt;
+        if (bias_tensor.has_value()) {
+            if (!channel_slice_bias_on_device.has_value()) {
+                const auto& bias = bias_tensor->get();
+                channel_slice_bias_on_device = ttnn::is_device_tensor(bias)
+                                                   ? bias
+                                                   : ttnn::operations::core::to_device(bias, device, dram_interleaved);
+            }
+            const auto& device_bias = channel_slice_bias_on_device.value();
+            bias_slice = ttnn::slice(
+                device_bias,
+                ttsl::SmallVector<uint32_t>{0, 0, 0, channel_start},
+                ttsl::SmallVector<uint32_t>{
+                    device_bias.logical_shape()[0],
+                    device_bias.logical_shape()[1],
+                    device_bias.logical_shape()[2],
+                    channel_end},
+                ttsl::SmallVector<uint32_t>{1, 1, 1, 1});
+        }
+
+        auto conv_config_l1 = conv_config;
+        conv_config_l1.deallocate_activation = true;
+        conv_config_l1.reallocate_halo_output = true;
+        // Force Conv2d_L1 to always output tiled layout to reduce CB Memory usage.
+        conv_config_l1.output_layout = Layout::TILE;
+        // shard_layout is deliberately left as the caller set it: when unset, conv2d_L1 auto-shards
+        // per slice using that slice's channel count. Unlike the spatial path this attr never
+        // caches a layout back, so each slice starts from the caller's config.
+
+        auto conv2d_result = conv2d_L1(
+            sliced_input_tensor,
+            weight_slice,
+            device,
+            channels,
+            channels,
+            batch_size,
+            input_height,
+            input_width,
+            kernel_size,
+            stride,
+            padding_n4,
+            dilation,
+            channels,  // depthwise: one group per channel in this slice
+            output_dtype,
+            bias_slice,
+            conv_config_l1,
+            compute_config,
+            std::nullopt);
+        return {std::get<0>(conv2d_result)};
+    }
 
     std::vector<ttnn::Tensor> run_L1_op(
         const ttnn::Tensor& sliced_input_tensor,

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp
@@ -12,7 +12,23 @@
 #include <ttnn/tensor/tensor.hpp>
 #include <ttnn/operations/experimental/slice_write/slice_write.hpp>
 #include <ttnn/operations/experimental/padded_slice/padded_slice.hpp>
+#include <ttnn/operations/data_movement/slice/slice.hpp>
+#include <ttnn/operations/data_movement/concat/concat.hpp>
 namespace ttnn::operations::op_slicing {
+
+// Ops opt in to channel slicing by overriding these; the defaults keep every existing
+// implementation spatial-only.
+uint32_t OpSliceAttr::channel_slice_granularity() const { return 0; }
+
+uint32_t OpSliceAttr::get_L1_usage_for_channel_slice(
+    uint32_t /*channel_start*/, uint32_t /*channel_end*/, const op_slicing::Op2DSliceConfig& /*slice_config*/) const {
+    TT_THROW("{} does not support channel slicing", name());
+}
+
+std::vector<ttnn::Tensor> OpSliceAttr::run_L1_op_channel_slice(
+    const ttnn::Tensor& /*sliced_input_tensor*/, uint32_t /*channel_start*/, uint32_t /*channel_end*/) {
+    TT_THROW("{} does not support channel slicing", name());
+}
 
 // Compute the rounding value for slice boundaries based on output layout and slice type.
 // For tiled outputs, slices must align to tile boundaries (32 elements).
@@ -22,6 +38,44 @@ static uint32_t compute_slice_rounding_value(
         return tt::constants::TILE_HEIGHT;
     }
     return 1;
+}
+
+static const char* slice_type_name(Op2DSliceConfig::SliceType slice_type) {
+    switch (slice_type) {
+        case Op2DSliceConfig::SliceType::DRAM_HEIGHT: return "height";
+        case Op2DSliceConfig::SliceType::DRAM_WIDTH: return "width";
+        case Op2DSliceConfig::SliceType::DRAM_CHANNEL: return "channel";
+        case Op2DSliceConfig::SliceType::L1_FULL: return "L1_FULL";
+    }
+    return "unknown";
+}
+
+// Channel slices must respect the op's own alignment requirement rather than the output layout:
+// the channel dimension is the innermost (stick) dimension, not the tilized height.
+static uint32_t compute_channel_slice_rounding_value(const OpSliceAttr* op_slice_attr) {
+    const uint32_t granularity = op_slice_attr->channel_slice_granularity();
+    TT_FATAL(granularity > 0, "{} does not support channel slicing", op_slice_attr->name());
+    return granularity;
+}
+
+// Walk the channel slices implied by num_slices, invoking `visit(start, end)` for each.
+// Shared by the L1 usage estimate and the execution loop so the two cannot disagree.
+template <typename VisitFn>
+static void for_each_channel_slice(uint32_t channels, uint32_t rounding_value, uint32_t num_slices, VisitFn&& visit) {
+    TT_FATAL(num_slices > 0, "Channel slicing requires at least one slice");
+    const uint32_t rounded_units = tt::div_up(channels, rounding_value);
+    const uint32_t min_units_per_slice = rounded_units / num_slices;
+    const uint32_t units_remainder = rounded_units % num_slices;
+
+    uint32_t channel_start = 0;
+    for (uint32_t slice_index = 0; slice_index < num_slices && channel_start < channels; slice_index++) {
+        const uint32_t slice_units = min_units_per_slice + ((slice_index < units_remainder) ? 1 : 0);
+        const uint32_t channel_end = std::min(channels, channel_start + slice_units * rounding_value);
+        if (channel_end > channel_start) {
+            visit(channel_start, channel_end);
+        }
+        channel_start = channel_end;
+    }
 }
 
 // Compute the maximum number of slices allowed for the given output dimension and layout.
@@ -43,6 +97,20 @@ static uint32_t compute_L1_usage_for_slice_config(
         dram_slice_config.num_slices > 0, "Number of slices must be greater than 0 for DRAM L1 usage calculation.");
     auto [batch_size, output_height, output_width, output_channels] = output_shape.to_array_4D();
     auto [in_batch_, input_height, input_width, input_channels] = input_shape.to_array_4D();
+
+    if (dram_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_CHANNEL) {
+        uint32_t max_memory_consumed = 0;
+        for_each_channel_slice(
+            output_channels,
+            compute_channel_slice_rounding_value(op_slice_attr),
+            dram_slice_config.num_slices,
+            [&](uint32_t channel_start, uint32_t channel_end) {
+                max_memory_consumed = std::max(
+                    max_memory_consumed,
+                    op_slice_attr->get_L1_usage_for_channel_slice(channel_start, channel_end, dram_slice_config));
+            });
+        return max_memory_consumed;
+    }
 
     // DRAM_HEIGHT = slice along image height, DRAM_WIDTH = slice along image width
     const uint32_t output_sliced_dim =
@@ -188,19 +256,29 @@ static Op2DSliceConfig determine_slice_config_internal(
         output_width,
         auto_slice_type);
 
-    const uint32_t slice_rounding_value = compute_slice_rounding_value(output_layout, return_slice_config.slice_type);
+    const bool channel_slicing = return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_CHANNEL;
 
-    // DRAM_HEIGHT = slice along image height, DRAM_WIDTH = slice along image width
+    const uint32_t slice_rounding_value =
+        channel_slicing ? compute_channel_slice_rounding_value(op_slice_attr)
+                        : compute_slice_rounding_value(output_layout, return_slice_config.slice_type);
+
+    // DRAM_HEIGHT = slice along image height, DRAM_WIDTH = slice along image width,
+    // DRAM_CHANNEL = slice along channels
     const uint32_t output_sliced_dim =
-        return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_HEIGHT ? output_height : output_width;
+        channel_slicing ? output_shape[3]
+                        : (return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_HEIGHT ? output_height
+                                                                                                     : output_width);
 
-    const uint32_t max_num_slices = compute_max_num_slices(output_sliced_dim, slice_rounding_value, output_layout);
+    // Channel slices are bounded by the op's alignment, not by the output layout's tiling.
+    const uint32_t max_num_slices =
+        channel_slicing ? tt::div_up(output_sliced_dim, slice_rounding_value)
+                        : compute_max_num_slices(output_sliced_dim, slice_rounding_value, output_layout);
 
     log_debug(
         tt::LogOp,
         "Max possible slices for {} layout and {}-slicing: {} (output_sliced_dim={})",
         output_layout == tt::tt_metal::Layout::TILE ? "TILE" : "ROW_MAJOR",
-        return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_HEIGHT ? "height" : "width",
+        slice_type_name(return_slice_config.slice_type),
         max_num_slices,
         output_sliced_dim);
 
@@ -229,7 +307,7 @@ static Op2DSliceConfig determine_slice_config_internal(
         log_warning(
             tt::LogOp,
             "Failed to find valid config with {}-slicing. Attempting fallback to {}-slicing.",
-            return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_HEIGHT ? "height" : "width",
+            slice_type_name(return_slice_config.slice_type),
             return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_HEIGHT ? "width" : "height");
 
         if (return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_WIDTH) {
@@ -254,6 +332,24 @@ static Op2DSliceConfig determine_slice_config_internal(
             true);  // Mark as retry attempt
     }
 
+    // Both spatial axes are exhausted. If the op has no cross-channel reduction, channels are still
+    // a legal axis to split on -- and the only one left when the image is small but very deep
+    // (e.g. a wide depthwise short convolution, whose output is 1 x 23 x 8192).
+    if (!found_valid_config && !channel_slicing && op_slice_attr->channel_slice_granularity() > 0) {
+        log_warning(
+            tt::LogOp,
+            "Failed to find valid config with {}-slicing. Attempting fallback to channel-slicing.",
+            slice_type_name(return_slice_config.slice_type));
+        return determine_slice_config_internal(
+            op_slice_attr,
+            input_shape,
+            output_shape,
+            Op2DSliceConfig{.slice_type = Op2DSliceConfig::SliceType::DRAM_CHANNEL, .num_slices = 0},
+            output_layout,
+            device,
+            true);  // Mark as retry attempt
+    }
+
     // If we haven't found a valid config, this is fatal
     TT_FATAL(
         found_valid_config,
@@ -261,7 +357,7 @@ static Op2DSliceConfig determine_slice_config_internal(
         "dimension {}. Available L1: {} bytes. Operation requires more memory than available even with maximum "
         "slicing.",
         current_num_slices - 1,
-        return_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_HEIGHT ? "height" : "width",
+        slice_type_name(return_slice_config.slice_type),
         output_sliced_dim,
         L1_stats.total_free_bytes);
 
@@ -278,6 +374,90 @@ Op2DSliceConfig determine_slice_config(
     MeshDevice* device) {
     return determine_slice_config_internal(
         op_slice_attr, input_shape, output_shape, slice_config_, output_layout, device, false);
+}
+
+// Execute the op one channel range at a time. Unlike the spatial loop there is no halo: slice N
+// reads exactly the channels it writes, so a plain slice replaces padded_slice and the op reshards
+// the activation itself.
+static void run_channel_sliced_op(
+    const ttnn::Tensor& input_tensor,
+    std::vector<OpSliceAttr::RefTensor>& output_tensors,
+    OpSliceAttr* op_slice_attr,
+    uint32_t num_slices,
+    tt::tt_metal::Layout output_layout) {
+    auto [batch_size, output_height, output_width, output_channels] =
+        output_tensors[0].get().logical_shape().to_array_4D();
+    auto [in_batch_, input_height, input_width, input_channels] = input_tensor.logical_shape().to_array_4D();
+    const uint32_t num_output_tensors = output_tensors.size();
+
+    // No halo means the input and output channel ranges coincide, which only holds for ops whose
+    // channels map one-to-one (pooling, depthwise convolution).
+    TT_FATAL(
+        input_channels == output_channels,
+        "Channel slicing requires matching input and output channel counts for {}, got {} and {}",
+        op_slice_attr->name(),
+        input_channels,
+        output_channels);
+
+    // slice_write cannot take a nonzero offset in the last dimension for a tiled sharded input
+    // (slice_write_tiled_sharded_input_program_factory: output_tensor_start[-1] == 0), so channel
+    // slices are gathered and concatenated rather than written in place. The preallocated output is
+    // replaced, as in the num_slices == 1 path.
+    const MemoryConfig dram_interleaved{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    std::vector<std::vector<ttnn::Tensor>> gathered_slices(num_output_tensors);
+
+    for_each_channel_slice(
+        output_channels,
+        compute_channel_slice_rounding_value(op_slice_attr),
+        num_slices,
+        [&](uint32_t channel_start, uint32_t channel_end) {
+            log_trace(
+                tt::LogOp,
+                "Op {} DRAM channel slicing: channels [{}, {})",
+                op_slice_attr->name(),
+                channel_start,
+                channel_end);
+
+            const Tensor sliced_input_tensor = ttnn::slice(
+                input_tensor,
+                ttsl::SmallVector<uint32_t>{0, 0, 0, channel_start},
+                ttsl::SmallVector<uint32_t>{batch_size, input_height, input_width, channel_end},
+                ttsl::SmallVector<uint32_t>{1, 1, 1, 1});
+
+            auto sliced_output_tensors =
+                op_slice_attr->run_L1_op_channel_slice(sliced_input_tensor, channel_start, channel_end);
+            TT_FATAL(
+                sliced_output_tensors.size() == num_output_tensors,
+                "Number of output tensors from run_L1_op_channel_slice {} does not match the expected number of "
+                "output tensors {}",
+                sliced_output_tensors.size(),
+                num_output_tensors);
+
+            const uint32_t channel_slice_size = channel_end - channel_start;
+            for (uint32_t output_tensor_index = 0; output_tensor_index < num_output_tensors; output_tensor_index++) {
+                auto& sliced_output_tensor = sliced_output_tensors[output_tensor_index];
+                // Spill each slice to DRAM so concat sees uniform, unsharded inputs and L1 is freed
+                // for the next slice.
+                sliced_output_tensor = ttnn::to_memory_config(sliced_output_tensor, dram_interleaved);
+                if (sliced_output_tensor.layout() != Layout::ROW_MAJOR && output_layout == Layout::ROW_MAJOR) {
+                    sliced_output_tensor = ttnn::untilize(sliced_output_tensor);
+                }
+                // The op returns a flattened activation; restore [N, H, W, C] so the concatenated
+                // result carries the 4D shape the caller allocated (it flattens this afterwards).
+                sliced_output_tensor = ttnn::reshape(
+                    sliced_output_tensor,
+                    ttnn::Shape({batch_size, output_height, output_width, channel_slice_size}),
+                    ttnn::Shape({batch_size, output_height, output_width, sliced_output_tensor.padded_shape()[3]}));
+                gathered_slices[output_tensor_index].push_back(sliced_output_tensor);
+            }
+        });
+
+    for (uint32_t output_tensor_index = 0; output_tensor_index < num_output_tensors; output_tensor_index++) {
+        auto& output_tensor = output_tensors[output_tensor_index].get();
+        // Free the preallocated output before concat allocates the real one.
+        output_tensor.deallocate(true);
+        output_tensor = ttnn::concat(gathered_slices[output_tensor_index], 3, dram_interleaved);
+    }
 }
 
 void run_sliced_op(
@@ -336,6 +516,13 @@ void run_sliced_op(
         input_tensor.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_free_bytes);
 
     log_debug(tt::LogOp, "{} DRAM with Slice Config {}", op_slice_attr->name(), dram_slice_config);
+
+    // Channels are sliced by their own loop: the bounds below are spatial, and the channel axis has
+    // no halo to compute.
+    if (dram_slice_config.slice_type == Op2DSliceConfig::SliceType::DRAM_CHANNEL) {
+        run_channel_sliced_op(input_tensor, output_tensors, op_slice_attr, dram_slice_config.num_slices, output_layout);
+        return;
+    }
 
     const uint32_t slice_rounding_value = compute_slice_rounding_value(output_layout, dram_slice_config.slice_type);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.hpp
@@ -18,8 +18,14 @@ struct Op2DSliceConfig {
     enum class SliceType : uint8_t {
         DRAM_HEIGHT,
         DRAM_WIDTH,
-        L1_FULL  // This option can be used to force conv2d with a DRAM Input to move it to L1, and output will be in
-                 // L1.
+        L1_FULL,  // This option can be used to force conv2d with a DRAM Input to move it to L1, and output will be in
+                  // L1.
+        // Appended rather than grouped with the DRAM_* values above so the existing enumerators keep
+        // their numeric values.
+        DRAM_CHANNEL  // Slice along the channel dimension. Only legal for ops with no cross-channel reduction (see
+                      // OpSliceAttr::channel_slice_granularity). Unlike height/width slicing there is no halo, so no
+                      // data is duplicated between slices; it is the only usable axis when both spatial dimensions are
+                      // too small to slice (e.g. a wide depthwise short convolution, output 1x23x8192).
     };
     SliceType slice_type = SliceType::DRAM_WIDTH;
 
@@ -49,6 +55,24 @@ public:
         const IOShape& output_slice_start,
         const IOShape& output_slice_end) = 0;
     virtual std::string name() const = 0;
+
+    // ---- Channel slicing (SliceType::DRAM_CHANNEL) -----------------------------------------------
+    // Opt-in: an op supports channel slicing only if each output channel can be computed without
+    // reducing over the channels held by other slices. True for pooling (fully per-channel) and for
+    // depthwise/grouped convolution when slices land on group boundaries; false for a dense
+    // convolution, where every output channel reduces over all input channels.
+    //
+    // Returns the required channel alignment of a slice boundary, or 0 if the op does not support
+    // channel slicing (the default, so existing ops keep their spatial-only behaviour).
+    virtual uint32_t channel_slice_granularity() const;
+
+    // As get_L1_usage / run_L1_op, but for a slice covering the full spatial extent and the
+    // half-open output channel range [channel_start, channel_end). Only called when
+    // channel_slice_granularity() > 0.
+    virtual uint32_t get_L1_usage_for_channel_slice(
+        uint32_t channel_start, uint32_t channel_end, const op_slicing::Op2DSliceConfig& slice_config) const;
+    virtual std::vector<ttnn::Tensor> run_L1_op_channel_slice(
+        const ttnn::Tensor& sliced_input_tensor, uint32_t channel_start, uint32_t channel_end);
 };
 
 Op2DSliceConfig determine_slice_config(

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window_nanobind.cpp
@@ -43,9 +43,10 @@ void bind_sliding_window(nb::module_& mod) {
         "slice_type",
         &Op2DSliceConfig::slice_type,
         R"doc(
-        | The type of slice to be used. Can be either SliceHeight or SliceWidth. When the tensor is in [N, H, W, C] format, then it can slice either along the height or width dimension.
+        | The type of slice to be used. When the tensor is in [N, H, W, C] format, it can slice along the height, width or channel dimension.
         | Slicing along the width is preferable as it reduces the size of the output of the Halo operation.
         | Use SliceHeight only when the height dimension is much larger than the width dimension.
+        | Use DRAMSliceChannel for ops with no cross-channel reduction (pooling, depthwise convolution); it has no halo, and it is the only usable axis when both spatial dimensions are too small to slice.
         )doc");
     py_op_slice_config.def_rw(
         "num_slices",
@@ -59,7 +60,8 @@ void bind_sliding_window(nb::module_& mod) {
     nb::enum_<Op2DSliceConfig::SliceType>(py_op_slice_config, "SliceTypeEnum")
         .value("L1Full", Op2DSliceConfig::SliceType::L1_FULL)
         .value("DRAMSliceHeight", Op2DSliceConfig::SliceType::DRAM_HEIGHT)
-        .value("DRAMSliceWidth", Op2DSliceConfig::SliceType::DRAM_WIDTH);
+        .value("DRAMSliceWidth", Op2DSliceConfig::SliceType::DRAM_WIDTH)
+        .value("DRAMSliceChannel", Op2DSliceConfig::SliceType::DRAM_CHANNEL);
 }
 
 }  // namespace ttnn::operations::sliding_window

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -594,6 +594,7 @@ from ttnn.operations.conv2d import (
     Conv2dSliceConfig,
     Conv2dDRAMSliceHeight,
     Conv2dDRAMSliceWidth,
+    Conv2dDRAMSliceChannel,
     Conv2dL1Full,
     Conv2dL1FullSliceConfig,
     prepare_conv_weights,

--- a/ttnn/ttnn/operations/conv2d.py
+++ b/ttnn/ttnn/operations/conv2d.py
@@ -18,12 +18,14 @@ PaddingMode = ttnn._ttnn.operations.conv.PaddingMode
 Conv2dSliceConfig = ttnn._ttnn.operations.sliding_window.Op2DSliceConfig
 Conv2dDRAMSliceHeight = Conv2dSliceConfig.SliceTypeEnum.DRAMSliceHeight
 Conv2dDRAMSliceWidth = Conv2dSliceConfig.SliceTypeEnum.DRAMSliceWidth
+Conv2dDRAMSliceChannel = Conv2dSliceConfig.SliceTypeEnum.DRAMSliceChannel
 Conv2dL1Full = Conv2dSliceConfig.SliceTypeEnum.L1Full
 Conv2dL1FullSliceConfig = Conv2dSliceConfig(slice_type=Conv2dL1Full)
 
 Op2DSliceConfig = ttnn._ttnn.operations.sliding_window.Op2DSliceConfig
 Op2DDRAMSliceHeight = Op2DSliceConfig.SliceTypeEnum.DRAMSliceHeight
 Op2DDRAMSliceWidth = Op2DSliceConfig.SliceTypeEnum.DRAMSliceWidth
+Op2DDRAMSliceChannel = Op2DSliceConfig.SliceTypeEnum.DRAMSliceChannel
 Op2DL1Full = Op2DSliceConfig.SliceTypeEnum.L1Full
 Op2DL1FullSliceConfig = Op2DSliceConfig(slice_type=Op2DL1Full)
 


### PR DESCRIPTION
### PR Category
Bug Fix

### Link to the issue
https://github.com/tenstorrent/tt-metal/issues/54564

### Summary

**Problem**

`conv2d` / `conv1d` with a DRAM input aborts when the op does not fit L1 and neither spatial dimension can be split. `Op2DSliceConfig::SliceType` offered only `DRAM_HEIGHT` and `DRAM_WIDTH` — both spatial  so `determine_slice_config_internal` tried width, fell back to height, then `TT_FATAL`ed even when the channel dimension had plenty of slack:

```
DRAM Auto slice could not find valid slice configuration. Tried up to 1 slices for
width-slicing on output dimension 23. Available L1: 1428608 bytes.
```

The shape that hits it is the Gated DeltaNet short convolution in Qwen 3.5 / 3.6 35B-A3B and Qwen 3.8 27B: a depthwise conv over the fused QKV stream, conv_dim 8192 (10240 for the 27B), kernel 4, 20-token prompt. Its output is `1 x 23 x 8192` height 1 gives one slice, width 23 rounds into a single 32-wide tile and also gives one slice, while the 8192 channels actually consuming L1 were not a slicing candidate at all. Splitting them is trivially legal for a depthwise conv (no cross-channel reduction, no halo) and 2 chunks of 4096 already fits.

The gap is general: any op reaching `op_slicing` whose output is spatially small but deep is unsliceable today.

**What's changed**

- `DRAM_CHANNEL` added to `SliceType`, appended after `L1_FULL` so existing enumerators keep their numeric values.
- Three opt-in virtuals on `OpSliceAttr`: `channel_slice_granularity()` (0 = unsupported, the default) plus channel-range variants of `get_L1_usage` and `run_L1_op`. Defaults are non-pure, so no existing implementor changes conv2d, conv_transpose2d, generic_pools and the quasar copies compile untouched and stay spatial-only.
- Channel branch in the L1 estimator and in `run_sliced_op`, sharing a `for_each_channel_slice` walker so the estimate and execution cannot disagree on slice boundaries. The axis is tried only after both spatial axes are exhausted, so shapes that already slice are unaffected.
- `Conv2dSliceAttr` opts in, gated to fully depthwise (`groups == in_channels == out_channels`), and slices weights/bias per chunk. Dense and partially grouped convs deliberately stay on the spatial path, since splitting channels there would compute the wrong result.
- `DRAMSliceChannel` exposed via the nanobind enum and the `Conv2dDRAMSlice*` / `Op2DDRAMSlice*`aliases so the axis can be requested explicitly.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sonalib/slice_depth)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sonalib/slice_depth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sonalib/slice_depth)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sonalib/slice_depth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sonalib/slice_depth)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sonalib/slice_depth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sonalib/slice_depth)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sonalib/slice_depth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sonalib/slice_depth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sonalib/slice_depth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sonalib/slice_depth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sonalib/slice_depth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sonalib/slice_depth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sonalib/slice_depth)