### PR TITLE
[LLK][Bug fix] Wormhole dest-reuse: back-port the Blackhole MOVD2A/MOVD2B bank-sync fix

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -163,7 +163,24 @@ static std::vector<T> apply_row_broadcast_to_tiled_input(const std::vector<T>& i
     return broadcast_input;
 }
 
-static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& test_config, bool is_quasar) {
+// Wormhole Src-register precision model for the Float32 stimulus.
+//
+// Float32 L1 operands with a 32-bit DEST are unpacked into SrcA/SrcB as TF32 (10 explicit mantissa
+// bits): all-fp32 CBs + fp32_dest_acc select unpack_conditional_dst_format = Tf32 in
+// compute_data_formats(), so ALU_FORMAT_SPEC_REG0_SrcA = Tf32. The conversion truncates.
+// MOVD2B moving DEST back into SrcB is likewise a truncation, ShuffleTF32(DstVal >> 13).
+// ELWMUL additionally ignores the least significant bit of the SrcA TF32 mantissa, leaving 9 bits.
+// Applied on Wormhole only: this was measured against Wormhole silicon, and Blackhole selects the
+// SrcA format differently (ImpliedSrcAFmt), so Blackhole keeps the plain Float32 golden until measured.
+static constexpr std::uint32_t kTf32SrcMask = 0xFFFFE000;      // 10 explicit mantissa bits
+static constexpr std::uint32_t kTf32MulSrcAMask = 0xFFFFC000;  // 9 bits: ELWMUL drops the SrcA mantissa LSB
+
+static float truncate_to_src(float value, std::uint32_t mask) {
+    return std::bit_cast<float>(std::bit_cast<std::uint32_t>(value) & mask);
+}
+
+static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& test_config, ARCH arch) {
+    const bool is_quasar = arch == ARCH::QUASAR;
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
     BinaryStimulus s;
     // Use fixed seeds so test results are deterministic and reproducible.
@@ -194,11 +211,24 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
         std::vector<float> golden(input0.size());
         if (test_config.precede_dest_reuse_with_col_broadcast) {
             const auto broadcast_input1 = apply_col_broadcast_to_tiled_input(input1, test_config.num_tiles);
+            const bool model_tf32_src = arch == ARCH::WORMHOLE_B0;
             for (size_t i = 0; i < golden.size(); ++i) {
                 constexpr size_t tile_size = 32 * 32;
-                golden[i] = input2[i % tile_size] * (input0[i] - broadcast_input1[i]);
+                if (model_tf32_src) {
+                    // ELWSUB reads both operands as TF32 and writes the FP32 DEST.
+                    const float sub =
+                        truncate_to_src(input0[i], kTf32SrcMask) - truncate_to_src(broadcast_input1[i], kTf32SrcMask);
+                    // MOVD2B truncates that DEST value into SrcB; in2 is the ELWMUL SrcA operand.
+                    const float srcb = truncate_to_src(sub, kTf32SrcMask);
+                    const float srca = truncate_to_src(input2[i % tile_size], kTf32MulSrcAMask);
+                    golden[i] = srca * srcb;
+                } else {
+                    golden[i] = input2[i % tile_size] * (input0[i] - broadcast_input1[i]);
+                }
             }
         } else {
+            // NOTE: this sibling Float32 path (broadcast DEST_TO_SRCA multiply) has the same TF32 Src
+            // precision gap but has not been measured against hardware, so it keeps the Float32 golden.
             TT_FATAL(
                 (test_config.col_broadcast || test_config.row_broadcast) &&
                     test_config.binary_op == "mul_with_dest_reuse" &&
@@ -410,7 +440,7 @@ bool single_core_binary(
         num_runs > 0 && test_config.block_size > 0 && test_config.num_tiles % test_config.block_size == 0,
         "num_runs and block_size must be positive, and num_tiles must be divisible by block_size");
     TT_FATAL(!(test_config.col_broadcast && test_config.row_broadcast), "Only one broadcast type may be selected");
-    const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
+    const ARCH arch = MetalContext::instance().get_cluster().arch();
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -418,7 +448,7 @@ bool single_core_binary(
         static_cast<std::uint32_t>(test_config.core.x), static_cast<std::uint32_t>(test_config.core.y)};
 
     // Math-fidelity masks model WH/BH LLK behavior; Quasar HW does not apply them.
-    auto stimulus = generate_binary_stimulus(test_config, is_quasar);
+    auto stimulus = generate_binary_stimulus(test_config, arch);
     auto buffers = create_and_populate_binary_buffers(mesh_device, cq, zero_coord, byte_size, stimulus);
     auto& input0_dram_buffer = buffers.input0;
     auto& input1_dram_buffer = buffers.input1;
@@ -631,11 +661,13 @@ bool single_core_binary(
 
         std::vector<std::uint32_t> packed_result;
         if (!read_and_validate_binary_result(cq, output_dram_buffer, zero_coord, stimulus, &packed_result)) {
+            log_error(tt::LogTest, "Run {} output does not match the golden", run);
             return false;
         }
         if (run == 0) {
             first_result = std::move(packed_result);
         } else if (packed_result != first_result) {
+            log_error(tt::LogTest, "Run {} output differs from run 0 -- result is not deterministic", run);
             return false;
         }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_2_0.cpp
@@ -12,8 +12,15 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
-#if defined(ARCH_BLACKHOLE) && defined(UCK_CHLKC_UNPACK) && defined(ELTWISE_DEST_REUSE_TYPE)
+// The dest-reuse dummy unpack must wait on the unpacker's own bank, not the matrix unit's. Guard the
+// encoding so the bit cannot be dropped silently: Blackhole spells it Stall_Clr_Cntrl (bit 5),
+// Wormhole spells it WaitLikeUnpacr inside the NoOp field (bit 4).
+#if (defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)) && defined(UCK_CHLKC_UNPACK) && defined(ELTWISE_DEST_REUSE_TYPE)
+#ifdef ARCH_BLACKHOLE
 constexpr std::uint32_t stall_clear_control_mask = 1U << 5;
+#else
+constexpr std::uint32_t stall_clear_control_mask = 1U << 4;
+#endif
 static_assert(
     (llk_unpack_a_detail::dest_reuse_dummy_unpack<ELTWISE_DEST_REUSE_TYPE>() & stall_clear_control_mask) != 0);
 #endif

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -153,7 +153,9 @@ inline void srcb_bank_wait()
 
 inline void move_d2a_fixed_face(const std::uint8_t addrmod)
 {
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCA_VLD); // MOVD2A for a whole face assumes unpacker will set a dummy data_valid, so we want to wait on that
+    // Drain preceding math instructions so their source-bank release is visible before testing
+    // the DVALID of the bank that MOVD2A will write.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCA_VLD);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, addrmod, p_movd2a::MOV_4_ROWS, 0);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 4, addrmod, p_movd2a::MOV_4_ROWS, 4);
     TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 8, addrmod, p_movd2a::MOV_4_ROWS, 8);
@@ -162,7 +164,9 @@ inline void move_d2a_fixed_face(const std::uint8_t addrmod)
 
 inline void move_d2b_fixed_face(const std::uint8_t addrmod)
 {
-    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy data_valid, so we want to wait on that
+    // Drain preceding math instructions so their source-bank release is visible before testing
+    // the DVALID of the bank that MOVD2B will write.
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH | p_stall::SRCB_VLD);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, addrmod, p_movd2b::MOV_4_ROWS, 0);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, addrmod, p_movd2b::MOV_4_ROWS, 4);
     TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, addrmod, p_movd2b::MOV_4_ROWS, 8);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -23,6 +23,25 @@
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
+namespace llk_unpack_a_detail
+{
+
+// Dummy source publication for destination reuse. WaitLikeUnpacr=1 so the instruction waits on
+// Unpackers[i].SrcBank -- the bank it actually clears -- rather than MatrixUnit.Src?Bank, which is a
+// different bank once double-buffering reaches steady state. This lets unpack prepare the next bank
+// while math consumes the current one. Mirrors the wait behaviour of the Blackhole helper of the same
+// name; Blackhole also sets dvalid in the same instruction, which Wormhole cannot -- there SETDVALID is
+// a separate UNPACR_NOP mode.
+template <EltwiseBinaryReuseDestType binary_reuse_dest>
+constexpr std::uint32_t dest_reuse_dummy_unpack()
+{
+    static_assert(binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA || binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB);
+    constexpr std::uint32_t source = binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA ? SrcA : SrcB;
+    return TT_OP_UNPACR_NOP(source, p_unpacr_nop::UNP_ZEROSRC_STALL_RESET_WR_RDY);
+}
+
+} // namespace llk_unpack_a_detail
+
 /**
  * @brief Program the unpacker MOP for a single-operand (A) unpack.
  *
@@ -63,7 +82,6 @@ inline void _llk_unpack_A_mop_config_(
         TT_OP_UNPACR(SrcA, 0b00100010 /*CH0/CH1 Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // ch0/ch1 z_inc
     static constexpr std::uint32_t unpack_srca_to_dest_transpose_of_faces =
         TT_OP_UNPACR(SrcA, 0b00010010, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // inc srcA ch1_z+=1, ch0_z+=2
-    static constexpr std::uint32_t unpack_srca_zerosrc    = TT_OP_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC);
     static constexpr std::uint32_t unpack_srca_set_dvalid = TT_OP_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_SET_DVALID);
     static constexpr std::uint32_t unpack_srcb =
         TT_OP_UNPACR(SrcB, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
@@ -178,10 +196,14 @@ inline void _llk_unpack_A_mop_config_(
             if constexpr (acc_to_dest)
             {
                 static constexpr std::uint32_t unpack_srca_reuse =
-                    (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? unpack_srca_zerosrc : unpack_srca;
+                    (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA)
+                        ? llk_unpack_a_detail::dest_reuse_dummy_unpack<EltwiseBinaryReuseDestType::DEST_TO_SRCA>()
+                        : unpack_srca;
 
                 static constexpr std::uint32_t unpack_srcb_reuse =
-                    (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB) ? unpack_srcb_zerosrc : unpack_srcb;
+                    (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
+                        ? llk_unpack_a_detail::dest_reuse_dummy_unpack<EltwiseBinaryReuseDestType::DEST_TO_SRCB>()
+                        : unpack_srcb;
 
                 const std::uint32_t outerloop     = num_faces;
                 constexpr std::uint32_t innerloop = 1;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Back-ports the Wormhole half of the Blackhole dest-reuse synchronization fix (#52256), and corrects
the Float32 golden the dest-reuse test compares against. Wormhole-only.

**1. Math — drain the FPU before testing source DVALID** (`cmath_common.h`)

`move_d2a_fixed_face` / `move_d2b_fixed_face` gate `MOVD2A`/`MOVD2B` on `SRC?_VLD`, which the Wait
Gate evaluates against the **live** `MatrixUnit.Src?Bank` pointer. A preceding FPU instruction flips
that pointer only in its epilogue, so with one still in the pipe the wait tests the stale bank, is
satisfied vacuously, and the move writes the post-flip bank. Adding `p_stall::MATH` drains the FPU so
the pointer is settled when the condition is tested. This is what #52256 applied to Blackhole
(HW-validated there); Wormhole never received it.

**2. Unpack — wait on the bank actually being cleared** (`llk_unpack_A.h`)

The dest-reuse MOP's dummy `UNPACR_NOP ZEROSRC` ran with `WaitLikeUnpacr=0`, so per the instruction's
functional model the wait indexes `MatrixUnit.Src?Bank` while the clear targets
`Unpackers[i].SrcBank` — different banks once double-buffering reaches steady state.
`UNP_ZEROSRC_STALL_RESET_WR_RDY` (`WaitLikeUnpacr=1`) makes the wait index the bank the instruction
actually clears, matching Blackhole's `dest_reuse_dummy_unpack()`. A `static_assert` in
`eltwise_binary_2_0.cpp` pins the encoding on both arches; reverting to plain `UNP_ZEROSRC` fails the
trisc0 build.

**3. Golden — model TF32 Src precision** (`test_single_core_binary_compute.cpp`)

Float32 operands with a 32-bit DEST reach the FPU as TF32, but the test compared against a full-FP32
host model. Now models unpack FP32→TF32 truncation, `MOVD2B` `ShuffleTF32(DstVal >> 13)`, and
`ELWMUL` ignoring the SrcA TF32 mantissa LSB. Truncation-vs-round-to-nearest and the SrcA LSB drop
were settled by fitting candidate models to real n150 output:

| model | bit-exact vs hardware |
|---|---|
| FP32 (previous golden) | 0.08% |
| **TF32 truncate, SrcA 9 bits** | **77.2%** |
| TF32 truncate, SrcA 10 bits | 39.0% |
| TF32 round-to-nearest, SrcA 9 bits | 36.8% |

Worst-element tolerance headroom improves **1.94x → 4.39x**. Wormhole only — Blackhole selects the
SrcA format differently (`ImpliedSrcAFmt`) and keeps the Float32 golden until measured there.

The run loop's pass/fail behaviour is unchanged; each failure path now logs which check it was, so a
failure says whether the output missed the golden or merely differed from run 0.

### Ticket

#53496

### Validation — Wormhole n150, slow dispatch

`unit_tests_llk` full suite: **270 passed / 182 skipped / 0 failed**, identical to unmodified main.
`*BinaryCompute*:*DestReuse*` (17 tests) x2 repeats pass, also with `TT_METAL_LLK_ASSERTS=1`.

### Notes for reviewers

**Please review this as a latent-defect / Blackhole-parity fix, not a fix for a live failure.**
#53496 no longer reproduces: `runtime_sd_llk [wh_n150_civ2]` has been green on main since Aug 29
(last failure Aug 28, run 33148645514), and the test passes 200+ consecutive local runs. The masking
change is in `b25bb937f097..b0273a2ff799`, most likely #49924, but that is not proven causal —
removing just that call does not bring the failure back.

**There is no fail-without/pass-with test, and one does not appear achievable.** A NOP sweep (unpack
thread 0–2000, math thread 0–256, injector verified active) leaves the output bit-identical at every
point, and dest-reuse output is byte-identical with and without the math-side hunks on this silicon.

**Scope.** Wormhole has 12 `SRC?_VLD` stall sites; this fixes the 2 in this code path — exactly the
two #52256 fixed on Blackhole. `move_d2a_row_broadcast_fixed_face` and `wait_bank_valid<>` have zero
callers repo-wide; `llk_math_transpose_dest.h` and the moe-gate LLKs are live but are different
operations and are *identically* unfixed on Blackhole, so they belong in a separate cross-arch change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-53496-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-53496-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-53496-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-53496-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-53496-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-53496-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-53496-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-53496-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-53496-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-53496-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-53496-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-53496-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-53496-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-53496-v1)
