### PR TITLE
[exabox] health check: reset ops don't gate the pass/fail verdict

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
@@ -32,6 +32,8 @@ import re
 import sys
 from datetime import datetime, timezone
 
+from utils.report import is_reset_op_check
+
 SCHEMA_VERSION = 1
 
 # check ip/phase -> dashboard category. "other" is the catch-all.
@@ -68,12 +70,6 @@ GDDR_INFO_PREFIX = "gddr_info_"
 
 SEVERITY = {"PASS": 0, "SKIP": 0, "EXCLUDED": 0, "WARN": 1, "FAIL": 2, "UNKNOWN": 3, "ERROR": 3}
 COVERED = {"PASS", "WARN", "FAIL"}
-
-
-# Reset *operation* steps (mirror of utils.report.is_reset_op_check): recorded with
-# their real status but acknowledged, so a recovered reset isn't counted as a fail.
-def is_reset_op_check(name: str) -> bool:
-    return name.startswith("reset_") or name == "cpld_auto_recover"
 
 
 RUNS_COLS = [

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
@@ -69,6 +69,13 @@ GDDR_INFO_PREFIX = "gddr_info_"
 SEVERITY = {"PASS": 0, "SKIP": 0, "EXCLUDED": 0, "WARN": 1, "FAIL": 2, "UNKNOWN": 3, "ERROR": 3}
 COVERED = {"PASS", "WARN", "FAIL"}
 
+
+# Reset *operation* steps (mirror of utils.report.is_reset_op_check): recorded with
+# their real status but acknowledged, so a recovered reset isn't counted as a fail.
+def is_reset_op_check(name: str) -> bool:
+    return name.startswith("reset_") or name == "cpld_auto_recover"
+
+
 RUNS_COLS = [
     "schema_version",
     "run_id",
@@ -333,7 +340,7 @@ def checks_rows(report: dict, meta: dict):
                 "is_fail": int(st == "FAIL"),
                 "is_skip": int(st == "SKIP"),
                 "is_covered": int(st in COVERED and executed == 1),
-                "acknowledged": int(name in ACKNOWLEDGED_CHECKS or excluded),
+                "acknowledged": int(name in ACKNOWLEDGED_CHECKS or excluded or is_reset_op_check(name)),
                 "testcases_passed": tp,
                 "testcases_failed": tf,
                 "executed": executed,

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/report.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/utils/report.py
@@ -18,6 +18,14 @@ from __future__ import annotations
 EXCLUDED_CHECKS = frozenset({"snapshot_capture"})
 
 
+# Reset *operation* steps (`tt-smi -r`/`-glx_reset` iterations, CPLD auto-recover):
+# a means to get the node testable, not a verdict. A node the resets can't fix still
+# fails via the tests phase / final snapshot, so these don't gate the verdict.
+# `post_reset_state_stable` is a real post-reset check, not a reset op.
+def is_reset_op_check(name: str) -> bool:
+    return name.startswith("reset_") or name == "cpld_auto_recover"
+
+
 def normalize_health_report(report: dict) -> dict:
     """Judge health on post-reset state: drop the pre-reset ``snapshot`` and promote
     the last post-reset re-snapshot in its place."""
@@ -43,10 +51,11 @@ def normalize_health_report(report: dict) -> dict:
 
 
 def has_actionable_failure(report: dict) -> bool:
-    """True if any non-excluded check FAILs in the (normalized) report."""
+    """True if any non-excluded, non-reset-op check FAILs in the (normalized) report."""
     for phase in report.get("phases", {}).values():
         for check in phase.get("checks", []):
-            if check.get("name") in EXCLUDED_CHECKS:
+            name = check.get("name", "")
+            if name in EXCLUDED_CHECKS or is_reset_op_check(name):
                 continue
             if check.get("status") == "FAIL":
                 return True


### PR DESCRIPTION
### PR Category
Feature

### Summary
Reset operation steps (`tt-smi -r` / `-glx_reset` iterations and CPLD auto-recover) no longer drive the health-check verdict, the final post-reset snapshot and the `tests` phase do. Nodes that fail a reset but recover (clean snapshot + tests pass) are no longer marked FAIL or ticketed, genuinely stuck nodes still fail via the tests phase. Reset steps stay recorded (with `reset_count`/`reset_stable`) for visibility.

Tests:
ran workflow trhough
https://tenstorrent.atlassian.net/browse/DCAMP-1547
it autoclosed the ticket as post tt-smi -glx_reset all is good

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-reset-loop-verdict)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/hc-reset-loop-verdict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-reset-loop-verdict)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/hc-reset-loop-verdict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/hc-reset-loop-verdict)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/hc-reset-loop-verdict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/hc-reset-loop-verdict)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/hc-reset-loop-verdict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/hc-reset-loop-verdict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/hc-reset-loop-verdict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/hc-reset-loop-verdict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/hc-reset-loop-verdict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/hc-reset-loop-verdict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/hc-reset-loop-verdict)